### PR TITLE
fix: remove the deprecated depends_on.condition format

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -114,12 +114,9 @@ services:
       # The sample rate for Sentry profiles. Default: `1.0`
       SENTRY_PROFILES_SAMPLE_RATE: 1.0
     depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      weaviate:
-        condition: service_started
+      - db
+      - redis
+      - weaviate
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
@@ -170,12 +167,9 @@ services:
       # the api-key for resend (https://resend.com)
       RESEND_API_KEY: ''
     depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      weaviate:
-        condition: service_started
+      - db
+      - redis
+      - weaviate
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage


### PR DESCRIPTION
remove the deprecated depends_on.condition format in docker compose v3