### PR TITLE
fix(web): fix svg unrecognized props

### DIFF
--- a/web/app/components/base/icons/utils.ts
+++ b/web/app/components/base/icons/utils.ts
@@ -15,6 +15,7 @@ export type Attrs = {
 export function normalizeAttrs(attrs: Attrs = {}): Attrs {
   return Object.keys(attrs).reduce((acc: Attrs, key) => {
     const val = attrs[key]
+    key = key.replace(/([-]\w)/g, (g: string) => g[1].toUpperCase())
     switch (key) {
       case 'class':
         acc.className = val


### PR DESCRIPTION
fix svg icon unrecognized props

similar to snapshot

<img width="1071" alt="iShot_2023-07-22_16 00 01" src="https://github.com/langgenius/dify/assets/20832069/6957c814-9aec-41e4-a34c-1f83e1e621eb">
