### PR TITLE
chore: apply ruff's pyupgrade linter rules to modernize Python code with targeted version

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import os
 
 from werkzeug.exceptions import Unauthorized

--- a/api/config.py
+++ b/api/config.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import os
 
 import dotenv

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import json
 import logging
 from datetime import datetime

--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import logging
 
 from flask import request

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -1,7 +1,7 @@
-# -*- coding:utf-8 -*-
 import json
 import logging
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 import flask_login
 from flask import Response, stream_with_context
@@ -169,8 +169,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 from flask import Response, stream_with_context
 from flask_login import current_user
@@ -246,8 +247,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/console/app/model_config.py
+++ b/api/controllers/console/app/model_config.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 
 from flask import request
 from flask_login import current_user

--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask_login import current_user
 from flask_restful import Resource, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden, NotFound

--- a/api/controllers/console/app/statistic.py
+++ b/api/controllers/console/app/statistic.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from datetime import datetime
 from decimal import Decimal
 

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import flask_login
 from flask import current_app, request
 from flask_restful import Resource, reqparse

--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import flask_restful
 from flask import current_app, request
 from flask_login import current_user

--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -1,6 +1,4 @@
-# -*- coding:utf-8 -*-
 from datetime import datetime
-from typing import List
 
 from flask import request
 from flask_login import current_user
@@ -71,7 +69,7 @@ class DocumentResource(Resource):
 
         return document
 
-    def get_batch_documents(self, dataset_id: str, batch: str) -> List[Document]:
+    def get_batch_documents(self, dataset_id: str, batch: str) -> list[Document]:
         dataset = DatasetService.get_dataset(dataset_id)
         if not dataset:
             raise NotFound('Dataset not found.')

--- a/api/controllers/console/datasets/datasets_segments.py
+++ b/api/controllers/console/datasets/datasets_segments.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import uuid
 from datetime import datetime
 

--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import logging
 
 from flask import request

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -1,8 +1,8 @@
-# -*- coding:utf-8 -*-
 import json
 import logging
+from collections.abc import Generator
 from datetime import datetime
-from typing import Generator, Union
+from typing import Union
 
 from flask import Response, stream_with_context
 from flask_login import current_user
@@ -164,8 +164,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/console/explore/conversation.py
+++ b/api/controllers/console/explore/conversation.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask_login import current_user
 from flask_restful import marshal_with, reqparse
 from flask_restful.inputs import int_range

--- a/api/controllers/console/explore/error.py
+++ b/api/controllers/console/explore/error.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from libs.exception import BaseHTTPException
 
 

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from datetime import datetime
 
 from flask_login import current_user

--- a/api/controllers/console/explore/message.py
+++ b/api/controllers/console/explore/message.py
@@ -1,7 +1,7 @@
-# -*- coding:utf-8 -*-
 import json
 import logging
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 from flask import Response, stream_with_context
 from flask_login import current_user
@@ -123,8 +123,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import json
 
 from flask import current_app

--- a/api/controllers/console/explore/recommended_app.py
+++ b/api/controllers/console/explore/recommended_app.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask_login import current_user
 from flask_restful import Resource, fields, marshal_with
 from sqlalchemy import and_

--- a/api/controllers/console/setup.py
+++ b/api/controllers/console/setup.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from functools import wraps
 
 from flask import current_app, request

--- a/api/controllers/console/version.py
+++ b/api/controllers/console/version.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 
 import json
 import logging

--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from datetime import datetime
 
 import pytz

--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask import current_app
 from flask_login import current_user
 from flask_restful import Resource, abort, fields, marshal_with, reqparse

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import logging
 
 from flask import request

--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import json
 from functools import wraps
 

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import json
 
 from flask import current_app

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 from flask import Response, stream_with_context
 from flask_restful import reqparse
@@ -182,8 +183,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask import request
 from flask_restful import marshal_with, reqparse
 from flask_restful.inputs import int_range

--- a/api/controllers/service_api/app/error.py
+++ b/api/controllers/service_api/app/error.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from libs.exception import BaseHTTPException
 
 

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask_restful import fields, marshal_with, reqparse
 from flask_restful.inputs import int_range
 from werkzeug.exceptions import NotFound

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from datetime import datetime
 from functools import wraps
 

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import json
 
 from flask import current_app

--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import logging
 
 from flask import request

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -1,7 +1,7 @@
-# -*- coding:utf-8 -*-
 import json
 import logging
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 from flask import Response, stream_with_context
 from flask_restful import reqparse
@@ -154,8 +154,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/web/conversation.py
+++ b/api/controllers/web/conversation.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from flask_restful import marshal_with, reqparse
 from flask_restful.inputs import int_range
 from werkzeug.exceptions import NotFound

--- a/api/controllers/web/error.py
+++ b/api/controllers/web/error.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from libs.exception import BaseHTTPException
 
 

--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -1,7 +1,7 @@
-# -*- coding:utf-8 -*-
 import json
 import logging
-from typing import Generator, Union
+from collections.abc import Generator
+from typing import Union
 
 from flask import Response, stream_with_context
 from flask_restful import fields, marshal_with, reqparse
@@ -160,8 +160,7 @@ def compact_response(response: Union[dict, Generator]) -> Response:
         return Response(response=json.dumps(response), status=200, mimetype='application/json')
     else:
         def generate() -> Generator:
-            for chunk in response:
-                yield chunk
+            yield from response
 
         return Response(stream_with_context(generate()), status=200,
                         mimetype='text/event-stream')

--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import uuid
 
 from flask import request

--- a/api/controllers/web/site.py
+++ b/api/controllers/web/site.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 
 from flask import current_app
 from flask_restful import fields, marshal_with

--- a/api/controllers/web/wraps.py
+++ b/api/controllers/web/wraps.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 from functools import wraps
 
 from flask import request

--- a/api/core/agent/agent/agent_llm_callback.py
+++ b/api/core/agent/agent/agent_llm_callback.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from core.callback_handler.agent_loop_gather_callback_handler import AgentLoopGatherCallbackHandler
 from core.model_runtime.callbacks.base_callback import Callback
@@ -17,7 +17,7 @@ class AgentLLMCallback(Callback):
 
     def on_before_invoke(self, llm_instance: AIModel, model: str, credentials: dict,
                          prompt_messages: list[PromptMessage], model_parameters: dict,
-                         tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                         tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                          stream: bool = True, user: Optional[str] = None) -> None:
         """
         Before invoke callback
@@ -38,7 +38,7 @@ class AgentLLMCallback(Callback):
 
     def on_new_chunk(self, llm_instance: AIModel, chunk: LLMResultChunk, model: str, credentials: dict,
                      prompt_messages: list[PromptMessage], model_parameters: dict,
-                     tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                     tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                      stream: bool = True, user: Optional[str] = None):
         """
         On new chunk callback
@@ -58,7 +58,7 @@ class AgentLLMCallback(Callback):
 
     def on_after_invoke(self, llm_instance: AIModel, result: LLMResult, model: str, credentials: dict,
                         prompt_messages: list[PromptMessage], model_parameters: dict,
-                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                         stream: bool = True, user: Optional[str] = None) -> None:
         """
         After invoke callback
@@ -80,7 +80,7 @@ class AgentLLMCallback(Callback):
 
     def on_invoke_error(self, llm_instance: AIModel, ex: Exception, model: str, credentials: dict,
                         prompt_messages: list[PromptMessage], model_parameters: dict,
-                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                         stream: bool = True, user: Optional[str] = None) -> None:
         """
         Invoke error callback

--- a/api/core/agent/agent/calc_token_mixin.py
+++ b/api/core/agent/agent/calc_token_mixin.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import cast
 
 from core.entities.application_entities import ModelConfigEntity
 from core.model_runtime.entities.message_entities import PromptMessage
@@ -8,7 +8,7 @@ from core.model_runtime.model_providers.__base.large_language_model import Large
 
 class CalcTokenMixin:
 
-    def get_message_rest_tokens(self, model_config: ModelConfigEntity, messages: List[PromptMessage], **kwargs) -> int:
+    def get_message_rest_tokens(self, model_config: ModelConfigEntity, messages: list[PromptMessage], **kwargs) -> int:
         """
         Got the rest tokens available for the model after excluding messages tokens and completion max tokens
 

--- a/api/core/agent/agent/multi_dataset_router_agent.py
+++ b/api/core/agent/agent/multi_dataset_router_agent.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Any, Optional, Union
 
 from langchain.agents import BaseSingleActionAgent, OpenAIFunctionsAgent
 from langchain.agents.openai_functions_agent.base import _format_intermediate_steps, _parse_ai_message
@@ -42,7 +43,7 @@ class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
 
     def plan(
         self,
-        intermediate_steps: List[Tuple[AgentAction, str]],
+        intermediate_steps: list[tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> Union[AgentAction, AgentFinish]:
@@ -85,7 +86,7 @@ class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
 
     def real_plan(
         self,
-        intermediate_steps: List[Tuple[AgentAction, str]],
+        intermediate_steps: list[tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> Union[AgentAction, AgentFinish]:
@@ -146,7 +147,7 @@ class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
 
     async def aplan(
             self,
-            intermediate_steps: List[Tuple[AgentAction, str]],
+            intermediate_steps: list[tuple[AgentAction, str]],
             callbacks: Callbacks = None,
             **kwargs: Any,
     ) -> Union[AgentAction, AgentFinish]:
@@ -158,7 +159,7 @@ class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
             model_config: ModelConfigEntity,
             tools: Sequence[BaseTool],
             callback_manager: Optional[BaseCallbackManager] = None,
-            extra_prompt_messages: Optional[List[BaseMessagePromptTemplate]] = None,
+            extra_prompt_messages: Optional[list[BaseMessagePromptTemplate]] = None,
             system_message: Optional[SystemMessage] = SystemMessage(
                 content="You are a helpful AI assistant."
             ),

--- a/api/core/agent/agent/openai_function_call.py
+++ b/api/core/agent/agent/openai_function_call.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Any, Optional, Union
 
 from langchain.agents import BaseSingleActionAgent, OpenAIFunctionsAgent
 from langchain.agents.openai_functions_agent.base import _format_intermediate_steps, _parse_ai_message
@@ -51,7 +52,7 @@ class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixi
             model_config: ModelConfigEntity,
             tools: Sequence[BaseTool],
             callback_manager: Optional[BaseCallbackManager] = None,
-            extra_prompt_messages: Optional[List[BaseMessagePromptTemplate]] = None,
+            extra_prompt_messages: Optional[list[BaseMessagePromptTemplate]] = None,
             system_message: Optional[SystemMessage] = SystemMessage(
                 content="You are a helpful AI assistant."
             ),
@@ -125,7 +126,7 @@ class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixi
 
     def plan(
             self,
-            intermediate_steps: List[Tuple[AgentAction, str]],
+            intermediate_steps: list[tuple[AgentAction, str]],
             callbacks: Callbacks = None,
             **kwargs: Any,
     ) -> Union[AgentAction, AgentFinish]:
@@ -207,7 +208,7 @@ class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixi
     def return_stopped_response(
             self,
             early_stopping_method: str,
-            intermediate_steps: List[Tuple[AgentAction, str]],
+            intermediate_steps: list[tuple[AgentAction, str]],
             **kwargs: Any,
     ) -> AgentFinish:
         try:
@@ -215,7 +216,7 @@ class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixi
         except ValueError:
             return AgentFinish({"output": "I'm sorry, I don't know how to respond to that."}, "")
 
-    def summarize_messages_if_needed(self, messages: List[PromptMessage], **kwargs) -> List[PromptMessage]:
+    def summarize_messages_if_needed(self, messages: list[PromptMessage], **kwargs) -> list[PromptMessage]:
         # calculate rest tokens and summarize previous function observation messages if rest_tokens < 0
         rest_tokens = self.get_message_rest_tokens(
             self.model_config,
@@ -264,7 +265,7 @@ class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixi
         return new_messages
 
     def predict_new_summary(
-        self, messages: List[BaseMessage], existing_summary: str
+        self, messages: list[BaseMessage], existing_summary: str
     ) -> str:
         new_lines = get_buffer_string(
             messages,
@@ -275,7 +276,7 @@ class AutoSummarizingOpenAIFunctionCallAgent(OpenAIFunctionsAgent, CalcTokenMixi
         chain = LLMChain(model_config=self.summary_model_config, prompt=SUMMARY_PROMPT)
         return chain.predict(summary=existing_summary, new_lines=new_lines)
 
-    def get_num_tokens_from_messages(self, model_config: ModelConfigEntity, messages: List[BaseMessage], **kwargs) -> int:
+    def get_num_tokens_from_messages(self, model_config: ModelConfigEntity, messages: list[BaseMessage], **kwargs) -> int:
         """Calculate num tokens for gpt-3.5-turbo and gpt-4 with tiktoken package.
 
         Official documentation: https://github.com/openai/openai-cookbook/blob/

--- a/api/core/agent/agent/structed_multi_dataset_router_agent.py
+++ b/api/core/agent/agent/structed_multi_dataset_router_agent.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+from collections.abc import Sequence
+from typing import Any, Optional, Union, cast
 
 from langchain import BasePromptTemplate, PromptTemplate
 from langchain.agents import Agent, AgentOutputParser, StructuredChatAgent
@@ -68,7 +69,7 @@ class StructuredMultiDatasetRouterAgent(StructuredChatAgent):
 
     def plan(
             self,
-            intermediate_steps: List[Tuple[AgentAction, str]],
+            intermediate_steps: list[tuple[AgentAction, str]],
             callbacks: Callbacks = None,
             **kwargs: Any,
     ) -> Union[AgentAction, AgentFinish]:
@@ -125,8 +126,8 @@ class StructuredMultiDatasetRouterAgent(StructuredChatAgent):
             suffix: str = SUFFIX,
             human_message_template: str = HUMAN_MESSAGE_TEMPLATE,
             format_instructions: str = FORMAT_INSTRUCTIONS,
-            input_variables: Optional[List[str]] = None,
-            memory_prompts: Optional[List[BasePromptTemplate]] = None,
+            input_variables: Optional[list[str]] = None,
+            memory_prompts: Optional[list[BasePromptTemplate]] = None,
     ) -> BasePromptTemplate:
         tool_strings = []
         for tool in tools:
@@ -153,7 +154,7 @@ class StructuredMultiDatasetRouterAgent(StructuredChatAgent):
             tools: Sequence[BaseTool],
             prefix: str = PREFIX,
             format_instructions: str = FORMAT_INSTRUCTIONS,
-            input_variables: Optional[List[str]] = None,
+            input_variables: Optional[list[str]] = None,
     ) -> PromptTemplate:
         """Create prompt in the style of the zero shot agent.
 
@@ -180,7 +181,7 @@ Thought: {agent_scratchpad}
         return PromptTemplate(template=template, input_variables=input_variables)
 
     def _construct_scratchpad(
-            self, intermediate_steps: List[Tuple[AgentAction, str]]
+            self, intermediate_steps: list[tuple[AgentAction, str]]
     ) -> str:
         agent_scratchpad = ""
         for action, observation in intermediate_steps:
@@ -213,8 +214,8 @@ Thought: {agent_scratchpad}
             suffix: str = SUFFIX,
             human_message_template: str = HUMAN_MESSAGE_TEMPLATE,
             format_instructions: str = FORMAT_INSTRUCTIONS,
-            input_variables: Optional[List[str]] = None,
-            memory_prompts: Optional[List[BasePromptTemplate]] = None,
+            input_variables: Optional[list[str]] = None,
+            memory_prompts: Optional[list[BasePromptTemplate]] = None,
             **kwargs: Any,
     ) -> Agent:
         """Construct an agent from an LLM and tools."""

--- a/api/core/agent/agent/structured_chat.py
+++ b/api/core/agent/agent/structured_chat.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+from collections.abc import Sequence
+from typing import Any, Optional, Union, cast
 
 from langchain import BasePromptTemplate, PromptTemplate
 from langchain.agents import Agent, AgentOutputParser, StructuredChatAgent
@@ -82,7 +83,7 @@ class AutoSummarizingStructuredChatAgent(StructuredChatAgent, CalcTokenMixin):
 
     def plan(
         self,
-        intermediate_steps: List[Tuple[AgentAction, str]],
+        intermediate_steps: list[tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> Union[AgentAction, AgentFinish]:
@@ -127,7 +128,7 @@ class AutoSummarizingStructuredChatAgent(StructuredChatAgent, CalcTokenMixin):
             return AgentFinish({"output": "I'm sorry, the answer of model is invalid, "
                                           "I don't know how to respond to that."}, "")
 
-    def summarize_messages(self, intermediate_steps: List[Tuple[AgentAction, str]], **kwargs):
+    def summarize_messages(self, intermediate_steps: list[tuple[AgentAction, str]], **kwargs):
         if len(intermediate_steps) >= 2 and self.summary_model_config:
             should_summary_intermediate_steps = intermediate_steps[self.moving_summary_index:-1]
             should_summary_messages = [AIMessage(content=observation)
@@ -154,7 +155,7 @@ class AutoSummarizingStructuredChatAgent(StructuredChatAgent, CalcTokenMixin):
         return self.get_full_inputs([intermediate_steps[-1]], **kwargs)
 
     def predict_new_summary(
-        self, messages: List[BaseMessage], existing_summary: str
+        self, messages: list[BaseMessage], existing_summary: str
     ) -> str:
         new_lines = get_buffer_string(
             messages,
@@ -173,8 +174,8 @@ class AutoSummarizingStructuredChatAgent(StructuredChatAgent, CalcTokenMixin):
             suffix: str = SUFFIX,
             human_message_template: str = HUMAN_MESSAGE_TEMPLATE,
             format_instructions: str = FORMAT_INSTRUCTIONS,
-            input_variables: Optional[List[str]] = None,
-            memory_prompts: Optional[List[BasePromptTemplate]] = None,
+            input_variables: Optional[list[str]] = None,
+            memory_prompts: Optional[list[BasePromptTemplate]] = None,
     ) -> BasePromptTemplate:
         tool_strings = []
         for tool in tools:
@@ -200,7 +201,7 @@ class AutoSummarizingStructuredChatAgent(StructuredChatAgent, CalcTokenMixin):
             tools: Sequence[BaseTool],
             prefix: str = PREFIX,
             format_instructions: str = FORMAT_INSTRUCTIONS,
-            input_variables: Optional[List[str]] = None,
+            input_variables: Optional[list[str]] = None,
     ) -> PromptTemplate:
         """Create prompt in the style of the zero shot agent.
 
@@ -227,7 +228,7 @@ Thought: {agent_scratchpad}
         return PromptTemplate(template=template, input_variables=input_variables)
 
     def _construct_scratchpad(
-        self, intermediate_steps: List[Tuple[AgentAction, str]]
+        self, intermediate_steps: list[tuple[AgentAction, str]]
     ) -> str:
         agent_scratchpad = ""
         for action, observation in intermediate_steps:
@@ -260,8 +261,8 @@ Thought: {agent_scratchpad}
             suffix: str = SUFFIX,
             human_message_template: str = HUMAN_MESSAGE_TEMPLATE,
             format_instructions: str = FORMAT_INSTRUCTIONS,
-            input_variables: Optional[List[str]] = None,
-            memory_prompts: Optional[List[BasePromptTemplate]] = None,
+            input_variables: Optional[list[str]] = None,
+            memory_prompts: Optional[list[BasePromptTemplate]] = None,
             agent_llm_callback: Optional[AgentLLMCallback] = None,
             **kwargs: Any,
     ) -> Agent:

--- a/api/core/app_runner/app_runner.py
+++ b/api/core/app_runner/app_runner.py
@@ -1,5 +1,6 @@
 import time
-from typing import Generator, List, Optional, Tuple, Union, cast
+from collections.abc import Generator
+from typing import Optional, Union, cast
 
 from core.application_queue_manager import ApplicationQueueManager, PublishFrom
 from core.entities.application_entities import (
@@ -84,7 +85,7 @@ class AppRunner:
         return rest_tokens
 
     def recale_llm_max_tokens(self, model_config: ModelConfigEntity,
-                              prompt_messages: List[PromptMessage]):
+                              prompt_messages: list[PromptMessage]):
         # recalc max_tokens if sum(prompt_token +  max_tokens) over model token limit
         model_type_instance = model_config.provider_model_bundle.model_type_instance
         model_type_instance = cast(LargeLanguageModel, model_type_instance)
@@ -126,7 +127,7 @@ class AppRunner:
                                  query: Optional[str] = None,
                                  context: Optional[str] = None,
                                  memory: Optional[TokenBufferMemory] = None) \
-            -> Tuple[List[PromptMessage], Optional[List[str]]]:
+            -> tuple[list[PromptMessage], Optional[list[str]]]:
         """
         Organize prompt messages
         :param context:
@@ -295,7 +296,7 @@ class AppRunner:
                               tenant_id: str,
                               app_orchestration_config_entity: AppOrchestrationConfigEntity,
                               inputs: dict,
-                              query: str) -> Tuple[bool, dict, str]:
+                              query: str) -> tuple[bool, dict, str]:
         """
         Process sensitive_word_avoidance.
         :param app_id: app id

--- a/api/core/app_runner/generate_task_pipeline.py
+++ b/api/core/app_runner/generate_task_pipeline.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import time
-from typing import Generator, Optional, Union, cast
+from collections.abc import Generator
+from typing import Optional, Union, cast
 
 from pydantic import BaseModel
 
@@ -118,7 +119,7 @@ class GenerateTaskPipeline:
                     }
 
                     self._task_state.llm_result.message.content = annotation.content
-            elif isinstance(event, (QueueStopEvent, QueueMessageEndEvent)):
+            elif isinstance(event, QueueStopEvent | QueueMessageEndEvent):
                 if isinstance(event, QueueMessageEndEvent):
                     self._task_state.llm_result = event.llm_result
                 else:
@@ -201,7 +202,7 @@ class GenerateTaskPipeline:
                 data = self._error_to_stream_response_data(self._handle_error(event))
                 yield self._yield_response(data)
                 break
-            elif isinstance(event, (QueueStopEvent, QueueMessageEndEvent)):
+            elif isinstance(event, QueueStopEvent | QueueMessageEndEvent):
                 if isinstance(event, QueueMessageEndEvent):
                     self._task_state.llm_result = event.llm_result
                 else:
@@ -353,7 +354,7 @@ class GenerateTaskPipeline:
 
                     yield self._yield_response(response)
 
-            elif isinstance(event, (QueueMessageEvent, QueueAgentMessageEvent)):
+            elif isinstance(event, QueueMessageEvent | QueueAgentMessageEvent):
                 chunk = event.chunk
                 delta_text = chunk.delta.message.content
                 if delta_text is None:

--- a/api/core/app_runner/moderation_handler.py
+++ b/api/core/app_runner/moderation_handler.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from flask import Flask, current_app
 from pydantic import BaseModel
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class ModerationRule(BaseModel):
     type: str
-    config: Dict[str, Any]
+    config: dict[str, Any]
 
 
 class OutputModerationHandler(BaseModel):

--- a/api/core/application_manager.py
+++ b/api/core/application_manager.py
@@ -2,7 +2,8 @@ import json
 import logging
 import threading
 import uuid
-from typing import Any, Generator, Optional, Tuple, Union, cast
+from collections.abc import Generator
+from typing import Any, Optional, Union, cast
 
 from flask import Flask, current_app
 from pydantic import ValidationError
@@ -585,7 +586,7 @@ class ApplicationManager:
         return AppOrchestrationConfigEntity(**properties)
 
     def _init_generate_records(self, application_generate_entity: ApplicationGenerateEntity) \
-            -> Tuple[Conversation, Message]:
+            -> tuple[Conversation, Message]:
         """
         Initialize generate records
         :param application_generate_entity: application generate entity

--- a/api/core/application_queue_manager.py
+++ b/api/core/application_queue_manager.py
@@ -1,7 +1,8 @@
 import queue
 import time
+from collections.abc import Generator
 from enum import Enum
-from typing import Any, Generator
+from typing import Any
 
 from sqlalchemy.orm import DeclarativeMeta
 

--- a/api/core/callback_handler/agent_loop_gather_callback_handler.py
+++ b/api/core/callback_handler/agent_loop_gather_callback_handler.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from langchain.agents import openai_functions_agent, openai_functions_multi_agent
 from langchain.callbacks.base import BaseCallbackHandler
@@ -37,7 +37,7 @@ class AgentLoopGatherCallbackHandler(BaseCallbackHandler):
         self._message_agent_thought = None
 
     @property
-    def agent_loops(self) -> List[AgentLoop]:
+    def agent_loops(self) -> list[AgentLoop]:
         return self._agent_loops
 
     def clear_agent_loops(self) -> None:
@@ -95,14 +95,14 @@ class AgentLoopGatherCallbackHandler(BaseCallbackHandler):
 
     def on_chat_model_start(
             self,
-            serialized: Dict[str, Any],
-            messages: List[List[BaseMessage]],
+            serialized: dict[str, Any],
+            messages: list[list[BaseMessage]],
             **kwargs: Any
     ) -> Any:
         pass
 
     def on_llm_start(
-        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+        self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any
     ) -> None:
         pass
 
@@ -120,7 +120,7 @@ class AgentLoopGatherCallbackHandler(BaseCallbackHandler):
 
     def on_tool_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: dict[str, Any],
         input_str: str,
         **kwargs: Any,
     ) -> None:

--- a/api/core/callback_handler/agent_tool_callback_handler.py
+++ b/api/core/callback_handler/agent_tool_callback_handler.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.input import print_text
@@ -21,7 +21,7 @@ class DifyAgentCallbackHandler(BaseCallbackHandler, BaseModel):
     def on_tool_start(
         self,
         tool_name: str,
-        tool_inputs: Dict[str, Any],
+        tool_inputs: dict[str, Any],
     ) -> None:
         """Do nothing."""
         print_text("\n[on_tool_start] ToolCall:" + tool_name + "\n" + str(tool_inputs) + "\n", color=self.color)
@@ -29,7 +29,7 @@ class DifyAgentCallbackHandler(BaseCallbackHandler, BaseModel):
     def on_tool_end(
         self,
         tool_name: str,
-        tool_inputs: Dict[str, Any],
+        tool_inputs: dict[str, Any],
         tool_outputs: str,
     ) -> None:
         """If not the final action, print out observation."""

--- a/api/core/callback_handler/index_tool_callback_handler.py
+++ b/api/core/callback_handler/index_tool_callback_handler.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from langchain.schema import Document
 
@@ -40,7 +39,7 @@ class DatasetIndexToolCallbackHandler:
         db.session.add(dataset_query)
         db.session.commit()
 
-    def on_tool_end(self, documents: List[Document]) -> None:
+    def on_tool_end(self, documents: list[Document]) -> None:
         """Handle tool end."""
         for document in documents:
             doc_id = document.metadata['doc_id']
@@ -55,7 +54,7 @@ class DatasetIndexToolCallbackHandler:
 
             db.session.commit()
 
-    def return_retriever_resource_info(self, resource: List):
+    def return_retriever_resource_info(self, resource: list):
         """Handle return_retriever_resource_info."""
         if resource and len(resource) > 0:
             for item in resource:

--- a/api/core/callback_handler/std_out_callback_handler.py
+++ b/api/core/callback_handler/std_out_callback_handler.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.input import print_text
@@ -16,8 +16,8 @@ class DifyStdOutCallbackHandler(BaseCallbackHandler):
 
     def on_chat_model_start(
             self,
-            serialized: Dict[str, Any],
-            messages: List[List[BaseMessage]],
+            serialized: dict[str, Any],
+            messages: list[list[BaseMessage]],
             **kwargs: Any
     ) -> Any:
         print_text("\n[on_chat_model_start]\n", color='blue')
@@ -26,7 +26,7 @@ class DifyStdOutCallbackHandler(BaseCallbackHandler):
                 print_text(str(sub_message) + "\n", color='blue')
 
     def on_llm_start(
-        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+        self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any
     ) -> None:
         """Print out the prompts."""
         print_text("\n[on_llm_start]\n", color='blue')
@@ -48,13 +48,13 @@ class DifyStdOutCallbackHandler(BaseCallbackHandler):
         print_text("\n[on_llm_error]\nError: " + str(error) + "\n", color='blue')
 
     def on_chain_start(
-        self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
+        self, serialized: dict[str, Any], inputs: dict[str, Any], **kwargs: Any
     ) -> None:
         """Print out that we are entering a chain."""
         chain_type = serialized['id'][-1]
         print_text("\n[on_chain_start]\nChain: " + chain_type + "\nInputs: " + str(inputs) + "\n", color='pink')
 
-    def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
+    def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Print out that we finished a chain."""
         print_text("\n[on_chain_end]\nOutputs: " + str(outputs) + "\n", color='pink')
 
@@ -66,7 +66,7 @@ class DifyStdOutCallbackHandler(BaseCallbackHandler):
 
     def on_tool_start(
         self,
-        serialized: Dict[str, Any],
+        serialized: dict[str, Any],
         input_str: str,
         **kwargs: Any,
     ) -> None:

