### PR TITLE
Fix handling of missing required parameters in ApiTool

### DIFF
--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -148,7 +148,7 @@ class ApiTool(Tool):
                 value = ''
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
-                elif parameter['required']:
+                elif parameter.get('required', False):
                     raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')
@@ -158,7 +158,7 @@ class ApiTool(Tool):
                 value = ''
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
-                elif parameter['required']:
+                elif parameter.get('required', False):
                     raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')
@@ -168,7 +168,7 @@ class ApiTool(Tool):
                 value = ''
                 if parameter['name'] in parameters:
                     value = parameters[parameter['name']]
-                elif parameter['required']:
+                elif parameter.get('required', False):
                     raise ToolParameterValidationError(f"Missing required parameter {parameter['name']}")
                 else:
                     value = (parameter.get('schema', {}) or {}).get('default', '')


### PR DESCRIPTION
# Description

Fixes "unknown error: 'required'" when "required" is not set in the schema.
Related documentation: https://spec.openapis.org/oas/v3.1.0#fixed-fields-9

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Develop a tool where the Parameter Object is used without the 'required' attribute specified. Verify whether it triggers the 'unknown error: 'required'' error message.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
