### PR TITLE
Change ZHIPU_MAX_LIMITS to 5. Fix issue 2323

### DIFF
--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_http_client.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_http_client.py
@@ -38,7 +38,7 @@ from httpx._config import DEFAULT_TIMEOUT_CONFIG as HTTPX_DEFAULT_TIMEOUT
 
 ZHIPUAI_DEFAULT_TIMEOUT = httpx.Timeout(timeout=300.0, connect=8.0)
 ZHIPUAI_DEFAULT_MAX_RETRIES = 3
-ZHIPUAI_DEFAULT_LIMITS = httpx.Limits(max_connections=50, max_keepalive_connections=10)
+ZHIPUAI_DEFAULT_LIMITS = httpx.Limits(max_connections=5, max_keepalive_connections=5)
 
 
 class HttpClient:


### PR DESCRIPTION
I learned from the sales staff of Zhipu that the embedding/generation model API provided by Zhipu can only support 5 concurrency, and the concurrency setting for the Zhipu API in our code is 50, which resulted in an error in the process.
https://github.com/langgenius/dify/issues/2323