### PR TITLE
fix: yi model price correction

### DIFF
--- a/api/core/model_runtime/model_providers/yi/llm/yi-34b-chat-0205.yaml
+++ b/api/core/model_runtime/model_providers/yi/llm/yi-34b-chat-0205.yaml
@@ -37,7 +37,7 @@ parameter_rules:
       zh_Hans: 控制生成结果的随机性。数值越小，随机性越弱；数值越大，随机性越强。一般而言，top_p 和 temperature 两个参数选择一个进行调整即可。
       en_US: Control the randomness of generated results. The smaller the value, the weaker the randomness; the larger the value, the stronger the randomness. Generally speaking, you can adjust one of the two parameters top_p and temperature.
 pricing:
-  input: '0.0025'
-  output: '0.0025'
-  unit: '0.00001'
+  input: '2.5'
+  output: '2.5'
+  unit: '0.000001'
   currency: RMB

--- a/api/core/model_runtime/model_providers/yi/llm/yi-34b-chat-200k.yaml
+++ b/api/core/model_runtime/model_providers/yi/llm/yi-34b-chat-200k.yaml
@@ -37,7 +37,7 @@ parameter_rules:
       zh_Hans: 控制生成结果的随机性。数值越小，随机性越弱；数值越大，随机性越强。一般而言，top_p 和 temperature 两个参数选择一个进行调整即可。
       en_US: Control the randomness of generated results. The smaller the value, the weaker the randomness; the larger the value, the stronger the randomness. Generally speaking, you can adjust one of the two parameters top_p and temperature.
 pricing:
-  input: '0.012'
-  output: '0.012'
-  unit: '0.00001'
+  input: '12'
+  output: '12'
+  unit: '0.000001'
   currency: RMB

--- a/api/core/model_runtime/model_providers/yi/llm/yi-vl-plus.yaml
+++ b/api/core/model_runtime/model_providers/yi/llm/yi-vl-plus.yaml
@@ -37,7 +37,7 @@ parameter_rules:
       zh_Hans: 控制生成结果的随机性。数值越小，随机性越弱；数值越大，随机性越强。一般而言，top_p 和 temperature 两个参数选择一个进行调整即可。
       en_US: Control the randomness of generated results. The smaller the value, the weaker the randomness; the larger the value, the stronger the randomness. Generally speaking, you can adjust one of the two parameters top_p and temperature.
 pricing:
-  input: '0.01'
-  output: '0.03'
-  unit: '0.001'
-  currency: USD
+  input: '6'
+  output: '6'
+  unit: '0.000001'
+  currency: RMB


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The model price of yi series are wrong. yi-34b-chat-0205 and yi-34b-chat-200k encountered a magnitude error. The price of yi-vl-plus is not consistent with the official price, and it is priced in US dollars instead of RMB.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [*] Just talk with the model and check the bill.
![image](https://github.com/langgenius/dify/assets/5905773/a12fc7f7-562c-4537-be19-a74679f01abb)


# Suggested Checklist:

- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] My changes generate no new warnings
- [*] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
