### PR TITLE
fix: skip linking /etc/localtime file first in api docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,9 +26,6 @@ EXPOSE 5001
 
 # set timezone
 ENV TZ UTC
-RUN rm -f /etc/localtime  \
-    && ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
-    && echo ${TZ} > /etc/timezone
 
 WORKDIR /app/api
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,7 +26,8 @@ EXPOSE 5001
 
 # set timezone
 ENV TZ UTC
-RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
+RUN rm -f /etc/localtime  \
+    && ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone
 
 WORKDIR /app/api


### PR DESCRIPTION
#2091 followup