### PR TITLE
fix: adjust popup panel's z-index value

### DIFF
--- a/web/app/(commonLayout)/apps/AppCard.tsx
+++ b/web/app/(commonLayout)/apps/AppCard.tsx
@@ -167,7 +167,7 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
                 style.actionIconWrapper,
               )
             }
-            className={'!w-[128px] h-fit !z-20'}
+            className={'!w-[128px] h-fit !z-0'}
             manualClose
           />}
         </div>


### PR DESCRIPTION
Here's the issues:
![image](https://github.com/langgenius/dify/assets/22975826/9d05a977-75af-432d-92db-56fe4304edc0)
