### PR TITLE
fix: resolve header.uid' length must be less or equal than 32 on Spark V1.5

### DIFF
--- a/api/core/model_runtime/model_providers/spark/llm/_client.py
+++ b/api/core/model_runtime/model_providers/spark/llm/_client.py
@@ -148,7 +148,9 @@ class SparkLLMClient:
         data = {
             "header": {
                 "app_id": self.app_id,
-                "uid": user_id
+                # "uid": user_id
+                # resolve this error message => $.header.uid' length must be less or equal than 32
+                "uid": user_id[:32] if user_id else None
             },
             "parameter": {
                 "chat": {

--- a/api/core/model_runtime/model_providers/spark/llm/_client.py
+++ b/api/core/model_runtime/model_providers/spark/llm/_client.py
@@ -148,7 +148,6 @@ class SparkLLMClient:
         data = {
             "header": {
                 "app_id": self.app_id,
-                # "uid": user_id
                 # resolve this error message => $.header.uid' length must be less or equal than 32
                 "uid": user_id[:32] if user_id else None
             },

--- a/api/core/model_runtime/model_providers/spark/llm/spark-1.5.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-1.5.yaml
@@ -1,4 +1,5 @@
 model: spark-1.5
+deprecated: true
 label:
   en_US: Spark V1.5
 model_type: llm

--- a/api/core/model_runtime/model_providers/spark/llm/spark-1.5.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-1.5.yaml
@@ -1,5 +1,4 @@
 model: spark-1.5
-deprecated: true
 label:
   en_US: Spark V1.5
 model_type: llm


### PR DESCRIPTION
# Description

fix: parameter user exceeded max length(32 words) when invoking Spark V1.5 llm

Fixes #2982

I referenced this modify：
https://github.com/langgenius/dify/blob/main/api/core/model_runtime/model_providers/moonshot/llm/llm.py#L16

## Type of Change

Please delete any options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
