### PR TITLE
Fix the primary key's field name of vector index

### DIFF
--- a/api/core/rag/datasource/vdb/field.py
+++ b/api/core/rag/datasource/vdb/field.py
@@ -7,4 +7,4 @@ class Field(Enum):
     GROUP_KEY = "group_id"
     VECTOR = "vector"
     TEXT_KEY = "text"
-    PRIMARY_KEY = " id"
+    PRIMARY_KEY = "id"


### PR DESCRIPTION
# Description

- the extra space in the primary key field name crashes the attu GUI for milvus
- bad practice to use an extra space in the front
- Without this PR:
![image](https://github.com/langgenius/dify/assets/1935105/09b67040-1643-4ed6-bd01-14f0e6a2b112)
- With this PR:
![image](https://github.com/langgenius/dify/assets/1935105/b7a0ef5b-f686-417f-88ad-44fd7f74862b)



## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
