### PR TITLE
ci: Bump Docker Github actions

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -14,10 +14,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -27,7 +27,7 @@ jobs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: langgenius/dify-api
         tags: |
@@ -37,7 +37,7 @@ jobs:
           type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: "{{defaultContext}}:api"
         platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/build-web-image.yml
+++ b/.github/workflows/build-web-image.yml
@@ -14,10 +14,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -27,7 +27,7 @@ jobs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: langgenius/dify-web
         tags: |
@@ -37,7 +37,7 @@ jobs:
           type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: "{{defaultContext}}:web"
         platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}


### PR DESCRIPTION
- Bump the following Docker Github Actions, with related release notes:
  - docker/setup-qemu-action@v2 -> v3： https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0
  - docker/setup-buildx-action@v2 -> v3 : https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
  - docker/login-action@v2 -> v3: https://github.com/docker/login-action/releases/tag/v3.0.0
  - docker/metadata-action@v4 -> v5: https://github.com/docker/metadata-action/releases/tag/v5.4.0
- No  breaking changes in usage, and the default NodeJS version inside the actions bumped from v16 to v20