### PR TITLE
feat: allow skipping disabled builtin tool providers

### DIFF
--- a/api/core/tools/provider/builtin/azuredalle/tools/dalle3.yaml
+++ b/api/core/tools/provider/builtin/azuredalle/tools/dalle3.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: dalle3
   author: Leslie

--- a/api/core/tools/provider/builtin/chart/chart.yaml
+++ b/api/core/tools/provider/builtin/chart/chart.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: chart

--- a/api/core/tools/provider/builtin/chart/tools/bar.yaml
+++ b/api/core/tools/provider/builtin/chart/tools/bar.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: bar_chart
   author: Dify

--- a/api/core/tools/provider/builtin/chart/tools/line.yaml
+++ b/api/core/tools/provider/builtin/chart/tools/line.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: line_chart
   author: Dify

--- a/api/core/tools/provider/builtin/chart/tools/pie.yaml
+++ b/api/core/tools/provider/builtin/chart/tools/pie.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: pie_chart
   author: Dify

--- a/api/core/tools/provider/builtin/dalle/dalle.yaml
+++ b/api/core/tools/provider/builtin/dalle/dalle.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: dalle

--- a/api/core/tools/provider/builtin/dalle/tools/dalle2.yaml
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle2.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: dalle2
   author: Dify

--- a/api/core/tools/provider/builtin/dalle/tools/dalle3.yaml
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle3.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: dalle3
   author: Dify

--- a/api/core/tools/provider/builtin/gaode/gaode.yaml
+++ b/api/core/tools/provider/builtin/gaode/gaode.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: CharlieWei
   name: gaode

--- a/api/core/tools/provider/builtin/gaode/tools/gaode_weather.yaml
+++ b/api/core/tools/provider/builtin/gaode/tools/gaode_weather.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: gaode_weather
   author: CharlieWei

--- a/api/core/tools/provider/builtin/github/github.yaml
+++ b/api/core/tools/provider/builtin/github/github.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: CharlieWei
   name: github

--- a/api/core/tools/provider/builtin/google/google.yaml
+++ b/api/core/tools/provider/builtin/google/google.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: google

--- a/api/core/tools/provider/builtin/google/tools/google_search.yaml
+++ b/api/core/tools/provider/builtin/google/tools/google_search.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: google_search
   author: Dify

--- a/api/core/tools/provider/builtin/stablediffusion/stablediffusion.yaml
+++ b/api/core/tools/provider/builtin/stablediffusion/stablediffusion.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: stablediffusion

--- a/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.yaml
+++ b/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: stable_diffusion
   author: Dify

--- a/api/core/tools/provider/builtin/time/time.yaml
+++ b/api/core/tools/provider/builtin/time/time.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: time

--- a/api/core/tools/provider/builtin/time/tools/current_time.yaml
+++ b/api/core/tools/provider/builtin/time/tools/current_time.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: current_time
   author: Dify

--- a/api/core/tools/provider/builtin/vectorizer/tools/vectorizer.yaml
+++ b/api/core/tools/provider/builtin/vectorizer/tools/vectorizer.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: vectorizer
   author: Dify

--- a/api/core/tools/provider/builtin/vectorizer/vectorizer.yaml
+++ b/api/core/tools/provider/builtin/vectorizer/vectorizer.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: vectorizer

--- a/api/core/tools/provider/builtin/webscraper/tools/webscraper.yaml
+++ b/api/core/tools/provider/builtin/webscraper/tools/webscraper.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: webscraper
   author: Dify

--- a/api/core/tools/provider/builtin/webscraper/webscraper.yaml
+++ b/api/core/tools/provider/builtin/webscraper/webscraper.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: webscraper

--- a/api/core/tools/provider/builtin/wikipedia/tools/wikipedia_search.yaml
+++ b/api/core/tools/provider/builtin/wikipedia/tools/wikipedia_search.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: wikipedia_search
   author: Dify

