### PR TITLE
fix recreating users' default tenant relations when loading user

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -56,18 +56,19 @@ class AccountService:
 
         if account.status in [AccountStatus.BANNED.value, AccountStatus.CLOSED.value]:
             raise Forbidden('Account is banned or closed.')
-        
-        # init owner's tenant
-        tenant_owner = TenantAccountJoin.query.filter_by(account_id=account.id, role='owner').first()
-        if not tenant_owner:
-            _create_tenant_for_account(account)
-        
+
         current_tenant = TenantAccountJoin.query.filter_by(account_id=account.id, current=True).first()
         if current_tenant:
             account.current_tenant_id = current_tenant.tenant_id
+            account.current_tenant_id = current_tenant.tenant_id
         else:
-            account.current_tenant_id = tenant_owner.tenant_id
-            tenant_owner.current = True
+            available_tenant = TenantAccountJoin.query.filter_by(account_id=account.id) \
+                .order_by(TenantAccountJoin.id.asc()).first()
+            if not available_tenant:
+                raise Forbidden('No available tenant for the user.')
+
+            account.current_tenant_id = available_tenant.tenant_id
+            available_tenant.current = True
             db.session.commit()
        
         if datetime.utcnow() - account.last_active_at > timedelta(minutes=10):


### PR DESCRIPTION
- fix bugs in `load_user` introduced by #2341
- 1. skip auto creating default tenant in this method. for the reasons that 
    - 1.1 it causes leak as it does not acquire locks to guarantee only one default tenant will be created
    - 1.2 it's not a right timing to create user's default tenant. A better way is to do it in register service.
- 2. reuse existed available tenant for the user

Caused by 1.2.
<img width="480" alt="image" src="https://github.com/langgenius/dify/assets/1935105/f3acbf41-49d0-4fad-8163-72a2551a820f">