--- a/api/core/chain/llm_chain.py
+++ b/api/core/chain/llm_chain.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from langchain import LLMChain as LCLLMChain
 from langchain.callbacks.manager import CallbackManagerForChainRun
@@ -16,12 +16,12 @@ class LLMChain(LCLLMChain):
     model_config: ModelConfigEntity
     """The language model instance to use."""
     llm: BaseLanguageModel = FakeLLM(response="")
-    parameters: Dict[str, Any] = {}
+    parameters: dict[str, Any] = {}
     agent_llm_callback: Optional[AgentLLMCallback] = None
 
     def generate(
         self,
-        input_list: List[Dict[str, Any]],
+        input_list: list[dict[str, Any]],
         run_manager: Optional[CallbackManagerForChainRun] = None,
     ) -> LLMResult:
         """Generate LLM result from inputs."""

--- a/api/core/data_loader/file_extractor.py
+++ b/api/core/data_loader/file_extractor.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import requests
 from flask import current_app
@@ -28,7 +28,7 @@ USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 
 class FileExtractor:
     @classmethod
-    def load(cls, upload_file: UploadFile, return_text: bool = False, is_automatic: bool = False) -> Union[List[Document], str]:
+    def load(cls, upload_file: UploadFile, return_text: bool = False, is_automatic: bool = False) -> Union[list[Document], str]:
         with tempfile.TemporaryDirectory() as temp_dir:
             suffix = Path(upload_file.key).suffix
             file_path = f"{temp_dir}/{next(tempfile._get_candidate_names())}{suffix}"
@@ -37,7 +37,7 @@ class FileExtractor:
             return cls.load_from_file(file_path, return_text, upload_file, is_automatic)
 
     @classmethod
-    def load_from_url(cls, url: str, return_text: bool = False) -> Union[List[Document], str]:
+    def load_from_url(cls, url: str, return_text: bool = False) -> Union[list[Document], str]:
         response = requests.get(url, headers={
             "User-Agent": USER_AGENT
         })
@@ -53,7 +53,7 @@ class FileExtractor:
     @classmethod
     def load_from_file(cls, file_path: str, return_text: bool = False,
                        upload_file: Optional[UploadFile] = None,
-                       is_automatic: bool = False) -> Union[List[Document], str]:
+                       is_automatic: bool = False) -> Union[list[Document], str]:
         input_file = Path(file_path)
         delimiter = '\n'
         file_extension = input_file.suffix.lower()

--- a/api/core/data_loader/loader/csv_loader.py
+++ b/api/core/data_loader/loader/csv_loader.py
@@ -1,6 +1,6 @@
 import csv
 import logging
-from typing import Dict, List, Optional
+from typing import Optional
 
 from langchain.document_loaders import CSVLoader as LCCSVLoader
 from langchain.document_loaders.helpers import detect_file_encodings
@@ -14,7 +14,7 @@ class CSVLoader(LCCSVLoader):
             self,
             file_path: str,
             source_column: Optional[str] = None,
-            csv_args: Optional[Dict] = None,
+            csv_args: Optional[dict] = None,
             encoding: Optional[str] = None,
             autodetect_encoding: bool = True,
     ):
@@ -24,7 +24,7 @@ class CSVLoader(LCCSVLoader):
         self.csv_args = csv_args or {}
         self.autodetect_encoding = autodetect_encoding
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         """Load data into document objects."""
         try:
             with open(self.file_path, newline="", encoding=self.encoding) as csvfile:

--- a/api/core/data_loader/loader/excel.py
+++ b/api/core/data_loader/loader/excel.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -23,7 +22,7 @@ class ExcelLoader(BaseLoader):
         """Initialize with file path."""
         self._file_path = file_path
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         data = []
         keys = []
         wb = load_workbook(filename=self._file_path, read_only=True)

--- a/api/core/data_loader/loader/html.py
+++ b/api/core/data_loader/loader/html.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from bs4 import BeautifulSoup
 from langchain.document_loaders.base import BaseLoader
@@ -23,7 +22,7 @@ class HTMLLoader(BaseLoader):
         """Initialize with file path."""
         self._file_path = file_path
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         return [Document(page_content=self._load_as_text())]
 
     def _load_as_text(self) -> str:

--- a/api/core/data_loader/loader/markdown.py
+++ b/api/core/data_loader/loader/markdown.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import List, Optional, Tuple, cast
+from typing import Optional, cast
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.document_loaders.helpers import detect_file_encodings
@@ -42,7 +42,7 @@ class MarkdownLoader(BaseLoader):
         self._encoding = encoding
         self._autodetect_encoding = autodetect_encoding
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         tups = self.parse_tups(self._file_path)
         documents = []
         for header, value in tups:
@@ -54,13 +54,13 @@ class MarkdownLoader(BaseLoader):
 
         return documents
 
-    def markdown_to_tups(self, markdown_text: str) -> List[Tuple[Optional[str], str]]:
+    def markdown_to_tups(self, markdown_text: str) -> list[tuple[Optional[str], str]]:
         """Convert a markdown file to a dictionary.
 
         The keys are the headers and the values are the text under each header.
 
         """
-        markdown_tups: List[Tuple[Optional[str], str]] = []
+        markdown_tups: list[tuple[Optional[str], str]] = []
         lines = markdown_text.split("\n")
 
         current_header = None
@@ -103,11 +103,11 @@ class MarkdownLoader(BaseLoader):
         content = re.sub(pattern, r"\1", content)
         return content
 
-    def parse_tups(self, filepath: str) -> List[Tuple[Optional[str], str]]:
+    def parse_tups(self, filepath: str) -> list[tuple[Optional[str], str]]:
         """Parse file into tuples."""
         content = ""
         try:
-            with open(filepath, "r", encoding=self._encoding) as f:
+            with open(filepath, encoding=self._encoding) as f:
                 content = f.read()
         except UnicodeDecodeError as e:
             if self._autodetect_encoding:

--- a/api/core/data_loader/loader/notion.py
+++ b/api/core/data_loader/loader/notion.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import requests
 from flask import current_app
@@ -67,7 +67,7 @@ class NotionLoader(BaseLoader):
             document_model=document_model
         )
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         self.update_last_edited_time(
             self._document_model
         )
@@ -78,7 +78,7 @@ class NotionLoader(BaseLoader):
 
     def _load_data_as_documents(
             self, notion_obj_id: str, notion_page_type: str
-    ) -> List[Document]:
+    ) -> list[Document]:
         docs = []
         if notion_page_type == 'database':
             # get all the pages in the database
@@ -94,8 +94,8 @@ class NotionLoader(BaseLoader):
         return docs
 
     def _get_notion_database_data(
-            self, database_id: str, query_dict: Dict[str, Any] = {}
-    ) -> List[Document]:
+            self, database_id: str, query_dict: dict[str, Any] = {}
+    ) -> list[Document]:
         """Get all the pages from a Notion database."""
         res = requests.post(
             DATABASE_URL_TMPL.format(database_id=database_id),
@@ -149,12 +149,12 @@ class NotionLoader(BaseLoader):
 
         return database_content_list
 
-    def _get_notion_block_data(self, page_id: str) -> List[str]:
+    def _get_notion_block_data(self, page_id: str) -> list[str]:
         result_lines_arr = []
         cur_block_id = page_id
         while True:
             block_url = BLOCK_CHILD_URL_TMPL.format(block_id=cur_block_id)
-            query_dict: Dict[str, Any] = {}
+            query_dict: dict[str, Any] = {}
 
             res = requests.request(
                 "GET",
@@ -216,7 +216,7 @@ class NotionLoader(BaseLoader):
         cur_block_id = block_id
         while True:
             block_url = BLOCK_CHILD_URL_TMPL.format(block_id=cur_block_id)
-            query_dict: Dict[str, Any] = {}
+            query_dict: dict[str, Any] = {}
 
             res = requests.request(
                 "GET",
@@ -280,7 +280,7 @@ class NotionLoader(BaseLoader):
         cur_block_id = block_id
         while not done:
             block_url = BLOCK_CHILD_URL_TMPL.format(block_id=cur_block_id)
-            query_dict: Dict[str, Any] = {}
+            query_dict: dict[str, Any] = {}
 
             res = requests.request(
                 "GET",
@@ -346,7 +346,7 @@ class NotionLoader(BaseLoader):
         else:
             retrieve_page_url = RETRIEVE_PAGE_URL_TMPL.format(page_id=obj_id)
 
-        query_dict: Dict[str, Any] = {}
+        query_dict: dict[str, Any] = {}
 
         res = requests.request(
             "GET",

--- a/api/core/data_loader/loader/pdf.py
+++ b/api/core/data_loader/loader/pdf.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from langchain.document_loaders import PyPDFium2Loader
 from langchain.document_loaders.base import BaseLoader
@@ -28,7 +28,7 @@ class PdfLoader(BaseLoader):
         self._file_path = file_path
         self._upload_file = upload_file
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         plaintext_file_key = ''
         plaintext_file_exists = False
         if self._upload_file:

--- a/api/core/data_loader/loader/unstructured/unstructured_eml.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_eml.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-from typing import List
 
 from bs4 import BeautifulSoup
 from langchain.document_loaders.base import BaseLoader
@@ -24,7 +23,7 @@ class UnstructuredEmailLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.email import partition_email
         elements = partition_email(filename=self._file_path, api_url=self._api_url)
 

--- a/api/core/data_loader/loader/unstructured/unstructured_markdown.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_markdown.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -34,7 +33,7 @@ class UnstructuredMarkdownLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.md import partition_md
 
         elements = partition_md(filename=self._file_path, api_url=self._api_url)

--- a/api/core/data_loader/loader/unstructured/unstructured_msg.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_msg.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -24,7 +23,7 @@ class UnstructuredMsgLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.msg import partition_msg
 
         elements = partition_msg(filename=self._file_path, api_url=self._api_url)

--- a/api/core/data_loader/loader/unstructured/unstructured_ppt.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_ppt.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -23,7 +22,7 @@ class UnstructuredPPTLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.ppt import partition_ppt
 
         elements = partition_ppt(filename=self._file_path, api_url=self._api_url)

--- a/api/core/data_loader/loader/unstructured/unstructured_pptx.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_pptx.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -22,7 +21,7 @@ class UnstructuredPPTXLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.pptx import partition_pptx
 
         elements = partition_pptx(filename=self._file_path, api_url=self._api_url)

--- a/api/core/data_loader/loader/unstructured/unstructured_text.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_text.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -24,7 +23,7 @@ class UnstructuredTextLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.text import partition_text
 
         elements = partition_text(filename=self._file_path, api_url=self._api_url)

--- a/api/core/data_loader/loader/unstructured/unstructured_xml.py
+++ b/api/core/data_loader/loader/unstructured/unstructured_xml.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
@@ -24,7 +23,7 @@ class UnstructuredXmlLoader(BaseLoader):
         self._file_path = file_path
         self._api_url = api_url
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         from unstructured.partition.xml import partition_xml
 
         elements = partition_xml(filename=self._file_path, xml_keep_tags=True, api_url=self._api_url)

--- a/api/core/docstore/dataset_docstore.py
+++ b/api/core/docstore/dataset_docstore.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Sequence, cast
+from collections.abc import Sequence
+from typing import Any, Optional, cast
 
 from langchain.schema import Document
 from sqlalchemy import func
@@ -22,10 +23,10 @@ class DatasetDocumentStore:
         self._document_id = document_id
 
     @classmethod
-    def from_dict(cls, config_dict: Dict[str, Any]) -> "DatasetDocumentStore":
+    def from_dict(cls, config_dict: dict[str, Any]) -> "DatasetDocumentStore":
         return cls(**config_dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to dict."""
         return {
             "dataset_id": self._dataset.id,
@@ -40,7 +41,7 @@ class DatasetDocumentStore:
         return self._user_id
 
     @property
-    def docs(self) -> Dict[str, Document]:
+    def docs(self) -> dict[str, Document]:
         document_segments = db.session.query(DocumentSegment).filter(
             DocumentSegment.dataset_id == self._dataset.id
         ).all()

--- a/api/core/embedding/cached_embedding.py
+++ b/api/core/embedding/cached_embedding.py
@@ -1,6 +1,6 @@
 import base64
 import logging
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import numpy as np
 from langchain.embeddings.base import Embeddings
@@ -21,7 +21,7 @@ class CacheEmbedding(Embeddings):
         self._model_instance = model_instance
         self._user = user
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embed search docs in batches of 10."""
         text_embeddings = []
         try:
@@ -52,7 +52,7 @@ class CacheEmbedding(Embeddings):
 
         return text_embeddings
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str) -> list[float]:
         """Embed query text."""
         # use doc embedding cache or store if not exists
         hash = helper.generate_text_hash(text)

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -1,8 +1,9 @@
 import datetime
 import json
 import logging
+from collections.abc import Iterator
 from json import JSONDecodeError
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -135,7 +136,7 @@ class ProviderConfiguration(BaseModel):
             if self.provider.provider_credential_schema else []
         )
 
-    def custom_credentials_validate(self, credentials: dict) -> Tuple[Provider, dict]:
+    def custom_credentials_validate(self, credentials: dict) -> tuple[Provider, dict]:
         """
         Validate custom credentials.
         :param credentials: provider credentials
@@ -282,7 +283,7 @@ class ProviderConfiguration(BaseModel):
         return None
 
     def custom_model_credentials_validate(self, model_type: ModelType, model: str, credentials: dict) \
-            -> Tuple[ProviderModel, dict]:
+            -> tuple[ProviderModel, dict]:
         """
         Validate custom model credentials.
 
@@ -711,7 +712,7 @@ class ProviderConfigurations(BaseModel):
     Model class for provider configuration dict.
     """
     tenant_id: str
-    configurations: Dict[str, ProviderConfiguration] = {}
+    configurations: dict[str, ProviderConfiguration] = {}
 
     def __init__(self, tenant_id: str):
         super().__init__(tenant_id=tenant_id)
@@ -759,7 +760,7 @@ class ProviderConfigurations(BaseModel):
 
         return all_models
 
-    def to_list(self) -> List[ProviderConfiguration]:
+    def to_list(self) -> list[ProviderConfiguration]:
         """
         Convert to list.
 

--- a/api/core/extension/extensible.py
+++ b/api/core/extension/extensible.py
@@ -61,7 +61,7 @@ class Extensible:
 
                     builtin_file_path = os.path.join(subdir_path, '__builtin__')
                     if os.path.exists(builtin_file_path):
-                        with open(builtin_file_path, 'r', encoding='utf-8') as f:
+                        with open(builtin_file_path, encoding='utf-8') as f:
                             position = int(f.read().strip())
 
                 if (extension_name + '.py') not in file_names:
@@ -93,7 +93,7 @@ class Extensible:
                     json_path = os.path.join(subdir_path, 'schema.json')
                     json_data = {}
                     if os.path.exists(json_path):
-                        with open(json_path, 'r', encoding='utf-8') as f:
+                        with open(json_path, encoding='utf-8') as f:
                             json_data = json.load(f)
 
                 extensions[extension_name] = ModuleExtension(

--- a/api/core/features/assistant_base_runner.py
+++ b/api/core/features/assistant_base_runner.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime
 from mimetypes import guess_extension
-from typing import List, Optional, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 from core.app_runner.app_runner import AppRunner
 from core.application_queue_manager import ApplicationQueueManager
@@ -50,7 +50,7 @@ class BaseAssistantApplicationRunner(AppRunner):
                  message: Message,
                  user_id: str,
                  memory: Optional[TokenBufferMemory] = None,
-                 prompt_messages: Optional[List[PromptMessage]] = None,
+                 prompt_messages: Optional[list[PromptMessage]] = None,
                  variables_pool: Optional[ToolRuntimeVariablePool] = None,
                  db_variables: Optional[ToolConversationVariables] = None,
                  model_instance: ModelInstance = None
@@ -122,7 +122,7 @@ class BaseAssistantApplicationRunner(AppRunner):
 
         return app_orchestration_config
 
-    def _convert_tool_response_to_str(self, tool_response: List[ToolInvokeMessage]) -> str:
+    def _convert_tool_response_to_str(self, tool_response: list[ToolInvokeMessage]) -> str:
         """
         Handle tool response
         """
@@ -140,7 +140,7 @@ class BaseAssistantApplicationRunner(AppRunner):
 
         return result
     
-    def _convert_tool_to_prompt_message_tool(self, tool: AgentToolEntity) -> Tuple[PromptMessageTool, Tool]:
+    def _convert_tool_to_prompt_message_tool(self, tool: AgentToolEntity) -> tuple[PromptMessageTool, Tool]:
         """
             convert tool to prompt message tool
         """
@@ -325,7 +325,7 @@ class BaseAssistantApplicationRunner(AppRunner):
 
         return prompt_tool
     
-    def extract_tool_response_binary(self, tool_response: List[ToolInvokeMessage]) -> List[ToolInvokeMessageBinary]:
+    def extract_tool_response_binary(self, tool_response: list[ToolInvokeMessage]) -> list[ToolInvokeMessageBinary]:
         """
         Extract tool response binary
         """
@@ -356,7 +356,7 @@ class BaseAssistantApplicationRunner(AppRunner):
 
         return result
     
-    def create_message_files(self, messages: List[ToolInvokeMessageBinary]) -> List[Tuple[MessageFile, bool]]:
+    def create_message_files(self, messages: list[ToolInvokeMessageBinary]) -> list[tuple[MessageFile, bool]]:
         """
         Create message file
 
@@ -404,7 +404,7 @@ class BaseAssistantApplicationRunner(AppRunner):
         return result
         
     def create_agent_thought(self, message_id: str, message: str, 
-                             tool_name: str, tool_input: str, messages_ids: List[str]
+                             tool_name: str, tool_input: str, messages_ids: list[str]
                              ) -> MessageAgentThought:
         """
         Create agent thought
@@ -449,7 +449,7 @@ class BaseAssistantApplicationRunner(AppRunner):
                            thought: str, 
                            observation: str, 
                            answer: str,
-                           messages_ids: List[str],
+                           messages_ids: list[str],
                            llm_usage: LLMUsage = None) -> MessageAgentThought:
         """
         Save agent thought
@@ -505,7 +505,7 @@ class BaseAssistantApplicationRunner(AppRunner):
 
         db.session.commit()
 
-    def get_history_prompt_messages(self) -> List[PromptMessage]:
+    def get_history_prompt_messages(self) -> list[PromptMessage]:
         """
         Get history prompt messages
         """
@@ -516,7 +516,7 @@ class BaseAssistantApplicationRunner(AppRunner):
 
         return self.history_prompt_messages
     
-    def transform_tool_invoke_messages(self, messages: List[ToolInvokeMessage]) -> List[ToolInvokeMessage]:
+    def transform_tool_invoke_messages(self, messages: list[ToolInvokeMessage]) -> list[ToolInvokeMessage]:
         """
         Transform tool message into agent thought
         """

--- a/api/core/features/assistant_cot_runner.py
+++ b/api/core/features/assistant_cot_runner.py
@@ -1,6 +1,7 @@
 import json
 import re
-from typing import Dict, Generator, List, Literal, Union
+from collections.abc import Generator
+from typing import Literal, Union
 
 from core.application_queue_manager import PublishFrom
 from core.entities.application_entities import AgentPromptEntity, AgentScratchpadUnit
@@ -29,7 +30,7 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
     def run(self, conversation: Conversation,
         message: Message,
         query: str,
-        inputs: Dict[str, str],
+        inputs: dict[str, str],
     ) -> Union[Generator, LLMResult]:
         """
         Run Cot agent application
@@ -37,7 +38,7 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
         app_orchestration_config = self.app_orchestration_config
         self._repack_app_orchestration_config(app_orchestration_config)
 
-        agent_scratchpad: List[AgentScratchpadUnit] = []
+        agent_scratchpad: list[AgentScratchpadUnit] = []
 
         # check model mode
         if self.app_orchestration_config.model_config.mode == "completion":
@@ -56,7 +57,7 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
         prompt_messages = self.history_prompt_messages
 
         # convert tools into ModelRuntime Tool format
-        prompt_messages_tools: List[PromptMessageTool] = []
+        prompt_messages_tools: list[PromptMessageTool] = []
         tool_instances = {}
         for tool in self.app_orchestration_config.agent.tools if self.app_orchestration_config.agent else []:
             try:
@@ -83,7 +84,7 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
         }
         final_answer = ''
 
-        def increase_usage(final_llm_usage_dict: Dict[str, LLMUsage], usage: LLMUsage):
+        def increase_usage(final_llm_usage_dict: dict[str, LLMUsage], usage: LLMUsage):
             if not final_llm_usage_dict['usage']:
                 final_llm_usage_dict['usage'] = usage
             else:
@@ -493,7 +494,7 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
             if not next_iteration.find("{{observation}}") >= 0:
                 raise ValueError("{{observation}} is required in next_iteration")
             
-    def _convert_scratchpad_list_to_str(self, agent_scratchpad: List[AgentScratchpadUnit]) -> str:
+    def _convert_scratchpad_list_to_str(self, agent_scratchpad: list[AgentScratchpadUnit]) -> str:
         """
             convert agent scratchpad list to str
         """
@@ -506,13 +507,13 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
         return result
     
     def _organize_cot_prompt_messages(self, mode: Literal["completion", "chat"],
-                                      prompt_messages: List[PromptMessage],
-                                      tools: List[PromptMessageTool], 
-                                      agent_scratchpad: List[AgentScratchpadUnit],
+                                      prompt_messages: list[PromptMessage],
+                                      tools: list[PromptMessageTool], 
+                                      agent_scratchpad: list[AgentScratchpadUnit],
                                       agent_prompt_message: AgentPromptEntity,
                                       instruction: str,
                                       input: str,
-        ) -> List[PromptMessage]:
+        ) -> list[PromptMessage]:
         """
             organize chain of thought prompt messages, a standard prompt message is like:
                 Respond to the human as helpfully and accurately as possible. 

--- a/api/core/features/assistant_fc_runner.py
+++ b/api/core/features/assistant_fc_runner.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Any, Dict, Generator, List, Tuple, Union
+from collections.abc import Generator
+from typing import Any, Union
 
 from core.application_queue_manager import PublishFrom
 from core.features.assistant_base_runner import BaseAssistantApplicationRunner
@@ -44,7 +45,7 @@ class AssistantFunctionCallApplicationRunner(BaseAssistantApplicationRunner):
         )
 
         # convert tools into ModelRuntime Tool format
-        prompt_messages_tools: List[PromptMessageTool] = []
+        prompt_messages_tools: list[PromptMessageTool] = []
         tool_instances = {}
         for tool in self.app_orchestration_config.agent.tools if self.app_orchestration_config.agent else []:
             try:
@@ -70,13 +71,13 @@ class AssistantFunctionCallApplicationRunner(BaseAssistantApplicationRunner):
 
         # continue to run until there is not any tool call
         function_call_state = True
-        agent_thoughts: List[MessageAgentThought] = []
+        agent_thoughts: list[MessageAgentThought] = []
         llm_usage = {
             'usage': None
         }
         final_answer = ''
 
-        def increase_usage(final_llm_usage_dict: Dict[str, LLMUsage], usage: LLMUsage):
+        def increase_usage(final_llm_usage_dict: dict[str, LLMUsage], usage: LLMUsage):
             if not final_llm_usage_dict['usage']:
                 final_llm_usage_dict['usage'] = usage
             else:
@@ -117,7 +118,7 @@ class AssistantFunctionCallApplicationRunner(BaseAssistantApplicationRunner):
                 callbacks=[],
             )
 
-            tool_calls: List[Tuple[str, str, Dict[str, Any]]] = []
+            tool_calls: list[tuple[str, str, dict[str, Any]]] = []
 
             # save full response
             response = ''
@@ -364,7 +365,7 @@ class AssistantFunctionCallApplicationRunner(BaseAssistantApplicationRunner):
             return True
         return False
 
-    def extract_tool_calls(self, llm_result_chunk: LLMResultChunk) -> Union[None, List[Tuple[str, str, Dict[str, Any]]]]:
+    def extract_tool_calls(self, llm_result_chunk: LLMResultChunk) -> Union[None, list[tuple[str, str, dict[str, Any]]]]:
         """
         Extract tool calls from llm result chunk
 
@@ -381,7 +382,7 @@ class AssistantFunctionCallApplicationRunner(BaseAssistantApplicationRunner):
 
         return tool_calls
     
-    def extract_blocking_tool_calls(self, llm_result: LLMResult) -> Union[None, List[Tuple[str, str, Dict[str, Any]]]]:
+    def extract_blocking_tool_calls(self, llm_result: LLMResult) -> Union[None, list[tuple[str, str, dict[str, Any]]]]:
         """
         Extract blocking tool calls from llm result
 

--- a/api/core/features/dataset_retrieval.py
+++ b/api/core/features/dataset_retrieval.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 from langchain.tools import BaseTool
 
@@ -96,7 +96,7 @@ class DatasetRetrievalFeature:
                                   return_resource: bool,
                                   invoke_from: InvokeFrom,
                                   hit_callback: DatasetIndexToolCallbackHandler) \
-            -> Optional[List[BaseTool]]:
+            -> Optional[list[BaseTool]]:
         """
         A dataset tool is a tool that can be used to retrieve information from a dataset
         :param tenant_id: tenant id

--- a/api/core/features/external_data_fetch.py
+++ b/api/core/features/external_data_fetch.py
@@ -2,7 +2,7 @@ import concurrent
 import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Tuple
+from typing import Optional
 
 from flask import Flask, current_app
 
@@ -62,7 +62,7 @@ class ExternalDataFetchFeature:
                                   app_id: str,
                                   external_data_tool: ExternalDataVariableEntity,
                                   inputs: dict,
-                                  query: str) -> Tuple[Optional[str], Optional[str]]:
+                                  query: str) -> tuple[Optional[str], Optional[str]]:
         """
         Query external data tool.
         :param flask_app: flask app

--- a/api/core/features/moderation.py
+++ b/api/core/features/moderation.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Tuple
 
 from core.entities.application_entities import AppOrchestrationConfigEntity
 from core.moderation.base import ModerationAction, ModerationException
@@ -13,7 +12,7 @@ class ModerationFeature:
               tenant_id: str,
               app_orchestration_config_entity: AppOrchestrationConfigEntity,
               inputs: dict,
-              query: str) -> Tuple[bool, dict, str]:
+              query: str) -> tuple[bool, dict, str]:
         """
         Process sensitive_word_avoidance.
         :param app_id: app id

--- a/api/core/file/message_file_parser.py
+++ b/api/core/file/message_file_parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import requests
 
@@ -15,8 +15,8 @@ class MessageFileParser:
         self.tenant_id = tenant_id
         self.app_id = app_id
 
-    def validate_and_transform_files_arg(self, files: List[dict], app_model_config: AppModelConfig,
-                                         user: Union[Account, EndUser]) -> List[FileObj]:
+    def validate_and_transform_files_arg(self, files: list[dict], app_model_config: AppModelConfig,
+                                         user: Union[Account, EndUser]) -> list[FileObj]:
         """
         validate and transform files arg
 
@@ -96,7 +96,7 @@ class MessageFileParser:
         # return all file objs
         return new_files
 
-    def transform_message_files(self, files: List[MessageFile], app_model_config: Optional[AppModelConfig]) -> List[FileObj]:
+    def transform_message_files(self, files: list[MessageFile], app_model_config: Optional[AppModelConfig]) -> list[FileObj]:
         """
         transform message files
 
@@ -110,8 +110,8 @@ class MessageFileParser:
         # return all file objs
         return [file_obj for file_objs in type_file_objs.values() for file_obj in file_objs]
 
-    def _to_file_objs(self, files: List[Union[Dict, MessageFile]],
-                      file_upload_config: dict) -> Dict[FileType, List[FileObj]]:
+    def _to_file_objs(self, files: list[Union[dict, MessageFile]],
+                      file_upload_config: dict) -> dict[FileType, list[FileObj]]:
         """
         transform files to file objs
 
@@ -119,7 +119,7 @@ class MessageFileParser:
         :param file_upload_config:
         :return:
         """
