### PR TITLE
fix: typo in gaode tool

### DIFF
--- a/api/core/tools/provider/builtin/gaode/tools/gaode_weather.py
+++ b/api/core/tools/provider/builtin/gaode/tools/gaode_weather.py
@@ -54,4 +54,4 @@ class GaodeRepositoriesTool(BuiltinTool):
             s.close()
             return self.create_text_message(f'No weather information for {city} was found.')
         except Exception as e:
-            return self.create_text_message("Github API Key and Api Version is invalid. {}".format(e))
+            return self.create_text_message("Gaode API Key and Api Version is invalid. {}".format(e))


### PR DESCRIPTION
# Description

- Fix the typo of "Gaode API key" in error message

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
