### PR TITLE
bump redis client to 5.0 and enable hiredis support

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk[flask]~=1.39.2
 sympy==1.12
 jieba==0.42.1
 celery==5.2.7
-redis~=4.5.4
+redis[hiredis]~=5.0.3
 openpyxl==3.1.2
 chardet~=5.1.0
 python-docx~=1.1.0


### PR DESCRIPTION
# Description

- bump redis client from 4.5.x to 5.0.x
   - to support Redis 7.0+, https://github.com/redis/redis-py?tab=readme-ov-file#supported-redis-versions
   - minimum required Redis server version 5.0 is not changed
- enable hiredis support for faster performance with compiled response parser
   - hiredis benchmarks https://github.com/redis/hiredis-py?tab=readme-ov-file#benchmarks
   - hiredis is a minimalistic redis C client maintained by Redis official
   - hiredis python package is also maintained by Redis official (https://github.com/redis/hiredis-py), and will be installed
   - https://github.com/redis/redis-py?tab=readme-ov-file#installation


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

- run ci jobs

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
