### PR TITLE
fix: bypass admin users to use dataset api with API key

### DIFF
--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -2,8 +2,6 @@
 from datetime import datetime
 from functools import wraps
 
-from sqlalchemy import or_
-
 from extensions.ext_database import db
 from flask import current_app, request
 from flask_login import user_logged_in
@@ -77,7 +75,7 @@ def validate_dataset_token(view=None):
             tenant_account_join = db.session.query(Tenant, TenantAccountJoin) \
                 .filter(Tenant.id == api_token.tenant_id) \
                 .filter(TenantAccountJoin.tenant_id == Tenant.id) \
-                .filter(or_(TenantAccountJoin.role == 'owner', TenantAccountJoin.role == 'admin')) \
+                .filter(TenantAccountJoin.role.in_(['owner', 'admin'])) \
                 .one_or_none()
             if tenant_account_join:
                 tenant, ta = tenant_account_join

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from functools import wraps
 
+from sqlalchemy import or_
+
 from extensions.ext_database import db
 from flask import current_app, request
 from flask_login import user_logged_in
@@ -75,7 +77,7 @@ def validate_dataset_token(view=None):
             tenant_account_join = db.session.query(Tenant, TenantAccountJoin) \
                 .filter(Tenant.id == api_token.tenant_id) \
                 .filter(TenantAccountJoin.tenant_id == Tenant.id) \
-                .filter(TenantAccountJoin.role == 'owner') \
+                .filter(or_(TenantAccountJoin.role == 'owner', TenantAccountJoin.role == 'admin')) \
                 .one_or_none()
             if tenant_account_join:
                 tenant, ta = tenant_account_join


### PR DESCRIPTION
- Before: only owner users successfully use datasetapi, for the admin users, it failes with `Unauthorized("Tenant is not exist.")`
- After: both owner and admin users passes