### PR TITLE
fix a typo in file agent_app_runner.py

### DIFF
--- a/api/core/app_runner/agent_app_runner.py
+++ b/api/core/app_runner/agent_app_runner.py
@@ -75,7 +75,7 @@ class AgentApplicationRunner(AppRunner):
         # reorganize all inputs and template to prompt messages
         # Include: prompt template, inputs, query(optional), files(optional)
         #          memory(optional)
-        prompt_messages, stop = self.originze_prompt_messages(
+        prompt_messages, stop = self.organize_prompt_messages(
             app_record=app_record,
             model_config=app_orchestration_config.model_config,
             prompt_template_entity=app_orchestration_config.prompt_template,
@@ -153,7 +153,7 @@ class AgentApplicationRunner(AppRunner):
             # reorganize all inputs and template to prompt messages
             # Include: prompt template, inputs, query(optional), files(optional)
             #          memory(optional), external data, dataset context(optional)
-            prompt_messages, stop = self.originze_prompt_messages(
+            prompt_messages, stop = self.organize_prompt_messages(
                 app_record=app_record,
                 model_config=app_orchestration_config.model_config,
                 prompt_template_entity=app_orchestration_config.prompt_template,

--- a/api/core/app_runner/app_runner.py
+++ b/api/core/app_runner/app_runner.py
@@ -50,7 +50,7 @@ class AppRunner:
             max_tokens = 0
 
         # get prompt messages without memory and context
-        prompt_messages, stop = self.originze_prompt_messages(
+        prompt_messages, stop = self.organize_prompt_messages(
             app_record=app_record,
             model_config=model_config,
             prompt_template_entity=prompt_template_entity,
@@ -107,7 +107,7 @@ class AppRunner:
                         or (parameter_rule.use_template and parameter_rule.use_template == 'max_tokens')):
                     model_config.parameters[parameter_rule.name] = max_tokens
 
-    def originze_prompt_messages(self, app_record: App,
+    def organize_prompt_messages(self, app_record: App,
                                  model_config: ModelConfigEntity,
                                  prompt_template_entity: PromptTemplateEntity,
                                  inputs: dict[str, str],

--- a/api/core/app_runner/basic_app_runner.py
+++ b/api/core/app_runner/basic_app_runner.py
@@ -79,7 +79,7 @@ class BasicApplicationRunner(AppRunner):
         # organize all inputs and template to prompt messages
         # Include: prompt template, inputs, query(optional), files(optional)
         #          memory(optional)
-        prompt_messages, stop = self.originze_prompt_messages(
+        prompt_messages, stop = self.organize_prompt_messages(
             app_record=app_record,
             model_config=app_orchestration_config.model_config,
             prompt_template_entity=app_orchestration_config.prompt_template,
@@ -164,7 +164,7 @@ class BasicApplicationRunner(AppRunner):
         # reorganize all inputs and template to prompt messages
         # Include: prompt template, inputs, query(optional), files(optional)
         #          memory(optional), external data, dataset context(optional)
-        prompt_messages, stop = self.originze_prompt_messages(
+        prompt_messages, stop = self.organize_prompt_messages(
             app_record=app_record,
             model_config=app_orchestration_config.model_config,
             prompt_template_entity=app_orchestration_config.prompt_template,


### PR DESCRIPTION
It seems that this function originally meant organize, but was misspelled as "originze"