-        type_file_objs: Dict[FileType, List[FileObj]] = {
+        type_file_objs: dict[FileType, list[FileObj]] = {
             # Currently only support image
             FileType.IMAGE: []
         }

--- a/api/core/index/base.py
+++ b/api/core/index/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List
+from typing import Any
 
 from langchain.schema import BaseRetriever, Document
 
@@ -53,7 +53,7 @@ class BaseIndex(ABC):
     def search(
             self, query: str,
             **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError
 
     def delete(self) -> None:

--- a/api/core/index/keyword_table_index/jieba_keyword_table_handler.py
+++ b/api/core/index/keyword_table_index/jieba_keyword_table_handler.py
@@ -1,5 +1,4 @@
 import re
-from typing import Set
 
 import jieba
 from jieba.analyse import default_tfidf
@@ -12,7 +11,7 @@ class JiebaKeywordTableHandler:
     def __init__(self):
         default_tfidf.stop_words = STOPWORDS
 
-    def extract_keywords(self, text: str, max_keywords_per_chunk: int = 10) -> Set[str]:
+    def extract_keywords(self, text: str, max_keywords_per_chunk: int = 10) -> set[str]:
         """Extract keywords with JIEBA tfidf."""
         keywords = jieba.analyse.extract_tags(
             sentence=text,
@@ -21,7 +20,7 @@ class JiebaKeywordTableHandler:
 
         return set(self._expand_tokens_with_subtokens(keywords))
 
-    def _expand_tokens_with_subtokens(self, tokens: Set[str]) -> Set[str]:
+    def _expand_tokens_with_subtokens(self, tokens: set[str]) -> set[str]:
         """Get subtokens from a list of tokens., filtering for stopwords."""
         results = set()
         for token in tokens:

--- a/api/core/index/keyword_table_index/keyword_table_index.py
+++ b/api/core/index/keyword_table_index/keyword_table_index.py
@@ -1,6 +1,6 @@
 import json
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from langchain.schema import BaseRetriever, Document
 from pydantic import BaseModel, Extra, Field
@@ -116,7 +116,7 @@ class KeywordTableIndex(BaseIndex):
     def search(
             self, query: str,
             **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         keyword_table = self._get_dataset_keyword_table()
 
         search_kwargs = kwargs.get('search_kwargs') if kwargs.get('search_kwargs') else {}
@@ -221,7 +221,7 @@ class KeywordTableIndex(BaseIndex):
         keywords = keyword_table_handler.extract_keywords(query)
 
         # go through text chunks in order of most matching keywords
-        chunk_indices_count: Dict[str, int] = defaultdict(int)
+        chunk_indices_count: dict[str, int] = defaultdict(int)
         keywords = [keyword for keyword in keywords if keyword in set(keyword_table.keys())]
         for keyword in keywords:
             for node_id in keyword_table[keyword]:
@@ -235,7 +235,7 @@ class KeywordTableIndex(BaseIndex):
 
         return sorted_chunk_indices[: k]
 
-    def _update_segment_keywords(self, dataset_id: str, node_id: str, keywords: List[str]):
+    def _update_segment_keywords(self, dataset_id: str, node_id: str, keywords: list[str]):
         document_segment = db.session.query(DocumentSegment).filter(
             DocumentSegment.dataset_id == dataset_id,
             DocumentSegment.index_node_id == node_id
@@ -244,7 +244,7 @@ class KeywordTableIndex(BaseIndex):
             document_segment.keywords = keywords
             db.session.commit()
 
-    def create_segment_keywords(self, node_id: str, keywords: List[str]):
+    def create_segment_keywords(self, node_id: str, keywords: list[str]):
         keyword_table = self._get_dataset_keyword_table()
         self._update_segment_keywords(self.dataset.id, node_id, keywords)
         keyword_table = self._add_text_to_keyword_table(keyword_table, node_id, keywords)
@@ -266,7 +266,7 @@ class KeywordTableIndex(BaseIndex):
                 keyword_table = self._add_text_to_keyword_table(keyword_table, segment.index_node_id, list(keywords))
         self._save_dataset_keyword_table(keyword_table)
 
-    def update_segment_keywords_index(self, node_id: str, keywords: List[str]):
+    def update_segment_keywords_index(self, node_id: str, keywords: list[str]):
         keyword_table = self._get_dataset_keyword_table()
         keyword_table = self._add_text_to_keyword_table(keyword_table, node_id, keywords)
         self._save_dataset_keyword_table(keyword_table)
@@ -282,7 +282,7 @@ class KeywordTableRetriever(BaseRetriever, BaseModel):
         extra = Extra.forbid
         arbitrary_types_allowed = True
 
-    def get_relevant_documents(self, query: str) -> List[Document]:
+    def get_relevant_documents(self, query: str) -> list[Document]:
         """Get documents relevant for a query.
 
         Args:
@@ -293,7 +293,7 @@ class KeywordTableRetriever(BaseRetriever, BaseModel):
         """
         return self.index.search(query, **self.search_kwargs)
 
-    async def aget_relevant_documents(self, query: str) -> List[Document]:
+    async def aget_relevant_documents(self, query: str) -> list[Document]:
         raise NotImplementedError("KeywordTableRetriever does not support async")
 
 

--- a/api/core/index/vector_index/base.py
+++ b/api/core/index/vector_index/base.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from abc import abstractmethod
-from typing import Any, List, cast
+from typing import Any, cast
 
 from langchain.embeddings.base import Embeddings
 from langchain.schema import BaseRetriever, Document
@@ -43,13 +43,13 @@ class BaseVectorIndex(BaseIndex):
     def search_by_full_text_index(
             self, query: str,
             **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError
 
     def search(
             self, query: str,
             **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         vector_store = self._get_vector_store()
         vector_store = cast(self._get_vector_store_class(), vector_store)
 

--- a/api/core/index/vector_index/milvus_vector_index.py
+++ b/api/core/index/vector_index/milvus_vector_index.py
@@ -1,4 +1,4 @@
-from typing import Any, List, cast
+from typing import Any, cast
 
 from langchain.embeddings.base import Embeddings
 from langchain.schema import Document
@@ -160,6 +160,6 @@ class MilvusVectorIndex(BaseVectorIndex):
             ],
         ))
 
-    def search_by_full_text_index(self, query: str, **kwargs: Any) -> List[Document]:
+    def search_by_full_text_index(self, query: str, **kwargs: Any) -> list[Document]:
         # milvus/zilliz doesn't support bm25 search
         return []

--- a/api/core/index/vector_index/qdrant_vector_index.py
+++ b/api/core/index/vector_index/qdrant_vector_index.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List, Optional, cast
+from typing import Any, Optional, cast
 
 import qdrant_client
 from langchain.embeddings.base import Embeddings
@@ -210,7 +210,7 @@ class QdrantVectorIndex(BaseVectorIndex):
 
         return False
 
-    def search_by_full_text_index(self, query: str, **kwargs: Any) -> List[Document]:
+    def search_by_full_text_index(self, query: str, **kwargs: Any) -> list[Document]:
         vector_store = self._get_vector_store()
         vector_store = cast(self._get_vector_store_class(), vector_store)
 

--- a/api/core/index/vector_index/weaviate_vector_index.py
+++ b/api/core/index/vector_index/weaviate_vector_index.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, cast
+from typing import Any, Optional, cast
 
 import requests
 import weaviate
@@ -172,7 +172,7 @@ class WeaviateVectorIndex(BaseVectorIndex):
 
         return False
 
-    def search_by_full_text_index(self, query: str, **kwargs: Any) -> List[Document]:
+    def search_by_full_text_index(self, query: str, **kwargs: Any) -> list[Document]:
         vector_store = self._get_vector_store()
         vector_store = cast(self._get_vector_store_class(), vector_store)
         return vector_store.similarity_search_by_bm25(query, kwargs.get('top_k', 2), **kwargs)

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -5,7 +5,7 @@ import re
 import threading
 import time
 import uuid
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 from flask import Flask, current_app
 from flask_login import current_user
@@ -40,7 +40,7 @@ class IndexingRunner:
         self.storage = storage
         self.model_manager = ModelManager()
 
-    def run(self, dataset_documents: List[DatasetDocument]):
+    def run(self, dataset_documents: list[DatasetDocument]):
         """Run the indexing process."""
         for dataset_document in dataset_documents:
             try:
@@ -238,7 +238,7 @@ class IndexingRunner:
             dataset_document.stopped_at = datetime.datetime.utcnow()
             db.session.commit()
 
-    def file_indexing_estimate(self, tenant_id: str, file_details: List[UploadFile], tmp_processing_rule: dict,
+    def file_indexing_estimate(self, tenant_id: str, file_details: list[UploadFile], tmp_processing_rule: dict,
                                doc_form: str = None, doc_language: str = 'English', dataset_id: str = None,
                                indexing_technique: str = 'economy') -> dict:
         """
@@ -494,7 +494,7 @@ class IndexingRunner:
             "preview": preview_texts
         }
 
-    def _load_data(self, dataset_document: DatasetDocument, automatic: bool = False) -> List[Document]:
+    def _load_data(self, dataset_document: DatasetDocument, automatic: bool = False) -> list[Document]:
         # load file
         if dataset_document.data_source_type not in ["upload_file", "notion_import"]:
             return []
@@ -526,7 +526,7 @@ class IndexingRunner:
         )
 
         # replace doc id to document model id
-        text_docs = cast(List[Document], text_docs)
+        text_docs = cast(list[Document], text_docs)
         for text_doc in text_docs:
             # remove invalid symbol
             text_doc.page_content = self.filter_string(text_doc.page_content)
@@ -540,7 +540,7 @@ class IndexingRunner:
         text = re.sub(r'\|>', '>', text)
         text = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\xEF\xBF\xBE]', '', text)
         # Unicode  U+FFFE
-        text = re.sub(u'\uFFFE', '', text)
+        text = re.sub('\uFFFE', '', text)
         return text
 
     def _get_splitter(self, processing_rule: DatasetProcessRule,
@@ -577,9 +577,9 @@ class IndexingRunner:
 
         return character_splitter
 
-    def _step_split(self, text_docs: List[Document], splitter: TextSplitter,
+    def _step_split(self, text_docs: list[Document], splitter: TextSplitter,
                     dataset: Dataset, dataset_document: DatasetDocument, processing_rule: DatasetProcessRule) \
-            -> List[Document]:
+            -> list[Document]:
         """
         Split the text documents into documents and save them to the document segment.
         """
@@ -624,9 +624,9 @@ class IndexingRunner:
 
         return documents
 
-    def _split_to_documents(self, text_docs: List[Document], splitter: TextSplitter,
+    def _split_to_documents(self, text_docs: list[Document], splitter: TextSplitter,
                             processing_rule: DatasetProcessRule, tenant_id: str,
-                            document_form: str, document_language: str) -> List[Document]:
+                            document_form: str, document_language: str) -> list[Document]:
         """
         Split the text documents into nodes.
         """
@@ -699,8 +699,8 @@ class IndexingRunner:
 
             all_qa_documents.extend(format_documents)
 
-    def _split_to_documents_for_estimate(self, text_docs: List[Document], splitter: TextSplitter,
-                                         processing_rule: DatasetProcessRule) -> List[Document]:
+    def _split_to_documents_for_estimate(self, text_docs: list[Document], splitter: TextSplitter,
+                                         processing_rule: DatasetProcessRule) -> list[Document]:
         """
         Split the text documents into nodes.
         """
@@ -770,7 +770,7 @@ class IndexingRunner:
             for q, a in matches if q and a
         ]
 
-    def _build_index(self, dataset: Dataset, dataset_document: DatasetDocument, documents: List[Document]) -> None:
+    def _build_index(self, dataset: Dataset, dataset_document: DatasetDocument, documents: list[Document]) -> None:
         """
         Build the index for the document.
         """
@@ -877,7 +877,7 @@ class IndexingRunner:
         DocumentSegment.query.filter_by(document_id=dataset_document_id).update(update_params)
         db.session.commit()
 
-    def batch_add_segments(self, segments: List[DocumentSegment], dataset: Dataset):
+    def batch_add_segments(self, segments: list[DocumentSegment], dataset: Dataset):
         """
         Batch add segments index processing
         """

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -1,4 +1,5 @@
-from typing import IO, Generator, List, Optional, Union, cast
+from collections.abc import Generator
+from typing import IO, Optional, Union, cast
 
 from core.entities.provider_configuration import ProviderModelBundle
 from core.errors.error import ProviderTokenNotInitError
@@ -47,7 +48,7 @@ class ModelInstance:
         return credentials
 
     def invoke_llm(self, prompt_messages: list[PromptMessage], model_parameters: Optional[dict] = None,
-                   tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                   tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                    stream: bool = True, user: Optional[str] = None, callbacks: list[Callback] = None) \
             -> Union[LLMResult, Generator]:
         """

--- a/api/core/model_runtime/callbacks/base_callback.py
+++ b/api/core/model_runtime/callbacks/base_callback.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Optional
+from typing import Optional
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
 from core.model_runtime.entities.message_entities import PromptMessage, PromptMessageTool
@@ -23,7 +23,7 @@ class Callback(ABC):
 
     def on_before_invoke(self, llm_instance: AIModel, model: str, credentials: dict,
                          prompt_messages: list[PromptMessage], model_parameters: dict,
-                         tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                         tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                          stream: bool = True, user: Optional[str] = None) -> None:
         """
         Before invoke callback
@@ -42,7 +42,7 @@ class Callback(ABC):
 
     def on_new_chunk(self, llm_instance: AIModel, chunk: LLMResultChunk, model: str, credentials: dict,
                      prompt_messages: list[PromptMessage], model_parameters: dict,
-                     tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                     tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                      stream: bool = True, user: Optional[str] = None):
         """
         On new chunk callback
@@ -62,7 +62,7 @@ class Callback(ABC):
 
     def on_after_invoke(self, llm_instance: AIModel, result: LLMResult, model: str, credentials: dict,
                         prompt_messages: list[PromptMessage], model_parameters: dict,
-                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                         stream: bool = True, user: Optional[str] = None) -> None:
         """
         After invoke callback
@@ -82,7 +82,7 @@ class Callback(ABC):
 
     def on_invoke_error(self, llm_instance: AIModel, ex: Exception, model: str, credentials: dict,
                         prompt_messages: list[PromptMessage], model_parameters: dict,
-                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                         stream: bool = True, user: Optional[str] = None) -> None:
         """
         Invoke error callback

--- a/api/core/model_runtime/callbacks/logging_callback.py
+++ b/api/core/model_runtime/callbacks/logging_callback.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import sys
-from typing import List, Optional
+from typing import Optional
 
 from core.model_runtime.callbacks.base_callback import Callback
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class LoggingCallback(Callback):
     def on_before_invoke(self, llm_instance: AIModel, model: str, credentials: dict,
                          prompt_messages: list[PromptMessage], model_parameters: dict,
-                         tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                         tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                          stream: bool = True, user: Optional[str] = None) -> None:
         """
         Before invoke callback
@@ -60,7 +60,7 @@ class LoggingCallback(Callback):
 
     def on_new_chunk(self, llm_instance: AIModel, chunk: LLMResultChunk, model: str, credentials: dict,
                      prompt_messages: list[PromptMessage], model_parameters: dict,
-                     tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                     tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                      stream: bool = True, user: Optional[str] = None):
         """
         On new chunk callback
@@ -81,7 +81,7 @@ class LoggingCallback(Callback):
 
     def on_after_invoke(self, llm_instance: AIModel, result: LLMResult, model: str, credentials: dict,
                         prompt_messages: list[PromptMessage], model_parameters: dict,
-                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                         stream: bool = True, user: Optional[str] = None) -> None:
         """
         After invoke callback
@@ -113,7 +113,7 @@ class LoggingCallback(Callback):
 
     def on_invoke_error(self, llm_instance: AIModel, ex: Exception, model: str, credentials: dict,
                         prompt_messages: list[PromptMessage], model_parameters: dict,
-                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                         stream: bool = True, user: Optional[str] = None) -> None:
         """
         Invoke error callback

--- a/api/core/model_runtime/entities/defaults.py
+++ b/api/core/model_runtime/entities/defaults.py
@@ -1,8 +1,7 @@
-from typing import Dict
 
 from core.model_runtime.entities.model_entities import DefaultParameterName
 
-PARAMETER_RULE_TEMPLATE: Dict[DefaultParameterName, dict] = {
+PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
     DefaultParameterName.TEMPERATURE: {
         'label': {
             'en_US': 'Temperature',

--- a/api/core/model_runtime/model_providers/__base/ai_model.py
+++ b/api/core/model_runtime/model_providers/__base/ai_model.py
@@ -153,7 +153,7 @@ class AIModel(ABC):
         # read _position.yaml file
         position_map = {}
         if os.path.exists(position_file_path):
-            with open(position_file_path, 'r', encoding='utf-8') as f:
+            with open(position_file_path, encoding='utf-8') as f:
                 positions = yaml.safe_load(f)
                 # convert list to dict with key as model provider name, value as index
                 position_map = {position: index for index, position in enumerate(positions)}
@@ -161,7 +161,7 @@ class AIModel(ABC):
         # traverse all model_schema_yaml_paths
         for model_schema_yaml_path in model_schema_yaml_paths:
             # read yaml data from yaml file
-            with open(model_schema_yaml_path, 'r', encoding='utf-8') as f:
+            with open(model_schema_yaml_path, encoding='utf-8') as f:
                 yaml_data = yaml.safe_load(f)
 
             new_parameter_rules = []

--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -3,7 +3,8 @@ import os
 import re
 import time
 from abc import abstractmethod
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from core.model_runtime.callbacks.base_callback import Callback
 from core.model_runtime.callbacks.logging_callback import LoggingCallback
@@ -29,7 +30,7 @@ class LargeLanguageModel(AIModel):
 
     def invoke(self, model: str, credentials: dict,
                prompt_messages: list[PromptMessage], model_parameters: Optional[dict] = None,
-               tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+               tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                stream: bool = True, user: Optional[str] = None, callbacks: list[Callback] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -122,7 +123,7 @@ class LargeLanguageModel(AIModel):
     def _invoke_result_generator(self, model: str, result: Generator, credentials: dict,
                                  prompt_messages: list[PromptMessage], model_parameters: dict,
                                  tools: Optional[list[PromptMessageTool]] = None,
-                                 stop: Optional[List[str]] = None, stream: bool = True,
+                                 stop: Optional[list[str]] = None, stream: bool = True,
                                  user: Optional[str] = None, callbacks: list[Callback] = None) -> Generator:
         """
         Invoke result generator
@@ -186,7 +187,7 @@ class LargeLanguageModel(AIModel):
     @abstractmethod
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -218,7 +219,7 @@ class LargeLanguageModel(AIModel):
         """
         raise NotImplementedError
 
-    def enforce_stop_tokens(self, text: str, stop: List[str]) -> str:
+    def enforce_stop_tokens(self, text: str, stop: list[str]) -> str:
         """Cut off the text as soon as any stop words occur."""
         return re.split("|".join(stop), text, maxsplit=1)[0]
 
@@ -329,7 +330,7 @@ class LargeLanguageModel(AIModel):
     def _trigger_before_invoke_callbacks(self, model: str, credentials: dict,
                                          prompt_messages: list[PromptMessage], model_parameters: dict,
                                          tools: Optional[list[PromptMessageTool]] = None,
-                                         stop: Optional[List[str]] = None, stream: bool = True,
+                                         stop: Optional[list[str]] = None, stream: bool = True,
                                          user: Optional[str] = None, callbacks: list[Callback] = None) -> None:
         """
         Trigger before invoke callbacks
@@ -367,7 +368,7 @@ class LargeLanguageModel(AIModel):
     def _trigger_new_chunk_callbacks(self, chunk: LLMResultChunk, model: str, credentials: dict,
                                      prompt_messages: list[PromptMessage], model_parameters: dict,
                                      tools: Optional[list[PromptMessageTool]] = None,
-                                     stop: Optional[List[str]] = None, stream: bool = True,
+                                     stop: Optional[list[str]] = None, stream: bool = True,
                                      user: Optional[str] = None, callbacks: list[Callback] = None) -> None:
         """
         Trigger new chunk callbacks
@@ -406,7 +407,7 @@ class LargeLanguageModel(AIModel):
     def _trigger_after_invoke_callbacks(self, model: str, result: LLMResult, credentials: dict,
                                         prompt_messages: list[PromptMessage], model_parameters: dict,
                                         tools: Optional[list[PromptMessageTool]] = None,
-                                        stop: Optional[List[str]] = None, stream: bool = True,
+                                        stop: Optional[list[str]] = None, stream: bool = True,
                                         user: Optional[str] = None, callbacks: list[Callback] = None) -> None:
         """
         Trigger after invoke callbacks
@@ -446,7 +447,7 @@ class LargeLanguageModel(AIModel):
     def _trigger_invoke_error_callbacks(self, model: str, ex: Exception, credentials: dict,
                                         prompt_messages: list[PromptMessage], model_parameters: dict,
                                         tools: Optional[list[PromptMessageTool]] = None,
-                                        stop: Optional[List[str]] = None, stream: bool = True,
+                                        stop: Optional[list[str]] = None, stream: bool = True,
                                         user: Optional[str] = None, callbacks: list[Callback] = None) -> None:
         """
         Trigger invoke error callbacks
@@ -527,7 +528,7 @@ class LargeLanguageModel(AIModel):
                     raise ValueError(
                         f"Model Parameter {parameter_name} should be less than or equal to {parameter_rule.max}.")
             elif parameter_rule.type == ParameterType.FLOAT:
-                if not isinstance(parameter_value, (float, int)):
+                if not isinstance(parameter_value, float | int):
                     raise ValueError(f"Model Parameter {parameter_name} should be float.")
 
                 # validate parameter value precision

--- a/api/core/model_runtime/model_providers/__base/model_provider.py
+++ b/api/core/model_runtime/model_providers/__base/model_provider.py
@@ -1,7 +1,6 @@
 import importlib
 import os
 from abc import ABC, abstractmethod
-from typing import Dict
 
 import yaml
 
@@ -12,7 +11,7 @@ from core.model_runtime.model_providers.__base.ai_model import AIModel
 
 class ModelProvider(ABC):
     provider_schema: ProviderEntity = None
-    model_instance_map: Dict[str, AIModel] = {}
+    model_instance_map: dict[str, AIModel] = {}
 
     @abstractmethod
     def validate_provider_credentials(self, credentials: dict) -> None:
@@ -47,7 +46,7 @@ class ModelProvider(ABC):
         yaml_path = os.path.join(current_path, f'{provider_name}.yaml')
         yaml_data = {}
         if os.path.exists(yaml_path):
-            with open(yaml_path, 'r', encoding='utf-8') as f:
+            with open(yaml_path, encoding='utf-8') as f:
                 yaml_data = yaml.safe_load(f)
 
         try:

--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 import anthropic
 from anthropic import Anthropic, Stream
@@ -29,7 +30,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -90,7 +91,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict,
                   prompt_messages: list[PromptMessage], model_parameters: dict,
-                  stop: Optional[List[str]] = None, stream: bool = True,
+                  stop: Optional[list[str]] = None, stream: bool = True,
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke large language model
@@ -255,7 +256,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
 
         return message_text
 
-    def _convert_messages_to_prompt_anthropic(self, messages: List[PromptMessage]) -> str:
+    def _convert_messages_to_prompt_anthropic(self, messages: list[PromptMessage]) -> str:
         """
         Format a list of messages into a full prompt for the Anthropic model
 

--- a/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
@@ -1,6 +1,7 @@
 import copy
 import logging
-from typing import Generator, List, Optional, Union, cast
+from collections.abc import Generator
+from typing import Optional, Union, cast
 
 import tiktoken
 from openai import AzureOpenAI, Stream
@@ -34,7 +35,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
 
@@ -121,7 +122,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         return ai_model_entity.entity if ai_model_entity else None
 
     def _generate(self, model: str, credentials: dict,
-                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[List[str]] = None,
+                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[list[str]] = None,
                   stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
 
         client = AzureOpenAI(**self._to_credential_kwargs(credentials))
@@ -239,7 +240,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
     def _chat_generate(self, model: str, credentials: dict,
                        prompt_messages: list[PromptMessage], model_parameters: dict,
-                       tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                       tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                        stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
 
         client = AzureOpenAI(**self._to_credential_kwargs(credentials))
@@ -537,7 +538,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
         return num_tokens
 
-    def _num_tokens_from_messages(self, credentials: dict, messages: List[PromptMessage],
+    def _num_tokens_from_messages(self, credentials: dict, messages: list[PromptMessage],
                                   tools: Optional[list[PromptMessageTool]] = None) -> int:
         """Calculate num tokens for gpt-3.5-turbo and gpt-4 with tiktoken package.
 

--- a/api/core/model_runtime/model_providers/azure_openai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/azure_openai/text_embedding/text_embedding.py
@@ -1,7 +1,7 @@
 import base64
 import copy
 import time
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import tiktoken
@@ -149,7 +149,7 @@ class AzureOpenAITextEmbeddingModel(_CommonAzureOpenAI, TextEmbeddingModel):
 
     @staticmethod
     def _embedding_invoke(model: str, client: AzureOpenAI, texts: Union[list[str], str],
-                          extra_model_kwargs: dict) -> Tuple[list[list[float]], int]:
+                          extra_model_kwargs: dict) -> tuple[list[list[float]], int]:
         response = client.embeddings.create(
             input=texts,
             model=model,

--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan_tokenizer.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan_tokenizer.py
@@ -1,7 +1,7 @@
 import re
 
 
-class BaichuanTokenizer(object):
+class BaichuanTokenizer:
     @classmethod
     def count_chinese_characters(cls, text: str) -> int:
         return len(re.findall(r'[\u4e00-\u9fa5]', text))

--- a/api/core/model_runtime/model_providers/baichuan/llm/baichuan_turbo.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/baichuan_turbo.py
@@ -1,7 +1,8 @@
+from collections.abc import Generator
 from enum import Enum
 from hashlib import md5
 from json import dumps, loads
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Union
 
 from requests import post
 
@@ -24,10 +25,10 @@ class BaichuanMessage:
 
     role: str = Role.USER.value
     content: str
-    usage: Dict[str, int] = None
+    usage: dict[str, int] = None
     stop_reason: str = ''
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             'role': self.role,
             'content': self.content,
@@ -37,7 +38,7 @@ class BaichuanMessage:
         self.content = content
         self.role = role
 
-class BaichuanModel(object):
+class BaichuanModel:
     api_key: str
     secret_key: str
 
@@ -106,9 +107,9 @@ class BaichuanModel(object):
                 message.stop_reason = stop_reason
                 yield message
 
-    def _build_parameters(self, model: str, stream: bool, messages: List[BaichuanMessage],
-                               parameters: Dict[str, Any]) \
-        -> Dict[str, Any]:
+    def _build_parameters(self, model: str, stream: bool, messages: list[BaichuanMessage],
+                               parameters: dict[str, Any]) \
+        -> dict[str, Any]:
         if model == 'baichuan2-turbo' or model == 'baichuan2-turbo-192k' or model == 'baichuan2-53b':
             prompt_messages = []
             for message in messages:
@@ -139,7 +140,7 @@ class BaichuanModel(object):
         else:
             raise BadRequestError(f"Unknown model: {model}")
         
-    def _build_headers(self, model: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _build_headers(self, model: str, data: dict[str, Any]) -> dict[str, Any]:
         if model == 'baichuan2-turbo' or model == 'baichuan2-turbo-192k' or model == 'baichuan2-53b':
             # there is no secret key for turbo api
             return {
@@ -153,8 +154,8 @@ class BaichuanModel(object):
     def _calculate_md5(self, input_string):
         return md5(input_string.encode('utf-8')).hexdigest()
 
-    def generate(self, model: str, stream: bool, messages: List[BaichuanMessage], 
-                 parameters: Dict[str, Any], timeout: int) \
+    def generate(self, model: str, stream: bool, messages: list[BaichuanMessage], 
+                 parameters: dict[str, Any], timeout: int) \
         -> Union[Generator, BaichuanMessage]:
         
         if model == 'baichuan2-turbo' or model == 'baichuan2-turbo-192k' or model == 'baichuan2-53b':

--- a/api/core/model_runtime/model_providers/baichuan/llm/llm.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, cast
+from collections.abc import Generator
+from typing import cast
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -33,7 +34,7 @@ from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors impor
 class BaichuanLarguageModel(LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, 
                 prompt_messages: list[PromptMessage], model_parameters: dict, 
-                tools: list[PromptMessageTool] | None = None, stop: List[str] | None = None, 
+                tools: list[PromptMessageTool] | None = None, stop: list[str] | None = None, 
                 stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         return self._generate(model=model, credentials=credentials, prompt_messages=prompt_messages,
@@ -43,7 +44,7 @@ class BaichuanLarguageModel(LargeLanguageModel):
                        tools: list[PromptMessageTool] | None = None) -> int:
         return self._num_tokens_from_messages(prompt_messages)
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage],) -> int:
+    def _num_tokens_from_messages(self, messages: list[PromptMessage],) -> int:
         """Calculate num tokens for baichuan model"""
         def tokens(text: str):
             return BaichuanTokenizer._get_num_tokens(text)
@@ -107,7 +108,7 @@ class BaichuanLarguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                  model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                 stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                 stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         if tools is not None and len(tools) > 0:
             raise InvokeBadRequestError("Baichuan model doesn't support tools")

--- a/api/core/model_runtime/model_providers/baichuan/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/baichuan/text_embedding/text_embedding.py
@@ -1,6 +1,6 @@
 import time
 from json import dumps
-from typing import Optional, Tuple
+from typing import Optional
 
 from requests import post
 
@@ -84,7 +84,7 @@ class BaichuanTextEmbeddingModel(TextEmbeddingModel):
         return result
     
     def embedding(self, model: str, api_key, texts: list[str], user: Optional[str] = None) \
-            -> Tuple[list[list[float]], int]:
+            -> tuple[list[list[float]], int]:
         """
         Embed given texts
 

--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 import boto3
 from botocore.config import Config
@@ -37,7 +38,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -159,7 +160,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         return message_text
 
-    def _convert_messages_to_prompt(self, messages: List[PromptMessage], model_prefix: str) -> str:
+    def _convert_messages_to_prompt(self, messages: list[PromptMessage], model_prefix: str) -> str:
         """
         Format a list of messages into a full prompt for the Anthropic, Amazon and Llama models
 
@@ -181,7 +182,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # trim off the trailing ' ' that might come from the "Assistant: "
         return text.rstrip()
 
-    def _create_payload(self, model_prefix: str, prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[List[str]] = None, stream: bool = True):
+    def _create_payload(self, model_prefix: str, prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[list[str]] = None, stream: bool = True):
         """
         Create payload for bedrock api call depending on model provider
         """
@@ -231,7 +232,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict,
                   prompt_messages: list[PromptMessage], model_parameters: dict,
-                  stop: Optional[List[str]] = None, stream: bool = True,
+                  stop: Optional[list[str]] = None, stream: bool = True,
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke large language model

--- a/api/core/model_runtime/model_providers/chatglm/llm/llm.py
+++ b/api/core/model_runtime/model_providers/chatglm/llm/llm.py
@@ -1,6 +1,7 @@
 import logging
+from collections.abc import Generator
 from os.path import join
-from typing import Generator, List, Optional, cast
+from typing import Optional, cast
 
 from httpx import Timeout
 from openai import (
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
 class ChatGLMLargeLanguageModel(LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, 
                 prompt_messages: list[PromptMessage], model_parameters: dict, 
-                tools: list[PromptMessageTool] | None = None, stop: List[str] | None = None, 
+                tools: list[PromptMessageTool] | None = None, stop: list[str] | None = None, 
                 stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         """
@@ -138,7 +139,7 @@ class ChatGLMLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict, 
                 prompt_messages: list[PromptMessage], model_parameters: dict, 
-                tools: list[PromptMessageTool] | None = None, stop: List[str] | None = None, 
+                tools: list[PromptMessageTool] | None = None, stop: list[str] | None = None, 
                 stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         """
@@ -394,7 +395,7 @@ class ChatGLMLargeLanguageModel(LargeLanguageModel):
 
         return num_tokens
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage],
+    def _num_tokens_from_messages(self, messages: list[PromptMessage],
                                   tools: Optional[list[PromptMessageTool]] = None) -> int:
         """Calculate num tokens for chatglm2 and chatglm3 with GPT2 tokenizer.
 

--- a/api/core/model_runtime/model_providers/cohere/llm/llm.py
+++ b/api/core/model_runtime/model_providers/cohere/llm/llm.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Generator, List, Optional, Tuple, Union, cast
+from collections.abc import Generator
+from typing import Optional, Union, cast
 
 import cohere
 from cohere.responses import Chat, Generations
@@ -38,7 +39,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -138,7 +139,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
             raise CredentialsValidateFailedError(str(ex))
 
     def _generate(self, model: str, credentials: dict,
-                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[List[str]] = None,
+                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[list[str]] = None,
                   stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke llm model
@@ -264,7 +265,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
                 break
 
     def _chat_generate(self, model: str, credentials: dict,
-                       prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[List[str]] = None,
+                       prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[list[str]] = None,
                        stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke llm chat model
@@ -306,7 +307,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         return self._handle_chat_generate_response(model, credentials, response, prompt_messages, stop)
 
     def _handle_chat_generate_response(self, model: str, credentials: dict, response: Chat,
-                                       prompt_messages: list[PromptMessage], stop: Optional[List[str]] = None) \
+                                       prompt_messages: list[PromptMessage], stop: Optional[list[str]] = None) \
             -> LLMResult:
         """
         Handle llm chat response
@@ -352,7 +353,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
 
     def _handle_chat_generate_stream_response(self, model: str, credentials: dict, response: StreamingChat,
                                               prompt_messages: list[PromptMessage],
-                                              stop: Optional[List[str]] = None) -> Generator:
+                                              stop: Optional[list[str]] = None) -> Generator:
         """
         Handle llm chat stream response
 
@@ -427,7 +428,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
                 index += 1
 
     def _convert_prompt_messages_to_message_and_chat_histories(self, prompt_messages: list[PromptMessage]) \
-            -> Tuple[str, list[dict]]:
+            -> tuple[str, list[dict]]:
         """
         Convert prompt messages to message and chat histories
         :param prompt_messages: prompt messages
@@ -495,7 +496,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
 
         return response.length
 
-    def _num_tokens_from_messages(self, model: str, credentials: dict, messages: List[PromptMessage]) -> int:
+    def _num_tokens_from_messages(self, model: str, credentials: dict, messages: list[PromptMessage]) -> int:
         """Calculate num tokens Cohere model."""
         messages = [self._convert_prompt_message_to_dict(m) for m in messages]
         message_strs = [f"{message['role']}: {message['message']}" for message in messages]

--- a/api/core/model_runtime/model_providers/cohere/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/cohere/text_embedding/text_embedding.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, Tuple
+from typing import Optional
 
 import cohere
 import numpy as np
@@ -168,7 +168,7 @@ class CohereTextEmbeddingModel(TextEmbeddingModel):
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
-    def _embedding_invoke(self, model: str, credentials: dict, texts: list[str]) -> Tuple[list[list[float]], int]:
+    def _embedding_invoke(self, model: str, credentials: dict, texts: list[str]) -> tuple[list[list[float]], int]:
         """
         Invoke embedding model
 

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 import google.api_core.exceptions as exceptions
 import google.generativeai as genai
@@ -34,7 +35,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -103,7 +104,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict,
                   prompt_messages: list[PromptMessage], model_parameters: dict,
-                  stop: Optional[List[str]] = None, stream: bool = True,
+                  stop: Optional[list[str]] = None, stream: bool = True,
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke large language model

--- a/api/core/model_runtime/model_providers/huggingface_hub/llm/llm.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from huggingface_hub import InferenceClient
 from huggingface_hub.hf_api import HfApi
@@ -29,7 +30,7 @@ from core.model_runtime.model_providers.huggingface_hub._common import _CommonHu
 
 class HuggingfaceHubLargeLanguageModel(_CommonHuggingfaceHub, LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None, stream: bool = True,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None, stream: bool = True,
                 user: Optional[str] = None) -> Union[LLMResult, Generator]:
 
         client = InferenceClient(token=credentials['huggingfacehub_api_token'])

--- a/api/core/model_runtime/model_providers/localai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/localai/llm/llm.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from os.path import join
-from typing import Generator, List, cast
+from typing import cast
 
 from httpx import Timeout
 from openai import (
@@ -52,7 +53,7 @@ from core.model_runtime.utils import helper
 class LocalAILarguageModel(LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, 
                 prompt_messages: list[PromptMessage], model_parameters: dict, 
-                tools: list[PromptMessageTool] | None = None, stop: List[str] | None = None, 
+                tools: list[PromptMessageTool] | None = None, stop: list[str] | None = None, 
                 stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         return self._generate(model=model, credentials=credentials, prompt_messages=prompt_messages,
@@ -63,7 +64,7 @@ class LocalAILarguageModel(LargeLanguageModel):
         # tools is not supported yet
         return self._num_tokens_from_messages(prompt_messages, tools=tools)
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage], tools: list[PromptMessageTool]) -> int:
+    def _num_tokens_from_messages(self, messages: list[PromptMessage], tools: list[PromptMessageTool]) -> int:
         """
             Calculate num tokens for baichuan model
             LocalAI does not supports 
@@ -241,7 +242,7 @@ class LocalAILarguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                  model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                 stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                 stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         
         kwargs = self._to_client_kwargs(credentials)
@@ -346,7 +347,7 @@ class LocalAILarguageModel(LargeLanguageModel):
         
         return message_dict
 
-    def _convert_prompt_message_to_completion_prompts(self, messages: List[PromptMessage]) -> str:
+    def _convert_prompt_message_to_completion_prompts(self, messages: list[PromptMessage]) -> str:
         """
         Convert PromptMessage to completion prompts
         """

--- a/api/core/model_runtime/model_providers/minimax/llm/chat_completion.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/chat_completion.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from json import dumps, loads
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Union
 
 from requests import Response, post
 
@@ -14,13 +15,13 @@ from core.model_runtime.model_providers.minimax.llm.errors import (
 from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 
 
-class MinimaxChatCompletion(object):
+class MinimaxChatCompletion:
     """
         Minimax Chat Completion API
     """
     def generate(self, model: str, api_key: str, group_id: str, 
-                 prompt_messages: List[MinimaxMessage], model_parameters: dict,
-                 tools: List[Dict[str, Any]], stop: List[str] | None, stream: bool, user: str) \
+                 prompt_messages: list[MinimaxMessage], model_parameters: dict,
+                 tools: list[dict[str, Any]], stop: list[str] | None, stream: bool, user: str) \
         -> Union[MinimaxMessage, Generator[MinimaxMessage, None, None]]:
         """
             generate chat completion

--- a/api/core/model_runtime/model_providers/minimax/llm/chat_completion_pro.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/chat_completion_pro.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from json import dumps, loads
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Union
 
 from requests import Response, post
 
@@ -14,14 +15,14 @@ from core.model_runtime.model_providers.minimax.llm.errors import (
 from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 
 
-class MinimaxChatCompletionPro(object):
+class MinimaxChatCompletionPro:
     """
         Minimax Chat Completion Pro API, supports function calling
         however, we do not have enough time and energy to implement it, but the parameters are reserved
     """
     def generate(self, model: str, api_key: str, group_id: str, 
-                 prompt_messages: List[MinimaxMessage], model_parameters: dict,
-                 tools: List[Dict[str, Any]], stop: List[str] | None, stream: bool, user: str) \
+                 prompt_messages: list[MinimaxMessage], model_parameters: dict,
+                 tools: list[dict[str, Any]], stop: list[str] | None, stream: bool, user: str) \
         -> Union[MinimaxMessage, Generator[MinimaxMessage, None, None]]:
         """
             generate chat completion

--- a/api/core/model_runtime/model_providers/minimax/llm/llm.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/llm.py
@@ -1,4 +1,4 @@
-from typing import Generator, List
+from collections.abc import Generator
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -42,7 +42,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                 model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
         -> LLMResult | Generator:
         return self._generate(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
 
@@ -79,7 +79,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                        tools: list[PromptMessageTool] | None = None) -> int:
         return self._num_tokens_from_messages(prompt_messages, tools)
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage], tools: list[PromptMessageTool]) -> int:
+    def _num_tokens_from_messages(self, messages: list[PromptMessage], tools: list[PromptMessageTool]) -> int:
         """
             Calculate num tokens for minimax model
 
@@ -94,7 +94,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                 model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
         -> LLMResult | Generator:
         """
             use MinimaxChatCompletionPro as the type of client, anyway,  MinimaxChatCompletion has the same interface

--- a/api/core/model_runtime/model_providers/minimax/llm/types.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict
+from typing import Any
 
 
 class MinimaxMessage:
@@ -11,11 +11,11 @@ class MinimaxMessage:
 
     role: str = Role.USER.value
     content: str
-    usage: Dict[str, int] = None
+    usage: dict[str, int] = None
     stop_reason: str = ''
-    function_call: Dict[str, Any] = None
+    function_call: dict[str, Any] = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         if self.function_call and self.role == MinimaxMessage.Role.ASSISTANT.value:
             return {
                 'sender_type': 'BOT',

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -220,7 +220,7 @@ class ModelProviderFactory:
         # read _position.yaml file
         position_map = {}
         if os.path.exists(position_file_path):
-            with open(position_file_path, 'r', encoding='utf-8') as f:
+            with open(position_file_path, encoding='utf-8') as f:
                 positions = yaml.safe_load(f)
                 # convert list to dict with key as model provider name, value as index
                 position_map = {position: index for index, position in enumerate(positions)}

--- a/api/core/model_runtime/model_providers/moonshot/llm/llm.py
+++ b/api/core/model_runtime/model_providers/moonshot/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult
 from core.model_runtime.entities.message_entities import PromptMessage, PromptMessageTool
@@ -8,7 +9,7 @@ from core.model_runtime.model_providers.openai_api_compatible.llm.llm import OAI
 class MoonshotLargeLanguageModel(OAIAPICompatLargeLanguageModel):
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         self._add_custom_parameters(credentials)

--- a/api/core/model_runtime/model_providers/ollama/llm/llm.py
+++ b/api/core/model_runtime/model_providers/ollama/llm/llm.py
@@ -1,8 +1,9 @@
 import json
 import logging
 import re
+from collections.abc import Generator
 from decimal import Decimal
-from typing import Generator, List, Optional, Union, cast
+from typing import Optional, Union, cast
 from urllib.parse import urljoin
 
 import requests
@@ -51,7 +52,7 @@ class OllamaLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -131,7 +132,7 @@ class OllamaLargeLanguageModel(LargeLanguageModel):
             raise CredentialsValidateFailedError(f'An error occurred during credentials validation: {str(ex)}')
 
     def _generate(self, model: str, credentials: dict,
-                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[List[str]] = None,
+                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[list[str]] = None,
                   stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke llm completion model
@@ -398,7 +399,7 @@ class OllamaLargeLanguageModel(LargeLanguageModel):
 
         return message_dict
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage]) -> int:
+    def _num_tokens_from_messages(self, messages: list[PromptMessage]) -> int:
         """
         Calculate num tokens.
 

--- a/api/core/model_runtime/model_providers/openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai/llm/llm.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Generator, List, Optional, Union, cast
+from collections.abc import Generator
+from typing import Optional, Union, cast
 
 import tiktoken
 from openai import OpenAI, Stream
@@ -35,7 +36,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -215,7 +216,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         return ai_model_entities
 
     def _generate(self, model: str, credentials: dict,
-                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[List[str]] = None,
+                  prompt_messages: list[PromptMessage], model_parameters: dict, stop: Optional[list[str]] = None,
                   stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke llm completion model
@@ -366,7 +367,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
 
     def _chat_generate(self, model: str, credentials: dict,
                        prompt_messages: list[PromptMessage], model_parameters: dict,
-                       tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                       tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                        stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke llm chat model
@@ -704,7 +705,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
 
         return num_tokens
 
-    def _num_tokens_from_messages(self, model: str, messages: List[PromptMessage],
+    def _num_tokens_from_messages(self, model: str, messages: list[PromptMessage],
                                   tools: Optional[list[PromptMessageTool]] = None) -> int:
         """Calculate num tokens for gpt-3.5-turbo and gpt-4 with tiktoken package.
 

--- a/api/core/model_runtime/model_providers/openai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/openai/text_embedding/text_embedding.py
@@ -1,6 +1,6 @@
 import base64
 import time
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import tiktoken
@@ -162,7 +162,7 @@ class OpenAITextEmbeddingModel(_CommonOpenAI, TextEmbeddingModel):
             raise CredentialsValidateFailedError(str(ex))
 
     def _embedding_invoke(self, model: str, client: OpenAI, texts: Union[list[str], str],
-                          extra_model_kwargs: dict) -> Tuple[list[list[float]], int]:
+                          extra_model_kwargs: dict) -> tuple[list[list[float]], int]:
         """
         Invoke embedding model
 

--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from collections.abc import Generator
 from decimal import Decimal
-from typing import Generator, List, Optional, Union, cast
+from typing import Optional, Union, cast
 from urllib.parse import urljoin
 
 import requests
@@ -46,7 +47,7 @@ class OAIAPICompatLargeLanguageModel(_CommonOAI_API_Compat, LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -245,7 +246,7 @@ class OAIAPICompatLargeLanguageModel(_CommonOAI_API_Compat, LargeLanguageModel):
 
     # validate_credentials method has been rewritten to use the requests library for compatibility with all providers following OpenAI's API standard.
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], model_parameters: dict,
-                  tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                  tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                   stream: bool = True, \
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
@@ -567,7 +568,7 @@ class OAIAPICompatLargeLanguageModel(_CommonOAI_API_Compat, LargeLanguageModel):
 
         return num_tokens
 
-    def _num_tokens_from_messages(self, model: str, messages: List[PromptMessage],
+    def _num_tokens_from_messages(self, model: str, messages: list[PromptMessage],
                                   tools: Optional[list[PromptMessageTool]] = None) -> int:
         """
         Approximate num tokens with GPT2 tokenizer.

--- a/api/core/model_runtime/model_providers/openllm/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/llm.py
@@ -1,4 +1,4 @@
-from typing import Generator, List
+from collections.abc import Generator
 
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
@@ -40,7 +40,7 @@ from core.model_runtime.model_providers.openllm.llm.openllm_generate_errors impo
 class OpenLLMLargeLanguageModel(LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                 model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
         -> LLMResult | Generator:
         return self._generate(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
 
@@ -77,7 +77,7 @@ class OpenLLMLargeLanguageModel(LargeLanguageModel):
                        tools: list[PromptMessageTool] | None = None) -> int:
         return self._num_tokens_from_messages(prompt_messages, tools)
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage], tools: list[PromptMessageTool]) -> int:
+    def _num_tokens_from_messages(self, messages: list[PromptMessage], tools: list[PromptMessageTool]) -> int:
         """
             Calculate num tokens for OpenLLM model
             it's a generate model, so we just join them by spe
@@ -87,7 +87,7 @@ class OpenLLMLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                 model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
         -> LLMResult | Generator:
         client = OpenLLMGenerate()
         response = client.generate(

--- a/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
@@ -1,6 +1,7 @@
+from collections.abc import Generator
 from enum import Enum
 from json import dumps, loads
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Union
 
 from requests import Response, post
 from requests.exceptions import ConnectionError, InvalidSchema, MissingSchema
@@ -19,10 +20,10 @@ class OpenLLMGenerateMessage:
 
     role: str = Role.USER.value
     content: str
-    usage: Dict[str, int] = None
+    usage: dict[str, int] = None
     stop_reason: str = ''
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             'role': self.role,
             'content': self.content,
@@ -33,10 +34,10 @@ class OpenLLMGenerateMessage:
         self.role = role
 
 
-class OpenLLMGenerate(object):
+class OpenLLMGenerate:
     def generate(
-            self, server_url: str, model_name: str, stream: bool, model_parameters: Dict[str, Any],
-            stop: List[str], prompt_messages: List[OpenLLMGenerateMessage], user: str,
+            self, server_url: str, model_name: str, stream: bool, model_parameters: dict[str, Any],
+            stop: list[str], prompt_messages: list[OpenLLMGenerateMessage], user: str,
     ) -> Union[Generator[OpenLLMGenerateMessage, None, None], OpenLLMGenerateMessage]:
         if not server_url:
             raise InvalidAuthenticationError('Invalid server URL')

--- a/api/core/model_runtime/model_providers/replicate/llm/llm.py
+++ b/api/core/model_runtime/model_providers/replicate/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from replicate import Client as ReplicateClient
 from replicate.exceptions import ReplicateError
@@ -29,7 +30,7 @@ from core.model_runtime.model_providers.replicate._common import _CommonReplicat
 class ReplicateLargeLanguageModel(_CommonReplicate, LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None, stream: bool = True,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None, stream: bool = True,
                 user: Optional[str] = None) -> Union[LLMResult, Generator]:
 
         version = credentials['model_version']

--- a/api/core/model_runtime/model_providers/spark/llm/llm.py
+++ b/api/core/model_runtime/model_providers/spark/llm/llm.py
@@ -1,5 +1,6 @@
 import threading
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -27,7 +28,7 @@ class SparkLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -86,7 +87,7 @@ class SparkLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict,
                   prompt_messages: list[PromptMessage], model_parameters: dict,
-                  stop: Optional[List[str]] = None, stream: bool = True,
+                  stop: Optional[list[str]] = None, stream: bool = True,
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke large language model
@@ -244,7 +245,7 @@ class SparkLargeLanguageModel(LargeLanguageModel):
 
         return message_text
     
-    def _convert_messages_to_prompt(self, messages: List[PromptMessage]) -> str:
+    def _convert_messages_to_prompt(self, messages: list[PromptMessage]) -> str:
         """
         Format a list of messages into a full prompt for the Anthropic model
 

--- a/api/core/model_runtime/model_providers/togetherai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/togetherai/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult
 from core.model_runtime.entities.message_entities import PromptMessage, PromptMessageTool
@@ -14,7 +15,7 @@ class TogetherAILargeLanguageModel(OAIAPICompatLargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         cred_with_endpoint = self._update_endpoint_url(credentials=credentials)
@@ -27,7 +28,7 @@ class TogetherAILargeLanguageModel(OAIAPICompatLargeLanguageModel):
         return super().validate_credentials(model, cred_with_endpoint)
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], model_parameters: dict,
-                  tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                  tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                   stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         cred_with_endpoint = self._update_endpoint_url(credentials=credentials)
 

--- a/api/core/model_runtime/model_providers/tongyi/llm/_client.py
+++ b/api/core/model_runtime/model_providers/tongyi/llm/_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms import Tongyi
@@ -8,7 +8,7 @@ from langchain.schema import Generation, LLMResult
 
 class EnhanceTongyi(Tongyi):
     @property
-    def _default_params(self) -> Dict[str, Any]:
+    def _default_params(self) -> dict[str, Any]:
         """Get the default parameters for calling OpenAI API."""
         normal_params = {
             "top_p": self.top_p,
@@ -19,13 +19,13 @@ class EnhanceTongyi(Tongyi):
 
     def _generate(
         self,
-        prompts: List[str],
-        stop: Optional[List[str]] = None,
+        prompts: list[str],
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> LLMResult:
         generations = []
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             **{"model": self.model_name},
             **self._default_params,
             **kwargs,

--- a/api/core/model_runtime/model_providers/tongyi/llm/llm.py
+++ b/api/core/model_runtime/model_providers/tongyi/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from dashscope import get_tokenizer
 from dashscope.api_entities.dashscope_response import DashScopeAPIResponse
@@ -38,7 +39,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -100,7 +101,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict,
                   prompt_messages: list[PromptMessage], model_parameters: dict,
-                  stop: Optional[List[str]] = None, stream: bool = True,
+                  stop: Optional[list[str]] = None, stream: bool = True,
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke large language model
@@ -268,7 +269,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
 
         return message_text
     
-    def _convert_messages_to_prompt(self, messages: List[PromptMessage]) -> str:
+    def _convert_messages_to_prompt(self, messages: list[PromptMessage]) -> str:
         """
         Format a list of messages into a full prompt for the Anthropic model
 

--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie_bot.py
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie_bot.py
@@ -1,8 +1,9 @@
+from collections.abc import Generator
 from datetime import datetime, timedelta
 from enum import Enum
 from json import dumps, loads
 from threading import Lock
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Union
 
 from requests import Response, post
 
@@ -16,7 +17,7 @@ from core.model_runtime.model_providers.wenxin.llm.ernie_bot_errors import (
 )
 
 # map api_key to access_token
-baidu_access_tokens: Dict[str, 'BaiduAccessToken'] = {}
+baidu_access_tokens: dict[str, 'BaiduAccessToken'] = {}
 baidu_access_tokens_lock = Lock()
 
 class BaiduAccessToken:
@@ -105,10 +106,10 @@ class ErnieMessage:
 
     role: str = Role.USER.value
     content: str
-    usage: Dict[str, int] = None
+    usage: dict[str, int] = None
     stop_reason: str = ''
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             'role': self.role,
             'content': self.content,
@@ -118,7 +119,7 @@ class ErnieMessage:
         self.content = content
         self.role = role
 
-class ErnieBotModel(object):
+class ErnieBotModel:
     api_bases = {
         'ernie-bot': 'https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions',
         'ernie-bot-4': 'https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions_pro',
@@ -138,9 +139,9 @@ class ErnieBotModel(object):
         self.api_key = api_key
         self.secret_key = secret_key
 
-    def generate(self, model: str, stream: bool, messages: List[ErnieMessage], 
-                 parameters: Dict[str, Any], timeout: int, tools: List[PromptMessageTool], \
-                 stop: List[str], user: str) \
+    def generate(self, model: str, stream: bool, messages: list[ErnieMessage], 
+                 parameters: dict[str, Any], timeout: int, tools: list[PromptMessageTool], \
+                 stop: list[str], user: str) \
         -> Union[Generator[ErnieMessage, None, None], ErnieMessage]:
 
         # check parameters
@@ -216,11 +217,11 @@ class ErnieBotModel(object):
         token = BaiduAccessToken.get_access_token(self.api_key, self.secret_key)
         return token.access_token
     
-    def _copy_messages(self, messages: List[ErnieMessage]) -> List[ErnieMessage]:
+    def _copy_messages(self, messages: list[ErnieMessage]) -> list[ErnieMessage]:
         return [ErnieMessage(message.content, message.role) for message in messages]
 
-    def _check_parameters(self, model: str, parameters: Dict[str, Any], 
-                          tools: List[PromptMessageTool], stop: List[str]) -> None:
+    def _check_parameters(self, model: str, parameters: dict[str, Any], 
+                          tools: list[PromptMessageTool], stop: list[str]) -> None:
         if model not in self.api_bases:
             raise BadRequestError(f'Invalid model: {model}')
         
@@ -241,16 +242,16 @@ class ErnieBotModel(object):
                 if len(s) > 20:
                     raise BadRequestError('stop item should not exceed 20 characters.')
         
-    def _build_request_body(self, model: str, messages: List[ErnieMessage], stream: bool, parameters: Dict[str, Any],
-                            tools: List[PromptMessageTool], stop: List[str], user: str) -> Dict[str, Any]:
+    def _build_request_body(self, model: str, messages: list[ErnieMessage], stream: bool, parameters: dict[str, Any],
+                            tools: list[PromptMessageTool], stop: list[str], user: str) -> dict[str, Any]:
         # if model in self.function_calling_supports:
         #     return self._build_function_calling_request_body(model, messages, parameters, tools, stop, user)
         return self._build_chat_request_body(model, messages, stream, parameters, stop, user)
         
-    def _build_function_calling_request_body(self, model: str, messages: List[ErnieMessage], stream: bool,
-                                                parameters: Dict[str, Any], tools: List[PromptMessageTool], 
-                                                stop: List[str], user: str) \
-        -> Dict[str, Any]:
+    def _build_function_calling_request_body(self, model: str, messages: list[ErnieMessage], stream: bool,
+                                                parameters: dict[str, Any], tools: list[PromptMessageTool], 
+                                                stop: list[str], user: str) \
+        -> dict[str, Any]:
         if len(messages) % 2 == 0:
             raise BadRequestError('The number of messages should be odd.')
         if messages[0].role == 'function':
@@ -260,9 +261,9 @@ class ErnieBotModel(object):
         TODO: implement function calling
         """
 
-    def _build_chat_request_body(self, model: str, messages: List[ErnieMessage], stream: bool, 
-                                 parameters: Dict[str, Any], stop: List[str], user: str) \
-        -> Dict[str, Any]:
+    def _build_chat_request_body(self, model: str, messages: list[ErnieMessage], stream: bool, 
+                                 parameters: dict[str, Any], stop: list[str], user: str) \
+        -> dict[str, Any]:
         if len(messages) == 0:
             raise BadRequestError('The number of messages should not be zero.')
         

--- a/api/core/model_runtime/model_providers/wenxin/llm/llm.py
+++ b/api/core/model_runtime/model_providers/wenxin/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, cast
+from collections.abc import Generator
+from typing import cast
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -32,7 +33,7 @@ from core.model_runtime.model_providers.wenxin.llm.ernie_bot_errors import (
 class ErnieBotLarguageModel(LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, 
                 prompt_messages: list[PromptMessage], model_parameters: dict, 
-                tools: list[PromptMessageTool] | None = None, stop: List[str] | None = None, 
+                tools: list[PromptMessageTool] | None = None, stop: list[str] | None = None, 
                 stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         return self._generate(model=model, credentials=credentials, prompt_messages=prompt_messages,
@@ -43,7 +44,7 @@ class ErnieBotLarguageModel(LargeLanguageModel):
         # tools is not supported yet
         return self._num_tokens_from_messages(prompt_messages)
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage],) -> int:
+    def _num_tokens_from_messages(self, messages: list[PromptMessage],) -> int:
         """Calculate num tokens for baichuan model"""
         def tokens(text: str):
             return self._get_num_tokens_by_gpt2(text)
@@ -78,7 +79,7 @@ class ErnieBotLarguageModel(LargeLanguageModel):
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                  model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                 stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                 stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         instance = ErnieBotModel(
             api_key=credentials['api_key'],

--- a/api/core/model_runtime/model_providers/xinference/llm/llm.py
+++ b/api/core/model_runtime/model_providers/xinference/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, Iterator, List, cast
+from collections.abc import Generator, Iterator
+from typing import cast
 
 from openai import (
     APIConnectionError,
@@ -62,7 +63,7 @@ from core.model_runtime.utils import helper
 class XinferenceAILargeLanguageModel(LargeLanguageModel):
     def _invoke(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                 model_parameters: dict, tools: list[PromptMessageTool] | None = None, 
-                stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
         -> LLMResult | Generator:
         """
             invoke LLM
@@ -131,7 +132,7 @@ class XinferenceAILargeLanguageModel(LargeLanguageModel):
         """
         return self._num_tokens_from_messages(prompt_messages, tools)
 
-    def _num_tokens_from_messages(self, messages: List[PromptMessage], tools: list[PromptMessageTool], 
+    def _num_tokens_from_messages(self, messages: list[PromptMessage], tools: list[PromptMessageTool], 
                                   is_completion_model: bool = False) -> int:
         def tokens(text: str):
             return self._get_num_tokens_by_gpt2(text)
@@ -359,7 +360,7 @@ class XinferenceAILargeLanguageModel(LargeLanguageModel):
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 
                  model_parameters: dict, extra_model_kwargs: XinferenceModelExtraParameter,
                  tools: list[PromptMessageTool] | None = None, 
-                 stop: List[str] | None = None, stream: bool = True, user: str | None = None) \
+                 stop: list[str] | None = None, stream: bool = True, user: str | None = None) \
             -> LLMResult | Generator:
         """
             generate text from LLM
@@ -404,7 +405,7 @@ class XinferenceAILargeLanguageModel(LargeLanguageModel):
                 } for tool in tools
             ]
 
-        if isinstance(xinference_model, (RESTfulChatModelHandle, RESTfulChatglmCppChatModelHandle)):
+        if isinstance(xinference_model, RESTfulChatModelHandle | RESTfulChatglmCppChatModelHandle):
             resp = client.chat.completions.create(
                 model=credentials['model_uid'],
                 messages=[self._convert_prompt_message_to_dict(message) for message in prompt_messages], 

--- a/api/core/model_runtime/model_providers/xinference/xinference_helper.py
+++ b/api/core/model_runtime/model_providers/xinference/xinference_helper.py
@@ -1,22 +1,21 @@
 from os import path
 from threading import Lock
 from time import time
-from typing import List
 
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, MissingSchema, Timeout
 from requests.sessions import Session
 
 
-class XinferenceModelExtraParameter(object):
+class XinferenceModelExtraParameter:
     model_format: str
     model_handle_type: str
-    model_ability: List[str]
+    model_ability: list[str]
     max_tokens: int = 512
     context_length: int = 2048
     support_function_call: bool = False
 
-    def __init__(self, model_format: str, model_handle_type: str, model_ability: List[str], 
+    def __init__(self, model_format: str, model_handle_type: str, model_ability: list[str], 
                  support_function_call: bool, max_tokens: int, context_length: int) -> None:
         self.model_format = model_format
         self.model_handle_type = model_handle_type

--- a/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
@@ -1,4 +1,5 @@
-from typing import Generator, List, Optional, Union
+from collections.abc import Generator
+from typing import Optional, Union
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -23,7 +24,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
 
     def _invoke(self, model: str, credentials: dict,
                 prompt_messages: list[PromptMessage], model_parameters: dict,
-                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[List[str]] = None,
+                tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                 stream: bool = True, user: Optional[str] = None) \
             -> Union[LLMResult, Generator]:
         """
@@ -89,7 +90,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
     def _generate(self, model: str, credentials_kwargs: dict,
                   prompt_messages: list[PromptMessage], model_parameters: dict,
                   tools: Optional[list[PromptMessageTool]] = None,
-                  stop: Optional[List[str]] = None, stream: bool = True,
+                  stop: Optional[list[str]] = None, stream: bool = True,
                   user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
         Invoke large language model
@@ -119,7 +120,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
                 prompt_messages = prompt_messages[1:]
 
         # resolve zhipuai model not support system message and user message, assistant message must be in sequence
-        new_prompt_messages: List[PromptMessage] = []
+        new_prompt_messages: list[PromptMessage] = []
         for prompt_message in prompt_messages:
             copy_prompt_message = prompt_message.copy()
             if copy_prompt_message.role in [PromptMessageRole.USER, PromptMessageRole.SYSTEM, PromptMessageRole.TOOL]:
@@ -275,7 +276,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
         :return: llm response
         """
         text = ''
-        assistant_tool_calls: List[AssistantPromptMessage.ToolCall] = []
+        assistant_tool_calls: list[AssistantPromptMessage.ToolCall] = []
         for choice in response.choices:
             if choice.message.tool_calls:
                 for tool_call in choice.message.tool_calls:
@@ -335,7 +336,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
             if delta.finish_reason is None and (delta.delta.content is None or delta.delta.content == ''):
                 continue
             
-            assistant_tool_calls: List[AssistantPromptMessage.ToolCall] = []
+            assistant_tool_calls: list[AssistantPromptMessage.ToolCall] = []
             for tool_call in delta.delta.tool_calls or []:
                 if tool_call.type == 'function':
                     assistant_tool_calls.append(
@@ -409,7 +410,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
         return message_text
 
 
-    def _convert_messages_to_prompt(self, messages: List[PromptMessage], tools: Optional[list[PromptMessageTool]] = None) -> str:
+    def _convert_messages_to_prompt(self, messages: list[PromptMessage], tools: Optional[list[PromptMessageTool]] = None) -> str:
         """
         :param messages: List of PromptMessage to combine.
         :return: Combined string with necessary human_prompt and ai_prompt tags.

--- a/api/core/model_runtime/model_providers/zhipuai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/zhipuai/text_embedding/text_embedding.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from core.model_runtime.entities.model_entities import PriceType
 from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, TextEmbeddingResult
@@ -81,7 +81,7 @@ class ZhipuAITextEmbeddingModel(_CommonZhipuaiAI, TextEmbeddingModel):
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
-    def embed_documents(self, model: str, client: ZhipuAI, texts: List[str]) -> Tuple[List[List[float]], int]:
+    def embed_documents(self, model: str, client: ZhipuAI, texts: list[str]) -> tuple[list[list[float]], int]:
         """Call out to ZhipuAI's embedding endpoint.
 
         Args:
@@ -101,7 +101,7 @@ class ZhipuAITextEmbeddingModel(_CommonZhipuaiAI, TextEmbeddingModel):
 
         return [list(map(float, e)) for e in embeddings], embedding_used_tokens
     
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str) -> list[float]:
         """Call out to ZhipuAI's embedding endpoint.
 
         Args:

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/_client.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/_client.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import Mapping, Union
+from collections.abc import Mapping
+from typing import Union
 
 import httpx
 from httpx import Timeout

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/chat/async_completions.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/chat/async_completions.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import httpx
-from typing_extensions import Literal
 
 from ...core._base_api import BaseAPI
 from ...core._base_type import NOT_GIVEN, Headers, NotGiven
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class AsyncCompletions(BaseAPI):
-    def __init__(self, client: "ZhipuAI") -> None:
+    def __init__(self, client: ZhipuAI) -> None:
         super().__init__(client)
 
 
@@ -29,8 +28,8 @@ class AsyncCompletions(BaseAPI):
             top_p: Optional[float] | NotGiven = NOT_GIVEN,
             max_tokens: int | NotGiven = NOT_GIVEN,
             seed: int | NotGiven = NOT_GIVEN,
-            messages: Union[str, List[str], List[int], List[List[int]], None],
-            stop: Optional[Union[str, List[str], None]] | NotGiven = NOT_GIVEN,
+            messages: Union[str, list[str], list[int], list[list[int]], None],
+            stop: Optional[Union[str, list[str], None]] | NotGiven = NOT_GIVEN,
             sensitive_word_check: Optional[object] | NotGiven = NOT_GIVEN,
             tools: Optional[object] | NotGiven = NOT_GIVEN,
             tool_choice: str | NotGiven = NOT_GIVEN,

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/chat/completions.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/chat/completions.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import httpx
-from typing_extensions import Literal
 
 from ...core._base_api import BaseAPI
 from ...core._base_type import NOT_GIVEN, Headers, NotGiven
@@ -17,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class Completions(BaseAPI):
-    def __init__(self, client: "ZhipuAI") -> None:
+    def __init__(self, client: ZhipuAI) -> None:
         super().__init__(client)
 
     def create(
@@ -31,8 +30,8 @@ class Completions(BaseAPI):
             top_p: Optional[float] | NotGiven = NOT_GIVEN,
             max_tokens: int | NotGiven = NOT_GIVEN,
             seed: int | NotGiven = NOT_GIVEN,
-            messages: Union[str, List[str], List[int], object, None],
-            stop: Optional[Union[str, List[str], None]] | NotGiven = NOT_GIVEN,
+            messages: Union[str, list[str], list[int], object, None],
+            stop: Optional[Union[str, list[str], None]] | NotGiven = NOT_GIVEN,
             sensitive_word_check: Optional[object] | NotGiven = NOT_GIVEN,
             tools: Optional[object] | NotGiven = NOT_GIVEN,
             tool_choice: str | NotGiven = NOT_GIVEN,

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/embeddings.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/embeddings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import httpx
 
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
 
 
 class Embeddings(BaseAPI):
-    def __init__(self, client: "ZhipuAI") -> None:
+    def __init__(self, client: ZhipuAI) -> None:
         super().__init__(client)
 
     def create(
             self,
             *,
-            input: Union[str, List[str], List[int], List[List[int]]],
+            input: Union[str, list[str], list[int], list[list[int]]],
             model: Union[str],
             encoding_format: str | NotGiven = NOT_GIVEN,
             user: str | NotGiven = NOT_GIVEN,

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/files.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/files.py
@@ -18,7 +18,7 @@ __all__ = ["Files"]
 
 class Files(BaseAPI):
 
-    def __init__(self, client: "ZhipuAI") -> None:
+    def __init__(self, client: ZhipuAI) -> None:
         super().__init__(client)
 
     def create(

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/fine_tuning/jobs.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/fine_tuning/jobs.py
@@ -17,7 +17,7 @@ __all__ = ["Jobs"]
 
 class Jobs(BaseAPI):
 
-    def __init__(self, client: "ZhipuAI") -> None:
+    def __init__(self, client: ZhipuAI) -> None:
         super().__init__(client)
 
     def create(

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/images.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/api_resource/images.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class Images(BaseAPI):
-    def __init__(self, client: "ZhipuAI") -> None:
+    def __init__(self, client: ZhipuAI) -> None:
         super().__init__(client)
 
     def generations(

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_base_type.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_base_type.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from os import PathLike
-from typing import IO, TYPE_CHECKING, Any, List, Mapping, Sequence, Tuple, Type, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar, Union
 
 import pydantic
-from typing_extensions import Literal, override
+from typing_extensions import override
 
 Query = Mapping[str, object]
 Body = object
 AnyMapping = Mapping[str, object]
 PrimitiveData = Union[str, int, float, bool, None]
-Data = Union[PrimitiveData, List[Any], Tuple[Any], "Mapping[str, Any]"]
+Data = Union[PrimitiveData, list[Any], tuple[Any], "Mapping[str, Any]"]
 ModelT = TypeVar("ModelT", bound=pydantic.BaseModel)
 _T = TypeVar("_T")
 
 if TYPE_CHECKING:
-    NoneType: Type[None]
+    NoneType: type[None]
 else:
     NoneType = type(None)
 
@@ -74,7 +75,7 @@ Headers = Mapping[str, Union[str, Omit]]
 
 ResponseT = TypeVar(
     "ResponseT",
-    bound="Union[str, None, BaseModel, List[Any], Dict[str, Any], Response, UnknownResponse, ModelBuilderProtocol, BinaryResponseContent]",
+    bound="Union[str, None, BaseModel, list[Any], Dict[str, Any], Response, UnknownResponse, ModelBuilderProtocol, BinaryResponseContent]",
 )
 
 # for user input files
@@ -85,21 +86,21 @@ else:
 
 FileTypes = Union[
     FileContent,  # file content
-    Tuple[str, FileContent],  # (filename, file)
-    Tuple[str, FileContent, str],  # (filename, file , content_type)
-    Tuple[str, FileContent, str, Mapping[str, str]],  # (filename, file , content_type, headers)
+    tuple[str, FileContent],  # (filename, file)
+    tuple[str, FileContent, str],  # (filename, file , content_type)
+    tuple[str, FileContent, str, Mapping[str, str]],  # (filename, file , content_type, headers)
 ]
 
-RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]
+RequestFiles = Union[Mapping[str, FileTypes], Sequence[tuple[str, FileTypes]]]
 
 # for httpx client supported files
 
 HttpxFileContent = Union[bytes, IO[bytes]]
 HttpxFileTypes = Union[
     FileContent,  # file content
-    Tuple[str, HttpxFileContent],  # (filename, file)
-    Tuple[str, HttpxFileContent, str],  # (filename, file , content_type)
-    Tuple[str, HttpxFileContent, str, Mapping[str, str]],  # (filename, file , content_type, headers)
+    tuple[str, HttpxFileContent],  # (filename, file)
+    tuple[str, HttpxFileContent, str],  # (filename, file , content_type)
+    tuple[str, HttpxFileContent, str, Mapping[str, str]],  # (filename, file , content_type, headers)
 ]
 
-HttpxRequestFiles = Union[Mapping[str, HttpxFileTypes], Sequence[Tuple[str, HttpxFileTypes]]]
+HttpxRequestFiles = Union[Mapping[str, HttpxFileTypes], Sequence[tuple[str, HttpxFileTypes]]]

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_files.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_files.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import io
 import os
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Mapping, Sequence
 
 from ._base_type import FileTypes, HttpxFileTypes, HttpxRequestFiles, RequestFiles
 
 
 def is_file_content(obj: object) -> bool:
-    return isinstance(obj, (bytes, tuple, io.IOBase, os.PathLike))
+    return isinstance(obj, bytes | tuple | io.IOBase | os.PathLike)
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_http_client.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_http_client.py
@@ -1,8 +1,8 @@
-# -*- coding:utf-8 -*-
 from __future__ import annotations
 
 import inspect
-from typing import Any, Mapping, Type, Union, cast
+from collections.abc import Mapping
+from typing import Any, Union, cast
 
 import httpx
 import pydantic
@@ -140,7 +140,7 @@ class HttpClient:
             for k, v in value.items():
                 items.extend(self._object_to_formfata(f"{key}[{k}]", v))
             return items
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, list | tuple):
             for v in value:
                 items.extend(self._object_to_formfata(key + "[]", v))
             return items
@@ -175,7 +175,7 @@ class HttpClient:
     def _parse_response(
             self,
             *,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             response: httpx.Response,
             enable_stream: bool,
             request_param: ClientRequestParam,
@@ -224,7 +224,7 @@ class HttpClient:
     def request(
             self,
             *,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             params: ClientRequestParam,
             enable_stream: bool = False,
             stream_cls: type[StreamResponse[Any]] | None = None,
@@ -259,7 +259,7 @@ class HttpClient:
             self,
             path: str,
             *,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             options: UserRequestInput = {},
             enable_stream: bool = False,
     ) -> ResponseT | StreamResponse:
@@ -274,7 +274,7 @@ class HttpClient:
             path: str,
             *,
             body: Body | None = None,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             options: UserRequestInput = {},
             files: RequestFiles | None = None,
             enable_stream: bool = False,
@@ -294,7 +294,7 @@ class HttpClient:
             path: str,
             *,
             body: Body | None = None,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             options: UserRequestInput = {},
     ) -> ResponseT:
         opts = ClientRequestParam.construct(method="patch", url=path, json_data=body, **options)
@@ -308,7 +308,7 @@ class HttpClient:
             path: str,
             *,
             body: Body | None = None,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             options: UserRequestInput = {},
             files: RequestFiles | None = None,
     ) -> ResponseT | StreamResponse:
@@ -324,7 +324,7 @@ class HttpClient:
             path: str,
             *,
             body: Body | None = None,
-            cast_type: Type[ResponseT],
+            cast_type: type[ResponseT],
             options: UserRequestInput = {},
     ) -> ResponseT | StreamResponse:
         opts = ClientRequestParam.construct(method="delete", url=path, json_data=body, **options)

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_jwt_token.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_jwt_token.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import time
 
 import cachetools.func

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_request_opt.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_request_opt.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, ClassVar, Union
 
 from httpx import Timeout
 from pydantic import ConfigDict
-from typing_extensions import ClassVar, TypedDict, Unpack
+from typing_extensions import TypedDict, Unpack
 
 from ._base_type import Body, Headers, HttpxRequestFiles, NotGiven, Query
 from ._utils import remove_notgiven_indict
@@ -17,7 +17,7 @@ class UserRequestInput(TypedDict, total=False):
     params: Query | None
 
 
-class ClientRequestParam():
+class ClientRequestParam:
     method: str
     url: str
     max_retries: Union[int, NotGiven] = NotGiven()

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_response.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_response.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, get_args, get_origin
 
 import httpx
 import pydantic
-from typing_extensions import ParamSpec, get_args, get_origin
+from typing_extensions import ParamSpec
 
 from ._base_type import NoneType
 from ._sse_client import StreamResponse
@@ -19,7 +19,7 @@ R = TypeVar("R")
 
 class HttpResponse(Generic[R]):
     _cast_type: type[R]
-    _client: "HttpClient"
+    _client: HttpClient
     _parsed: R | None
     _enable_stream: bool
     _stream_cls: type[StreamResponse[Any]]
@@ -30,7 +30,7 @@ class HttpResponse(Generic[R]):
             *,
             raw_response: httpx.Response,
             cast_type: type[R],
-            client: "HttpClient",
+            client: HttpClient,
             enable_stream: bool = False,
             stream_cls: type[StreamResponse[Any]] | None = None,
     ) -> None:

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_sse_client.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_sse_client.py
@@ -1,8 +1,8 @@
-# -*- coding:utf-8 -*-
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Generic, Iterator, Mapping
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Generic
 
 import httpx
 
@@ -36,8 +36,7 @@ class StreamResponse(Generic[ResponseT]):
         return self._stream_chunks.__next__()
 
     def __iter__(self) -> Iterator[ResponseT]:
-        for item in self._stream_chunks:
-            yield item
+        yield from self._stream_chunks
 
     def __stream__(self) -> Iterator[ResponseT]:
 
@@ -62,7 +61,7 @@ class StreamResponse(Generic[ResponseT]):
             pass
 
 
-class Event(object):
+class Event:
     def __init__(
             self,
             event: str | None = None,

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_utils.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Iterable, Mapping, TypeVar
+from collections.abc import Iterable, Mapping
+from typing import TypeVar
 
 from ._base_type import NotGiven
 

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/chat/async_chat_completion.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/chat/async_chat_completion.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -19,5 +19,5 @@ class AsyncCompletion(BaseModel):
     request_id: Optional[str] = None
     model: Optional[str] = None
     task_status: str
-    choices: List[CompletionChoice]
+    choices: list[CompletionChoice]
     usage: CompletionUsage

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/chat/chat_completion.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/chat/chat_completion.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -19,7 +19,7 @@ class CompletionMessageToolCall(BaseModel):
 class CompletionMessage(BaseModel):
     content: Optional[str] = None
     role: str
-    tool_calls: Optional[List[CompletionMessageToolCall]] = None
+    tool_calls: Optional[list[CompletionMessageToolCall]] = None
 
 
 class CompletionUsage(BaseModel):
@@ -37,7 +37,7 @@ class CompletionChoice(BaseModel):
 class Completion(BaseModel):
     model: Optional[str] = None
     created: Optional[int] = None
-    choices: List[CompletionChoice]
+    choices: list[CompletionChoice]
     request_id: Optional[str] = None
     id: Optional[str] = None
     usage: CompletionUsage

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/chat/chat_completion_chunk.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/chat/chat_completion_chunk.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -32,7 +32,7 @@ class ChoiceDeltaToolCall(BaseModel):
 class ChoiceDelta(BaseModel):
     content: Optional[str] = None
     role: Optional[str] = None
-    tool_calls: Optional[List[ChoiceDeltaToolCall]] = None
+    tool_calls: Optional[list[ChoiceDeltaToolCall]] = None
 
 
 class Choice(BaseModel):
@@ -49,7 +49,7 @@ class CompletionUsage(BaseModel):
 
 class ChatCompletionChunk(BaseModel):
     id: Optional[str] = None
-    choices: List[Choice]
+    choices: list[Choice]
     created: Optional[int] = None
     model: Optional[str] = None
     usage: Optional[CompletionUsage] = None

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/embeddings.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/embeddings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -12,11 +12,11 @@ __all__ = ["Embedding", "EmbeddingsResponded"]
 class Embedding(BaseModel):
     object: str
     index: Optional[int] = None
-    embedding: List[float]
+    embedding: list[float]
 
 
 class EmbeddingsResponded(BaseModel):
     object: str
-    data: List[Embedding]
+    data: list[Embedding]
     model: str
     usage: CompletionUsage

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/file_object.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/file_object.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -20,5 +20,5 @@ class FileObject(BaseModel):
 class ListOfFileObject(BaseModel):
 
     object: Optional[str] = None
-    data: List[FileObject]
+    data: list[FileObject]
     has_more: Optional[bool] = None

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -34,7 +34,7 @@ class FineTuningJob(BaseModel):
 
     object: Optional[str] = None
 
-    result_files: List[str]
+    result_files: list[str]
 
     status: str
 
@@ -47,5 +47,5 @@ class FineTuningJob(BaseModel):
 
 class ListOfFineTuningJob(BaseModel):
     object: Optional[str] = None
-    data: List[FineTuningJob]
+    data: list[FineTuningJob]
     has_more: Optional[bool] = None

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job_event.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/fine_tuning_job_event.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -31,5 +31,5 @@ class JobEvent(BaseModel):
 
 class FineTuningJobEvent(BaseModel):
     object: Optional[str] = None
-    data: List[JobEvent]
+    data: list[JobEvent]
     has_more: Optional[bool] = None

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/job_create_params.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/fine_tuning/job_create_params.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Literal, Union
 
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 __all__ = ["Hyperparameters"]
 

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/image.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/types/image.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -15,4 +15,4 @@ class GeneratedImage(BaseModel):
 
 class ImagesResponded(BaseModel):
     created: int
-    data: List[GeneratedImage]
+    data: list[GeneratedImage]

--- a/api/core/model_runtime/utils/_compat.py
+++ b/api/core/model_runtime/utils/_compat.py
@@ -1,8 +1,7 @@
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 from pydantic.version import VERSION as PYDANTIC_VERSION
-from typing_extensions import Literal
 
 PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 

--- a/api/core/model_runtime/utils/encoders.py
+++ b/api/core/model_runtime/utils/encoders.py
@@ -1,13 +1,14 @@
 import dataclasses
 import datetime
 from collections import defaultdict, deque
+from collections.abc import Callable
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path, PurePath
 from re import Pattern
 from types import GeneratorType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -46,7 +47,7 @@ def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
         return float(dec_value)
 
 
-ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
+ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
     bytes: lambda o: o.decode(),
     Color: str,
     datetime.date: isoformat,
@@ -77,9 +78,9 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 
 
 def generate_encoders_by_class_tuples(
-    type_encoder_map: Dict[Any, Callable[[Any], Any]]
-) -> Dict[Callable[[Any], Any], Tuple[Any, ...]]:
-    encoders_by_class_tuples: Dict[Callable[[Any], Any], Tuple[Any, ...]] = defaultdict(
+    type_encoder_map: dict[Any, Callable[[Any], Any]]
+) -> dict[Callable[[Any], Any], tuple[Any, ...]]:
+    encoders_by_class_tuples: dict[Callable[[Any], Any], tuple[Any, ...]] = defaultdict(
         tuple
     )
     for type_, encoder in type_encoder_map.items():
@@ -96,7 +97,7 @@ def jsonable_encoder(
     exclude_unset: bool = False,
     exclude_defaults: bool = False,
     exclude_none: bool = False,
-    custom_encoder: Optional[Dict[Any, Callable[[Any], Any]]] = None,
+    custom_encoder: Optional[dict[Any, Callable[[Any], Any]]] = None,
     sqlalchemy_safe: bool = True,
 ) -> Any:
     custom_encoder = custom_encoder or {}
@@ -109,7 +110,7 @@ def jsonable_encoder(
                     return encoder_instance(obj)
     if isinstance(obj, BaseModel):
         # TODO: remove when deprecating Pydantic v1
-        encoders: Dict[Any, Any] = {}
+        encoders: dict[Any, Any] = {}
         if not PYDANTIC_V2:
             encoders = getattr(obj.__config__, "json_encoders", {})  # type: ignore[attr-defined]
             if custom_encoder:
@@ -149,7 +150,7 @@ def jsonable_encoder(
         return obj.value
     if isinstance(obj, PurePath):
         return str(obj)
-    if isinstance(obj, (str, int, float, type(None))):
+    if isinstance(obj, str | int | float | type(None)):
         return obj
     if isinstance(obj, Decimal):
         return format(obj, 'f')
@@ -184,7 +185,7 @@ def jsonable_encoder(
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
-    if isinstance(obj, (list, set, frozenset, GeneratorType, tuple, deque)):
+    if isinstance(obj, list | set | frozenset | GeneratorType | tuple | deque):
         encoded_list = []
         for item in obj:
             encoded_list.append(
@@ -209,7 +210,7 @@ def jsonable_encoder(
     try:
         data = dict(obj)
     except Exception as e:
-        errors: List[Exception] = []
+        errors: list[Exception] = []
         errors.append(e)
         try:
             data = vars(obj)

--- a/api/core/prompt/prompt_transform.py
+++ b/api/core/prompt/prompt_transform.py
@@ -2,7 +2,7 @@ import enum
 import json
 import os
 import re
-from typing import List, Optional, Tuple, cast
+from typing import Optional, cast
 
 from core.entities.application_entities import (
     AdvancedCompletionPromptTemplateEntity,
@@ -67,11 +67,11 @@ class PromptTransform:
                    prompt_template_entity: PromptTemplateEntity,
                    inputs: dict,
                    query: str,
-                   files: List[FileObj],
+                   files: list[FileObj],
                    context: Optional[str],
                    memory: Optional[TokenBufferMemory],
                    model_config: ModelConfigEntity) -> \
-            Tuple[List[PromptMessage], Optional[List[str]]]:
+            tuple[list[PromptMessage], Optional[list[str]]]:
         app_mode = AppMode.value_of(app_mode)
         model_mode = ModelMode.value_of(model_config.mode)
 
@@ -115,10 +115,10 @@ class PromptTransform:
                             prompt_template_entity: PromptTemplateEntity,
                             inputs: dict,
                             query: str,
-                            files: List[FileObj],
+                            files: list[FileObj],
                             context: Optional[str],
                             memory: Optional[TokenBufferMemory],
-                            model_config: ModelConfigEntity) -> List[PromptMessage]:
+                            model_config: ModelConfigEntity) -> list[PromptMessage]:
         app_mode = AppMode.value_of(app_mode)
         model_mode = ModelMode.value_of(model_config.mode)
 
@@ -182,7 +182,7 @@ class PromptTransform:
         )
 
     def _get_history_messages_list_from_memory(self, memory: TokenBufferMemory,
-                                               max_token_limit: int) -> List[PromptMessage]:
+                                               max_token_limit: int) -> list[PromptMessage]:
         """Get memory messages."""
         return memory.get_history_prompt_messages(
             max_token_limit=max_token_limit
@@ -217,7 +217,7 @@ class PromptTransform:
 
         json_file_path = os.path.join(prompt_path, f'{prompt_name}.json')
         # Open the JSON file and read its content
-        with open(json_file_path, 'r', encoding='utf-8') as json_file:
+        with open(json_file_path, encoding='utf-8') as json_file:
             return json.load(json_file)
 
     def _get_simple_chat_app_chat_model_prompt_messages(self, prompt_rules: dict,
@@ -225,9 +225,9 @@ class PromptTransform:
                                                         inputs: dict,
                                                         query: str,
                                                         context: Optional[str],
-                                                        files: List[FileObj],
+                                                        files: list[FileObj],
                                                         memory: Optional[TokenBufferMemory],
-                                                        model_config: ModelConfigEntity) -> List[PromptMessage]:
+                                                        model_config: ModelConfigEntity) -> list[PromptMessage]:
         prompt_messages = []
 
         context_prompt_content = ''
@@ -280,8 +280,8 @@ class PromptTransform:
                                            query: str,
                                            context: Optional[str],
                                            memory: Optional[TokenBufferMemory],
-                                           files: List[FileObj],
-                                           model_config: ModelConfigEntity) -> List[PromptMessage]:
+                                           files: list[FileObj],
+                                           model_config: ModelConfigEntity) -> list[PromptMessage]:
         context_prompt_content = ''
         if context and 'context_prompt' in prompt_rules:
             prompt_template = PromptTemplateParser(template=prompt_rules['context_prompt'])
@@ -451,10 +451,10 @@ class PromptTransform:
                                                        prompt_template_entity: PromptTemplateEntity,
                                                        inputs: dict,
                                                        query: str,
-                                                       files: List[FileObj],
+                                                       files: list[FileObj],
                                                        context: Optional[str],
                                                        memory: Optional[TokenBufferMemory],
-                                                       model_config: ModelConfigEntity) -> List[PromptMessage]:
+                                                       model_config: ModelConfigEntity) -> list[PromptMessage]:
 
         raw_prompt = prompt_template_entity.advanced_completion_prompt_template.prompt
         role_prefix = prompt_template_entity.advanced_completion_prompt_template.role_prefix
@@ -494,10 +494,10 @@ class PromptTransform:
                                                  prompt_template_entity: PromptTemplateEntity,
                                                  inputs: dict,
                                                  query: str,
-                                                 files: List[FileObj],
+                                                 files: list[FileObj],
                                                  context: Optional[str],
                                                  memory: Optional[TokenBufferMemory],
-                                                 model_config: ModelConfigEntity) -> List[PromptMessage]:
+                                                 model_config: ModelConfigEntity) -> list[PromptMessage]:
         raw_prompt_list = prompt_template_entity.advanced_chat_prompt_template.messages
 
         prompt_messages = []
@@ -535,7 +535,7 @@ class PromptTransform:
     def _get_completion_app_completion_model_prompt_messages(self,
                                                              prompt_template_entity: PromptTemplateEntity,
                                                              inputs: dict,
-                                                             context: Optional[str]) -> List[PromptMessage]:
+                                                             context: Optional[str]) -> list[PromptMessage]:
         raw_prompt = prompt_template_entity.advanced_completion_prompt_template.prompt
 
         prompt_messages = []
@@ -554,8 +554,8 @@ class PromptTransform:
     def _get_completion_app_chat_model_prompt_messages(self,
                                                        prompt_template_entity: PromptTemplateEntity,
                                                        inputs: dict,
-                                                       files: List[FileObj],
-                                                       context: Optional[str]) -> List[PromptMessage]:
+                                                       files: list[FileObj],
+                                                       context: Optional[str]) -> list[PromptMessage]:
         raw_prompt_list = prompt_template_entity.advanced_chat_prompt_template.messages
 
         prompt_messages = []

--- a/api/core/rerank/rerank.py
+++ b/api/core/rerank/rerank.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from langchain.schema import Document
 
@@ -9,8 +9,8 @@ class RerankRunner:
     def __init__(self, rerank_model_instance: ModelInstance) -> None:
         self.rerank_model_instance = rerank_model_instance
 
-    def run(self, query: str, documents: List[Document], score_threshold: Optional[float] = None,
-            top_n: Optional[int] = None, user: Optional[str] = None) -> List[Document]:
+    def run(self, query: str, documents: list[Document], score_threshold: Optional[float] = None,
+            top_n: Optional[int] = None, user: Optional[str] = None) -> list[Document]:
         """
         Run rerank model
         :param query: search query

--- a/api/core/splitter/fixed_text_splitter.py
+++ b/api/core/splitter/fixed_text_splitter.py
@@ -1,7 +1,7 @@
 """Functionality for splitting text."""
 from __future__ import annotations
 
-from typing import Any, List, Optional, cast
+from typing import Any, Optional, cast
 
 from langchain.text_splitter import (
     TS,
@@ -28,8 +28,8 @@ class EnhanceRecursiveCharacterTextSplitter(RecursiveCharacterTextSplitter):
     def from_encoder(
             cls: Type[TS],
             embedding_model_instance: Optional[ModelInstance],
-            allowed_special: Union[Literal["all"], AbstractSet[str]] = set(),
-            disallowed_special: Union[Literal["all"], Collection[str]] = "all",
+            allowed_special: Union[Literal[all], AbstractSet[str]] = set(),
+            disallowed_special: Union[Literal[all], Collection[str]] = "all",
             **kwargs: Any,
     ):
         def _token_encoder(text: str) -> int:
@@ -59,13 +59,13 @@ class EnhanceRecursiveCharacterTextSplitter(RecursiveCharacterTextSplitter):
 
 
 class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter):
-    def __init__(self, fixed_separator: str = "\n\n", separators: Optional[List[str]] = None, **kwargs: Any):
+    def __init__(self, fixed_separator: str = "\n\n", separators: Optional[list[str]] = None, **kwargs: Any):
         """Create a new TextSplitter."""
         super().__init__(**kwargs)
         self._fixed_separator = fixed_separator
         self._separators = separators or ["\n\n", "\n", " ", ""]
 
-    def split_text(self, text: str) -> List[str]:
+    def split_text(self, text: str) -> list[str]:
         """Split incoming text and return chunks."""
         if self._fixed_separator:
             chunks = text.split(self._fixed_separator)
@@ -81,7 +81,7 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
 
         return final_chunks
 
-    def recursive_split_text(self, text: str) -> List[str]:
+    def recursive_split_text(self, text: str) -> list[str]:
         """Split incoming text and return chunks."""
         final_chunks = []
         # Get appropriate separator to use

--- a/api/core/third_party/langchain/llms/fake.py
+++ b/api/core/third_party/langchain/llms/fake.py
@@ -1,5 +1,6 @@
 import time
-from typing import Any, List, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any, Optional
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.chat_models.base import SimpleChatModel
@@ -19,8 +20,8 @@ class FakeLLM(SimpleChatModel):
 
     def _call(
         self,
-        messages: List[BaseMessage],
-        stop: Optional[List[str]] = None,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
@@ -36,8 +37,8 @@ class FakeLLM(SimpleChatModel):
 
     def _generate(
         self,
-        messages: List[BaseMessage],
-        stop: Optional[List[str]] = None,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> ChatResult:

--- a/api/core/tool/current_datetime_tool.py
+++ b/api/core/tool/current_datetime_tool.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Type
 
 from langchain.tools import BaseTool
 from pydantic import BaseModel, Field
@@ -12,7 +11,7 @@ class DatetimeToolInput(BaseModel):
 class DatetimeTool(BaseTool):
     """Tool for querying current datetime."""
     name: str = "current_datetime"
-    args_schema: Type[BaseModel] = DatetimeToolInput
+    args_schema: type[BaseModel] = DatetimeToolInput
     description: str = "A tool when you want to get the current date, time, week, month or year, " \
                        "and the time zone is UTC. Result is \"<date> <time> <timezone> <week>\"."
 

--- a/api/core/tool/web_reader_tool.py
+++ b/api/core/tool/web_reader_tool.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 import unicodedata
 from contextlib import contextmanager
-from typing import Any, Type
+from typing import Any
 
 import requests
 from bs4 import BeautifulSoup, CData, Comment, NavigableString
@@ -56,7 +56,7 @@ class WebReaderTool(BaseTool):
     """Reader tool for getting website title and contents. Gives more control than SimpleReaderTool."""
 
     name: str = "web_reader"
-    args_schema: Type[BaseModel] = WebReaderToolInput
+    args_schema: type[BaseModel] = WebReaderToolInput
     description: str = "use this to read a website. " \
                        "If you can answer the question based on the information provided, " \
                        "there is no need to use."
@@ -208,7 +208,7 @@ def extract_using_readabilipy(html):
         subprocess.check_call(["node", "ExtractArticle.js", "-i", html_path, "-o", article_json_path])
 
     # Read output of call to Readability.parse() from JSON file and return as Python dictionary
-    with open(article_json_path, "r", encoding="utf-8") as json_file:
+    with open(article_json_path, encoding="utf-8") as json_file:
         input_json = json.loads(json_file.read())
 
     # Deleting files after processing

--- a/api/core/tools/entities/tool_bundle.py
+++ b/api/core/tools/entities/tool_bundle.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -18,7 +18,7 @@ class ApiBasedToolBundle(BaseModel):
     # operation_id
     operation_id: str = None
     # parameters
-    parameters: Optional[List[ToolParameter]] = None
+    parameters: Optional[list[ToolParameter]] = None
     # author
     author: str
     # icon
@@ -31,6 +31,6 @@ class AppToolBundle(BaseModel):
     This class is used to store the schema information of an tool for an app.
     """
     type: ToolProviderType
-    credential: Optional[Dict[str, Any]] = None
+    credential: Optional[dict[str, Any]] = None
     provider_id: str
     tool_name: str

--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from pydantic import BaseModel, Field
 
@@ -82,7 +82,7 @@ class ToolInvokeMessage(BaseModel):
         plain text, image url or link url
     """
     message: Union[str, bytes] = None
-    meta: Dict[str, Any] = None
+    meta: dict[str, Any] = None
     save_as: str = ''
 
 class ToolInvokeMessageBinary(BaseModel):
@@ -116,12 +116,12 @@ class ToolParameter(BaseModel):
     default: Optional[str] = None
     min: Optional[Union[float, int]] = None
     max: Optional[Union[float, int]] = None
-    options: Optional[List[ToolParameterOption]] = None
+    options: Optional[list[ToolParameterOption]] = None
 
     @classmethod
     def get_simple_instance(cls, 
                        name: str, llm_description: str, type: ToolParameterType, 
-                       required: bool, options: Optional[List[str]] = None) -> 'ToolParameter':
+                       required: bool, options: Optional[list[str]] = None) -> 'ToolParameter':
         """
             get a simple tool parameter
 
@@ -192,7 +192,7 @@ class ToolProviderCredentials(BaseModel):
     type: CredentialsType = Field(..., description="The type of the credentials")
     required: bool = False
     default: Optional[str] = None
-    options: Optional[List[ToolCredentialsOption]] = None
+    options: Optional[list[ToolCredentialsOption]] = None
     label: Optional[I18nObject] = None
     help: Optional[I18nObject] = None
     url: Optional[str] = None
@@ -232,7 +232,7 @@ class ToolRuntimeVariablePool(BaseModel):
     user_id: str = Field(..., description="The user id")
     tenant_id: str = Field(..., description="The tenant id of assistant")
 
-    pool: List[ToolRuntimeVariable] = Field(..., description="The pool of variables")
+    pool: list[ToolRuntimeVariable] = Field(..., description="The pool of variables")
 
     def __init__(self, **data: Any):
         pool = data.get('pool', [])

--- a/api/core/tools/entities/user_entities.py
+++ b/api/core/tools/entities/user_entities.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -40,11 +40,11 @@ class UserToolProvider(BaseModel):
         }
 
 class UserToolProviderCredentials(BaseModel):
-    credentials: Dict[str, ToolProviderCredentials]
+    credentials: dict[str, ToolProviderCredentials]
 
 class UserTool(BaseModel):
     author: str
     name: str # identifier
     label: I18nObject # label
     description: I18nObject
-    parameters: Optional[List[ToolParameter]]
+    parameters: Optional[list[ToolParameter]]

--- a/api/core/tools/model/tool_model_manager.py
+++ b/api/core/tools/model/tool_model_manager.py
@@ -5,7 +5,7 @@
 """
 
 import json
-from typing import List, cast
+from typing import cast
 
 from core.model_manager import ModelManager
 from core.model_runtime.entities.llm_entities import LLMResult
@@ -56,7 +56,7 @@ class ToolModelManager:
     @staticmethod
     def calculate_tokens(
         tenant_id: str,
-        prompt_messages: List[PromptMessage]
+        prompt_messages: list[PromptMessage]
     ) -> int:
         """
             calculate tokens from prompt messages and model parameters
@@ -82,7 +82,7 @@ class ToolModelManager:
     def invoke(
         user_id: str, tenant_id: str,
         tool_type: str, tool_name: str,
-        prompt_messages: List[PromptMessage]
+        prompt_messages: list[PromptMessage]
     ) -> LLMResult:
         """
         invoke model with parameters in user's own context

--- a/api/core/tools/provider/api_tool_provider.py
+++ b/api/core/tools/provider/api_tool_provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
@@ -83,10 +83,10 @@ class ApiBasedToolProviderController(ToolProviderController):
     def app_type(self) -> ToolProviderType:
         return ToolProviderType.API_BASED
     
-    def _validate_credentials(self, tool_name: str, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, tool_name: str, credentials: dict[str, Any]) -> None:
         pass
 
-    def validate_parameters(self, tool_name: str, tool_parameters: Dict[str, Any]) -> None:
+    def validate_parameters(self, tool_name: str, tool_parameters: dict[str, Any]) -> None:
         pass
 
     def _parse_tool_bundle(self, tool_bundle: ApiBasedToolBundle) -> ApiTool:
@@ -117,7 +117,7 @@ class ApiBasedToolProviderController(ToolProviderController):
             'parameters' : tool_bundle.parameters if tool_bundle.parameters else [],
         })
 
-    def load_bundled_tools(self, tools: List[ApiBasedToolBundle]) -> List[ApiTool]:
+    def load_bundled_tools(self, tools: list[ApiBasedToolBundle]) -> list[ApiTool]:
         """
             load bundled tools
 
@@ -128,7 +128,7 @@ class ApiBasedToolProviderController(ToolProviderController):
 
         return self.tools
 
-    def get_tools(self, user_id: str, tenant_id: str) -> List[ApiTool]:
+    def get_tools(self, user_id: str, tenant_id: str) -> list[ApiTool]:
         """
             fetch tools from database
 
@@ -139,10 +139,10 @@ class ApiBasedToolProviderController(ToolProviderController):
         if self.tools is not None:
             return self.tools
         
-        tools: List[Tool] = []
+        tools: list[Tool] = []
 
         # get tenant api providers
-        db_providers: List[ApiToolProvider] = db.session.query(ApiToolProvider).filter(
+        db_providers: list[ApiToolProvider] = db.session.query(ApiToolProvider).filter(
             ApiToolProvider.tenant_id == tenant_id,
             ApiToolProvider.name == self.identity.name
         ).all()

--- a/api/core/tools/provider/app_tool_provider.py
+++ b/api/core/tools/provider/app_tool_provider.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import ToolParameter, ToolParameterOption, ToolProviderType
@@ -16,21 +16,21 @@ class AppBasedToolProviderEntity(ToolProviderController):
     def app_type(self) -> ToolProviderType:
         return ToolProviderType.APP_BASED
     
-    def _validate_credentials(self, tool_name: str, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, tool_name: str, credentials: dict[str, Any]) -> None:
         pass
 
-    def validate_parameters(self, tool_name: str, tool_parameters: Dict[str, Any]) -> None:
+    def validate_parameters(self, tool_name: str, tool_parameters: dict[str, Any]) -> None:
         pass
 
-    def get_tools(self, user_id: str) -> List[Tool]:
-        db_tools: List[PublishedAppTool] = db.session.query(PublishedAppTool).filter(
+    def get_tools(self, user_id: str) -> list[Tool]:
+        db_tools: list[PublishedAppTool] = db.session.query(PublishedAppTool).filter(
             PublishedAppTool.user_id == user_id,
         ).all()
 
         if not db_tools or len(db_tools) == 0:
             return []
 
-        tools: List[Tool] = []
+        tools: list[Tool] = []
 
         for db_tool in db_tools:
             tool = {

--- a/api/core/tools/provider/builtin/_positions.py
+++ b/api/core/tools/provider/builtin/_positions.py
@@ -1,5 +1,4 @@
 import os.path
-from typing import List
 
 from yaml import FullLoader, load
 
@@ -9,12 +8,12 @@ position = {}
 
 class BuiltinToolProviderSort:
     @staticmethod
-    def sort(providers: List[UserToolProvider]) -> List[UserToolProvider]:
+    def sort(providers: list[UserToolProvider]) -> list[UserToolProvider]:
         global position
         if not position:
             tmp_position = {}
             file_path = os.path.join(os.path.dirname(__file__), '..', '_position.yaml')
-            with open(file_path, 'r') as f:
+            with open(file_path) as f:
                 for pos, val in enumerate(load(f, Loader=FullLoader)):
                     tmp_position[val] = pos
             position = tmp_position

--- a/api/core/tools/provider/builtin/azuredalle/azuredalle.py
+++ b/api/core/tools/provider/builtin/azuredalle/azuredalle.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.azuredalle.tools.dalle3 import DallE3Tool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class AzureDALLEProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             DallE3Tool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/azuredalle/tools/dalle3.py
+++ b/api/core/tools/provider/builtin/azuredalle/tools/dalle3.py
@@ -1,5 +1,5 @@
 from base64 import b64decode
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from openai import AzureOpenAI
 
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class DallE3Tool(BuiltinTool):
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/bing/bing.py
+++ b/api/core/tools/provider/builtin/bing/bing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.bing.tools.bing_web_search import BingSearchTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class BingProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             BingSearchTool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/bing/tools/bing_web_search.py
+++ b/api/core/tools/provider/builtin/bing/tools/bing_web_search.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from requests import get
 
@@ -11,8 +11,8 @@ class BingSearchTool(BuiltinTool):
 
     def _invoke(self, 
                 user_id: str,
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/chart/tools/bar.py
+++ b/api/core/tools/provider/builtin/chart/tools/bar.py
@@ -1,5 +1,5 @@
 import io
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import matplotlib.pyplot as plt
 
@@ -8,8 +8,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class BarChartTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) \
-          -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) \
+          -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         data = tool_parameters.get('data', '')
         if not data:
             return self.create_text_message('Please input data')

--- a/api/core/tools/provider/builtin/chart/tools/line.py
+++ b/api/core/tools/provider/builtin/chart/tools/line.py
@@ -1,5 +1,5 @@
 import io
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import matplotlib.pyplot as plt
 
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class LinearChartTool(BuiltinTool):
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         data = tool_parameters.get('data', '')
         if not data:
             return self.create_text_message('Please input data')

--- a/api/core/tools/provider/builtin/chart/tools/pie.py
+++ b/api/core/tools/provider/builtin/chart/tools/pie.py
@@ -1,5 +1,5 @@
 import io
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import matplotlib.pyplot as plt
 
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class PieChartTool(BuiltinTool):
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         data = tool_parameters.get('data', '')
         if not data:
             return self.create_text_message('Please input data')

--- a/api/core/tools/provider/builtin/dalle/dalle.py
+++ b/api/core/tools/provider/builtin/dalle/dalle.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.dalle.tools.dalle2 import DallE2Tool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class DALLEProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             DallE2Tool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/dalle/tools/dalle2.py
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle2.py
@@ -1,6 +1,6 @@
 from base64 import b64decode
 from os.path import join
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from openai import OpenAI
 
@@ -11,8 +11,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class DallE2Tool(BuiltinTool):
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/dalle/tools/dalle3.py
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle3.py
@@ -1,6 +1,6 @@
 from base64 import b64decode
 from os.path import join
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from openai import OpenAI
 
@@ -11,8 +11,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class DallE3Tool(BuiltinTool):
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/gaode/tools/gaode_weather.py
+++ b/api/core/tools/provider/builtin/gaode/tools/gaode_weather.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import requests
 
@@ -8,7 +8,7 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class GaodeRepositoriesTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/github/tools/github_repositories.py
+++ b/api/core/tools/provider/builtin/github/tools/github_repositories.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 from urllib.parse import quote
 
 import requests
@@ -10,7 +10,7 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class GihubRepositoriesTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/google/google.py
+++ b/api/core/tools/provider/builtin/google/google.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.google.tools.google_search import GoogleSearchTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class GoogleProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             GoogleSearchTool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/google/tools/google_search.py
+++ b/api/core/tools/provider/builtin/google/tools/google_search.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from serpapi import GoogleSearch
 
@@ -48,7 +48,7 @@ class SerpAPI:
             res = search.get_dict()
         return res
 
-    def get_params(self, query: str) -> Dict[str, str]:
+    def get_params(self, query: str) -> dict[str, str]:
         """Get parameters for SerpAPI."""
         _params = {
             "api_key": self.serpapi_api_key,
@@ -148,8 +148,8 @@ class SerpAPI:
 class GoogleSearchTool(BuiltinTool):
     def _invoke(self, 
                 user_id: str,
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/maths/maths.py
+++ b/api/core/tools/provider/builtin/maths/maths.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.maths.tools.eval_expression import EvaluateExpressionTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class MathsProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             EvaluateExpressionTool().invoke(
                 user_id='',

--- a/api/core/tools/provider/builtin/maths/tools/eval_expression.py
+++ b/api/core/tools/provider/builtin/maths/tools/eval_expression.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import numexpr as ne
 
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class EvaluateExpressionTool(BuiltinTool):
     def _invoke(self, 
                 user_id: str,
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/stablediffusion/stablediffusion.py
+++ b/api/core/tools/provider/builtin/stablediffusion/stablediffusion.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.stablediffusion.tools.stable_diffusion import StableDiffusionTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class StableDiffusionProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             StableDiffusionTool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.py
+++ b/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.py
@@ -3,7 +3,7 @@ import json
 from base64 import b64decode, b64encode
 from copy import deepcopy
 from os.path import join
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from httpx import get, post
 from PIL import Image
@@ -60,8 +60,8 @@ DRAW_TEXT_OPTIONS = {
 
 
 class StableDiffusionTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) \
-        -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) \
+        -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """
@@ -141,7 +141,7 @@ class StableDiffusionTool(BuiltinTool):
                              height=height,
                              steps=steps)
 
-    def validate_models(self) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def validate_models(self) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             validate models
         """
@@ -168,7 +168,7 @@ class StableDiffusionTool(BuiltinTool):
     def img2img(self, base_url: str, lora: str, image_binary: bytes, 
                 prompt: str, negative_prompt: str,
                 width: int, height: int, steps: int) \
-        -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+        -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             generate image
         """
@@ -207,7 +207,7 @@ class StableDiffusionTool(BuiltinTool):
             return self.create_text_message('Failed to generate image')
 
     def text2img(self, base_url: str, lora: str, prompt: str, negative_prompt: str, width: int, height: int, steps: int) \
-        -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+        -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             generate image
         """
@@ -239,7 +239,7 @@ class StableDiffusionTool(BuiltinTool):
         except Exception as e:
             return self.create_text_message('Failed to generate image')
 
-    def get_runtime_parameters(self) -> List[ToolParameter]:
+    def get_runtime_parameters(self) -> list[ToolParameter]:
         parameters = [
             ToolParameter(name='prompt',
                          label=I18nObject(en_US='Prompt', zh_Hans='Prompt'),

--- a/api/core/tools/provider/builtin/time/time.py
+++ b/api/core/tools/provider/builtin/time/time.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.time.tools.current_time import CurrentTimeTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class WikiPediaProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             CurrentTimeTool().invoke(
                 user_id='',

--- a/api/core/tools/provider/builtin/time/tools/current_time.py
+++ b/api/core/tools/provider/builtin/time/tools/current_time.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from pytz import timezone as pytz_timezone
 
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class CurrentTimeTool(BuiltinTool):
     def _invoke(self, 
                 user_id: str,
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/vectorizer/tools/vectorizer.py
+++ b/api/core/tools/provider/builtin/vectorizer/tools/vectorizer.py
@@ -1,5 +1,5 @@
 from base64 import b64decode
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from httpx import post
 
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class VectorizerTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) \
-        -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) \
+        -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """
@@ -56,7 +56,7 @@ class VectorizerTool(BuiltinTool):
                                     meta={'mime_type': 'image/svg+xml'})
         ]
     
-    def get_runtime_parameters(self) -> List[ToolParameter]:
+    def get_runtime_parameters(self) -> list[ToolParameter]:
         """
         override the runtime parameters
         """

--- a/api/core/tools/provider/builtin/vectorizer/vectorizer.py
+++ b/api/core/tools/provider/builtin/vectorizer/vectorizer.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.vectorizer.tools.vectorizer import VectorizerTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class VectorizerProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             VectorizerTool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/webscraper/tools/webscraper.py
+++ b/api/core/tools/provider/builtin/webscraper/tools/webscraper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError
@@ -8,8 +8,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class WebscraperTool(BuiltinTool):
     def _invoke(self,
                user_id: str,
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/webscraper/webscraper.py
+++ b/api/core/tools/provider/builtin/webscraper/webscraper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.webscraper.tools.webscraper import WebscraperTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class WebscraperProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             WebscraperTool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/wikipedia/tools/wikipedia_search.py
+++ b/api/core/tools/provider/builtin/wikipedia/tools/wikipedia_search.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from langchain import WikipediaAPIWrapper
 from langchain.tools import WikipediaQueryRun
@@ -14,8 +14,8 @@ class WikipediaInput(BaseModel):
 class WikiPediaSearchTool(BuiltinTool):
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/wolframalpha/tools/wolframalpha.py
+++ b/api/core/tools/provider/builtin/wolframalpha/tools/wolframalpha.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from httpx import get
 
@@ -12,8 +12,8 @@ class WolframAlphaTool(BuiltinTool):
 
     def _invoke(self, 
                 user_id: str, 
-               tool_parameters: Dict[str, Any], 
-        ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+               tool_parameters: dict[str, Any], 
+        ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/wolframalpha/wolframalpha.py
+++ b/api/core/tools/provider/builtin/wolframalpha/wolframalpha.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.wolframalpha.tools.wolframalpha import WolframAlphaTool
@@ -6,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 class GoogleProvider(BuiltinToolProviderController):
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             WolframAlphaTool().fork_tool_runtime(
                 meta={

--- a/api/core/tools/provider/builtin/yahoo/tools/analytics.py
+++ b/api/core/tools/provider/builtin/yahoo/tools/analytics.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import pandas as pd
 from requests.exceptions import HTTPError, ReadTimeout
@@ -10,8 +10,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class YahooFinanceAnalyticsTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) \
-          -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) \
+          -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/yahoo/tools/news.py
+++ b/api/core/tools/provider/builtin/yahoo/tools/news.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import yfinance
 from requests.exceptions import HTTPError, ReadTimeout
@@ -8,8 +8,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class YahooFinanceSearchTickerTool(BuiltinTool):
-    def _invoke(self,user_id: str, tool_parameters: Dict[str, Any]) \
-          -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self,user_id: str, tool_parameters: dict[str, Any]) \
+          -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         '''
             invoke tools
         '''

--- a/api/core/tools/provider/builtin/yahoo/tools/ticker.py
+++ b/api/core/tools/provider/builtin/yahoo/tools/ticker.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from requests.exceptions import HTTPError, ReadTimeout
 from yfinance import Ticker
@@ -8,8 +8,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class YahooFinanceSearchTickerTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) \
-          -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) \
+          -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin/youtube/tools/videos.py
+++ b/api/core/tools/provider/builtin/youtube/tools/videos.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from googleapiclient.discovery import build
 
@@ -8,8 +8,8 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class YoutubeVideosAnalyticsTool(BuiltinTool):
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) \
-          -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) \
+          -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             invoke tools
         """

--- a/api/core/tools/provider/builtin_tool_provider.py
+++ b/api/core/tools/provider/builtin_tool_provider.py
@@ -1,7 +1,7 @@
 import importlib
 from abc import abstractmethod
 from os import listdir, path
-from typing import Any, Dict, List
+from typing import Any
 
 from yaml import FullLoader, load
 
@@ -28,7 +28,7 @@ class BuiltinToolProviderController(ToolProviderController):
         provider = self.__class__.__module__.split('.')[-1]
         yaml_path = path.join(path.dirname(path.realpath(__file__)), 'builtin', provider, f'{provider}.yaml')
         try:
-            with open(yaml_path, 'r') as f:
+            with open(yaml_path) as f:
                 provider_yaml = load(f.read(), FullLoader)
         except:
             raise ToolProviderNotFoundError(f'can not load provider yaml for {provider}')
@@ -43,7 +43,7 @@ class BuiltinToolProviderController(ToolProviderController):
             'credentials_schema': provider_yaml['credentials_for_provider'] if 'credentials_for_provider' in provider_yaml else None,
         })
 
-    def _get_builtin_tools(self) -> List[Tool]:
+    def _get_builtin_tools(self) -> list[Tool]:
         """
             returns a list of tools that the provider can provide
 
