### PR TITLE
fix: gpt-4-32k model name empty in OpenAI response

### DIFF
--- a/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
@@ -309,7 +309,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
         # transform response
         response = LLMResult(
-            model=response.model,
+            model=response.model or model,
             prompt_messages=prompt_messages,
             message=assistant_prompt_message,
             usage=usage,


### PR DESCRIPTION
fix #1920