### PR TITLE
Authentication is only applied when both the username and password have values.

### DIFF
--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -16,7 +16,7 @@ class SMTPClient:
         smtp = smtplib.SMTP(self.server, self.port)
         if self._use_tls:
             smtp.starttls()
-        if (self.username):
+        if self.username and self.password:
             smtp.login(self.username, self.password)
         msg = MIMEMultipart()
         msg['Subject'] = mail['subject']


### PR DESCRIPTION
# Description

`no auth` in smtp is implemented in https://github.com/langgenius/dify/pull/2765 , but there's a bug, [SMTP.sendmail](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.sendmail) requires the first sender address as the first argument.

When username is set to none, the auth is skipped but `sendmail` would fail due to the type error

When username is set to empty string, the auth is skipped , mail was sent, but this mail envelope does not include sender info, which could lead to rejection by server.

So the correct configuration for `no-auth` smtp would be 

```
SMTP_USERNAME=no-reply@example.com
SMTP_PASSWORD="" # or just dont set
```

In the current logic, if a username is provided, authentication will be performed, which is not as expected. Therefore, the logic of authentication at this point needs to be modified from authenticating when a username is present to authenticating only when both username and password are provided.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] import SMPTClient and try to send a mail

```
>>> from smtp import SMTPClient
>>> c = SMTPClient("mail.example.com", 25, "no-reply@example.com", "", "no-reply@example.com")
>>> c.send({"subject": "test", "to": "my-box@example.com", "html": "<p>hello</p>"})
```

And I can receive the mail.


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [x] `optional` New and existing unit tests pass locally with my changes
