### PR TITLE
remove: parameters in seeds

### DIFF
--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4-0125-preview.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4-0125-preview.yaml
@@ -37,9 +37,6 @@ parameter_rules:
         the same result. Determinism is not guaranteed, and you should refer to the
         system_fingerprint response parameter to monitor changes in the backend.
     required: false
-    precision: 2
-    min: 0
-    max: 1
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4-1106-preview.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4-1106-preview.yaml
@@ -37,9 +37,6 @@ parameter_rules:
         the same result. Determinism is not guaranteed, and you should refer to the
         system_fingerprint response parameter to monitor changes in the backend.
     required: false
-    precision: 2
-    min: 0
-    max: 1
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4-32k.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4-32k.yaml
@@ -37,9 +37,6 @@ parameter_rules:
         the same result. Determinism is not guaranteed, and you should refer to the
         system_fingerprint response parameter to monitor changes in the backend.
     required: false
-    precision: 2
-    min: 0
-    max: 1
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4-turbo-preview.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4-turbo-preview.yaml
@@ -37,9 +37,6 @@ parameter_rules:
         the same result. Determinism is not guaranteed, and you should refer to the
         system_fingerprint response parameter to monitor changes in the backend.
     required: false
-    precision: 2
-    min: 0
-    max: 1
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4-vision-preview.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4-vision-preview.yaml
@@ -35,9 +35,6 @@ parameter_rules:
         the same result. Determinism is not guaranteed, and you should refer to the
         system_fingerprint response parameter to monitor changes in the backend.
     required: false
-    precision: 2
-    min: 0
-    max: 1
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4.yaml
@@ -37,9 +37,6 @@ parameter_rules:
         the same result. Determinism is not guaranteed, and you should refer to the
         system_fingerprint response parameter to monitor changes in the backend.
     required: false
-    precision: 2
-    min: 0
-    max: 1
   - name: response_format
     label:
       zh_Hans: 回复格式


### PR DESCRIPTION
# Description

See below

Fixes # (issue)

https://discord.com/channels/1082486657678311454/1107330913139970128/1208854559661891654
> per the (https://cookbook.openai.com/examples/reproducible_outputs_with_the_seed_parameter) openai seed information, we can enter custom seeds but in dify it seems to be a slidebar of value from 0 to 1

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
