### PR TITLE
chore: bump superlinter action from v5 to v6

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -60,11 +60,10 @@ jobs:
           yarn run lint
 
       - name: Super-linter
-        uses: super-linter/super-linter/slim@v5
+        uses: super-linter/super-linter/slim@v6
         env:
           BASH_SEVERITY: warning
           DEFAULT_BRANCH: main
-          ERROR_ON_MISSING_EXEC_BIT: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GENERATED_FILES: true
           IGNORE_GITIGNORED_FILES: true


### PR DESCRIPTION
- SuperLinter GitHub action 6.0.0 release note: https://github.com/super-linter/super-linter/releases/tag/v6.0.0
- migration guide: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md#upgrade-from-v5-to-v6
- deprecate error_on_missing_exec_bit check in 6.x
- Speed up checks by running linters in parallel since 6.x, shrinking the time cost from 2m30s+ to 45s for running the linting checks