### PR TITLE
bump alpine from 3.18 to 3.19 in web image

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:20.11.0-alpine AS base
+FROM node:20.11-alpine3.19 AS base
 LABEL maintainer="takatost@gmail.com"
 
 RUN apk add --no-cache tzdata


### PR DESCRIPTION
- explicitly set the alpine version in the base image tag, showing the 3.x for reference (eg. preparing apk source mirror URL)
   - available tags referring to : https://hub.docker.com/_/node/
- bump NodeJS base image in web dockerfile from 3.18 to 3.19
   - Alpine 3.19 released as stable version in Dec 2023: https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html
   - Alpine 3.19 guarantee Nodejs 20 statisfaction （see release note）