### PR TITLE
enhance: use override_settings for concurrent stable diffusion

### DIFF
--- a/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.py
+++ b/api/core/tools/provider/builtin/stablediffusion/tools/stable_diffusion.py
@@ -131,7 +131,8 @@ class StableDiffusionTool(BuiltinTool):
                                     negative_prompt=negative_prompt,
                                     width=width,
                                     height=height,
-                                    steps=steps)
+                                    steps=steps,
+                                    model=model)
             
         return self.text2img(base_url=base_url,
                              lora=lora,
@@ -139,7 +140,8 @@ class StableDiffusionTool(BuiltinTool):
                              negative_prompt=negative_prompt,
                              width=width,
                              height=height,
-                             steps=steps)
+                             steps=steps,
+                             model=model)
 
     def validate_models(self) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
@@ -197,7 +199,7 @@ class StableDiffusionTool(BuiltinTool):
 
     def img2img(self, base_url: str, lora: str, image_binary: bytes, 
                 prompt: str, negative_prompt: str,
-                width: int, height: int, steps: int) \
+                width: int, height: int, steps: int, model: str) \
         -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             generate image
@@ -213,7 +215,8 @@ class StableDiffusionTool(BuiltinTool):
             "sampler_name": "Euler a",
             "restore_faces": False,
             "steps": steps,
-            "script_args": ["outpainting mk2"]
+            "script_args": ["outpainting mk2"],
+            "override_settings": {"sd_model_checkpoint": model}
         }
 
         if lora:
@@ -236,7 +239,7 @@ class StableDiffusionTool(BuiltinTool):
         except Exception as e:
             return self.create_text_message('Failed to generate image')
 
-    def text2img(self, base_url: str, lora: str, prompt: str, negative_prompt: str, width: int, height: int, steps: int) \
+    def text2img(self, base_url: str, lora: str, prompt: str, negative_prompt: str, width: int, height: int, steps: int, model: str) \
         -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         """
             generate image
@@ -253,6 +256,7 @@ class StableDiffusionTool(BuiltinTool):
         draw_options['height'] = height
         draw_options['steps'] = steps
         draw_options['negative_prompt'] = negative_prompt
+        draw_options['override_settings']['sd_model_checkpoint'] = model
         
         try:
             url = str(URL(base_url) / 'sdapi' / 'v1' / 'txt2img')


### PR DESCRIPTION
# Description

**Put the model name into `override_settings` for concurrent.**

The origin function is including:
1. "/sdapi/v1/options": set model
2. "/sdapi/v1/txt2img(img2img)": generate images

However, when there are two concurrent requests, it might not work as expected:
- set model(first request) -> set model(second request) -> generate images(first request) -> generate images(second request)
- The second request will get the wrong images with wrong model.

So, we could put the model name into `override_settings` to ensure generate correct images with the corresponding model.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
