### PR TITLE
fix: check webhook key of Wecom tool in valid UUID form and fix typo

### DIFF
--- a/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
+++ b/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Any, Union
 
 import httpx

--- a/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
+++ b/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
@@ -1,9 +1,11 @@
+import uuid
 from typing import Any, Union
 
 import httpx
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
+from core.tools.utils.uuid_utils import is_valid_uuid
 
 
 class WecomRepositoriesTool(BuiltinTool):
@@ -17,8 +19,9 @@ class WecomRepositoriesTool(BuiltinTool):
             return self.create_text_message('Invalid parameter content')
 
         hook_key = tool_parameters.get('hook_key', '')
-        if not hook_key:
-            return self.create_text_message('Invalid parameter hook_key')
+        if not is_valid_uuid(hook_key):
+            return self.create_text_message(
+                f'Invalid parameter hook_key ${hook_key}, not a valid UUID')
 
         msgtype = 'text'
         api_url = 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send'

--- a/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
+++ b/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
@@ -7,7 +7,7 @@ from core.tools.tool.builtin_tool import BuiltinTool
 from core.tools.utils.uuid_utils import is_valid_uuid
 
 
-class WecomRepositoriesTool(BuiltinTool):
+class WecomGroupBotTool(BuiltinTool):
     def _invoke(self, user_id: str, tool_parameters: dict[str, Any]
                 ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """

--- a/api/core/tools/provider/builtin/wecom/wecom.py
+++ b/api/core/tools/provider/builtin/wecom/wecom.py
@@ -1,8 +1,8 @@
-from core.tools.provider.builtin.wecom.tools.wecom_group_bot import WecomRepositoriesTool
+from core.tools.provider.builtin.wecom.tools.wecom_group_bot import WecomGroupBotTool
 from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
 
 
 class WecomProvider(BuiltinToolProviderController):
     def _validate_credentials(self, credentials: dict) -> None:
-        WecomRepositoriesTool()
+        WecomGroupBotTool()
         pass

--- a/api/core/tools/utils/uuid_utils.py
+++ b/api/core/tools/utils/uuid_utils.py
@@ -1,0 +1,9 @@
+import uuid
+
+
+def is_valid_uuid(uuid_str: str) -> bool:
+    try:
+        uuid.UUID(uuid_str)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
# Description

- check if the `hook_key` parameter a valid UUID of  version 1, 3, 4, and 5  according to RFC4122 : https://docs.python.org/3/library/uuid.html
- fix the typo in Wecom tool

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
