### PR TITLE
fix: app card hover selector

### DIFF
--- a/web/app/components/explore/app-card/index.tsx
+++ b/web/app/components/explore/app-card/index.tsx
@@ -30,7 +30,7 @@ const AppCard = ({
   const { t } = useTranslation()
   const { app: appBasicInfo } = app
   return (
-    <div className='col-span-1 bg-white border-2 border-solid border-transparent rounded-lg shadow-sm min-h-[160px] flex flex-col transition-all duration-200 ease-in-out cursor-pointer hover:shadow-lg'>
+    <div className={cn(s.wrap, 'col-span-1 bg-white border-2 border-solid border-transparent rounded-lg shadow-sm min-h-[160px] flex flex-col transition-all duration-200 ease-in-out cursor-pointer hover:shadow-lg')}>
       <div className='flex pt-[14px] px-[14px] pb-3 h-[66px] items-center gap-3 grow-0 shrink-0'>
         <AppIcon size='small' icon={app.app.icon} background={app.app.icon_background} />
         <div className='relative h-8 text-sm font-medium leading-8 grow'>

--- a/web/app/components/explore/app-card/style.module.css
+++ b/web/app/components/explore/app-card/style.module.css
@@ -1,3 +1,7 @@
+.wrap {
+  display: flex;
+}
+
 .mode {
   display: flex;
   height: 28px;


### PR DESCRIPTION
# Fix app card hover

Hovering on app cards are not working because a css class was removed unexpectedly.
- Before
  <img width="1443" alt="image" src="https://github.com/langgenius/dify/assets/26663836/0597432e-9ca3-439f-bd6d-5871f0d91460">
- After
  <img width="1674" alt="image" src="https://github.com/langgenius/dify/assets/26663836/76353d8e-5ea2-42f0-976e-f785c71998a2">
