### PR TITLE
fix [baichuan] Error: argument of type 'NoneType' is not iterable

### DIFF
--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan2-53b.yaml
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan2-53b.yaml
@@ -31,6 +31,9 @@ parameter_rules:
     use_template: presence_penalty
   - name: frequency_penalty
     use_template: frequency_penalty
+    default: 1
+    min: 1
+    max: 2
   - name: with_search_enhance
     label:
       zh_Hans: 搜索增强

--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan2-turbo-192k.yaml
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan2-turbo-192k.yaml
@@ -31,6 +31,9 @@ parameter_rules:
     use_template: presence_penalty
   - name: frequency_penalty
     use_template: frequency_penalty
+    default: 1
+    min: 1
+    max: 2
   - name: with_search_enhance
     label:
       zh_Hans: 搜索增强

--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan2-turbo.yaml
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan2-turbo.yaml
@@ -31,6 +31,9 @@ parameter_rules:
     use_template: presence_penalty
   - name: frequency_penalty
     use_template: frequency_penalty
+    default: 1
+    min: 1
+    max: 2
   - name: with_search_enhance
     label:
       zh_Hans: 搜索增强

--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan_turbo.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan_turbo.py
@@ -125,6 +125,9 @@ class BaichuanModel(object):
                         'content': message.content,
                         'role': message.role,
                     })
+            # [baichuan] frequency_penalty must be between 1 and 2
+            if parameters['frequency_penalty'] < 1 or parameters['frequency_penalty'] > 2:
+                parameters['frequency_penalty'] = 1
             # turbo api accepts flat parameters
             return {
                 'model': self._model_mapping(model),


### PR DESCRIPTION
When the Baichuan model API is called frequency_penalty parameters must be between 1 and 2, otherwise an error will be reported, and abnormal data will be returned, resulting in the error: [baichuan] Error: argument of type 'NoneType' is not iterable.