### PR TITLE
fix: update current tenant id of account when switching tenant

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -282,9 +282,9 @@ class TenantService:
         else: 
             TenantAccountJoin.query.filter(TenantAccountJoin.account_id == account.id, TenantAccountJoin.tenant_id != tenant_id).update({'current': False})
             tenant_account_join.current = True
-            db.session.commit()
             # Set the current tenant for the account
             account.current_tenant_id = tenant_account_join.tenant_id
+            db.session.commit()
 
     @staticmethod
     def get_tenant_members(tenant: Tenant) -> list[Account]:


### PR DESCRIPTION
# Description

- fix the problem of occasional error `App not found` when running chat completions
- reason: the `CompletionMessageApi.post` uses the `_get_app` method of `controllers.console.app` to lookup the app info , which relies on the current tenant id in account, while it seems not updated properly when switching tenant.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