@@ -58,7 +58,7 @@ class BuiltinToolProviderController(ToolProviderController):
         tool_files = list(filter(lambda x: x.endswith(".yaml") and not x.startswith("__"), listdir(tool_path)))
         tools = []
         for tool_file in tool_files:
-            with open(path.join(tool_path, tool_file), "r") as f:
+            with open(path.join(tool_path, tool_file)) as f:
                 # get tool name
                 tool_name = tool_file.split(".")[0]
                 tool = load(f.read(), FullLoader)
@@ -78,7 +78,7 @@ class BuiltinToolProviderController(ToolProviderController):
         self.tools = tools
         return tools
     
-    def get_credentials_schema(self) -> Dict[str, ToolProviderCredentials]:
+    def get_credentials_schema(self) -> dict[str, ToolProviderCredentials]:
         """
             returns the credentials schema of the provider
 
@@ -98,7 +98,7 @@ class BuiltinToolProviderController(ToolProviderController):
         credentials = self.credentials_schema.copy()
         return UserToolProviderCredentials(credentials=credentials)
 
-    def get_tools(self) -> List[Tool]:
+    def get_tools(self) -> list[Tool]:
         """
             returns a list of tools that the provider can provide
 
@@ -112,7 +112,7 @@ class BuiltinToolProviderController(ToolProviderController):
         """
         return next(filter(lambda x: x.identity.name == tool_name, self.get_tools()), None)
 
-    def get_parameters(self, tool_name: str) -> List[ToolParameter]:
+    def get_parameters(self, tool_name: str) -> list[ToolParameter]:
         """
             returns the parameters of the tool
 
