### PR TITLE
Add jina-embeddings-v2-base-zh model configuration

### DIFF
--- a/api/core/model_runtime/model_providers/jina/text_embedding/jina-embeddings-v2-base-zh.yaml
+++ b/api/core/model_runtime/model_providers/jina/text_embedding/jina-embeddings-v2-base-zh.yaml
@@ -1,0 +1,9 @@
+model: jina-embeddings-v2-base-zh
+model_type: text-embedding
+model_properties:
+  context_size: 8192
+  max_chunks: 2048
+pricing:
+  input: '0.001'
+  unit: '0.001'
+  currency: USD

--- a/api/core/model_runtime/model_providers/jina/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/jina/text_embedding/text_embedding.py
@@ -17,7 +17,7 @@ class JinaTextEmbeddingModel(TextEmbeddingModel):
     Model class for Jina text embedding model.
     """
     api_base: str = 'https://api.jina.ai/v1/embeddings'
-    models: list[str] = ['jina-embeddings-v2-base-en', 'jina-embeddings-v2-small-en']
+    models: list[str] = ['jina-embeddings-v2-base-en', 'jina-embeddings-v2-small-en', 'jina-embeddings-v2-base-zh']
 
     def _invoke(self, model: str, credentials: dict,
                 texts: list[str], user: Optional[str] = None) \


### PR DESCRIPTION
Add support to `jina-embeddings-v2-base-zh`

Reference:
1. https://jina.ai/news/8k-token-length-bilingual-embeddings-break-language-barriers-in-chinese-and-english/
2. https://jina.ai/embeddings