### PR TITLE
fix tool_inputs parse error in message that in CoT(ReAct) agent mode

### DIFF
--- a/api/core/features/assistant_base_runner.py
+++ b/api/core/features/assistant_base_runner.py
@@ -566,7 +566,11 @@ class BaseAssistantApplicationRunner(AppRunner):
                         tools = tools.split(';')
                         tool_calls: list[AssistantPromptMessage.ToolCall] = []
                         tool_call_response: list[ToolPromptMessage] = []
-                        tool_inputs = json.loads(agent_thought.tool_input)
+                        try:
+                            tool_inputs = json.loads(agent_thought.tool_input)
+                        except Exception as e:
+                            logging.warning("tool execution error: {}, tool_input: {}.".format(str(e), agent_thought.tool_input))
+                            tool_inputs = { agent_thought.tool: agent_thought.tool_input }
                         for tool in tools:
                             # generate a uuid for tool call
                             tool_call_id = str(uuid.uuid4())

--- a/api/core/features/assistant_cot_runner.py
+++ b/api/core/features/assistant_cot_runner.py
@@ -182,7 +182,7 @@ class AssistantCotApplicationRunner(BaseAssistantApplicationRunner):
                             delta=LLMResultChunkDelta(
                                 index=0,
                                 message=AssistantPromptMessage(
-                                    content=json.dumps(chunk)
+                                    content=json.dumps(chunk, ensure_ascii=False) # if ensure_ascii=True, the text in webui maybe garbled text
                                 ),
                                 usage=None
                             )


### PR DESCRIPTION
# Description

Occasionally, the **action_input** result provided by the LLM (depending on its specific capabilities, like the 'moonshot-v1-8k') may not yield a valid JSON string when operating in the CoT agent mode. This can lead to disrupt the flow of the conversation.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Try to ask "计算一百二十八乘以六等于多少" with a tool *eval_expression*, the answer from the LLM **moonshot-v1-8k** will be "action_input='128乘以6的结果是768'". The fixed code will not raising an excetion in this situation, and will not interfere with other result that the LLM provided valid JSON outputs.

- [ ] TODO

# Suggested Checklist:

- [ X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