@@ -142,7 +142,7 @@ class BuiltinToolProviderController(ToolProviderController):
         """
         return ToolProviderType.BUILT_IN
 
-    def validate_parameters(self, tool_id: int, tool_name: str, tool_parameters: Dict[str, Any]) -> None:
+    def validate_parameters(self, tool_id: int, tool_name: str, tool_parameters: dict[str, Any]) -> None:
         """
             validate the parameters of the tool and set the default value if needed
 
@@ -151,7 +151,7 @@ class BuiltinToolProviderController(ToolProviderController):
         """
         tool_parameters_schema = self.get_parameters(tool_name)
         
-        tool_parameters_need_to_validate: Dict[str, ToolParameter] = {}
+        tool_parameters_need_to_validate: dict[str, ToolParameter] = {}
         for parameter in tool_parameters_schema:
             tool_parameters_need_to_validate[parameter.name] = parameter
 
@@ -166,7 +166,7 @@ class BuiltinToolProviderController(ToolProviderController):
                     raise ToolParameterValidationError(f'parameter {parameter} should be string')
             
             elif parameter_schema.type == ToolParameter.ToolParameterType.NUMBER:
-                if not isinstance(tool_parameters[parameter], (int, float)):
+                if not isinstance(tool_parameters[parameter], int | float):
                     raise ToolParameterValidationError(f'parameter {parameter} should be number')
                 
                 if parameter_schema.min is not None and tool_parameters[parameter] < parameter_schema.min:
@@ -211,7 +211,7 @@ class BuiltinToolProviderController(ToolProviderController):
 
                 tool_parameters[parameter] = default_value
 
-    def validate_credentials_format(self, credentials: Dict[str, Any]) -> None:
+    def validate_credentials_format(self, credentials: dict[str, Any]) -> None:
         """
             validate the format of the credentials of the provider and set the default value if needed
 
