### PR TITLE
enhancement: speed up app lauching by lazy importing transformers

### DIFF
--- a/api/core/model_runtime/model_providers/__base/tokenizers/gpt2_tokenzier.py
+++ b/api/core/model_runtime/model_providers/__base/tokenizers/gpt2_tokenzier.py
@@ -2,8 +2,6 @@ from os.path import abspath, dirname, join
 from threading import Lock
 from typing import Any
 
-from transformers import GPT2Tokenizer as TransformerGPT2Tokenizer
-
 _tokenizer = None
 _lock = Lock()
 
@@ -28,6 +26,7 @@ class GPT2Tokenizer:
             if _tokenizer is None:
                 base_path = abspath(__file__)
                 gpt2_tokenizer_path = join(dirname(base_path), 'gpt2')
+                from transformers import GPT2Tokenizer as TransformerGPT2Tokenizer
                 _tokenizer = TransformerGPT2Tokenizer.from_pretrained(gpt2_tokenizer_path)
 
             return _tokenizer

--- a/api/core/model_runtime/model_providers/jina/text_embedding/jina_tokenizer.py
+++ b/api/core/model_runtime/model_providers/jina/text_embedding/jina_tokenizer.py
@@ -1,7 +1,5 @@
 from os.path import abspath, dirname, join
 
-from transformers import AutoTokenizer
-
 
 class JinaTokenizer:
     @staticmethod
@@ -11,6 +9,7 @@ class JinaTokenizer:
         """
         base_path = abspath(__file__)
         gpt2_tokenizer_path = join(dirname(base_path), 'tokenizer')
+        from transformers import AutoTokenizer
         tokenizer = AutoTokenizer.from_pretrained(gpt2_tokenizer_path)
         tokens = tokenizer.encode(text)
         return len(tokens)


### PR DESCRIPTION
- importing the `transformers` package cost much amount of the app launching time, while it's not a required pre-load package for API serivce
- last importing `transformers` package as where it's used to speed up app launching

- before:
```
[app.py][100] App started in 7.410 seconds
```

- after:
```
[app.py][101] App started in 2.511 seconds
```