### PR TITLE
Fix the issue of decoding a non-UTF-8 encoded file using UTF-8 encodi…

### DIFF
--- a/api/controllers/console/datasets/file.py
+++ b/api/controllers/console/datasets/file.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 import tempfile
+import chardet
 import time
 import uuid
 from pathlib import Path
@@ -141,7 +142,8 @@ class FilePreviewApi(Resource):
                 # ['txt', 'markdown', 'md']
                 with open(filepath, "rb") as fp:
                     data = fp.read()
-                    text = data.decode(encoding='utf-8').strip() if data else ''
+                    encoding = chardet.detect(data)['encoding']
+                    text = data.decode(encoding=encoding).strip() if data else ''
 
         text = text[0:PREVIEW_WORDS_LIMIT] if text else ''
         return {'content': text}


### PR DESCRIPTION
![image](https://github.com/langgenius/dify/assets/36625222/39c5ae7f-ba52-4519-b1c7-3c0827ea48f7)
读取非UTF-8文件时会发生致命报错，采用chardet检测编码格式自适应解码