### PR TITLE
fix: app setting click pop

### DIFF
--- a/web/app/(commonLayout)/apps/AppCard.tsx
+++ b/web/app/(commonLayout)/apps/AppCard.tsx
@@ -138,6 +138,8 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
     <>
       <div
         onClick={(e) => {
+          if (showSettingsModal)
+            return
           e.preventDefault()
           push(`/app/${app.id}/overview`)
         }}


### PR DESCRIPTION
When clicking and holding the mouse on the input field, then dragging it outside the configuration page, it unexpectedly navigates to the overview page.