### PR TITLE
fix: Ignore some emtpy page_content when append to split_documents

### DIFF
--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -45,11 +45,12 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
                     # delete Spliter character
                     page_content = document_node.page_content
                     if page_content.startswith(".") or page_content.startswith("。"):
-                        page_content = page_content[1:]
+                        page_content = page_content[1:].strip()
                     else:
                         page_content = page_content
-                    document_node.page_content = page_content
-                    split_documents.append(document_node)
+                    if len(page_content) > 0:
+                        document_node.page_content = page_content
+                        split_documents.append(document_node)
             all_documents.extend(split_documents)
         return all_documents
 


### PR DESCRIPTION
# Description

After splitting a document into several chunks, some chunks may end up containing only the characters '.' or '。'. Therefore, when the # Delete Splitter Character code is executed, these chunks will be transformed into empty strings. To prevent appending empty strings to split_documents, such chunks should be disregarded beforehand. Failing to do so could introduce unexpected outcomes during the embedding and re-ranking process.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When importing documents containing paragraphs that consist solely of spaces and conclude with '。', ensure there are no empty strings appended to split_documents.

- [ ] TODO

# Suggested Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
