### PR TITLE
Fix the email validation problem for a.b@c.club.

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -21,7 +21,7 @@ class TimestampField(fields.Raw):
 
 def email(email):
     # Define a regex pattern for email addresses
-    pattern = r"^[\w-.]+@([\w-]+.)+[\w-]{2,4}$"
+    pattern = r"^[\w\.-]+@([\w-]+\.)+[\w-]{2,4}$"
     # Check if the email matches the pattern
     if re.match(pattern, email) is not None:
         return email

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -21,7 +21,7 @@ class TimestampField(fields.Raw):
 
 def email(email):
     # Define a regex pattern for email addresses
-    pattern = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+    pattern = r"^[\w-.]+@([\w-]+.)+[\w-]{2,4}$"
     # Check if the email matches the pattern
     if re.match(pattern, email) is not None:
         return email

--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation'
 import Toast from '../components/base/toast'
 import { setup } from '@/service/common'
 
-const validEmailReg = /^[\w-.]+@([\w-]+.)+[\w-]{2,4}$/
+const validEmailReg = /^[\w\.-]+@([\w-]+\.)+[\w-]{2,4}$/
 const validPassword = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/
 
 const InstallForm = () => {

--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation'
 import Toast from '../components/base/toast'
 import { setup } from '@/service/common'
 
-const validEmailReg = /^([a-zA-Z0-9_-])+@([a-zA-Z0-9_-])+(\.[a-zA-Z0-9_-])+/
+const validEmailReg = /^[\w-.]+@([\w-]+.)+[\w-]{2,4}$/
 const validPassword = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/
 
 const InstallForm = () => {

--- a/web/app/signin/normalForm.tsx
+++ b/web/app/signin/normalForm.tsx
@@ -13,7 +13,7 @@ import Button from '@/app/components/base/button'
 import { login, oauth } from '@/service/common'
 import { apiPrefix } from '@/config'
 
-const validEmailReg = /^[\w-.]+@([\w-]+.)+[\w-]{2,4}$/
+const validEmailReg = /^[\w\.-]+@([\w-]+\.)+[\w-]{2,4}$/
 
 type IState = {
   formValid: boolean

--- a/web/app/signin/normalForm.tsx
+++ b/web/app/signin/normalForm.tsx
@@ -13,7 +13,7 @@ import Button from '@/app/components/base/button'
 import { login, oauth } from '@/service/common'
 import { apiPrefix } from '@/config'
 
-const validEmailReg = /^([a-zA-Z0-9_-])+@([a-zA-Z0-9_-])+(\.[a-zA-Z0-9_-])+/
+const validEmailReg = /^[\w-.]+@([\w-]+.)+[\w-]{2,4}$/
 
 type IState = {
   formValid: boolean

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -80,7 +80,7 @@ export const DEFAULT_VALUE_MAX_LEN = 48
 
 export const zhRegex = /^[\u4e00-\u9fa5]$/gm
 export const emojiRegex = /^[\uD800-\uDBFF][\uDC00-\uDFFF]$/gm
-export const emailRegex = /^[\w-.]+@([\w-]+.)+[\w-]{2,4}$/gm
+export const emailRegex = /^[\w\.-]+@([\w-]+\.)+[\w-]{2,4}$/gm
 const MAX_ZN_VAR_NAME_LENGHT = 8
 const MAX_EN_VAR_VALUE_LENGHT = 16
 export const getMaxVarNameLength = (value: string) => {

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -80,7 +80,7 @@ export const DEFAULT_VALUE_MAX_LEN = 48
 
 export const zhRegex = /^[\u4e00-\u9fa5]$/gm
 export const emojiRegex = /^[\uD800-\uDBFF][\uDC00-\uDFFF]$/gm
-export const emailRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+export const emailRegex = /^[\w-.]+@([\w-]+.)+[\w-]{2,4}$/gm
 const MAX_ZN_VAR_NAME_LENGHT = 8
 const MAX_EN_VAR_VALUE_LENGHT = 16
 export const getMaxVarNameLength = (value: string) => {


### PR DESCRIPTION
There are two points in the email verification logic that are easily overlooked. Firstly, the username before the "@" symbol can include not only the conventional requirements of uppercase and lowercase letters, numbers, and underscores for variable naming, but also support "-" and "." symbols. Secondly, the domain name after the "@" symbol needs to meet the first point and also support multiple levels of domains, with the top-level domain being 2 to 4 characters long and typically ending in "io," "org," "club," etc. A good test case is the email address "[abc.def@alibaba-inc.com](mailto:abc.def@alibaba-inc.com)" from Alibaba Group.