### PR TITLE
fix entrypoint script line endings

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -25,7 +25,7 @@ RUN yarn build
 # production stage
 FROM base as production
 
-ENV NODE_ENV=production
+ENV NODE_ENV production
 ENV EDITION SELF_HOSTED
 ENV DEPLOY_ENV PRODUCTION
 ENV CONSOLE_API_URL http://127.0.0.1:5001

--- a/web/docker/entrypoint.sh
+++ b/web/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
Entrypoint script would cause container running error due to Windows and Unix have different line endings. ("\r\n" & "\n")