### PR TITLE
fix weaviate delete_by_ids

### DIFF
--- a/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
+++ b/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
@@ -150,10 +150,11 @@ class WeaviateVector(BaseVector):
         return True
 
     def delete_by_ids(self, ids: list[str]) -> None:
-        self._client.data_object.delete(
-            ids,
-            class_name=self._collection_name
-        )
+        for uuid in ids:
+            self._client.data_object.delete(
+                class_name=self._collection_name,
+                uuid=uuid,
+            )
 
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:
         """Look up similar documents by embedding vector in Weaviate."""


### PR DESCRIPTION
# Description

- fix the error when disabling document for deleting docs from weaviate vector
- the weaviate client's delete method of data object accepts the uuid in type of string or UUID
```
def delete(
        self,
        uuid: Union[str, uuid_lib.UUID],
        class_name: Optional[str] = None,
        consistency_level: Optional[ConsistencyLevel] = None,
    ) -> None:
```
- Deleting all the doc ids one by one instead of using `ContainsAny` filter, as `ContainsAny` is only available in Weaviat 1.19+ 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
