### PR TITLE
fix: valid password on reset-password page

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -15,7 +15,7 @@ from events.tenant_event import tenant_was_created
 from extensions.ext_redis import redis_client
 from libs.helper import get_remote_ip
 from libs.passport import PassportService
-from libs.password import compare_password, hash_password
+from libs.password import compare_password, hash_password, valid_password
 from libs.rsa import generate_key_pair
 from models.account import *
 from services.errors.account import (
@@ -58,7 +58,7 @@ class AccountService:
             account.current_tenant_id = available_ta.tenant_id
             available_ta.current = True
             db.session.commit()
-       
+
         if datetime.utcnow() - account.last_active_at > timedelta(minutes=10):
             account.last_active_at = datetime.utcnow()
             db.session.commit()
@@ -104,6 +104,9 @@ class AccountService:
         if account.password and not compare_password(password, account.password, account.password_salt):
             raise CurrentPasswordIncorrectError("Current password is incorrect.")
 
+        # may be raised
+        valid_password(new_password)
+
         # generate password salt
         salt = secrets.token_bytes(16)
         base64_salt = base64.b64encode(salt).decode()
@@ -140,9 +143,9 @@ class AccountService:
 
         account.interface_language = interface_language
         account.interface_theme = interface_theme
-        
+
         # Set timezone based on language
-        account.timezone = language_timezone_mapping.get(interface_language, 'UTC') 
+        account.timezone = language_timezone_mapping.get(interface_language, 'UTC')
 
         db.session.add(account)
         db.session.commit()
@@ -279,7 +282,7 @@ class TenantService:
         tenant_account_join = TenantAccountJoin.query.filter_by(account_id=account.id, tenant_id=tenant_id).first()
         if not tenant_account_join:
             raise AccountNotLinkTenantError("Tenant not found or account is not a member of the tenant.")
-        else: 
+        else:
             TenantAccountJoin.query.filter(TenantAccountJoin.account_id == account.id, TenantAccountJoin.tenant_id != tenant_id).update({'current': False})
             tenant_account_join.current = True
             # Set the current tenant for the account
@@ -449,7 +452,7 @@ class RegisterService:
         return account
 
     @classmethod
-    def invite_new_member(cls, tenant: Tenant, email: str, language: str, role: str = 'normal', inviter: Account = None) -> str:    
+    def invite_new_member(cls, tenant: Tenant, email: str, language: str, role: str = 'normal', inviter: Account = None) -> str:
         """Invite new member"""
         account = Account.query.filter_by(email=email).first()
 

--- a/web/app/activate/activateForm.tsx
+++ b/web/app/activate/activateForm.tsx
@@ -62,8 +62,10 @@ const ActivateForm = () => {
       showErrorMessage(t('login.error.passwordEmpty'))
       return false
     }
-    if (!validPassword.test(password))
+    if (!validPassword.test(password)) {
       showErrorMessage(t('login.error.passwordInvalid'))
+      return false
+    }
 
     return true
   }, [name, password, showErrorMessage, t])

--- a/web/app/components/header/account-setting/account-page/index.tsx
+++ b/web/app/components/header/account-setting/account-page/index.tsx
@@ -71,10 +71,14 @@ export default function AccountPage() {
       showErrorMessage(t('login.error.passwordEmpty'))
       return false
     }
-    if (!validPassword.test(password))
+    if (!validPassword.test(password)) {
       showErrorMessage(t('login.error.passwordInvalid'))
-    if (password !== confirmPassword)
+      return false
+    }
+    if (password !== confirmPassword) {
       showErrorMessage(t('common.account.notEqual'))
+      return false
+    }
 
     return true
   }


### PR DESCRIPTION
# Description

web: if new_password is invalid, it should be stop request to api.
api: if new_password is invalid, it should be raised on the `/account/password`

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

old: 
1. click Account -> Settings -> Reset Password 
2. input a new simple password
3. save, it is successful, but re-login is fail

new: 
1. click Account -> Settings -> Reset Password 
2. input a new simple password
3. save, it is stop request

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