@@ -221,7 +221,7 @@ class BuiltinToolProviderController(ToolProviderController):
         if credentials_schema is None:
             return
         
-        credentials_need_to_validate: Dict[str, ToolProviderCredentials] = {}
+        credentials_need_to_validate: dict[str, ToolProviderCredentials] = {}
         for credential_name in credentials_schema:
             credentials_need_to_validate[credential_name] = credentials_schema[credential_name]
 
@@ -266,7 +266,7 @@ class BuiltinToolProviderController(ToolProviderController):
 
                 credentials[credential_name] = default_value
     
-    def validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def validate_credentials(self, credentials: dict[str, Any]) -> None:
         """
             validate the credentials of the provider
 
@@ -280,7 +280,7 @@ class BuiltinToolProviderController(ToolProviderController):
         self._validate_credentials(credentials)
 
     @abstractmethod
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         """
             validate the credentials of the provider
 

--- a/api/core/tools/provider/tool_provider.py
+++ b/api/core/tools/provider/tool_provider.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -16,10 +16,10 @@ from core.tools.tool.tool import Tool
 
 class ToolProviderController(BaseModel, ABC):
     identity: Optional[ToolProviderIdentity] = None
-    tools: Optional[List[Tool]] = None
-    credentials_schema: Optional[Dict[str, ToolProviderCredentials]] = None
+    tools: Optional[list[Tool]] = None
+    credentials_schema: Optional[dict[str, ToolProviderCredentials]] = None
 
