### PR TITLE
Feat: site code can be explicitly set to a specified value when being reset

### DIFF
--- a/api/controllers/console/app/error.py
+++ b/api/controllers/console/app/error.py
@@ -47,3 +47,9 @@ class AppMoreLikeThisDisabledError(BaseHTTPException):
     error_code = 'app_more_like_this_disabled'
     description = "More like this disabled."
     code = 403
+
+
+class SiteCodeExistedError(BaseHTTPException):
+    error_code = 'site_code_existed_error'
+    description = 'Site code already existed'
+    code = 400

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,21 +8,21 @@ services:
       # Startup mode, 'api' starts the API server.
       MODE: api
       # The log level for the application. Supported values are `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
-      LOG_LEVEL: INFO
+      LOG_LEVEL: DEBUG
       # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
       SECRET_KEY: sk-9f73s3ljTXVcMT3Blb3ljTqtsKiGHXVcMT3BlbkFJLK7U
       # The base URL of console application, refers to the Console base URL of WEB service if console domain is
       # different from api or web app domain.
       # example: http://cloud.dify.ai
-      CONSOLE_URL: ''
+      CONSOLE_URL: 'http://10.1.4.15'
       # The URL for Service API endpoints，refers to the base URL of the current API service if api domain is
       # different from console domain.
       # example: http://api.dify.ai
-      API_URL: ''
+      API_URL: 'http://10.1.4.15'
       # The URL for Web APP, refers to the Web App base URL of WEB service if web app domain is different from
       # console or api domain.
       # example: http://udify.app
-      APP_URL: ''
+      APP_URL: 'http://10.1.4.15'
       # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
       MIGRATION_ENABLED: 'true'
       # The configurations of postgres database connection.
@@ -119,7 +119,7 @@ services:
       # --- All the configurations below are the same as those in the 'api' service. ---
 
       # The log level for the application. Supported values are `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
-      LOG_LEVEL: INFO
+      LOG_LEVEL: DEBUG
       # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
       # same as the API service
       SECRET_KEY: sk-9f73s3ljTXVcMT3Blb3ljTqtsKiGHXVcMT3BlbkFJLK7U
@@ -163,11 +163,11 @@ services:
       # The base URL of console application, refers to the Console base URL of WEB service if console domain is
       # different from api or web app domain.
       # example: http://cloud.dify.ai
-      CONSOLE_URL: ''
+      CONSOLE_URL: 'http://10.1.4.15'
       # The URL for Web APP, refers to the Web App base URL of WEB service if web app domain is different from
       # console or api domain.
       # example: http://udify.app
-      APP_URL: ''
+      APP_URL: 'http://10.1.4.15'
 
   # The postgres database.
   db:

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/cardView.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/cardView.tsx
@@ -61,7 +61,7 @@ const CardView: FC<ICardViewProps> = ({ appId }) => {
   }
 
   const onGenerateCode = async () => {
-    const [err] = await asyncRunSafe<App>(updateAppSiteAccessToken as any, { url: `/apps/${appId}/site/access-token-reset` }, notify, t)
+    const [err] = await asyncRunSafe<App>(updateAppSiteAccessToken as any, { url: `/apps/${appId}/site/access-token-reset`, body: {} }, notify, t)
     if (!err)
       mutate(detailParams)
   }

--- a/web/service/apps.ts
+++ b/web/service/apps.ts
@@ -42,8 +42,8 @@ export const updateAppRateLimit: Fetcher<AppDetailResponse, { url: string; body:
   return post(url, { body }) as Promise<AppDetailResponse>
 }
 
-export const updateAppSiteAccessToken: Fetcher<UpdateAppSiteCodeResponse, { url: string }> = ({ url }) => {
-  return post(url) as Promise<UpdateAppSiteCodeResponse>
+export const updateAppSiteAccessToken: Fetcher<UpdateAppSiteCodeResponse, { url: string, body: Record<string, any> }> = ({ url }) => {
+  return post(url, { body }) as Promise<UpdateAppSiteCodeResponse>
 }
 
 export const updateAppSiteConfig: Fetcher<AppDetailResponse, { url: string; body: Record<string, any> }> = ({ url, body }) => {


### PR DESCRIPTION
Currently api `AppSiteAccessTokenReset` only supports generate a random `site.code`
So I add this feature that `code` can be explicitly set, this feature brings convenience for generate a more friendly and remember "share url" for end users.