### PR TITLE
fix: `line-clamp-2` class does not exist error

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
     "@next/mdx": "^13.2.4",
     "@sentry/react": "^7.54.0",
     "@sentry/utils": "^7.54.0",
-    "@tailwindcss/line-clamp": "^0.4.2",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.9",
     "@types/crypto-js": "^4.1.1",
     "@types/lodash-es": "^4.17.7",

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -64,6 +64,7 @@ module.exports = {
     },
   },
   plugins: [
+    require('@tailwindcss/line-clamp'),
     require('@tailwindcss/typography'),
   ],
 }


### PR DESCRIPTION
fix start `pnpm dev` commend error 
```
platform：MacOs m1 pro
node: v18.15.0
pnpm: 8.6.11
```

<img width="1012" alt="image" src="https://github.com/langgenius/dify/assets/47295879/33488ebf-ae0d-4857-92a3-240c10a8ee4e">
