### PR TITLE
chore(docker-compose): use proper comment indentation for users to easily toggle on and off features

### DIFF
--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -52,15 +52,15 @@ services:
       - "8080:8080"
 
   # Qdrant vector store.
-#  uncomment to use qdrant as vector store.
-#  (if uncommented, you need to comment out the weaviate service above,
-#  and set VECTOR_STORE to qdrant in the api & worker service.)
-#  qdrant:
-#    image: qdrant/qdrant:latest
-#    restart: always
-#    volumes:
-#      - ./volumes/qdrant:/qdrant/storage
-#    environment:
-#      QDRANT__API_KEY: 'difyai123456'
-#    ports:
-#      - "6333:6333"
+  # uncomment to use qdrant as vector store.
+  # (if uncommented, you need to comment out the weaviate service above,
+  # and set VECTOR_STORE to qdrant in the api & worker service.)
+  # qdrant:
+  #   image: qdrant/qdrant:latest
+  #   restart: always
+  #   volumes:
+  #     - ./volumes/qdrant:/qdrant/storage
+  #   environment:
+  #     QDRANT__API_KEY: 'difyai123456'
+  #   ports:
+  #     - "6333:6333"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -121,9 +121,9 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-#    uncomment to expose dify-api port to host
-#    ports:
-#      - "5001:5001"
+    # uncomment to expose dify-api port to host
+    # ports:
+    #   - "5001:5001"
 
   # worker service
   # The Celery worker for processing the queue.
@@ -210,9 +210,9 @@ services:
       APP_API_URL: ''
       # The DSN for Sentry error reporting. If not set, Sentry error reporting will be disabled.
       SENTRY_DSN: ''
-#    uncomment to expose dify-web port to host
-#    ports:
-#      - "3000:3000"
+    # uncomment to expose dify-web port to host
+    # ports:
+    #   - "3000:3000"
 
   # The postgres database.
   db:
@@ -247,9 +247,9 @@ services:
     command: redis-server --requirepass difyai123456
     healthcheck:
       test: ["CMD", "redis-cli","ping"]
-#    uncomment to expose redis port to host
-#    ports:
-#      - "6379:6379"
+    # uncomment to expose redis port to host
+    # ports:
+    #   - "6379:6379"
 
   # The Weaviate vector store.
   weaviate:
@@ -271,24 +271,24 @@ services:
       AUTHENTICATION_APIKEY_USERS: 'hello@dify.ai'
       AUTHORIZATION_ADMINLIST_ENABLED: 'true'
       AUTHORIZATION_ADMINLIST_USERS: 'hello@dify.ai'
-#    uncomment to expose weaviate port to host
-#    ports:
-#      - "8080:8080"
+    # uncomment to expose weaviate port to host
+    # ports:
+    #  - "8080:8080"
 
   # Qdrant vector store.
-#  uncomment to use qdrant as vector store.
-#  (if uncommented, you need to comment out the weaviate service above,
-#  and set VECTOR_STORE to qdrant in the api & worker service.)
-#  qdrant:
-#    image: langgenius/qdrant:latest
-#    restart: always
-#    volumes:
-#      - ./volumes/qdrant:/qdrant/storage
-#    environment:
-#      QDRANT__API_KEY: 'difyai123456'
-##    uncomment to expose qdrant port to host
-##    ports:
-##      - "6333:6333"
+  # uncomment to use qdrant as vector store.
+  # (if uncommented, you need to comment out the weaviate service above,
+  # and set VECTOR_STORE to qdrant in the api & worker service.)
+  # qdrant:
+  #   image: langgenius/qdrant:latest
+  #   restart: always
+  #   volumes:
+  #     - ./volumes/qdrant:/qdrant/storage
+  #   environment:
+  #     QDRANT__API_KEY: 'difyai123456'
+  #   # uncomment to expose qdrant port to host
+  #   # ports:
+  #   #  - "6333:6333"
 
   # The nginx reverse proxy.
   # used for reverse proxying the API service and Web service.


### PR DESCRIPTION
## Summary

As title.

## Changes

Currently the indentations of comments are kind of broken in `docker-compose.yaml` files, often requires me to manually indent the toggled-on services and ports one by one. Updated to a proper indentation of comments with alignment.