### PR TITLE
enhancement: introduce Ruff for Python linter for reordering and removing unused imports with automated pre-commit and sytle check

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,9 +10,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  python-style:
+    name: Python Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Python dependencies
+        run: pip install ruff
+
+      - name: Ruff check
+        run: ruff check ./api
+
+      - name: Lint hints
+        if: failure()
+        run: echo "Please run 'dev/reformat' to fix the fixable linting errors."
+
   test:
     name: ESLint and SuperLinter
     runs-on: ubuntu-latest
+    needs: python-style
 
     steps:
       - name: Checkout code

--- a/api/app.py
+++ b/api/app.py
@@ -19,18 +19,28 @@ import threading
 import time
 import warnings
 
-from commands import register_commands
-from config import CloudEditionConfig, Config
-from events import event_handlers
-from extensions import (ext_celery, ext_code_based_extension, ext_database, ext_hosting_provider, ext_login, ext_mail,
-                        ext_migrate, ext_redis, ext_sentry, ext_storage)
-from extensions.ext_database import db
-from extensions.ext_login import login_manager
 from flask import Flask, Response, request
 from flask_cors import CORS
+
+from commands import register_commands
+from config import CloudEditionConfig, Config
+from extensions import (
+    ext_celery,
+    ext_code_based_extension,
+    ext_database,
+    ext_hosting_provider,
+    ext_login,
+    ext_mail,
+    ext_migrate,
+    ext_redis,
+    ext_sentry,
+    ext_storage,
+)
+from extensions.ext_database import db
+from extensions.ext_login import login_manager
 from libs.passport import PassportService
+
 # DO NOT REMOVE BELOW
-from models import account, dataset, model, source, task, tool, tools, web
 from services.account_service import AccountService
 
 # DO NOT REMOVE ABOVE

--- a/api/commands.py
+++ b/api/commands.py
@@ -3,11 +3,13 @@ import json
 import secrets
 
 import click
+from flask import current_app
+from werkzeug.exceptions import NotFound
+
 from core.embedding.cached_embedding import CacheEmbedding
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from extensions.ext_database import db
-from flask import current_app
 from libs.helper import email as email_validate
 from libs.password import hash_password, password_pattern, valid_password
 from libs.rsa import generate_key_pair
@@ -15,7 +17,6 @@ from models.account import Tenant
 from models.dataset import Dataset
 from models.model import Account
 from models.provider import Provider, ProviderModel
-from werkzeug.exceptions import NotFound
 
 
 @click.command('reset-password', help='Reset the account password.')

--- a/api/constants/model_template.py
+++ b/api/constants/model_template.py
@@ -1,7 +1,5 @@
 import json
 
