### PR TITLE
fix: error Class 'builtins.list' is not mapped

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -106,7 +106,8 @@ class IndexingRunner:
                 document_id=dataset_document.id
             ).all()
 
-            db.session.delete(document_segments)
+            for document_segment in document_segments:
+                db.session.delete(document_segment)
             db.session.commit()
 
             # load file


### PR DESCRIPTION
This resolves the error "Class 'builtins.list' is not mapped" when indexing a document. Users see this error in the dify web UI when attempting to index a document.