### PR TITLE
add a config to disable provider config validation

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -46,6 +46,7 @@ DEFAULTS = {
     'CELERY_BACKEND': 'database',
     'PDF_PREVIEW': 'True',
     'LOG_LEVEL': 'INFO',
+    'DISABLE_PROVIDER_CONFIG_VALIDATION': 'False',
 }
 
 
@@ -176,6 +177,9 @@ class Config:
         # hosted provider credentials
         self.OPENAI_API_KEY = get_env('OPENAI_API_KEY')
 
+        # By default it is False
+        # You could disable it for compatibility with certain OpenAPI providers
+        self.DISABLE_PROVIDER_CONFIG_VALIDATION = get_bool_env('DISABLE_PROVIDER_CONFIG_VALIDATION')
 
 class CloudEditionConfig(Config):
 

--- a/api/services/provider_service.py
+++ b/api/services/provider_service.py
@@ -62,6 +62,8 @@ class ProviderService:
 
     @staticmethod
     def validate_provider_configs(tenant, provider_name: ProviderName, configs: Union[dict | str]):
+        if current_app.config['DISABLE_PROVIDER_CONFIG_VALIDATION']:
+            return
         llm_provider_service = LLMProviderService(tenant.id, provider_name.value)
         return llm_provider_service.config_validate(configs)
 


### PR DESCRIPTION
some API proxy providers don't support `/moderations` API. It will make API Key Setting failed in console.

I add a config called `DISABLE_PROVIDER_CONFIG_VALIDATION`. If its value is `True`, it will skip the validation.


related issues: #80 #69 