-from models.model import App, AppModelConfig
-
 model_templates = {
     # completion default mode
     'completion_default': {

--- a/api/controllers/console/admin.py
+++ b/api/controllers/console/admin.py
@@ -1,14 +1,15 @@
 import os
 from functools import wraps
 
+from flask import request
+from flask_restful import Resource, reqparse
+from werkzeug.exceptions import NotFound, Unauthorized
+
 from constants.languages import supported_language
 from controllers.console import api
 from controllers.console.wraps import only_edition_cloud
 from extensions.ext_database import db
-from flask import request
-from flask_restful import Resource, reqparse
 from models.model import App, InstalledApp, RecommendedApp
-from werkzeug.exceptions import NotFound, Unauthorized
 
 
 def admin_required(view):

--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -1,12 +1,13 @@
 import flask_restful
-from extensions.ext_database import db
 from flask_login import current_user
 from flask_restful import Resource, fields, marshal_with
+from werkzeug.exceptions import Forbidden
+
+from extensions.ext_database import db
 from libs.helper import TimestampField
 from libs.login import login_required
 from models.dataset import Dataset
 from models.model import ApiToken, App
-from werkzeug.exceptions import Forbidden
 
 from . import api
 from .setup import setup_required

--- a/api/controllers/console/app/advanced_prompt_template.py
+++ b/api/controllers/console/app/advanced_prompt_template.py
@@ -1,7 +1,8 @@
+from flask_restful import Resource, reqparse
+
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
-from flask_restful import Resource, reqparse
 from libs.login import login_required
 from services.advanced_prompt_template_service import AdvancedPromptTemplateService
 

--- a/api/controllers/console/app/annotation.py
+++ b/api/controllers/console/app/annotation.py
@@ -1,17 +1,20 @@
+from flask import request
+from flask_login import current_user
+from flask_restful import Resource, marshal, marshal_with, reqparse
+from werkzeug.exceptions import Forbidden
+
 from controllers.console import api
 from controllers.console.app.error import NoFileUploadedError
 from controllers.console.datasets.error import TooManyFilesError
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required, cloud_edition_billing_resource_check
 from extensions.ext_redis import redis_client
-from fields.annotation_fields import (annotation_fields, annotation_hit_history_fields,
-                                      annotation_hit_history_list_fields, annotation_list_fields)
-from flask import request
-from flask_login import current_user
-from flask_restful import Resource, marshal, marshal_with, reqparse
+from fields.annotation_fields import (
+    annotation_fields,
+    annotation_hit_history_fields,
+)
 from libs.login import login_required
 from services.annotation_service import AppAnnotationService
-from werkzeug.exceptions import Forbidden
 
 
 class AnnotationReplyActionApi(Resource):

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -3,6 +3,10 @@ import json
 import logging
 from datetime import datetime
 
+from flask_login import current_user
+from flask_restful import Resource, abort, inputs, marshal_with, reqparse
+from werkzeug.exceptions import Forbidden
+
 from constants.languages import demo_model_templates, languages
 from constants.model_template import model_templates
 from controllers.console import api
@@ -15,16 +19,15 @@ from core.model_runtime.entities.model_entities import ModelType
 from core.provider_manager import ProviderManager
 from events.app_event import app_was_created, app_was_deleted
 from extensions.ext_database import db
-from fields.app_fields import (app_detail_fields, app_detail_fields_with_site, app_pagination_fields,
-                               template_list_fields)
-from flask import current_app
-from flask_login import current_user
-from flask_restful import Resource, abort, inputs, marshal_with, reqparse
+from fields.app_fields import (
+    app_detail_fields,
+    app_detail_fields_with_site,
+    app_pagination_fields,
+    template_list_fields,
+)
 from libs.login import login_required
 from models.model import App, AppModelConfig, Site
-from models.tools import ApiToolProvider
 from services.app_model_config_service import AppModelConfigService
-from werkzeug.exceptions import Forbidden
 
 
 def _get_app(app_id, tenant_id):

--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -1,24 +1,36 @@
 # -*- coding:utf-8 -*-
 import logging
 
+from flask import request
+from flask_restful import Resource
+from werkzeug.exceptions import InternalServerError
+
 import services
 from controllers.console import api
 from controllers.console.app import _get_app
-from controllers.console.app.error import (AppUnavailableError, AudioTooLargeError, CompletionRequestError,
-                                           NoAudioUploadedError, ProviderModelCurrentlyNotSupportError,
-                                           ProviderNotInitializeError, ProviderNotSupportSpeechToTextError,
-                                           ProviderQuotaExceededError, UnsupportedAudioTypeError)
+from controllers.console.app.error import (
+    AppUnavailableError,
+    AudioTooLargeError,
+    CompletionRequestError,
+    NoAudioUploadedError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderNotSupportSpeechToTextError,
+    ProviderQuotaExceededError,
+    UnsupportedAudioTypeError,
+)
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import request
-from flask_restful import Resource
 from libs.login import login_required
 from services.audio_service import AudioService
-from services.errors.audio import (AudioTooLargeServiceError, NoAudioUploadedServiceError,
-                                   ProviderNotSupportSpeechToTextServiceError, UnsupportedAudioTypeServiceError)
-from werkzeug.exceptions import InternalServerError
+from services.errors.audio import (
+    AudioTooLargeServiceError,
+    NoAudioUploadedServiceError,
+    ProviderNotSupportSpeechToTextServiceError,
+    UnsupportedAudioTypeServiceError,
+)
 
 
 class ChatMessageAudioApi(Resource):

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -4,24 +4,30 @@ import logging
 from typing import Generator, Union
 
 import flask_login
+from flask import Response, stream_with_context
+from flask_restful import Resource, reqparse
+from werkzeug.exceptions import InternalServerError, NotFound
+
 import services
 from controllers.console import api
 from controllers.console.app import _get_app
-from controllers.console.app.error import (AppUnavailableError, CompletionRequestError, ConversationCompletedError,
-                                           ProviderModelCurrentlyNotSupportError, ProviderNotInitializeError,
-                                           ProviderQuotaExceededError)
+from controllers.console.app.error import (
+    AppUnavailableError,
+    CompletionRequestError,
+    ConversationCompletedError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from core.application_queue_manager import ApplicationQueueManager
 from core.entities.application_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import Response, stream_with_context
-from flask_restful import Resource, reqparse
 from libs.helper import uuid_value
 from libs.login import login_required
 from services.completion_service import CompletionService
-from werkzeug.exceptions import InternalServerError, NotFound
 
 
 # define completion message api for user

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -1,22 +1,27 @@
 from datetime import datetime
 
 import pytz
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
+from flask_restful.inputs import int_range
+from sqlalchemy import func, or_
+from sqlalchemy.orm import joinedload
+from werkzeug.exceptions import NotFound
+
 from controllers.console import api
 from controllers.console.app import _get_app
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from extensions.ext_database import db
-from fields.conversation_fields import (conversation_detail_fields, conversation_message_detail_fields,
-                                        conversation_pagination_fields, conversation_with_summary_pagination_fields)
-from flask_login import current_user
-from flask_restful import Resource, marshal_with, reqparse
-from flask_restful.inputs import int_range
+from fields.conversation_fields import (
+    conversation_detail_fields,
+    conversation_message_detail_fields,
+    conversation_pagination_fields,
+    conversation_with_summary_pagination_fields,
+)
 from libs.helper import datetime_string
 from libs.login import login_required
 from models.model import Conversation, Message, MessageAnnotation
-from sqlalchemy import func, or_
-from sqlalchemy.orm import joinedload
-from werkzeug.exceptions import NotFound
 
 
 class CompletionConversationApi(Resource):

--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -1,13 +1,18 @@
+from flask_login import current_user
+from flask_restful import Resource, reqparse
+
 from controllers.console import api
-from controllers.console.app.error import (CompletionRequestError, ProviderModelCurrentlyNotSupportError,
-                                           ProviderNotInitializeError, ProviderQuotaExceededError)
+from controllers.console.app.error import (
+    CompletionRequestError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.generator.llm_generator import LLMGenerator
 from core.model_runtime.errors.invoke import InvokeError
-from flask_login import current_user
-from flask_restful import Resource, reqparse
 from libs.login import login_required
 
 

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -2,11 +2,21 @@ import json
 import logging
 from typing import Generator, Union
 
+from flask import Response, stream_with_context
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
+
 from controllers.console import api
 from controllers.console.app import _get_app
-from controllers.console.app.error import (AppMoreLikeThisDisabledError, CompletionRequestError,
-                                           ProviderModelCurrentlyNotSupportError, ProviderNotInitializeError,
-                                           ProviderQuotaExceededError)
+from controllers.console.app.error import (
+    AppMoreLikeThisDisabledError,
+    CompletionRequestError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required, cloud_edition_billing_resource_check
 from core.entities.application_entities import InvokeFrom
@@ -14,10 +24,6 @@ from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotIni
 from core.model_runtime.errors.invoke import InvokeError
 from extensions.ext_database import db
 from fields.conversation_fields import annotation_fields, message_detail_fields
-from flask import Response, stream_with_context
-from flask_login import current_user
-from flask_restful import Resource, fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
 from libs.helper import uuid_value
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from libs.login import login_required
@@ -28,7 +34,6 @@ from services.errors.app import MoreLikeThisDisabledError
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import MessageNotExistsError
 from services.message_service import MessageService
-from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
 
 class ChatMessageListApi(Resource):

--- a/api/controllers/console/app/model_config.py
+++ b/api/controllers/console/app/model_config.py
@@ -1,14 +1,15 @@
 # -*- coding:utf-8 -*-
 
+from flask import request
+from flask_login import current_user
+from flask_restful import Resource
+
 from controllers.console import api
 from controllers.console.app import _get_app
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from events.app_event import app_model_config_was_updated
 from extensions.ext_database import db
-from flask import request
-from flask_login import current_user
-from flask_restful import Resource
 from libs.login import login_required
 from models.model import AppModelConfig
 from services.app_model_config_service import AppModelConfigService

--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -1,4 +1,8 @@
 # -*- coding:utf-8 -*-
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
+from werkzeug.exceptions import Forbidden, NotFound
+
 from constants.languages import supported_language
 from controllers.console import api
 from controllers.console.app import _get_app
@@ -6,11 +10,8 @@ from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from extensions.ext_database import db
 from fields.app_fields import app_site_fields
-from flask_login import current_user
-from flask_restful import Resource, marshal_with, reqparse
 from libs.login import login_required
 from models.model import Site
-from werkzeug.exceptions import Forbidden, NotFound
 
 
 def parse_app_site_args():

--- a/api/controllers/console/app/statistic.py
+++ b/api/controllers/console/app/statistic.py
@@ -3,14 +3,15 @@ from datetime import datetime
 from decimal import Decimal
 
 import pytz
+from flask import jsonify
+from flask_login import current_user
+from flask_restful import Resource, reqparse
+
 from controllers.console import api
 from controllers.console.app import _get_app
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from extensions.ext_database import db
-from flask import jsonify
-from flask_login import current_user
-from flask_restful import Resource, reqparse
 from libs.helper import datetime_string
 from libs.login import login_required
 

--- a/api/controllers/console/auth/activate.py
+++ b/api/controllers/console/auth/activate.py
@@ -2,14 +2,15 @@ import base64
 import secrets
 from datetime import datetime
 
+from flask_restful import Resource, reqparse
+
 from constants.languages import supported_language
 from controllers.console import api
 from controllers.console.error import AlreadyActivateError
 from extensions.ext_database import db
-from flask_restful import Resource, reqparse
 from libs.helper import email, str_len, timezone
 from libs.password import hash_password, valid_password
-from models.account import AccountStatus, Tenant
+from models.account import AccountStatus
 from services.account_service import RegisterService
 
 

--- a/api/controllers/console/auth/data_source_oauth.py
+++ b/api/controllers/console/auth/data_source_oauth.py
@@ -1,13 +1,14 @@
 import logging
 
 import requests
-from controllers.console import api
 from flask import current_app, redirect, request
 from flask_login import current_user
 from flask_restful import Resource
+from werkzeug.exceptions import Forbidden
+
+from controllers.console import api
 from libs.login import login_required
 from libs.oauth_data_source import NotionOAuth
-from werkzeug.exceptions import Forbidden
 
 from ..setup import setup_required
 from ..wraps import account_initialization_required

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -1,11 +1,11 @@
 # -*- coding:utf-8 -*-
-import flask
 import flask_login
+from flask import current_app, request
+from flask_restful import Resource, reqparse
+
 import services
 from controllers.console import api
 from controllers.console.setup import setup_required
-from flask import current_app, request
-from flask_restful import Resource, reqparse
 from libs.helper import email
 from libs.password import valid_password
 from services.account_service import AccountService

--- a/api/controllers/console/auth/oauth.py
+++ b/api/controllers/console/auth/oauth.py
@@ -3,10 +3,11 @@ from datetime import datetime
 from typing import Optional
 
 import requests
-from constants.languages import languages
-from extensions.ext_database import db
 from flask import current_app, redirect, request
 from flask_restful import Resource
+
+from constants.languages import languages
+from extensions.ext_database import db
 from libs.oauth import GitHubOAuth, GoogleOAuth, OAuthUserInfo
 from models.account import Account, AccountStatus
 from services.account_service import AccountService, RegisterService

--- a/api/controllers/console/billing/billing.py
+++ b/api/controllers/console/billing/billing.py
@@ -1,8 +1,9 @@
+from flask_login import current_user
+from flask_restful import Resource, reqparse
+
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required, only_edition_cloud
-from flask_login import current_user
-from flask_restful import Resource, reqparse
 from libs.login import login_required
 from services.billing_service import BillingService
 

--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -1,6 +1,11 @@
 import datetime
 import json
 
+from flask import request
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
+from werkzeug.exceptions import NotFound
+
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
@@ -8,15 +13,11 @@ from core.data_loader.loader.notion import NotionLoader
 from core.indexing_runner import IndexingRunner
 from extensions.ext_database import db
 from fields.data_source_fields import integrate_list_fields, integrate_notion_info_list_fields
-from flask import request
-from flask_login import current_user
-from flask_restful import Resource, marshal_with, reqparse
 from libs.login import login_required
 from models.dataset import Document
 from models.source import DataSourceBinding
 from services.dataset_service import DatasetService, DocumentService
 from tasks.document_indexing_sync_task import document_indexing_sync_task
-from werkzeug.exceptions import NotFound
 
 
 class DataSourceApi(Resource):

--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -1,5 +1,10 @@
 # -*- coding:utf-8 -*-
 import flask_restful
+from flask import current_app, request
+from flask_login import current_user
+from flask_restful import Resource, marshal, marshal_with, reqparse
+from werkzeug.exceptions import Forbidden, NotFound
+
 import services
 from controllers.console import api
 from controllers.console.apikey import api_key_fields, api_key_list
@@ -15,14 +20,10 @@ from extensions.ext_database import db
 from fields.app_fields import related_app_list
 from fields.dataset_fields import dataset_detail_fields, dataset_query_detail_fields
 from fields.document_fields import document_status_fields
-from flask import current_app, request
-from flask_login import current_user
-from flask_restful import Resource, marshal, marshal_with, reqparse
 from libs.login import login_required
 from models.dataset import Dataset, Document, DocumentSegment
 from models.model import ApiToken, UploadFile
 from services.dataset_service import DatasetService, DocumentService
-from werkzeug.exceptions import Forbidden, NotFound
 
 
 def _validate_name(name):

--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -2,35 +2,52 @@
 from datetime import datetime
 from typing import List
 
+from flask import request
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal, marshal_with, reqparse
+from sqlalchemy import asc, desc
+from werkzeug.exceptions import Forbidden, NotFound
+
 import services
 from controllers.console import api
-from controllers.console.app.error import (ProviderModelCurrentlyNotSupportError, ProviderNotInitializeError,
-                                           ProviderQuotaExceededError)
-from controllers.console.datasets.error import (ArchivedDocumentImmutableError, DocumentAlreadyFinishedError,
-                                                DocumentIndexingError, InvalidActionError, InvalidMetadataError)
+from controllers.console.app.error import (
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
+from controllers.console.datasets.error import (
+    ArchivedDocumentImmutableError,
+    DocumentAlreadyFinishedError,
+    DocumentIndexingError,
+    InvalidActionError,
+    InvalidMetadataError,
+)
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required, cloud_edition_billing_resource_check
-from core.errors.error import (LLMBadRequestError, ModelCurrentlyNotSupportError, ProviderTokenNotInitError,
-                               QuotaExceededError)
+from core.errors.error import (
+    LLMBadRequestError,
+    ModelCurrentlyNotSupportError,
+    ProviderTokenNotInitError,
+    QuotaExceededError,
+)
 from core.indexing_runner import IndexingRunner
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.invoke import InvokeAuthorizationError
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from fields.document_fields import (dataset_and_document_fields, document_fields, document_status_fields,
-                                    document_with_segments_fields)
-from flask import request
-from flask_login import current_user
-from flask_restful import Resource, fields, marshal, marshal_with, reqparse
+from fields.document_fields import (
+    dataset_and_document_fields,
+    document_fields,
+    document_status_fields,
+    document_with_segments_fields,
+)
 from libs.login import login_required
 from models.dataset import Dataset, DatasetProcessRule, Document, DocumentSegment
 from models.model import UploadFile
 from services.dataset_service import DatasetService, DocumentService
-from sqlalchemy import asc, desc
 from tasks.add_document_to_index_task import add_document_to_index_task
 from tasks.remove_document_from_index_task import remove_document_from_index_task
-from werkzeug.exceptions import Forbidden, NotFound
 
 
 class DocumentResource(Resource):

--- a/api/controllers/console/datasets/datasets_segments.py
+++ b/api/controllers/console/datasets/datasets_segments.py
@@ -3,6 +3,11 @@ import uuid
 from datetime import datetime
 
 import pandas as pd
+from flask import request
+from flask_login import current_user
+from flask_restful import Resource, marshal, reqparse
+from werkzeug.exceptions import Forbidden, NotFound
+
 import services
 from controllers.console import api
 from controllers.console.app.error import ProviderNotInitializeError
@@ -15,16 +20,12 @@ from core.model_runtime.entities.model_entities import ModelType
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from fields.segment_fields import segment_fields
-from flask import request
-from flask_login import current_user
-from flask_restful import Resource, marshal, reqparse
 from libs.login import login_required
 from models.dataset import DocumentSegment
 from services.dataset_service import DatasetService, DocumentService, SegmentService
 from tasks.batch_create_segment_to_index_task import batch_create_segment_to_index_task
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
 from tasks.enable_segment_to_index_task import enable_segment_to_index_task
-from werkzeug.exceptions import Forbidden, NotFound
 
 
 class DatasetDocumentSegmentListApi(Resource):

--- a/api/controllers/console/datasets/file.py
+++ b/api/controllers/console/datasets/file.py
@@ -1,13 +1,18 @@
-import services
-from controllers.console import api
-from controllers.console.datasets.error import (FileTooLargeError, NoFileUploadedError, TooManyFilesError,
-                                                UnsupportedFileTypeError)
-from controllers.console.setup import setup_required
-from controllers.console.wraps import account_initialization_required
-from fields.file_fields import file_fields, upload_config_fields
 from flask import current_app, request
 from flask_login import current_user
 from flask_restful import Resource, marshal_with
+
+import services
+from controllers.console import api
+from controllers.console.datasets.error import (
+    FileTooLargeError,
+    NoFileUploadedError,
+    TooManyFilesError,
+    UnsupportedFileTypeError,
+)
+from controllers.console.setup import setup_required
+from controllers.console.wraps import account_initialization_required
+from fields.file_fields import file_fields, upload_config_fields
 from libs.login import login_required
 from services.file_service import ALLOWED_EXTENSIONS, UNSTRUSTURED_ALLOWED_EXTENSIONS, FileService
 

--- a/api/controllers/console/datasets/hit_testing.py
+++ b/api/controllers/console/datasets/hit_testing.py
@@ -1,22 +1,31 @@
 import logging
 
+from flask_login import current_user
+from flask_restful import Resource, marshal, reqparse
+from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
+
 import services
 from controllers.console import api
-from controllers.console.app.error import (CompletionRequestError, ProviderModelCurrentlyNotSupportError,
-                                           ProviderNotInitializeError, ProviderQuotaExceededError)
+from controllers.console.app.error import (
+    CompletionRequestError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.console.datasets.error import DatasetNotInitializedError, HighQualityDatasetOnlyError
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
-from core.errors.error import (LLMBadRequestError, ModelCurrentlyNotSupportError, ProviderTokenNotInitError,
-                               QuotaExceededError)
+from core.errors.error import (
+    LLMBadRequestError,
+    ModelCurrentlyNotSupportError,
+    ProviderTokenNotInitError,
+    QuotaExceededError,
+)
 from core.model_runtime.errors.invoke import InvokeError
 from fields.hit_testing_fields import hit_testing_record_fields
-from flask_login import current_user
-from flask_restful import Resource, marshal, reqparse
 from libs.login import login_required
 from services.dataset_service import DatasetService
 from services.hit_testing_service import HitTestingService
-from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
 
 class HitTestingApi(Resource):

--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -1,21 +1,33 @@
 # -*- coding:utf-8 -*-
 import logging
 
+from flask import request
+from werkzeug.exceptions import InternalServerError
+
 import services
 from controllers.console import api
-from controllers.console.app.error import (AppUnavailableError, AudioTooLargeError, CompletionRequestError,
-                                           NoAudioUploadedError, ProviderModelCurrentlyNotSupportError,
-                                           ProviderNotInitializeError, ProviderNotSupportSpeechToTextError,
-                                           ProviderQuotaExceededError, UnsupportedAudioTypeError)
+from controllers.console.app.error import (
+    AppUnavailableError,
+    AudioTooLargeError,
+    CompletionRequestError,
+    NoAudioUploadedError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderNotSupportSpeechToTextError,
+    ProviderQuotaExceededError,
+    UnsupportedAudioTypeError,
+)
 from controllers.console.explore.wraps import InstalledAppResource
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import request
 from models.model import AppModelConfig
 from services.audio_service import AudioService
-from services.errors.audio import (AudioTooLargeServiceError, NoAudioUploadedServiceError,
-                                   ProviderNotSupportSpeechToTextServiceError, UnsupportedAudioTypeServiceError)
-from werkzeug.exceptions import InternalServerError
+from services.errors.audio import (
+    AudioTooLargeServiceError,
+    NoAudioUploadedServiceError,
+    ProviderNotSupportSpeechToTextServiceError,
+    UnsupportedAudioTypeServiceError,
+)
 
 
 class ChatAudioApi(InstalledAppResource):

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -4,11 +4,21 @@ import logging
 from datetime import datetime
 from typing import Generator, Union
 
+from flask import Response, stream_with_context
+from flask_login import current_user
+from flask_restful import reqparse
+from werkzeug.exceptions import InternalServerError, NotFound
+
 import services
 from controllers.console import api
-from controllers.console.app.error import (AppUnavailableError, CompletionRequestError, ConversationCompletedError,
-                                           ProviderModelCurrentlyNotSupportError, ProviderNotInitializeError,
-                                           ProviderQuotaExceededError)
+from controllers.console.app.error import (
+    AppUnavailableError,
+    CompletionRequestError,
+    ConversationCompletedError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.console.explore.error import NotChatAppError, NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
 from core.application_queue_manager import ApplicationQueueManager
@@ -16,12 +26,8 @@ from core.entities.application_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
 from extensions.ext_database import db
-from flask import Response, stream_with_context
-from flask_login import current_user
-from flask_restful import reqparse
 from libs.helper import uuid_value
 from services.completion_service import CompletionService
-from werkzeug.exceptions import InternalServerError, NotFound
 
 
 # define completion api for user

--- a/api/controllers/console/explore/conversation.py
+++ b/api/controllers/console/explore/conversation.py
@@ -1,16 +1,17 @@
 # -*- coding:utf-8 -*-
+from flask_login import current_user
+from flask_restful import marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import NotFound
+
 from controllers.console import api
 from controllers.console.explore.error import NotChatAppError
 from controllers.console.explore.wraps import InstalledAppResource
 from fields.conversation_fields import conversation_infinite_scroll_pagination_fields, simple_conversation_fields
-from flask_login import current_user
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
-from libs.helper import TimestampField, uuid_value
+from libs.helper import uuid_value
 from services.conversation_service import ConversationService
 from services.errors.conversation import ConversationNotExistsError, LastConversationNotExistsError
 from services.web_conversation_service import WebConversationService
-from werkzeug.exceptions import NotFound
 
 
 class ConversationListApi(InstalledAppResource):

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -1,18 +1,19 @@
 # -*- coding:utf-8 -*-
 from datetime import datetime
 
+from flask_login import current_user
+from flask_restful import Resource, inputs, marshal_with, reqparse
+from sqlalchemy import and_
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+
 from controllers.console import api
 from controllers.console.explore.wraps import InstalledAppResource
 from controllers.console.wraps import account_initialization_required, cloud_edition_billing_resource_check
 from extensions.ext_database import db
 from fields.installed_app_fields import installed_app_list_fields
-from flask_login import current_user
-from flask_restful import Resource, inputs, marshal_with, reqparse
 from libs.login import login_required
 from models.model import App, InstalledApp, RecommendedApp
 from services.account_service import TenantService
-from sqlalchemy import and_
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 
 class InstalledAppsListApi(Resource):

--- a/api/controllers/console/explore/message.py
+++ b/api/controllers/console/explore/message.py
@@ -3,29 +3,37 @@ import json
 import logging
 from typing import Generator, Union
 
+from flask import Response, stream_with_context
+from flask_login import current_user
+from flask_restful import marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import InternalServerError, NotFound
+
 import services
 from controllers.console import api
-from controllers.console.app.error import (AppMoreLikeThisDisabledError, CompletionRequestError,
-                                           ProviderModelCurrentlyNotSupportError, ProviderNotInitializeError,
-                                           ProviderQuotaExceededError)
-from controllers.console.explore.error import (AppSuggestedQuestionsAfterAnswerDisabledError, NotChatAppError,
-                                               NotCompletionAppError)
+from controllers.console.app.error import (
+    AppMoreLikeThisDisabledError,
+    CompletionRequestError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
+from controllers.console.explore.error import (
+    AppSuggestedQuestionsAfterAnswerDisabledError,
+    NotChatAppError,
+    NotCompletionAppError,
+)
 from controllers.console.explore.wraps import InstalledAppResource
 from core.entities.application_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
 from fields.message_fields import message_infinite_scroll_pagination_fields
-from flask import Response, stream_with_context
-from flask_login import current_user
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
-from libs.helper import TimestampField, uuid_value
+from libs.helper import uuid_value
 from services.completion_service import CompletionService
 from services.errors.app import MoreLikeThisDisabledError
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import MessageNotExistsError, SuggestedQuestionsAfterAnswerDisabledError
 from services.message_service import MessageService
-from werkzeug.exceptions import InternalServerError, NotFound
 
 
 class MessageListApi(InstalledAppResource):

--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -1,11 +1,12 @@
 # -*- coding:utf-8 -*-
 import json
 
+from flask import current_app
+from flask_restful import fields, marshal_with
+
 from controllers.console import api
 from controllers.console.explore.wraps import InstalledAppResource
 from extensions.ext_database import db
-from flask import current_app
-from flask_restful import fields, marshal_with
 from models.model import AppModelConfig, InstalledApp
 from models.tools import ApiToolProvider
 

--- a/api/controllers/console/explore/recommended_app.py
+++ b/api/controllers/console/explore/recommended_app.py
@@ -1,15 +1,16 @@
 # -*- coding:utf-8 -*-
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal_with
+from sqlalchemy import and_
+
 from constants.languages import languages
 from controllers.console import api
 from controllers.console.app.error import AppNotFoundError
 from controllers.console.wraps import account_initialization_required
 from extensions.ext_database import db
-from flask_login import current_user
-from flask_restful import Resource, fields, marshal_with
 from libs.login import login_required
 from models.model import App, InstalledApp, RecommendedApp
 from services.account_service import TenantService
-from sqlalchemy import and_
 
 app_fields = {
     'id': fields.String,

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -1,14 +1,15 @@
+from flask_login import current_user
+from flask_restful import fields, marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import NotFound
+
 from controllers.console import api
 from controllers.console.explore.error import NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
 from fields.conversation_fields import message_file_fields
-from flask_login import current_user
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
 from libs.helper import TimestampField, uuid_value
 from services.errors.message import MessageNotExistsError
 from services.saved_message_service import SavedMessageService
-from werkzeug.exceptions import NotFound
 
 feedback_fields = {
     'rating': fields.String

--- a/api/controllers/console/explore/wraps.py
+++ b/api/controllers/console/explore/wraps.py
@@ -1,12 +1,13 @@
 from functools import wraps
 
-from controllers.console.wraps import account_initialization_required
-from extensions.ext_database import db
 from flask_login import current_user
 from flask_restful import Resource
+from werkzeug.exceptions import NotFound
+
+from controllers.console.wraps import account_initialization_required
+from extensions.ext_database import db
 from libs.login import login_required
 from models.model import InstalledApp
-from werkzeug.exceptions import NotFound
 
 
 def installed_app_required(view=None):

--- a/api/controllers/console/extension.py
+++ b/api/controllers/console/extension.py
@@ -1,9 +1,10 @@
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
+
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from fields.api_based_extension_fields import api_based_extension_fields
-from flask_login import current_user
-from flask_restful import Resource, marshal_with, reqparse
 from libs.login import login_required
 from models.api_based_extension import APIBasedExtension
 from services.api_based_extension_service import APIBasedExtensionService

--- a/api/controllers/console/feature.py
+++ b/api/controllers/console/feature.py
@@ -1,5 +1,6 @@
 from flask_login import current_user
 from flask_restful import Resource
+
 from services.feature_service import FeatureService
 
 from . import api

--- a/api/controllers/console/init_validate.py
+++ b/api/controllers/console/init_validate.py
@@ -2,6 +2,7 @@ import os
 
 from flask import current_app, session
 from flask_restful import Resource, reqparse
+
 from libs.helper import str_len
 from models.model import DifySetup
 from services.account_service import TenantService

--- a/api/controllers/console/setup.py
+++ b/api/controllers/console/setup.py
@@ -1,9 +1,10 @@
 # -*- coding:utf-8 -*-
 from functools import wraps
 
-from extensions.ext_database import db
 from flask import current_app, request
 from flask_restful import Resource, reqparse
+
+from extensions.ext_database import db
 from libs.helper import email, str_len
 from libs.password import valid_password
 from models.model import DifySetup

--- a/api/controllers/console/version.py
+++ b/api/controllers/console/version.py
@@ -6,7 +6,6 @@ import logging
 import requests
 from flask import current_app
 from flask_restful import Resource, reqparse
-from werkzeug.exceptions import InternalServerError
 
 from . import api
 

--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -2,16 +2,21 @@
 from datetime import datetime
 
 import pytz
-from constants.languages import supported_language
-from controllers.console import api
-from controllers.console.setup import setup_required
-from controllers.console.workspace.error import (AccountAlreadyInitedError, CurrentPasswordIncorrectError,
-                                                 InvalidInvitationCodeError, RepeatPasswordNotMatchError)
-from controllers.console.wraps import account_initialization_required
-from extensions.ext_database import db
 from flask import current_app, request
 from flask_login import current_user
 from flask_restful import Resource, fields, marshal_with, reqparse
+
+from constants.languages import supported_language
+from controllers.console import api
+from controllers.console.setup import setup_required
+from controllers.console.workspace.error import (
+    AccountAlreadyInitedError,
+    CurrentPasswordIncorrectError,
+    InvalidInvitationCodeError,
+    RepeatPasswordNotMatchError,
+)
+from controllers.console.wraps import account_initialization_required
+from extensions.ext_database import db
 from libs.helper import TimestampField, timezone
 from libs.login import login_required
 from models.account import AccountIntegrate, InvitationCode

--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -1,12 +1,13 @@
 # -*- coding:utf-8 -*-
+from flask import current_app
+from flask_login import current_user
+from flask_restful import Resource, abort, fields, marshal_with, reqparse
+
 import services
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required, cloud_edition_billing_resource_check
 from extensions.ext_database import db
-from flask import current_app
-from flask_login import current_user
-from flask_restful import Resource, abort, fields, marshal_with, reqparse
 from libs.helper import TimestampField
 from libs.login import login_required
 from models.account import Account

--- a/api/controllers/console/workspace/model_providers.py
+++ b/api/controllers/console/workspace/model_providers.py
@@ -1,18 +1,19 @@
 import io
 
+from flask import send_file
+from flask_login import current_user
+from flask_restful import Resource, reqparse
+from werkzeug.exceptions import Forbidden
+
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.utils.encoders import jsonable_encoder
-from flask import send_file
-from flask_login import current_user
-from flask_restful import Resource, reqparse
 from libs.login import login_required
 from services.billing_service import BillingService
 from services.model_provider_service import ModelProviderService
-from werkzeug.exceptions import Forbidden
 
 
 class ModelProviderListApi(Resource):

--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -1,16 +1,17 @@
 import logging
 
+from flask_login import current_user
+from flask_restful import Resource, reqparse
+from werkzeug.exceptions import Forbidden
+
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.utils.encoders import jsonable_encoder
-from flask_login import current_user
-from flask_restful import Resource, reqparse
 from libs.login import login_required
 from services.model_provider_service import ModelProviderService
-from werkzeug.exceptions import Forbidden
 
 
 class DefaultModelApi(Resource):

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,15 +1,15 @@
 import io
-import json
+
+from flask import send_file
+from flask_login import current_user
+from flask_restful import Resource, reqparse
+from werkzeug.exceptions import Forbidden
 
 from controllers.console import api
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required
-from flask import send_file
-from flask_login import current_user
-from flask_restful import Resource, reqparse
 from libs.login import login_required
 from services.tools_manage_service import ToolManageService
-from werkzeug.exceptions import Forbidden
 
 
 class ToolProviderListApi(Resource):

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -1,18 +1,23 @@
 # -*- coding:utf-8 -*-
 import logging
 
+from flask import request
+from flask_login import current_user
+from flask_restful import Resource, fields, inputs, marshal, marshal_with, reqparse
+
 import services
 from controllers.console import api
 from controllers.console.admin import admin_required
-from controllers.console.datasets.error import (FileTooLargeError, NoFileUploadedError, TooManyFilesError,
-                                                UnsupportedFileTypeError)
+from controllers.console.datasets.error import (
+    FileTooLargeError,
+    NoFileUploadedError,
+    TooManyFilesError,
+    UnsupportedFileTypeError,
+)
 from controllers.console.error import AccountNotLinkTenantError
 from controllers.console.setup import setup_required
 from controllers.console.wraps import account_initialization_required, cloud_edition_billing_resource_check
 from extensions.ext_database import db
-from flask import request
-from flask_login import current_user
-from flask_restful import Resource, fields, inputs, marshal, marshal_with, reqparse
 from libs.helper import TimestampField
 from libs.login import login_required
 from models.account import Tenant

--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -2,9 +2,10 @@
 import json
 from functools import wraps
 
-from controllers.console.workspace.error import AccountNotInitializedError
 from flask import abort, current_app, request
 from flask_login import current_user
+
+from controllers.console.workspace.error import AccountNotInitializedError
 from services.feature_service import FeatureService
 from services.operation_service import OperationService
 

--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -1,11 +1,12 @@
-import services
-from controllers.files import api
 from flask import Response, request
 from flask_restful import Resource
+from werkzeug.exceptions import NotFound
+
+import services
+from controllers.files import api
 from libs.exception import BaseHTTPException
 from services.account_service import TenantService
 from services.file_service import FileService
-from werkzeug.exceptions import NotFound
 
 
 class ImagePreviewApi(Resource):

--- a/api/controllers/files/tool_files.py
+++ b/api/controllers/files/tool_files.py
@@ -1,9 +1,10 @@
-from controllers.files import api
-from core.tools.tool_file_manager import ToolFileManager
 from flask import Response
 from flask_restful import Resource, reqparse
-from libs.exception import BaseHTTPException
 from werkzeug.exceptions import Forbidden, NotFound
+
+from controllers.files import api
+from core.tools.tool_file_manager import ToolFileManager
+from libs.exception import BaseHTTPException
 
 
 class ToolFilePreviewApi(Resource):

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -1,11 +1,12 @@
 # -*- coding:utf-8 -*-
 import json
 
+from flask import current_app
+from flask_restful import fields, marshal_with
+
 from controllers.service_api import api
 from controllers.service_api.wraps import AppApiResource
 from extensions.ext_database import db
-from flask import current_app
-from flask_restful import fields, marshal_with
 from models.model import App, AppModelConfig
 from models.tools import ApiToolProvider
 

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -1,21 +1,33 @@
 import logging
 
+from flask import request
+from flask_restful import reqparse
+from werkzeug.exceptions import InternalServerError
+
 import services
 from controllers.service_api import api
-from controllers.service_api.app.error import (AppUnavailableError, AudioTooLargeError, CompletionRequestError,
-                                               NoAudioUploadedError, ProviderModelCurrentlyNotSupportError,
-                                               ProviderNotInitializeError, ProviderNotSupportSpeechToTextError,
-                                               ProviderQuotaExceededError, UnsupportedAudioTypeError)
+from controllers.service_api.app.error import (
+    AppUnavailableError,
+    AudioTooLargeError,
+    CompletionRequestError,
+    NoAudioUploadedError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderNotSupportSpeechToTextError,
+    ProviderQuotaExceededError,
+    UnsupportedAudioTypeError,
+)
 from controllers.service_api.wraps import AppApiResource
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import request
-from flask_restful import reqparse
 from models.model import App, AppModelConfig
 from services.audio_service import AudioService
-from services.errors.audio import (AudioTooLargeServiceError, NoAudioUploadedServiceError,
-                                   ProviderNotSupportSpeechToTextServiceError, UnsupportedAudioTypeServiceError)
-from werkzeug.exceptions import InternalServerError
+from services.errors.audio import (
+    AudioTooLargeServiceError,
+    NoAudioUploadedServiceError,
+    ProviderNotSupportSpeechToTextServiceError,
+    UnsupportedAudioTypeServiceError,
+)
 
 
 class AudioApi(AppApiResource):

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -2,22 +2,29 @@ import json
 import logging
 from typing import Generator, Union
 
+from flask import Response, stream_with_context
+from flask_restful import reqparse
+from werkzeug.exceptions import InternalServerError, NotFound
+
 import services
 from controllers.service_api import api
 from controllers.service_api.app import create_or_update_end_user_for_user_id
-from controllers.service_api.app.error import (AppUnavailableError, CompletionRequestError, ConversationCompletedError,
-                                               NotChatAppError, ProviderModelCurrentlyNotSupportError,
-                                               ProviderNotInitializeError, ProviderQuotaExceededError)
+from controllers.service_api.app.error import (
+    AppUnavailableError,
+    CompletionRequestError,
+    ConversationCompletedError,
+    NotChatAppError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.service_api.wraps import AppApiResource
 from core.application_queue_manager import ApplicationQueueManager
 from core.entities.application_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import Response, stream_with_context
-from flask_restful import reqparse
 from libs.helper import uuid_value
 from services.completion_service import CompletionService
-from werkzeug.exceptions import InternalServerError, NotFound
 
 
 class CompletionApi(AppApiResource):

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -1,16 +1,17 @@
 # -*- coding:utf-8 -*-
+from flask import request
+from flask_restful import marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import NotFound
+
 import services
 from controllers.service_api import api
 from controllers.service_api.app import create_or_update_end_user_for_user_id
 from controllers.service_api.app.error import NotChatAppError
 from controllers.service_api.wraps import AppApiResource
 from fields.conversation_fields import conversation_infinite_scroll_pagination_fields, simple_conversation_fields
-from flask import request
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
-from libs.helper import TimestampField, uuid_value
+from libs.helper import uuid_value
 from services.conversation_service import ConversationService
-from werkzeug.exceptions import NotFound
 
 
 class ConversationApi(AppApiResource):

--- a/api/controllers/service_api/app/file.py
+++ b/api/controllers/service_api/app/file.py
@@ -1,12 +1,17 @@
+from flask import request
+from flask_restful import marshal_with
+
 import services
 from controllers.service_api import api
 from controllers.service_api.app import create_or_update_end_user_for_user_id
-from controllers.service_api.app.error import (FileTooLargeError, NoFileUploadedError, TooManyFilesError,
-                                               UnsupportedFileTypeError)
+from controllers.service_api.app.error import (
+    FileTooLargeError,
+    NoFileUploadedError,
+    TooManyFilesError,
+    UnsupportedFileTypeError,
+)
 from controllers.service_api.wraps import AppApiResource
 from fields.file_fields import file_fields
-from flask import request
-from flask_restful import marshal_with
 from services.file_service import FileService
 
 

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -1,4 +1,8 @@
 # -*- coding:utf-8 -*-
+from flask_restful import fields, marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import NotFound
+
 import services
 from controllers.service_api import api
 from controllers.service_api.app import create_or_update_end_user_for_user_id
@@ -6,12 +10,9 @@ from controllers.service_api.app.error import NotChatAppError
 from controllers.service_api.wraps import AppApiResource
 from extensions.ext_database import db
 from fields.conversation_fields import message_file_fields
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
 from libs.helper import TimestampField, uuid_value
 from models.model import EndUser, Message
 from services.message_service import MessageService
-from werkzeug.exceptions import NotFound
 
 
 class MessageListApi(AppApiResource):

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -1,3 +1,6 @@
+from flask import request
+from flask_restful import marshal, reqparse
+
 import services.dataset_service
 from controllers.service_api import api
 from controllers.service_api.dataset.error import DatasetNameDuplicateError
@@ -5,8 +8,6 @@ from controllers.service_api.wraps import DatasetApiResource
 from core.model_runtime.entities.model_entities import ModelType
 from core.provider_manager import ProviderManager
 from fields.dataset_fields import dataset_detail_fields
-from flask import request
-from flask_restful import marshal, reqparse
 from libs.login import current_user
 from models.dataset import Dataset
 from services.dataset_service import DatasetService

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -1,23 +1,28 @@
 import json
 
+from flask import request
+from flask_login import current_user
+from flask_restful import marshal, reqparse
+from sqlalchemy import desc
+from werkzeug.exceptions import NotFound
+
 import services.dataset_service
 from controllers.service_api import api
 from controllers.service_api.app.error import ProviderNotInitializeError
-from controllers.service_api.dataset.error import (ArchivedDocumentImmutableError, DocumentIndexingError,
-                                                   NoFileUploadedError, TooManyFilesError)
+from controllers.service_api.dataset.error import (
+    ArchivedDocumentImmutableError,
+    DocumentIndexingError,
+    NoFileUploadedError,
+    TooManyFilesError,
+)
 from controllers.service_api.wraps import DatasetApiResource, cloud_edition_billing_resource_check
 from core.errors.error import ProviderTokenNotInitError
 from extensions.ext_database import db
 from fields.document_fields import document_fields, document_status_fields
-from flask import request
-from flask_login import current_user
-from flask_restful import marshal, reqparse
 from libs.login import current_user
 from models.dataset import Dataset, Document, DocumentSegment
 from services.dataset_service import DocumentService
 from services.file_service import FileService
-from sqlalchemy import desc
-from werkzeug.exceptions import NotFound
 
 
 class DocumentAddByTextApi(DatasetApiResource):

--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -1,3 +1,7 @@
+from flask_login import current_user
+from flask_restful import marshal, reqparse
+from werkzeug.exceptions import NotFound
+
 from controllers.service_api import api
 from controllers.service_api.app.error import ProviderNotInitializeError
 from controllers.service_api.wraps import DatasetApiResource, cloud_edition_billing_resource_check
@@ -6,11 +10,8 @@ from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from extensions.ext_database import db
 from fields.segment_fields import segment_fields
-from flask_login import current_user
-from flask_restful import marshal, reqparse
 from models.dataset import Dataset, DocumentSegment
 from services.dataset_service import DatasetService, DocumentService, SegmentService
-from werkzeug.exceptions import NotFound
 
 
 class SegmentApi(DatasetApiResource):

--- a/api/controllers/service_api/index.py
+++ b/api/controllers/service_api/index.py
@@ -1,6 +1,7 @@
-from controllers.service_api import api
 from flask import current_app
 from flask_restful import Resource
+
+from controllers.service_api import api
 
 
 class IndexApi(Resource):

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -2,15 +2,16 @@
 from datetime import datetime
 from functools import wraps
 
-from extensions.ext_database import db
 from flask import current_app, request
 from flask_login import user_logged_in
 from flask_restful import Resource
+from werkzeug.exceptions import NotFound, Unauthorized
+
+from extensions.ext_database import db
 from libs.login import _get_user
 from models.account import Account, Tenant, TenantAccountJoin
 from models.model import ApiToken, App
 from services.feature_service import FeatureService
-from werkzeug.exceptions import NotFound, Unauthorized
 
 
 def validate_app_token(view=None):

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -1,11 +1,12 @@
 # -*- coding:utf-8 -*-
 import json
 
+from flask import current_app
+from flask_restful import fields, marshal_with
+
 from controllers.web import api
 from controllers.web.wraps import WebApiResource
 from extensions.ext_database import db
-from flask import current_app
-from flask_restful import fields, marshal_with
 from models.model import App, AppModelConfig
 from models.tools import ApiToolProvider
 

--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -1,21 +1,33 @@
 # -*- coding:utf-8 -*-
 import logging
 
+from flask import request
+from werkzeug.exceptions import InternalServerError
+
 import services
 from controllers.web import api
-from controllers.web.error import (AppUnavailableError, AudioTooLargeError, CompletionRequestError,
-                                   NoAudioUploadedError, ProviderModelCurrentlyNotSupportError,
-                                   ProviderNotInitializeError, ProviderNotSupportSpeechToTextError,
-                                   ProviderQuotaExceededError, UnsupportedAudioTypeError)
+from controllers.web.error import (
+    AppUnavailableError,
+    AudioTooLargeError,
+    CompletionRequestError,
+    NoAudioUploadedError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderNotSupportSpeechToTextError,
+    ProviderQuotaExceededError,
+    UnsupportedAudioTypeError,
+)
 from controllers.web.wraps import WebApiResource
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import request
 from models.model import App, AppModelConfig
 from services.audio_service import AudioService
-from services.errors.audio import (AudioTooLargeServiceError, NoAudioUploadedServiceError,
-                                   ProviderNotSupportSpeechToTextServiceError, UnsupportedAudioTypeServiceError)
-from werkzeug.exceptions import InternalServerError
+from services.errors.audio import (
+    AudioTooLargeServiceError,
+    NoAudioUploadedServiceError,
+    ProviderNotSupportSpeechToTextServiceError,
+    UnsupportedAudioTypeServiceError,
+)
 
 
 class AudioApi(WebApiResource):

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -3,21 +3,29 @@ import json
 import logging
 from typing import Generator, Union
 
+from flask import Response, stream_with_context
+from flask_restful import reqparse
+from werkzeug.exceptions import InternalServerError, NotFound
+
 import services
 from controllers.web import api
-from controllers.web.error import (AppUnavailableError, CompletionRequestError, ConversationCompletedError,
-                                   NotChatAppError, NotCompletionAppError, ProviderModelCurrentlyNotSupportError,
-                                   ProviderNotInitializeError, ProviderQuotaExceededError)
+from controllers.web.error import (
+    AppUnavailableError,
+    CompletionRequestError,
+    ConversationCompletedError,
+    NotChatAppError,
+    NotCompletionAppError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.web.wraps import WebApiResource
 from core.application_queue_manager import ApplicationQueueManager
 from core.entities.application_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
-from flask import Response, stream_with_context
-from flask_restful import reqparse
 from libs.helper import uuid_value
 from services.completion_service import CompletionService
-from werkzeug.exceptions import InternalServerError, NotFound
 
 
 # define completion api for user

--- a/api/controllers/web/conversation.py
+++ b/api/controllers/web/conversation.py
@@ -1,15 +1,16 @@
 # -*- coding:utf-8 -*-
+from flask_restful import marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import NotFound
+
 from controllers.web import api
 from controllers.web.error import NotChatAppError
 from controllers.web.wraps import WebApiResource
 from fields.conversation_fields import conversation_infinite_scroll_pagination_fields, simple_conversation_fields
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
-from libs.helper import TimestampField, uuid_value
+from libs.helper import uuid_value
 from services.conversation_service import ConversationService
 from services.errors.conversation import ConversationNotExistsError, LastConversationNotExistsError
 from services.web_conversation_service import WebConversationService
-from werkzeug.exceptions import NotFound
 
 
 class ConversationListApi(WebApiResource):

--- a/api/controllers/web/file.py
+++ b/api/controllers/web/file.py
@@ -1,10 +1,11 @@
+from flask import request
+from flask_restful import marshal_with
+
 import services
 from controllers.web import api
 from controllers.web.error import FileTooLargeError, NoFileUploadedError, TooManyFilesError, UnsupportedFileTypeError
 from controllers.web.wraps import WebApiResource
 from fields.file_fields import file_fields
-from flask import request
-from flask_restful import marshal_with
 from services.file_service import FileService
 
 

--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -3,28 +3,35 @@ import json
 import logging
 from typing import Generator, Union
 
+from flask import Response, stream_with_context
+from flask_restful import fields, marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import InternalServerError, NotFound
+
 import services
 from controllers.web import api
-from controllers.web.error import (AppMoreLikeThisDisabledError, AppSuggestedQuestionsAfterAnswerDisabledError,
-                                   CompletionRequestError, NotChatAppError, NotCompletionAppError,
-                                   ProviderModelCurrentlyNotSupportError, ProviderNotInitializeError,
-                                   ProviderQuotaExceededError)
+from controllers.web.error import (
+    AppMoreLikeThisDisabledError,
+    AppSuggestedQuestionsAfterAnswerDisabledError,
+    CompletionRequestError,
+    NotChatAppError,
+    NotCompletionAppError,
+    ProviderModelCurrentlyNotSupportError,
+    ProviderNotInitializeError,
+    ProviderQuotaExceededError,
+)
 from controllers.web.wraps import WebApiResource
 from core.entities.application_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.errors.invoke import InvokeError
 from fields.conversation_fields import message_file_fields
 from fields.message_fields import agent_thought_fields
-from flask import Response, stream_with_context
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
 from libs.helper import TimestampField, uuid_value
 from services.completion_service import CompletionService
 from services.errors.app import MoreLikeThisDisabledError
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import MessageNotExistsError, SuggestedQuestionsAfterAnswerDisabledError
 from services.message_service import MessageService
-from werkzeug.exceptions import InternalServerError, NotFound
 
 
 class MessageListApi(WebApiResource):

--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -1,13 +1,14 @@
 # -*- coding:utf-8 -*-
 import uuid
 
-from controllers.web import api
-from extensions.ext_database import db
 from flask import request
 from flask_restful import Resource
+from werkzeug.exceptions import NotFound, Unauthorized
+
+from controllers.web import api
+from extensions.ext_database import db
 from libs.passport import PassportService
 from models.model import App, EndUser, Site
-from werkzeug.exceptions import NotFound, Unauthorized
 
 
 class PassportResource(Resource):

--- a/api/controllers/web/saved_message.py
+++ b/api/controllers/web/saved_message.py
@@ -1,13 +1,14 @@
+from flask_restful import fields, marshal_with, reqparse
+from flask_restful.inputs import int_range
+from werkzeug.exceptions import NotFound
+
 from controllers.web import api
 from controllers.web.error import NotCompletionAppError
 from controllers.web.wraps import WebApiResource
 from fields.conversation_fields import message_file_fields
-from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range
 from libs.helper import TimestampField, uuid_value
 from services.errors.message import MessageNotExistsError
 from services.saved_message_service import SavedMessageService
-from werkzeug.exceptions import NotFound
 
 feedback_fields = {
     'rating': fields.String

--- a/api/controllers/web/site.py
+++ b/api/controllers/web/site.py
@@ -1,14 +1,14 @@
 # -*- coding:utf-8 -*-
-import os
+
+from flask import current_app
+from flask_restful import fields, marshal_with
+from werkzeug.exceptions import Forbidden
 
 from controllers.web import api
 from controllers.web.wraps import WebApiResource
 from extensions.ext_database import db
-from flask import current_app
-from flask_restful import fields, marshal_with
 from models.model import Site
 from services.feature_service import FeatureService
-from werkzeug.exceptions import Forbidden
 
 
 class AppSiteApi(WebApiResource):

--- a/api/controllers/web/wraps.py
+++ b/api/controllers/web/wraps.py
@@ -1,12 +1,13 @@
 # -*- coding:utf-8 -*-
 from functools import wraps
 
-from extensions.ext_database import db
 from flask import request
 from flask_restful import Resource
+from werkzeug.exceptions import NotFound, Unauthorized
+
+from extensions.ext_database import db
 from libs.passport import PassportService
 from models.model import App, EndUser, Site
-from werkzeug.exceptions import NotFound, Unauthorized
 
 
 def validate_jwt_token(view=None):

--- a/api/core/agent/agent/calc_token_mixin.py
+++ b/api/core/agent/agent/calc_token_mixin.py
@@ -1,11 +1,9 @@
 from typing import List, cast
 
 from core.entities.application_entities import ModelConfigEntity
-from core.entities.message_entities import lc_messages_to_prompt_messages
 from core.model_runtime.entities.message_entities import PromptMessage
 from core.model_runtime.entities.model_entities import ModelPropertyKey
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from langchain.schema import BaseMessage
 
 
 class CalcTokenMixin:

--- a/api/core/agent/agent/multi_dataset_router_agent.py
+++ b/api/core/agent/agent/multi_dataset_router_agent.py
@@ -1,10 +1,5 @@
-from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
-from core.entities.application_entities import ModelConfigEntity
-from core.entities.message_entities import lc_messages_to_prompt_messages
-from core.model_manager import ModelInstance
-from core.model_runtime.entities.message_entities import PromptMessageTool
-from core.third_party.langchain.llms.fake import FakeLLM
 from langchain.agents import BaseSingleActionAgent, OpenAIFunctionsAgent
 from langchain.agents.openai_functions_agent.base import _format_intermediate_steps, _parse_ai_message
 from langchain.callbacks.base import BaseCallbackManager
@@ -13,6 +8,12 @@ from langchain.prompts.chat import BaseMessagePromptTemplate
 from langchain.schema import AgentAction, AgentFinish, AIMessage, SystemMessage
 from langchain.tools import BaseTool
 from pydantic import root_validator
+
+from core.entities.application_entities import ModelConfigEntity
+from core.entities.message_entities import lc_messages_to_prompt_messages
+from core.model_manager import ModelInstance
+from core.model_runtime.entities.message_entities import PromptMessageTool
+from core.third_party.langchain.llms.fake import FakeLLM
 
 
 class MultiDatasetRouterAgent(OpenAIFunctionsAgent):

--- a/api/core/agent/agent/openai_function_call.py
+++ b/api/core/agent/agent/openai_function_call.py
@@ -1,4 +1,23 @@
-from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+from langchain.agents import BaseSingleActionAgent, OpenAIFunctionsAgent
+from langchain.agents.openai_functions_agent.base import _format_intermediate_steps, _parse_ai_message
+from langchain.callbacks.base import BaseCallbackManager
+from langchain.callbacks.manager import Callbacks
+from langchain.chat_models.openai import _convert_message_to_dict, _import_tiktoken
+from langchain.memory.prompt import SUMMARY_PROMPT
+from langchain.prompts.chat import BaseMessagePromptTemplate
+from langchain.schema import (
+    AgentAction,
+    AgentFinish,
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    get_buffer_string,
+)
+from langchain.tools import BaseTool
+from pydantic import root_validator
 
 from core.agent.agent.agent_llm_callback import AgentLLMCallback
 from core.agent.agent.calc_token_mixin import CalcTokenMixin, ExceededLLMTokensLimitError
@@ -7,19 +26,7 @@ from core.entities.application_entities import ModelConfigEntity
 from core.entities.message_entities import lc_messages_to_prompt_messages
 from core.model_manager import ModelInstance
 from core.model_runtime.entities.message_entities import PromptMessage, PromptMessageTool
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.third_party.langchain.llms.fake import FakeLLM
-from langchain.agents import BaseSingleActionAgent, OpenAIFunctionsAgent
-from langchain.agents.openai_functions_agent.base import _format_intermediate_steps, _parse_ai_message
-from langchain.callbacks.base import BaseCallbackManager
-from langchain.callbacks.manager import Callbacks
-from langchain.chat_models.openai import _convert_message_to_dict, _import_tiktoken
-from langchain.memory.prompt import SUMMARY_PROMPT
-from langchain.prompts.chat import BaseMessagePromptTemplate
-from langchain.schema import (AgentAction, AgentFinish, AIMessage, BaseMessage, HumanMessage, SystemMessage,
-                              get_buffer_string)
-from langchain.tools import BaseTool
-from pydantic import root_validator
 
 
 class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixin):

--- a/api/core/agent/agent/structed_multi_dataset_router_agent.py
+++ b/api/core/agent/agent/structed_multi_dataset_router_agent.py
@@ -1,8 +1,6 @@
 import re
 from typing import Any, List, Optional, Sequence, Tuple, Union, cast
 
-from core.chain.llm_chain import LLMChain
-from core.entities.application_entities import ModelConfigEntity
 from langchain import BasePromptTemplate, PromptTemplate
 from langchain.agents import Agent, AgentOutputParser, StructuredChatAgent
 from langchain.agents.structured_chat.base import HUMAN_MESSAGE_TEMPLATE
@@ -12,6 +10,9 @@ from langchain.callbacks.manager import Callbacks
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate
 from langchain.schema import AgentAction, AgentFinish, OutputParserException
 from langchain.tools import BaseTool
+
+from core.chain.llm_chain import LLMChain
+from core.entities.application_entities import ModelConfigEntity
 
 FORMAT_INSTRUCTIONS = """Use a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).
 The nouns in the format of "Thought", "Action", "Action Input", "Final Answer" must be expressed in English.

--- a/api/core/agent/agent/structured_chat.py
+++ b/api/core/agent/agent/structured_chat.py
@@ -1,11 +1,6 @@
 import re
 from typing import Any, List, Optional, Sequence, Tuple, Union, cast
 
-from core.agent.agent.agent_llm_callback import AgentLLMCallback
-from core.agent.agent.calc_token_mixin import CalcTokenMixin, ExceededLLMTokensLimitError
-from core.chain.llm_chain import LLMChain
-from core.entities.application_entities import ModelConfigEntity
-from core.entities.message_entities import lc_messages_to_prompt_messages
 from langchain import BasePromptTemplate, PromptTemplate
 from langchain.agents import Agent, AgentOutputParser, StructuredChatAgent
 from langchain.agents.structured_chat.base import HUMAN_MESSAGE_TEMPLATE
@@ -14,9 +9,22 @@ from langchain.callbacks.base import BaseCallbackManager
 from langchain.callbacks.manager import Callbacks
 from langchain.memory.prompt import SUMMARY_PROMPT
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate
-from langchain.schema import (AgentAction, AgentFinish, AIMessage, BaseMessage, HumanMessage, OutputParserException,
-                              get_buffer_string)
+from langchain.schema import (
+    AgentAction,
+    AgentFinish,
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    OutputParserException,
+    get_buffer_string,
+)
 from langchain.tools import BaseTool
+
+from core.agent.agent.agent_llm_callback import AgentLLMCallback
+from core.agent.agent.calc_token_mixin import CalcTokenMixin, ExceededLLMTokensLimitError
+from core.chain.llm_chain import LLMChain
+from core.entities.application_entities import ModelConfigEntity
+from core.entities.message_entities import lc_messages_to_prompt_messages
 
 FORMAT_INSTRUCTIONS = """Use a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).
 The nouns in the format of "Thought", "Action", "Action Input", "Final Answer" must be expressed in English.

--- a/api/core/agent/agent_executor.py
+++ b/api/core/agent/agent_executor.py
@@ -2,6 +2,12 @@ import enum
 import logging
 from typing import Optional, Union
 
+from langchain.agents import AgentExecutor as LCAgentExecutor
+from langchain.agents import BaseMultiActionAgent, BaseSingleActionAgent
+from langchain.callbacks.manager import Callbacks
+from langchain.tools import BaseTool
+from pydantic import BaseModel, Extra
+
 from core.agent.agent.agent_llm_callback import AgentLLMCallback
 from core.agent.agent.multi_dataset_router_agent import MultiDatasetRouterAgent
 from core.agent.agent.openai_function_call import AutoSummarizingOpenAIFunctionCallAgent
@@ -15,11 +21,6 @@ from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_runtime.errors.invoke import InvokeError
 from core.tools.tool.dataset_retriever.dataset_multi_retriever_tool import DatasetMultiRetrieverTool
 from core.tools.tool.dataset_retriever.dataset_retriever_tool import DatasetRetrieverTool
-from langchain.agents import AgentExecutor as LCAgentExecutor
-from langchain.agents import BaseMultiActionAgent, BaseSingleActionAgent
-from langchain.callbacks.manager import Callbacks
-from langchain.tools import BaseTool
-from pydantic import BaseModel, Extra
 
 
 class PlanningStrategy(str, enum.Enum):

--- a/api/core/app_runner/app_runner.py
+++ b/api/core/app_runner/app_runner.py
@@ -2,9 +2,14 @@ import time
 from typing import Generator, List, Optional, Tuple, Union, cast
 
 from core.application_queue_manager import ApplicationQueueManager, PublishFrom
-from core.entities.application_entities import (ApplicationGenerateEntity, AppOrchestrationConfigEntity,
-                                                ExternalDataVariableEntity, InvokeFrom, ModelConfigEntity,
-                                                PromptTemplateEntity)
+from core.entities.application_entities import (
+    ApplicationGenerateEntity,
+    AppOrchestrationConfigEntity,
+    ExternalDataVariableEntity,
+    InvokeFrom,
+    ModelConfigEntity,
+    PromptTemplateEntity,
+)
 from core.features.annotation_reply import AnnotationReplyFeature
 from core.features.external_data_fetch import ExternalDataFetchFeature
 from core.features.hosting_moderation import HostingModerationFeature

--- a/api/core/app_runner/generate_task_pipeline.py
+++ b/api/core/app_runner/generate_task_pipeline.py
@@ -3,28 +3,42 @@ import logging
 import time
 from typing import Generator, Optional, Union, cast
 
+from pydantic import BaseModel
+
 from core.app_runner.moderation_handler import ModerationRule, OutputModerationHandler
 from core.application_queue_manager import ApplicationQueueManager, PublishFrom
 from core.entities.application_entities import ApplicationGenerateEntity, InvokeFrom
-from core.entities.queue_entities import (AnnotationReplyEvent, QueueAgentMessageEvent, QueueAgentThoughtEvent,
-                                          QueueErrorEvent, QueueMessageEndEvent, QueueMessageEvent,
-                                          QueueMessageFileEvent, QueueMessageReplaceEvent, QueuePingEvent,
-                                          QueueRetrieverResourcesEvent, QueueStopEvent)
+from core.entities.queue_entities import (
+    AnnotationReplyEvent,
+    QueueAgentMessageEvent,
+    QueueAgentThoughtEvent,
+    QueueErrorEvent,
+    QueueMessageEndEvent,
+    QueueMessageEvent,
+    QueueMessageFileEvent,
+    QueueMessageReplaceEvent,
+    QueuePingEvent,
+    QueueRetrieverResourcesEvent,
+    QueueStopEvent,
+)
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, PromptMessageContentType, PromptMessageRole,
-                                                          TextPromptMessageContent)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageRole,
+    TextPromptMessageContent,
+)
 from core.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.utils.encoders import jsonable_encoder
 from core.prompt.prompt_template import PromptTemplateParser
 from core.tools.tool_file_manager import ToolFileManager
-from core.tools.tool_manager import ToolManager
 from events.message_event import message_was_created
 from extensions.ext_database import db
 from models.model import Conversation, Message, MessageAgentThought, MessageFile
-from pydantic import BaseModel
 from services.annotation_service import AppAnnotationService
 
 logger = logging.getLogger(__name__)

--- a/api/core/app_runner/moderation_handler.py
+++ b/api/core/app_runner/moderation_handler.py
@@ -3,11 +3,12 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
+from flask import Flask, current_app
+from pydantic import BaseModel
+
 from core.application_queue_manager import PublishFrom
 from core.moderation.base import ModerationAction, ModerationOutputsResult
 from core.moderation.factory import ModerationFactory
-from flask import Flask, current_app
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/application_manager.py
+++ b/api/core/application_manager.py
@@ -4,17 +4,30 @@ import threading
 import uuid
 from typing import Any, Generator, Optional, Tuple, Union, cast
 
+from flask import Flask, current_app
+from pydantic import ValidationError
+
 from core.app_runner.assistant_app_runner import AssistantApplicationRunner
 from core.app_runner.basic_app_runner import BasicApplicationRunner
 from core.app_runner.generate_task_pipeline import GenerateTaskPipeline
 from core.application_queue_manager import ApplicationQueueManager, ConversationTaskStoppedException, PublishFrom
-from core.entities.application_entities import (AdvancedChatPromptTemplateEntity,
-                                                AdvancedCompletionPromptTemplateEntity, AgentEntity, AgentPromptEntity,
-                                                AgentToolEntity, ApplicationGenerateEntity,
-                                                AppOrchestrationConfigEntity, DatasetEntity,
-                                                DatasetRetrieveConfigEntity, ExternalDataVariableEntity,
-                                                FileUploadEntity, InvokeFrom, ModelConfigEntity, PromptTemplateEntity,
-                                                SensitiveWordAvoidanceEntity)
+from core.entities.application_entities import (
+    AdvancedChatPromptTemplateEntity,
+    AdvancedCompletionPromptTemplateEntity,
+    AgentEntity,
+    AgentPromptEntity,
+    AgentToolEntity,
+    ApplicationGenerateEntity,
+    AppOrchestrationConfigEntity,
+    DatasetEntity,
+    DatasetRetrieveConfigEntity,
+    ExternalDataVariableEntity,
+    FileUploadEntity,
+    InvokeFrom,
+    ModelConfigEntity,
+    PromptTemplateEntity,
+    SensitiveWordAvoidanceEntity,
+)
 from core.entities.model_entities import ModelStatus
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.file.file_obj import FileObj
@@ -26,10 +39,8 @@ from core.prompt.prompt_template import PromptTemplateParser
 from core.provider_manager import ProviderManager
 from core.tools.prompt.template import REACT_PROMPT_TEMPLATES
 from extensions.ext_database import db
-from flask import Flask, current_app
 from models.account import Account
 from models.model import App, Conversation, EndUser, Message, MessageFile
-from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/application_queue_manager.py
+++ b/api/core/application_queue_manager.py
@@ -3,15 +3,27 @@ import time
 from enum import Enum
 from typing import Any, Generator
 
+from sqlalchemy.orm import DeclarativeMeta
+
 from core.entities.application_entities import InvokeFrom
-from core.entities.queue_entities import (AnnotationReplyEvent, AppQueueEvent, QueueAgentMessageEvent,
-                                          QueueAgentThoughtEvent, QueueErrorEvent, QueueMessage, QueueMessageEndEvent,
-                                          QueueMessageEvent, QueueMessageFileEvent, QueueMessageReplaceEvent,
-                                          QueuePingEvent, QueueRetrieverResourcesEvent, QueueStopEvent)
+from core.entities.queue_entities import (
+    AnnotationReplyEvent,
+    AppQueueEvent,
+    QueueAgentMessageEvent,
+    QueueAgentThoughtEvent,
+    QueueErrorEvent,
+    QueueMessage,
+    QueueMessageEndEvent,
+    QueueMessageEvent,
+    QueueMessageFileEvent,
+    QueueMessageReplaceEvent,
+    QueuePingEvent,
+    QueueRetrieverResourcesEvent,
+    QueueStopEvent,
+)
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
 from extensions.ext_redis import redis_client
 from models.model import MessageAgentThought, MessageFile
-from sqlalchemy.orm import DeclarativeMeta
 
 
 class PublishFrom(Enum):

--- a/api/core/callback_handler/agent_loop_gather_callback_handler.py
+++ b/api/core/callback_handler/agent_loop_gather_callback_handler.py
@@ -3,6 +3,10 @@ import logging
 import time
 from typing import Any, Dict, List, Optional, Union, cast
 
+from langchain.agents import openai_functions_agent, openai_functions_multi_agent
+from langchain.callbacks.base import BaseCallbackHandler
+from langchain.schema import AgentAction, AgentFinish, BaseMessage, LLMResult
+
 from core.application_queue_manager import ApplicationQueueManager, PublishFrom
 from core.callback_handler.entity.agent_loop import AgentLoop
 from core.entities.application_entities import ModelConfigEntity
@@ -10,9 +14,6 @@ from core.model_runtime.entities.llm_entities import LLMResult as RuntimeLLMResu
 from core.model_runtime.entities.message_entities import AssistantPromptMessage, PromptMessage, UserPromptMessage
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from extensions.ext_database import db
-from langchain.agents import openai_functions_agent, openai_functions_multi_agent
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain.schema import AgentAction, AgentFinish, BaseMessage, ChatGeneration, LLMResult
 from models.model import Message, MessageAgentThought, MessageChain
 
 

--- a/api/core/callback_handler/index_tool_callback_handler.py
+++ b/api/core/callback_handler/index_tool_callback_handler.py
@@ -1,9 +1,10 @@
-from typing import List, Union
+from typing import List
+
+from langchain.schema import Document
 
 from core.application_queue_manager import ApplicationQueueManager, PublishFrom
 from core.entities.application_entities import InvokeFrom
 from extensions.ext_database import db
-from langchain.schema import Document
 from models.dataset import DatasetQuery, DocumentSegment
 from models.model import DatasetRetrieverResource
 

--- a/api/core/chain/llm_chain.py
+++ b/api/core/chain/llm_chain.py
@@ -1,14 +1,15 @@
 from typing import Any, Dict, List, Optional
 
+from langchain import LLMChain as LCLLMChain
+from langchain.callbacks.manager import CallbackManagerForChainRun
+from langchain.schema import Generation, LLMResult
+from langchain.schema.language_model import BaseLanguageModel
+
 from core.agent.agent.agent_llm_callback import AgentLLMCallback
 from core.entities.application_entities import ModelConfigEntity
 from core.entities.message_entities import lc_messages_to_prompt_messages
 from core.model_manager import ModelInstance
 from core.third_party.langchain.llms.fake import FakeLLM
-from langchain import LLMChain as LCLLMChain
-from langchain.callbacks.manager import CallbackManagerForChainRun
-from langchain.schema import Generation, LLMResult
-from langchain.schema.language_model import BaseLanguageModel
 
 
 class LLMChain(LCLLMChain):

--- a/api/core/data_loader/file_extractor.py
+++ b/api/core/data_loader/file_extractor.py
@@ -3,6 +3,10 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import requests
+from flask import current_app
+from langchain.document_loaders import Docx2txtLoader, TextLoader
+from langchain.schema import Document
+
 from core.data_loader.loader.csv_loader import CSVLoader
 from core.data_loader.loader.excel import ExcelLoader
 from core.data_loader.loader.html import HTMLLoader
@@ -16,9 +20,6 @@ from core.data_loader.loader.unstructured.unstructured_pptx import UnstructuredP
 from core.data_loader.loader.unstructured.unstructured_text import UnstructuredTextLoader
 from core.data_loader.loader.unstructured.unstructured_xml import UnstructuredXmlLoader
 from extensions.ext_storage import storage
-from flask import current_app
-from langchain.document_loaders import Docx2txtLoader, TextLoader
-from langchain.schema import Document
 from models.model import UploadFile
 
 SUPPORT_URL_CONTENT_TYPES = ['application/pdf', 'text/plain']

--- a/api/core/data_loader/loader/excel.py
+++ b/api/core/data_loader/loader/excel.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import List
 

--- a/api/core/data_loader/loader/notion.py
+++ b/api/core/data_loader/loader/notion.py
@@ -3,10 +3,11 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import requests
-from extensions.ext_database import db
 from flask import current_app
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
+
+from extensions.ext_database import db
 from models.dataset import Document as DocumentModel
 from models.source import DataSourceBinding
 

--- a/api/core/data_loader/loader/pdf.py
+++ b/api/core/data_loader/loader/pdf.py
@@ -1,10 +1,11 @@
 import logging
 from typing import List, Optional
 
-from extensions.ext_storage import storage
 from langchain.document_loaders import PyPDFium2Loader
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
+
+from extensions.ext_storage import storage
 from models.model import UploadFile
 
 logger = logging.getLogger(__name__)

--- a/api/core/docstore/dataset_docstore.py
+++ b/api/core/docstore/dataset_docstore.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, Optional, Sequence, cast
 
+from langchain.schema import Document
+from sqlalchemy import func
+
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from extensions.ext_database import db
-from langchain.schema import Document
 from models.dataset import Dataset, DocumentSegment
-from sqlalchemy import func
 
 
 class DatasetDocumentStore:

--- a/api/core/embedding/cached_embedding.py
+++ b/api/core/embedding/cached_embedding.py
@@ -1,18 +1,17 @@
 import base64
-import json
 import logging
 from typing import List, Optional, cast
 
 import numpy as np
+from langchain.embeddings.base import Embeddings
+from sqlalchemy.exc import IntegrityError
+
 from core.model_manager import ModelInstance
 from core.model_runtime.entities.model_entities import ModelPropertyKey
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.embeddings.base import Embeddings
 from libs import helper
-from models.dataset import Embedding
-from sqlalchemy.exc import IntegrityError
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/entities/application_entities.py
+++ b/api/core/entities/application_entities.py
@@ -1,11 +1,12 @@
 from enum import Enum
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, Literal, Optional, Union
+
+from pydantic import BaseModel
 
 from core.entities.provider_configuration import ProviderModelBundle
 from core.file.file_obj import FileObj
 from core.model_runtime.entities.message_entities import PromptMessageRole
 from core.model_runtime.entities.model_entities import AIModelEntity
-from pydantic import BaseModel
 
 
 class ModelConfigEntity(BaseModel):

--- a/api/core/entities/message_entities.py
+++ b/api/core/entities/message_entities.py
@@ -1,11 +1,18 @@
 import enum
 from typing import Any, cast
 
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, SystemPromptMessage, TextPromptMessageContent,
-                                                          ToolPromptMessage, UserPromptMessage)
 from langchain.schema import AIMessage, BaseMessage, FunctionMessage, HumanMessage, SystemMessage
 from pydantic import BaseModel
+
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    PromptMessage,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
 
 
 class PromptMessageFileType(enum.Enum):

--- a/api/core/entities/model_entities.py
+++ b/api/core/entities/model_entities.py
@@ -1,10 +1,11 @@
 from enum import Enum
 from typing import Optional
 
+from pydantic import BaseModel
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import ModelType, ProviderModel
-from core.model_runtime.entities.provider_entities import ProviderEntity, SimpleProviderEntity
-from pydantic import BaseModel
+from core.model_runtime.entities.provider_entities import ProviderEntity
 
 
 class ModelStatus(Enum):

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -4,20 +4,24 @@ import logging
 from json import JSONDecodeError
 from typing import Dict, Iterator, List, Optional, Tuple
 
+from pydantic import BaseModel
+
 from core.entities.model_entities import ModelStatus, ModelWithProviderEntity, SimpleModelProviderEntity
 from core.entities.provider_entities import CustomConfiguration, SystemConfiguration, SystemConfigurationStatus
 from core.helper import encrypter
 from core.helper.model_provider_cache import ProviderCredentialsCache, ProviderCredentialsCacheType
 from core.model_runtime.entities.model_entities import FetchFrom, ModelType
-from core.model_runtime.entities.provider_entities import (ConfigurateMethod, CredentialFormSchema, FormType,
-                                                           ProviderEntity)
+from core.model_runtime.entities.provider_entities import (
+    ConfigurateMethod,
+    CredentialFormSchema,
+    FormType,
+    ProviderEntity,
+)
 from core.model_runtime.model_providers import model_provider_factory
 from core.model_runtime.model_providers.__base.ai_model import AIModel
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
-from core.model_runtime.utils import encoders
 from extensions.ext_database import db
 from models.provider import Provider, ProviderModel, ProviderType, TenantPreferredModelProvider
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/entities/provider_entities.py
+++ b/api/core/entities/provider_entities.py
@@ -1,9 +1,10 @@
 from enum import Enum
 from typing import Optional
 
+from pydantic import BaseModel
+
 from core.model_runtime.entities.model_entities import ModelType
 from models.provider import ProviderQuotaType
-from pydantic import BaseModel
 
 
 class QuotaUnit(Enum):

--- a/api/core/entities/queue_entities.py
+++ b/api/core/entities/queue_entities.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from typing import Any
 
-from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
 from pydantic import BaseModel
+
+from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
 
 
 class QueueEvent(Enum):

--- a/api/core/extension/api_based_extension_requestor.py
+++ b/api/core/extension/api_based_extension_requestor.py
@@ -1,6 +1,7 @@
 import os
 
 import requests
+
 from models.api_based_extension import APIBasedExtensionPoint
 
 

--- a/api/core/features/agent_runner.py
+++ b/api/core/features/agent_runner.py
@@ -1,5 +1,7 @@
 import logging
-from typing import List, Optional, cast
+from typing import Optional, cast
+
+from langchain.tools import BaseTool
 
 from core.agent.agent.agent_llm_callback import AgentLLMCallback
 from core.agent.agent_executor import AgentConfiguration, AgentExecutor, PlanningStrategy
@@ -7,20 +9,20 @@ from core.application_queue_manager import ApplicationQueueManager
 from core.callback_handler.agent_loop_gather_callback_handler import AgentLoopGatherCallbackHandler
 from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCallbackHandler
 from core.callback_handler.std_out_callback_handler import DifyStdOutCallbackHandler
-from core.entities.application_entities import (AgentEntity, AgentToolEntity, AppOrchestrationConfigEntity, InvokeFrom,
-                                                ModelConfigEntity)
+from core.entities.application_entities import (
+    AgentEntity,
+    AppOrchestrationConfigEntity,
+    InvokeFrom,
+    ModelConfigEntity,
+)
 from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_runtime.entities.model_entities import ModelFeature, ModelType
 from core.model_runtime.model_providers import model_provider_factory
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.tools.tool.dataset_retriever.dataset_retriever_tool import DatasetRetrieverTool
 from extensions.ext_database import db
-from langchain import WikipediaAPIWrapper
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain.tools import BaseTool, Tool, WikipediaQueryRun
 from models.dataset import Dataset
 from models.model import Message
-from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/features/annotation_reply.py
+++ b/api/core/features/annotation_reply.py
@@ -1,13 +1,14 @@
 import logging
 from typing import Optional
 
+from flask import current_app
+
 from core.embedding.cached_embedding import CacheEmbedding
 from core.entities.application_entities import InvokeFrom
 from core.index.vector_index.vector_index import VectorIndex
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from extensions.ext_database import db
-from flask import current_app
 from models.dataset import Dataset
 from models.model import App, AppAnnotationSetting, Message, MessageAnnotation
 from services.annotation_service import AppAnnotationService

--- a/api/core/features/assistant_base_runner.py
+++ b/api/core/features/assistant_base_runner.py
@@ -8,8 +8,14 @@ from core.app_runner.app_runner import AppRunner
 from core.application_queue_manager import ApplicationQueueManager
 from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackHandler
 from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCallbackHandler
-from core.entities.application_entities import (AgentEntity, AgentToolEntity, ApplicationGenerateEntity,
-                                                AppOrchestrationConfigEntity, InvokeFrom, ModelConfigEntity)
+from core.entities.application_entities import (
+    AgentEntity,
+    AgentToolEntity,
+    ApplicationGenerateEntity,
+    AppOrchestrationConfigEntity,
+    InvokeFrom,
+    ModelConfigEntity,
+)
 from core.file.message_file_parser import FileTransferMethod
 from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_manager import ModelInstance
@@ -18,8 +24,12 @@ from core.model_runtime.entities.message_entities import PromptMessage, PromptMe
 from core.model_runtime.entities.model_entities import ModelFeature
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.utils.encoders import jsonable_encoder
-from core.tools.entities.tool_entities import (ToolInvokeMessage, ToolInvokeMessageBinary, ToolParameter,
-                                               ToolRuntimeVariablePool)
+from core.tools.entities.tool_entities import (
+    ToolInvokeMessage,
+    ToolInvokeMessageBinary,
+    ToolParameter,
+    ToolRuntimeVariablePool,
+)
 from core.tools.tool.dataset_retriever_tool import DatasetRetrieverTool
 from core.tools.tool.tool import Tool
 from core.tools.tool_file_manager import ToolFileManager

--- a/api/core/features/assistant_cot_runner.py
+++ b/api/core/features/assistant_cot_runner.py
@@ -1,18 +1,27 @@
 import json
-import logging
 import re
 from typing import Dict, Generator, List, Literal, Union
 
 from core.application_queue_manager import PublishFrom
 from core.entities.application_entities import AgentPromptEntity, AgentScratchpadUnit
 from core.features.assistant_base_runner import BaseAssistantApplicationRunner
-from core.model_manager import ModelInstance
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
 from core.model_runtime.utils.encoders import jsonable_encoder
-from core.tools.errors import (ToolInvokeError, ToolNotFoundError, ToolNotSupportedError, ToolParameterValidationError,
-                               ToolProviderCredentialValidationError, ToolProviderNotFoundError)
+from core.tools.errors import (
+    ToolInvokeError,
+    ToolNotFoundError,
+    ToolNotSupportedError,
+    ToolParameterValidationError,
+    ToolProviderCredentialValidationError,
+    ToolProviderNotFoundError,
+)
 from models.model import Conversation, Message
 
 

--- a/api/core/features/assistant_fc_runner.py
+++ b/api/core/features/assistant_fc_runner.py
@@ -4,12 +4,23 @@ from typing import Any, Dict, Generator, List, Tuple, Union
 
 from core.application_queue_manager import PublishFrom
 from core.features.assistant_base_runner import BaseAssistantApplicationRunner
-from core.model_manager import ModelInstance
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, ToolPromptMessage, UserPromptMessage)
-from core.tools.errors import (ToolInvokeError, ToolNotFoundError, ToolNotSupportedError, ToolParameterValidationError,
-                               ToolProviderCredentialValidationError, ToolProviderNotFoundError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.tools.errors import (
+    ToolInvokeError,
+    ToolNotFoundError,
+    ToolNotSupportedError,
+    ToolParameterValidationError,
+    ToolProviderCredentialValidationError,
+    ToolProviderNotFoundError,
+)
 from models.model import Conversation, Message, MessageAgentThought
 
 logger = logging.getLogger(__name__)

--- a/api/core/features/dataset_retrieval.py
+++ b/api/core/features/dataset_retrieval.py
@@ -1,5 +1,7 @@
 from typing import List, Optional, cast
 
+from langchain.tools import BaseTool
+
 from core.agent.agent_executor import AgentConfiguration, AgentExecutor, PlanningStrategy
 from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCallbackHandler
 from core.entities.application_entities import DatasetEntity, DatasetRetrieveConfigEntity, InvokeFrom, ModelConfigEntity
@@ -9,7 +11,6 @@ from core.model_runtime.model_providers.__base.large_language_model import Large
 from core.tools.tool.dataset_retriever.dataset_multi_retriever_tool import DatasetMultiRetrieverTool
 from core.tools.tool.dataset_retriever.dataset_retriever_tool import DatasetRetrieverTool
 from extensions.ext_database import db
-from langchain.tools import BaseTool
 from models.dataset import Dataset
 
 

--- a/api/core/features/external_data_fetch.py
+++ b/api/core/features/external_data_fetch.py
@@ -4,9 +4,10 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Tuple
 
+from flask import Flask, current_app
+
 from core.entities.application_entities import ExternalDataVariableEntity
 from core.external_data_tool.factory import ExternalDataToolFactory
-from flask import Flask, current_app
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/file/file_obj.py
+++ b/api/core/file/file_obj.py
@@ -1,11 +1,12 @@
 import enum
 from typing import Optional
 
+from pydantic import BaseModel
+
 from core.file.upload_file_parser import UploadFileParser
 from core.model_runtime.entities.message_entities import ImagePromptMessageContent
 from extensions.ext_database import db
 from models.model import UploadFile
-from pydantic import BaseModel
 
 
 class FileType(enum.Enum):

--- a/api/core/file/message_file_parser.py
+++ b/api/core/file/message_file_parser.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Union
 
 import requests
+
 from core.file.file_obj import FileBelongsTo, FileObj, FileTransferMethod, FileType
 from extensions.ext_database import db
 from models.account import Account

--- a/api/core/file/upload_file_parser.py
+++ b/api/core/file/upload_file_parser.py
@@ -6,8 +6,9 @@ import os
 import time
 from typing import Optional
 
-from extensions.ext_storage import storage
 from flask import current_app
+
+from extensions.ext_storage import storage
 
 IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg']
 IMAGE_EXTENSIONS.extend([ext.upper() for ext in IMAGE_EXTENSIONS])

--- a/api/core/generator/llm_generator.py
+++ b/api/core/generator/llm_generator.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from langchain.schema import OutputParserException
+
 from core.model_manager import ModelManager
 from core.model_runtime.entities.message_entities import SystemPromptMessage, UserPromptMessage
 from core.model_runtime.entities.model_entities import ModelType
@@ -9,7 +11,6 @@ from core.prompt.output_parser.rule_config_generator import RuleConfigGeneratorO
 from core.prompt.output_parser.suggested_questions_after_answer import SuggestedQuestionsAfterAnswerOutputParser
 from core.prompt.prompt_template import PromptTemplateParser
 from core.prompt.prompts import CONVERSATION_TITLE_PROMPT, GENERATOR_QA_PROMPT
-from langchain.schema import OutputParserException
 
 
 class LLMGenerator:

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -2,10 +2,15 @@
 Proxy requests to avoid SSRF
 """
 
-from httpx import get as _get, post as _post, put as _put, patch as _patch, head as _head, options as _options
-from requests import delete as _delete
-
 import os
+
+from httpx import get as _get
+from httpx import head as _head
+from httpx import options as _options
+from httpx import patch as _patch
+from httpx import post as _post
+from httpx import put as _put
+from requests import delete as _delete
 
 SSRF_PROXY_HTTP_URL = os.getenv('SSRF_PROXY_HTTP_URL', '')
 SSRF_PROXY_HTTPS_URL = os.getenv('SSRF_PROXY_HTTPS_URL', '')

--- a/api/core/hosting_configuration.py
+++ b/api/core/hosting_configuration.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
+from flask import Config, Flask
+from pydantic import BaseModel
+
 from core.entities.provider_entities import QuotaUnit, RestrictModel
 from core.model_runtime.entities.model_entities import ModelType
-from flask import Config, Flask
 from models.provider import ProviderQuotaType
-from pydantic import BaseModel
 
 
 class HostingQuota(BaseModel):

--- a/api/core/index/base.py
+++ b/api/core/index/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List
 
 from langchain.schema import BaseRetriever, Document
+
 from models.dataset import Dataset
 
 

--- a/api/core/index/index.py
+++ b/api/core/index/index.py
@@ -1,10 +1,11 @@
+from flask import current_app
+from langchain.embeddings import OpenAIEmbeddings
+
 from core.embedding.cached_embedding import CacheEmbedding
 from core.index.keyword_table_index.keyword_table_index import KeywordTableConfig, KeywordTableIndex
 from core.index.vector_index.vector_index import VectorIndex
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
-from flask import current_app
-from langchain.embeddings import OpenAIEmbeddings
 from models.dataset import Dataset
 
 

--- a/api/core/index/keyword_table_index/jieba_keyword_table_handler.py
+++ b/api/core/index/keyword_table_index/jieba_keyword_table_handler.py
@@ -2,8 +2,9 @@ import re
 from typing import Set
 
 import jieba
-from core.index.keyword_table_index.stopwords import STOPWORDS
 from jieba.analyse import default_tfidf
+
+from core.index.keyword_table_index.stopwords import STOPWORDS
 
 
 class JiebaKeywordTableHandler:

--- a/api/core/index/keyword_table_index/keyword_table_index.py
+++ b/api/core/index/keyword_table_index/keyword_table_index.py
@@ -2,12 +2,13 @@ import json
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
+from langchain.schema import BaseRetriever, Document
+from pydantic import BaseModel, Extra, Field
+
 from core.index.base import BaseIndex
 from core.index.keyword_table_index.jieba_keyword_table_handler import JiebaKeywordTableHandler
 from extensions.ext_database import db
-from langchain.schema import BaseRetriever, Document
 from models.dataset import Dataset, DatasetKeywordTable, DocumentSegment
-from pydantic import BaseModel, Extra, Field
 
 
 class KeywordTableConfig(BaseModel):

--- a/api/core/index/vector_index/base.py
+++ b/api/core/index/vector_index/base.py
@@ -3,14 +3,14 @@ import logging
 from abc import abstractmethod
 from typing import Any, List, cast
 
-from core.index.base import BaseIndex
-from extensions.ext_database import db
 from langchain.embeddings.base import Embeddings
 from langchain.schema import BaseRetriever, Document
 from langchain.vectorstores import VectorStore
-from models.dataset import Dataset, DatasetCollectionBinding
+
+from core.index.base import BaseIndex
+from extensions.ext_database import db
+from models.dataset import Dataset, DatasetCollectionBinding, DocumentSegment
 from models.dataset import Document as DatasetDocument
-from models.dataset import DocumentSegment
 
 
 class BaseVectorIndex(BaseIndex):

--- a/api/core/index/vector_index/milvus_vector_index.py
+++ b/api/core/index/vector_index/milvus_vector_index.py
@@ -1,13 +1,14 @@
 from typing import Any, List, cast
 
-from core.index.base import BaseIndex
-from core.index.vector_index.base import BaseVectorIndex
-from core.vector_store.milvus_vector_store import MilvusVectorStore
 from langchain.embeddings.base import Embeddings
 from langchain.schema import Document
 from langchain.vectorstores import VectorStore
-from models.dataset import Dataset
 from pydantic import BaseModel, root_validator
+
+from core.index.base import BaseIndex
+from core.index.vector_index.base import BaseVectorIndex
+from core.vector_store.milvus_vector_store import MilvusVectorStore
+from models.dataset import Dataset
 
 
 class MilvusConfig(BaseModel):

--- a/api/core/index/vector_index/qdrant_vector_index.py
+++ b/api/core/index/vector_index/qdrant_vector_index.py
@@ -2,16 +2,17 @@ import os
 from typing import Any, List, Optional, cast
 
 import qdrant_client
+from langchain.embeddings.base import Embeddings
+from langchain.schema import Document
+from langchain.vectorstores import VectorStore
+from pydantic import BaseModel
+from qdrant_client.http.models import HnswConfigDiff
+
 from core.index.base import BaseIndex
 from core.index.vector_index.base import BaseVectorIndex
 from core.vector_store.qdrant_vector_store import QdrantVectorStore
 from extensions.ext_database import db
-from langchain.embeddings.base import Embeddings
-from langchain.schema import BaseRetriever, Document
-from langchain.vectorstores import VectorStore
 from models.dataset import Dataset, DatasetCollectionBinding
-from pydantic import BaseModel
-from qdrant_client.http.models import HnswConfigDiff
 
 
 class QdrantConfig(BaseModel):

--- a/api/core/index/vector_index/vector_index.py
+++ b/api/core/index/vector_index/vector_index.py
@@ -1,9 +1,10 @@
 import json
 
-from core.index.vector_index.base import BaseVectorIndex
-from extensions.ext_database import db
 from flask import current_app
 from langchain.embeddings.base import Embeddings
+
+from core.index.vector_index.base import BaseVectorIndex
+from extensions.ext_database import db
 from models.dataset import Dataset, Document
 
 

--- a/api/core/index/vector_index/weaviate_vector_index.py
+++ b/api/core/index/vector_index/weaviate_vector_index.py
@@ -2,14 +2,15 @@ from typing import Any, List, Optional, cast
 
 import requests
 import weaviate
+from langchain.embeddings.base import Embeddings
+from langchain.schema import Document
+from langchain.vectorstores import VectorStore
+from pydantic import BaseModel, root_validator
+
 from core.index.base import BaseIndex
 from core.index.vector_index.base import BaseVectorIndex
 from core.vector_store.weaviate_vector_store import WeaviateVectorStore
-from langchain.embeddings.base import Embeddings
-from langchain.schema import BaseRetriever, Document
-from langchain.vectorstores import VectorStore
 from models.dataset import Dataset
-from pydantic import BaseModel, root_validator
 
 
 class WeaviateConfig(BaseModel):

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -5,7 +5,13 @@ import re
 import threading
 import time
 import uuid
-from typing import AbstractSet, Any, Collection, List, Literal, Optional, Type, Union, cast
+from typing import List, Optional, cast
+
+from flask import Flask, current_app
+from flask_login import current_user
+from langchain.schema import Document
+from langchain.text_splitter import TextSplitter
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from core.data_loader.file_extractor import FileExtractor
 from core.data_loader.loader.notion import NotionLoader
@@ -17,22 +23,15 @@ from core.model_manager import ModelInstance, ModelManager
 from core.model_runtime.entities.model_entities import ModelType, PriceType
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
-from core.model_runtime.model_providers.__base.tokenizers.gpt2_tokenzier import GPT2Tokenizer
 from core.spiltter.fixed_text_splitter import EnhanceRecursiveCharacterTextSplitter, FixedRecursiveCharacterTextSplitter
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from extensions.ext_storage import storage
-from flask import Flask, current_app
-from flask_login import current_user
-from langchain.schema import Document
-from langchain.text_splitter import TS, TextSplitter, TokenTextSplitter
 from libs import helper
-from models.dataset import Dataset, DatasetProcessRule
+from models.dataset import Dataset, DatasetProcessRule, DocumentSegment
 from models.dataset import Document as DatasetDocument
-from models.dataset import DocumentSegment
 from models.model import UploadFile
 from models.source import DataSourceBinding
-from sqlalchemy.orm.exc import ObjectDeletedError
 
 
 class IndexingRunner:

--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -1,7 +1,12 @@
 from core.file.message_file_parser import MessageFileParser
 from core.model_manager import ModelInstance
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageRole,
-                                                          TextPromptMessageContent, UserPromptMessage)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageRole,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.model_providers import model_provider_factory
 from extensions.ext_database import db

--- a/api/core/model_runtime/entities/llm_entities.py
+++ b/api/core/model_runtime/entities/llm_entities.py
@@ -2,9 +2,10 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
+from pydantic import BaseModel
+
 from core.model_runtime.entities.message_entities import AssistantPromptMessage, PromptMessage
 from core.model_runtime.entities.model_entities import ModelUsage, PriceInfo
-from pydantic import BaseModel
 
 
 class LLMMode(Enum):

--- a/api/core/model_runtime/entities/model_entities.py
+++ b/api/core/model_runtime/entities/model_entities.py
@@ -2,8 +2,9 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Optional
 
-from core.model_runtime.entities.common_entities import I18nObject
 from pydantic import BaseModel
+
+from core.model_runtime.entities.common_entities import I18nObject
 
 
 class ModelType(Enum):

--- a/api/core/model_runtime/entities/provider_entities.py
+++ b/api/core/model_runtime/entities/provider_entities.py
@@ -1,9 +1,10 @@
 from enum import Enum
 from typing import Optional
 
+from pydantic import BaseModel
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, ModelType, ProviderModel
-from pydantic import BaseModel
 
 
 class ConfigurateMethod(Enum):

--- a/api/core/model_runtime/entities/text_embedding_entities.py
+++ b/api/core/model_runtime/entities/text_embedding_entities.py
@@ -1,7 +1,8 @@
 from decimal import Decimal
 
-from core.model_runtime.entities.model_entities import ModelUsage
 from pydantic import BaseModel
+
+from core.model_runtime.entities.model_entities import ModelUsage
 
 
 class EmbeddingUsage(ModelUsage):

--- a/api/core/model_runtime/model_providers/__base/ai_model.py
+++ b/api/core/model_runtime/model_providers/__base/ai_model.py
@@ -4,10 +4,18 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import yaml
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.defaults import PARAMETER_RULE_TEMPLATE
-from core.model_runtime.entities.model_entities import (AIModelEntity, DefaultParameterName, FetchFrom, ModelType,
-                                                        PriceConfig, PriceInfo, PriceType)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    DefaultParameterName,
+    FetchFrom,
+    ModelType,
+    PriceConfig,
+    PriceInfo,
+    PriceType,
+)
 from core.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
 from core.model_runtime.model_providers.__base.tokenizers.gpt2_tokenzier import GPT2Tokenizer
 

--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -9,8 +9,13 @@ from core.model_runtime.callbacks.base_callback import Callback
 from core.model_runtime.callbacks.logging_callback import LoggingCallback
 from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from core.model_runtime.entities.message_entities import AssistantPromptMessage, PromptMessage, PromptMessageTool
-from core.model_runtime.entities.model_entities import (ModelPropertyKey, ModelType, ParameterRule, ParameterType,
-                                                        PriceType)
+from core.model_runtime.entities.model_entities import (
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+    PriceType,
+)
 from core.model_runtime.model_providers.__base.ai_model import AIModel
 
 logger = logging.getLogger(__name__)

--- a/api/core/model_runtime/model_providers/__base/model_provider.py
+++ b/api/core/model_runtime/model_providers/__base/model_provider.py
@@ -1,9 +1,10 @@
 import importlib
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict
 
 import yaml
+
 from core.model_runtime.entities.model_entities import AIModelEntity, ModelType
 from core.model_runtime.entities.provider_entities import ProviderEntity
 from core.model_runtime.model_providers.__base.ai_model import AIModel

--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -3,14 +3,26 @@ from typing import Generator, List, Optional, Union
 import anthropic
 from anthropic import Anthropic, Stream
 from anthropic.types import Completion, completion_create_params
+from httpx import Timeout
+
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from httpx import Timeout
 
 
 class AnthropicLargeLanguageModel(LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/azure_openai/_common.py
+++ b/api/core/model_runtime/model_providers/azure_openai/_common.py
@@ -1,8 +1,15 @@
 import openai
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
-from core.model_runtime.model_providers.azure_openai._constant import AZURE_OPENAI_API_VERSION
 from httpx import Timeout
+
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+from core.model_runtime.model_providers.azure_openai._constant import AZURE_OPENAI_API_VERSION
 
 
 class _CommonAzureOpenAI:

--- a/api/core/model_runtime/model_providers/azure_openai/_constant.py
+++ b/api/core/model_runtime/model_providers/azure_openai/_constant.py
@@ -1,9 +1,18 @@
+from pydantic import BaseModel
+
 from core.model_runtime.entities.defaults import PARAMETER_RULE_TEMPLATE
 from core.model_runtime.entities.llm_entities import LLMMode
-from core.model_runtime.entities.model_entities import (AIModelEntity, DefaultParameterName, FetchFrom, I18nObject,
-                                                        ModelFeature, ModelPropertyKey, ModelType, ParameterRule,
-                                                        PriceConfig)
-from pydantic import BaseModel
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    DefaultParameterName,
+    FetchFrom,
+    I18nObject,
+    ModelFeature,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    PriceConfig,
+)
 
 AZURE_OPENAI_API_VERSION = '2023-12-01-preview'
 

--- a/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
@@ -3,21 +3,29 @@ import logging
 from typing import Generator, List, Optional, Union, cast
 
 import tiktoken
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, PromptMessageContentType, PromptMessageTool,
-                                                          SystemPromptMessage, TextPromptMessageContent,
-                                                          ToolPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import AIModelEntity, ModelPropertyKey
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from core.model_runtime.model_providers.azure_openai._common import _CommonAzureOpenAI
-from core.model_runtime.model_providers.azure_openai._constant import LLM_BASE_MODELS, AzureBaseModel
 from openai import AzureOpenAI, Stream
 from openai.types import Completion
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaFunctionCall, ChoiceDeltaToolCall
 from openai.types.chat.chat_completion_message import FunctionCall
+
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageTool,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import AIModelEntity, ModelPropertyKey
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.azure_openai._common import _CommonAzureOpenAI
+from core.model_runtime.model_providers.azure_openai._constant import LLM_BASE_MODELS, AzureBaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/model_runtime/model_providers/azure_openai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/azure_openai/text_embedding/text_embedding.py
@@ -5,13 +5,14 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import tiktoken
+from openai import AzureOpenAI
+
 from core.model_runtime.entities.model_entities import AIModelEntity, PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.azure_openai._common import _CommonAzureOpenAI
 from core.model_runtime.model_providers.azure_openai._constant import EMBEDDING_BASE_MODELS, AzureBaseModel
-from openai import AzureOpenAI
 
 
 class AzureOpenAITextEmbeddingModel(_CommonAzureOpenAI, TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan_turbo.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan_turbo.py
@@ -1,17 +1,18 @@
 from enum import Enum
 from hashlib import md5
 from json import dumps, loads
-from os.path import join
-from time import time
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import Any, Dict, Generator, List, Union
 
-from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (BadRequestError,
-                                                                                   InsufficientAccountBalance,
-                                                                                   InternalServerError,
-                                                                                   InvalidAPIKeyError,
-                                                                                   InvalidAuthenticationError,
-                                                                                   RateLimitReachedError)
 from requests import post
+
+from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (
+    BadRequestError,
+    InsufficientAccountBalance,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 
 class BaichuanMessage:

--- a/api/core/model_runtime/model_providers/baichuan/llm/llm.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/llm.py
@@ -1,20 +1,33 @@
-from typing import Generator, List, Optional, Union, cast
+from typing import Generator, List, cast
 
-from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.baichuan.llm.baichuan_tokenizer import BaichuanTokenizer
 from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo import BaichuanMessage, BaichuanModel
-from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (BadRequestError,
-                                                                                   InsufficientAccountBalance,
-                                                                                   InternalServerError,
-                                                                                   InvalidAPIKeyError,
-                                                                                   InvalidAuthenticationError,
-                                                                                   RateLimitReachedError)
+from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (
+    BadRequestError,
+    InsufficientAccountBalance,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 
 class BaichuanLarguageModel(LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/baichuan/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/baichuan/text_embedding/text_embedding.py
@@ -1,21 +1,30 @@
 import time
-from json import dumps, loads
+from json import dumps
 from typing import Optional, Tuple
+
+from requests import post
 
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.baichuan.llm.baichuan_tokenizer import BaichuanTokenizer
-from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (BadRequestError,
-                                                                                   InsufficientAccountBalance,
-                                                                                   InternalServerError,
-                                                                                   InvalidAPIKeyError,
-                                                                                   InvalidAuthenticationError,
-                                                                                   RateLimitReachedError)
-from requests import post
+from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (
+    BadRequestError,
+    InsufficientAccountBalance,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 
 class BaichuanTextEmbeddingModel(TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -4,13 +4,30 @@ from typing import Generator, List, Optional, Union
 
 import boto3
 from botocore.config import Config
-from botocore.exceptions import (ClientError, EndpointConnectionError, NoRegionError, ServiceNotInRegionError,
-                                 UnknownServiceError)
+from botocore.exceptions import (
+    ClientError,
+    EndpointConnectionError,
+    NoRegionError,
+    ServiceNotInRegionError,
+    UnknownServiceError,
+)
+
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 

--- a/api/core/model_runtime/model_providers/chatglm/llm/llm.py
+++ b/api/core/model_runtime/model_providers/chatglm/llm/llm.py
@@ -1,23 +1,44 @@
 import logging
-from json import dumps
 from os.path import join
 from typing import Generator, List, Optional, cast
 
+from httpx import Timeout
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AuthenticationError,
+    ConflictError,
+    InternalServerError,
+    NotFoundError,
+    OpenAI,
+    PermissionDeniedError,
+    RateLimitError,
+    Stream,
+    UnprocessableEntityError,
+)
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.chat_completion_message import FunctionCall
+
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageFunction,
-                                                          PromptMessageTool, SystemPromptMessage, ToolPromptMessage,
-                                                          UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.utils import helper
-from httpx import Timeout
-from openai import (APIConnectionError, APITimeoutError, AuthenticationError, ConflictError, InternalServerError,
-                    NotFoundError, OpenAI, PermissionDeniedError, RateLimitError, Stream, UnprocessableEntityError)
-from openai.types.chat import ChatCompletion, ChatCompletionChunk
-from openai.types.chat.chat_completion_message import FunctionCall
-from requests import post
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/model_runtime/model_providers/cohere/llm/llm.py
+++ b/api/core/model_runtime/model_providers/cohere/llm/llm.py
@@ -5,14 +5,26 @@ import cohere
 from cohere.responses import Chat, Generations
 from cohere.responses.chat import StreamEnd, StreamingChat, StreamTextGeneration
 from cohere.responses.generation import StreamingGenerations, StreamingText
+
 from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage,
-                                                          PromptMessageContentType, PromptMessageTool,
-                                                          SystemPromptMessage, TextPromptMessageContent,
-                                                          UserPromptMessage)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageTool,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, I18nObject, ModelType
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 

--- a/api/core/model_runtime/model_providers/cohere/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/cohere/rerank/rerank.py
@@ -1,9 +1,16 @@
 from typing import Optional
 
 import cohere
+
 from core.model_runtime.entities.rerank_entities import RerankDocument, RerankResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.rerank_model import RerankModel
 

--- a/api/core/model_runtime/model_providers/cohere/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/cohere/text_embedding/text_embedding.py
@@ -4,10 +4,17 @@ from typing import Optional, Tuple
 import cohere
 import numpy as np
 from cohere.responses import Tokens
+
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -4,17 +4,29 @@ from typing import Generator, List, Optional, Union
 import google.api_core.exceptions as exceptions
 import google.generativeai as genai
 import google.generativeai.client as client
-from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage,
-                                                          PromptMessageContentType, PromptMessageRole,
-                                                          PromptMessageTool, SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers import google
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from google.generativeai.types import ContentType, GenerateContentResponse, HarmBlockThreshold, HarmCategory
 from google.generativeai.types.content_types import to_part
+
+from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageRole,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/model_runtime/model_providers/huggingface_hub/_common.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/_common.py
@@ -1,5 +1,6 @@
-from core.model_runtime.errors.invoke import InvokeBadRequestError, InvokeError
 from huggingface_hub.utils import BadRequestError, HfHubHTTPError
+
+from core.model_runtime.errors.invoke import InvokeBadRequestError, InvokeError
 
 
 class _CommonHuggingfaceHub:

--- a/api/core/model_runtime/model_providers/huggingface_hub/llm/llm.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/llm/llm.py
@@ -1,18 +1,30 @@
 from typing import Generator, List, Optional, Union
 
-from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.defaults import PARAMETER_RULE_TEMPLATE
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, DefaultParameterName, FetchFrom,
-                                                        ModelPropertyKey, ModelType, ParameterRule)
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from core.model_runtime.model_providers.huggingface_hub._common import _CommonHuggingfaceHub
 from huggingface_hub import InferenceClient
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import BadRequestError
+
+from core.model_runtime.entities.common_entities import I18nObject
+from core.model_runtime.entities.defaults import PARAMETER_RULE_TEMPLATE
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    DefaultParameterName,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+)
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.huggingface_hub._common import _CommonHuggingfaceHub
 
 
 class HuggingfaceHubLargeLanguageModel(_CommonHuggingfaceHub, LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/huggingface_hub/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/text_embedding/text_embedding.py
@@ -4,13 +4,14 @@ from typing import Optional
 
 import numpy as np
 import requests
+from huggingface_hub import HfApi, InferenceClient
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelType, PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.huggingface_hub._common import _CommonHuggingfaceHub
-from huggingface_hub import HfApi, InferenceClient
 
 HUGGINGFACE_ENDPOINT_API = 'https://api.endpoints.huggingface.cloud/v2/endpoint/'
 

--- a/api/core/model_runtime/model_providers/jina/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/jina/text_embedding/text_embedding.py
@@ -2,14 +2,21 @@ import time
 from json import JSONDecodeError, dumps
 from typing import Optional
 
+from requests import post
+
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.jina.text_embedding.jina_tokenizer import JinaTokenizer
-from requests import post
 
 
 class JinaTextEmbeddingModel(TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/localai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/localai/llm/llm.py
@@ -1,23 +1,52 @@
 from os.path import join
-from typing import Generator, List, Optional, Union, cast
+from typing import Generator, List, cast
 
-from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, FetchFrom, ModelPropertyKey, ModelType,
-                                                        ParameterRule, ParameterType)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from core.model_runtime.utils import helper
 from httpx import Timeout
-from openai import (APIConnectionError, APITimeoutError, AuthenticationError, ConflictError, InternalServerError,
-                    NotFoundError, OpenAI, PermissionDeniedError, RateLimitError, Stream, UnprocessableEntityError)
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AuthenticationError,
+    ConflictError,
+    InternalServerError,
+    NotFoundError,
+    OpenAI,
+    PermissionDeniedError,
+    RateLimitError,
+    Stream,
+    UnprocessableEntityError,
+)
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.chat_completion_message import FunctionCall
 from openai.types.completion import Completion
+
+from core.model_runtime.entities.common_entities import I18nObject
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.utils import helper
 
 
 class LocalAILarguageModel(LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/localai/localai.py
+++ b/api/core/model_runtime/model_providers/localai/localai.py
@@ -1,7 +1,5 @@
 import logging
 
-from core.model_runtime.entities.model_entities import ModelType
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)

--- a/api/core/model_runtime/model_providers/localai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/localai/text_embedding/text_embedding.py
@@ -3,13 +3,20 @@ from json import JSONDecodeError, dumps
 from os.path import join
 from typing import Optional
 
+from requests import post
+
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
-from requests import post
 
 
 class LocalAITextEmbeddingModel(TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/minimax/llm/chat_completion.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/chat_completion.py
@@ -1,13 +1,17 @@
-from hashlib import md5
 from json import dumps, loads
-from time import time
 from typing import Any, Dict, Generator, List, Union
 
-from core.model_runtime.model_providers.minimax.llm.errors import (BadRequestError, InsufficientAccountBalanceError,
-                                                                   InternalServerError, InvalidAPIKeyError,
-                                                                   InvalidAuthenticationError, RateLimitReachedError)
-from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 from requests import Response, post
+
+from core.model_runtime.model_providers.minimax.llm.errors import (
+    BadRequestError,
+    InsufficientAccountBalanceError,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
+from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 
 
 class MinimaxChatCompletion(object):

--- a/api/core/model_runtime/model_providers/minimax/llm/chat_completion_pro.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/chat_completion_pro.py
@@ -1,13 +1,17 @@
-from hashlib import md5
 from json import dumps, loads
-from time import time
 from typing import Any, Dict, Generator, List, Union
 
-from core.model_runtime.model_providers.minimax.llm.errors import (BadRequestError, InsufficientAccountBalanceError,
-                                                                   InternalServerError, InvalidAPIKeyError,
-                                                                   InvalidAuthenticationError, RateLimitReachedError)
-from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 from requests import Response, post
+
+from core.model_runtime.model_providers.minimax.llm.errors import (
+    BadRequestError,
+    InsufficientAccountBalanceError,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
+from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 
 
 class MinimaxChatCompletionPro(object):

--- a/api/core/model_runtime/model_providers/minimax/llm/llm.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/llm.py
@@ -1,17 +1,34 @@
 from typing import Generator, List
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, ToolPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.minimax.llm.chat_completion import MinimaxChatCompletion
 from core.model_runtime.model_providers.minimax.llm.chat_completion_pro import MinimaxChatCompletionPro
-from core.model_runtime.model_providers.minimax.llm.errors import (BadRequestError, InsufficientAccountBalanceError,
-                                                                   InternalServerError, InvalidAPIKeyError,
-                                                                   InvalidAuthenticationError, RateLimitReachedError)
+from core.model_runtime.model_providers.minimax.llm.errors import (
+    BadRequestError,
+    InsufficientAccountBalanceError,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 
 

--- a/api/core/model_runtime/model_providers/minimax/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/minimax/text_embedding/text_embedding.py
@@ -1,17 +1,29 @@
 import time
-from json import dumps, loads
+from json import dumps
 from typing import Optional
+
+from requests import post
 
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
-from core.model_runtime.model_providers.minimax.llm.errors import (BadRequestError, InsufficientAccountBalanceError,
-                                                                   InternalServerError, InvalidAPIKeyError,
-                                                                   InvalidAuthenticationError, RateLimitReachedError)
-from requests import post
+from core.model_runtime.model_providers.minimax.llm.errors import (
+    BadRequestError,
+    InsufficientAccountBalanceError,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 
 class MinimaxTextEmbeddingModel(TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -5,12 +5,13 @@ from collections import OrderedDict
 from typing import Optional
 
 import yaml
+from pydantic import BaseModel
+
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.entities.provider_entities import ProviderConfig, ProviderEntity, SimpleProviderEntity
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 from core.model_runtime.schema_validators.model_credential_schema_validator import ModelCredentialSchemaValidator
 from core.model_runtime.schema_validators.provider_credential_schema_validator import ProviderCredentialSchemaValidator
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/model_runtime/model_providers/moonshot/llm/llm.py
+++ b/api/core/model_runtime/model_providers/moonshot/llm/llm.py
@@ -1,7 +1,7 @@
-from typing import List, Optional, Union, Generator
+from typing import Generator, List, Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult
-from core.model_runtime.entities.message_entities import (PromptMessage, PromptMessageTool)
+from core.model_runtime.entities.message_entities import PromptMessage, PromptMessageTool
 from core.model_runtime.model_providers.openai_api_compatible.llm.llm import OAIAPICompatLargeLanguageModel
 
 

--- a/api/core/model_runtime/model_providers/moonshot/moonshot.py
+++ b/api/core/model_runtime/model_providers/moonshot/moonshot.py
@@ -1,6 +1,6 @@
 import logging
 
-from core.model_runtime.entities.model_entities import AIModelEntity, ModelType
+from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 

--- a/api/core/model_runtime/model_providers/ollama/llm/llm.py
+++ b/api/core/model_runtime/model_providers/ollama/llm/llm.py
@@ -6,16 +6,38 @@ from typing import Generator, List, Optional, Union, cast
 from urllib.parse import urljoin
 
 import requests
+
 from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, PromptMessageContentType, PromptMessageTool,
-                                                          SystemPromptMessage, TextPromptMessageContent,
-                                                          UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, DefaultParameterName, FetchFrom, I18nObject,
-                                                        ModelFeature, ModelPropertyKey, ModelType, ParameterRule,
-                                                        ParameterType, PriceConfig)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageTool,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    DefaultParameterName,
+    FetchFrom,
+    I18nObject,
+    ModelFeature,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+    PriceConfig,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 

--- a/api/core/model_runtime/model_providers/ollama/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/ollama/text_embedding/text_embedding.py
@@ -7,12 +7,25 @@ from urllib.parse import urljoin
 
 import numpy as np
 import requests
+
 from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.model_entities import (AIModelEntity, FetchFrom, ModelPropertyKey, ModelType,
-                                                        PriceConfig, PriceType)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    PriceConfig,
+    PriceType,
+)
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 

--- a/api/core/model_runtime/model_providers/openai/_common.py
+++ b/api/core/model_runtime/model_providers/openai/_common.py
@@ -1,7 +1,14 @@
 import openai
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
 from httpx import Timeout
+
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 
 
 class _CommonOpenAI:

--- a/api/core/model_runtime/model_providers/openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai/llm/llm.py
@@ -2,22 +2,28 @@ import logging
 from typing import Generator, List, Optional, Union, cast
 
 import tiktoken
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, PromptMessageContentType,
-                                                          PromptMessageFunction, PromptMessageTool, SystemPromptMessage,
-                                                          TextPromptMessageContent, ToolPromptMessage,
-                                                          UserPromptMessage)
-from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, I18nObject, ModelType, PriceConfig
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from core.model_runtime.model_providers.openai._common import _CommonOpenAI
-from core.model_runtime.utils import helper
 from openai import OpenAI, Stream
 from openai.types import Completion
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaFunctionCall, ChoiceDeltaToolCall
 from openai.types.chat.chat_completion_message import FunctionCall
+
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageTool,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, I18nObject, ModelType, PriceConfig
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.openai._common import _CommonOpenAI
 
 logger = logging.getLogger(__name__)
 

--- a/api/core/model_runtime/model_providers/openai/moderation/moderation.py
+++ b/api/core/model_runtime/model_providers/openai/moderation/moderation.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
+from openai import OpenAI
+from openai.types import ModerationCreateResponse
+
 from core.model_runtime.entities.model_entities import ModelPropertyKey
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.moderation_model import ModerationModel
 from core.model_runtime.model_providers.openai._common import _CommonOpenAI
-from openai import OpenAI
-from openai.types import ModerationCreateResponse
 
 
 class OpenAIModerationModel(_CommonOpenAI, ModerationModel):

--- a/api/core/model_runtime/model_providers/openai/speech2text/speech2text.py
+++ b/api/core/model_runtime/model_providers/openai/speech2text/speech2text.py
@@ -1,9 +1,10 @@
 from typing import IO, Optional
 
+from openai import OpenAI
+
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.speech2text_model import Speech2TextModel
 from core.model_runtime.model_providers.openai._common import _CommonOpenAI
-from openai import OpenAI
 
 
 class OpenAISpeech2TextModel(_CommonOpenAI, Speech2TextModel):

--- a/api/core/model_runtime/model_providers/openai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/openai/text_embedding/text_embedding.py
@@ -4,12 +4,13 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import tiktoken
+from openai import OpenAI
+
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.openai._common import _CommonOpenAI
-from openai import OpenAI
 
 
 class OpenAITextEmbeddingModel(_CommonOpenAI, TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/openai/tts/tts.py
+++ b/api/core/model_runtime/model_providers/openai/tts/tts.py
@@ -3,13 +3,14 @@ from functools import reduce
 from io import BytesIO
 from typing import Optional
 
+from flask import Response, stream_with_context
+from openai import OpenAI
+from pydub import AudioSegment
+
 from core.model_runtime.errors.invoke import InvokeBadRequestError
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.tts_model import TTSModel
 from core.model_runtime.model_providers.openai._common import _CommonOpenAI
-from flask import Response, stream_with_context
-from openai import OpenAI
-from pydub import AudioSegment
 
 
 class OpenAIText2SpeechModel(_CommonOpenAI, TTSModel):

--- a/api/core/model_runtime/model_providers/openai_api_compatible/_common.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/_common.py
@@ -1,13 +1,14 @@
-from decimal import Decimal
 
 import requests
-from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.llm_entities import LLMMode
-from core.model_runtime.entities.model_entities import (AIModelEntity, DefaultParameterName, FetchFrom,
-                                                        ModelPropertyKey, ModelType, ParameterRule, ParameterType,
-                                                        PriceConfig)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 
 
 class _CommonOAI_API_Compat:

--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -5,15 +5,31 @@ from typing import Generator, List, Optional, Union, cast
 from urllib.parse import urljoin
 
 import requests
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, PromptMessageContent, PromptMessageContentType,
-                                                          PromptMessageFunction, PromptMessageTool, SystemPromptMessage,
-                                                          ToolPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, DefaultParameterName, FetchFrom,
-                                                        ModelPropertyKey, ModelType, ParameterRule, ParameterType,
-                                                        PriceConfig)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageContent,
+    PromptMessageContentType,
+    PromptMessageFunction,
+    PromptMessageTool,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    DefaultParameterName,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+    PriceConfig,
+)
 from core.model_runtime.errors.invoke import InvokeError
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel

--- a/api/core/model_runtime/model_providers/openai_api_compatible/openai_api_compatible.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/openai_api_compatible.py
@@ -1,7 +1,5 @@
 import logging
 
-from core.model_runtime.entities.model_entities import ModelType
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)

--- a/api/core/model_runtime/model_providers/openai_api_compatible/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/text_embedding/text_embedding.py
@@ -6,9 +6,16 @@ from urllib.parse import urljoin
 
 import numpy as np
 import requests
+
 from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.model_entities import (AIModelEntity, FetchFrom, ModelPropertyKey, ModelType,
-                                                        PriceConfig, PriceType)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    PriceConfig,
+    PriceType,
+)
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel

--- a/api/core/model_runtime/model_providers/openllm/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/llm.py
@@ -1,22 +1,40 @@
-from typing import Generator, List, Optional, Union
+from typing import Generator, List
 
 from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, FetchFrom, ModelPropertyKey, ModelType,
-                                                        ParameterRule, ParameterType)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.openllm.llm.openllm_generate import OpenLLMGenerate, OpenLLMGenerateMessage
-from core.model_runtime.model_providers.openllm.llm.openllm_generate_errors import (BadRequestError,
-                                                                                    InsufficientAccountBalanceError,
-                                                                                    InternalServerError,
-                                                                                    InvalidAPIKeyError,
-                                                                                    InvalidAuthenticationError,
-                                                                                    RateLimitReachedError)
+from core.model_runtime.model_providers.openllm.llm.openllm_generate_errors import (
+    BadRequestError,
+    InsufficientAccountBalanceError,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 
 class OpenLLMLargeLanguageModel(LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
@@ -2,14 +2,14 @@ from enum import Enum
 from json import dumps, loads
 from typing import Any, Dict, Generator, List, Union
 
-from core.model_runtime.model_providers.openllm.llm.openllm_generate_errors import (BadRequestError,
-                                                                                    InsufficientAccountBalanceError,
-                                                                                    InternalServerError,
-                                                                                    InvalidAPIKeyError,
-                                                                                    InvalidAuthenticationError,
-                                                                                    RateLimitReachedError)
 from requests import Response, post
 from requests.exceptions import ConnectionError, InvalidSchema, MissingSchema
+
+from core.model_runtime.model_providers.openllm.llm.openllm_generate_errors import (
+    BadRequestError,
+    InternalServerError,
+    InvalidAuthenticationError,
+)
 
 
 class OpenLLMGenerateMessage:

--- a/api/core/model_runtime/model_providers/openllm/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/openllm/text_embedding/text_embedding.py
@@ -1,15 +1,22 @@
 import time
-from json import dumps, loads
+from json import dumps
 from typing import Optional
+
+from requests import post
+from requests.exceptions import ConnectionError, InvalidSchema, MissingSchema
 
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
-from requests import post
-from requests.exceptions import ConnectionError, InvalidSchema, MissingSchema
 
 
 class OpenLLMTextEmbeddingModel(TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/replicate/_common.py
+++ b/api/core/model_runtime/model_providers/replicate/_common.py
@@ -1,5 +1,6 @@
-from core.model_runtime.errors.invoke import InvokeBadRequestError, InvokeError
 from replicate.exceptions import ModelError, ReplicateError
+
+from core.model_runtime.errors.invoke import InvokeBadRequestError, InvokeError
 
 
 class _CommonReplicate:

--- a/api/core/model_runtime/model_providers/replicate/llm/llm.py
+++ b/api/core/model_runtime/model_providers/replicate/llm/llm.py
@@ -1,17 +1,29 @@
 from typing import Generator, List, Optional, Union
 
-from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageRole,
-                                                          PromptMessageTool, SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, FetchFrom, ModelPropertyKey, ModelType,
-                                                        ParameterRule)
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from core.model_runtime.model_providers.replicate._common import _CommonReplicate
 from replicate import Client as ReplicateClient
 from replicate.exceptions import ReplicateError
 from replicate.prediction import Prediction
+
+from core.model_runtime.entities.common_entities import I18nObject
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageRole,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+)
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.replicate._common import _CommonReplicate
 
 
 class ReplicateLargeLanguageModel(_CommonReplicate, LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/replicate/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/replicate/text_embedding/text_embedding.py
@@ -2,13 +2,14 @@ import json
 import time
 from typing import Optional
 
+from replicate import Client as ReplicateClient
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelType, PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.replicate._common import _CommonReplicate
-from replicate import Client as ReplicateClient
 
 
 class ReplicateEmbeddingModel(_CommonReplicate, TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/spark/llm/llm.py
+++ b/api/core/model_runtime/model_providers/spark/llm/llm.py
@@ -2,10 +2,21 @@ import threading
 from typing import Generator, List, Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 

--- a/api/core/model_runtime/model_providers/spark/spark.py
+++ b/api/core/model_runtime/model_providers/spark/spark.py
@@ -1,7 +1,5 @@
 import logging
 
-from core.model_runtime.entities.model_entities import ModelType
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)

--- a/api/core/model_runtime/model_providers/togetherai/togetherai.py
+++ b/api/core/model_runtime/model_providers/togetherai/togetherai.py
@@ -1,7 +1,5 @@
 import logging
 
-from core.model_runtime.entities.model_entities import ModelType
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)

--- a/api/core/model_runtime/model_providers/tongyi/llm/llm.py
+++ b/api/core/model_runtime/model_providers/tongyi/llm/llm.py
@@ -1,17 +1,35 @@
 from typing import Generator, List, Optional, Union
 
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from dashscope import get_tokenizer
 from dashscope.api_entities.dashscope_response import DashScopeAPIResponse
-from dashscope.common.error import (AuthenticationError, InvalidParameter, RequestFailure, ServiceUnavailableError,
-                                    UnsupportedHTTPMethod, UnsupportedModel)
+from dashscope.common.error import (
+    AuthenticationError,
+    InvalidParameter,
+    RequestFailure,
+    ServiceUnavailableError,
+    UnsupportedHTTPMethod,
+    UnsupportedModel,
+)
 from langchain.llms.tongyi import generate_with_retry, stream_generate_with_retry
+
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 
 from ._client import EnhanceTongyi
 

--- a/api/core/model_runtime/model_providers/tongyi/tts/tts.py
+++ b/api/core/model_runtime/model_providers/tongyi/tts/tts.py
@@ -4,12 +4,13 @@ from io import BytesIO
 from typing import Optional
 
 import dashscope
+from flask import Response, stream_with_context
+from pydub import AudioSegment
+
 from core.model_runtime.errors.invoke import InvokeBadRequestError
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.tts_model import TTSModel
 from core.model_runtime.model_providers.tongyi._common import _CommonTongyi
-from flask import Response, stream_with_context
-from pydub import AudioSegment
 
 
 class TongyiText2SpeechModel(_CommonTongyi, TTSModel):

--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie_bot.py
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie_bot.py
@@ -4,12 +4,16 @@ from json import dumps, loads
 from threading import Lock
 from typing import Any, Dict, Generator, List, Union
 
-from core.model_runtime.entities.message_entities import PromptMessageTool
-from core.model_runtime.model_providers.wenxin.llm.ernie_bot_errors import (BadRequestError, InternalServerError,
-                                                                            InvalidAPIKeyError,
-                                                                            InvalidAuthenticationError,
-                                                                            RateLimitReachedError)
 from requests import Response, post
+
+from core.model_runtime.entities.message_entities import PromptMessageTool
+from core.model_runtime.model_providers.wenxin.llm.ernie_bot_errors import (
+    BadRequestError,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 # map api_key to access_token
 baidu_access_tokens: Dict[str, 'BaiduAccessToken'] = {}

--- a/api/core/model_runtime/model_providers/wenxin/llm/llm.py
+++ b/api/core/model_runtime/model_providers/wenxin/llm/llm.py
@@ -1,17 +1,32 @@
-from typing import Generator, List, Optional, Union, cast
+from typing import Generator, List, cast
 
-from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, UserPromptMessage)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.wenxin.llm.ernie_bot import BaiduAccessToken, ErnieBotModel, ErnieMessage
-from core.model_runtime.model_providers.wenxin.llm.ernie_bot_errors import (BadRequestError, InsufficientAccountBalance,
-                                                                            InternalServerError, InvalidAPIKeyError,
-                                                                            InvalidAuthenticationError,
-                                                                            RateLimitReachedError)
+from core.model_runtime.model_providers.wenxin.llm.ernie_bot_errors import (
+    BadRequestError,
+    InsufficientAccountBalance,
+    InternalServerError,
+    InvalidAPIKeyError,
+    InvalidAuthenticationError,
+    RateLimitReachedError,
+)
 
 
 class ErnieBotLarguageModel(LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/xinference/llm/llm.py
+++ b/api/core/model_runtime/model_providers/xinference/llm/llm.py
@@ -1,26 +1,62 @@
-from typing import Generator, Iterator, List, Optional, Union, cast
+from typing import Generator, Iterator, List, cast
 
-from core.model_runtime.entities.common_entities import I18nObject
-from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageTool,
-                                                          SystemPromptMessage, ToolPromptMessage, UserPromptMessage)
-from core.model_runtime.entities.model_entities import (AIModelEntity, FetchFrom, ModelFeature, ModelPropertyKey,
-                                                        ModelType, ParameterRule, ParameterType)
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
-from core.model_runtime.errors.validate import CredentialsValidateFailedError
-from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
-from core.model_runtime.model_providers.xinference.xinference_helper import (XinferenceHelper,
-                                                                             XinferenceModelExtraParameter)
-from core.model_runtime.utils import helper
-from openai import (APIConnectionError, APITimeoutError, AuthenticationError, ConflictError, InternalServerError,
-                    NotFoundError, OpenAI, PermissionDeniedError, RateLimitError, Stream, UnprocessableEntityError)
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AuthenticationError,
+    ConflictError,
+    InternalServerError,
+    NotFoundError,
+    OpenAI,
+    PermissionDeniedError,
+    RateLimitError,
+    UnprocessableEntityError,
+)
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaFunctionCall, ChoiceDeltaToolCall
 from openai.types.chat.chat_completion_message import FunctionCall
 from openai.types.completion import Completion
-from xinference_client.client.restful.restful_client import (Client, RESTfulChatglmCppChatModelHandle,
-                                                             RESTfulChatModelHandle, RESTfulGenerateModelHandle)
+from xinference_client.client.restful.restful_client import (
+    Client,
+    RESTfulChatglmCppChatModelHandle,
+    RESTfulChatModelHandle,
+    RESTfulGenerateModelHandle,
+)
+
+from core.model_runtime.entities.common_entities import I18nObject
+from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelFeature,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.xinference.xinference_helper import (
+    XinferenceHelper,
+    XinferenceModelExtraParameter,
+)
+from core.model_runtime.utils import helper
 
 
 class XinferenceAILargeLanguageModel(LargeLanguageModel):

--- a/api/core/model_runtime/model_providers/xinference/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/xinference/rerank/rerank.py
@@ -1,13 +1,20 @@
 from typing import Optional
 
+from xinference_client.client.restful.restful_client import Client, RESTfulRerankModelHandle
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelType
 from core.model_runtime.entities.rerank_entities import RerankDocument, RerankResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.rerank_model import RerankModel
-from xinference_client.client.restful.restful_client import Client, RESTfulRerankModelHandle
 
 
 class XinferenceRerankModel(RerankModel):

--- a/api/core/model_runtime/model_providers/xinference/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/xinference/text_embedding/text_embedding.py
@@ -1,15 +1,22 @@
 import time
 from typing import Optional
 
+from xinference_client.client.restful.restful_client import Client, RESTfulEmbeddingModelHandle
+
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelPropertyKey, ModelType, PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.xinference.xinference_helper import XinferenceHelper
-from xinference_client.client.restful.restful_client import Client, RESTfulEmbeddingModelHandle, RESTfulModelHandle
 
 
 class XinferenceTextEmbeddingModel(TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/xinference/xinference_helper.py
+++ b/api/core/model_runtime/model_providers/xinference/xinference_helper.py
@@ -3,7 +3,6 @@ from threading import Lock
 from time import time
 from typing import List
 
-from requests import get
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, MissingSchema, Timeout
 from requests.sessions import Session

--- a/api/core/model_runtime/model_providers/zhipuai/_common.py
+++ b/api/core/model_runtime/model_providers/zhipuai/_common.py
@@ -1,5 +1,11 @@
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeError, InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 
 
 class _CommonZhipuaiAI:

--- a/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
@@ -1,12 +1,15 @@
-import json
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import Generator, List, Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, ImagePromptMessageContent,
-                                                          PromptMessage, PromptMessageContentType, PromptMessageRole,
-                                                          PromptMessageTool, SystemPromptMessage,
-                                                          TextPromptMessageContent, ToolPromptMessage,
-                                                          UserPromptMessage)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageContentType,
+    PromptMessageRole,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.zhipuai._common import _CommonZhipuaiAI

--- a/api/core/model_runtime/model_providers/zhipuai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/zhipuai/text_embedding/text_embedding.py
@@ -7,7 +7,6 @@ from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.zhipuai._common import _CommonZhipuaiAI
 from core.model_runtime.model_providers.zhipuai.zhipuai_sdk._client import ZhipuAI
-from langchain.schema.language_model import _get_token_ids_default_method
 
 
 class ZhipuAITextEmbeddingModel(_CommonZhipuaiAI, TextEmbeddingModel):

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/files.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/files.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from ..core._base_api import BaseAPI
-from ..core._base_type import NOT_GIVEN, Body, FileTypes, Headers, NotGiven, Query
+from ..core._base_type import NOT_GIVEN, FileTypes, Headers, NotGiven
 from ..core._files import is_file_content
 from ..core._http_client import make_user_request_input
 from ..types.file_object import FileObject, ListOfFileObject

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/images.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/images.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import httpx
 

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_request_opt.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_request_opt.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Union, cast
+from typing import Any, Union
 
-import pydantic.generics
 from httpx import Timeout
 from pydantic import ConfigDict
 from typing_extensions import ClassVar, TypedDict, Unpack

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Union
 
 from pydantic import BaseModel
-from typing_extensions import Literal
 
 __all__ = ["FineTuningJob", "Error", "Hyperparameters", "ListOfFineTuningJob" ]
 

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job_event.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job_event.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Union
 
 from pydantic import BaseModel
-from typing_extensions import Literal
 
 __all__ = ["FineTuningJobEvent", "Metric", "JobEvent"]
 

--- a/api/core/moderation/api/api.py
+++ b/api/core/moderation/api/api.py
@@ -1,9 +1,10 @@
+from pydantic import BaseModel
+
 from core.extension.api_based_extension_requestor import APIBasedExtensionPoint, APIBasedExtensionRequestor
 from core.helper.encrypter import decrypt_token
 from core.moderation.base import Moderation, ModerationAction, ModerationInputsResult, ModerationOutputsResult
 from extensions.ext_database import db
 from models.api_based_extension import APIBasedExtension
-from pydantic import BaseModel
 
 
 class ModerationInputParams(BaseModel):

--- a/api/core/moderation/base.py
+++ b/api/core/moderation/base.py
@@ -2,8 +2,9 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Optional
 
-from core.extension.extensible import Extensible, ExtensionModule
 from pydantic import BaseModel
+
+from core.extension.extensible import Extensible, ExtensionModule
 
 
 class ModerationAction(Enum):

--- a/api/core/prompt/output_parser/rule_config_generator.py
+++ b/api/core/prompt/output_parser/rule_config_generator.py
@@ -1,7 +1,8 @@
 from typing import Any
 
-from core.prompt.prompts import RULE_CONFIG_GENERATE_TEMPLATE
 from langchain.schema import BaseOutputParser, OutputParserException
+
+from core.prompt.prompts import RULE_CONFIG_GENERATE_TEMPLATE
 from libs.json_in_md_parser import parse_and_check_json_markdown
 
 

--- a/api/core/prompt/output_parser/suggested_questions_after_answer.py
+++ b/api/core/prompt/output_parser/suggested_questions_after_answer.py
@@ -2,9 +2,10 @@ import json
 import re
 from typing import Any
 
+from langchain.schema import BaseOutputParser
+
 from core.model_runtime.errors.invoke import InvokeError
 from core.prompt.prompts import SUGGESTED_QUESTIONS_AFTER_ANSWER_INSTRUCTION_PROMPT
-from langchain.schema import BaseOutputParser
 
 
 class SuggestedQuestionsAfterAnswerOutputParser(BaseOutputParser):

--- a/api/core/prompt/prompt_transform.py
+++ b/api/core/prompt/prompt_transform.py
@@ -4,13 +4,21 @@ import os
 import re
 from typing import List, Optional, Tuple, cast
 
-from core.entities.application_entities import (AdvancedCompletionPromptTemplateEntity, ModelConfigEntity,
-                                                PromptTemplateEntity)
+from core.entities.application_entities import (
+    AdvancedCompletionPromptTemplateEntity,
+    ModelConfigEntity,
+    PromptTemplateEntity,
+)
 from core.file.file_obj import FileObj
 from core.memory.token_buffer_memory import TokenBufferMemory
-from core.model_runtime.entities.message_entities import (AssistantPromptMessage, PromptMessage, PromptMessageRole,
-                                                          SystemPromptMessage, TextPromptMessageContent,
-                                                          UserPromptMessage)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageRole,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
 from core.model_runtime.entities.model_entities import ModelPropertyKey
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.prompt.prompt_builder import PromptBuilder

--- a/api/core/provider_manager.py
+++ b/api/core/provider_manager.py
@@ -3,21 +3,36 @@ from collections import defaultdict
 from json import JSONDecodeError
 from typing import Optional
 
+from sqlalchemy.exc import IntegrityError
+
 from core.entities.model_entities import DefaultModelEntity, DefaultModelProviderEntity
 from core.entities.provider_configuration import ProviderConfiguration, ProviderConfigurations, ProviderModelBundle
-from core.entities.provider_entities import (CustomConfiguration, CustomModelConfiguration, CustomProviderConfiguration,
-                                             QuotaConfiguration, SystemConfiguration)
+from core.entities.provider_entities import (
+    CustomConfiguration,
+    CustomModelConfiguration,
+    CustomProviderConfiguration,
+    QuotaConfiguration,
+    SystemConfiguration,
+)
 from core.helper import encrypter
 from core.helper.model_provider_cache import ProviderCredentialsCache, ProviderCredentialsCacheType
 from core.model_runtime.entities.model_entities import ModelType
-from core.model_runtime.entities.provider_entities import (ConfigurateMethod, CredentialFormSchema, FormType,
-                                                           ProviderEntity)
+from core.model_runtime.entities.provider_entities import (
+    CredentialFormSchema,
+    FormType,
+    ProviderEntity,
+)
 from core.model_runtime.model_providers import model_provider_factory
 from extensions import ext_hosting_provider
 from extensions.ext_database import db
-from models.provider import (Provider, ProviderModel, ProviderQuotaType, ProviderType, TenantDefaultModel,
-                             TenantPreferredModelProvider)
-from sqlalchemy.exc import IntegrityError
+from models.provider import (
+    Provider,
+    ProviderModel,
+    ProviderQuotaType,
+    ProviderType,
+    TenantDefaultModel,
+    TenantPreferredModelProvider,
+)
 
 
 class ProviderManager:

--- a/api/core/rerank/rerank.py
+++ b/api/core/rerank/rerank.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
-from core.model_manager import ModelInstance
 from langchain.schema import Document
+
+from core.model_manager import ModelInstance
 
 
 class RerankRunner:

--- a/api/core/spiltter/fixed_text_splitter.py
+++ b/api/core/spiltter/fixed_text_splitter.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, cast
 
+from langchain.text_splitter import (
+    TS,
+    AbstractSet,
+    Collection,
+    Literal,
+    RecursiveCharacterTextSplitter,
+    TokenTextSplitter,
+    Type,
+    Union,
+)
+
 from core.model_manager import ModelInstance
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.__base.tokenizers.gpt2_tokenzier import GPT2Tokenizer
-from langchain.text_splitter import (TS, AbstractSet, Collection, Literal, RecursiveCharacterTextSplitter,
-                                     TokenTextSplitter, Type, Union)
 
 
 class EnhanceRecursiveCharacterTextSplitter(RecursiveCharacterTextSplitter):

--- a/api/core/tool/web_reader_tool.py
+++ b/api/core/tool/web_reader_tool.py
@@ -11,10 +11,6 @@ from typing import Any, Type
 
 import requests
 from bs4 import BeautifulSoup, CData, Comment, NavigableString
-from core.chain.llm_chain import LLMChain
-from core.data_loader import file_extractor
-from core.data_loader.file_extractor import FileExtractor
-from core.entities.application_entities import ModelConfigEntity
 from langchain.chains import RefineDocumentsChain
 from langchain.chains.summarize import refine_prompts
 from langchain.schema import Document
@@ -23,6 +19,11 @@ from langchain.tools.base import BaseTool
 from newspaper import Article
 from pydantic import BaseModel, Field
 from regex import regex
+
+from core.chain.llm_chain import LLMChain
+from core.data_loader import file_extractor
+from core.data_loader.file_extractor import FileExtractor
+from core.entities.application_entities import ModelConfigEntity
 
 FULL_TEMPLATE = """
 TITLE: {title}

--- a/api/core/tools/entities/tool_bundle.py
+++ b/api/core/tools/entities/tool_bundle.py
@@ -1,7 +1,8 @@
 from typing import Any, Dict, List, Optional
 
-from core.tools.entities.tool_entities import ToolParameter, ToolProviderType
 from pydantic import BaseModel
+
+from core.tools.entities.tool_entities import ToolParameter, ToolProviderType
 
 
 class ApiBasedToolBundle(BaseModel):

--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union, cast
 
-from core.tools.entities.common_entities import I18nObject
 from pydantic import BaseModel, Field
+
+from core.tools.entities.common_entities import I18nObject
 
 
 class ToolProviderType(Enum):

--- a/api/core/tools/entities/user_entities.py
+++ b/api/core/tools/entities/user_entities.py
@@ -1,10 +1,11 @@
 from enum import Enum
 from typing import Dict, List, Optional
 
+from pydantic import BaseModel
+
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import ToolProviderCredentials
 from core.tools.tool.tool import ToolParameter
-from pydantic import BaseModel
 
 
 class UserToolProvider(BaseModel):

--- a/api/core/tools/model/tool_model_manager.py
+++ b/api/core/tools/model/tool_model_manager.py
@@ -11,8 +11,13 @@ from core.model_manager import ModelManager
 from core.model_runtime.entities.llm_entities import LLMResult
 from core.model_runtime.entities.message_entities import PromptMessage
 from core.model_runtime.entities.model_entities import ModelType
-from core.model_runtime.errors.invoke import (InvokeAuthorizationError, InvokeBadRequestError, InvokeConnectionError,
-                                              InvokeRateLimitError, InvokeServerUnavailableError)
+from core.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel, ModelPropertyKey
 from core.model_runtime.utils.encoders import jsonable_encoder
 from core.tools.model.errors import InvokeModelError

--- a/api/core/tools/provider/api_tool_provider.py
+++ b/api/core/tools/provider/api_tool_provider.py
@@ -2,8 +2,12 @@ from typing import Any, Dict, List
 
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
-from core.tools.entities.tool_entities import (ApiProviderAuthType, ToolCredentialsOption, ToolProviderCredentials,
-                                               ToolProviderType)
+from core.tools.entities.tool_entities import (
+    ApiProviderAuthType,
+    ToolCredentialsOption,
+    ToolProviderCredentials,
+    ToolProviderType,
+)
 from core.tools.provider.tool_provider import ToolProviderController
 from core.tools.tool.api_tool import ApiTool
 from core.tools.tool.tool import Tool

--- a/api/core/tools/provider/builtin/_positions.py
+++ b/api/core/tools/provider/builtin/_positions.py
@@ -1,9 +1,9 @@
-from core.tools.entities.user_entities import UserToolProvider
-from core.tools.entities.tool_entities import ToolProviderType
-from typing import List
-from yaml import load, FullLoader
-
 import os.path
+from typing import List
+
+from yaml import FullLoader, load
+
+from core.tools.entities.user_entities import UserToolProvider
 
 position = {}
 

--- a/api/core/tools/provider/builtin/azuredalle/tools/dalle3.py
+++ b/api/core/tools/provider/builtin/azuredalle/tools/dalle3.py
@@ -1,10 +1,10 @@
 from base64 import b64decode
-from os.path import join
 from typing import Any, Dict, List, Union
+
+from openai import AzureOpenAI
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from openai import AzureOpenAI
 
 
 class DallE3Tool(BuiltinTool):

--- a/api/core/tools/provider/builtin/bing/bing.py
+++ b/api/core/tools/provider/builtin/bing/bing.py
@@ -1,9 +1,9 @@
-from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
+from typing import Any, Dict
+
 from core.tools.errors import ToolProviderCredentialValidationError
-
 from core.tools.provider.builtin.bing.tools.bing_web_search import BingSearchTool
+from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
 
-from typing import Any, Dict, List
 
 class BingProvider(BuiltinToolProviderController):
     def _validate_credentials(self, credentials: Dict[str, Any]) -> None:

--- a/api/core/tools/provider/builtin/bing/tools/bing_web_search.py
+++ b/api/core/tools/provider/builtin/bing/tools/bing_web_search.py
@@ -1,9 +1,10 @@
-from core.tools.tool.builtin_tool import BuiltinTool
-from core.tools.entities.tool_entities import ToolInvokeMessage
-
 from typing import Any, Dict, List, Union
-from os import path
+
 from requests import get
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool.builtin_tool import BuiltinTool
+
 
 class BingSearchTool(BuiltinTool):
     url = 'https://api.bing.microsoft.com/v7.0/search'

--- a/api/core/tools/provider/builtin/chart/chart.py
+++ b/api/core/tools/provider/builtin/chart/chart.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.chart.tools.line import LinearChartTool
 from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController

--- a/api/core/tools/provider/builtin/chart/tools/bar.py
+++ b/api/core/tools/provider/builtin/chart/tools/bar.py
@@ -2,6 +2,7 @@ import io
 from typing import Any, Dict, List, Union
 
 import matplotlib.pyplot as plt
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 

--- a/api/core/tools/provider/builtin/chart/tools/line.py
+++ b/api/core/tools/provider/builtin/chart/tools/line.py
@@ -2,6 +2,7 @@ import io
 from typing import Any, Dict, List, Union
 
 import matplotlib.pyplot as plt
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 

--- a/api/core/tools/provider/builtin/chart/tools/pie.py
+++ b/api/core/tools/provider/builtin/chart/tools/pie.py
@@ -2,6 +2,7 @@ import io
 from typing import Any, Dict, List, Union
 
 import matplotlib.pyplot as plt
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 

--- a/api/core/tools/provider/builtin/dalle/tools/dalle2.py
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle2.py
@@ -2,9 +2,10 @@ from base64 import b64decode
 from os.path import join
 from typing import Any, Dict, List, Union
 
+from openai import OpenAI
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from openai import OpenAI
 
 
 class DallE2Tool(BuiltinTool):

--- a/api/core/tools/provider/builtin/dalle/tools/dalle3.py
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle3.py
@@ -2,9 +2,10 @@ from base64 import b64decode
 from os.path import join
 from typing import Any, Dict, List, Union
 
+from openai import OpenAI
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from openai import OpenAI
 
 
 class DallE3Tool(BuiltinTool):

--- a/api/core/tools/provider/builtin/gaode/gaode.py
+++ b/api/core/tools/provider/builtin/gaode/gaode.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 import requests
+
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
 

--- a/api/core/tools/provider/builtin/gaode/tools/gaode_weather.py
+++ b/api/core/tools/provider/builtin/gaode/tools/gaode_weather.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, List, Union
 
 import requests
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 

--- a/api/core/tools/provider/builtin/github/github.py
+++ b/api/core/tools/provider/builtin/github/github.py
@@ -1,4 +1,5 @@
 import requests
+
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
 

--- a/api/core/tools/provider/builtin/github/tools/github_repositories.py
+++ b/api/core/tools/provider/builtin/github/tools/github_repositories.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Union
 from urllib.parse import quote
 
 import requests
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 

--- a/api/core/tools/provider/builtin/google/google.py
+++ b/api/core/tools/provider/builtin/google/google.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.google.tools.google_search import GoogleSearchTool

--- a/api/core/tools/provider/builtin/google/tools/google_search.py
+++ b/api/core/tools/provider/builtin/google/tools/google_search.py
@@ -2,9 +2,10 @@ import os
 import sys
 from typing import Any, Dict, List, Union
 
+from serpapi import GoogleSearch
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from serpapi import GoogleSearch
 
 
 class HiddenPrints:

--- a/api/core/tools/provider/builtin/maths/tools/eval_expression.py
+++ b/api/core/tools/provider/builtin/maths/tools/eval_expression.py
@@ -1,11 +1,11 @@
 import logging
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Union
+
+import numexpr as ne
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from pytz import timezone as pytz_timezone
-import numexpr as ne
+
 
 class EvaluateExpressionTool(BuiltinTool):
     def _invoke(self, 

--- a/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.py
+++ b/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.py
@@ -5,12 +5,13 @@ from copy import deepcopy
 from os.path import join
 from typing import Any, Dict, List, Union
 
+from httpx import get, post
+from PIL import Image
+
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import ToolInvokeMessage, ToolParameter, ToolParameterOption
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.tool.builtin_tool import BuiltinTool
-from httpx import get, post
-from PIL import Image
 
 DRAW_TEXT_OPTIONS = {
     "prompt": "",

--- a/api/core/tools/provider/builtin/time/tools/current_time.py
+++ b/api/core/tools/provider/builtin/time/tools/current_time.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Union
 
+from pytz import timezone as pytz_timezone
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from pytz import timezone as pytz_timezone
 
 
 class CurrentTimeTool(BuiltinTool):

--- a/api/core/tools/provider/builtin/vectorizer/tools/vectorizer.py
+++ b/api/core/tools/provider/builtin/vectorizer/tools/vectorizer.py
@@ -1,11 +1,12 @@
 from base64 import b64decode
 from typing import Any, Dict, List, Union
 
+from httpx import post
+
 from core.tools.entities.tool_entities import ToolInvokeMessage, ToolParameter
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.vectorizer.tools.test_data import VECTORIZER_ICON_PNG
 from core.tools.tool.builtin_tool import BuiltinTool
-from httpx import post
 
 
 class VectorizerTool(BuiltinTool):

--- a/api/core/tools/provider/builtin/webscraper/webscraper.py
+++ b/api/core/tools/provider/builtin/webscraper/webscraper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.webscraper.tools.webscraper import WebscraperTool

--- a/api/core/tools/provider/builtin/wikipedia/tools/wikipedia_search.py
+++ b/api/core/tools/provider/builtin/wikipedia/tools/wikipedia_search.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, List, Union
 
-from core.tools.entities.tool_entities import ToolInvokeMessage
-from core.tools.tool.builtin_tool import BuiltinTool
 from langchain import WikipediaAPIWrapper
 from langchain.tools import WikipediaQueryRun
 from pydantic import BaseModel, Field
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class WikipediaInput(BaseModel):

--- a/api/core/tools/provider/builtin/wolframalpha/tools/wolframalpha.py
+++ b/api/core/tools/provider/builtin/wolframalpha/tools/wolframalpha.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List, Union
 
+from httpx import get
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError, ToolProviderCredentialValidationError
 from core.tools.tool.builtin_tool import BuiltinTool
-from httpx import get
 
 
 class WolframAlphaTool(BuiltinTool):

--- a/api/core/tools/provider/builtin/wolframalpha/wolframalpha.py
+++ b/api/core/tools/provider/builtin/wolframalpha/wolframalpha.py
@@ -1,10 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-from core.tools.entities.tool_entities import ToolInvokeMessage, ToolProviderType
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.wolframalpha.tools.wolframalpha import WolframAlphaTool
 from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
-from core.tools.tool.tool import Tool
 
 
 class GoogleProvider(BuiltinToolProviderController):

--- a/api/core/tools/provider/builtin/yahoo/tools/analytics.py
+++ b/api/core/tools/provider/builtin/yahoo/tools/analytics.py
@@ -2,10 +2,11 @@ from datetime import datetime
 from typing import Any, Dict, List, Union
 
 import pandas as pd
-from core.tools.entities.tool_entities import ToolInvokeMessage
-from core.tools.tool.builtin_tool import BuiltinTool
 from requests.exceptions import HTTPError, ReadTimeout
 from yfinance import download
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class YahooFinanceAnalyticsTool(BuiltinTool):

--- a/api/core/tools/provider/builtin/yahoo/tools/news.py
+++ b/api/core/tools/provider/builtin/yahoo/tools/news.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List, Union
 
 import yfinance
+from requests.exceptions import HTTPError, ReadTimeout
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from requests.exceptions import HTTPError, ReadTimeout
 
 
 class YahooFinanceSearchTickerTool(BuiltinTool):

--- a/api/core/tools/provider/builtin/yahoo/tools/ticker.py
+++ b/api/core/tools/provider/builtin/yahoo/tools/ticker.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List, Union
 
-from core.tools.entities.tool_entities import ToolInvokeMessage
-from core.tools.tool.builtin_tool import BuiltinTool
 from requests.exceptions import HTTPError, ReadTimeout
 from yfinance import Ticker
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class YahooFinanceSearchTickerTool(BuiltinTool):

--- a/api/core/tools/provider/builtin/youtube/tools/videos.py
+++ b/api/core/tools/provider/builtin/youtube/tools/videos.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from typing import Any, Dict, List, Union
 
+from googleapiclient.discovery import build
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
-from googleapiclient.discovery import build
 
 
 class YoutubeVideosAnalyticsTool(BuiltinTool):

--- a/api/core/tools/provider/builtin_tool_provider.py
+++ b/api/core/tools/provider/builtin_tool_provider.py
@@ -3,14 +3,19 @@ from abc import abstractmethod
 from os import listdir, path
 from typing import Any, Dict, List
 
+from yaml import FullLoader, load
+
 from core.tools.entities.tool_entities import ToolParameter, ToolProviderCredentials, ToolProviderType
 from core.tools.entities.user_entities import UserToolProviderCredentials
-from core.tools.errors import (ToolNotFoundError, ToolParameterValidationError, ToolProviderCredentialValidationError,
-                               ToolProviderNotFoundError)
+from core.tools.errors import (
+    ToolNotFoundError,
+    ToolParameterValidationError,
+    ToolProviderCredentialValidationError,
+    ToolProviderNotFoundError,
+)
 from core.tools.provider.tool_provider import ToolProviderController
 from core.tools.tool.builtin_tool import BuiltinTool
 from core.tools.tool.tool import Tool
-from yaml import FullLoader, load
 
 
 class BuiltinToolProviderController(ToolProviderController):

--- a/api/core/tools/provider/tool_provider.py
+++ b/api/core/tools/provider/tool_provider.py
@@ -1,12 +1,17 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-from core.tools.entities.tool_entities import (ToolParameter, ToolProviderCredentials, ToolProviderIdentity,
-                                               ToolProviderType)
+from pydantic import BaseModel
+
+from core.tools.entities.tool_entities import (
+    ToolParameter,
+    ToolProviderCredentials,
+    ToolProviderIdentity,
+    ToolProviderType,
+)
 from core.tools.entities.user_entities import UserToolProviderCredentials
 from core.tools.errors import ToolNotFoundError, ToolParameterValidationError, ToolProviderCredentialValidationError
 from core.tools.tool.tool import Tool
-from pydantic import BaseModel
 
 
 class ToolProviderController(BaseModel, ABC):

--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Union
 
 import httpx
 import requests
+
 import core.helper.ssrf_proxy as ssrf_proxy
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
 from core.tools.entities.tool_entities import ToolInvokeMessage

--- a/api/core/tools/tool/builtin_tool.py
+++ b/api/core/tools/tool/builtin_tool.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import List
 
 from core.model_runtime.entities.llm_entities import LLMResult

--- a/api/core/tools/tool/dataset_retriever/dataset_multi_retriever_tool.py
+++ b/api/core/tools/tool/dataset_retriever/dataset_multi_retriever_tool.py
@@ -1,6 +1,9 @@
-import json
 import threading
 from typing import List, Optional, Type
+
+from flask import Flask, current_app
+from langchain.tools import BaseTool
+from pydantic import BaseModel, Field
 
 from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCallbackHandler
 from core.embedding.cached_embedding import CacheEmbedding
@@ -10,10 +13,7 @@ from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from core.rerank.rerank import RerankRunner
 from extensions.ext_database import db
-from flask import Flask, current_app
-from langchain.tools import BaseTool
 from models.dataset import Dataset, Document, DocumentSegment
-from pydantic import BaseModel, Field
 from services.retrieval_service import RetrievalService
 
 default_retrieval_model = {

--- a/api/core/tools/tool/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/tool/dataset_retriever/dataset_retriever_tool.py
@@ -1,6 +1,10 @@
 import threading
 from typing import List, Optional, Type
 
+from flask import current_app
+from langchain.tools import BaseTool
+from pydantic import BaseModel, Field
+
 from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCallbackHandler
 from core.embedding.cached_embedding import CacheEmbedding
 from core.index.keyword_table_index.keyword_table_index import KeywordTableConfig, KeywordTableIndex
@@ -9,10 +13,7 @@ from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.invoke import InvokeAuthorizationError
 from core.rerank.rerank import RerankRunner
 from extensions.ext_database import db
-from flask import current_app
-from langchain.tools import BaseTool
 from models.dataset import Dataset, Document, DocumentSegment
-from pydantic import BaseModel, Field
 from services.retrieval_service import RetrievalService
 
 default_retrieval_model = {

--- a/api/core/tools/tool/dataset_retriever_tool.py
+++ b/api/core/tools/tool/dataset_retriever_tool.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
+
+from langchain.tools import BaseTool
 
 from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCallbackHandler
 from core.entities.application_entities import DatasetRetrieveConfigEntity, InvokeFrom
@@ -6,7 +8,6 @@ from core.features.dataset_retrieval import DatasetRetrievalFeature
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import ToolDescription, ToolIdentity, ToolInvokeMessage, ToolParameter
 from core.tools.tool.tool import Tool
-from langchain.tools import BaseTool
 
 
 class DatasetRetrieverTool(Tool):

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -2,11 +2,19 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackHandler
-from core.tools.entities.tool_entities import (ToolDescription, ToolIdentity, ToolInvokeMessage, ToolParameter,
-                                               ToolRuntimeImageVariable, ToolRuntimeVariable, ToolRuntimeVariablePool)
-from core.tools.tool_file_manager import ToolFileManager
 from pydantic import BaseModel
+
+from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackHandler
+from core.tools.entities.tool_entities import (
+    ToolDescription,
+    ToolIdentity,
+    ToolInvokeMessage,
+    ToolParameter,
+    ToolRuntimeImageVariable,
+    ToolRuntimeVariable,
+    ToolRuntimeVariablePool,
+)
+from core.tools.tool_file_manager import ToolFileManager
 
 
 class Tool(BaseModel, ABC):

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -8,10 +8,11 @@ from mimetypes import guess_extension, guess_type
 from typing import Generator, Tuple, Union
 from uuid import uuid4
 
-from extensions.ext_database import db
-from extensions.ext_storage import storage
 from flask import current_app
 from httpx import get
+
+from extensions.ext_database import db
+from extensions.ext_storage import storage
 from models.model import MessageFile
 from models.tools import ToolFile
 

--- a/api/core/tools/utils/configuration.py
+++ b/api/core/tools/utils/configuration.py
@@ -1,10 +1,12 @@
-from typing import Dict, Any
+from typing import Any, Dict
+
 from pydantic import BaseModel
 
+from core.helper import encrypter
+from core.helper.tool_provider_cache import ToolProviderCredentialsCache, ToolProviderCredentialsCacheType
 from core.tools.entities.tool_entities import ToolProviderCredentials
 from core.tools.provider.tool_provider import ToolProviderController
-from core.helper import encrypter
-from core.helper.tool_provider_cache import ToolProviderCredentialsCacheType, ToolProviderCredentialsCache
+
 
 class ToolConfiguration(BaseModel):
     tenant_id: str

--- a/api/core/tools/utils/encoder.py
+++ b/api/core/tools/utils/encoder.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import List
 
 from pydantic import BaseModel

--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -1,14 +1,14 @@
 
-from json import dumps as json_dumps
 from json import loads as json_loads
 from typing import List, Tuple
 
-from core.tools.entities.common_entities import I18nObject
-from core.tools.entities.tool_bundle import ApiBasedToolBundle
-from core.tools.entities.tool_entities import ApiProviderSchemaType, ToolParameter, ToolParameterOption
-from core.tools.errors import ToolApiSchemaError, ToolNotSupportedError, ToolProviderNotFoundError
 from requests import get
 from yaml import FullLoader, load
+
+from core.tools.entities.common_entities import I18nObject
+from core.tools.entities.tool_bundle import ApiBasedToolBundle
+from core.tools.entities.tool_entities import ApiProviderSchemaType, ToolParameter
+from core.tools.errors import ToolApiSchemaError, ToolNotSupportedError, ToolProviderNotFoundError
 
 
 class ApiBasedToolSchemaParser:

--- a/api/core/tools/utils/web_reader_tool.py
+++ b/api/core/tools/utils/web_reader_tool.py
@@ -11,10 +11,6 @@ from typing import Any, Type
 
 import requests
 from bs4 import BeautifulSoup, CData, Comment, NavigableString
-from core.chain.llm_chain import LLMChain
-from core.data_loader import file_extractor
-from core.data_loader.file_extractor import FileExtractor
-from core.entities.application_entities import ModelConfigEntity
 from langchain.chains import RefineDocumentsChain
 from langchain.chains.summarize import refine_prompts
 from langchain.schema import Document
@@ -23,6 +19,11 @@ from langchain.tools.base import BaseTool
 from newspaper import Article
 from pydantic import BaseModel, Field
 from regex import regex
+
+from core.chain.llm_chain import LLMChain
+from core.data_loader import file_extractor
+from core.data_loader.file_extractor import FileExtractor
+from core.entities.application_entities import ModelConfigEntity
 
 FULL_TEMPLATE = """
 TITLE: {title}

--- a/api/core/vector_store/qdrant_vector_store.py
+++ b/api/core/vector_store/qdrant_vector_store.py
@@ -1,9 +1,10 @@
 from typing import Any, cast
 
-from core.vector_store.vector.qdrant import Qdrant
 from langchain.schema import Document
 from qdrant_client.http.models import Filter, FilterSelector, PointIdsList
 from qdrant_client.local.qdrant_local import QdrantLocal
+
+from core.vector_store.vector.qdrant import Qdrant
 
 
 class QdrantVectorStore(Qdrant):

--- a/api/core/vector_store/vector/qdrant.py
+++ b/api/core/vector_store/vector/qdrant.py
@@ -14,7 +14,7 @@ from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
 from langchain.vectorstores import VectorStore
 from langchain.vectorstores.utils import maximal_marginal_relevance
-from qdrant_client.http.models import FilterSelector, PayloadSchemaType, TextIndexParams, TextIndexType, TokenizerType
+from qdrant_client.http.models import PayloadSchemaType, TextIndexParams, TextIndexType, TokenizerType
 
 if TYPE_CHECKING:
     from qdrant_client import grpc  # noqa
@@ -1396,9 +1396,7 @@ class Qdrant(VectorStore):
                 "Could not import qdrant-client python package. "
                 "Please install it with `pip install qdrant-client`."
             )
-        from grpc import RpcError
         from qdrant_client.http import models as rest
-        from qdrant_client.http.exceptions import UnexpectedResponse
 
         # Just do a single quick embedding to get vector size
         partial_embeddings = embedding.embed_documents(texts[:1])

--- a/api/events/event_handlers/create_document_index.py
+++ b/api/events/event_handlers/create_document_index.py
@@ -3,13 +3,12 @@ import logging
 import time
 
 import click
-from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.indexing_runner import DocumentIsPausedException, IndexingRunner
-from events.dataset_event import dataset_was_deleted
 from events.event_handlers.document_index_event import document_index_created
 from extensions.ext_database import db
 from models.dataset import Document
-from werkzeug.exceptions import NotFound
 
 
 @document_index_created.connect

--- a/api/extensions/ext_hosting_provider.py
+++ b/api/extensions/ext_hosting_provider.py
@@ -1,5 +1,6 @@
-from core.hosting_configuration import HostingConfiguration
 from flask import Flask
+
+from core.hosting_configuration import HostingConfiguration
 
 hosting_configuration = HostingConfiguration()
 

--- a/api/fields/annotation_fields.py
+++ b/api/fields/annotation_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 account_fields = {

--- a/api/fields/api_based_extension_fields.py
+++ b/api/fields/api_based_extension_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 

--- a/api/fields/app_fields.py
+++ b/api/fields/app_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 app_detail_kernel_fields = {

--- a/api/fields/conversation_fields.py
+++ b/api/fields/conversation_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 

--- a/api/fields/data_source_fields.py
+++ b/api/fields/data_source_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 integrate_icon_fields = {

--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 dataset_fields = {

--- a/api/fields/document_fields.py
+++ b/api/fields/document_fields.py
@@ -1,5 +1,6 @@
-from fields.dataset_fields import dataset_fields
 from flask_restful import fields
+
+from fields.dataset_fields import dataset_fields
 from libs.helper import TimestampField
 
 document_fields = {

--- a/api/fields/file_fields.py
+++ b/api/fields/file_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 upload_config_fields = {

--- a/api/fields/hit_testing_fields.py
+++ b/api/fields/hit_testing_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 document_fields = {

--- a/api/fields/installed_app_fields.py
+++ b/api/fields/installed_app_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 app_fields = {

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -1,5 +1,6 @@
-from fields.conversation_fields import message_file_fields
 from flask_restful import fields
+
+from fields.conversation_fields import message_file_fields
 from libs.helper import TimestampField
 
 feedback_fields = {

--- a/api/fields/segment_fields.py
+++ b/api/fields/segment_fields.py
@@ -1,4 +1,5 @@
 from flask_restful import fields
+
 from libs.helper import TimestampField
 
 segment_fields = {

--- a/api/libs/login.py
+++ b/api/libs/login.py
@@ -1,13 +1,14 @@
 import os
 from functools import wraps
 
-from extensions.ext_database import db
-from flask import current_app, g, has_request_context, request, session
+from flask import current_app, g, has_request_context, request
 from flask_login import user_logged_in
 from flask_login.config import EXEMPT_METHODS
-from models.account import Account, Tenant, TenantAccountJoin
 from werkzeug.exceptions import Unauthorized
 from werkzeug.local import LocalProxy
+
+from extensions.ext_database import db
+from models.account import Account, Tenant, TenantAccountJoin
 
 #: A proxy for the current user. If no user is logged in, this will be an
 #: anonymous user

--- a/api/libs/oauth.py
+++ b/api/libs/oauth.py
@@ -1,11 +1,7 @@
-import json
 import urllib.parse
 from dataclasses import dataclass
 
 import requests
-from extensions.ext_database import db
-from flask_login import current_user
-from models.source import DataSourceBinding
 
 
 @dataclass

--- a/api/libs/oauth_data_source.py
+++ b/api/libs/oauth_data_source.py
@@ -1,9 +1,9 @@
-import json
 import urllib.parse
 
 import requests
-from extensions.ext_database import db
 from flask_login import current_user
+
+from extensions.ext_database import db
 from models.source import DataSourceBinding
 
 

--- a/api/libs/rsa.py
+++ b/api/libs/rsa.py
@@ -1,10 +1,11 @@
 # -*- coding:utf-8 -*-
 import hashlib
 
-import libs.gmpy2_pkcs10aep_cipher as gmpy2_pkcs10aep_cipher
 from Crypto.Cipher import AES
 from Crypto.PublicKey import RSA
 from Crypto.Random import get_random_bytes
+
+import libs.gmpy2_pkcs10aep_cipher as gmpy2_pkcs10aep_cipher
 from extensions.ext_redis import redis_client
 from extensions.ext_storage import storage
 

--- a/api/migrations/versions/16830a790f0f_.py
+++ b/api/migrations/versions/16830a790f0f_.py
@@ -5,9 +5,8 @@ Revises: 380c6aa5a70d
 Create Date: 2024-02-01 08:21:31.111119
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '16830a790f0f'

--- a/api/migrations/versions/187385f442fc_modify_provider_model_name_length.py
+++ b/api/migrations/versions/187385f442fc_modify_provider_model_name_length.py
@@ -7,7 +7,6 @@ Create Date: 2024-01-02 07:18:43.887428
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '187385f442fc'

--- a/api/migrations/versions/4829e54d2fee_change_message_chain_id_to_nullable.py
+++ b/api/migrations/versions/4829e54d2fee_change_message_chain_id_to_nullable.py
@@ -5,7 +5,6 @@ Revises: 114eed84c228
 Create Date: 2024-01-12 03:42:27.362415
 
 """
-import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 

--- a/api/migrations/versions/853f9b9cd3b6_add_message_price_unit.py
+++ b/api/migrations/versions/853f9b9cd3b6_add_message_price_unit.py
@@ -7,7 +7,6 @@ Create Date: 2023-08-19 17:01:57.471562
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '853f9b9cd3b6'

--- a/api/migrations/versions/8ae9bc661daa_add_tool_conversation_variables_idx.py
+++ b/api/migrations/versions/8ae9bc661daa_add_tool_conversation_variables_idx.py
@@ -5,7 +5,6 @@ Revises: 9fafbd60eca1
 Create Date: 2024-01-15 14:22:03.597692
 
 """
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/api/migrations/versions/a9836e3baeee_add_external_data_tools_in_app_model_.py
+++ b/api/migrations/versions/a9836e3baeee_add_external_data_tools_in_app_model_.py
@@ -7,7 +7,6 @@ Create Date: 2023-11-02 04:04:57.609485
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = 'a9836e3baeee'

--- a/api/migrations/versions/dfb3b7f477da_add_tool_index.py
+++ b/api/migrations/versions/dfb3b7f477da_add_tool_index.py
@@ -5,7 +5,6 @@ Revises: b24be59fbb04
 Create Date: 2024-01-24 02:17:01.631635
 
 """
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -2,9 +2,10 @@ import enum
 import json
 from typing import List
 
-from extensions.ext_database import db
 from flask_login import UserMixin
 from sqlalchemy.dialects.postgresql import UUID
+
+from extensions.ext_database import db
 
 
 class AccountStatus(str, enum.Enum):

--- a/api/models/api_based_extension.py
+++ b/api/models/api_based_extension.py
@@ -1,7 +1,8 @@
 import enum
 
-from extensions.ext_database import db
 from sqlalchemy.dialects.postgresql import UUID
+
+from extensions.ext_database import db
 
 
 class APIBasedExtensionPoint(enum.Enum):

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -2,11 +2,12 @@ import json
 import pickle
 from json import JSONDecodeError
 
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
 from extensions.ext_database import db
 from models.account import Account
 from models.model import App, UploadFile
-from sqlalchemy import func
-from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 
 class Dataset(db.Model):

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1,14 +1,15 @@
 import json
 import uuid
 
+from flask import current_app, request
+from flask_login import UserMixin
+from sqlalchemy import Float, text
+from sqlalchemy.dialects.postgresql import UUID
+
 from core.file.tool_file_parser import ToolFileParser
 from core.file.upload_file_parser import UploadFileParser
 from extensions.ext_database import db
-from flask import current_app, request
-from flask_login import UserMixin
 from libs.helper import generate_string
-from sqlalchemy import Float, text
-from sqlalchemy.dialects.postgresql import UUID
 
 from .account import Account, Tenant
 

--- a/api/models/provider.py
+++ b/api/models/provider.py
@@ -1,7 +1,8 @@
 from enum import Enum
 
-from extensions.ext_database import db
 from sqlalchemy.dialects.postgresql import UUID
+
+from extensions.ext_database import db
 
 
 class ProviderType(Enum):

--- a/api/models/source.py
+++ b/api/models/source.py
@@ -1,5 +1,6 @@
-from extensions.ext_database import db
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from extensions.ext_database import db
 
 
 class DataSourceBinding(db.Model):

--- a/api/models/task.py
+++ b/api/models/task.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from celery import states
+
 from extensions.ext_database import db
 
 

--- a/api/models/tool.py
+++ b/api/models/tool.py
@@ -1,8 +1,9 @@
 import json
 from enum import Enum
 
-from extensions.ext_database import db
 from sqlalchemy.dialects.postgresql import UUID
+
+from extensions.ext_database import db
 
 
 class ToolProviderName(Enum):

--- a/api/models/tools.py
+++ b/api/models/tools.py
@@ -1,14 +1,14 @@
 import json
-from enum import Enum
 from typing import List
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
 
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
-from core.tools.entities.tool_entities import ApiProviderSchemaType, ToolRuntimeVariablePool
+from core.tools.entities.tool_entities import ApiProviderSchemaType
 from extensions.ext_database import db
 from models.model import Account, App, Tenant
-from sqlalchemy import ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
 
 
 class BuiltinToolProvider(db.Model):

--- a/api/models/web.py
+++ b/api/models/web.py
@@ -1,6 +1,7 @@
+from sqlalchemy.dialects.postgresql import UUID
+
 from extensions.ext_database import db
 from models.model import Message
-from sqlalchemy.dialects.postgresql import UUID
 
 
 class SavedMessage(db.Model):

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+requires-python = ">=3.10"
+
+[tool.ruff]
+exclude = [
+    "__init__.py",
+    "tests/",
+]
+line-length = 120
+
+[tool.ruff.lint]
+ignore-init-module-imports = true
+select = [
+    "F401", # unused-import
+    "I001", # unsorted-imports
+    "I002", # missing-required-import
+]

--- a/api/schedule/clean_embedding_cache_task.py
+++ b/api/schedule/clean_embedding_cache_task.py
@@ -1,12 +1,13 @@
 import datetime
 import time
 
-import app
 import click
-from extensions.ext_database import db
 from flask import current_app
-from models.dataset import Embedding
 from werkzeug.exceptions import NotFound
+
+import app
+from extensions.ext_database import db
+from models.dataset import Embedding
 
 
 @app.celery.task(queue='dataset')

--- a/api/schedule/clean_unused_datasets_task.py
+++ b/api/schedule/clean_unused_datasets_task.py
@@ -1,14 +1,14 @@
 import datetime
-import logging
 import time
 
-import app
 import click
+from flask import current_app
+from werkzeug.exceptions import NotFound
+
+import app
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
-from flask import current_app
-from models.dataset import Dataset, DatasetCollectionBinding, DatasetQuery, Document
-from werkzeug.exceptions import NotFound
+from models.dataset import Dataset, DatasetQuery, Document
 
 
 @app.celery.task(queue='dataset')

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -8,23 +8,33 @@ from datetime import datetime, timedelta
 from hashlib import sha256
 from typing import Any, Dict, Optional
 
+from flask import current_app
+from sqlalchemy import func
+from werkzeug.exceptions import Forbidden
+
 from constants.languages import language_timezone_mapping, languages
 from events.tenant_event import tenant_was_created
 from extensions.ext_redis import redis_client
-from flask import current_app
 from libs.helper import get_remote_ip
 from libs.passport import PassportService
 from libs.password import compare_password, hash_password
 from libs.rsa import generate_key_pair
 from models.account import *
-from services.errors.account import (AccountAlreadyInTenantError, AccountLoginError, AccountNotLinkTenantError,
-                                     AccountRegisterError, CannotOperateSelfError, CurrentPasswordIncorrectError,
-                                     InvalidActionError, LinkAccountIntegrateError, MemberNotInTenantError,
-                                     NoPermissionError, RoleAlreadyAssignedError, TenantNotFound)
-from sqlalchemy import func
+from services.errors.account import (
+    AccountAlreadyInTenantError,
+    AccountLoginError,
+    AccountNotLinkTenantError,
+    AccountRegisterError,
+    CannotOperateSelfError,
+    CurrentPasswordIncorrectError,
+    InvalidActionError,
+    LinkAccountIntegrateError,
+    MemberNotInTenantError,
+    NoPermissionError,
+    RoleAlreadyAssignedError,
+    TenantNotFound,
+)
 from tasks.mail_invite_member_task import send_invite_member_mail_task
-from werkzeug.exceptions import Forbidden
-from sqlalchemy import exc
 
 
 def _create_tenant_for_account(account) -> Tenant:

--- a/api/services/advanced_prompt_template_service.py
+++ b/api/services/advanced_prompt_template_service.py
@@ -1,13 +1,18 @@
 
 import copy
 
-from core.prompt.advanced_prompt_templates import (BAICHUAN_CHAT_APP_CHAT_PROMPT_CONFIG,
-                                                   BAICHUAN_CHAT_APP_COMPLETION_PROMPT_CONFIG,
-                                                   BAICHUAN_COMPLETION_APP_CHAT_PROMPT_CONFIG,
-                                                   BAICHUAN_COMPLETION_APP_COMPLETION_PROMPT_CONFIG, BAICHUAN_CONTEXT,
-                                                   CHAT_APP_CHAT_PROMPT_CONFIG, CHAT_APP_COMPLETION_PROMPT_CONFIG,
-                                                   COMPLETION_APP_CHAT_PROMPT_CONFIG,
-                                                   COMPLETION_APP_COMPLETION_PROMPT_CONFIG, CONTEXT)
+from core.prompt.advanced_prompt_templates import (
+    BAICHUAN_CHAT_APP_CHAT_PROMPT_CONFIG,
+    BAICHUAN_CHAT_APP_COMPLETION_PROMPT_CONFIG,
+    BAICHUAN_COMPLETION_APP_CHAT_PROMPT_CONFIG,
+    BAICHUAN_COMPLETION_APP_COMPLETION_PROMPT_CONFIG,
+    BAICHUAN_CONTEXT,
+    CHAT_APP_CHAT_PROMPT_CONFIG,
+    CHAT_APP_COMPLETION_PROMPT_CONFIG,
+    COMPLETION_APP_CHAT_PROMPT_CONFIG,
+    COMPLETION_APP_COMPLETION_PROMPT_CONFIG,
+    CONTEXT,
+)
 from core.prompt.prompt_transform import AppMode
 
 

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -1,21 +1,21 @@
 import datetime
-import json
 import uuid
 
 import pandas as pd
+from flask_login import current_user
+from sqlalchemy import or_
+from werkzeug.datastructures import FileStorage
+from werkzeug.exceptions import NotFound
+
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from flask_login import current_user
 from models.model import App, AppAnnotationHitHistory, AppAnnotationSetting, Message, MessageAnnotation
-from sqlalchemy import or_
 from tasks.annotation.add_annotation_to_index_task import add_annotation_to_index_task
 from tasks.annotation.batch_import_annotations_task import batch_import_annotations_task
 from tasks.annotation.delete_annotation_index_task import delete_annotation_index_task
 from tasks.annotation.disable_annotation_reply_task import disable_annotation_reply_task
 from tasks.annotation.enable_annotation_reply_task import enable_annotation_reply_task
 from tasks.annotation.update_annotation_to_index_task import update_annotation_to_index_task
-from werkzeug.datastructures import FileStorage
-from werkzeug.exceptions import NotFound
 
 
 class AppAnnotationService:

--- a/api/services/audio_service.py
+++ b/api/services/audio_service.py
@@ -1,12 +1,17 @@
 import io
 from typing import Optional
 
+from werkzeug.datastructures import FileStorage
+
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
-from services.errors.audio import (AudioTooLargeServiceError, NoAudioUploadedServiceError,
-                                   ProviderNotSupportSpeechToTextServiceError,
-                                   ProviderNotSupportTextToSpeechServiceError, UnsupportedAudioTypeServiceError)
-from werkzeug.datastructures import FileStorage
+from services.errors.audio import (
+    AudioTooLargeServiceError,
+    NoAudioUploadedServiceError,
+    ProviderNotSupportSpeechToTextServiceError,
+    ProviderNotSupportTextToSpeechServiceError,
+    UnsupportedAudioTypeServiceError,
+)
 
 FILE_SIZE = 15
 FILE_SIZE_LIMIT = FILE_SIZE * 1024 * 1024

--- a/api/services/billing_service.py
+++ b/api/services/billing_service.py
@@ -1,6 +1,7 @@
 import os
 
 import requests
+
 from extensions.ext_database import db
 from models.account import TenantAccountJoin
 

--- a/api/services/completion_service.py
+++ b/api/services/completion_service.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any, Generator, Union
 
+from sqlalchemy import and_
+
 from core.application_manager import ApplicationManager
 from core.entities.application_entities import InvokeFrom
 from core.file.message_file_parser import MessageFileParser
@@ -11,7 +13,6 @@ from services.errors.app import MoreLikeThisDisabledError
 from services.errors.app_model_config import AppModelConfigBrokenError
 from services.errors.conversation import ConversationCompletedError, ConversationNotExistsError
 from services.errors.message import MessageNotExistsError
-from sqlalchemy import and_
 
 
 class CompletionService:

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -6,6 +6,10 @@ import time
 import uuid
 from typing import List, Optional, cast
 
+from flask import current_app
+from flask_login import current_user
+from sqlalchemy import func
+
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.index.index import IndexBuilder
 from core.model_manager import ModelManager
@@ -15,12 +19,17 @@ from events.dataset_event import dataset_was_deleted
 from events.document_event import document_was_deleted
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from flask import current_app
-from flask_login import current_user
 from libs import helper
 from models.account import Account
-from models.dataset import (AppDatasetJoin, Dataset, DatasetCollectionBinding, DatasetProcessRule, DatasetQuery,
-                            Document, DocumentSegment)
+from models.dataset import (
+    AppDatasetJoin,
+    Dataset,
+    DatasetCollectionBinding,
+    DatasetProcessRule,
+    DatasetQuery,
+    Document,
+    DocumentSegment,
+)
 from models.model import UploadFile
 from models.source import DataSourceBinding
 from services.errors.account import NoPermissionError
@@ -28,7 +37,6 @@ from services.errors.dataset import DatasetNameDuplicateError
 from services.errors.document import DocumentIndexingError
 from services.errors.file import FileNotExistsError
 from services.vector_service import VectorService
-from sqlalchemy import func
 from tasks.clean_notion_document_task import clean_notion_document_task
 from tasks.deal_dataset_vector_index_task import deal_dataset_vector_index_task
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task

--- a/api/services/entities/model_provider_entities.py
+++ b/api/services/entities/model_provider_entities.py
@@ -1,16 +1,21 @@
 from enum import Enum
 from typing import Optional
 
+from flask import current_app
+from pydantic import BaseModel
+
 from core.entities.model_entities import ModelStatus, ModelWithProviderEntity
 from core.entities.provider_entities import QuotaConfiguration
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import ModelType, ProviderModel
-from core.model_runtime.entities.provider_entities import (ConfigurateMethod, ModelCredentialSchema,
-                                                           ProviderCredentialSchema, ProviderHelpEntity,
-                                                           SimpleProviderEntity)
-from flask import current_app
+from core.model_runtime.entities.provider_entities import (
+    ConfigurateMethod,
+    ModelCredentialSchema,
+    ProviderCredentialSchema,
+    ProviderHelpEntity,
+    SimpleProviderEntity,
+)
 from models.provider import ProviderQuotaType, ProviderType
-from pydantic import BaseModel
 
 
 class CustomConfigurationStatus(Enum):

--- a/api/services/feature_service.py
+++ b/api/services/feature_service.py
@@ -1,5 +1,6 @@
 from flask import current_app
 from pydantic import BaseModel
+
 from services.billing_service import BillingService
 
 

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -3,17 +3,18 @@ import hashlib
 import uuid
 from typing import Generator, Tuple, Union
 
+from flask import current_app
+from flask_login import current_user
+from werkzeug.datastructures import FileStorage
+from werkzeug.exceptions import NotFound
+
 from core.data_loader.file_extractor import FileExtractor
 from core.file.upload_file_parser import UploadFileParser
 from extensions.ext_database import db
 from extensions.ext_storage import storage
-from flask import current_app
-from flask_login import current_user
 from models.account import Account
 from models.model import EndUser, UploadFile
 from services.errors.file import FileTooLargeError, UnsupportedFileTypeError
-from werkzeug.datastructures import FileStorage
-from werkzeug.exceptions import NotFound
 
 IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg']
 IMAGE_EXTENSIONS.extend([ext.upper() for ext in IMAGE_EXTENSIONS])

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -4,18 +4,19 @@ import time
 from typing import List
 
 import numpy as np
+from flask import current_app
+from langchain.embeddings.base import Embeddings
+from langchain.schema import Document
+from sklearn.manifold import TSNE
+
 from core.embedding.cached_embedding import CacheEmbedding
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from core.rerank.rerank import RerankRunner
 from extensions.ext_database import db
-from flask import current_app
-from langchain.embeddings.base import Embeddings
-from langchain.schema import Document
 from models.account import Account
 from models.dataset import Dataset, DatasetQuery, DocumentSegment
 from services.retrieval_service import RetrievalService
-from sklearn.manifold import TSNE
 
 default_retrieval_model = {
     'search_method': 'semantic_search',

--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -12,8 +12,12 @@ from models.model import App, AppModelConfig, EndUser, Message, MessageFeedback
 from services.conversation_service import ConversationService
 from services.errors.app_model_config import AppModelConfigBrokenError
 from services.errors.conversation import ConversationCompletedError, ConversationNotExistsError
-from services.errors.message import (FirstMessageNotExistsError, LastMessageNotExistsError, MessageNotExistsError,
-                                     SuggestedQuestionsAfterAnswerDisabledError)
+from services.errors.message import (
+    FirstMessageNotExistsError,
+    LastMessageNotExistsError,
+    MessageNotExistsError,
+    SuggestedQuestionsAfterAnswerDisabledError,
+)
 
 
 class MessageService:

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -4,18 +4,25 @@ import os
 from typing import Optional, Tuple, cast
 
 import requests
+from flask import current_app
+
 from core.entities.model_entities import ModelStatus
 from core.model_runtime.entities.model_entities import ModelType, ParameterRule
 from core.model_runtime.model_providers import model_provider_factory
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.provider_manager import ProviderManager
-from flask import current_app
 from models.provider import ProviderType
-from services.entities.model_provider_entities import (CustomConfigurationResponse, CustomConfigurationStatus,
-                                                       DefaultModelResponse, ModelResponse,
-                                                       ModelWithProviderEntityResponse, ProviderResponse,
-                                                       ProviderWithModelsResponse, SimpleProviderEntityResponse,
-                                                       SystemConfigurationResponse)
+from services.entities.model_provider_entities import (
+    CustomConfigurationResponse,
+    CustomConfigurationStatus,
+    DefaultModelResponse,
+    ModelResponse,
+    ModelWithProviderEntityResponse,
+    ProviderResponse,
+    ProviderWithModelsResponse,
+    SimpleProviderEntityResponse,
+    SystemConfigurationResponse,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/api/services/retrieval_service.py
+++ b/api/services/retrieval_service.py
@@ -1,13 +1,14 @@
 from typing import Optional
 
+from flask import Flask, current_app
+from langchain.embeddings.base import Embeddings
+
 from core.index.vector_index.vector_index import VectorIndex
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.invoke import InvokeAuthorizationError
 from core.rerank.rerank import RerankRunner
 from extensions.ext_database import db
-from flask import Flask, current_app
-from langchain.embeddings.base import Embeddings
 from models.dataset import Dataset
 
 default_retrieval_model = {

--- a/api/services/tools_manage_service.py
+++ b/api/services/tools_manage_service.py
@@ -1,10 +1,17 @@
 import json
-from typing import List, Tuple
+from typing import List
+
+from flask import current_app
+from httpx import get
 
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
-from core.tools.entities.tool_entities import (ApiProviderAuthType, ApiProviderSchemaType, ToolCredentialsOption,
-                                               ToolProviderCredentials)
+from core.tools.entities.tool_entities import (
+    ApiProviderAuthType,
+    ApiProviderSchemaType,
+    ToolCredentialsOption,
+    ToolProviderCredentials,
+)
 from core.tools.entities.user_entities import UserTool, UserToolProvider
 from core.tools.errors import ToolNotFoundError, ToolProviderCredentialValidationError, ToolProviderNotFoundError
 from core.tools.provider.api_tool_provider import ApiBasedToolProviderController
@@ -14,8 +21,6 @@ from core.tools.utils.configuration import ToolConfiguration
 from core.tools.utils.encoder import serialize_base_model_array, serialize_base_model_dict
 from core.tools.utils.parser import ApiBasedToolSchemaParser
 from extensions.ext_database import db
-from flask import current_app
-from httpx import get
 from models.tools import ApiToolProvider, BuiltinToolProvider
 
 

--- a/api/services/vector_service.py
+++ b/api/services/vector_service.py
@@ -1,8 +1,9 @@
 
 from typing import List, Optional
 
-from core.index.index import IndexBuilder
 from langchain.schema import Document
+
+from core.index.index import IndexBuilder
 from models.dataset import Dataset, DocumentSegment
 
 

--- a/api/services/workspace_service.py
+++ b/api/services/workspace_service.py
@@ -1,8 +1,7 @@
-from extensions.ext_database import db
-from flask import current_app
 from flask_login import current_user
+
+from extensions.ext_database import db
 from models.account import Tenant, TenantAccountJoin, TenantAccountJoinRole
-from models.provider import Provider
 from services.account_service import TenantService
 from services.feature_service import FeatureService
 

--- a/api/tasks/add_document_to_index_task.py
+++ b/api/tasks/add_document_to_index_task.py
@@ -4,13 +4,14 @@ import time
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import Document as DatasetDocument
 from models.dataset import DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/annotation/add_annotation_to_index_task.py
+++ b/api/tasks/annotation/add_annotation_to_index_task.py
@@ -3,8 +3,9 @@ import time
 
 import click
 from celery import shared_task
-from core.index.index import IndexBuilder
 from langchain.schema import Document
+
+from core.index.index import IndexBuilder
 from models.dataset import Dataset
 from services.dataset_service import DatasetCollectionBindingService
 

--- a/api/tasks/annotation/batch_import_annotations_task.py
+++ b/api/tasks/annotation/batch_import_annotations_task.py
@@ -1,17 +1,17 @@
-import json
 import logging
 import time
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import Dataset
 from models.model import App, AppAnnotationSetting, MessageAnnotation
 from services.dataset_service import DatasetCollectionBindingService
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/annotation/delete_annotation_index_task.py
+++ b/api/tasks/annotation/delete_annotation_index_task.py
@@ -1,9 +1,9 @@
-import datetime
 import logging
 import time
 
 import click
 from celery import shared_task
+
 from core.index.index import IndexBuilder
 from models.dataset import Dataset
 from services.dataset_service import DatasetCollectionBindingService

--- a/api/tasks/annotation/disable_annotation_reply_task.py
+++ b/api/tasks/annotation/disable_annotation_reply_task.py
@@ -1,15 +1,15 @@
-import datetime
 import logging
 import time
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.dataset import Dataset
-from models.model import App, AppAnnotationSetting, MessageAnnotation
-from werkzeug.exceptions import NotFound
+from models.model import App, AppAnnotationSetting
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/annotation/enable_annotation_reply_task.py
+++ b/api/tasks/annotation/enable_annotation_reply_task.py
@@ -4,14 +4,15 @@ import time
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import Dataset
 from models.model import App, AppAnnotationSetting, MessageAnnotation
 from services.dataset_service import DatasetCollectionBindingService
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/annotation/update_annotation_to_index_task.py
+++ b/api/tasks/annotation/update_annotation_to_index_task.py
@@ -3,8 +3,9 @@ import time
 
 import click
 from celery import shared_task
-from core.index.index import IndexBuilder
 from langchain.schema import Document
+
+from core.index.index import IndexBuilder
 from models.dataset import Dataset
 from services.dataset_service import DatasetCollectionBindingService
 

--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -6,6 +6,8 @@ from typing import List, cast
 
 import click
 from celery import shared_task
+from sqlalchemy import func
+
 from core.indexing_runner import IndexingRunner
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
@@ -14,7 +16,6 @@ from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from libs import helper
 from models.dataset import Dataset, Document, DocumentSegment
-from sqlalchemy import func
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -3,12 +3,17 @@ import time
 
 import click
 from celery import shared_task
+
 from core.index.index import IndexBuilder
-from core.index.vector_index.vector_index import VectorIndex
 from extensions.ext_database import db
-from flask import current_app
-from models.dataset import (AppDatasetJoin, Dataset, DatasetKeywordTable, DatasetProcessRule, DatasetQuery, Document,
-                            DocumentSegment)
+from models.dataset import (
+    AppDatasetJoin,
+    Dataset,
+    DatasetProcessRule,
+    DatasetQuery,
+    Document,
+    DocumentSegment,
+)
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -3,6 +3,7 @@ import time
 
 import click
 from celery import shared_task
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from models.dataset import Dataset, DocumentSegment

--- a/api/tasks/clean_notion_document_task.py
+++ b/api/tasks/clean_notion_document_task.py
@@ -4,6 +4,7 @@ from typing import List
 
 import click
 from celery import shared_task
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from models.dataset import Dataset, Document, DocumentSegment

--- a/api/tasks/create_segment_to_index_task.py
+++ b/api/tasks/create_segment_to_index_task.py
@@ -5,12 +5,13 @@ from typing import List, Optional
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/deal_dataset_vector_index_task.py
+++ b/api/tasks/deal_dataset_vector_index_task.py
@@ -3,12 +3,12 @@ import time
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
-from langchain.schema import Document
-from models.dataset import Dataset
+from models.dataset import Dataset, DocumentSegment
 from models.dataset import Document as DatasetDocument
-from models.dataset import DocumentSegment
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/delete_segment_from_index_task.py
+++ b/api/tasks/delete_segment_from_index_task.py
@@ -3,11 +3,11 @@ import time
 
 import click
 from celery import shared_task
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from models.dataset import Dataset, Document, DocumentSegment
-from werkzeug.exceptions import NotFound
+from models.dataset import Dataset, Document
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/disable_segment_from_index_task.py
+++ b/api/tasks/disable_segment_from_index_task.py
@@ -3,11 +3,12 @@ import time
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.dataset import DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/document_indexing_sync_task.py
+++ b/api/tasks/document_indexing_sync_task.py
@@ -4,13 +4,14 @@ import time
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.data_loader.loader.notion import NotionLoader
 from core.index.index import IndexBuilder
 from core.indexing_runner import DocumentIsPausedException, IndexingRunner
 from extensions.ext_database import db
 from models.dataset import Dataset, Document, DocumentSegment
 from models.source import DataSourceBinding
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/document_indexing_task.py
+++ b/api/tasks/document_indexing_task.py
@@ -4,10 +4,10 @@ import time
 
 import click
 from celery import shared_task
+
 from core.indexing_runner import DocumentIsPausedException, IndexingRunner
 from extensions.ext_database import db
 from models.dataset import Document
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/document_indexing_update_task.py
+++ b/api/tasks/document_indexing_update_task.py
@@ -4,11 +4,12 @@ import time
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from core.indexing_runner import DocumentIsPausedException, IndexingRunner
 from extensions.ext_database import db
 from models.dataset import Dataset, Document, DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/enable_segment_to_index_task.py
+++ b/api/tasks/enable_segment_to_index_task.py
@@ -4,12 +4,13 @@ import time
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/mail_invite_member_task.py
+++ b/api/tasks/mail_invite_member_task.py
@@ -3,9 +3,9 @@ import time
 
 import click
 from celery import shared_task
-from constants.languages import languages
-from extensions.ext_mail import mail
 from flask import current_app, render_template
+
+from extensions.ext_mail import mail
 
 
 @shared_task(queue='mail')

--- a/api/tasks/recover_document_indexing_task.py
+++ b/api/tasks/recover_document_indexing_task.py
@@ -3,10 +3,11 @@ import time
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.indexing_runner import DocumentIsPausedException, IndexingRunner
 from extensions.ext_database import db
 from models.dataset import Document
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/remove_document_from_index_task.py
+++ b/api/tasks/remove_document_from_index_task.py
@@ -3,11 +3,12 @@ import time
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.dataset import Document, DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/update_segment_index_task.py
+++ b/api/tasks/update_segment_index_task.py
@@ -5,12 +5,13 @@ from typing import List, Optional
 
 import click
 from celery import shared_task
+from langchain.schema import Document
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/api/tasks/update_segment_keyword_index_task.py
+++ b/api/tasks/update_segment_keyword_index_task.py
@@ -1,16 +1,15 @@
 import datetime
 import logging
 import time
-from typing import List, Optional
 
 import click
 from celery import shared_task
+from werkzeug.exceptions import NotFound
+
 from core.index.index import IndexBuilder
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
-from langchain.schema import Document
 from models.dataset import DocumentSegment
-from werkzeug.exceptions import NotFound
 
 
 @shared_task(queue='dataset')

--- a/dev/reformat
+++ b/dev/reformat
@@ -2,10 +2,11 @@
 
 set -x
 
-# python style checks rely on `isort` in path
-if ! command -v isort &> /dev/null
-then
-    echo "Skip Python imports linting, since 'isort' is not available. Please install it with 'pip install isort'."
-else
-    isort  --settings ./.github/linters/.isort.cfg ./
+# python style checks rely on `ruff` in path
+if ! command -v ruff &> /dev/null; then
+    echo "Installing Ruff ..."
+    pip install ruff
 fi
+
+# run ruff linter
+ruff check --fix ./api

--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -1,4 +1,35 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 . "$(dirname -- "$0")/_/husky.sh"
 
-cd ./web && npx lint-staged
+# get the list of modified files
+files=$(git diff --cached --name-only)
+
+# check if api or web directory is modified
+
+api_modified=false
+web_modified=false
+
+for file in $files
+do
+    if [[ $file == "api/"* && $file == *.py ]]; then
+        # set api_modified flag to true
+        api_modified=true
+    elif [[ $file == "web/"* ]]; then
+        # set web_modified flag to true
+        web_modified=true
+    fi
+done
+
+# run linters based on the modified modules
+
+if $api_modified; then
+    echo "Running Ruff linter on api module"
+    ./dev/reformat
+fi
+
+if $web_modified; then
+    echo "Running ESLint on web module"
+    cd ./web || exit 1
+    npx lint-staged
+    cd ../
+fi


### PR DESCRIPTION
- The Ruff tool is a general linting and formatting tools for Python code
- Ruff is blazingly fast, as it finished lining or fixing all the hundreds of Python scripts of Dify project in less than a second, with the support of local cache and the core written in Rust
- Ruff linter is designed as drop-in replacement for [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [pyupgrade](https://pypi.org/project/pyupgrade/), [autoflake](https://pypi.org/project/autoflake/), and more
- To sort Python imports, the isort rules (I001, I002) in Ruff are applied (https://docs.astral.sh/ruff/rules/#isort-i)
   - although the line breaks in a style closer to `black` 
- Re-arranged Python imports in sections separated in source parties for better readability, in the order of "future", "standard-library", "third-party", "first-party", "local-folder". This greatly improves the readability and understandability.
- To remove the unused imports, F401 rule of Flake8 in Ruff is applied (https://docs.astral.sh/ruff/rules/#pyflakes-f)
   - fixed 190 violations
   - the tests directory is skipped as the tests requires some unused-like imports for importing mocking methods

The key changes in this PR:
1. apply ruff auto-fixes in one-key linting script `dev/reformat`
2. automatically run linter scripts in `pre-commit` (via husky support) when committing changes, if API module changes
3. check Python style in CI style workflow by running ruff linter and list all the violations if it fails