### PR TITLE
reuse layout

### DIFF
--- a/web/app/(commonLayout)/datasets/NewDatasetCard.tsx
+++ b/web/app/(commonLayout)/datasets/NewDatasetCard.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import { forwardRef, useState } from 'react'
+import { forwardRef } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
+import Link from 'next/link'
 import style from '../list.module.css'
 
 const CreateAppCard = forwardRef<HTMLAnchorElement>((_, ref) => {
   const { t } = useTranslation()
-  const [showNewAppDialog, setShowNewAppDialog] = useState(false)
 
   return (
-    <a ref={ref} className={classNames(style.listItem, style.newItemCard)} href='/datasets/create'>
+    <Link ref={ref} className={classNames(style.listItem, style.newItemCard)} href='/datasets/create'>
       <div className={style.listItemTitle}>
         <span className={style.newItemIcon}>
           <span className={classNames(style.newItemIconImage, style.newItemIconAdd)} />
@@ -21,8 +21,10 @@ const CreateAppCard = forwardRef<HTMLAnchorElement>((_, ref) => {
       </div>
       <div className={style.listItemDescription}>{t('dataset.createDatasetIntro')}</div>
       {/* <div className='text-xs text-gray-500'>{t('app.createFromConfigFile')}</div> */}
-    </a>
+    </Link>
   )
 })
+
+CreateAppCard.displayName = 'CreateAppCard'
 
 export default CreateAppCard

--- a/web/app/components/header/HeaderWrapper.tsx
+++ b/web/app/components/header/HeaderWrapper.tsx
@@ -11,7 +11,7 @@ const HeaderWrapper = ({
   children,
 }: HeaderWrapperProps) => {
   const pathname = usePathname()
-  const isBordered = ['/apps', '/datasets'].includes(pathname)
+  const isBordered = ['/apps', '/datasets', '/datasets/create'].includes(pathname)
 
   return (
     <div className={classNames(


### PR DESCRIPTION
# Description

Using the `<a>` tag will trigger a page reload when navigating from the '/datasets' page to the '/datasets/create' page.

## Type of Change

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
