### PR TITLE
fix: chat log wont show up

### DIFF
--- a/web/app/components/app/chat/log/index.tsx
+++ b/web/app/components/app/chat/log/index.tsx
@@ -46,7 +46,11 @@ const Log: FC<LogProps> = ({
               `}>
                 <div
                   className='flex items-center justify-center rounded-md w-full h-full hover:bg-gray-100'
-                  onClick={() => setShowModal(true)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setShowModal(true)
+                  }
+                  }
                 >
                   <File02 className='w-4 h-4 text-gray-500' />
                 </div>


### PR DESCRIPTION
This bug was introduced by the upgrade to `Next`. 

For reasons unknown, the `chat/log/index.tsx` component is executed twice, which also results in two instances of `PromptLogModal` being triggered. 

When a user activates the `onClick` event in `chat/log/index.tsx`, the first `PromptLogModal` is successfully rendered. However, the second `PromptLogModal` inadvertently triggers the `onCancel` of the first modal through the 
```
useClickAway(() => {
    if (mounted)
      onCancel()
  }, ref)
```
Consequently, the entire `PromptLogModal` is prematurely dismissed.

The current solution involves stopping the event propagation in `chat/log/index.tsx` to prevent the double triggering of `PromptLogModal`. This approach is both controlled and effectively resolves the issue.