### PR TITLE
fix: ignore spark provider credential validate

### DIFF
--- a/api/core/model_runtime/model_providers/spark/spark.py
+++ b/api/core/model_runtime/model_providers/spark/spark.py
@@ -16,26 +16,5 @@ class SparkProvider(ModelProvider):
 
         :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
         """
-        try:
-            model_instance = self.get_model_instance(ModelType.LLM)
-
-            model_instance.validate_credentials(
-                model='spark-1.5',
-                credentials=credentials
-            )
-        except CredentialsValidateFailedError as ex:
-            try:
-                model_instance = self.get_model_instance(ModelType.LLM)
-
-                model_instance.validate_credentials(
-                    model='spark-3',
-                    credentials=credentials
-                )
-            except CredentialsValidateFailedError as ex:
-                raise ex
-            except Exception as ex:
-                logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
-                raise ex
-        except Exception as ex:
-            logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
-            raise ex
+        # ignore credentials validation because every model has their own spark quota pool
+        pass


### PR DESCRIPTION
## Problem

Because every model has their own spark quota pool, no unified validate method.
Causing the need for iterative validation of all LLM credentials for new model released.

## Action

Ignore spark provider credential validate method.