### PR TITLE
hit_testing

### DIFF
--- a/api/core/tools/provider/builtin_tool_provider.py
+++ b/api/core/tools/provider/builtin_tool_provider.py
@@ -58,7 +58,7 @@ class BuiltinToolProviderController(ToolProviderController):
         tool_files = list(filter(lambda x: x.endswith(".yaml") and not x.startswith("__"), listdir(tool_path)))
         tools = []
         for tool_file in tool_files:
-            with open(path.join(tool_path, tool_file)) as f:
+            with open(path.join(tool_path, tool_file), encoding='utf-8') as f:
                 # get tool name
                 tool_name = tool_file.split(".")[0]
                 tool = load(f.read(), FullLoader)


### PR DESCRIPTION
# Description

When using hit_testing, if the text is exactly the same as the query, then the vector after embedding is also the same. In this case, if we want to calculate get_tsne_positionsfrom_embedding (which seems to be a vector distance, I don't quite understand this concept), an error will be reported as eg: self. expanded_variance-ratio_=self. expanded_variance_/total_var, the total_var is zero...My Knowledge Base Settings setting .
![image](https://github.com/langgenius/dify/assets/67894866/b679f2fa-03e8-49cb-84da-c2938a53ea7b)


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
