### PR TITLE
bump flask from 2.3 to 3.0

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,7 @@
 coverage~=7.2.4
 beautifulsoup4==4.12.2
 flask~=3.0.1
-Flask-SQLAlchemy~=3.0.1
+Flask-SQLAlchemy~=3.0.5
 SQLAlchemy~=1.4.28
 flask-login~=0.6.3
 flask-migrate~=4.0.5

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,13 +1,12 @@
 coverage~=7.2.4
 beautifulsoup4==4.12.2
-flask~=2.3.2
-Flask-SQLAlchemy~=3.0.3
+flask~=3.0.1
+Flask-SQLAlchemy~=3.0.1
 SQLAlchemy~=1.4.28
-flask-login==0.6.2
-flask-migrate~=4.0.4
-flask-restful==0.3.9
-flask-session2==1.3.1
-flask-cors==3.0.10
+flask-login~=0.6.3
+flask-migrate~=4.0.5
+flask-restful~=0.3.10
+flask-cors~=4.0.0
 gunicorn~=21.2.0
 gevent~=23.9.1
 langchain==0.0.250
@@ -25,7 +24,7 @@ cachetools~=5.3.0
 weaviate-client~=3.21.0
 mailchimp-transactional~=1.0.50
 scikit-learn==1.2.2
-sentry-sdk[flask]~=1.21.1
+sentry-sdk[flask]~=1.39.2
 sympy==1.12
 jieba==0.42.1
 celery==5.2.7
@@ -51,7 +50,7 @@ pandas==1.5.3
 xinference-client~=0.6.4
 safetensors==0.3.2
 zhipuai==1.0.7
-werkzeug==2.3.8
+werkzeug~=3.0.1
 pymilvus==2.3.0
 qdrant-client==1.6.4
 cohere~=4.44


### PR DESCRIPTION
- Flask 3.0 released on 2023-09-30, and the `3.0.1` released on 2024-01-18
  - Release note: https://flask.palletsprojects.com/en/3.0.x/changes/
  - No remarkable breaking changes or impacts
- Bump required dependencies 
  - Werkzeug from `2.x` to `3.0`
  - other Flask-related dependencies
- Pin Flask-SQLAlchemy to `3.0`, as from the latest version `3.1` it requires SQLAlchemy `2.x`
- Remove unused `flask-session2` package
  - out of date and no longer maintained since 2022
  - no usage or imports of `from flask_session`
  - Reported possible malfunctioning on existed Flask `2.x`