### PR TITLE
Update SMTP environment variable name in docker-compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -108,7 +108,7 @@ services:
       MAIL_TYPE: ''
       # default send from email address, if not specified
       MAIL_DEFAULT_SEND_FROM: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
-      SMTP_HOST: ''
+      SMTP_SERVER: ''
       SMTP_PORT: 587
       SMTP_USERNAME: ''
       SMTP_PASSWORD: ''


### PR DESCRIPTION
Changed the environment variable name from SMTP_HOST to SMTP_SERVER in the docker-compose.yml file to fix: ValueError: SMTP_SERVER and SMTP_PORT are required for smtp mail type

This change ensures compatibility with the updated email service configuration requirements, improving clarity and consistency across our deployment configuration files.

- Renamed SMTP_HOST to SMTP_SERVER under the environment section for the relevant service.