### PR TITLE
fix: credential verification of baichuan did not throw all errors

### DIFF
--- a/api/core/model_runtime/model_providers/baichuan/llm/llm.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/llm.py
@@ -103,7 +103,7 @@ class BaichuanLarguageModel(LargeLanguageModel):
             ], parameters={
                 'max_tokens': 1,
             }, timeout=60)
-        except (InvalidAPIKeyError, InvalidAuthenticationError) as e:
+        except Exception as e:
             raise CredentialsValidateFailedError(f"Invalid API key: {e}")
 
     def _generate(self, model: str, credentials: dict, prompt_messages: list[PromptMessage], 


### PR DESCRIPTION
# Description

credential verification of baichuan did not throw all errors

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual testing, passing in an invalid api-key of Baichuan

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
