### PR TITLE
improve api docker file and lock Debian version in base image tag

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # packages install stage
-FROM python:3.10-slim AS base
+FROM python:3.10-slim-bookworm AS base
 
 LABEL maintainer="takatost@gmail.com"
 
@@ -30,7 +30,7 @@ ENV TZ UTC
 WORKDIR /app/api
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bash curl wget vim nodejs ffmpeg \
+    && apt-get install -y --no-install-recommends curl wget vim nodejs ffmpeg \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -40,6 +40,7 @@ COPY --from=packages /pkg /usr/local
 COPY . /app/api/
 
 COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA ${COMMIT_SHA}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -38,7 +38,6 @@ COPY --from=base /pkg /usr/local
 COPY . /app/api/
 
 COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA ${COMMIT_SHA}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,10 @@
-# packages install stage
+# base image
 FROM python:3.10-slim-bookworm AS base
 
 LABEL maintainer="takatost@gmail.com"
+
+# install packages
+FROM base as packages
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc g++ python3-dev libc-dev libffi-dev
@@ -10,9 +13,8 @@ COPY requirements.txt /requirements.txt
 
 RUN pip install --prefix=/pkg -r requirements.txt
 
-# build stage
-FROM python:3.10-slim AS builder
-
+# production stage
+FROM base AS production
 
 ENV FLASK_APP app.py
 ENV EDITION SELF_HOSTED
@@ -34,7 +36,7 @@ RUN apt-get update \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=base /pkg /usr/local
+COPY --from=packages /pkg /usr/local
 COPY . /app/api/
 
 COPY docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
- reuse the base stage with base image
- `3.10-slim-bookworm` is equivalent tag with `3.10-slim`, with explicitly set the Debian version in the base image tag, showing the `bookworm` for reference (eg. preparing apt-get source mirror URL)
- skip reinstalling the `bash` package as the Debian slim image is shipping with it
- skip resetting `/entrypoint.sh` to executable as the source script `api/docker/entrypoint.sh` is executable