### PR TITLE
fix: generate_more_like_this function issue

### DIFF
--- a/api/core/completion.py
+++ b/api/core/completion.py
@@ -388,7 +388,6 @@ And answer according to the language of the user's question.
             pre_prompt=pre_prompt,
             query=message.query,
             inputs=message.inputs,
-            chain_output=None,
             agent_execute_result=None,
             memory=None
         )


### PR DESCRIPTION
The parameter `chain_output` has been removed from `completion.py/get_main_llm_prompt`, but it is still incorrectly being used here. The `generate_more_like_this` functionality will work properly when the parameter is removed.