--- a/api/core/tools/provider/builtin/wikipedia/wikipedia.yaml
+++ b/api/core/tools/provider/builtin/wikipedia/wikipedia.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: wikipedia

--- a/api/core/tools/provider/builtin/wolframalpha/tools/wolframalpha.yaml
+++ b/api/core/tools/provider/builtin/wolframalpha/tools/wolframalpha.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: wolframalpha
   author: Dify

--- a/api/core/tools/provider/builtin/yahoo/tools/analytics.yaml
+++ b/api/core/tools/provider/builtin/yahoo/tools/analytics.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: yahoo_finance_analytics
   author: Dify

--- a/api/core/tools/provider/builtin/yahoo/tools/news.yaml
+++ b/api/core/tools/provider/builtin/yahoo/tools/news.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: yahoo_finance_news
   author: Dify

--- a/api/core/tools/provider/builtin/yahoo/tools/ticker.yaml
+++ b/api/core/tools/provider/builtin/yahoo/tools/ticker.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: yahoo_finance_ticker
   author: Dify

--- a/api/core/tools/provider/builtin/yahoo/yahoo.yaml
+++ b/api/core/tools/provider/builtin/yahoo/yahoo.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: yahoo

--- a/api/core/tools/provider/builtin/youtube/tools/videos.yaml
+++ b/api/core/tools/provider/builtin/youtube/tools/videos.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   name: youtube_video_statistics
   author: Dify

--- a/api/core/tools/provider/builtin/youtube/youtube.yaml
+++ b/api/core/tools/provider/builtin/youtube/youtube.yaml
@@ -1,3 +1,4 @@
+enabled: true
 identity:
   author: Dify
   name: youtube

--- a/api/core/tools/provider/builtin_tool_provider.py
+++ b/api/core/tools/provider/builtin_tool_provider.py
@@ -38,6 +38,7 @@ class BuiltinToolProviderController(ToolProviderController):
         super().__init__(**{
             'identity': provider_yaml['identity'],
             'credentials_schema': provider_yaml['credentials_for_provider'] if 'credentials_for_provider' in provider_yaml else None,
+            'enabled': provider_yaml.get('enabled', True),
         })
 
     def _get_builtin_tools(self) -> List[Tool]:

--- a/api/core/tools/provider/tool_provider.py
+++ b/api/core/tools/provider/tool_provider.py
@@ -14,6 +14,7 @@ class ToolProviderController(BaseModel, ABC):
     identity: Optional[ToolProviderIdentity] = None
     tools: Optional[List[Tool]] = None
     credentials_schema: Optional[Dict[str, ToolProviderCredentials]] = None
+    enabled: bool = True
 
     def get_credentials_schema(self) -> Dict[str, ToolProviderCredentials]:
         """

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -262,6 +262,9 @@ class ToolManager:
                 provider_class = classes[0]
                 builtin_providers.append(provider_class())
 
+        # skip disabled builtin tool providers
+        builtin_providers = [provider for provider in builtin_providers if provider.enabled is True]
+
         # cache the builtin providers
         for provider in builtin_providers:
             _builtin_providers[provider.identity.name] = provider


### PR DESCRIPTION
- introduced `enabled` field for builtin tools provider, which is default to true
- if `enabled` set to false in builtin tools provider's YAML config, it's not listed on the tools page

When `enabled` is empty or set to `true`:

<img width="934" alt="image" src="https://github.com/langgenius/dify/assets/1935105/798e5012-47e7-490b-9cbc-984a8c3b5f96">


When `enabled` field set to `false`, the builtin google tool is skipped:

<img width="508" alt="image" src="https://github.com/langgenius/dify/assets/1935105/97e95efe-0e17-47f4-85d1-3a947816ce89">

<img width="911" alt="image" src="https://github.com/langgenius/dify/assets/1935105/e9cb95da-62f3-4f87-b2f1-6ca9e51b6db2">
