### PR TITLE
version to 0.5.7

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -90,7 +90,7 @@ class Config:
         # ------------------------
         # General Configurations.
         # ------------------------
-        self.CURRENT_VERSION = "0.5.6"
+        self.CURRENT_VERSION = "0.5.7"
         self.COMMIT_SHA = get_env('COMMIT_SHA')
         self.EDITION = "SELF_HOSTED"
         self.DEPLOY_ENV = get_env('DEPLOY_ENV')

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.5.6
+    image: langgenius/dify-api:0.5.7
     restart: always
     environment:
       # Startup mode, 'api' starts the API server.
@@ -135,7 +135,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.5.6
+    image: langgenius/dify-api:0.5.7
     restart: always
     environment:
       # Startup mode, 'worker' starts the Celery worker for processing the queue.
@@ -206,7 +206,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.5.6
+    image: langgenius/dify-web:0.5.7
     restart: always
     environment:
       EDITION: SELF_HOSTED

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Description

- Bump version to 0.5.7
- Added `Mistral AI` model provider. #2594
- Added Vector Database migrate tool, see below. #2562
- Added `response format`(JSON/XML) for `google`, `anthropic`, `openai`, `wenxin`, `chatglm`, `tongyi` LLMs. #2563
- refactor RAG(knowledge) module, remove dependency on langchain to increase scalability and flexibility. #2528
- Agent uses a model that does not support function calling (ReACT mode) to enable streaming output. #2498
- Added DuckDuckGo Search Tool for Enhanced Privacy-Focused Search Functionality by @Yash-1511 #2499

## Vector Database Migrate Tool

When you want to switch to another vector database, you can deactivate or delete the original vector database after switching.

### How to use

Step:
1.  If you are starting from local source code, modify the environment variable in the `.env` file to the vector database you want to migrate to. 
For example: 

```
VECTOR_STORE=qdrant
````

2.  If you are starting from `docker compose`, modify the environment variable in the `docker-compose.yaml` file to the vector database you want to migrate to, both api and worker are all needed.

For example: 

```
# The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
VECTOR_STORE: qdrant
```

4. run the below command in your terminal or docker container

```
flask vdb-migrarte
```

# Type of Change

- [x] Version release
