### PR TITLE
feat: displaying the tool description when clicking on a custom tool

### DIFF
--- a/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
@@ -153,18 +153,18 @@ const AgentTools: FC = () => {
                   )
                   : (
                     <div className='hidden group-hover:flex items-center'>
-                      {item.provider_type === CollectionType.builtIn && (
-                        <TooltipPlus
-                          popupContent={t('tools.setBuiltInTools.infoAndSetting')}
-                        >
-                          <div className='mr-1 p-1 rounded-md hover:bg-black/5  cursor-pointer' onClick={() => {
-                            setCurrentTool(item)
-                            setIsShowSettingTool(true)
-                          }}>
-                            <InfoCircle className='w-4 h-4 text-gray-500' />
-                          </div>
-                        </TooltipPlus>
-                      )}
+                      {/* {item.provider_type === CollectionType.builtIn && ( */}
+                      <TooltipPlus
+                        popupContent={t('tools.setBuiltInTools.infoAndSetting')}
+                      >
+                        <div className='mr-1 p-1 rounded-md hover:bg-black/5  cursor-pointer' onClick={() => {
+                          setCurrentTool(item)
+                          setIsShowSettingTool(true)
+                        }}>
+                          <InfoCircle className='w-4 h-4 text-gray-500' />
+                        </div>
+                      </TooltipPlus>
+                      {/* )} */}
 
                       <div className='p-1 rounded-md hover:bg-black/5 cursor-pointer' onClick={() => {
                         const newModelConfig = produce(modelConfig, (draft) => {
@@ -209,6 +209,7 @@ const AgentTools: FC = () => {
             toolName={currentTool?.tool_name as string}
             setting={currentTool?.tool_parameters as any}
             collection={currentTool?.collection as Collection}
+            isBuiltIn={currentTool?.collection?.type === CollectionType.builtIn}
             onSave={handleToolSettingChange}
             onHide={() => setIsShowSettingTool(false)}
           />)

--- a/web/app/components/app/configuration/config/agent/agent-tools/setting-built-in-tool.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/setting-built-in-tool.tsx
@@ -8,14 +8,17 @@ import Drawer from '@/app/components/base/drawer-plus'
 import Form from '@/app/components/header/account-setting/model-provider-page/model-modal/Form'
 import { addDefaultValue, toolParametersToFormSchemas } from '@/app/components/tools/utils/to-form-schema'
 import type { Collection, Tool } from '@/app/components/tools/types'
-import { fetchBuiltInToolList } from '@/service/tools'
+import { fetchBuiltInToolList, fetchCustomToolList } from '@/service/tools'
 import I18n from '@/context/i18n'
 import Button from '@/app/components/base/button'
 import Loading from '@/app/components/base/loading'
 import { DiagonalDividingLine } from '@/app/components/base/icons/src/public/common'
 import { getLanguage } from '@/i18n/language'
+import AppIcon from '@/app/components/base/app-icon'
+
 type Props = {
   collection: Collection
+  isBuiltIn?: boolean
   toolName: string
   setting?: Record<string, any>
   readonly?: boolean
@@ -25,6 +28,7 @@ type Props = {
 
 const SettingBuiltInTool: FC<Props> = ({
   collection,
+  isBuiltIn = true,
   toolName,
   setting = {},
   readonly,
@@ -52,7 +56,7 @@ const SettingBuiltInTool: FC<Props> = ({
     (async () => {
       setIsLoading(true)
       try {
-        const list = await fetchBuiltInToolList(collection.name)
+        const list = isBuiltIn ? await fetchBuiltInToolList(collection.name) : await fetchCustomToolList(collection.name)
         setTools(list)
         const currTool = list.find(tool => tool.name === toolName)
         if (currTool) {
@@ -135,12 +139,24 @@ const SettingBuiltInTool: FC<Props> = ({
       onHide={onHide}
       title={(
         <div className='flex'>
-          <div
-            className='w-6 h-6 bg-cover bg-center rounded-md'
-            style={{
-              backgroundImage: `url(${collection.icon})`,
-            }}
-          ></div>
+          {collection.icon === 'string'
+            ? (
+              <div
+                className='w-6 h-6 bg-cover bg-center rounded-md'
+                style={{
+                  backgroundImage: `url(${collection.icon})`,
+                }}
+              ></div>
+            )
+            : (
+              <AppIcon
+                className='rounded-md'
+                size='tiny'
+                icon={(collection.icon as any)?.content}
+                background={(collection.icon as any)?.background}
+              />
+            )}
+
           <div className='ml-2 leading-6 text-base font-semibold text-gray-900'>{currTool?.label[language]}</div>
           {(hasSetting && !readonly) && (<>
             <DiagonalDividingLine className='mx-4' />

--- a/web/app/components/tools/index.tsx
+++ b/web/app/components/tools/index.tsx
@@ -16,7 +16,6 @@ import EditCustomToolModal from './edit-custom-collection-modal'
 import NoCustomTool from './info/no-custom-tool'
 import NoSearchRes from './info/no-search-res'
 import NoCustomToolPlaceholder from './no-custom-tool-placeholder'
-import { useTabSearchParams } from '@/hooks/use-tab-searchparams'
 import TabSlider from '@/app/components/base/tab-slider'
 import { createCustomCollection, fetchCollectionList as doFetchCollectionList, fetchBuiltInToolList, fetchCustomToolList } from '@/service/tools'
 import type { AgentTool } from '@/types/app'
@@ -69,9 +68,7 @@ const Tools: FC<Props> = ({
   })()
 
   const [query, setQuery] = useState('')
-  const [collectionType, setCollectionType] = useTabSearchParams({
-    defaultTab: collectionTypeOptions[0].value,
-  })
+  const [collectionType, setCollectionType] = useState(collectionTypeOptions[0].value)
 
   const showCollectionList = (() => {
     let typeFilteredList: Collection[] = []

--- a/web/app/components/tools/index.tsx
+++ b/web/app/components/tools/index.tsx
@@ -16,6 +16,7 @@ import EditCustomToolModal from './edit-custom-collection-modal'
 import NoCustomTool from './info/no-custom-tool'
 import NoSearchRes from './info/no-search-res'
 import NoCustomToolPlaceholder from './no-custom-tool-placeholder'
+import { useTabSearchParams } from '@/hooks/use-tab-searchparams'
 import TabSlider from '@/app/components/base/tab-slider'
 import { createCustomCollection, fetchCollectionList as doFetchCollectionList, fetchBuiltInToolList, fetchCustomToolList } from '@/service/tools'
 import type { AgentTool } from '@/types/app'
@@ -68,7 +69,22 @@ const Tools: FC<Props> = ({
   })()
 
   const [query, setQuery] = useState('')
-  const [collectionType, setCollectionType] = useState(collectionTypeOptions[0].value)
+  const [toolPageCollectionType, setToolPageCollectionType] = useTabSearchParams({
+    defaultTab: collectionTypeOptions[0].value,
+  })
+  const [appPageCollectionType, setAppPageCollectionType] = useState(collectionTypeOptions[0].value)
+  const { collectionType, setCollectionType } = (() => {
+    if (isInToolsPage) {
+      return {
+        collectionType: toolPageCollectionType,
+        setCollectionType: setToolPageCollectionType,
+      }
+    }
+    return {
+      collectionType: appPageCollectionType,
+      setCollectionType: setAppPageCollectionType,
+    }
+  })()
 
   const showCollectionList = (() => {
     let typeFilteredList: Collection[] = []

--- a/web/app/components/tools/tool-list/item.tsx
+++ b/web/app/components/tools/tool-list/item.tsx
@@ -63,7 +63,7 @@ const Item: FC<Props> = ({
           )}
         </div>
       </div>
-      {showDetail && isBuiltIn && (
+      {showDetail && (
         <SettingBuiltInTool
           collection={collection}
           toolName={payload.name}
@@ -71,6 +71,7 @@ const Item: FC<Props> = ({
           onHide={() => {
             setShowDetail(false)
           }}
+          isBuiltIn={isBuiltIn}
         />
       )}
     </>


### PR DESCRIPTION
# Description

Support displaying the tool description when clicking on a custom tool.

Fixes # (issue)
In app config page won't refresh page when the tools collection type changed.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
