### PR TITLE
ci: Properly cache pip packages

### DIFF
--- a/.github/workflows/api-model-runtime-tests.yml
+++ b/.github/workflows/api-model-runtime-tests.yml
@@ -31,28 +31,19 @@ jobs:
       HUGGINGFACE_EMBEDDINGS_ENDPOINT_URL: c
       MOCK_SWITCH: true
 
-
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-
-    - name: Cache pip dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('api/requirements.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
+        cache: 'pip'
+        cache-dependency-path: ./api/requirements.txt
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        pip install -r api/requirements.txt
+      run: pip install -r ./api/requirements.txt
 
     - name: Run pytest
       run: pytest api/tests/integration_tests/model_runtime/anthropic api/tests/integration_tests/model_runtime/azure_openai api/tests/integration_tests/model_runtime/openai api/tests/integration_tests/model_runtime/chatglm api/tests/integration_tests/model_runtime/google api/tests/integration_tests/model_runtime/xinference api/tests/integration_tests/model_runtime/huggingface_hub/test_llm.py

--- a/.github/workflows/api-model-runtime-tests.yml
+++ b/.github/workflows/api-model-runtime-tests.yml
@@ -46,11 +46,4 @@ jobs:
       run: pip install -r ./api/requirements.txt
 
     - name: Run pytest
-      run: pytest \
-        api/tests/integration_tests/model_runtime/anthropic \
-        api/tests/integration_tests/model_runtime/azure_openai \
-        api/tests/integration_tests/model_runtime/openai \
-        api/tests/integration_tests/model_runtime/chatglm \
-        api/tests/integration_tests/model_runtime/google \
-        api/tests/integration_tests/model_runtime/xinference \
-        api/tests/integration_tests/model_runtime/huggingface_hub/test_llm.py
+      run: pytest api/tests/integration_tests/model_runtime/anthropic api/tests/integration_tests/model_runtime/azure_openai api/tests/integration_tests/model_runtime/openai api/tests/integration_tests/model_runtime/chatglm api/tests/integration_tests/model_runtime/google api/tests/integration_tests/model_runtime/xinference api/tests/integration_tests/model_runtime/huggingface_hub/test_llm.py

--- a/.github/workflows/api-model-runtime-tests.yml
+++ b/.github/workflows/api-model-runtime-tests.yml
@@ -46,4 +46,11 @@ jobs:
       run: pip install -r ./api/requirements.txt
 
     - name: Run pytest
-      run: pytest api/tests/integration_tests/model_runtime/anthropic api/tests/integration_tests/model_runtime/azure_openai api/tests/integration_tests/model_runtime/openai api/tests/integration_tests/model_runtime/chatglm api/tests/integration_tests/model_runtime/google api/tests/integration_tests/model_runtime/xinference api/tests/integration_tests/model_runtime/huggingface_hub/test_llm.py
+      run: pytest \
+        api/tests/integration_tests/model_runtime/anthropic \
+        api/tests/integration_tests/model_runtime/azure_openai \
+        api/tests/integration_tests/model_runtime/openai \
+        api/tests/integration_tests/model_runtime/chatglm \
+        api/tests/integration_tests/model_runtime/google \
+        api/tests/integration_tests/model_runtime/xinference \
+        api/tests/integration_tests/model_runtime/huggingface_hub/test_llm.py


### PR DESCRIPTION
- the existed step for pip caching seems often miss hitting caching 
- resolve the problem of pip packages caching by configuring `actions/setup-python`, with os-aware caching support

With this PR, pip packages cache is properly reused in `Setup Python` step:
![image](https://github.com/langgenius/dify/assets/1935105/29ded74d-b375-4e59-8283-ebb5dd839e5c)
