### PR TITLE
fix: tolerate exceptions in cleaning up index when vector db service unavailable

### DIFF
--- a/api/tasks/remove_document_from_index_task.py
+++ b/api/tasks/remove_document_from_index_task.py
@@ -42,7 +42,10 @@ def remove_document_from_index_task(document_id: str):
         segments = db.session.query(DocumentSegment).filter(DocumentSegment.document_id == document.id).all()
         index_node_ids = [segment.index_node_id for segment in segments]
         if index_node_ids:
-            index_processor.clean(dataset, index_node_ids)
+            try:
+                index_processor.clean(dataset, index_node_ids)
+            except Exception:
+                logging.exception(f"clean dataset {dataset.id} from index failed")
 
         end_at = time.perf_counter()
         logging.info(


### PR DESCRIPTION
# Description


- the error blocks disabling docs, if the existing docs rely on the specific type of vector db service (milvus for example as following) which is no longer available
![image](https://github.com/langgenius/dify/assets/1935105/60abf528-dd1f-4a71-ad47-9c5578dff126)
- this breaking change/bug was introduced from #2528 the refactored code structure of RAG
- tolerate exceptions in cleaning up index

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
