### PR TITLE
automate isort styling by adding to pre-commit hooks

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -48,4 +48,5 @@ jobs:
           VALIDATE_BASH_EXEC: true
           VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_PYTHON_ISORT: true
           VALIDATE_YAML: true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,6 +25,16 @@ jobs:
           cache: yarn
           cache-dependency-path: ./web/package.json
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10
+
+      - name: Python style check
+        run: |
+          pip install isort
+          isort --check-only --settings ./.github/linters/.isort.cfg --gitignore ./
+
       - name: Web dependencies
         run: |
           cd ./web
@@ -48,5 +58,4 @@ jobs:
           VALIDATE_BASH_EXEC: true
           VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_DOCKERFILE_HADOLINT: true
-          VALIDATE_PYTHON_ISORT: true
           VALIDATE_YAML: true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Python style check
         run: |

--- a/dev/reformat
+++ b/dev/reformat
@@ -5,7 +5,8 @@ set -x
 # python style checks rely on `isort` in path
 if ! command -v isort &> /dev/null
 then
-    echo "Skip Python imports linting, since 'isort' is not available. Please install it with 'pip install isort'."
+    echo "'isort' is not available for linting Python codes. Please run 'pip install isort'."
+    exit 1
 else
     isort  --settings ./.github/linters/.isort.cfg ./
 fi

--- a/dev/reformat
+++ b/dev/reformat
@@ -8,5 +8,5 @@ then
     echo "'isort' is not available for linting Python codes. Please run 'pip install isort'."
     exit 1
 else
-    isort  --settings ./.github/linters/.isort.cfg ./
+    isort  --settings ./.github/linters/.isort.cfg --gitignore ./
 fi

--- a/dev/reformat
+++ b/dev/reformat
@@ -8,5 +8,5 @@ then
     echo "'isort' is not available for linting Python codes. Please run 'pip install isort'."
     exit 1
 else
-    isort  --settings ./.github/linters/.isort.cfg --gitignore ./
+    isort  --settings ./.github/linters/.isort.cfg --gitignore --only-modified ./
 fi

--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -2,3 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 cd ./web && npx lint-staged
+cd ../
+
+# lint python code
+dev/reformat


### PR DESCRIPTION
- as #1983 introduced isort and one-key linting scripts for linting Python imports, it helps to conform a steady output in sorted imports within a unified style.
- this PR add the isort script into Husky for git's pre-commit hooks, which is to be executed automatically before each commit
- This will greatly help the developer out of the dirty work when rebasing onto the new release and branches without worrying the conflict in Python imports.