### PR TITLE
feat: remove redundant classes

### DIFF
--- a/web/app/components/app/chat/index.tsx
+++ b/web/app/components/app/chat/index.tsx
@@ -385,10 +385,10 @@ const Chat: FC<IChatProps> = ({
                 )
               }
               <Textarea
-                className={`
-                  block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-sm text-gray-700 outline-none appearance-none resize-none
-                  ${visionConfig?.enabled && 'pl-12'}
-                `}
+                className={cn(
+                  'block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-sm text-gray-700 outline-none appearance-none resize-none',
+                  visionConfig?.enabled && 'pl-12')
+                }
                 value={query}
                 onChange={handleContentChange}
                 onKeyUp={handleKeyUp}

--- a/web/app/components/app/chat/question/index.tsx
+++ b/web/app/components/app/chat/question/index.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react'
 import React, { useRef } from 'react'
 import { useContext } from 'use-context-selector'
+import cn from 'classnames'
 import s from '../style.module.css'
 import type { IChatItem } from '../type'
 import Log from '../log'
@@ -23,7 +24,7 @@ const Question: FC<IQuestionProps> = ({ id, content, more, useCurrentUserAvatar,
   const imgSrcs = item.message_files?.map(item => item.url)
 
   return (
-    <div className={`flex items-start justify-end ${isShowPromptLog && 'first-of-type:pt-[14px]'}`} key={id} ref={ref}>
+    <div className={cn('flex items-start justify-end', isShowPromptLog && 'first-of-type:pt-[14px]')} key={id} ref={ref}>
       <div className={s.questionWrapWrap}>
 
         <div className={`${s.question} group relative text-sm text-gray-900`}>

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useMemo,
 } from 'react'
+import cn from 'classnames'
 import { APP_CHAT_WITH_MULTIPLE_MODEL } from '../types'
 import DebugItem from './debug-item'
 import {
@@ -104,13 +105,13 @@ const DebugWithMultipleModel = () => {
             <DebugItem
               key={modelConfig.id}
               modelAndParameter={modelConfig}
-              className={`
-                absolute left-6 top-0 min-h-[200px]
-                ${twoLine && index === 0 && 'mr-2'}
-                ${threeLine && (index === 0 || index === 1) && 'mr-2'}
-                ${fourLine && (index === 0 || index === 2) && 'mr-2'}
-                ${fourLine && (index === 0 || index === 1) && 'mb-2'}
-              `}
+              className={cn(
+                'absolute left-6 top-0 min-h-[200px]',
+                twoLine && index === 0 && 'mr-2',
+                threeLine && (index === 0 || index === 1) && 'mr-2',
+                fourLine && (index === 0 || index === 2) && 'mr-2',
+                fourLine && (index === 0 || index === 1) && 'mb-2')
+              }
               style={{
                 width: size.width,
                 height: size.height,

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/model-parameter-trigger.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/model-parameter-trigger.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import type { ModelAndParameter } from '../types'
 import { useDebugWithMultipleModelContext } from './context'
 import ModelParameterModal from '@/app/components/header/account-setting/model-provider-page/model-parameter-modal'
@@ -71,11 +72,11 @@ const ModelParameterTrigger: FC<ModelParameterTriggerProps> = ({
         currentModel,
       }) => (
         <div
-          className={`
-            flex items-center max-w-[200px] h-8 px-2 rounded-lg cursor-pointer
-            ${open && 'bg-gray-100'}
-            ${currentModel && currentModel.status !== ModelStatusEnum.active && '!bg-[#FFFAEB]'}
-          `}
+          className={cn(
+            'flex items-center max-w-[200px] h-8 px-2 rounded-lg cursor-pointer',
+            { 'bg-gray-100': open },
+            { '!bg-[#FFFAEB]': currentModel && currentModel.status !== ModelStatusEnum.active },
+          )}
         >
           {
             currentProvider && (

--- a/web/app/components/app/configuration/debug/index.tsx
+++ b/web/app/components/app/configuration/debug/index.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { setAutoFreeze } from 'immer'
 import { useBoolean } from 'ahooks'
 import { useContext } from 'use-context-selector'
+import cn from 'classnames'
 import HasNotSetAPIKEY from '../base/warning-mask/has-not-set-api'
 import FormattingChanged from '../base/warning-mask/formatting-changed'
 import GroupName from '../base/group-name'
@@ -376,10 +377,10 @@ const Debug: FC<IDebug> = ({
                 ? (
                   <>
                     <Button
-                      className={`
-                        h-8 px-2.5 text-[13px] font-medium text-primary-600 bg-white
-                        ${multipleModelConfigs.length >= 4 && 'opacity-30'}
-                      `}
+                      className={cn(
+                        'h-8 px-2.5 text-[13px] font-medium text-primary-600 bg-white',
+                        multipleModelConfigs.length >= 4 && 'opacity-30')
+                      }
                       onClick={() => onMultipleModelConfigsChange(true, [...multipleModelConfigs, { id: `${Date.now()}`, model: '', provider: '', parameters: {} }])}
                       disabled={multipleModelConfigs.length >= 4}
                     >

--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -751,7 +751,7 @@ const Configuration: FC = () => {
       <>
         <div className="flex flex-col h-full">
           <div className='flex grow h-[200px]'>
-            <div className={`w-full sm:w-1/2 shrink-0 flex flex-col h-full ${debugWithMultipleModel && 'max-w-[560px]'}`}>
+            <div className={cn('w-full sm:w-1/2 shrink-0 flex flex-col h-full', debugWithMultipleModel && 'max-w-[560px]')}>
               {/* Header Left */}
               <div className='flex justify-between items-center px-6 h-14'>
                 <div className='flex items-center'>

--- a/web/app/components/app/configuration/toolbox/moderation/moderation-setting-modal.tsx
+++ b/web/app/components/app/configuration/toolbox/moderation/moderation-setting-modal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import useSWR from 'swr'
 import { useContext } from 'use-context-selector'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import ModerationContent from './moderation-content'
 import FormGeneration from './form-generation'
 import ApiBasedExtensionSelector from '@/app/components/header/account-setting/api-based-extension-page/selector'
@@ -251,11 +252,11 @@ const ModerationSettingModal: FC<ModerationSettingModalProps> = ({
             providers.map(provider => (
               <div
                 key={provider.key}
-                className={`
-                  flex items-center px-3 py-2 rounded-lg text-sm text-gray-900 cursor-pointer
-                  ${localeData.type === provider.key ? 'bg-white border-[1.5px] border-primary-400 shadow-sm' : 'border border-gray-100 bg-gray-25'}
-                  ${localeData.type === 'openai_moderation' && provider.key === 'openai_moderation' && !openaiProviderConfiged && 'opacity-50'}
-                `}
+                className={cn(
+                  'flex items-center px-3 py-2 rounded-lg text-sm text-gray-900 cursor-pointer',
+                  localeData.type === provider.key ? 'bg-white border-[1.5px] border-primary-400 shadow-sm' : 'border border-gray-100 bg-gray-25',
+                  localeData.type === 'openai_moderation' && provider.key === 'openai_moderation' && !openaiProviderConfiged && 'opacity-50',
+                )}
                 onClick={() => handleDataTypeChange(provider.key)}
               >
                 <div className={`

--- a/web/app/components/app/configuration/tools/index.tsx
+++ b/web/app/components/app/configuration/tools/index.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import copy from 'copy-to-clipboard'
+import cn from 'classnames'
 import { useContext } from 'use-context-selector'
 import ConfigContext from '@/context/debug-configuration'
 import Switch from '@/app/components/base/switch'
@@ -85,10 +86,10 @@ const Tools = () => {
       <div className='flex items-center h-12'>
         <div className='grow flex items-center'>
           <div
-            className={`
-              group flex items-center justify-center mr-1 w-6 h-6 rounded-md 
-              ${externalDataToolsConfig.length && 'hover:shadow-xs hover:bg-white'}
-            `}
+            className={cn(
+              'group flex items-center justify-center mr-1 w-6 h-6 rounded-md',
+              externalDataToolsConfig.length && 'hover:shadow-xs hover:bg-white',
+            )}
             onClick={() => setExpanded(v => !v)}
           >
             {

--- a/web/app/components/base/button/index.tsx
+++ b/web/app/components/base/button/index.tsx
@@ -1,5 +1,6 @@
 import type { FC, MouseEventHandler } from 'react'
 import React from 'react'
+import cn from 'classnames'
 import Spinner from '../spinner'
 
 export type IButtonProps = {
@@ -36,7 +37,7 @@ const Button: FC<IButtonProps> = ({
 
   return (
     <div
-      className={`btn ${style} ${className || ''}`}
+      className={cn('btn', style, className)}
       tabIndex={tabIndex}
       onClick={disabled ? undefined : onClick}
     >

--- a/web/app/components/base/button/index.tsx
+++ b/web/app/components/base/button/index.tsx
@@ -36,7 +36,7 @@ const Button: FC<IButtonProps> = ({
 
   return (
     <div
-      className={`btn ${style} ${className && className}`}
+      className={`btn ${style} ${className || ''}`}
       tabIndex={tabIndex}
       onClick={disabled ? undefined : onClick}
     >

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
+import cn from 'classnames'
 import Chat from '../chat'
 import type {
   ChatConfig,
@@ -99,7 +100,7 @@ const ChatWrapper = () => {
           />
           {
             !currentConversationId && (
-              <div className={`mx-auto w-full max-w-[720px] ${isMobile && 'px-4'}`}>
+              <div className={cn('mx-auto w-full max-w-[720px]', isMobile && 'px-4')}>
                 <div className='mb-6' />
                 <ConfigPanel />
                 <div
@@ -131,9 +132,9 @@ const ChatWrapper = () => {
       config={appConfig}
       chatList={chatList}
       isResponding={isResponding}
-      chatContainerInnerClassName={`mx-auto pt-6 w-full max-w-[720px] ${isMobile && 'px-4'}`}
+      chatContainerInnerClassName={cn('mx-auto pt-6 w-full max-w-[720px]', isMobile && 'px-4')}
       chatFooterClassName='pb-4'
-      chatFooterInnerClassName={`mx-auto w-full max-w-[720px] ${isMobile && 'px-4'}`}
+      chatFooterInnerClassName={cn('mx-auto w-full max-w-[720px]', isMobile && 'px-4')}
       onSend={doSend}
       onStopResponding={handleStop}
       chatNode={chatNode}

--- a/web/app/components/base/chat/chat-with-history/config-panel/form.tsx
+++ b/web/app/components/base/chat/chat-with-history/config-panel/form.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import { useChatWithHistoryContext } from '../context'
 import Input from './form-input'
 import { PortalSelect } from '@/app/components/base/select'
@@ -58,9 +59,9 @@ const Form = () => {
         inputsForms.map(form => (
           <div
             key={form.variable}
-            className={`flex mb-3 last-of-type:mb-0 text-sm text-gray-900 ${isMobile && '!flex-wrap'}`}
+            className={cn('flex mb-3 last-of-type:mb-0 text-sm text-gray-900', isMobile && '!flex-wrap')}
           >
-            <div className={`shrink-0 mr-2 py-2 w-[128px] ${isMobile && '!w-full'}`}>{form.label}</div>
+            <div className={cn('shrink-0 mr-2 py-2 w-[128px]', isMobile && '!w-full')}>{form.label}</div>
             {renderField(form)}
           </div>
         ))

--- a/web/app/components/base/chat/chat-with-history/config-panel/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/config-panel/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import { useChatWithHistoryContext } from '../context'
 import Form from './form'
 import Button from '@/app/components/base/button'
@@ -25,18 +26,18 @@ const ConfigPanel = () => {
   return (
     <div className='flex flex-col max-h-[80%] w-full max-w-[720px]'>
       <div
-        className={`
-          grow rounded-xl overflow-y-auto
-          ${showConfigPanelBeforeChat && 'border-[0.5px] border-gray-100 shadow-lg'}
-          ${!showConfigPanelBeforeChat && collapsed && 'border border-indigo-100'}
-          ${!showConfigPanelBeforeChat && !collapsed && 'border-[0.5px] border-gray-100 shadow-lg'}
-        `}
+        className={cn(
+          'grow rounded-xl overflow-y-auto',
+          showConfigPanelBeforeChat && 'border-[0.5px] border-gray-100 shadow-lg',
+          !showConfigPanelBeforeChat && collapsed && 'border border-indigo-100',
+          !showConfigPanelBeforeChat && !collapsed && 'border-[0.5px] border-gray-100 shadow-lg',
+        )}
       >
         <div
-          className={`
-            flex flex-wrap px-6 py-4 rounded-t-xl bg-indigo-25
-            ${isMobile && '!px-4 !py-3'}
-          `}
+          className={cn(`
+              flex flex-wrap px-6 py-4 rounded-t-xl bg-indigo-25
+            `, isMobile && '!px-4 !py-3')
+          }
         >
           {
             showConfigPanelBeforeChat && (
@@ -91,7 +92,7 @@ const ConfigPanel = () => {
           !collapsed && !showConfigPanelBeforeChat && (
             <div className='p-6 rounded-b-xl'>
               <Form />
-              <div className={`pl-[136px] flex items-center ${isMobile && '!pl-0'}`}>
+              <div className={cn('pl-[136px] flex items-center', isMobile && '!pl-0')}>
                 <Button
                   type='primary'
                   className='mr-2 text-sm font-medium'
@@ -117,7 +118,7 @@ const ConfigPanel = () => {
             <div className='p-6 rounded-b-xl'>
               <Form />
               <Button
-                className={`px-4 py-0 h-9 ${inputsForms.length && !isMobile && 'ml-[136px]'}`}
+                className={cn('px-4 py-0 h-9', inputsForms.length && !isMobile && 'ml-[136px]')}
                 type='primary'
                 onClick={handleStartChat}
               >
@@ -132,7 +133,7 @@ const ConfigPanel = () => {
         showConfigPanelBeforeChat && (site || customConfig) && (
           <div className='mt-4 flex flex-wrap justify-between items-center py-2 text-xs text-gray-400'>
             {site?.privacy_policy
-              ? <div className={`flex items-center ${isMobile && 'w-full justify-end'}`}>{t('share.chat.privacyPolicyLeft')}
+              ? <div className={cn('flex items-center', isMobile && 'w-full justify-end')}>{t('share.chat.privacyPolicyLeft')}
                 <a
                   className='text-gray-500'
                   href={site?.privacy_policy}
@@ -145,7 +146,7 @@ const ConfigPanel = () => {
               customConfig?.remove_webapp_brand
                 ? null
                 : (
-                  <div className={`flex items-center justify-end ${isMobile && 'w-full'}`}>
+                  <div className={cn('flex items-center justify-end', isMobile && 'w-full')}>
                     <a className='flex items-center pr-3 space-x-3' href="https://dify.ai/" target="_blank">
                       <span className='uppercase'>{t('share.chat.powerBy')}</span>
                       {

--- a/web/app/components/base/chat/chat-with-history/header.tsx
+++ b/web/app/components/base/chat/chat-with-history/header.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { memo } from 'react'
+import cn from 'classnames'
 
 type HeaderProps = {
   title: string
@@ -11,11 +12,10 @@ const Header: FC<HeaderProps> = ({
 }) => {
   return (
     <div
-      className={`
+      className={cn(`
       sticky top-0 flex items-center px-8 h-16 bg-white/80 text-base font-medium 
-      text-gray-900 border-b-[0.5px] border-b-gray-100 backdrop-blur-md z-10
-      ${isMobile && '!h-12'}
-      `}
+    text-gray-900 border-b-[0.5px] border-b-gray-100 backdrop-blur-md z-10`,
+      isMobile && '!h-12')}
     >
       {title}
     </div>

--- a/web/app/components/base/chat/chat-with-history/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/index.tsx
@@ -4,6 +4,7 @@ import {
   useState,
 } from 'react'
 import { useAsyncEffect } from 'ahooks'
+import cn from 'classnames'
 import {
   ChatWithHistoryContext,
   useChatWithHistoryContext,
@@ -62,7 +63,7 @@ const ChatWithHistory: FC<ChatWithHistoryProps> = ({
   }
 
   return (
-    <div className={`h-full flex bg-white ${className} ${isMobile && 'flex-col'}`}>
+    <div className={cn(`h-full flex bg-white ${className}`, isMobile && 'flex-col')}>
       {
         !isMobile && (
           <Sidebar />
@@ -73,10 +74,10 @@ const ChatWithHistory: FC<ChatWithHistoryProps> = ({
           <HeaderInMobile />
         )
       }
-      <div className={`grow overflow-hidden ${showConfigPanelBeforeChat && !appPrevChatList.length && 'flex items-center justify-center'}`}>
+      <div className={cn('grow overflow-hidden', showConfigPanelBeforeChat && !appPrevChatList.length && 'flex items-center justify-center')}>
         {
           showConfigPanelBeforeChat && !appChatListDataLoading && !appPrevChatList.length && (
-            <div className={`flex w-full items-center justify-center h-full ${isMobile && 'px-4'}`}>
+            <div className={cn('flex w-full items-center justify-center h-full', isMobile && 'px-4')}>
               <ConfigPanel />
             </div>
           )

--- a/web/app/components/base/chat/chat-with-history/sidebar/item.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/item.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
 } from 'react'
 import { useHover } from 'ahooks'
+import cn from 'classnames'
 import type { ConversationItem } from '@/models/share'
 import { MessageDotsCircle } from '@/app/components/base/icons/src/vender/solid/communication'
 import ItemOperation from '@/app/components/explore/item-operation'
@@ -29,14 +30,14 @@ const Item: FC<ItemProps> = ({
     <div
       ref={ref}
       key={item.id}
-      className={`
-        flex mb-0.5 last-of-type:mb-0 py-1.5 pl-3 pr-1.5 text-sm font-medium text-gray-700 
-        rounded-lg cursor-pointer hover:bg-gray-50 group
-        ${currentConversationId === item.id && 'text-primary-600 bg-primary-50'}
-      `}
+      className={cn(
+        `flex mb-0.5 last-of-type:mb-0 py-1.5 pl-3 pr-1.5 text-sm font-medium text-gray-700 
+        rounded-lg cursor-pointer hover:bg-gray-50 group`,
+        currentConversationId === item.id && 'text-primary-600 bg-primary-50',
+      )}
       onClick={() => onChangeConversation(item.id)}
     >
-      <MessageDotsCircle className={`shrink-0 mt-1 mr-2 w-4 h-4 text-gray-400 ${currentConversationId === item.id && 'text-primary-600'}`} />
+      <MessageDotsCircle className={cn('shrink-0 mt-1 mr-2 w-4 h-4 text-gray-400', currentConversationId === item.id && 'text-primary-600')} />
       <div className='grow py-0.5 break-all' title={item.name}>{item.name}</div>
       {item.id !== '' && (
         <div className='shrink-0 h-6' onClick={e => e.stopPropagation()}>

--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -5,6 +5,7 @@ import {
   useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import type { ChatItem } from '../../types'
 import { useChatContext } from '../context'
 import CopyBtn from '@/app/components/app/chat/copy-btn'
@@ -146,11 +147,11 @@ const Operation: FC<OperationProps> = ({
         config?.supportFeedback && localFeedback?.rating && onFeedback && !isOpeningStatement && (
           <TooltipPlus popupContent={localFeedback.rating === 'like' ? t('appDebug.operation.cancelAgree') : t('appDebug.operation.cancelDisagree')}>
             <div
-              className={`
-                flex items-center justify-center w-7 h-7 rounded-[10px] border-[2px] border-white cursor-pointer
-                ${localFeedback.rating === 'like' && 'bg-blue-50 text-blue-600'}
-                ${localFeedback.rating === 'dislike' && 'bg-red-100 text-red-600'}
-              `}
+              className={cn(
+                'flex items-center justify-center w-7 h-7 rounded-[10px] border-[2px] border-white cursor-pointer',
+                localFeedback.rating === 'like' && 'bg-blue-50 text-blue-600',
+                localFeedback.rating === 'dislike' && 'bg-red-100 text-red-600',
+              )}
               onClick={() => handleFeedback(null)}
             >
               {

--- a/web/app/components/base/chat/chat/chat-input.tsx
+++ b/web/app/components/base/chat/chat/chat-input.tsx
@@ -8,6 +8,7 @@ import { useContext } from 'use-context-selector'
 import Recorder from 'js-audio-recorder'
 import { useTranslation } from 'react-i18next'
 import Textarea from 'rc-textarea'
+import cn from 'classnames'
 import type {
   EnableType,
   OnSend,
@@ -118,10 +119,10 @@ const ChatInput: FC<ChatInputProps> = ({
       onClick={handleSend}
     >
       <Send03
-        className={`
-          w-5 h-5 text-gray-300 group-hover:text-primary-600
-          ${query.trim() ? 'text-primary-600' : ''}
-        `}
+        className={cn(
+          'w-5 h-5 text-gray-300 group-hover:text-primary-600',
+          query.trim() && 'text-primary-600',
+        )}
       />
     </div>
   )
@@ -129,10 +130,10 @@ const ChatInput: FC<ChatInputProps> = ({
   return (
     <div className='relative'>
       <div
-        className={`
-          p-[5.5px] max-h-[150px] bg-white border-[1.5px] border-gray-200 rounded-xl overflow-y-auto
-          ${isDragActive ? 'border-primary-600' : ''}
-        `}
+        className={cn(
+          'p-[5.5px] max-h-[150px] bg-white border-[1.5px] border-gray-200 rounded-xl overflow-y-auto',
+          isDragActive && 'border-primary-600',
+        )}
       >
         {
           visionConfig?.enabled && (
@@ -158,10 +159,10 @@ const ChatInput: FC<ChatInputProps> = ({
           )
         }
         <Textarea
-          className={`
-            block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-sm text-gray-700 outline-none appearance-none resize-none
-            ${visionConfig?.enabled ? 'pl-12' : ''}
-          `}
+          className={cn(
+            'block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-sm text-gray-700 outline-none appearance-none resize-none',
+            visionConfig?.enabled && 'pl-12',
+          )}
           value={query}
           onChange={handleContentChange}
           onKeyUp={handleKeyUp}

--- a/web/app/components/base/chat/chat/chat-input.tsx
+++ b/web/app/components/base/chat/chat/chat-input.tsx
@@ -120,7 +120,7 @@ const ChatInput: FC<ChatInputProps> = ({
       <Send03
         className={`
           w-5 h-5 text-gray-300 group-hover:text-primary-600
-          ${!!query.trim() && 'text-primary-600'}
+          ${query.trim() ? 'text-primary-600' : ''}
         `}
       />
     </div>
@@ -131,7 +131,7 @@ const ChatInput: FC<ChatInputProps> = ({
       <div
         className={`
           p-[5.5px] max-h-[150px] bg-white border-[1.5px] border-gray-200 rounded-xl overflow-y-auto
-          ${isDragActive && 'border-primary-600'}
+          ${isDragActive ? 'border-primary-600' : ''}
         `}
       >
         {
@@ -160,7 +160,7 @@ const ChatInput: FC<ChatInputProps> = ({
         <Textarea
           className={`
             block w-full px-2 pr-[118px] py-[7px] leading-5 max-h-none text-sm text-gray-700 outline-none appearance-none resize-none
-            ${visionConfig?.enabled && 'pl-12'}
+            ${visionConfig?.enabled ? 'pl-12' : ''}
           `}
           value={query}
           onChange={handleContentChange}

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -191,7 +191,7 @@ const Chat: FC<ChatProps> = ({
           </div>
         </div>
         <div
-          className={`absolute bottom-0 ${(hasTryToAsk || !noChatInput || !noStopResponding) && chatFooterClassName}`}
+          className={`absolute bottom-0 ${(hasTryToAsk || !noChatInput || !noStopResponding) ? chatFooterClassName : ''}`}
           ref={chatFooterRef}
           style={{
             background: 'linear-gradient(0deg, #F9FAFB 40%, rgba(255, 255, 255, 0.00) 100%)',

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { useThrottleEffect } from 'ahooks'
 import { debounce } from 'lodash-es'
+import cn from 'classnames'
 import type {
   ChatConfig,
   ChatItem,
@@ -191,7 +192,7 @@ const Chat: FC<ChatProps> = ({
           </div>
         </div>
         <div
-          className={`absolute bottom-0 ${(hasTryToAsk || !noChatInput || !noStopResponding) ? chatFooterClassName : ''}`}
+          className={cn('absolute bottom-0', (hasTryToAsk || !noChatInput || !noStopResponding) && chatFooterClassName)}
           ref={chatFooterRef}
           style={{
             background: 'linear-gradient(0deg, #F9FAFB 40%, rgba(255, 255, 255, 0.00) 100%)',

--- a/web/app/components/base/dropdown/index.tsx
+++ b/web/app/components/base/dropdown/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useState } from 'react'
+import cn from 'classnames'
 import { DotsHorizontal } from '@/app/components/base/icons/src/vender/line/general'
 import {
   PortalToFollowElem,
@@ -44,10 +45,10 @@ const Dropdown: FC<DropdownProps> = ({
             ? renderTrigger(open)
             : (
               <div
-                className={`
-                  flex items-center justify-center w-6 h-6 cursor-pointer rounded-md
-                  ${open && 'bg-black/5'}
-                `}
+                className={cn(
+                  'flex items-center justify-center w-6 h-6 cursor-pointer rounded-md',
+                  open && 'bg-black/5',
+                )}
               >
                 <DotsHorizontal className='w-4 h-4 text-gray-500' />
               </div>

--- a/web/app/components/base/image-uploader/chat-image-uploader.tsx
+++ b/web/app/components/base/image-uploader/chat-image-uploader.tsx
@@ -28,10 +28,10 @@ const UploadOnlyFromLocal: FC<UploadOnlyFromLocalProps> = ({
     <Uploader onUpload={onUpload} disabled={disabled} limit={limit}>
       {hovering => (
         <div
-          className={`
-            relative flex items-center justify-center w-8 h-8 rounded-lg cursor-pointer
-            ${hovering && 'bg-gray-100'}
-          `}
+          className={cn(
+            'relative flex items-center justify-center w-8 h-8 rounded-lg cursor-pointer',
+            hovering && 'bg-gray-100',
+          )}
         >
           <ImagePlus className="w-4 h-4 text-gray-500" />
         </div>

--- a/web/app/components/base/image-uploader/text-generation-image-uploader.tsx
+++ b/web/app/components/base/image-uploader/text-generation-image-uploader.tsx
@@ -5,6 +5,7 @@ import {
   useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import Uploader from './uploader'
 import ImageLinkInput from './image-link-input'
 import ImageList from './image-list'
@@ -97,11 +98,11 @@ const TextGenerationImageUploader: FC<TextGenerationImageUploaderProps> = ({
     >
       {
         hovering => (
-          <div className={`
-            flex items-center justify-center px-3 h-8 bg-gray-100
-            text-xs text-gray-500 rounded-lg cursor-pointer
-            ${hovering && 'bg-gray-200'}
-          `}>
+          <div className={cn(
+            `flex items-center justify-center px-3 h-8 bg-gray-100
+            text-xs text-gray-500 rounded-lg cursor-pointer`,
+            hovering && 'bg-gray-200',
+          )}>
             <ImagePlus className='mr-2 w-4 h-4' />
             {t('common.imageUploader.uploadFromComputer')}
           </div>

--- a/web/app/components/base/notion-page-selector/workspace-selector/index.tsx
+++ b/web/app/components/base/notion-page-selector/workspace-selector/index.tsx
@@ -25,7 +25,7 @@ export default function WorkspaceSelector({
       {
         ({ open }) => (
           <>
-            <Menu.Button className={`flex items-center justify-center h-7 rounded-md hover:bg-gray-50 ${open && 'bg-gray-50'} cursor-pointer`}>
+            <Menu.Button className={cn('flex items-center justify-center h-7 rounded-md hover:bg-gray-50 cursor-pointer', open && 'bg-gray-50')}>
               <NotionIcon
                 className='ml-1 mr-2'
                 src={currentWorkspace?.workspace_icon}

--- a/web/app/components/base/prompt-editor/plugins/component-picker.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker.tsx
@@ -8,6 +8,7 @@ import {
   LexicalTypeaheadMenuPlugin,
   MenuOption,
 } from '@lexical/react/LexicalTypeaheadMenuPlugin'
+import cn from 'classnames'
 import { useBasicTypeaheadTriggerMatch } from '../hooks'
 import { INSERT_CONTEXT_BLOCK_COMMAND } from './context-block'
 import { INSERT_VARIABLE_BLOCK_COMMAND } from './variable-block'
@@ -66,11 +67,11 @@ const ComponentPickerMenuItem: FC<ComponentPickerMenuItemProps> = ({
   return (
     <div
       key={option.key}
-      className={`
-        flex items-center px-3 py-1.5 rounded-lg 
-        ${isSelected && !option.disabled && '!bg-gray-50'}
-        ${option.disabled ? 'cursor-not-allowed opacity-30' : 'hover:bg-gray-50 cursor-pointer'}
-      `}
+      className={cn(
+        'flex items-center px-3 py-1.5 rounded-lg',
+        { '!bg-gray-50': isSelected && !option.disabled },
+        option.disabled ? 'cursor-not-allowed opacity-30' : 'hover:bg-gray-50 cursor-pointer',
+      )}
       tabIndex={-1}
       ref={option.setRefElement}
       onMouseEnter={onMouseEnter}

--- a/web/app/components/base/prompt-editor/plugins/context-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/context-block/component.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import { useSelectOrDelete, useTrigger } from '../../hooks'
 import { UPDATE_DATASETS_EVENT_EMITTER } from '../../constants'
 import type { Dataset } from './index'
@@ -37,11 +38,11 @@ const ContextBlockComponent: FC<ContextBlockComponentProps> = ({
   })
 
   return (
-    <div className={`
-      group inline-flex items-center pl-1 pr-0.5 h-6 border border-transparent bg-[#F4F3FF] text-[#6938EF] rounded-[5px] hover:bg-[#EBE9FE]
-      ${open ? 'bg-[#EBE9FE]' : 'bg-[#F4F3FF]'}
-      ${isSelected ? '!border-[#9B8AFB]' : ''}
-    `} ref={ref}>
+    <div className={cn(
+      'group inline-flex items-center pl-1 pr-0.5 h-6 border border-transparent bg-[#F4F3FF] text-[#6938EF] rounded-[5px] hover:bg-[#EBE9FE]',
+      open ? 'bg-[#EBE9FE]' : 'bg-[#F4F3FF]',
+      isSelected && '!border-[#9B8AFB]',
+    )} ref={ref}>
       <File05 className='mr-1 w-[14px] h-[14px]' />
       <div className='mr-1 text-xs font-medium'>{t('common.promptEditor.context.item.title')}</div>
       <PortalToFollowElem

--- a/web/app/components/base/prompt-editor/plugins/context-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/context-block/component.tsx
@@ -40,7 +40,7 @@ const ContextBlockComponent: FC<ContextBlockComponentProps> = ({
     <div className={`
       group inline-flex items-center pl-1 pr-0.5 h-6 border border-transparent bg-[#F4F3FF] text-[#6938EF] rounded-[5px] hover:bg-[#EBE9FE]
       ${open ? 'bg-[#EBE9FE]' : 'bg-[#F4F3FF]'}
-      ${isSelected && '!border-[#9B8AFB]'}
+      ${isSelected ? '!border-[#9B8AFB]' : ''}
     `} ref={ref}>
       <File05 className='mr-1 w-[14px] h-[14px]' />
       <div className='mr-1 text-xs font-medium'>{t('common.promptEditor.context.item.title')}</div>

--- a/web/app/components/base/prompt-editor/plugins/history-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/history-block/component.tsx
@@ -40,7 +40,7 @@ const HistoryBlockComponent: FC<HistoryBlockComponentProps> = ({
     <div className={`
       group inline-flex items-center pl-1 pr-0.5 h-6 border border-transparent text-[#DD2590] rounded-[5px] hover:bg-[#FCE7F6]
       ${open ? 'bg-[#FCE7F6]' : 'bg-[#FDF2FA]'}
-      ${isSelected && '!border-[#F670C7]'}
+      ${isSelected ? '!border-[#F670C7]' : ''}
     `} ref={ref}>
       <MessageClockCircle className='mr-1 w-[14px] h-[14px]' />
       <div className='mr-1 text-xs font-medium'>{t('common.promptEditor.history.item.title')}</div>

--- a/web/app/components/base/prompt-editor/plugins/history-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/history-block/component.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import { useSelectOrDelete, useTrigger } from '../../hooks'
 import { UPDATE_HISTORY_EVENT_EMITTER } from '../../constants'
 import type { RoleName } from './index'
@@ -37,11 +38,11 @@ const HistoryBlockComponent: FC<HistoryBlockComponentProps> = ({
   })
 
   return (
-    <div className={`
-      group inline-flex items-center pl-1 pr-0.5 h-6 border border-transparent text-[#DD2590] rounded-[5px] hover:bg-[#FCE7F6]
-      ${open ? 'bg-[#FCE7F6]' : 'bg-[#FDF2FA]'}
-      ${isSelected ? '!border-[#F670C7]' : ''}
-    `} ref={ref}>
+    <div className={cn(
+      'group inline-flex items-center pl-1 pr-0.5 h-6 border border-transparent text-[#DD2590] rounded-[5px] hover:bg-[#FCE7F6]',
+      open ? 'bg-[#FCE7F6]' : 'bg-[#FDF2FA]',
+      isSelected && '!border-[#F670C7]',
+    )} ref={ref}>
       <MessageClockCircle className='mr-1 w-[14px] h-[14px]' />
       <div className='mr-1 text-xs font-medium'>{t('common.promptEditor.history.item.title')}</div>
       <PortalToFollowElem

--- a/web/app/components/base/prompt-editor/plugins/query-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/query-block/component.tsx
@@ -18,7 +18,7 @@ const QueryBlockComponent: FC<QueryBlockComponentProps> = ({
     <div
       className={`
         inline-flex items-center pl-1 pr-0.5 h-6 bg-[#FFF6ED] border border-transparent rounded-[5px] hover:bg-[#FFEAD5]
-        ${isSelected && '!border-[#FD853A]'}
+        ${isSelected ? '!border-[#FD853A]' : ''}
       `}
       ref={ref}
     >

--- a/web/app/components/base/prompt-editor/plugins/query-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/query-block/component.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import { useSelectOrDelete } from '../../hooks'
 import { DELETE_QUERY_BLOCK_COMMAND } from './index'
 import { UserEdit02 } from '@/app/components/base/icons/src/vender/solid/users'
@@ -16,10 +17,10 @@ const QueryBlockComponent: FC<QueryBlockComponentProps> = ({
 
   return (
     <div
-      className={`
-        inline-flex items-center pl-1 pr-0.5 h-6 bg-[#FFF6ED] border border-transparent rounded-[5px] hover:bg-[#FFEAD5]
-        ${isSelected ? '!border-[#FD853A]' : ''}
-      `}
+      className={cn(
+        'inline-flex items-center pl-1 pr-0.5 h-6 bg-[#FFF6ED] border border-transparent rounded-[5px] hover:bg-[#FFEAD5]',
+        isSelected && '!border-[#FD853A]',
+      )}
       ref={ref}
     >
       <UserEdit02 className='mr-1 w-[14px] h-[14px] text-[#FD853A]' />

--- a/web/app/components/base/prompt-editor/plugins/variable-picker.tsx
+++ b/web/app/components/base/prompt-editor/plugins/variable-picker.tsx
@@ -8,6 +8,7 @@ import {
   MenuOption,
 } from '@lexical/react/LexicalTypeaheadMenuPlugin'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import cn from 'classnames'
 import { useBasicTypeaheadTriggerMatch } from '../hooks'
 import { INSERT_VARIABLE_VALUE_BLOCK_COMMAND } from './variable-block'
 import { $createCustomTextNode } from './custom-text/node'
@@ -78,10 +79,10 @@ const VariablePickerMenuItem: FC<VariablePickerMenuItemProps> = ({
   return (
     <div
       key={option.key}
-      className={`
-        flex items-center px-3 h-6 rounded-md hover:bg-primary-50 cursor-pointer
-        ${isSelected && 'bg-primary-50'}
-      `}
+      className={cn(
+        'flex items-center px-3 h-6 rounded-md hover:bg-primary-50 cursor-pointer',
+        isSelected && 'bg-primary-50',
+      )}
       tabIndex={-1}
       ref={option.setRefElement}
       onMouseEnter={onMouseEnter}
@@ -280,10 +281,10 @@ const VariablePicker: FC<VariablePickerProps> = ({
               }
               <div className='p-1'>
                 <div
-                  className={`
-                    flex items-center px-3 h-6 rounded-md hover:bg-primary-50 cursor-pointer
-                    ${selectedIndex === options.length + toolOptions.length && 'bg-primary-50'}
-                  `}
+                  className={cn(
+                    'flex items-center px-3 h-6 rounded-md hover:bg-primary-50 cursor-pointer',
+                    selectedIndex === options.length + toolOptions.length && 'bg-primary-50',
+                  )}
                   ref={newOption.setRefElement}
                   tabIndex={-1}
                   onClick={() => {
@@ -299,10 +300,10 @@ const VariablePicker: FC<VariablePickerProps> = ({
                   <div className='text-[13px] text-gray-900'>{newOption.title}</div>
                 </div>
                 <div
-                  className={`
-                    flex items-center px-3 h-6 rounded-md hover:bg-primary-50 cursor-pointer
-                    ${selectedIndex === options.length + toolOptions.length + 1 && 'bg-primary-50'}
-                  `}
+                  className={cn(
+                    'flex items-center px-3 h-6 rounded-md hover:bg-primary-50 cursor-pointer',
+                    selectedIndex === options.length + toolOptions.length + 1 && 'bg-primary-50',
+                  )}
                   ref={newToolOption.setRefElement}
                   tabIndex={-1}
                   onClick={() => {

--- a/web/app/components/base/select/index.tsx
+++ b/web/app/components/base/select/index.tsx
@@ -267,7 +267,7 @@ const PortalSelect: FC<PortalSelectProps> = ({
           <span
             className={`
               grow truncate
-              ${!selectedItem?.name && 'text-gray-400'}
+              ${!selectedItem?.name ? 'text-gray-400' : ''}
             `}
           >
             {selectedItem?.name ?? localPlaceholder}
@@ -284,7 +284,7 @@ const PortalSelect: FC<PortalSelectProps> = ({
               key={item.value}
               className={`
                 flex items-center justify-between px-2.5 h-9 cursor-pointer rounded-lg hover:bg-gray-100 text-gray-700
-                ${item.value === value && 'bg-gray-100'}
+                ${item.value === value ? 'bg-gray-100' : ''}
               `}
               title={item.name}
               onClick={() => {

--- a/web/app/components/base/select/index.tsx
+++ b/web/app/components/base/select/index.tsx
@@ -265,10 +265,10 @@ const PortalSelect: FC<PortalSelectProps> = ({
           title={selectedItem?.name}
         >
           <span
-            className={`
-              grow truncate
-              ${!selectedItem?.name ? 'text-gray-400' : ''}
-            `}
+            className={classNames(
+              'grow truncate',
+              !selectedItem?.name && 'text-gray-400',
+            )}
           >
             {selectedItem?.name ?? localPlaceholder}
           </span>
@@ -282,10 +282,10 @@ const PortalSelect: FC<PortalSelectProps> = ({
           {items.map((item: Item) => (
             <div
               key={item.value}
-              className={`
-                flex items-center justify-between px-2.5 h-9 cursor-pointer rounded-lg hover:bg-gray-100 text-gray-700
-                ${item.value === value ? 'bg-gray-100' : ''}
-              `}
+              className={classNames(
+                'flex items-center justify-between px-2.5 h-9 cursor-pointer rounded-lg hover:bg-gray-100 text-gray-700',
+                item.value === value && 'bg-gray-100',
+              )}
               title={item.name}
               onClick={() => {
                 onSelect(item)

--- a/web/app/components/base/tab-slider/index.tsx
+++ b/web/app/components/base/tab-slider/index.tsx
@@ -32,7 +32,7 @@ const TabSlider: FC<TabSliderProps> = ({
               flex justify-center items-center h-7 text-[13px] 
               font-semibold text-gray-600 rounded-[7px] cursor-pointer
               hover:bg-gray-50
-              ${index !== options.length - 1 && 'mr-[1px]'}
+              ${index !== options.length - 1 ? 'mr-[1px]' : ''}
             `}
             style={{
               width: itemWidth,

--- a/web/app/components/base/tab-slider/index.tsx
+++ b/web/app/components/base/tab-slider/index.tsx
@@ -28,12 +28,12 @@ const TabSlider: FC<TabSliderProps> = ({
         options.map((option, index) => (
           <div
             key={option.value}
-            className={`
-              flex justify-center items-center h-7 text-[13px] 
+            className={cn(
+              `flex justify-center items-center h-7 text-[13px] 
               font-semibold text-gray-600 rounded-[7px] cursor-pointer
-              hover:bg-gray-50
-              ${index !== options.length - 1 ? 'mr-[1px]' : ''}
-            `}
+              hover:bg-gray-50`,
+              index !== options.length - 1 && 'mr-[1px]',
+            )}
             style={{
               width: itemWidth,
             }}

--- a/web/app/components/base/tag-input/index.tsx
+++ b/web/app/components/base/tag-input/index.tsx
@@ -86,10 +86,10 @@ const TagInput: FC<TagInputProps> = ({
         !disableAdd && (
           <AutosizeInput
             inputClassName={cn('outline-none appearance-none placeholder:text-gray-300 caret-primary-600 hover:placeholder:text-gray-400', isSpecialMode ? 'bg-transparent' : '')}
-            className={`
-              mt-1 py-1 rounded-lg border border-transparent text-sm max-w-[300px] overflow-hidden
-              ${focused ? 'px-2 border !border-dashed !border-gray-200' : ''}
-            `}
+            className={cn(
+              'mt-1 py-1 rounded-lg border border-transparent text-sm max-w-[300px] overflow-hidden',
+              focused && 'px-2 border !border-dashed !border-gray-200',
+            )}
             onFocus={() => setFocused(true)}
             onBlur={handleBlur}
             value={value}

--- a/web/app/components/base/tag-input/index.tsx
+++ b/web/app/components/base/tag-input/index.tsx
@@ -88,7 +88,7 @@ const TagInput: FC<TagInputProps> = ({
             inputClassName={cn('outline-none appearance-none placeholder:text-gray-300 caret-primary-600 hover:placeholder:text-gray-400', isSpecialMode ? 'bg-transparent' : '')}
             className={`
               mt-1 py-1 rounded-lg border border-transparent text-sm max-w-[300px] overflow-hidden
-              ${focused && 'px-2 border !border-dashed !border-gray-200'}
+              ${focused ? 'px-2 border !border-dashed !border-gray-200' : ''}
             `}
             onFocus={() => setFocused(true)}
             onBlur={handleBlur}

--- a/web/app/components/custom/custom-web-app-brand/index.tsx
+++ b/web/app/components/custom/custom-web-app-brand/index.tsx
@@ -140,7 +140,7 @@ const CustomWebAppBrand = () => {
       </div>
       <div className={`
         flex items-center justify-between px-4 py-3 rounded-xl border-[0.5px] border-gray-200 bg-gray-50
-        ${webappBrandRemoved && 'opacity-30'}
+        ${webappBrandRemoved ? 'opacity-30' : ''}
       `}>
         <div>
           <div className='leading-5 text-sm font-medium text-gray-900'>{t('custom.webapp.changeLogo')}</div>

--- a/web/app/components/custom/custom-web-app-brand/index.tsx
+++ b/web/app/components/custom/custom-web-app-brand/index.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import s from './style.module.css'
 import LogoSite from '@/app/components/base/logo/logo-site'
 import Switch from '@/app/components/base/switch'
@@ -138,10 +139,10 @@ const CustomWebAppBrand = () => {
           onChange={handleSwitch}
         />
       </div>
-      <div className={`
-        flex items-center justify-between px-4 py-3 rounded-xl border-[0.5px] border-gray-200 bg-gray-50
-        ${webappBrandRemoved ? 'opacity-30' : ''}
-      `}>
+      <div className={cn(
+        'flex items-center justify-between px-4 py-3 rounded-xl border-[0.5px] border-gray-200 bg-gray-50',
+        webappBrandRemoved && 'opacity-30',
+      )}>
         <div>
           <div className='leading-5 text-sm font-medium text-gray-900'>{t('custom.webapp.changeLogo')}</div>
           <div className='leading-[18px] text-xs text-gray-500'>{t('custom.webapp.changeLogoTip')}</div>

--- a/web/app/components/header/account-dropdown/index.tsx
+++ b/web/app/components/header/account-dropdown/index.tsx
@@ -50,13 +50,13 @@ export default function AppSelector({ isMobile }: IAppSelecotr) {
             <>
               <div>
                 <Menu.Button
-                  className={`
-                    inline-flex items-center
+                  className={classNames(
+                    `inline-flex items-center
                     rounded-[20px] py-1 pr-2.5 pl-1 text-sm
                   text-gray-700 hover:bg-gray-200
-                    mobile:px-1
-                    ${open ? 'bg-gray-200' : ''}
-                  `}
+                    mobile:px-1`,
+                    open && 'bg-gray-200',
+                  )}
                 >
                   <Avatar name={userProfile.name} className='sm:mr-2 mr-0' size={32} />
                   {!isMobile && <>

--- a/web/app/components/header/account-dropdown/index.tsx
+++ b/web/app/components/header/account-dropdown/index.tsx
@@ -55,7 +55,7 @@ export default function AppSelector({ isMobile }: IAppSelecotr) {
                     rounded-[20px] py-1 pr-2.5 pl-1 text-sm
                   text-gray-700 hover:bg-gray-200
                     mobile:px-1
-                    ${open && 'bg-gray-200'}
+                    ${open ? 'bg-gray-200' : ''}
                   `}
                 >
                   <Avatar name={userProfile.name} className='sm:mr-2 mr-0' size={32} />

--- a/web/app/components/header/account-setting/data-source-page/data-source-notion/operate/index.tsx
+++ b/web/app/components/header/account-setting/data-source-page/data-source-notion/operate/index.tsx
@@ -50,7 +50,7 @@ export default function Operate({
       {
         ({ open }) => (
           <>
-            <Menu.Button className={`flex items-center justify-center w-8 h-8 rounded-lg hover:bg-gray-100 ${open && 'bg-gray-100'}`}>
+            <Menu.Button className={`flex items-center justify-center w-8 h-8 rounded-lg hover:bg-gray-100 ${open ? 'bg-gray-100' : ''}`}>
               <EllipsisHorizontalIcon className='w-4 h-4' />
             </Menu.Button>
             <Transition

--- a/web/app/components/header/account-setting/data-source-page/data-source-notion/operate/index.tsx
+++ b/web/app/components/header/account-setting/data-source-page/data-source-notion/operate/index.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react'
 import { useSWRConfig } from 'swr'
 import { EllipsisHorizontalIcon } from '@heroicons/react/24/solid'
 import { Menu, Transition } from '@headlessui/react'
+import cn from 'classnames'
 import { syncDataSourceNotion, updateDataSourceNotionAction } from '@/service/common'
 import Toast from '@/app/components/base/toast'
 import type { DataSourceNotion } from '@/models/common'
@@ -50,7 +51,7 @@ export default function Operate({
       {
         ({ open }) => (
           <>
-            <Menu.Button className={`flex items-center justify-center w-8 h-8 rounded-lg hover:bg-gray-100 ${open ? 'bg-gray-100' : ''}`}>
+            <Menu.Button className={cn('flex items-center justify-center w-8 h-8 rounded-lg hover:bg-gray-100', open && 'bg-gray-100')}>
               <EllipsisHorizontalIcon className='w-4 h-4' />
             </Menu.Button>
             <Transition

--- a/web/app/components/header/account-setting/model-provider-page/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import SystemModelSelector from './system-model-selector'
 import ProviderAddedCard, { UPDATE_MODEL_PROVIDER_CUSTOM_MODEL_LIST } from './provider-added-card'
 import ProviderCard from './provider-card'
@@ -89,7 +90,7 @@ const ModelProviderPage = () => {
 
   return (
     <div className='relative pt-1 -mt-2'>
-      <div className={`flex items-center justify-between mb-2 h-8 ${defaultModelNotConfigured ? 'px-3 bg-[#FFFAEB] rounded-lg border border-[#FEF0C7]' : ''}`}>
+      <div className={cn('flex items-center justify-between mb-2 h-8', defaultModelNotConfigured && 'px-3 bg-[#FFFAEB] rounded-lg border border-[#FEF0C7]')}>
         {
           defaultModelNotConfigured
             ? (

--- a/web/app/components/header/account-setting/model-provider-page/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/index.tsx
@@ -89,7 +89,7 @@ const ModelProviderPage = () => {
 
   return (
     <div className='relative pt-1 -mt-2'>
-      <div className={`flex items-center justify-between mb-2 h-8 ${defaultModelNotConfigured && 'px-3 bg-[#FFFAEB] rounded-lg border border-[#FEF0C7]'}`}>
+      <div className={`flex items-center justify-between mb-2 h-8 ${defaultModelNotConfigured ? 'px-3 bg-[#FFFAEB] rounded-lg border border-[#FEF0C7]' : ''}`}>
         {
           defaultModelNotConfigured
             ? (

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
@@ -149,18 +149,18 @@ const Form: FC<FormProps> = ({
                 return true
               }).map(option => (
                 <div
-                  className={`
-                    flex items-center px-3 py-2 rounded-lg border border-gray-100 bg-gray-25 cursor-pointer
-                    ${value[variable] === option.value && 'bg-white border-[1.5px] border-primary-400 shadow-sm'}
-                    ${disabed ? '!cursor-not-allowed opacity-60' : ''}
-                  `}
+                  className={cn(
+                    'flex items-center px-3 py-2 rounded-lg border border-gray-100 bg-gray-25 cursor-pointer',
+                    value[variable] === option.value && 'bg-white border-[1.5px] border-primary-400 shadow-sm',
+                    disabed && '!cursor-not-allowed opacity-60',
+                  )}
                   onClick={() => handleFormChange(variable, option.value)}
                   key={`${variable}-${option.value}`}
                 >
-                  <div className={`
-                    flex justify-center items-center mr-2 w-4 h-4 border border-gray-300 rounded-full
-                    ${value[variable] === option.value ? 'border-[5px] border-primary-600' : ''}
-                  `} />
+                  <div className={cn(
+                    'flex justify-center items-center mr-2 w-4 h-4 border border-gray-300 rounded-full',
+                    value[variable] === option.value && 'border-[5px] border-primary-600',
+                  )} />
                   <div className='text-sm text-gray-900'>{option.label[language]}</div>
                 </div>
               ))

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
@@ -152,14 +152,14 @@ const Form: FC<FormProps> = ({
                   className={`
                     flex items-center px-3 py-2 rounded-lg border border-gray-100 bg-gray-25 cursor-pointer
                     ${value[variable] === option.value && 'bg-white border-[1.5px] border-primary-400 shadow-sm'}
-                    ${disabed && '!cursor-not-allowed opacity-60'}
+                    ${disabed ? '!cursor-not-allowed opacity-60' : ''}
                   `}
                   onClick={() => handleFormChange(variable, option.value)}
                   key={`${variable}-${option.value}`}
                 >
                   <div className={`
                     flex justify-center items-center mr-2 w-4 h-4 border border-gray-300 rounded-full
-                    ${value[variable] === option.value && 'border-[5px] border-primary-600'}
+                    ${value[variable] === option.value ? 'border-[5px] border-primary-600' : ''}
                   `} />
                   <div className='text-sm text-gray-900'>{option.label[language]}</div>
                 </div>

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Input.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Input.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react'
+import cn from 'classnames'
 import { CheckCircle } from '@/app/components/base/icons/src/vender/solid/general'
 
 type InputProps = {
@@ -40,15 +41,15 @@ const Input: FC<InputProps> = ({
     <div className='relative'>
       <input
         tabIndex={-1}
-        className={`
-          block px-3 w-full h-9 bg-gray-100 text-sm rounded-lg border border-transparent
+        className={cn(
+          `block px-3 w-full h-9 bg-gray-100 text-sm rounded-lg border border-transparent
           appearance-none outline-none caret-primary-600
           hover:border-[rgba(0,0,0,0.08)] hover:bg-gray-50
           focus:bg-white focus:border-gray-300 focus:shadow-xs
-          placeholder:text-sm placeholder:text-gray-400
-          ${validated ? 'pr-[30px]' : ''}
-          ${className}
-        `}
+          placeholder:text-sm placeholder:text-gray-400`,
+          validated && 'pr-[30px]',
+          className,
+        )}
         placeholder={placeholder || ''}
         onChange={e => onChange(e.target.value)}
         onBlur={e => toLimit(e.target.value)}

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Input.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Input.tsx
@@ -46,7 +46,7 @@ const Input: FC<InputProps> = ({
           hover:border-[rgba(0,0,0,0.08)] hover:bg-gray-50
           focus:bg-white focus:border-gray-300 focus:shadow-xs
           placeholder:text-sm placeholder:text-gray-400
-          ${validated && 'pr-[30px]'}
+          ${validated ? 'pr-[30px]' : ''}
           ${className}
         `}
         placeholder={placeholder || ''}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import Dropdown from '@/app/components/base/dropdown'
 import { SlidersH } from '@/app/components/base/icons/src/vender/line/mediaAndDevices'
 import { ChevronDown } from '@/app/components/base/icons/src/vender/line/arrows'
@@ -19,11 +20,11 @@ const PresetsParameter: FC<PresetsParameterProps> = ({
   const renderTrigger = useCallback((open: boolean) => {
     return (
       <div
-        className={`
-          flex items-center px-[7px] h-7 rounded-md border-[0.5px] border-gray-200 shadow-xs
-          text-xs font-medium text-gray-700 cursor-pointer
-          ${open ? 'bg-gray-100' : ''}
-        `}
+        className={cn(
+          `flex items-center px-[7px] h-7 rounded-md border-[0.5px] border-gray-200 shadow-xs
+          text-xs font-medium text-gray-700 cursor-pointer`,
+          open && 'bg-gray-100',
+        )}
       >
         <SlidersH className='mr-[5px] w-3.5 h-3.5 text-gray-500' />
         {t('common.modelProvider.loadPresets')}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx
@@ -22,7 +22,7 @@ const PresetsParameter: FC<PresetsParameterProps> = ({
         className={`
           flex items-center px-[7px] h-7 rounded-md border-[0.5px] border-gray-200 shadow-xs
           text-xs font-medium text-gray-700 cursor-pointer
-          ${open && 'bg-gray-100'}
+          ${open ? 'bg-gray-100' : ''}
         `}
       >
         <SlidersH className='mr-[5px] w-3.5 h-3.5 text-gray-500' />

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/empty-trigger.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/empty-trigger.tsx
@@ -15,7 +15,7 @@ const ModelTrigger: FC<ModelTriggerProps> = ({
       className={`
         flex items-center px-2 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer
         ${className}
-        ${open && '!bg-gray-200'}
+        ${open ? '!bg-gray-200' : ''}
       `}
     >
       <div className='grow flex items-center'>

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/empty-trigger.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/empty-trigger.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react'
+import cn from 'classnames'
 import { ChevronDown } from '@/app/components/base/icons/src/vender/line/arrows'
 import { CubeOutline } from '@/app/components/base/icons/src/vender/line/shapes'
 
@@ -12,11 +13,11 @@ const ModelTrigger: FC<ModelTriggerProps> = ({
 }) => {
   return (
     <div
-      className={`
-        flex items-center px-2 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer
-        ${className}
-        ${open ? '!bg-gray-200' : ''}
-      `}
+      className={cn(
+        'flex items-center px-2 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer',
+        className,
+        open && '!bg-gray-200',
+      )}
     >
       <div className='grow flex items-center'>
         <div className='mr-1.5 flex items-center justify-center w-4 h-4 rounded-[5px] border border-dashed border-black/5'>

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/model-trigger.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/model-trigger.tsx
@@ -33,8 +33,8 @@ const ModelTrigger: FC<ModelTriggerProps> = ({
       className={`
         group flex items-center px-2 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer
         ${className}
-        ${open && '!bg-gray-200'}
-        ${model.status !== ModelStatusEnum.active && '!bg-[#FFFAEB]'}
+        ${open ? '!bg-gray-200' : ''}
+        ${model.status !== ModelStatusEnum.active ? '!bg-[#FFFAEB]' : ''}
       `}
     >
       <ModelIcon

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/model-trigger.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/model-trigger.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react'
+import cn from 'classnames'
 import type {
   Model,
   ModelItem,
@@ -30,12 +31,12 @@ const ModelTrigger: FC<ModelTriggerProps> = ({
 
   return (
     <div
-      className={`
-        group flex items-center px-2 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer
-        ${className}
-        ${open ? '!bg-gray-200' : ''}
-        ${model.status !== ModelStatusEnum.active ? '!bg-[#FFFAEB]' : ''}
-      `}
+      className={cn(
+        'group flex items-center px-2 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer',
+        className,
+        open && '!bg-gray-200',
+        model.status !== ModelStatusEnum.active && '!bg-[#FFFAEB]',
+      )}
     >
       <ModelIcon
         className='shrink-0 mr-1.5'

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import type {
   DefaultModel,
   Model,
@@ -84,18 +85,18 @@ const PopupItem: FC<PopupItemProps> = ({
               onClick={() => handleSelect(model.provider, modelItem)}
             >
               <ModelIcon
-                className={`
-                  shrink-0 mr-2 w-4 h-4
-                  ${modelItem.status !== ModelStatusEnum.active ? 'opacity-60' : ''}
-                `}
+                className={cn(
+                  'shrink-0 mr-2 w-4 h-4',
+                  modelItem.status !== ModelStatusEnum.active && 'opacity-60',
+                )}
                 provider={model}
                 modelName={modelItem.model}
               />
               <ModelName
-                className={`
-                  grow text-sm font-normal text-gray-900
-                  ${modelItem.status !== ModelStatusEnum.active ? 'opacity-60' : ''}
-                `}
+                className={cn(
+                  'grow text-sm font-normal text-gray-900',
+                  modelItem.status !== ModelStatusEnum.active && 'opacity-60',
+                )}
                 modelItem={modelItem}
                 showMode
                 showFeatures

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
@@ -86,7 +86,7 @@ const PopupItem: FC<PopupItemProps> = ({
               <ModelIcon
                 className={`
                   shrink-0 mr-2 w-4 h-4
-                  ${modelItem.status !== ModelStatusEnum.active && 'opacity-60'}
+                  ${modelItem.status !== ModelStatusEnum.active ? 'opacity-60' : ''}
                 `}
                 provider={model}
                 modelName={modelItem.model}
@@ -94,7 +94,7 @@ const PopupItem: FC<PopupItemProps> = ({
               <ModelName
                 className={`
                   grow text-sm font-normal text-gray-900
-                  ${modelItem.status !== ModelStatusEnum.active && 'opacity-60'}
+                  ${modelItem.status !== ModelStatusEnum.active ? 'opacity-60' : ''}
                 `}
                 modelItem={modelItem}
                 showMode

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list.tsx
@@ -77,8 +77,8 @@ const ModelList: FC<ModelListProps> = ({
               key={model.model}
               className={`
                 group flex items-center pl-2 pr-2.5 h-8 rounded-lg
-                ${canCustomConfig && 'hover:bg-gray-50'}
-                ${model.deprecated && 'opacity-60'}
+                ${canCustomConfig ? 'hover:bg-gray-50' : ''}
+                ${model.deprecated ? 'opacity-60' : ''}
               `}
             >
               <ModelIcon

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import type {
   CustomConfigrationModelFixedFields,
   ModelItem,
@@ -75,11 +76,11 @@ const ModelList: FC<ModelListProps> = ({
           models.map(model => (
             <div
               key={model.model}
-              className={`
-                group flex items-center pl-2 pr-2.5 h-8 rounded-lg
-                ${canCustomConfig ? 'hover:bg-gray-50' : ''}
-                ${model.deprecated ? 'opacity-60' : ''}
-              `}
+              className={cn(
+                'group flex items-center pl-2 pr-2.5 h-8 rounded-lg',
+                canCustomConfig && 'hover:bg-gray-50',
+                model.deprecated && 'opacity-60',
+              )}
             >
               <ModelIcon
                 className='shrink-0 mr-2'

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/priority-selector.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/priority-selector.tsx
@@ -33,7 +33,7 @@ const Selector: FC<SelectorProps> = ({
           ({ open }) => (
             <Button className={`
               px-0 w-6 h-6 bg-white rounded-md
-              ${open && '!bg-gray-100'}
+              ${open ? '!bg-gray-100' : ''}
             `}>
               <DotsHorizontal className='w-3 h-3 text-gray-700' />
             </Button>

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/priority-selector.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/priority-selector.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react'
 import type { FC } from 'react'
 import { Popover, Transition } from '@headlessui/react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import { PreferredProviderTypeEnum } from '../declarations'
 import { Check, DotsHorizontal } from '@/app/components/base/icons/src/vender/line/general'
 import Button from '@/app/components/base/button'
@@ -31,10 +32,10 @@ const Selector: FC<SelectorProps> = ({
       <Popover.Button>
         {
           ({ open }) => (
-            <Button className={`
-              px-0 w-6 h-6 bg-white rounded-md
-              ${open ? '!bg-gray-100' : ''}
-            `}>
+            <Button className={cn(
+              'px-0 w-6 h-6 bg-white rounded-md',
+              open && '!bg-gray-100',
+            )}>
               <DotsHorizontal className='w-3 h-3 text-gray-700' />
             </Button>
           )

--- a/web/app/components/header/account-setting/model-provider-page/provider-card/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-card/index.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import type {
   ModelProvider,
   TypeWithI18N,
@@ -74,7 +75,7 @@ const ProviderCard: FC<ProviderCardProps> = ({
         }
       </div>
       <div>
-        <div className={`flex flex-wrap group-hover:hidden gap-0.5 ${canGetFreeQuota ? 'pb-[18px]' : ''}`}>
+        <div className={cn('flex flex-wrap group-hover:hidden gap-0.5', canGetFreeQuota && 'pb-[18px]')}>
           {
             provider.supported_model_types.map(modelType => (
               <ModelBadge key={modelType}>

--- a/web/app/components/header/account-setting/model-provider-page/provider-card/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-card/index.tsx
@@ -74,7 +74,7 @@ const ProviderCard: FC<ProviderCardProps> = ({
         }
       </div>
       <div>
-        <div className={`flex flex-wrap group-hover:hidden gap-0.5 ${canGetFreeQuota && 'pb-[18px]'}`}>
+        <div className={`flex flex-wrap group-hover:hidden gap-0.5 ${canGetFreeQuota ? 'pb-[18px]' : ''}`}>
           {
             provider.supported_model_types.map(modelType => (
               <ModelBadge key={modelType}>

--- a/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
@@ -129,7 +129,7 @@ const SystemModel: FC<SystemModelSelectorProps> = ({
         <div className={`
           flex items-center px-2 h-6 text-xs text-gray-700 cursor-pointer bg-white rounded-md border-[0.5px] border-gray-200 shadow-xs
           hover:bg-gray-100 hover:shadow-none
-          ${open && 'bg-gray-100 shadow-none'}
+          ${open ? 'bg-gray-100 shadow-none' : ''}
         `}>
           <Settings01 className='mr-1 w-3 h-3 text-gray-500' />
           {t('common.modelProvider.systemModelSettings')}

--- a/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import cn from 'classnames'
 import ModelSelector from '../model-selector'
 import {
   useModelList,
@@ -126,11 +127,11 @@ const SystemModel: FC<SystemModelSelectorProps> = ({
       }}
     >
       <PortalToFollowElemTrigger onClick={() => setOpen(v => !v)}>
-        <div className={`
-          flex items-center px-2 h-6 text-xs text-gray-700 cursor-pointer bg-white rounded-md border-[0.5px] border-gray-200 shadow-xs
-          hover:bg-gray-100 hover:shadow-none
-          ${open ? 'bg-gray-100 shadow-none' : ''}
-        `}>
+        <div className={cn(
+          `flex items-center px-2 h-6 text-xs text-gray-700 cursor-pointer bg-white rounded-md border-[0.5px] border-gray-200 shadow-xs
+          hover:bg-gray-100 hover:shadow-none`,
+          open && 'bg-gray-100 shadow-none',
+        )}>
           <Settings01 className='mr-1 w-3 h-3 text-gray-500' />
           {t('common.modelProvider.systemModelSettings')}
         </div>

--- a/web/app/components/header/nav/index.tsx
+++ b/web/app/components/header/nav/index.tsx
@@ -33,18 +33,18 @@ const Nav = ({
   const isActived = Array.isArray(activeSegment) ? activeSegment.includes(segment!) : segment === activeSegment
 
   return (
-    <div className={`
-      flex items-center h-8 mr-0 sm:mr-3 px-0.5 rounded-xl text-sm shrink-0 font-medium
-      ${isActived && 'bg-white shadow-md font-semibold'}
-      ${!curNav && !isActived && 'hover:bg-gray-200'}
-    `}>
+    <div className={classNames(
+      'flex items-center h-8 mr-0 sm:mr-3 px-0.5 rounded-xl text-sm shrink-0 font-medium',
+      isActived && 'bg-white shadow-md font-semibold',
+      !curNav && !isActived && 'hover:bg-gray-200')
+    }>
       <Link href={link}>
         <div
-          className={classNames(`
-            flex items-center h-7 px-2.5 cursor-pointer rounded-[10px]
-            ${isActived ? 'text-primary-600' : 'text-gray-500'}
-            ${curNav && isActived && 'hover:bg-primary-50'}
-          `)}
+          className={classNames(
+            'flex items-center h-7 px-2.5 cursor-pointer rounded-[10px]',
+            isActived ? 'text-primary-600' : 'text-gray-500',
+            (curNav && isActived && 'hover:bg-primary-50'))
+          }
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >


### PR DESCRIPTION
# Description
When using the && operator to conditionally apply certain classes, redundant "false" and "undefined" classes may be generated.

```js
let classes = `flex ${false && 'h-5'}`  // 'flex false'
let classes = `flex ${undefined && 'h-5'}`  // 'flex undefined'
```

 There are two ways to remove these redundant classes:
1. Utilizing the ternary operator
  ```js
  let classes = `some-class ${expression ? 'dynamic-class' : ''}`
  ```
2. Utilizing classnames
```js
let classes = classnames('some-class', expression && 'dynamic-class')
// or
let classes = classnames('some-class', {
  'dynamic-class': expression
})


```
## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement，including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade
