### PR TITLE
skip installing python3-dev package on base stage in api docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10-slim AS base
 LABEL maintainer="takatost@gmail.com"
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc g++ python3-dev libc-dev libffi-dev
+    && apt-get install -y --no-install-recommends gcc g++ libc-dev libffi-dev
 
 COPY requirements.txt /requirements.txt
 


### PR DESCRIPTION
- skip installing `python3-dev` package on base stage in api docker image
- `python3-dev` ships with `python 3.11` which may causes possible confusion in header links, although it does not have great impact currently.
- `python3-dev` package does not bring any gain for `pip install` with current depended pip packages.

With running `apt-get install python3-dev` on `python:3.10-slim` base image, different python3 versions vary in `3.10` and `3.11`.
```
root@19e47d416c0d:/# which -a python3
/usr/local/bin/python3
/usr/local/bin/python3
/usr/bin/python3
/bin/python3
root@19e47d416c0d:/# /usr/local/bin/python3 -V
Python 3.10.13
root@19e47d416c0d:/# /usr/bin/python3 -V
Python 3.11.2
root@19e47d416c0d:/# /bin/python3 -V
Python 3.11.2
root@19e47d416c0d:/# python3 -V
Python 3.10.13
root@19e47d416c0d:/# which python3
/usr/local/bin/python3
```