### PR TITLE
refactor event handlers in GenerateTaskPipeline for expansibility

### DIFF
--- a/api/core/app_runner/generate_task_pipeline.py
+++ b/api/core/app_runner/generate_task_pipeline.py
@@ -118,7 +118,7 @@ class GenerateTaskPipeline:
                 try:
                     result = handler(event)
                     if result:
-                        yield result
+                        return result
                 except Exception as e:
                     raise e
             else:


### PR DESCRIPTION
# Description

- refactor event handlers in GenerateTaskPipeline in blocking and streaming mode
- reduce redundant code for handling events (especially no-return-response events), eg. AnnotationReplyEvent, 
QueueRetrieverResourcesEvent
Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
