### PR TITLE
fix: compatibility of Python 3.12 by bumping numpy to 1.26

### DIFF
--- a/.github/workflows/api-model-runtime-tests.yml
+++ b/.github/workflows/api-model-runtime-tests.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  test:
+  api-model-runtime-test:
     runs-on: ubuntu-latest
 
     env:
@@ -27,6 +27,13 @@ jobs:
       HUGGINGFACE_EMBEDDINGS_ENDPOINT_URL: c
       MOCK_SWITCH: true
 
+    strategy:
+      matrix:
+        python-version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: ./api/requirements.txt
 

--- a/.github/workflows/tool-tests.yaml
+++ b/.github/workflows/tool-tests.yaml
@@ -8,12 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: ./api/requirements.txt
 

--- a/.github/workflows/tool-tests.yaml
+++ b/.github/workflows/tool-tests.yaml
@@ -8,6 +8,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -15,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: ./api/requirements.txt
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -55,7 +55,7 @@ pymilvus==2.3.0
 qdrant-client==1.6.4
 cohere~=4.44
 pyyaml~=6.0.1
-numpy~=1.25.2
+numpy~=1.26.3
 unstructured[docx,pptx,msg,md,ppt]~=0.10.27
 bs4~=0.0.1
 markdown~=3.5.1


### PR DESCRIPTION
- numpy 1.26 with Python versions 3.9-3.12 supported, according to the 1.26.0 release note: https://github.com/numpy/numpy/releases/tag/v1.26.0
- fixing when installing Python requirements on Python 3.12
```
Collecting numpy~=1.25.2 (from -r requirements.txt (line 58))
  Using cached http://mirrors.aliyun.com/pypi/packages/a0/41/8f53eff8e969dd8576ddfb45e7ed315407d27c7518ae49418be8ed532b07/numpy-1.25.2.tar.gz (10.8 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [33 lines of output]
      Traceback (most recent call last):
        File "/usr/local/Caskroom/miniforge/base/envs/dify/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/Caskroom/miniforge/base/envs/dify/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/Caskroom/miniforge/base/envs/dify/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 112, in get_requires_for_build_wheel
          backend = _build_backend()
                    ^^^^^^^^^^^^^^^^
        File "/usr/local/Caskroom/miniforge/base/envs/dify/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 77, in _build_backend
          obj = import_module(mod_path)
                ^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/Caskroom/miniforge/base/envs/dify/lib/python3.12/importlib/__init__.py", line 90, in import_module
          return _bootstrap._gcd_import(name[level:], package, level)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
        File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
        File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
        File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
        File "<frozen importlib._bootstrap_external>", line 994, in exec_module
        File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
        File "/private/var/folders/qk/mybpyz211x3935t53wr9r86m0000gn/T/pip-build-env-x1zflfd_/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 16, in <module>
          import setuptools.version
        File "/private/var/folders/qk/mybpyz211x3935t53wr9r86m0000gn/T/pip-build-env-x1zflfd_/overlay/lib/python3.12/site-packages/setuptools/version.py", line 1, in <module>
          import pkg_resources
        File "/private/var/folders/qk/mybpyz211x3935t53wr9r86m0000gn/T/pip-build-env-x1zflfd_/overlay/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2172, in <module>
          register_finder(pkgutil.ImpImporter, find_on_path)
                          ^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```