### PR TITLE
perf(console/setup/SetupApi/post): remove login logic

### DIFF
--- a/api/controllers/console/setup.py
+++ b/api/controllers/console/setup.py
@@ -58,10 +58,6 @@ class SetupApi(Resource):
 
         setup()
 
-        # Login
-        flask_login.login_user(account)
-        AccountService.update_last_login(account, request)
-
         return {'result': 'success'}, 201
 
 


### PR DESCRIPTION
The signin step following the setup stage requires re-login, so one should not login during the setup stage.