### PR TITLE
doc: Respect and prevent updating existed yarn lockfile when installing dependencies

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -10,7 +10,7 @@ First, install the dependencies:
 ```bash
 npm install
 # or
-yarn
+yarn install --frozen-lockfile
 ```
 
 Then, configure the environment variables. Create a file named `.env.local` in the current directory and copy the contents from `.env.example`. Modify the values of these environment variables according to your requirements:


### PR DESCRIPTION
Update docs for web service for installing npm dependencies via `yarn` with `--frozen-files` to respect existed yarn lock file and prevent updating yarn lockfile unexpectedly locally.

- docs of `yarn install ---frozen-lockfile`: https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install