### PR TITLE
fix: Resolved the issue of duplicate display of supported file types during text file upload

### DIFF
--- a/web/app/components/datasets/create/file-uploader/index.tsx
+++ b/web/app/components/datasets/create/file-uploader/index.tsx
@@ -72,6 +72,8 @@ const FileUploader = ({
 
       return item
     })
+    res = res.map(item => item.toLowerCase())
+    res = res.filter((item, index, self) => self.indexOf(item) === index)
 
     return res.map(item => item.toUpperCase()).join(language !== LanguagesSupportedUnderscore[1] ? ', ' : '、 ')
   })()


### PR DESCRIPTION
Fixed the problem of repeated display of supported file types when uploading knowledge text files

<img width="1334" alt="iShot_2024-01-26_18 22 34" src="https://github.com/langgenius/dify/assets/9191067/1e06d3c9-d1ca-46b3-9921-cd91ee86694b">