-    def get_credentials_schema(self) -> Dict[str, ToolProviderCredentials]:
+    def get_credentials_schema(self) -> dict[str, ToolProviderCredentials]:
         """
             returns the credentials schema of the provider
 
@@ -37,7 +37,7 @@ class ToolProviderController(BaseModel, ABC):
         return UserToolProviderCredentials(credentials=credentials)
 
     @abstractmethod
-    def get_tools(self) -> List[Tool]:
+    def get_tools(self) -> list[Tool]:
         """
             returns a list of tools that the provider can provide
 
@@ -54,7 +54,7 @@ class ToolProviderController(BaseModel, ABC):
         """
         pass
 
-    def get_parameters(self, tool_name: str) -> List[ToolParameter]:
+    def get_parameters(self, tool_name: str) -> list[ToolParameter]:
         """
             returns the parameters of the tool
 
@@ -75,7 +75,7 @@ class ToolProviderController(BaseModel, ABC):
         """
         return ToolProviderType.BUILT_IN
 
-    def validate_parameters(self, tool_id: int, tool_name: str, tool_parameters: Dict[str, Any]) -> None:
+    def validate_parameters(self, tool_id: int, tool_name: str, tool_parameters: dict[str, Any]) -> None:
         """
             validate the parameters of the tool and set the default value if needed
 
@@ -84,7 +84,7 @@ class ToolProviderController(BaseModel, ABC):
         """
         tool_parameters_schema = self.get_parameters(tool_name)
         
-        tool_parameters_need_to_validate: Dict[str, ToolParameter] = {}
+        tool_parameters_need_to_validate: dict[str, ToolParameter] = {}
         for parameter in tool_parameters_schema:
             tool_parameters_need_to_validate[parameter.name] = parameter
 
@@ -99,7 +99,7 @@ class ToolProviderController(BaseModel, ABC):
                     raise ToolParameterValidationError(f'parameter {parameter} should be string')
             
             elif parameter_schema.type == ToolParameter.ToolParameterType.NUMBER:
-                if not isinstance(tool_parameters[parameter], (int, float)):
+                if not isinstance(tool_parameters[parameter], int | float):
                     raise ToolParameterValidationError(f'parameter {parameter} should be number')
                 
                 if parameter_schema.min is not None and tool_parameters[parameter] < parameter_schema.min:
@@ -144,7 +144,7 @@ class ToolProviderController(BaseModel, ABC):
 
                 tool_parameters[parameter] = default_value
 
-    def validate_credentials_format(self, credentials: Dict[str, Any]) -> None:
+    def validate_credentials_format(self, credentials: dict[str, Any]) -> None:
         """
             validate the format of the credentials of the provider and set the default value if needed
 
@@ -154,7 +154,7 @@ class ToolProviderController(BaseModel, ABC):
         if credentials_schema is None:
             return
         
-        credentials_need_to_validate: Dict[str, ToolProviderCredentials] = {}
+        credentials_need_to_validate: dict[str, ToolProviderCredentials] = {}
         for credential_name in credentials_schema:
             credentials_need_to_validate[credential_name] = credentials_schema[credential_name]
 
@@ -198,7 +198,7 @@ class ToolProviderController(BaseModel, ABC):
 
                 credentials[credential_name] = default_value
     
-    def validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def validate_credentials(self, credentials: dict[str, Any]) -> None:
         """
             validate the credentials of the provider
 
@@ -212,7 +212,7 @@ class ToolProviderController(BaseModel, ABC):
         self._validate_credentials(credentials)
 
     @abstractmethod
-    def _validate_credentials(self, credentials: Dict[str, Any]) -> None:
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         """
             validate the credentials of the provider
 

--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -1,6 +1,6 @@
 import json
 from json import dumps
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import httpx
 import requests
@@ -18,7 +18,7 @@ class ApiTool(Tool):
     """
     Api tool
     """
-    def fork_tool_runtime(self, meta: Dict[str, Any]) -> 'Tool':
+    def fork_tool_runtime(self, meta: dict[str, Any]) -> 'Tool':
         """
             fork a new tool with meta data
 
@@ -33,7 +33,7 @@ class ApiTool(Tool):
             runtime=Tool.Runtime(**meta)
         )
 
-    def validate_credentials(self, credentials: Dict[str, Any], parameters: Dict[str, Any], format_only: bool = False) -> str:
+    def validate_credentials(self, credentials: dict[str, Any], parameters: dict[str, Any], format_only: bool = False) -> str:
         """
             validate the credentials for Api tool
         """
@@ -47,7 +47,7 @@ class ApiTool(Tool):
         # validate response
         return self.validate_and_parse_response(response)
 
-    def assembling_request(self, parameters: Dict[str, Any]) -> Dict[str, Any]:
+    def assembling_request(self, parameters: dict[str, Any]) -> dict[str, Any]:
         headers = {}
         credentials = self.runtime.credentials or {}
 
@@ -108,7 +108,7 @@ class ApiTool(Tool):
         else:
             raise ValueError(f'Invalid response type {type(response)}')
     
-    def do_http_request(self, url: str, method: str, headers: Dict[str, Any], parameters: Dict[str, Any]) -> httpx.Response:
+    def do_http_request(self, url: str, method: str, headers: dict[str, Any], parameters: dict[str, Any]) -> httpx.Response:
         """
             do http request depending on api bundle
         """
@@ -225,7 +225,7 @@ class ApiTool(Tool):
         
         return response
 
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) -> ToolInvokeMessage | List[ToolInvokeMessage]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> ToolInvokeMessage | list[ToolInvokeMessage]:
         """
         invoke http request
         """

--- a/api/core/tools/tool/builtin_tool.py
+++ b/api/core/tools/tool/builtin_tool.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from core.model_runtime.entities.llm_entities import LLMResult
 from core.model_runtime.entities.message_entities import PromptMessage, SystemPromptMessage, UserPromptMessage
@@ -22,7 +21,7 @@ class BuiltinTool(Tool):
     """
 
     def invoke_model(
-        self, user_id: str, prompt_messages: List[PromptMessage], stop: List[str]
+        self, user_id: str, prompt_messages: list[PromptMessage], stop: list[str]
     ) -> LLMResult:
         """
             invoke model
@@ -52,7 +51,7 @@ class BuiltinTool(Tool):
             tenant_id=self.runtime.tenant_id,
         )
 
-    def get_prompt_tokens(self, prompt_messages: List[PromptMessage]) -> int:
+    def get_prompt_tokens(self, prompt_messages: list[PromptMessage]) -> int:
         """
             get prompt tokens
 
@@ -104,7 +103,7 @@ class BuiltinTool(Tool):
                 new_lines.append(line)
 
         # merge lines into messages with max tokens
-        messages: List[str] = []
+        messages: list[str] = []
         for i in new_lines:
             if len(messages) == 0:
                 messages.append(i)

--- a/api/core/tools/tool/dataset_retriever/dataset_multi_retriever_tool.py
+++ b/api/core/tools/tool/dataset_retriever/dataset_multi_retriever_tool.py
@@ -1,5 +1,5 @@
 import threading
-from typing import List, Optional, Type
+from typing import Optional
 
 from flask import Flask, current_app
 from langchain.tools import BaseTool
@@ -35,20 +35,20 @@ class DatasetMultiRetrieverToolInput(BaseModel):
 class DatasetMultiRetrieverTool(BaseTool):
     """Tool for querying multi dataset."""
     name: str = "dataset-"
-    args_schema: Type[BaseModel] = DatasetMultiRetrieverToolInput
+    args_schema: type[BaseModel] = DatasetMultiRetrieverToolInput
     description: str = "dataset multi retriever and rerank. "
     tenant_id: str
-    dataset_ids: List[str]
+    dataset_ids: list[str]
     top_k: int = 2
     score_threshold: Optional[float] = None
     reranking_provider_name: str
     reranking_model_name: str
     return_resource: bool
     retriever_from: str
-    hit_callbacks: List[DatasetIndexToolCallbackHandler] = []
+    hit_callbacks: list[DatasetIndexToolCallbackHandler] = []
 
     @classmethod
-    def from_dataset(cls, dataset_ids: List[str], tenant_id: str, **kwargs):
+    def from_dataset(cls, dataset_ids: list[str], tenant_id: str, **kwargs):
         return cls(
             name=f'dataset-{tenant_id}',
             tenant_id=tenant_id,
@@ -155,8 +155,8 @@ class DatasetMultiRetrieverTool(BaseTool):
     async def _arun(self, tool_input: str) -> str:
         raise NotImplementedError()
 
-    def _retriever(self, flask_app: Flask, dataset_id: str, query: str, all_documents: List,
-                   hit_callbacks: List[DatasetIndexToolCallbackHandler]):
+    def _retriever(self, flask_app: Flask, dataset_id: str, query: str, all_documents: list,
+                   hit_callbacks: list[DatasetIndexToolCallbackHandler]):
         with flask_app.app_context():
             dataset = db.session.query(Dataset).filter(
                 Dataset.tenant_id == self.tenant_id,

--- a/api/core/tools/tool/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/tool/dataset_retriever/dataset_retriever_tool.py
@@ -1,5 +1,5 @@
 import threading
-from typing import List, Optional, Type
+from typing import Optional
 
 from flask import current_app
 from langchain.tools import BaseTool
@@ -35,14 +35,14 @@ class DatasetRetrieverToolInput(BaseModel):
 class DatasetRetrieverTool(BaseTool):
     """Tool for querying a Dataset."""
     name: str = "dataset"
-    args_schema: Type[BaseModel] = DatasetRetrieverToolInput
+    args_schema: type[BaseModel] = DatasetRetrieverToolInput
     description: str = "use this to retrieve a dataset. "
 
     tenant_id: str
     dataset_id: str
     top_k: int = 2
     score_threshold: Optional[float] = None
-    hit_callbacks: List[DatasetIndexToolCallbackHandler] = []
+    hit_callbacks: list[DatasetIndexToolCallbackHandler] = []
     return_resource: bool
     retriever_from: str
 

--- a/api/core/tools/tool/dataset_retriever_tool.py
+++ b/api/core/tools/tool/dataset_retriever_tool.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from langchain.tools import BaseTool
 
@@ -20,7 +20,7 @@ class DatasetRetrieverTool(Tool):
                          return_resource: bool,
                          invoke_from: InvokeFrom,
                          hit_callback: DatasetIndexToolCallbackHandler
-    ) -> List['DatasetRetrieverTool']:
+    ) -> list['DatasetRetrieverTool']:
         """
         get dataset tool
         """
@@ -65,7 +65,7 @@ class DatasetRetrieverTool(Tool):
 
         return tools
 
-    def get_runtime_parameters(self) -> List[ToolParameter]:
+    def get_runtime_parameters(self) -> list[ToolParameter]:
         return [
             ToolParameter(name='query',
                          label=I18nObject(en_US='', zh_Hans=''),
@@ -77,7 +77,7 @@ class DatasetRetrieverTool(Tool):
                          default=''),
         ]
 
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) -> ToolInvokeMessage | List[ToolInvokeMessage]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> ToolInvokeMessage | list[ToolInvokeMessage]:
         """
         invoke dataset retriever tool
         """
@@ -90,7 +90,7 @@ class DatasetRetrieverTool(Tool):
 
         return self.create_text_message(text=result)
 
-    def validate_credentials(self, credentials: Dict[str, Any], parameters: Dict[str, Any]) -> None:
+    def validate_credentials(self, credentials: dict[str, Any], parameters: dict[str, Any]) -> None:
         """
         validate the credentials for dataset retriever tool
         """

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel
 
@@ -19,7 +19,7 @@ from core.tools.tool_file_manager import ToolFileManager
 
 class Tool(BaseModel, ABC):
     identity: ToolIdentity = None
-    parameters: Optional[List[ToolParameter]] = None
+    parameters: Optional[list[ToolParameter]] = None
     description: ToolDescription = None
     is_team_authorization: bool = False
     agent_callback: Optional[DifyAgentCallbackHandler] = None
@@ -36,8 +36,8 @@ class Tool(BaseModel, ABC):
 
         tenant_id: str = None
         tool_id: str = None
-        credentials: Dict[str, Any] = None
-        runtime_parameters: Dict[str, Any] = None
+        credentials: dict[str, Any] = None
+        runtime_parameters: dict[str, Any] = None
 
     runtime: Runtime = None
     variables: ToolRuntimeVariablePool = None
@@ -53,7 +53,7 @@ class Tool(BaseModel, ABC):
     class VARIABLE_KEY(Enum):
         IMAGE = 'image'
 
-    def fork_tool_runtime(self, meta: Dict[str, Any], agent_callback: DifyAgentCallbackHandler = None) -> 'Tool':
+    def fork_tool_runtime(self, meta: dict[str, Any], agent_callback: DifyAgentCallbackHandler = None) -> 'Tool':
         """
             fork a new tool with meta data
 
@@ -146,7 +146,7 @@ class Tool(BaseModel, ABC):
         
         return file_binary[0]
     
-    def list_variables(self) -> List[ToolRuntimeVariable]:
+    def list_variables(self) -> list[ToolRuntimeVariable]:
         """
             list all variables
 
@@ -157,7 +157,7 @@ class Tool(BaseModel, ABC):
         
         return self.variables.pool
     
-    def list_default_image_variables(self) -> List[ToolRuntimeVariable]:
+    def list_default_image_variables(self) -> list[ToolRuntimeVariable]:
         """
             list all image variables
 
@@ -174,7 +174,7 @@ class Tool(BaseModel, ABC):
 
         return result
 
-    def invoke(self, user_id: str, tool_parameters: Dict[str, Any]) -> List[ToolInvokeMessage]:
+    def invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> list[ToolInvokeMessage]:
         # update tool_parameters
         if self.runtime.runtime_parameters:
             tool_parameters.update(self.runtime.runtime_parameters)
@@ -209,7 +209,7 @@ class Tool(BaseModel, ABC):
         
         return result
     
-    def _convert_tool_response_to_str(self, tool_response: List[ToolInvokeMessage]) -> str:
+    def _convert_tool_response_to_str(self, tool_response: list[ToolInvokeMessage]) -> str:
         """
         Handle tool response
         """
@@ -233,10 +233,10 @@ class Tool(BaseModel, ABC):
         return result
 
     @abstractmethod
-    def _invoke(self, user_id: str, tool_parameters: Dict[str, Any]) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+    def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         pass
     
-    def validate_credentials(self, credentials: Dict[str, Any], parameters: Dict[str, Any]) -> None:
+    def validate_credentials(self, credentials: dict[str, Any], parameters: dict[str, Any]) -> None:
         """
             validate the credentials
 
@@ -245,7 +245,7 @@ class Tool(BaseModel, ABC):
         """
         pass
 
-    def get_runtime_parameters(self) -> List[ToolParameter]:
+    def get_runtime_parameters(self) -> list[ToolParameter]:
         """
             get the runtime parameters
 

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -4,8 +4,9 @@ import hmac
 import logging
 import os
 import time
+from collections.abc import Generator
 from mimetypes import guess_extension, guess_type
-from typing import Generator, Tuple, Union
+from typing import Union
 from uuid import uuid4
 
 from flask import current_app
@@ -113,7 +114,7 @@ class ToolFileManager:
         return tool_file
     
     @staticmethod
-    def get_file_binary(id: str) -> Union[Tuple[bytes, str], None]:
+    def get_file_binary(id: str) -> Union[tuple[bytes, str], None]:
         """
         get file binary
 
@@ -133,7 +134,7 @@ class ToolFileManager:
         return blob, tool_file.mimetype
     
     @staticmethod
-    def get_file_binary_by_message_file_id(id: str) -> Union[Tuple[bytes, str], None]:
+    def get_file_binary_by_message_file_id(id: str) -> Union[tuple[bytes, str], None]:
         """
         get file binary
 
@@ -162,7 +163,7 @@ class ToolFileManager:
         return blob, tool_file.mimetype
         
     @staticmethod
-    def get_file_generator_by_message_file_id(id: str) -> Union[Tuple[Generator, str], None]:
+    def get_file_generator_by_message_file_id(id: str) -> Union[tuple[Generator, str], None]:
         """
         get file binary
 

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -3,7 +3,7 @@ import json
 import logging
 import mimetypes
 from os import listdir, path
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Union
 
 from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackHandler
 from core.model_runtime.entities.message_entities import PromptMessage
@@ -35,10 +35,10 @@ class ToolManager:
         provider: str,
         tool_id: str,
         tool_name: str,
-        tool_parameters: Dict[str, Any],
-        credentials: Dict[str, Any],
-        prompt_messages: List[PromptMessage],
-    ) -> List[ToolInvokeMessage]:
+        tool_parameters: dict[str, Any],
+        credentials: dict[str, Any],
+        prompt_messages: list[PromptMessage],
+    ) -> list[ToolInvokeMessage]:
         """
             invoke the assistant
 
@@ -200,7 +200,7 @@ class ToolManager:
             raise ToolProviderNotFoundError(f'provider type {provider_type} not found')
 
     @staticmethod
-    def get_builtin_provider_icon(provider: str) -> Tuple[str, str]:
+    def get_builtin_provider_icon(provider: str) -> tuple[str, str]:
         """
             get the absolute path of the icon of the builtin provider
 
@@ -223,14 +223,14 @@ class ToolManager:
         return absolute_path, mime_type
 
     @staticmethod
-    def list_builtin_providers() -> List[BuiltinToolProviderController]:
+    def list_builtin_providers() -> list[BuiltinToolProviderController]:
         global _builtin_providers
 
         # use cache first
         if len(_builtin_providers) > 0:
             return list(_builtin_providers.values())
         
-        builtin_providers: List[BuiltinToolProviderController] = []
+        builtin_providers: list[BuiltinToolProviderController] = []
         for provider in listdir(path.join(path.dirname(path.realpath(__file__)), 'provider', 'builtin')):
             if provider.startswith('__'):
                 continue
@@ -289,8 +289,8 @@ class ToolManager:
     def user_list_providers(
         user_id: str,
         tenant_id: str,
-    ) -> List[UserToolProvider]:
-        result_providers: Dict[str, UserToolProvider] = {}
+    ) -> list[UserToolProvider]:
+        result_providers: dict[str, UserToolProvider] = {}
         # get builtin providers
         builtin_providers = ToolManager.list_builtin_providers()
         # append builtin providers
@@ -325,7 +325,7 @@ class ToolManager:
                 result_providers[provider.identity.name].allow_delete = False
 
         # get db builtin providers
-        db_builtin_providers: List[BuiltinToolProvider] = db.session.query(BuiltinToolProvider). \
+        db_builtin_providers: list[BuiltinToolProvider] = db.session.query(BuiltinToolProvider). \
             filter(BuiltinToolProvider.tenant_id == tenant_id).all()
         
         for db_builtin_provider in db_builtin_providers:
@@ -346,7 +346,7 @@ class ToolManager:
             result_providers[provider_name].team_credentials = masked_credentials
 
         # get db api providers
-        db_api_providers: List[ApiToolProvider] = db.session.query(ApiToolProvider). \
+        db_api_providers: list[ApiToolProvider] = db.session.query(ApiToolProvider). \
             filter(ApiToolProvider.tenant_id == tenant_id).all()
         
         for db_api_provider in db_api_providers:
@@ -394,7 +394,7 @@ class ToolManager:
         return BuiltinToolProviderSort.sort(list(result_providers.values()))
     
     @staticmethod
-    def get_api_provider_controller(tenant_id: str, provider_id: str) -> Tuple[ApiBasedToolProviderController, Dict[str, Any]]:
+    def get_api_provider_controller(tenant_id: str, provider_id: str) -> tuple[ApiBasedToolProviderController, dict[str, Any]]:
         """
             get the api provider
 

--- a/api/core/tools/utils/configuration.py
+++ b/api/core/tools/utils/configuration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -12,13 +12,13 @@ class ToolConfiguration(BaseModel):
     tenant_id: str
     provider_controller: ToolProviderController
 
-    def _deep_copy(self, credentials: Dict[str, str]) -> Dict[str, str]:
+    def _deep_copy(self, credentials: dict[str, str]) -> dict[str, str]:
         """
         deep copy credentials
         """
         return {key: value for key, value in credentials.items()}
     
-    def encrypt_tool_credentials(self, credentials: Dict[str, str]) -> Dict[str, str]:
+    def encrypt_tool_credentials(self, credentials: dict[str, str]) -> dict[str, str]:
         """
         encrypt tool credentials with tenant id
 
@@ -36,7 +36,7 @@ class ToolConfiguration(BaseModel):
         
         return credentials
     
-    def mask_tool_credentials(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
+    def mask_tool_credentials(self, credentials: dict[str, Any]) -> dict[str, Any]:
         """
         mask tool credentials
 
@@ -59,7 +59,7 @@ class ToolConfiguration(BaseModel):
 
         return credentials
 
-    def decrypt_tool_credentials(self, credentials: Dict[str, str]) -> Dict[str, str]:
+    def decrypt_tool_credentials(self, credentials: dict[str, str]) -> dict[str, str]:
         """
         decrypt tool credentials with tenant id
 

--- a/api/core/tools/utils/encoder.py
+++ b/api/core/tools/utils/encoder.py
@@ -1,11 +1,10 @@
-from typing import List
 
 from pydantic import BaseModel
 
 
-def serialize_base_model_array(l: List[BaseModel]) -> str:
+def serialize_base_model_array(l: list[BaseModel]) -> str:
     class _BaseModel(BaseModel):
-        __root__: List[BaseModel]
+        __root__: list[BaseModel]
 
     """
         {"__root__": [BaseModel, BaseModel, ...]}

--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -1,6 +1,5 @@
 
 from json import loads as json_loads
-from typing import List, Tuple
 
 from requests import get
 from yaml import FullLoader, load
@@ -13,7 +12,7 @@ from core.tools.errors import ToolApiSchemaError, ToolNotSupportedError, ToolPro
 
 class ApiBasedToolSchemaParser:
     @staticmethod
-    def parse_openapi_to_tool_bundle(openapi: dict, extra_info: dict = None, warning: dict = None) -> List[ApiBasedToolBundle]:
+    def parse_openapi_to_tool_bundle(openapi: dict, extra_info: dict = None, warning: dict = None) -> list[ApiBasedToolBundle]:
         warning = warning if warning is not None else {}
         extra_info = extra_info if extra_info is not None else {}
 
@@ -132,7 +131,7 @@ class ApiBasedToolSchemaParser:
         return bundles
         
     @staticmethod
-    def parse_openapi_yaml_to_tool_bundle(yaml: str, extra_info: dict = None, warning: dict = None) -> List[ApiBasedToolBundle]:
+    def parse_openapi_yaml_to_tool_bundle(yaml: str, extra_info: dict = None, warning: dict = None) -> list[ApiBasedToolBundle]:
         """
             parse openapi yaml to tool bundle
 
@@ -148,7 +147,7 @@ class ApiBasedToolSchemaParser:
         return ApiBasedToolSchemaParser.parse_openapi_to_tool_bundle(openapi, extra_info=extra_info, warning=warning)
     
     @staticmethod
-    def parse_openapi_json_to_tool_bundle(json: str, extra_info: dict = None, warning: dict = None) -> List[ApiBasedToolBundle]:
+    def parse_openapi_json_to_tool_bundle(json: str, extra_info: dict = None, warning: dict = None) -> list[ApiBasedToolBundle]:
         """
             parse openapi yaml to tool bundle
 
@@ -232,7 +231,7 @@ class ApiBasedToolSchemaParser:
         return openapi
 
     @staticmethod
-    def parse_swagger_yaml_to_tool_bundle(yaml: str, extra_info: dict = None, warning: dict = None) -> List[ApiBasedToolBundle]:
+    def parse_swagger_yaml_to_tool_bundle(yaml: str, extra_info: dict = None, warning: dict = None) -> list[ApiBasedToolBundle]:
         """
             parse swagger yaml to tool bundle
 
@@ -248,7 +247,7 @@ class ApiBasedToolSchemaParser:
         return ApiBasedToolSchemaParser.parse_openapi_to_tool_bundle(openapi, extra_info=extra_info, warning=warning)
 
     @staticmethod
-    def parse_swagger_json_to_tool_bundle(json: str, extra_info: dict = None, warning: dict = None) -> List[ApiBasedToolBundle]:
+    def parse_swagger_json_to_tool_bundle(json: str, extra_info: dict = None, warning: dict = None) -> list[ApiBasedToolBundle]:
         """
             parse swagger yaml to tool bundle
 
@@ -264,7 +263,7 @@ class ApiBasedToolSchemaParser:
         return ApiBasedToolSchemaParser.parse_openapi_to_tool_bundle(openapi, extra_info=extra_info, warning=warning)
 
     @staticmethod
-    def parse_openai_plugin_json_to_tool_bundle(json: str, extra_info: dict = None, warning: dict = None) -> List[ApiBasedToolBundle]:
+    def parse_openai_plugin_json_to_tool_bundle(json: str, extra_info: dict = None, warning: dict = None) -> list[ApiBasedToolBundle]:
         """
             parse openapi plugin yaml to tool bundle
 
@@ -296,7 +295,7 @@ class ApiBasedToolSchemaParser:
         return ApiBasedToolSchemaParser.parse_openapi_yaml_to_tool_bundle(response.text, extra_info=extra_info, warning=warning)
     
     @staticmethod
-    def auto_parse_to_tool_bundle(content: str, extra_info: dict = None, warning: dict = None) -> Tuple[List[ApiBasedToolBundle], str]:
+    def auto_parse_to_tool_bundle(content: str, extra_info: dict = None, warning: dict = None) -> tuple[list[ApiBasedToolBundle], str]:
         """
             auto parse to tool bundle
 

--- a/api/core/tools/utils/web_reader_tool.py
+++ b/api/core/tools/utils/web_reader_tool.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 import unicodedata
 from contextlib import contextmanager
-from typing import Any, Type
+from typing import Any
 
 import requests
 from bs4 import BeautifulSoup, CData, Comment, NavigableString
@@ -56,7 +56,7 @@ class WebReaderTool(BaseTool):
     """Reader tool for getting website title and contents. Gives more control than SimpleReaderTool."""
 
     name: str = "web_reader"
