### PR TITLE
Perf: Support for password display and hiding

### DIFF
--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -17,6 +17,7 @@ const InstallForm = () => {
   const [email, setEmail] = React.useState('')
   const [name, setName] = React.useState('')
   const [password, setPassword] = React.useState('')
+  const [showPassword, setShowPassword] = React.useState(false)
   const showErrorMessage = (message: string) => {
     Toast.notify({
       type: 'error',
@@ -108,12 +109,21 @@ const InstallForm = () => {
               <div className="mt-1 relative rounded-md shadow-sm">
                 <input
                   id="password"
-                  type='password'
+                  type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={e => setPassword(e.target.value)}
                   placeholder={t('login.passwordPlaceholder') || ''}
                   className={'appearance-none block w-full rounded-lg pl-[14px] px-3 py-2 border border-gray-200 hover:border-gray-300 hover:shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 placeholder-gray-400 caret-primary-600 sm:text-sm pr-10'}
                 />
+                <div className="absolute inset-y-0 right-0 flex items-center pr-3">
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="text-gray-400 hover:text-gray-500 focus:outline-none focus:text-gray-500"
+                  >
+                    {showPassword ? '👀' : '😝'}
+                  </button>
+                </div>
               </div>
               <div className='mt-1 text-xs text-gray-500'>{t('login.error.passwordInvalid')}</div>
 


### PR DESCRIPTION
设置管理员账户密码时由于无法显示密码，导致密码设置错误也不知道。
修改为与登录页面一致，支持密码的显示与隐藏

When setting the administrator account password, the password could not be displayed, resulting in setting the wrong password without knowing. Modify it to be consistent with the login page and support showing and hiding passwords.

<img width="610" alt="Screenshot 2023-07-22 at 23 22 42" src="https://github.com/langgenius/dify/assets/29670394/3cbd0d18-9022-4be1-8d32-70d43d6f9982">
<img width="589" alt="Screenshot 2023-07-22 at 23 23 03" src="https://github.com/langgenius/dify/assets/29670394/ca4585cd-919e-4212-9fa9-ec0c7ffbe6fa">
