### PR TITLE
fix: hybrid search may pass rerank enable false

### DIFF
--- a/web/app/components/datasets/common/retrieval-method-config/index.tsx
+++ b/web/app/components/datasets/common/retrieval-method-config/index.tsx
@@ -89,6 +89,7 @@ const RetrievalMethodConfig: FC<Props> = ({
           onChosen={() => onChange({
             ...value,
             search_method: RETRIEVE_METHOD.hybrid,
+            reranking_enable: true,
           })}
           chosenConfig={
             <RetrievalParamConfig


### PR DESCRIPTION
# Description

Hybrid search may pass rerank enable false in save dataset config.


## Type of Change
-  Bug fix (non-breaking change which fixes an issue)
