### PR TITLE
support markdown message type in Wecom group bot tool

### DIFF
--- a/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
+++ b/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
@@ -3,16 +3,29 @@ from typing import Any, Union
 import httpx
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.provider.builtin.wecom.tools.constants import supported_msgtypes
 from core.tools.tool.builtin_tool import BuiltinTool
 from core.tools.utils.uuid_utils import is_valid_uuid
 
 
 class WecomGroupBotTool(BuiltinTool):
+    """
+        Wecom group bot API docs:
+        https://developer.work.weixin.qq.com/document/path/91770
+    """
+
+    MSGTYPE_TEXT = 'text'
+    MSGTYPE_MARKDOWN = 'markdown'
+    supported_msgtypes = [MSGTYPE_TEXT, MSGTYPE_MARKDOWN]
+
     def _invoke(self, user_id: str, tool_parameters: dict[str, Any]
                 ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
-        """
-            invoke tools
-        """
+
+        msgtype = tool_parameters.get('msgtype', self.MSGTYPE_TEXT)
+        if msgtype not in supported_msgtypes:
+            return self.create_text_message(
+                f'Invalid parameter msg_type ${msgtype}, not in supported msg types {self.supported_msgtypes}')
+
         content = tool_parameters.get('content', '')
         if not content:
             return self.create_text_message('Invalid parameter content')
@@ -22,7 +35,6 @@ class WecomGroupBotTool(BuiltinTool):
             return self.create_text_message(
                 f'Invalid parameter hook_key ${hook_key}, not a valid UUID')
 
-        msgtype = 'text'
         api_url = 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send'
         headers = {
             'Content-Type': 'application/json',
@@ -30,14 +42,10 @@ class WecomGroupBotTool(BuiltinTool):
         params = {
             'key': hook_key,
         }
-        payload = {
-            "msgtype": msgtype,
-            "text": {
-                "content": content,
-            }
-        }
 
         try:
+            payload = self.assemble_payload(msgtype, content)
+
             res = httpx.post(api_url, headers=headers, params=params, json=payload)
             if res.is_success:
                 return self.create_text_message("Text message sent successfully")
@@ -46,3 +54,28 @@ class WecomGroupBotTool(BuiltinTool):
                     f"Failed to send the text message, status code: {res.status_code}, response: {res.text}")
         except Exception as e:
             return self.create_text_message("Failed to send message to group chat bot. {}".format(e))
+
+    def assemble_payload(self, msgtype: str, content: str) -> dict[str, Any]:
+        match msgtype:
+            case self.MSGTYPE_TEXT:
+                # doc ref:
+                # https://developer.work.weixin.qq.com/document/path/91770#%E6%96%87%E6%9C%AC%E7%B1%BB%E5%9E%8B
+                payload = {
+                    'msgtype': msgtype,
+                    'text': {
+                        'content': content,
+                    }
+                }
+            case self.MSGTYPE_MARKDOWN:
+                # doc ref:
+                # https://developer.work.weixin.qq.com/document/path/91770#markdown%E7%B1%BB%E5%9E%8B
+                payload = {
+                    'msgtype': msgtype,
+                    'markdown': {
+                        'content': content,
+                    }
+                }
+            case _:
+                raise ValueError(f"Unsupported msgtype: {msgtype}")
+
+        return payload

--- a/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
+++ b/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.py
@@ -3,7 +3,6 @@ from typing import Any, Union
 import httpx
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from core.tools.provider.builtin.wecom.tools.constants import supported_msgtypes
 from core.tools.tool.builtin_tool import BuiltinTool
 from core.tools.utils.uuid_utils import is_valid_uuid
 

--- a/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.yaml
+++ b/api/core/tools/provider/builtin/wecom/tools/wecom_group_bot.yaml
@@ -25,6 +25,26 @@ parameters:
       zh_Hans: 群机器人webhook的key
       pt_BR: Wecom Group bot webhook key
     form: form
+  - name: msgtype
+    type: select
+    required: true
+    default: text
+    options:
+      - value: text
+        label:
+          en_US: Text
+          zh_Hans: 文本类型
+      - value: markdown
+        label:
+          en_US: Markdown
+          zh_Hans: markdown类型
+    label:
+      en_US: Message Type
+      zh_Hans: 消息类型
+    human_description:
+      en_US: Message Type
+      zh_Hans: 消息类型
+    form: form
   - name: content
     type: string
     required: true
@@ -36,5 +56,5 @@ parameters:
       en_US: Content to sent to the group.
       zh_Hans: 群消息文本
       pt_BR: Content to sent to the group.
-    llm_description: Content of the message
+    llm_description: Text content of the message. If the message type is text, the content should be plain text. If the message type is markdown, the content should be in markdown format.
     form: llm


### PR DESCRIPTION
# Description

- allow to set message type in `markdown` and sent to Wecom group with text in markdown format
- API ref: https://developer.work.weixin.qq.com/document/path/91770#markdown%E7%B1%BB%E5%9E%8B

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
