### PR TITLE
fix: support azure gpt4-vision-preview model

### DIFF
--- a/api/core/model_providers/providers/azure_openai_provider.py
+++ b/api/core/model_providers/providers/azure_openai_provider.py
@@ -76,6 +76,13 @@ class AzureOpenAIProvider(BaseModelProvider):
                     model_dict['features'] = [
                         ModelFeature.AGENT_THOUGHT.value
                     ]
+                
+                if credentials['base_model_name'] in [
+                    'gpt-4-vision-preview',
+                ]:
+                    model_dict['features'] = [
+                        ModelFeature.VISION.value
+                    ]
 
                 model_list.append(model_dict)
         else:


### PR DESCRIPTION
Currently custom `gpt4-vision-preview` in azure provider doesn't support vision feature. This PR add this.