### PR TITLE
Refactor Markdown component to include paragraph after image

### DIFF
--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -162,14 +162,17 @@ export function Markdown(props: { content: string; className?: string }) {
               const image = node.children[0]
 
               return (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={image.properties.src}
-                  width={250}
-                  height={250}
-                  className="max-w-full h-auto align-middle border-none rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out mt-2 mb-2"
-                  alt={image.properties.alt}
-                />
+                <>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={image.properties.src}
+                    width={250}
+                    height={250}
+                    className="max-w-full h-auto align-middle border-none rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out mt-2 mb-2"
+                    alt={image.properties.alt}
+                  />
+                  <p>{paragraph.children.slice(1)}</p>
+                </>
               )
             }
             return <p>{paragraph.children}</p>


### PR DESCRIPTION
# Description

When the return result of the model is in the following image-plus-text format, the text following the image is not rendered:
```
![text](url)
Description of the image
```

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Create an Agent Assistant (gpt-4-0125-preview) that includes Google tools, using the following Instruction:

> When a user needs you to search for an image, you perform a search using Google and then use the first URL (and only the first) result to answer the question. 
> Your response must be in this format:
> ```markdown
> ![text](url)
> Description of the image source
> ```

2. Send "search "Image of Elon Musk"
3. Display the image followed by a text description

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
