### PR TITLE
fix: occasional multiple responses displayed in frontend due to unexpected message_id from onData

### DIFF
--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -110,7 +110,7 @@ const handleStream = (response: Response, onData: IOnData, onCompleted?: IOnComp
               // mute handle message cut off
               onData('', isFirstMessage, {
                 conversationId: bufferObj?.conversation_id,
-                messageId: bufferObj?.id,
+                messageId: bufferObj?.message_id,
               })
               return
             }


### PR DESCRIPTION
The error shows as follows:
![image](https://github.com/langgenius/dify/assets/5317425/81f417ba-2a65-4b5d-b143-0e233ebe453c)

The fundamental cause of the error is that the content returned from the tool call fails to be parsed by `JSON.parse` in the frontend, resulting in the unexpected creation of two chatLists.

------

This issue can be divided into two parts: 

1) How to prevent problems with the content returned by the tool, such as encoding format issues
2) Ensuring that even if the content returned by the tool is problematic, it does not result in disordered display in the frontend.

**This PR is focus on the second part**,  as sometimes the content returned by the tool is unpredictable.

-----

Specifically, this issue is triggered through the following steps:

1. The result of the Tool call is written into the `agent_thought` `observation` and sent to the frontend in stream mode.
2. Due to unknown reasons, the stream json parsing fails, triggering the following error.
```
SyntaxError: Bad Unicode escape in JSON at position 12276 (line 1 column 12277)
```
![image](https://github.com/langgenius/dify/assets/5317425/8275ad66-902e-4e47-84fc-1fe2edc316ed)

3. At this point, `onData` returns **`bufferObj?.id`**, which is the **`thought id`**.
4. This id is different from the previous **`thought.message_id`** getting from **`onThought`**, leading to the introduction of an additional chatList.

-----

In summary,  my proposal is to change `bufferObj?.id` to `bufferObj?.message_id`. 
This change will prevent the misuse of `thought_id` as `message_id`.