### PR TITLE
workflow: fix code template json dumps ensure_ascii

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,10 @@
+# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
+node_modules/
+dist/
+build/
+coverage/
+.env
+*.log
+*.tmp
+*.temp
+*.svg

--- a/api/core/helper/code_executor/jina2_transformer.py
+++ b/api/core/helper/code_executor/jina2_transformer.py
@@ -32,10 +32,10 @@ class Jinja2TemplateTransformer(TemplateTransformer):
 
         # transform jinja2 template to python code
         runner = PYTHON_RUNNER.replace('{{code}}', code)
-        runner = runner.replace('{{inputs}}', json.dumps(inputs, indent=4))
+        runner = runner.replace('{{inputs}}', json.dumps(inputs, indent=4, ensure_ascii=False))
 
         return runner
-    
+
     @classmethod
     def transform_response(cls, response: str) -> dict:
         """

--- a/api/core/helper/code_executor/python_transformer.py
+++ b/api/core/helper/code_executor/python_transformer.py
@@ -30,16 +30,16 @@ class PythonTemplateTransformer(TemplateTransformer):
         :param inputs: inputs
         :return:
         """
-        
+
         # transform inputs to json string
-        inputs_str = json.dumps(inputs, indent=4)
+        inputs_str = json.dumps(inputs, indent=4, ensure_ascii=False)
 
         # replace code and inputs
         runner = PYTHON_RUNNER.replace('{{code}}', code)
         runner = runner.replace('{{inputs}}', inputs_str)
 
         return runner
-    
+
     @classmethod
     def transform_response(cls, response: str) -> dict:
         """


### PR DESCRIPTION
# Description
- Fixes a Unicode bug in workflow Jinja2 template rendering.

### Before

![Xnip2024-03-25_09-36-21](https://github.com/langgenius/dify/assets/14071051/9da87a89-9091-4f93-9840-b1fbb91cf55f)

### After
![Capture-2024-03-25-093436](https://github.com/langgenius/dify/assets/14071051/513b2e2e-bd45-4281-a2bd-dd387cdbec98)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Tested by updating JSON dumps in both `jina2_transformer.py` and `python_transformer.py` to include `ensure_ascii=False` and verifying that Unicode characters are correctly preserved in outputs.
# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
