### PR TITLE
fix: charts encoding

### DIFF
--- a/api/core/tools/provider/builtin/chart/chart.py
+++ b/api/core/tools/provider/builtin/chart/chart.py
@@ -1,4 +1,6 @@
 import matplotlib.pyplot as plt
+from fontTools.ttLib import TTFont
+from matplotlib.font_manager import findSystemFonts
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin.chart.tools.line import LinearChartTool
@@ -6,6 +8,37 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 # use a business theme
 plt.style.use('seaborn-v0_8-darkgrid')
+plt.rcParams['axes.unicode_minus'] = False
+
+def init_fonts():
+    fonts = findSystemFonts()
+
+    popular_unicode_fonts = [
+        'Arial Unicode MS', 'DejaVu Sans', 'DejaVu Sans Mono', 'DejaVu Serif', 'FreeMono', 'FreeSans', 'FreeSerif',
+        'Liberation Mono', 'Liberation Sans', 'Liberation Serif', 'Noto Mono', 'Noto Sans', 'Noto Serif', 'Open Sans',
+        'Roboto', 'Source Code Pro', 'Source Sans Pro', 'Source Serif Pro', 'Ubuntu', 'Ubuntu Mono'
+    ]
+
+    supported_fonts = []
+
+    for font_path in fonts:
+        try:
+            font = TTFont(font_path)
+            # get family name
+            family_name = font['name'].getName(1, 3, 1).toUnicode()
+            if family_name in popular_unicode_fonts:
+                supported_fonts.append(family_name)
+        except:
+            pass
+
+    plt.rcParams['font.family'] = 'sans-serif'
+    # sort by order of popular_unicode_fonts
+    for font in popular_unicode_fonts:
+        if font in supported_fonts:
+            plt.rcParams['font.sans-serif'] = font
+            break
+    
+init_fonts()
 
 class ChartProvider(BuiltinToolProviderController):
     def _validate_credentials(self, credentials: dict) -> None:


### PR DESCRIPTION
# Description

Fetch all fonts support Unicode and then set the default encoding of matplotlib.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
