### PR TITLE
fix: change frontend start script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next dev",
     "lint": "next lint",
     "fix": "next lint --fix",
     "eslint-fix": "eslint --fix",


### PR DESCRIPTION
Next.js output use output: 'standalone' to improve build speed. So it doesnt't support `next start`.
Details: https://nextjs.org/docs/app/api-reference/next-config-js/output