### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate Models - using litellm

### DIFF
--- a/api/core/third_party/langchain/llms/chat_open_ai.py
+++ b/api/core/third_party/langchain/llms/chat_open_ai.py
@@ -2,11 +2,11 @@ import os
 
 from typing import Dict, Any, Optional, Union, Tuple
 
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 from pydantic import root_validator
 
 
-class EnhanceChatOpenAI(ChatOpenAI):
+class EnhanceChatOpenAI(ChatLiteLLM):
     request_timeout: Optional[Union[float, Tuple[float, float]]] = (5.0, 300.0)
     """Timeout for requests to OpenAI completion API. Default is 600 seconds."""
     max_retries: int = 1


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the OpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```
