### PR TITLE
fix: yarn install command in web Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,16 +1,16 @@
 # base image
 FROM node:20.11.0-alpine AS base
+LABEL maintainer="takatost@gmail.com"
 
 # install packages
 FROM base as packages
-LABEL maintainer="takatost@gmail.com"
 
 WORKDIR /app/web
 
 COPY package.json .
 COPY yarn.lock .
 
-RUN yarn --only=prod
+RUN yarn install --frozen-lockfile
 
 
 # build resources
@@ -40,7 +40,6 @@ COPY --from=builder /app/web/.next/static ./.next/static
 
 
 COPY docker/entrypoint.sh ./entrypoint.sh
-RUN chmod +x ./entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA ${COMMIT_SHA}


### PR DESCRIPTION
- `--only=prod` is removed as `--only` is not a valid option for `yarn` or `yarn install command`
- for the `packages` stage in dockerfile, all the npm packages should be installed, as it used for building production files later in `builder` stage. and the npm packages are not shipped with `production` stage
- the `entrypoint.sh` has been set to executable since #1966 