### PR TITLE
Add S3_ADDRESS_STYLE configuration option

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -22,6 +22,7 @@ DEFAULTS = {
     'SERVICE_API_URL': 'https://api.dify.ai',
     'APP_WEB_URL': 'https://udify.app',
     'FILES_URL': '',
+    'S3_ADDRESS_STYLE': 'auto',
     'STORAGE_TYPE': 'local',
     'STORAGE_LOCAL_PATH': 'storage',
     'CHECK_UPDATE_URL': 'https://updates.dify.ai',
@@ -180,6 +181,7 @@ class Config:
         self.S3_ACCESS_KEY = get_env('S3_ACCESS_KEY')
         self.S3_SECRET_KEY = get_env('S3_SECRET_KEY')
         self.S3_REGION = get_env('S3_REGION')
+        self.S3_ADDRESS_STYLE = get_env('S3_ADDRESS_STYLE')
         self.AZURE_BLOB_ACCOUNT_NAME = get_env('AZURE_BLOB_ACCOUNT_NAME')
         self.AZURE_BLOB_ACCOUNT_KEY = get_env('AZURE_BLOB_ACCOUNT_KEY')
         self.AZURE_BLOB_CONTAINER_NAME = get_env('AZURE_BLOB_CONTAINER_NAME')

--- a/api/extensions/ext_storage.py
+++ b/api/extensions/ext_storage.py
@@ -8,6 +8,7 @@ from typing import Union
 import boto3
 from azure.storage.blob import AccountSasPermissions, BlobServiceClient, ResourceTypes, generate_account_sas
 from botocore.exceptions import ClientError
+from botocore.client import Config
 from flask import Flask
 
 
@@ -27,7 +28,8 @@ class Storage:
                 aws_secret_access_key=app.config.get('S3_SECRET_KEY'),
                 aws_access_key_id=app.config.get('S3_ACCESS_KEY'),
                 endpoint_url=app.config.get('S3_ENDPOINT'),
-                region_name=app.config.get('S3_REGION')
+                region_name=app.config.get('S3_REGION'),
+                config=Config(s3={'addressing_style': app.config.get('S3_ADDRESS_STYLE')})
             )
         elif self.storage_type == 'azure-blob':
             self.bucket_name = app.config.get('AZURE_BLOB_CONTAINER_NAME')

--- a/api/extensions/ext_storage.py
+++ b/api/extensions/ext_storage.py
@@ -7,8 +7,8 @@ from typing import Union
 
 import boto3
 from azure.storage.blob import AccountSasPermissions, BlobServiceClient, ResourceTypes, generate_account_sas
-from botocore.exceptions import ClientError
 from botocore.client import Config
+from botocore.exceptions import ClientError
 from flask import Flask
 
 


### PR DESCRIPTION
# Description

Tencent COS does not support virtual-hosted-style bucket after 2024.1.1, see the [notice](https://cloud.tencent.com/document/product/436/96243)

In order to use Tencent COS as external storage, addressing style must set to `virtual` instead of `auto`(default value)

https://boto3.amazonaws.com/v1/documentation/api/1.9.42/guide/s3.html#changing-the-addressing-style 

This pull request add a new configuration key to support this.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] import config and execute get_env

```
>>> from config import get_env
>>> get_env('S3_ADDRESS_STYLE')
'auto'
```

This return the default value of s3 client, which will not change the default behavior, anyone in need can change the settings to archive their goal.

IMHO, The code change is trivial and need no further test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [x] `optional` New and existing unit tests pass locally with my changes
