### PR TITLE
fix: Improved fallback solution for avatar image loading failure

### DIFF
--- a/web/app/components/base/avatar/index.tsx
+++ b/web/app/components/base/avatar/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import cn from 'classnames'
+import { useState } from 'react'
 
 type AvatarProps = {
   name: string
@@ -17,14 +18,20 @@ const Avatar = ({
 }: AvatarProps) => {
   const avatarClassName = 'shrink-0 flex items-center rounded-full bg-primary-600'
   const style = { width: `${size}px`, height: `${size}px`, fontSize: `${size}px`, lineHeight: `${size}px` }
+  const [imgError, setImgError] = useState(false)
 
-  if (avatar) {
+  const handleError = () => {
+    setImgError(true)
+  }
+
+  if (avatar && !imgError) {
     return (
       <img
         className={cn(avatarClassName, className)}
         style={style}
         alt={name}
         src={avatar}
+        onError={handleError}
       />
     )
   }


### PR DESCRIPTION
若头像图片显示异常，将自动回退至文本模式。
If the image displays abnormally, it will automatically revert to text mode.

<img width="1926" alt="image" src="https://github.com/langgenius/dify/assets/38089200/c5dda307-bd18-422e-8e9e-a060c7a3b13c">

> 修改前 before

<img width="1913" alt="image" src="https://github.com/langgenius/dify/assets/38089200/cb04a687-8ae5-4e99-a43e-dac25e944159">

> 修改后 after