### PR TITLE
fix incorrect exception raised by api tool which leads to incorrect L…

### DIFF
--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -9,11 +9,7 @@ import requests
 import core.helper.ssrf_proxy as ssrf_proxy
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from core.tools.errors import (
-    ToolProviderCredentialValidationError, 
-    ToolParameterValidationError, 
-    ToolInvokeError
-)
+from core.tools.errors import ToolInvokeError, ToolParameterValidationError, ToolProviderCredentialValidationError
 from core.tools.tool.tool import Tool
 
 API_TOOL_DEFAULT_TIMEOUT = (10, 60)

--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -9,7 +9,11 @@ import requests
 import core.helper.ssrf_proxy as ssrf_proxy
 from core.tools.entities.tool_bundle import ApiBasedToolBundle
 from core.tools.entities.tool_entities import ToolInvokeMessage
-from core.tools.errors import ToolProviderCredentialValidationError
+from core.tools.errors import (
+    ToolProviderCredentialValidationError, 
+    ToolParameterValidationError, 
+    ToolInvokeError
+)
 from core.tools.tool.tool import Tool
 
 API_TOOL_DEFAULT_TIMEOUT = (10, 60)
@@ -81,7 +85,7 @@ class ApiTool(Tool):
         needed_parameters = [parameter for parameter in self.api_bundle.parameters if parameter.required]
         for parameter in needed_parameters:
             if parameter.required and parameter.name not in parameters:
-                raise ToolProviderCredentialValidationError(f"Missing required parameter {parameter.name}")
+                raise ToolParameterValidationError(f"Missing required parameter {parameter.name}")
             
             if parameter.default is not None and parameter.name not in parameters:
                 parameters[parameter.name] = parameter.default
@@ -94,7 +98,7 @@ class ApiTool(Tool):
         """
         if isinstance(response, httpx.Response):
             if response.status_code >= 400:
-                raise ToolProviderCredentialValidationError(f"Request failed with status code {response.status_code}")
+                raise ToolInvokeError(f"Request failed with status code {response.status_code} and {response.text}")
             if not response.content:
                 return 'Empty response from the tool, please check your parameters and try again.'
             try:
@@ -107,7 +111,7 @@ class ApiTool(Tool):
                 return response.text
         elif isinstance(response, requests.Response):
             if not response.ok:
-                raise ToolProviderCredentialValidationError(f"Request failed with status code {response.status_code}")
+                raise ToolInvokeError(f"Request failed with status code {response.status_code} and {response.text}")
             if not response.content:
                 return 'Empty response from the tool, please check your parameters and try again.'
             try:
@@ -139,7 +143,7 @@ class ApiTool(Tool):
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
                 elif parameter['required']:
-                    raise ToolProviderCredentialValidationError(f"Missing required parameter {parameter['name']}")
+                    raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')
                 path_params[parameter['name']] = value
@@ -149,7 +153,7 @@ class ApiTool(Tool):
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
                 elif parameter['required']:
-                    raise ToolProviderCredentialValidationError(f"Missing required parameter {parameter['name']}")
+                    raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')
                 params[parameter['name']] = value
@@ -159,7 +163,7 @@ class ApiTool(Tool):
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
                 elif parameter['required']:
-                    raise ToolProviderCredentialValidationError(f"Missing required parameter {parameter['name']}")
+                    raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')
                 cookies[parameter['name']] = value
@@ -169,7 +173,7 @@ class ApiTool(Tool):
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
                 elif parameter['required']:
-                    raise ToolProviderCredentialValidationError(f"Missing required parameter {parameter['name']}")
+                    raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')
                 headers[parameter['name']] = value
@@ -188,7 +192,7 @@ class ApiTool(Tool):
                             # convert type
                             body[name] = self._convert_body_property_type(property, parameters[name])
                         elif name in required:
-                            raise ToolProviderCredentialValidationError(
+                            raise ToolParameterValidationError(
                                 f"Missing required parameter {name} in operation {self.api_bundle.operation_id}"
                             )
                         elif 'default' in property:


### PR DESCRIPTION
fix incorrect exception raised by api tool which leads to incorrect LLM response

# Description

The current code always raise ToolProviderCredentialValidationError exception event though credential is correct

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
