### PR TITLE
bump default NodeJS version to 20 LTS

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: ./web/package.json
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:18.17.0-alpine AS base
+FROM node:20.11.0-alpine AS base
 
 # install packages
 FROM base as packages


### PR DESCRIPTION
- NodeJS 20 has become LTS since 2023-10-24, Version 20.9.0 'Iron' (LTS)
- https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md