### PR TITLE
support setting timezone in docker images

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,15 +6,15 @@ LABEL maintainer="takatost@gmail.com"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc g++ python3-dev libc-dev libffi-dev
 
-# set timezone
-ENV TZ UTC
-
 COPY requirements.txt /requirements.txt
 
 RUN pip install --prefix=/pkg -r requirements.txt
 
 # build stage
 FROM python:3.10-slim AS builder
+
+# set timezone
+ENV TZ UTC
 
 ENV FLASK_APP app.py
 ENV EDITION SELF_HOSTED

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,8 +13,6 @@ RUN pip install --prefix=/pkg -r requirements.txt
 # build stage
 FROM python:3.10-slim AS builder
 
-# set timezone
-ENV TZ UTC
 
 ENV FLASK_APP app.py
 ENV EDITION SELF_HOSTED
@@ -25,6 +23,11 @@ ENV SERVICE_API_URL http://127.0.0.1:5001
 ENV APP_WEB_URL http://127.0.0.1:3000
 
 EXPOSE 5001
+
+# set timezone
+ENV TZ UTC
+RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone
 
 WORKDIR /app/api
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="takatost@gmail.com"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc g++ python3-dev libc-dev libffi-dev
 
+# set timezone
 ENV TZ UTC
 
 COPY requirements.txt /requirements.txt

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,8 @@ LABEL maintainer="takatost@gmail.com"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc g++ python3-dev libc-dev libffi-dev
 
+ENV TZ UTC
+
 COPY requirements.txt /requirements.txt
 
 RUN pip install --prefix=/pkg -r requirements.txt

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,6 +3,10 @@ FROM node:20.11.0-alpine AS base
 
 RUN apk add --no-cache tzdata
 
+# set timezone
+ENV TZ UTC
+RUN ln -s /usr/share/zoneinfo/$TZ /etc/localtime
+
 # install packages
 FROM base as packages
 LABEL maintainer="takatost@gmail.com"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,9 +3,6 @@ FROM node:20.11.0-alpine AS base
 
 RUN apk add --no-cache tzdata
 
-# set timezone
-ENV TZ UTC
-RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
 
 # install packages
 FROM base as packages
@@ -38,6 +35,10 @@ ENV CONSOLE_API_URL http://127.0.0.1:5001
 ENV APP_API_URL http://127.0.0.1:5001
 ENV PORT 3000
 
+# set timezone
+ENV TZ UTC
+RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone
 
 WORKDIR /app/web
 COPY --from=builder /app/web/public ./public

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache tzdata
 
 # set timezone
 ENV TZ UTC
-RUN ln -s /usr/share/zoneinfo/$TZ /etc/localtime
+RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
 
 # install packages
 FROM base as packages

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,8 @@
 # base image
 FROM node:20.11.0-alpine AS base
 
+RUN apk add --no-cache tzdata
+
 # install packages
 FROM base as packages
 LABEL maintainer="takatost@gmail.com"


### PR DESCRIPTION
- install `tzdata` module in web docker image for timezone support
- in web docker image, set the default `TZ` system env to `UTC` and be linked to `/etc/localtime`, referring Alpine docs: https://wiki.alpinelinux.org/wiki/Setting_the_timezone
- in web docker image, set the default `TZ` system env to `UTC`