### PR TITLE
fix: correct response hint for generated image to avoid illusion of regernerated image link

### DIFF
--- a/api/core/features/assistant_base_runner.py
+++ b/api/core/features/assistant_base_runner.py
@@ -145,7 +145,7 @@ class BaseAssistantApplicationRunner(AppRunner):
                 result += f"result link: {response.message}. please tell user to check it."
             elif response.type == ToolInvokeMessage.MessageType.IMAGE_LINK or \
                  response.type == ToolInvokeMessage.MessageType.IMAGE:
-                result += "image has been created and sent to user already, you should tell user to check it now."
+                result += "image has been created and sent to user already, you do not need to create it, just tell the user to check it now."
             else:
                 result += f"tool response: {response.message}."
 

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -232,7 +232,7 @@ class Tool(BaseModel, ABC):
                 result += f"result link: {response.message}. please tell user to check it."
             elif response.type == ToolInvokeMessage.MessageType.IMAGE_LINK or \
                  response.type == ToolInvokeMessage.MessageType.IMAGE:
-                result += "image has been created and sent to user already, you should tell user to check it now."
+                result += "image has been created and sent to user already, you do not need to create it, just tell the user to check it now."
             elif response.type == ToolInvokeMessage.MessageType.BLOB:
                 if len(response.message) > 114:
                     result += str(response.message[:114]) + '...'


### PR DESCRIPTION
# Description

- fix the illusion appendix for the generated image, tell the LLM not to regenerated again to avoid unrelated image link from Qwen 72b model

- Before:
<img width="1218" alt="image" src="https://github.com/langgenius/dify/assets/1935105/1d6fbb9c-c253-4138-91f8-5e0da40bcf4b">



- After:
![企业微信截图_db1a9774-d32b-4e6b-bf6d-334abb992104](https://github.com/langgenius/dify/assets/1935105/be6a1541-9d7b-488e-9c50-30344f773f0b)


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement，including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