-    args_schema: Type[BaseModel] = WebReaderToolInput
+    args_schema: type[BaseModel] = WebReaderToolInput
     description: str = "use this to read a website. " \
                        "If you can answer the question based on the information provided, " \
                        "there is no need to use."
@@ -211,7 +211,7 @@ def extract_using_readabilipy(html):
         subprocess.check_call(["node", "ExtractArticle.js", "-i", html_path, "-o", article_json_path])
 
     # Read output of call to Readability.parse() from JSON file and return as Python dictionary
-    with open(article_json_path, "r", encoding="utf-8") as json_file:
+    with open(article_json_path, encoding="utf-8") as json_file:
         input_json = json.loads(json_file.read())
 
     # Deleting files after processing

--- a/api/core/vector_store/vector/milvus.py
+++ b/api/core/vector_store/vector/milvus.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union
+from collections.abc import Iterable, Sequence
+from typing import Any, Optional, Union
 from uuid import uuid4
 
 import numpy as np
@@ -381,11 +382,11 @@ class Milvus(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         timeout: Optional[int] = None,
         batch_size: int = 1000,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Insert text data into Milvus.
 
         Inserting data when the collection has not be made yet will result
@@ -476,7 +477,7 @@ class Milvus(VectorStore):
         expr: Optional[str] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Perform a similarity search against the query string.
 
         Args:
@@ -502,13 +503,13 @@ class Milvus(VectorStore):
 
     def similarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         param: Optional[dict] = None,
         expr: Optional[str] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Perform a similarity search against the query string.
 
         Args:
@@ -540,7 +541,7 @@ class Milvus(VectorStore):
         expr: Optional[str] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Perform a search on a query string and return results with score.
 
         For more information about the search parameters, take a look at the pymilvus
@@ -577,7 +578,7 @@ class Milvus(VectorStore):
         query: str,
         k: int = 4,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and relevance scores in the range [0, 1].
 
         0 is dissimilar, 1 is most similar.
@@ -596,13 +597,13 @@ class Milvus(VectorStore):
 
     def similarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         param: Optional[dict] = None,
         expr: Optional[str] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Perform a search on a query string and return results with score.
 
         For more information about the search parameters, take a look at the pymilvus
@@ -664,7 +665,7 @@ class Milvus(VectorStore):
         expr: Optional[str] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Perform a search and return results that are reordered by MMR.
 
         Args:
@@ -714,7 +715,7 @@ class Milvus(VectorStore):
         expr: Optional[str] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Perform a search and return results that are reordered by MMR.
 
         Args:
@@ -797,9 +798,9 @@ class Milvus(VectorStore):
     @classmethod
     def from_texts(
         cls,
-        texts: List[str],
+        texts: list[str],
         embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         collection_name: str = "LangChainCollection",
         connection_args: dict[str, Any] = DEFAULT_MILVUS_CONNECTION,
         consistency_level: str = "Session",

--- a/api/core/vector_store/vector/qdrant.py
+++ b/api/core/vector_store/vector/qdrant.py
@@ -5,9 +5,10 @@ import asyncio
 import functools
 import uuid
 import warnings
+from collections.abc import Callable, Generator, Iterable, Sequence
 from itertools import islice
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from langchain.docstore.document import Document
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from qdrant_client.conversions import common_types
     from qdrant_client.http import models as rest
 
-    DictFilter = Dict[str, Union[str, int, bool, dict, list]]
+    DictFilter = dict[str, Union[str, int, bool, dict, list]]
     MetadataFilter = Union[DictFilter, common_types.Filter]
 
 
@@ -148,11 +149,11 @@ class Qdrant(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[Sequence[str]] = None,
         batch_size: int = 64,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Run more texts through the embeddings and add to the vectorstore.
 
         Args:
@@ -200,11 +201,11 @@ class Qdrant(VectorStore):
     async def aadd_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[Sequence[str]] = None,
         batch_size: int = 64,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Run more texts through the embeddings and add to the vectorstore.
 
         Args:
@@ -247,7 +248,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to query.
 
         Args:
@@ -299,7 +300,7 @@ class Qdrant(VectorStore):
         k: int = 4,
         filter: Optional[MetadataFilter] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to query.
         Args:
             query: Text to look up documents similar to.
@@ -321,7 +322,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to query.
 
         Args:
@@ -376,7 +377,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to query.
 
         Args:
@@ -422,7 +423,7 @@ class Qdrant(VectorStore):
 
     def similarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         filter: Optional[MetadataFilter] = None,
         search_params: Optional[common_types.SearchParams] = None,
@@ -430,7 +431,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to embedding vector.
 
         Args:
@@ -478,7 +479,7 @@ class Qdrant(VectorStore):
     @sync_call_fallback
     async def asimilarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         filter: Optional[MetadataFilter] = None,
         search_params: Optional[common_types.SearchParams] = None,
@@ -486,7 +487,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to embedding vector.
 
         Args:
@@ -533,7 +534,7 @@ class Qdrant(VectorStore):
 
     def similarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         filter: Optional[MetadataFilter] = None,
         search_params: Optional[common_types.SearchParams] = None,
@@ -541,7 +542,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to embedding vector.
 
         Args:
@@ -616,7 +617,7 @@ class Qdrant(VectorStore):
         self,
         filter: Optional[MetadataFilter] = None,
         k: int = 4
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar by bm25.
 
         Args:
@@ -648,7 +649,7 @@ class Qdrant(VectorStore):
     @sync_call_fallback
     async def asimilarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         filter: Optional[MetadataFilter] = None,
         search_params: Optional[common_types.SearchParams] = None,
@@ -656,7 +657,7 @@ class Qdrant(VectorStore):
         score_threshold: Optional[float] = None,
         consistency: Optional[common_types.ReadConsistency] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs most similar to embedding vector.
 
         Args:
@@ -741,7 +742,7 @@ class Qdrant(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -772,7 +773,7 @@ class Qdrant(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -797,12 +798,12 @@ class Qdrant(VectorStore):
 
     def max_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -827,12 +828,12 @@ class Qdrant(VectorStore):
     @sync_call_fallback
     async def amax_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
         Maximal marginal relevance optimizes for similarity to query AND diversity
         among selected documents.
@@ -856,12 +857,12 @@ class Qdrant(VectorStore):
 
     def max_marginal_relevance_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs selected using the maximal marginal relevance.
         Maximal marginal relevance optimizes for similarity to query AND diversity
         among selected documents.
@@ -911,12 +912,12 @@ class Qdrant(VectorStore):
     @sync_call_fallback
     async def amax_marginal_relevance_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs selected using the maximal marginal relevance.
         Maximal marginal relevance optimizes for similarity to query AND diversity
         among selected documents.
@@ -949,13 +950,13 @@ class Qdrant(VectorStore):
         results = [
             GrpcToRest.convert_vectors(result.vectors) for result in response.result
         ]
-        embeddings: List[List[float]] = [
+        embeddings: list[list[float]] = [
             result.get(self.vector_name)  # type: ignore
             if isinstance(result, dict)
             else result
             for result in results
         ]
-        mmr_selected: List[int] = maximal_marginal_relevance(
+        mmr_selected: list[int] = maximal_marginal_relevance(
             np.array(embedding),
             embeddings,
             k=k,
@@ -973,7 +974,7 @@ class Qdrant(VectorStore):
             for i in mmr_selected
         ]
 
-    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+    def delete(self, ids: Optional[list[str]] = None, **kwargs: Any) -> Optional[bool]:
         """Delete by vector ID or other criteria.
 
         Args:
@@ -994,10 +995,10 @@ class Qdrant(VectorStore):
 
     @classmethod
     def from_texts(
-        cls: Type[Qdrant],
-        texts: List[str],
+        cls: type[Qdrant],
+        texts: list[str],
         embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[Sequence[str]] = None,
         location: Optional[str] = None,
         url: Optional[str] = None,
@@ -1179,10 +1180,10 @@ class Qdrant(VectorStore):
     @classmethod
     @sync_call_fallback
     async def afrom_texts(
-        cls: Type[Qdrant],
-        texts: List[str],
+        cls: type[Qdrant],
+        texts: list[str],
         embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[Sequence[str]] = None,
         location: Optional[str] = None,
         url: Optional[str] = None,
@@ -1354,10 +1355,10 @@ class Qdrant(VectorStore):
 
     @classmethod
     def _construct_instance(
-        cls: Type[Qdrant],
-        texts: List[str],
+        cls: type[Qdrant],
+        texts: list[str],
         embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[Sequence[str]] = None,
         location: Optional[str] = None,
         url: Optional[str] = None,
@@ -1553,7 +1554,7 @@ class Qdrant(VectorStore):
         query: str,
         k: int = 4,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and relevance scores in the range [0, 1].
 
         0 is dissimilar, 1 is most similar.
@@ -1574,12 +1575,12 @@ class Qdrant(VectorStore):
     def _build_payloads(
         cls,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]],
+        metadatas: Optional[list[dict]],
         content_payload_key: str,
         metadata_payload_key: str,
         group_id: str,
         group_payload_key: str
-    ) -> List[dict]:
+    ) -> list[dict]:
         payloads = []
         for i, text in enumerate(texts):
             if text is None:
@@ -1625,7 +1626,7 @@ class Qdrant(VectorStore):
             metadata=payload.get(metadata_payload_key) or {},
         )
 
-    def _build_condition(self, key: str, value: Any) -> List[rest.FieldCondition]:
+    def _build_condition(self, key: str, value: Any) -> list[rest.FieldCondition]:
         from qdrant_client.http import models as rest
 
         out = []
@@ -1665,7 +1666,7 @@ class Qdrant(VectorStore):
             ]
         )
 
-    def _embed_query(self, query: str) -> List[float]:
+    def _embed_query(self, query: str) -> list[float]:
         """Embed query text.
 
         Used to provide backward compatibility with `embedding_function` argument.
@@ -1685,7 +1686,7 @@ class Qdrant(VectorStore):
                 raise ValueError("Neither of embeddings or embedding_function is set")
         return embedding.tolist() if hasattr(embedding, "tolist") else embedding
 
-    def _embed_texts(self, texts: Iterable[str]) -> List[List[float]]:
+    def _embed_texts(self, texts: Iterable[str]) -> list[list[float]]:
         """Embed search texts.
 
         Used to provide backward compatibility with `embedding_function` argument.
@@ -1715,11 +1716,11 @@ class Qdrant(VectorStore):
     def _generate_rest_batches(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[Sequence[str]] = None,
         batch_size: int = 64,
         group_id: Optional[str] = None,
-    ) -> Generator[Tuple[List[str], List[rest.PointStruct]], None, None]:
+    ) -> Generator[tuple[list[str], list[rest.PointStruct]], None, None]:
         from qdrant_client.http import models as rest
 
         texts_iterator = iter(texts)

--- a/api/core/vector_store/vector/weaviate.py
+++ b/api/core/vector_store/vector/weaviate.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+from collections.abc import Callable, Iterable
+from typing import Any, Optional
 from uuid import uuid4
 
 import numpy as np
@@ -13,7 +14,7 @@ from langchain.vectorstores.base import VectorStore
 from langchain.vectorstores.utils import maximal_marginal_relevance
 
 
-def _default_schema(index_name: str) -> Dict:
+def _default_schema(index_name: str) -> dict:
     return {
         "class": index_name,
         "properties": [
@@ -89,7 +90,7 @@ class Weaviate(VectorStore):
         index_name: str,
         text_key: str,
         embedding: Optional[Embeddings] = None,
-        attributes: Optional[List[str]] = None,
+        attributes: Optional[list[str]] = None,
         relevance_score_fn: Optional[
             Callable[[float], float]
         ] = _default_score_normalizer,
@@ -131,14 +132,14 @@ class Weaviate(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Upload texts with metadata (properties) to Weaviate."""
         from weaviate.util import get_valid_uuid
 
         ids = []
-        embeddings: Optional[List[List[float]]] = None
+        embeddings: Optional[list[list[float]]] = None
         if self._embedding:
             if not isinstance(texts, list):
                 texts = list(texts)
@@ -172,7 +173,7 @@ class Weaviate(VectorStore):
 
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to query.
 
         Args:
@@ -195,7 +196,7 @@ class Weaviate(VectorStore):
 
     def similarity_search_by_text(
         self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs most similar to query.
 
         Args:
@@ -205,7 +206,7 @@ class Weaviate(VectorStore):
         Returns:
             List of Documents most similar to the query.
         """
-        content: Dict[str, Any] = {"concepts": [query]}
+        content: dict[str, Any] = {"concepts": [query]}
         if kwargs.get("search_distance"):
             content["certainty"] = kwargs.get("search_distance")
         query_obj = self._client.query.get(self._index_name, self._query_attrs)
@@ -224,7 +225,7 @@ class Weaviate(VectorStore):
 
     def similarity_search_by_bm25(
         self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs using BM25F.
 
         Args:
@@ -234,7 +235,7 @@ class Weaviate(VectorStore):
         Returns:
             List of Documents most similar to the query.
         """
-        content: Dict[str, Any] = {"concepts": [query]}
+        content: dict[str, Any] = {"concepts": [query]}
         if kwargs.get("search_distance"):
             content["certainty"] = kwargs.get("search_distance")
         query_obj = self._client.query.get(self._index_name, self._query_attrs)
@@ -253,8 +254,8 @@ class Weaviate(VectorStore):
         return docs
 
     def similarity_search_by_vector(
-        self, embedding: List[float], k: int = 4, **kwargs: Any
-    ) -> List[Document]:
+        self, embedding: list[float], k: int = 4, **kwargs: Any
+    ) -> list[Document]:
         """Look up similar documents by embedding vector in Weaviate."""
         vector = {"vector": embedding}
         query_obj = self._client.query.get(self._index_name, self._query_attrs)
@@ -278,7 +279,7 @@ class Weaviate(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -309,12 +310,12 @@ class Weaviate(VectorStore):
 
     def max_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -359,7 +360,7 @@ class Weaviate(VectorStore):
 
     def similarity_search_with_score(
         self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """
         Return list of documents most similar to the query
         text and cosine distance in float for each.
@@ -369,7 +370,7 @@ class Weaviate(VectorStore):
             raise ValueError(
                 "_embedding cannot be None for similarity_search_with_score"
             )
-        content: Dict[str, Any] = {"concepts": [query]}
+        content: dict[str, Any] = {"concepts": [query]}
         if kwargs.get("search_distance"):
             content["certainty"] = kwargs.get("search_distance")
         query_obj = self._client.query.get(self._index_name, self._query_attrs)
@@ -403,10 +404,10 @@ class Weaviate(VectorStore):
 
     @classmethod
     def from_texts(
-        cls: Type[Weaviate],
-        texts: List[str],
+        cls: type[Weaviate],
+        texts: list[str],
         embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[list[dict]] = None,
         **kwargs: Any,
     ) -> Weaviate:
         """Construct Weaviate wrapper from raw documents.
@@ -490,7 +491,7 @@ class Weaviate(VectorStore):
             by_text=by_text,
         )
 
-    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
+    def delete(self, ids: Optional[list[str]] = None, **kwargs: Any) -> None:
         """Delete by vector IDs.
 
         Args:

--- a/api/extensions/ext_storage.py
+++ b/api/extensions/ext_storage.py
@@ -1,7 +1,8 @@
 import os
 import shutil
+from collections.abc import Generator
 from contextlib import closing
-from typing import Generator, Union
+from typing import Union
 
 import boto3
 from botocore.exceptions import ClientError

--- a/api/libs/gmpy2_pkcs10aep_cipher.py
+++ b/api/libs/gmpy2_pkcs10aep_cipher.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #  Cipher/PKCS1_OAEP.py : PKCS#1 OAEP
 #

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import random
 import re
 import string
@@ -57,7 +56,7 @@ def timestamp_value(timestamp):
         raise ValueError(error)
 
 
-class str_len(object):
+class str_len:
     """ Restrict input to an integer in a range (inclusive) """
 
     def __init__(self, max_length, argument='argument'):
@@ -74,7 +73,7 @@ class str_len(object):
         return value
 
 
-class float_range(object):
+class float_range:
     """ Restrict input to an float in a range (inclusive) """
     def __init__(self, low, high, argument='argument'):
         self.low = low
@@ -91,7 +90,7 @@ class float_range(object):
         return value
 
 
-class datetime_string(object):
+class datetime_string:
     def __init__(self, format, argument='argument'):
         self.format = format
         self.argument = argument
@@ -111,7 +110,7 @@ def _get_float(value):
     try:
         return float(value)
     except (TypeError, ValueError):
-        raise ValueError('{0} is not a valid float'.format(value))
+        raise ValueError('{} is not a valid float'.format(value))
 
 def timezone(timezone_string):
     if timezone_string and timezone_string in available_timezones():

--- a/api/libs/infinite_scroll_pagination.py
+++ b/api/libs/infinite_scroll_pagination.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 
 class InfiniteScrollPagination:
     def __init__(self, data, limit, has_more):

--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 
 from langchain.schema import OutputParserException
 
@@ -30,7 +29,7 @@ def parse_json_markdown(json_string: str) -> dict:
     return parsed
 
 
-def parse_and_check_json_markdown(text: str, expected_keys: List[str]) -> dict:
+def parse_and_check_json_markdown(text: str, expected_keys: list[str]) -> dict:
     try:
         json_obj = parse_json_markdown(text)
     except json.JSONDecodeError as e:

--- a/api/libs/passport.py
+++ b/api/libs/passport.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import jwt
 from flask import current_app
 from werkzeug.exceptions import Unauthorized

--- a/api/libs/password.py
+++ b/api/libs/password.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import base64
 import binascii
 import hashlib

--- a/api/libs/rsa.py
+++ b/api/libs/rsa.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import hashlib
 
 from Crypto.Cipher import AES

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -1,6 +1,5 @@
 import enum
 import json
-from typing import List
 
 from flask_login import UserMixin
 from sqlalchemy.dialects.postgresql import UUID
@@ -96,7 +95,7 @@ class Account(UserMixin, db.Model):
                 one_or_none()
         return None
 
-    def get_integrates(self) -> List[db.Model]:
+    def get_integrates(self) -> list[db.Model]:
         ai = db.Model
         return db.session.query(ai).filter(
             ai.account_id == self.id
@@ -121,7 +120,7 @@ class Tenant(db.Model):
     created_at = db.Column(db.DateTime, nullable=False, server_default=db.text('CURRENT_TIMESTAMP(0)'))
     updated_at = db.Column(db.DateTime, nullable=False, server_default=db.text('CURRENT_TIMESTAMP(0)'))
 
-    def get_accounts(self) -> List[db.Model]:
+    def get_accounts(self) -> list[db.Model]:
         Account = db.Model
         return db.session.query(Account).filter(
             Account.id == TenantAccountJoin.account_id,

--- a/api/models/tools.py
+++ b/api/models/tools.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
@@ -117,7 +116,7 @@ class ApiToolProvider(db.Model):
         return ApiProviderSchemaType.value_of(self.schema_type_str)
     
     @property
-    def tools(self) -> List[ApiBasedToolBundle]:
+    def tools(self) -> list[ApiBasedToolBundle]:
         return [ApiBasedToolBundle(**tool) for tool in json.loads(self.tools_str)]
     
     @property

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -14,10 +14,13 @@ select = [
     "F", # pyflakes rules
     "I001", # unsorted-imports
     "I002", # missing-required-import
+    "UP",   # pyupgrade rules
 ]
 ignore = [
     "F403", # undefined-local-with-import-star
     "F405", # undefined-local-with-import-star-usage
     "F821", # undefined-name
     "F841", # unused-variable
+    "UP007", # non-pep604-annotation
+    "UP032", # f-string
 ]

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 import base64
 import json
 import logging
@@ -6,7 +5,7 @@ import secrets
 import uuid
 from datetime import datetime, timedelta
 from hashlib import sha256
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from flask import current_app
 from sqlalchemy import func
@@ -510,7 +509,7 @@ class RegisterService:
             redis_client.delete(cls._get_invitation_token_key(token))
 
     @classmethod
-    def get_invitation_if_token_valid(cls, workspace_id: str, email: str, token: str) -> Optional[Dict[str, Any]]:
+    def get_invitation_if_token_valid(cls, workspace_id: str, email: str, token: str) -> Optional[dict[str, Any]]:
         invitation_data = cls._get_invitation_by_token(token, workspace_id, email)
         if not invitation_data:
             return None
@@ -544,7 +543,7 @@ class RegisterService:
         }
 
     @classmethod
-    def _get_invitation_by_token(cls, token: str, workspace_id: str, email: str) -> Optional[Dict[str, str]]:
+    def _get_invitation_by_token(cls, token: str, workspace_id: str, email: str) -> Optional[dict[str, str]]:
         if workspace_id is not None and email is not None:
             email_hash = sha256(email.encode()).hexdigest()
             cache_key = f'member_invite_token:{workspace_id}, {email_hash}:{token}'

--- a/api/services/completion_service.py
+++ b/api/services/completion_service.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Generator, Union
+from collections.abc import Generator
+from typing import Any, Union
 
 from sqlalchemy import and_
 

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -4,7 +4,7 @@ import logging
 import random
 import time
 import uuid
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 from flask import current_app
 from flask_login import current_user
@@ -366,7 +366,7 @@ class DocumentService:
         return document
 
     @staticmethod
-    def get_document_by_dataset_id(dataset_id: str) -> List[Document]:
+    def get_document_by_dataset_id(dataset_id: str) -> list[Document]:
         documents = db.session.query(Document).filter(
             Document.dataset_id == dataset_id,
             Document.enabled == True
@@ -375,7 +375,7 @@ class DocumentService:
         return documents
 
     @staticmethod
-    def get_batch_documents(dataset_id: str, batch: str) -> List[Document]:
+    def get_batch_documents(dataset_id: str, batch: str) -> list[Document]:
         documents = db.session.query(Document).filter(
             Document.batch == batch,
             Document.dataset_id == dataset_id,

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -1,7 +1,8 @@
 import datetime
 import hashlib
 import uuid
-from typing import Generator, Tuple, Union
+from collections.abc import Generator
+from typing import Union
 
 from flask import current_app
 from flask_login import current_user
@@ -141,7 +142,7 @@ class FileService:
         return text
 
     @staticmethod
-    def get_image_preview(file_id: str, timestamp: str, nonce: str, sign: str) -> Tuple[Generator, str]:
+    def get_image_preview(file_id: str, timestamp: str, nonce: str, sign: str) -> tuple[Generator, str]:
         result = UploadFileParser.verify_image_file_signature(file_id, timestamp, nonce, sign)
         if not result:
             raise NotFound("File not found or signature is invalid")

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import time
-from typing import List
 
 import numpy as np
 from flask import current_app
@@ -131,7 +130,7 @@ class HitTestingService:
         return cls.compact_retrieve_response(dataset, embeddings, query, all_documents)
 
     @classmethod
-    def compact_retrieve_response(cls, dataset: Dataset, embeddings: Embeddings, query: str, documents: List[Document]):
+    def compact_retrieve_response(cls, dataset: Dataset, embeddings: Embeddings, query: str, documents: list[Document]):
         text_embeddings = [
             embeddings.embed_query(query)
         ]

--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from core.generator.llm_generator import LLMGenerator
 from core.memory.token_buffer_memory import TokenBufferMemory
@@ -177,7 +177,7 @@ class MessageService:
 
     @classmethod
     def get_suggested_questions_after_answer(cls, app_model: App, user: Optional[Union[Account, EndUser]],
-                                             message_id: str, check_enabled: bool = True) -> List[Message]:
+                                             message_id: str, check_enabled: bool = True) -> list[Message]:
         if not user:
             raise ValueError('user cannot be None')
 

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -1,7 +1,7 @@
 import logging
 import mimetypes
 import os
-from typing import Optional, Tuple, cast
+from typing import Optional, cast
 
 import requests
 from flask import current_app
@@ -418,7 +418,7 @@ class ModelProviderService:
             model=model
         )
 
-    def get_model_provider_icon(self, provider: str, icon_type: str, lang: str) -> Tuple[Optional[bytes], Optional[str]]:
+    def get_model_provider_icon(self, provider: str, icon_type: str, lang: str) -> tuple[Optional[bytes], Optional[str]]:
         """
         get model provider icon.
 

--- a/api/services/tools_manage_service.py
+++ b/api/services/tools_manage_service.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 
 from flask import current_app
 from httpx import get
@@ -103,7 +102,7 @@ class ToolManageService:
         ]
 
     @staticmethod
-    def parser_api_schema(schema: str) -> List[ApiBasedToolBundle]:
+    def parser_api_schema(schema: str) -> list[ApiBasedToolBundle]:
         """
             parse api schema to tool bundle
         """
@@ -173,7 +172,7 @@ class ToolManageService:
             raise ValueError(f'invalid schema: {str(e)}')
 
     @staticmethod
-    def convert_schema_to_tool_bundles(schema: str, extra_info: dict = None) -> List[ApiBasedToolBundle]:
+    def convert_schema_to_tool_bundles(schema: str, extra_info: dict = None) -> list[ApiBasedToolBundle]:
         """
             convert schema to tool bundles
 

--- a/api/services/vector_service.py
+++ b/api/services/vector_service.py
@@ -1,5 +1,5 @@
 
-from typing import List, Optional
+from typing import Optional
 
 from langchain.schema import Document
 
@@ -10,7 +10,7 @@ from models.dataset import Dataset, DocumentSegment
 class VectorService:
 
     @classmethod
-    def create_segment_vector(cls, keywords: Optional[List[str]], segment: DocumentSegment, dataset: Dataset):
+    def create_segment_vector(cls, keywords: Optional[list[str]], segment: DocumentSegment, dataset: Dataset):
         document = Document(
             page_content=segment.content,
             metadata={
@@ -61,7 +61,7 @@ class VectorService:
             keyword_index.multi_create_segment_keywords(pre_segment_data_list)
 
     @classmethod
-    def update_segment_vector(cls, keywords: Optional[List[str]], segment: DocumentSegment, dataset: Dataset):
+    def update_segment_vector(cls, keywords: Optional[list[str]], segment: DocumentSegment, dataset: Dataset):
         # update segment index task
         vector_index = IndexBuilder.get_index(dataset, 'high_quality')
         kw_index = IndexBuilder.get_index(dataset, 'economy')

--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import time
 import uuid
-from typing import List, cast
+from typing import cast
 
 import click
 from celery import shared_task
@@ -19,7 +19,7 @@ from models.dataset import Dataset, Document, DocumentSegment
 
 
 @shared_task(queue='dataset')
-def batch_create_segment_to_index_task(job_id: str, content: List, dataset_id: str, document_id: str,
+def batch_create_segment_to_index_task(job_id: str, content: list, dataset_id: str, document_id: str,
                                        tenant_id: str, user_id: str):
     """
     Async batch create segment to index

--- a/api/tasks/clean_notion_document_task.py
+++ b/api/tasks/clean_notion_document_task.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from typing import List
 
 import click
 from celery import shared_task
@@ -11,7 +10,7 @@ from models.dataset import Dataset, Document, DocumentSegment
 
 
 @shared_task(queue='dataset')
-def clean_notion_document_task(document_ids: List[str], dataset_id: str):
+def clean_notion_document_task(document_ids: list[str], dataset_id: str):
     """
     Clean document when document deleted.
     :param document_ids: document ids

--- a/api/tasks/create_segment_to_index_task.py
+++ b/api/tasks/create_segment_to_index_task.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import time
-from typing import List, Optional
+from typing import Optional
 
 import click
 from celery import shared_task
@@ -15,7 +15,7 @@ from models.dataset import DocumentSegment
 
 
 @shared_task(queue='dataset')
-def create_segment_to_index_task(segment_id: str, keywords: Optional[List[str]] = None):
+def create_segment_to_index_task(segment_id: str, keywords: Optional[list[str]] = None):
     """
     Async create segment to index
     :param segment_id:

--- a/api/tasks/update_segment_index_task.py
+++ b/api/tasks/update_segment_index_task.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import time
-from typing import List, Optional
+from typing import Optional
 
 import click
 from celery import shared_task
@@ -15,7 +15,7 @@ from models.dataset import DocumentSegment
 
 
 @shared_task(queue='dataset')
-def update_segment_index_task(segment_id: str, keywords: Optional[List[str]] = None):
+def update_segment_index_task(segment_id: str, keywords: Optional[list[str]] = None):
     """
     Async update segment index
     :param segment_id:


### PR DESCRIPTION
- to modernize Python code with the targeted version
- `pyupgrade` rules in Ruff: https://docs.astral.sh/ruff/rules/#pyupgrade-up
  - to prefer native builtin collections over from typing, e.g. `list` instead of `List`
  - to prefer collections from `collections.abc` (abstract base class container from Python3.3) over from `collections`
  - skip UTF-8 encoding in the headline, as it's already the default encoding in Python
  - prefer `yield from` in generator
- ignoring the following rules
  - UP007: Use X \| Y for type annotations
    - to prevent enforcing `Unin[type1, type2]` into `type1, type2` or breaking `Optional[]`
  - UP032: Use f-string instead of format call
- Ruff respects the required Python version from config file, which is `>=3.10`.