### PR TITLE
fix(i18n): Make text gender neutral

### DIFF
--- a/web/i18n/lang/common.en.ts
+++ b/web/i18n/lang/common.en.ts
@@ -110,7 +110,7 @@ const translation = {
     normal: 'Normal',
     normalTip: 'Only can use apps，can not build apps',
     inviteTeamMember: 'Add team member',
-    inviteTeamMemberTip: 'He can access your team data directly after signing in.',
+    inviteTeamMemberTip: 'They can access your team data directly after signing in.',
     email: 'Email',
     emailInvalid: 'Invalid Email Format',
     emailPlaceholder: 'Input Email',


### PR DESCRIPTION
Simple language change to make text language neutral

<img width="730" alt="image" src="https://github.com/langgenius/dify/assets/15050019/a2ce9045-14bd-4504-98d2-6ef8ed448769">
