### PR TITLE
fix: windows load provider file error

### DIFF
--- a/api/core/tools/provider/builtin_tool_provider.py
+++ b/api/core/tools/provider/builtin_tool_provider.py
@@ -28,7 +28,7 @@ class BuiltinToolProviderController(ToolProviderController):
         provider = self.__class__.__module__.split('.')[-1]
         yaml_path = path.join(path.dirname(path.realpath(__file__)), 'builtin', provider, f'{provider}.yaml')
         try:
-            with open(yaml_path) as f:
+            with open(yaml_path, 'rb') as f:
                 provider_yaml = load(f.read(), FullLoader)
         except:
             raise ToolProviderNotFoundError(f'can not load provider yaml for {provider}')


### PR DESCRIPTION
# Description

Fixed source code startup loading provider error on windows platform

Failure to do so will result in the following error

**`/console/api/workspaces/current/tool-providers`**

![image](https://github.com/langgenius/dify/assets/25095045/380c7de4-e5b6-4abc-b167-690e108ba8db)


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (fix window provider file load)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I only have a local windows environment, so I only test the problems of windows platform,linux,mac platform and hope that the maintainer can test it
