### PR TITLE
improve: cache tool icons by setting max-age HTTP header and enable gzip compression SVG icons from backend

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -59,7 +59,8 @@ DEFAULTS = {
     'CAN_REPLACE_LOGO': 'False',
     'ETL_TYPE': 'dify',
     'KEYWORD_STORE': 'jieba',
-    'BATCH_UPLOAD_LIMIT': 20
+    'BATCH_UPLOAD_LIMIT': 20,
+    'TOOL_ICON_CACHE_MAX_AGE': 3600,
 }
 
 
@@ -298,6 +299,7 @@ class Config:
         self.BATCH_UPLOAD_LIMIT = get_env('BATCH_UPLOAD_LIMIT')
 
         self.API_COMPRESSION_ENABLED = get_bool_env('API_COMPRESSION_ENABLED')
+        self.TOOL_ICON_CACHE_MAX_AGE = get_env('TOOL_ICON_CACHE_MAX_AGE')
 
 
 class CloudEditionConfig(Config):

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,6 +1,6 @@
 import io
 
-from flask import send_file
+from flask import current_app, send_file
 from flask_login import current_user
 from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
@@ -80,7 +80,8 @@ class ToolBuiltinProviderIconApi(Resource):
     @setup_required
     def get(self, provider):
         icon_bytes, minetype = ToolManageService.get_builtin_tool_provider_icon(provider)
-        return send_file(io.BytesIO(icon_bytes), mimetype=minetype)
+        icon_cache_max_age = int(current_app.config.get('TOOL_ICON_CACHE_MAX_AGE'))
+        return send_file(io.BytesIO(icon_bytes), mimetype=minetype, max_age=icon_cache_max_age)
 
 class ToolModelProviderIconApi(Resource):
     @setup_required

--- a/api/extensions/ext_compress.py
+++ b/api/extensions/ext_compress.py
@@ -5,6 +5,12 @@ def init_app(app: Flask):
     if app.config.get('API_COMPRESSION_ENABLED', False):
         from flask_compress import Compress
 
+        app.config['COMPRESS_MIMETYPES'] = [
+            'application/json',
+            'image/svg+xml',
+            'text/html',
+        ]
+
         compress = Compress()
         compress.init_app(app)
 


### PR DESCRIPTION
# Description

- currently, all the tool icons is repeatedly pulled from the backend, this PR sets max-age HTTP header for tool icons enabling browser caching to improve the load time and minimize HTTP requests
![Uploading image.png…]()


- enable gzip/br compression on SVG mime types for tool icons. the gzip/br compression extension is still disabled by default.
![image](https://github.com/langgenius/dify/assets/1935105/41e13964-9c61-4b03-afc6-50f78a8d65ad)


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement，including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
