### PR TITLE
fix: init qdrant vector max recursion

### DIFF
--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -66,7 +66,7 @@ class Vector:
                     raise ValueError('Dataset Collection Bindings is not exist!')
             else:
                 if self._dataset.index_struct_dict:
-                    class_prefix: str = self.dataset.index_struct_dict['vector_store']['class_prefix']
+                    class_prefix: str = self._dataset.index_struct_dict['vector_store']['class_prefix']
                     collection_name = class_prefix
                 else:
                     dataset_id = self._dataset.id


### PR DESCRIPTION
# Description

init qdrant vector will report max recursion error when exec:

class_prefix: str = self.dataset.index_struct_dict['vector_store']['class_prefix']

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
