### PR TITLE
chore: remove redundant casting flask app config into dict

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -132,7 +132,7 @@ def vdb_migrate():
     """
     click.echo(click.style('Start migrate vector db.', fg='green'))
     create_count = 0
-    config = cast(dict, current_app.config)
+    config = current_app.config
     vector_type = config.get('VECTOR_STORE')
     page = 1
     while True:

--- a/api/commands.py
+++ b/api/commands.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import secrets
-from typing import cast
 
 import click
 from flask import current_app

--- a/api/core/rag/datasource/keyword/keyword_factory.py
+++ b/api/core/rag/datasource/keyword/keyword_factory.py
@@ -14,7 +14,7 @@ class Keyword:
         self._keyword_processor = self._init_keyword()
 
     def _init_keyword(self) -> BaseKeyword:
-        config = cast(dict, current_app.config)
+        config = current_app.config
         keyword_type = config.get('KEYWORD_STORE')
 
         if not keyword_type:

--- a/api/core/rag/datasource/keyword/keyword_factory.py
+++ b/api/core/rag/datasource/keyword/keyword_factory.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 from flask import current_app
 

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, cast
+from typing import Any
 
 from flask import current_app
 

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -23,7 +23,7 @@ class Vector:
         self._vector_processor = self._init_vector()
 
     def _init_vector(self) -> BaseVector:
-        config = cast(dict, current_app.config)
+        config = current_app.config
         vector_type = config.get('VECTOR_STORE')
 
         if self._dataset.index_struct_dict:


### PR DESCRIPTION
# Description

- remove redundant casting flask app config into dict, as the class Config of the Flask app inherits `dict` type.
  - `class Config(dict):`

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
