### PR TITLE
fix: bump lamejs from 1.2.0 to 1.2.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
     "js-audio-recorder": "^1.0.7",
     "js-cookie": "^3.0.1",
     "katex": "^0.16.7",
-    "lamejs": "1.2.0",
+    "lamejs": "^1.2.1",
     "lexical": "^0.12.2",
     "lodash-es": "^4.17.21",
     "mermaid": "10.4.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4061,10 +4061,10 @@ kleur@^4.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
 
-lamejs@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/lamejs/-/lamejs-1.2.0.tgz"
-  integrity sha512-xEYvsB2sZ9jIccqfUQpQEBdB6UYQDG/ta2xQkH7oEpENb0JHFJii965WVF8ErUMdZzoe7EdIruz1WpICdhZ9Pw==
+lamejs@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/lamejs/-/lamejs-1.2.1.tgz#0f92d38729213f106d4a19ded20821da7e89c8e4"
+  integrity sha512-s7bxvjvYthw6oPLCm5pFxvA84wUROODB8jEO2+CE1adhKgrIvVOlmMgY8zyugxGrvRaDHNJanOiS21/emty6dQ==
   dependencies:
     use-strict "1.0.1"
 


### PR DESCRIPTION
- bump lamejs from 1.2.0 to 1.2.1 to fix "Lame is not defined" error when running web image built on v0.4.8
- lamejs 1.2.1 release note: https://github.com/zhuker/lamejs/releases/tag/1.2.1a
   - bring the fix from : https://github.com/zhuker/lamejs/issues/58