### PR TITLE
fix: The generate conversation name was not saved

### DIFF
--- a/api/events/event_handlers/generate_conversation_name_when_first_message_created.py
+++ b/api/events/event_handlers/generate_conversation_name_when_first_message_created.py
@@ -26,5 +26,6 @@ def handle(sender, **kwargs):
                 conversation.name = name
             except:
                 pass
-
+                
+            db.session.merge(conversation)
             db.session.commit()


### PR DESCRIPTION
# Description

fixed the conversation name was not saved,  
The handle function received a conversation in a detached state, causing the conversation's name to not be saved.
This results in the preview page conversation name always being 'new conversation'.
Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
