### PR TITLE
fix: answer returned null when response_mode was blocking

### DIFF
--- a/api/services/completion_service.py
+++ b/api/services/completion_service.py
@@ -367,7 +367,7 @@ class CompletionService:
                         result = json.loads(result)
                         if result.get('error'):
                             cls.handle_error(result)
-                        if 'data' in result:
+                        if result['event'] == 'message' and 'data' in result:
                             return cls.get_message_response_data(result.get('data'))
             except ValueError as e:
                 if e.args[0] != "I/O operation on closed file.":  # ignore this error


### PR DESCRIPTION
## How to reproduce

When selecting multiple datasets, subscribing to the messages of agent_thought, there is no content in the answer, which ultimately results in a Null response.

## Solution

Only subscribe to messages with the event "message"