### PR TITLE
support markdown message type in Dingtalk group bot tool #2817

### DIFF
--- a/api/core/tools/provider/builtin/dingtalk/tools/dingtalk_group_bot.yaml
+++ b/api/core/tools/provider/builtin/dingtalk/tools/dingtalk_group_bot.yaml
@@ -37,6 +37,26 @@ parameters:
       zh_Hans: 加签秘钥
       pt_BR: secret key for signing
     form: form
+  - name: msgtype
+    type: select
+    required: true
+    default: text
+    options:
+      - value: text
+        label:
+          en_US: Text
+          zh_Hans: 文本类型
+      - value: markdown
+        label:
+          en_US: Markdown
+          zh_Hans: markdown类型
+    label:
+      en_US: Message Type
+      zh_Hans: 消息类型
+    human_description:
+      en_US: Message Type
+      zh_Hans: 消息类型
+    form: form
   - name: content
     type: string
     required: true

--- a/api/core/tools/provider/builtin/dingtalk/tools/dingtalk_group_bot.yaml
+++ b/api/core/tools/provider/builtin/dingtalk/tools/dingtalk_group_bot.yaml
@@ -70,3 +70,14 @@ parameters:
       pt_BR: Content to sent to the group.
     llm_description: Content of the message
     form: llm
+  - name: title
+    type: string
+    required: false
+    label:
+      en_US: Title of message (Required for markdown message type)
+      zh_Hans: 消息标题(Markdown类型消息时为必须)
+    human_description:
+      en_US: Title of message (Required for markdown message type)
+      zh_Hans: 消息标题(Markdown类型消息时为必须)
+    llm_description: Title of the message. If the message type is markdown, this field is required.
+    form: llm


### PR DESCRIPTION
# Description

- allow to set message type in `markdown` and sent to Dingtalk group with text in markdown format
- API ref for message type: https://open.dingtalk.com/document/orgapp/custom-robot-access#title-72m-8ag-pqw

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
