### PR TITLE
Use `python-docx` to extract docx files

### DIFF
--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -10,7 +10,7 @@ from core.rag.models.document import Document
 
 
 class WordExtractor(BaseExtractor):
-    """Load pdf files.
+    """Load docx files.
 
 
     Args:

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -49,14 +49,13 @@ class WordExtractor(BaseExtractor):
         from docx import Document as docx_Document
 
         document = docx_Document(self.file_path)
-        doc_texts = []
-        for paragraph in document.paragraphs:
-            doc_texts.append(Document(
-                page_content=paragraph.text,
-                metadata={"source": self.file_path},
-            ))
+        doc_texts = [paragraph.text for paragraph in document.paragraphs]
+        content = '\n'.join(doc_texts)
 
-        return doc_texts
+        return [Document(
+            page_content=content,
+            metadata={"source": self.file_path},
+        )]
 
     @staticmethod
     def _is_valid_url(url: str) -> bool:

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -46,14 +46,17 @@ class WordExtractor(BaseExtractor):
 
     def extract(self) -> list[Document]:
         """Load given path as single page."""
-        import docx2txt
+        from docx import Document as docx_Document
 
-        return [
-            Document(
-                page_content=docx2txt.process(self.file_path),
+        document = docx_Document(self.file_path)
+        doc_texts = []
+        for paragraph in document.paragraphs:
+            doc_texts.append(Document(
+                page_content=paragraph.text,
                 metadata={"source": self.file_path},
-            )
-        ]
+            ))
+
+        return doc_texts
 
     @staticmethod
     def _is_valid_url(url: str) -> bool:

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -31,7 +31,7 @@ celery==5.2.7
 redis~=4.5.4
 openpyxl==3.1.2
 chardet~=5.1.0
-docx2txt==0.8
+python-docx~=1.1.0
 pypdfium2==4.16.0
 resend~=0.7.0
 pyjwt~=2.8.0


### PR DESCRIPTION
# Description

- Replacing the `docx2text` is an outdated python package since 2019 with `python-docx` to extract content texts in docx files
- the `docx2text`(`ankushshah89/python-docx2txt`) itself is from the code taken and adapted from `python-docx`, quoted at its repo README. https://github.com/ankushshah89/python-docx2txt?tab=readme-ov-file#python-docx2txt
- the `python-openxml/python-docx` is better in maintenance with the latest version 1.1.0 released in Nov 2023, https://github.com/python-openxml/python-docx

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
