### PR TITLE
refactor: typo in dataset docstore

### DIFF
--- a/api/core/docstore/dataset_docstore.py
+++ b/api/core/docstore/dataset_docstore.py
@@ -8,7 +8,7 @@ from extensions.ext_database import db
 from models.dataset import Dataset, DocumentSegment
 
 
-class DatesetDocumentStore:
+class DatasetDocumentStore:
     def __init__(
             self,
             dataset: Dataset,
@@ -20,7 +20,7 @@ class DatesetDocumentStore:
         self._document_id = document_id
 
     @classmethod
-    def from_dict(cls, config_dict: Dict[str, Any]) -> "DatesetDocumentStore":
+    def from_dict(cls, config_dict: Dict[str, Any]) -> "DatasetDocumentStore":
         return cls(**config_dict)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm.exc import ObjectDeletedError
 
 from core.data_loader.file_extractor import FileExtractor
 from core.data_loader.loader.notion import NotionLoader
-from core.docstore.dataset_docstore import DatesetDocumentStore
+from core.docstore.dataset_docstore import DatasetDocumentStore
 from core.generator.llm_generator import LLMGenerator
 from core.index.index import IndexBuilder
 from core.model_providers.error import ProviderTokenNotInitError
@@ -474,7 +474,7 @@ class IndexingRunner:
         )
 
         # save node to document segment
-        doc_store = DatesetDocumentStore(
+        doc_store = DatasetDocumentStore(
             dataset=dataset,
             user_id=dataset_document.created_by,
             document_id=dataset_document.id


### PR DESCRIPTION
I think it's unintended that the class is called Dat[e](/#)setDocumentStore since the file is named `dataset_docstore.py`.