### PR TITLE
fix: possible unsent function call in the last chunk of streaming response in OpenAI provider

### DIFF
--- a/api/core/model_runtime/model_providers/openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai/llm/llm.py
@@ -497,8 +497,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 continue
 
             delta = chunk.choices[0]
+            has_finish_reason = delta.finish_reason is not None
 
-            if delta.finish_reason is None and (delta.delta.content is None or delta.delta.content == '') and \
+            if not has_finish_reason and (delta.delta.content is None or delta.delta.content == '') and \
                 delta.delta.function_call is None:
                 continue
 
@@ -520,7 +521,8 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 if assistant_message_function_call:
                     # start of stream function call
                     delta_assistant_message_function_call_storage = assistant_message_function_call
-                    continue
+                    if not has_finish_reason:
+                        continue
 
             # tool_calls = self._extract_response_tool_calls(assistant_message_tool_calls)
             function_call = self._extract_response_function_call(assistant_message_function_call)
@@ -534,7 +536,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
 
             full_assistant_content += delta.delta.content if delta.delta.content else ''
 
-            if delta.finish_reason is not None:
+            if has_finish_reason:
                 # calculate num tokens
                 prompt_tokens = self._num_tokens_from_messages(model, prompt_messages, tools)
 


### PR DESCRIPTION
- fix possible unsent function call in the last chunk of streaming response in OpenAI provider
- the `delta_assistant_message_function_call_storage` caches the function calls when function_call is found and then it continues to process the next chuck. However, if the last message itself contains a full function calling, it's skipped and never sent
- the corner case comes with using OpenAI provider to call the LLMs under Open-compatible proxies, like we have GLM3 and Qwen