### PR TITLE
fix: default mail type invalid in .env.example

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -82,7 +82,7 @@ UPLOAD_IMAGE_FILE_SIZE_LIMIT=10
 MULTIMODAL_SEND_IMAGE_FORMAT=base64
 
 # Mail configuration, support: resend, smtp
-MAIL_TYPE=resend
+MAIL_TYPE=
 MAIL_DEFAULT_SEND_FROM=no-reply <no-reply@dify.ai>
 RESEND_API_KEY=
 RESEND_API_URL=https://api.resend.com


### PR DESCRIPTION
# Description

fix: default mail type invalid in .env.example

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual Test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
