### PR TITLE
SMTP authentication is optional

### DIFF
--- a/api/extensions/ext_mail.py
+++ b/api/extensions/ext_mail.py
@@ -32,8 +32,6 @@ class Mail:
                 from libs.smtp import SMTPClient
                 if not app.config.get('SMTP_SERVER') or not app.config.get('SMTP_PORT'):
                     raise ValueError('SMTP_SERVER and SMTP_PORT are required for smtp mail type')
-                if not app.config.get('SMTP_USERNAME') or not app.config.get('SMTP_PASSWORD'):
-                    raise ValueError('SMTP_USERNAME and SMTP_PASSWORD are required for smtp mail type')
                 self._client = SMTPClient(
                     server=app.config.get('SMTP_SERVER'),
                     port=app.config.get('SMTP_PORT'),

--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -16,7 +16,8 @@ class SMTPClient:
         smtp = smtplib.SMTP(self.server, self.port)
         if self._use_tls:
             smtp.starttls()
-        smtp.login(self.username, self.password)
+        if (self.username):
+            smtp.login(self.username, self.password)
         msg = MIMEMultipart()
         msg['Subject'] = mail['subject']
         msg['From'] = self._from


### PR DESCRIPTION
# Description

Not all SMTP servers require authentication. It should be possible to configure SMTP servers to use either authenticated or unauthenticated SMTP

Fixes #2764

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I rebuild the docker image and configure an smtp server without username/password, then add a user from the gui and verify that the user receive the email.
- [X] also check the log : Task tasks.mail_invite_member_task.send_invite_member_mail_task[ae4e5264-3990-4370-bd3b-5f9c1e3cbd38] succeeded in 0.2560313250000945s: None

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
