### PR TITLE
fix: Incorrect order of embedded documents in CacheEmbedding

### DIFF
--- a/api/core/embedding/cached_embedding.py
+++ b/api/core/embedding/cached_embedding.py
@@ -18,31 +18,30 @@ class CacheEmbedding(Embeddings):
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Embed search docs."""
         # use doc embedding cache or store if not exists
-        text_embeddings = []
-        embedding_queue_texts = []
+        text_embeddings = [None for _ in range(len(texts))]
+        embedding_queue_indices = []
         for text in texts:
             hash = helper.generate_text_hash(text)
             embedding = db.session.query(Embedding).filter_by(model_name=self._embeddings.name, hash=hash).first()
             if embedding:
-                text_embeddings.append(embedding.get_embedding())
+                text_embeddings[i] = embedding.get_embedding()
             else:
-                embedding_queue_texts.append(text)
+                embedding_queue_indices.append(i)
 
-        if embedding_queue_texts:
+        if embedding_queue_indices:
             try:
-                embedding_results = self._embeddings.client.embed_documents(embedding_queue_texts)
+                embedding_results = self._embeddings.client.embed_documents([texts[i] for i in embedding_queue_indices])
             except Exception as ex:
                 raise self._embeddings.handle_exceptions(ex)
-            i = 0
-            normalized_embedding_results = []
-            for text in embedding_queue_texts:
-                hash = helper.generate_text_hash(text)
+
+            for i, indice in enumerate(embedding_queue_indices):
+                hash = helper.generate_text_hash(texts[indice])
 
                 try:
                     embedding = Embedding(model_name=self._embeddings.name, hash=hash)
                     vector = embedding_results[i]
                     normalized_embedding = (vector / np.linalg.norm(vector)).tolist()
-                    normalized_embedding_results.append(normalized_embedding)
+                    text_embeddings[indice] = normalized_embedding
                     embedding.set_embedding(normalized_embedding)
                     db.session.add(embedding)
                     db.session.commit()
@@ -52,10 +51,7 @@ class CacheEmbedding(Embeddings):
                 except:
                     logging.exception('Failed to add embedding to db')
                     continue
-                finally:
-                    i += 1
 
-            text_embeddings.extend(normalized_embedding_results)
         return text_embeddings
 
     def embed_query(self, text: str) -> List[float]:

--- a/api/core/embedding/cached_embedding.py
+++ b/api/core/embedding/cached_embedding.py
@@ -20,7 +20,7 @@ class CacheEmbedding(Embeddings):
         # use doc embedding cache or store if not exists
         text_embeddings = [None for _ in range(len(texts))]
         embedding_queue_indices = []
-        for text in texts:
+        for i, text in enumerate(texts):
             hash = helper.generate_text_hash(text)
             embedding = db.session.query(Embedding).filter_by(model_name=self._embeddings.name, hash=hash).first()
             if embedding:


### PR DESCRIPTION
Dify uses CacheEmbedding by default. When some documents have been embeded, those would not correspond to the order of text. The text and vectors stored in the vector database will not correspond.

````python
class Weaviate(VectorStore):

    def add_texts(
        self,
        texts: Iterable[str],
        metadatas: Optional[List[dict]] = None,
        **kwargs: Any,
    ) -> List[str]:
        """Upload texts with metadata (properties) to Weaviate."""
        from weaviate.util import get_valid_uuid

        ids = []
        embeddings: Optional[List[List[float]]] = None
        if self._embedding:
            if not isinstance(texts, list):
                texts = list(texts)
            embeddings = self._embedding.embed_documents(texts)  # <--- when some documents have been embeded, those would not correspond to the order of text

        with self._client.batch as batch:
            for i, text in enumerate(texts): # <--- Loop according to text order
                data_properties = {self._text_key: text}
                if metadatas is not None:
                    for key, val in metadatas[i].items():
                        data_properties[key] = _json_serializable(val)

                # Allow for ids (consistent w/ other methods)
                # # Or uuids (backwards compatble w/ existing arg)
                # If the UUID of one of the objects already exists
                # then the existing object will be replaced by the new object.
                _id = get_valid_uuid(uuid4())
                if "uuids" in kwargs:
                    _id = kwargs["uuids"][i]
                elif "ids" in kwargs:
                    _id = kwargs["ids"][i]

                batch.add_data_object(
                    data_object=data_properties,
                    class_name=self._index_name,
                    uuid=_id,
                    vector=embeddings[i] if embeddings else None, # <--- In this case, a corresponding error will occur
                )
                ids.append(_id)

```



