### PR TITLE
Windows local deployment switch "tool“ interface failed

### DIFF
--- a/api/core/tools/provider/builtin_tool_provider.py
+++ b/api/core/tools/provider/builtin_tool_provider.py
@@ -58,7 +58,7 @@ class BuiltinToolProviderController(ToolProviderController):
         tool_files = list(filter(lambda x: x.endswith(".yaml") and not x.startswith("__"), listdir(tool_path)))
         tools = []
         for tool_file in tool_files:
-            with open(path.join(tool_path, tool_file)) as f:
+            with open(path.join(tool_path, tool_file), encoding='utf-8') as f:
                 # get tool name
                 tool_name = tool_file.split(".")[0]
                 tool = load(f.read(), FullLoader)


### PR DESCRIPTION

# Description

Deploy locally from the Windows environment. A Unicode DecodeError error occurred while accessing the "Tools" page. The problem is that the correct encoding format was not specified when reading the YAML file. Python uses GBK encoding to read files by default on Windows, while Dalle3. yaml is encoded in UTF-8, especially if the file contains non ASCII characters (such as Chinese, Portuguese, etc.).

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TODO

# Suggested Checklist:

 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas
 My changes generate no new warnings
 I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

