### PR TITLE
fix: hiding addToWorkspace for installed apps in explor page

### DIFF
--- a/web/app/components/explore/app-card/index.tsx
+++ b/web/app/components/explore/app-card/index.tsx
@@ -44,10 +44,10 @@ const AppCard = ({
             <AppModeLabel mode={appBasicInfo.mode} />
           </div>
           <div className={cn(s.opWrap, 'flex items-center w-full space-x-2')}>
-            <Button type='primary' className='grow flex items-center !h-7' onClick={() => onAddToWorkspace(appBasicInfo.id)}>
+            {!app.installed && (<Button type='primary' className='grow flex items-center !h-7' onClick={() => onAddToWorkspace(appBasicInfo.id)}>
               <PlusIcon className='w-4 h-4 mr-1' />
               <span className='text-xs'>{t('explore.appCard.addToWorkspace')}</span>
-            </Button>
+            </Button>)}
             {canCreate && (
               <Button className='grow flex items-center !h-7 space-x-1' onClick={onCreate}>
                 {CustomizeBtn}


### PR DESCRIPTION
* Optimize code.
* Fix the follow issue:  
It doesn't make any sense that shows `addToWorkspace` for installed apps:
![image](https://github.com/langgenius/dify/assets/1320925/0ab728c8-a59a-436a-9ed4-eb942f6da40d)

Screen recording after fixing:

https://github.com/langgenius/dify/assets/1320925/92984167-c9dc-4017-9c66-694bcbddf872

