### PR TITLE
fix: click tool item in app debug page would show detail

### DIFF
--- a/web/app/components/tools/tool-list/item.tsx
+++ b/web/app/components/tools/tool-list/item.tsx
@@ -35,9 +35,10 @@ const Item: FC<Props> = ({
   const language = getLanguage(locale)
 
   const isBuiltIn = collection.type === CollectionType.builtIn
-  const canShowDetail = !isBuiltIn || (isBuiltIn && isInToolsPage)
+  const canShowDetail = isInToolsPage
   const [showDetail, setShowDetail] = useState(false)
-  const addBtn = <Button className='shrink-0 flex items-center h-7 !px-3 !text-xs !font-medium !text-gray-700' disabled={added || !collection.is_team_authorization} onClick={() => onAdd?.(payload)}>{t(`common.operation.${added ? 'added' : 'add'}`)}</Button>
+  const addBtn = <Button className='shrink-0 flex items-center h-7 !px-3 !text-xs !font-medium !text-gray-700' disabled={added || !collection.is_team_authorization} onClick={e => onAdd?.(payload)}>{t(`common.operation.${added ? 'added' : 'add'}`)}</Button>
+
   return (
     <>
       <div

--- a/web/app/components/tools/tool-list/item.tsx
+++ b/web/app/components/tools/tool-list/item.tsx
@@ -37,7 +37,7 @@ const Item: FC<Props> = ({
   const isBuiltIn = collection.type === CollectionType.builtIn
   const canShowDetail = isInToolsPage
   const [showDetail, setShowDetail] = useState(false)
-  const addBtn = <Button className='shrink-0 flex items-center h-7 !px-3 !text-xs !font-medium !text-gray-700' disabled={added || !collection.is_team_authorization} onClick={e => onAdd?.(payload)}>{t(`common.operation.${added ? 'added' : 'add'}`)}</Button>
+  const addBtn = <Button className='shrink-0 flex items-center h-7 !px-3 !text-xs !font-medium !text-gray-700' disabled={added || !collection.is_team_authorization} onClick={() => onAdd?.(payload)}>{t(`common.operation.${added ? 'added' : 'add'}`)}</Button>
 
   return (
     <>


### PR DESCRIPTION
# Description


Fixes # (issue)
Click tool item in app debug page show detail.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
