### PR TITLE
fix: add 'sentence-similarity' in allowed hugging face model tasks

### DIFF
--- a/api/core/model_providers/providers/huggingface_hub_provider.py
+++ b/api/core/model_providers/providers/huggingface_hub_provider.py
@@ -118,9 +118,9 @@ class HuggingfaceHubProvider(BaseModelProvider):
                 if 'inference' in model_info.cardData and not model_info.cardData['inference']:
                     raise ValueError(f'Inference API has been turned off for this model {model_name}.')
 
-                VALID_TASKS = ("text2text-generation", "text-generation", "feature-extraction")
+                VALID_TASKS = ("text2text-generation", "text-generation", "feature-extraction", "sentence-similarity")
                 if model_info.pipeline_tag not in VALID_TASKS:
-                    raise ValueError(f"Model {model_name} is not a valid task, "
+                    raise ValueError(f"Task {model_info.pipeline_tag} of model {model_name} is not valid, "
                                      f"must be one of {VALID_TASKS}.")
             except Exception as e:
                 raise CredentialsValidateFailedError(f"{e.__class__.__name__}:{str(e)}")


### PR DESCRIPTION
many popular embedding models fall under 'sentence-similarity' tasks on hugging face such as [this one](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2). this fix makes them accessible.