### PR TITLE
feat: optimize celery start cmd

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -52,7 +52,7 @@
    flask run --host 0.0.0.0 --port=5001 --debug
    ```
 7. Setup your application by visiting http://localhost:5001/console/api/setup or other apis...
-8. If you need to debug local async processing, you can run `celery -A app.celery worker -Q dataset,generation,mail`, celery can do dataset importing and other async tasks.
+8. If you need to debug local async processing, you can run `celery -A app.celery worker -P gevent -c 1 --loglevel INFO -Q dataset,generation,mail`, celery can do dataset importing and other async tasks.
 
 8. Start frontend
 


### PR DESCRIPTION
The default `prefork` pool may not work properly on macOS, so switch to `gevent`.