### PR TITLE
fix: qa regex

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -632,8 +632,8 @@ class IndexingRunner:
         return text
 
     def format_split_text(self, text):
-        regex = r"Q\d+:\s*(.*?)\s*A\d+:\s*([\s\S]*?)(?=Q|$)"
-        matches = re.findall(regex, text, re.MULTILINE)
+        regex = r"Q\d+:\s*(.*?)\s*A\d+:\s*([\s\S]*?)(?=Q\d+:|$)" 
+        matches = re.findall(regex, text, re.UNICODE)
 
         return [
             {


### PR DESCRIPTION
1. **First Regular Expression** (`regex = r"Q\d+:\s*(.*?)\s*A\d+:\s*([\s\S]*?)(?=Q|$)"`):
   - This pattern is designed to match questions and answers in a text. It starts with "Q" followed by a number (indicating the question number), then captures any text following it as the question.
   - It then looks for an "A" followed by a number (indicating the answer number) and captures any text following as the answer.
   - The important part here is the lookahead assertion `(?=Q|$)`. This means that the regex captures the answer text up until it encounters the next "Q" or the end of the string. It implies that each answer can span multiple lines until the next question begins or the text ends.

2. **Second Regular Expression** (`regex = r"Q\d+:\s*(.*?)\s*A\d+:\s*([\s\S]*?)(?=Q\d+:|$)"`):
   - This regex is quite similar to the first one but has a significant difference in the lookahead assertion.
   - Here, the assertion `(?=Q\d+:|$)` specifies that the answer text is captured up until it encounters the next sequence of "Q" followed by a number (indicating the start of the next question) or the end of the string. This means the answer continues until the pattern finds the next question marked by "Q" followed by a number.

**Key Differences**:
- The first regex might incorrectly determine the end of an answer if there's a standalone "Q" in the text, as it only checks for the presence of "Q" and not whether it is followed by a number.
- The second regex is stricter as it requires a "Q" followed by a number to mark the next question. This makes it more accurate in defining the boundaries of questions and answers, especially in cases where the answer text might contain "Q" but not as the start of a new question.