### PR TITLE
feat: use a specific version of model config

### DIFF
--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -49,6 +49,7 @@ class CompletionMessageApi(Resource):
         parser.add_argument('model_config', type=dict, required=True, location='json')
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='dev', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
         args = parser.parse_args()
 
         streaming = args['response_mode'] != 'blocking'
@@ -124,6 +125,7 @@ class ChatMessageApi(Resource):
         parser.add_argument('conversation_id', type=uuid_value, location='json')
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='dev', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
         args = parser.parse_args()
 
         streaming = args['response_mode'] != 'blocking'

--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -32,7 +32,8 @@ from services.errors.audio import (
 class ChatAudioApi(InstalledAppResource):
     def post(self, installed_app):
         app_model = installed_app.app
-        app_model_config: AppModelConfig = app_model.app_model_config
+        app_model_config_id = request.form['app_model_config_id'] if 'app_model_config_id' in request.form else None
+        app_model_config: AppModelConfig = app_model.get_app_model_config(app_model_config_id)
 
         if not app_model_config.speech_to_text_dict['enabled']:
             raise AppUnavailableError()
@@ -76,7 +77,8 @@ class ChatAudioApi(InstalledAppResource):
 class ChatTextApi(InstalledAppResource):
     def post(self, installed_app):
         app_model = installed_app.app
-        app_model_config: AppModelConfig = app_model.app_model_config
+        app_model_config_id = request.form['app_model_config_id'] if 'app_model_config_id' in request.form else None
+        app_model_config: AppModelConfig = app_model.get_app_model_config(app_model_config_id)
 
         if not app_model_config.text_to_speech_dict['enabled']:
             raise AppUnavailableError()

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -44,6 +44,7 @@ class CompletionApi(InstalledAppResource):
         parser.add_argument('files', type=list, required=False, location='json')
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='explore_app', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
         args = parser.parse_args()
 
         streaming = args['response_mode'] == 'streaming'
@@ -108,6 +109,7 @@ class ChatApi(InstalledAppResource):
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('conversation_id', type=uuid_value, location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='explore_app', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
         args = parser.parse_args()
 
         streaming = args['response_mode'] == 'streaming'

--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -1,7 +1,7 @@
 import json
 
 from flask import current_app
-from flask_restful import fields, marshal_with
+from flask_restful import fields, marshal_with, reqparse
 
 from controllers.console import api
 from controllers.console.explore.wraps import InstalledAppResource
@@ -44,8 +44,14 @@ class AppParameterApi(InstalledAppResource):
     @marshal_with(parameters_fields)
     def get(self, installed_app: InstalledApp):
         """Retrieve app parameters."""
+        parser = reqparse.RequestParser()
+        parser.add_argument('app_model_config_id', type=str, required=False, location='args')
+        args = parser.parse_args()
+
+        app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+
         app_model = installed_app.app
-        app_model_config = app_model.app_model_config
+        app_model_config = app_model.get_app_model_config(app_model_config_id)
 
         return {
             'opening_statement': app_model_config.opening_statement,
@@ -67,7 +73,12 @@ class AppParameterApi(InstalledAppResource):
 class ExploreAppMetaApi(InstalledAppResource):
     def get(self, installed_app: InstalledApp):
         """Get app meta"""
-        app_model_config: AppModelConfig = installed_app.app.app_model_config
+        parser = reqparse.RequestParser()
+        parser.add_argument('app_model_config_id', type=str, required=False, location='args')
+        args = parser.parse_args()
+
+        app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+        app_model_config: AppModelConfig = installed_app.app.get_app_model_config(app_model_config_id)
 
         agent_config = app_model_config.agent_mode_dict or {}
         meta = {

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -1,7 +1,7 @@
 import json
 
 from flask import current_app
-from flask_restful import fields, marshal_with
+from flask_restful import fields, marshal_with, reqparse
 
 from controllers.service_api import api
 from controllers.service_api.wraps import AppApiResource
@@ -45,7 +45,12 @@ class AppParameterApi(AppApiResource):
     @marshal_with(parameters_fields)
     def get(self, app_model: App, end_user):
         """Retrieve app parameters."""
-        app_model_config = app_model.app_model_config
+        parser = reqparse.RequestParser()
+        parser.add_argument('app_model_config_id', type=str, required=False, location='args')
+        args = parser.parse_args()
+
+        app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+        app_model_config = app_model.get_app_model_config(app_model_config_id)
 
         return {
             'opening_statement': app_model_config.opening_statement,
@@ -67,7 +72,12 @@ class AppParameterApi(AppApiResource):
 class AppMetaApi(AppApiResource):
     def get(self, app_model: App, end_user):
         """Get app meta"""
-        app_model_config: AppModelConfig = app_model.app_model_config
+        parser = reqparse.RequestParser()
+        parser.add_argument('app_model_config_id', type=str, required=False, location='args')
+        args = parser.parse_args()
+
+        app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+        app_model_config: AppModelConfig = app_model.get_app_model_config(app_model_config_id)
 
         agent_config = app_model_config.agent_mode_dict or {}
         meta = {

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -32,7 +32,8 @@ from services.errors.audio import (
 
 class AudioApi(AppApiResource):
     def post(self, app_model: App, end_user):
-        app_model_config: AppModelConfig = app_model.app_model_config
+        app_model_config_id = request.form['app_model_config_id'] if 'app_model_config_id' in request.form else None
+        app_model_config: AppModelConfig = app_model.get_app_model_config(app_model_config_id)
 
         if not app_model_config.speech_to_text_dict['enabled']:
             raise AppUnavailableError()

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -40,6 +40,7 @@ class CompletionApi(AppApiResource):
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('user', required=True, nullable=False, type=str, location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='dev', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
 
         args = parser.parse_args()
 
@@ -117,6 +118,7 @@ class ChatApi(AppApiResource):
         parser.add_argument('user', type=str, required=True, nullable=False, location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='dev', location='json')
         parser.add_argument('auto_generate_name', type=bool, required=False, default=True, location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
 
         args = parser.parse_args()
 

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -1,7 +1,7 @@
 import json
 
 from flask import current_app
-from flask_restful import fields, marshal_with
+from flask_restful import fields, marshal_with, reqparse
 
 from controllers.web import api
 from controllers.web.wraps import WebApiResource
@@ -44,7 +44,12 @@ class AppParameterApi(WebApiResource):
     @marshal_with(parameters_fields)
     def get(self, app_model: App, end_user):
         """Retrieve app parameters."""
-        app_model_config = app_model.app_model_config
+        parser = reqparse.RequestParser()
+        parser.add_argument('app_model_config_id', type=str, required=False, location='args')
+        args = parser.parse_args()
+
+        app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+        app_model_config = app_model.get_app_model_config(app_model_config_id)
 
         return {
             'opening_statement': app_model_config.opening_statement,
@@ -66,7 +71,12 @@ class AppParameterApi(WebApiResource):
 class AppMeta(WebApiResource):
     def get(self, app_model: App, end_user):
         """Get app meta"""
-        app_model_config: AppModelConfig = app_model.app_model_config
+        parser = reqparse.RequestParser()
+        parser.add_argument('app_model_config_id', type=str, required=False, location='args')
+        args = parser.parse_args()
+
+        app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+        app_model_config: AppModelConfig = app_model.get_app_model_config(app_model_config_id)
 
         agent_config = app_model_config.agent_mode_dict or {}
         meta = {

--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -31,7 +31,8 @@ from services.errors.audio import (
 
 class AudioApi(WebApiResource):
     def post(self, app_model: App, end_user):
-        app_model_config: AppModelConfig = app_model.app_model_config
+        app_model_config_id = request.form['app_model_config_id'] if 'app_model_config_id' in request.form else None
+        app_model_config: AppModelConfig = app_model.get_app_model_config(app_model_config_id)
 
         if not app_model_config.speech_to_text_dict['enabled']:
             raise AppUnavailableError()

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -41,6 +41,7 @@ class CompletionApi(WebApiResource):
         parser.add_argument('files', type=list, required=False, location='json')
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='web_app', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
 
         args = parser.parse_args()
 
@@ -101,6 +102,7 @@ class ChatApi(WebApiResource):
         parser.add_argument('response_mode', type=str, choices=['blocking', 'streaming'], location='json')
         parser.add_argument('conversation_id', type=uuid_value, location='json')
         parser.add_argument('retriever_from', type=str, required=False, default='web_app', location='json')
+        parser.add_argument('app_model_config_id', type=str, required=False, location='json')
 
         args = parser.parse_args()
 

--- a/api/controllers/web/site.py
+++ b/api/controllers/web/site.py
@@ -85,5 +85,5 @@ class AppSiteInfo:
             }
 
         if app.enable_site and site.prompt_public:
-            app_model_config = app.app_model_config
+            app_model_config = app.get_app_model_config()
             self.model_config = app_model_config

--- a/api/core/tools/provider/app_tool_provider.py
+++ b/api/core/tools/provider/app_tool_provider.py
@@ -15,7 +15,7 @@ class AppBasedToolProviderEntity(ToolProviderController):
     @property
     def app_type(self) -> ToolProviderType:
         return ToolProviderType.APP_BASED
-    
+
     def _validate_credentials(self, tool_name: str, credentials: dict[str, Any]) -> None:
         pass
 
@@ -59,7 +59,7 @@ class AppBasedToolProviderEntity(ToolProviderController):
                 logger.error(f"app {db_tool.app_id} not found")
                 continue
 
-            app_model_config: AppModelConfig = app.app_model_config
+            app_model_config: AppModelConfig = app.get_app_model_config()
             user_input_form_list = app_model_config.user_input_form_list
             for input_form in user_input_form_list:
                 # get type

--- a/api/services/completion_service.py
+++ b/api/services/completion_service.py
@@ -103,7 +103,8 @@ class CompletionService:
             if app_model.app_model_config_id is None:
                 raise AppModelConfigBrokenError()
 
-            app_model_config = app_model.app_model_config
+            app_model_config_id = args['app_model_config_id'] if 'app_model_config_id' in args else None
+            app_model_config = app_model.get_app_model_config(app_model_config_id)
 
             if not app_model_config:
                 raise AppModelConfigBrokenError()
@@ -175,13 +176,12 @@ class CompletionService:
         if not message:
             raise MessageNotExistsError()
 
-        current_app_model_config = app_model.app_model_config
-        more_like_this = current_app_model_config.more_like_this_dict
+        app_model_config = message.app_model_config
+        more_like_this = app_model_config.more_like_this_dict
 
-        if not current_app_model_config.more_like_this or more_like_this.get("enabled", False) is False:
+        if not app_model_config.more_like_this or more_like_this.get("enabled", False) is False:
             raise MoreLikeThisDisabledError()
 
-        app_model_config = message.app_model_config
         model_dict = app_model_config.model_dict
         completion_params = model_dict.get('completion_params')
         completion_params['temperature'] = 0.9


### PR DESCRIPTION
Make the backend API use an `app_model` specified by `app_config_model_id`, so that a specific version of the model config can be called without worrying about the config being changed afterward.