### PR TITLE
fix: filter empty value in xlsx to improve vector similarity hit

### DIFF
--- a/api/core/index/readers/xlsx_parser.py
+++ b/api/core/index/readers/xlsx_parser.py
@@ -28,6 +28,6 @@ class XLSXParser(BaseParser):
                         keys = list(map(str, row))
                     else:
                         row_dict = dict(zip(keys, row))
-                        row_dict = {k: v for k, v in row_dict.items() if v is not None}
+                        row_dict = {k: v for k, v in row_dict.items() if v}
                         data.append(json.dumps(row_dict, ensure_ascii=False))
         return '\n\n'.join(data)

--- a/api/core/index/readers/xlsx_parser.py
+++ b/api/core/index/readers/xlsx_parser.py
@@ -27,5 +27,7 @@ class XLSXParser(BaseParser):
                     if keys == []:
                         keys = list(map(str, row))
                     else:
-                        data.append(json.dumps(dict(zip(keys, list(map(str, row)))), ensure_ascii=False))
+                        row_dict = dict(zip(keys, row))
+                        row_dict = {k: v for k, v in row_dict.items() if v is not None}
+                        data.append(json.dumps(row_dict, ensure_ascii=False))
         return '\n\n'.join(data)

--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout.tsx
@@ -124,7 +124,7 @@ const DatasetDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
         ? (
           <>
             <div className={s.subTitle}>{relatedApps?.total || '--'} {t('common.datasetMenus.relatedApp')}</div>
-            {relatedApps?.data?.map(item => (<LikedItem detail={item} />))}
+            {relatedApps?.data?.map((item, index) => (<LikedItem key={index} detail={item} />))}
           </>
         )
         : (

--- a/web/app/components/datasets/hit-testing/index.tsx
+++ b/web/app/components/datasets/hit-testing/index.tsx
@@ -137,8 +137,9 @@ const HitTesting: FC<Props> = ({ datasetId }: Props) => {
               <div className='text-gray-600 font-semibold mb-4'>{t('datasetHitTesting.hit.title')}</div>
               <div className='overflow-auto flex-1'>
                 <div className={s.cardWrapper}>
-                  {hitResult?.records.map((record) => {
+                  {hitResult?.records.map((record, idx) => {
                     return <SegmentCard
+                      key={idx}
                       loading={false}
                       detail={record.segment as any}
                       score={record.score}


### PR DESCRIPTION
Exclude empty value during xlsx parsing, to make hit-test result more accurate.
By the way, we should exclude any redundant text in original dataset, so that the indexing and query result can be more accurate.

Fix: https://github.com/langgenius/dify/issues/388