### PR TITLE
feat: support HTTP response compression in api server

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -26,6 +26,7 @@ from config import CloudEditionConfig, Config
 from extensions import (
     ext_celery,
     ext_code_based_extension,
+    ext_compress,
     ext_database,
     ext_hosting_provider,
     ext_login,
@@ -96,6 +97,7 @@ def create_app(test_config=None) -> Flask:
 def initialize_extensions(app):
     # Since the application instance is now created, pass it to each Flask
     # extension instance to bind it to the Flask application instance (app)
+    ext_compress.init_app(app)
     ext_code_based_extension.init()
     ext_database.init_app(app)
     ext_migrate.init(app, db)

--- a/api/config.py
+++ b/api/config.py
@@ -293,6 +293,8 @@ class Config:
 
         self.BATCH_UPLOAD_LIMIT = get_env('BATCH_UPLOAD_LIMIT')
 
+        self.API_COMPRESSION_ENABLED = get_bool_env('API_COMPRESSION_ENABLED')
+
 
 class CloudEditionConfig(Config):
 

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -1,0 +1,8 @@
+from flask import Flask
+from flask_compress import Compress
+
+compress = Compress()
+
+
+def init_app(app: Flask):
+    compress.init_app(app)

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -2,8 +2,6 @@ from flask import Flask
 from flask_compress import Compress
 
 
-
-
 def init_app(app: Flask):
     if app.config['API_COMPRESSION_ENABLED']:
         compress = Compress()

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -4,6 +4,6 @@ from flask import Flask
 def init_app(app: Flask):
     from flask_compress import Compress
 
-    if app.config['API_COMPRESSION_ENABLED']:
+    if app.config('API_COMPRESSION_ENABLED', False):
         compress = Compress()
         compress.init_app(app)

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -2,8 +2,9 @@ from flask import Flask
 
 
 def init_app(app: Flask):
-    from flask_compress import Compress
+    if app.config.get('API_COMPRESSION_ENABLED', False):
+        from flask_compress import Compress
 
-    if app.config('API_COMPRESSION_ENABLED', False):
         compress = Compress()
         compress.init_app(app)
+

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -1,8 +1,10 @@
 from flask import Flask
 from flask_compress import Compress
 
-compress = Compress()
+
 
 
 def init_app(app: Flask):
-    compress.init_app(app)
+    if app.config['API_COMPRESSION_ENABLED']:
+        compress = Compress()
+        compress.init_app(app)

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -1,8 +1,9 @@
 from flask import Flask
-from flask_compress import Compress
 
 
 def init_app(app: Flask):
+    from flask_compress import Compress
+
     if app.config['API_COMPRESSION_ENABLED']:
         compress = Compress()
         compress.init_app(app)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -68,3 +68,4 @@ gmpy2~=2.1.5
 numexpr~=2.9.0
 duckduckgo-search==4.4.3
 arxiv==2.1.0
+Flask-Compress~=1.14

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4==4.12.2
 flask~=3.0.1
 Flask-SQLAlchemy~=3.0.5
 SQLAlchemy~=1.4.28
+Flask-Compress~=1.14
 flask-login~=0.6.3
 flask-migrate~=4.0.5
 flask-restful~=0.3.10
@@ -68,4 +69,3 @@ gmpy2~=2.1.5
 numexpr~=2.9.0
 duckduckgo-search==4.4.3
 arxiv==2.1.0
-Flask-Compress~=1.14


### PR DESCRIPTION
# Description

- Support response compression in api module on demand, if `Accept-Encoding` header in request is set to `gzip` or `br`
- content compression helps to reduce the traffic impact when the browser accessing API modules, considering ~100KB response content respond for pulling model providers, tool providers and etc, will be shrinked down to ~20KB
- The reverse proxy like nginx will bypass the content from API module if they are properly compressed avoiding repeated compression
- `flask-compress` module is used, docs and available options refer to : https://github.com/colour-science/flask-compress
- Introduce `API_COMPRESSION_ENABLED` env to control whether enable response compresson
- Compress the following MIME types by default:
  -  'application/json'
  - 'application/javascript',  
  - 'text/css'
  - 'text/html'
  - 'text/javascript'
  - 'text/xml'
- taking `/console/api/workspaces/current/model-providers` for example, transferred size gets down from 112KB to 7.6KB
![image](https://github.com/langgenius/dify/assets/1935105/a1cdadae-ab7d-4275-9237-5f53329f0681)


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
