### PR TITLE
upgrade pydantic to 2.*

### DIFF
--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from core.model_runtime.entities.message_entities import PromptMessageRole
 from models.model import AppMode
@@ -16,6 +16,8 @@ class ModelConfigEntity(BaseModel):
     mode: Optional[str] = None
     parameters: dict[str, Any] = {}
     stop: list[str] = []
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class AdvancedChatMessageEntity(BaseModel):

--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from core.model_runtime.entities.message_entities import PromptMessageRole
 from models.model import AppMode

--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from core.app.app_config.entities import AppConfig, EasyUIBasedAppConfig, WorkflowUIBasedAppConfig
 from core.entities.provider_configuration import ProviderModelBundle
@@ -61,6 +61,8 @@ class ModelConfigWithCredentialsEntity(BaseModel):
     credentials: dict[str, Any] = {}
     parameters: dict[str, Any] = {}
     stop: list[str] = []
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class AppGenerateEntity(BaseModel):

--- a/api/core/app/entities/queue_entities.py
+++ b/api/core/app/entities/queue_entities.py
@@ -44,7 +44,7 @@ class QueueLLMChunkEvent(AppQueueEvent):
     """
     QueueLLMChunkEvent entity
     """
-    event = QueueEvent.LLM_CHUNK
+    event: QueueEvent = QueueEvent.LLM_CHUNK
     chunk: LLMResultChunk
 
 
@@ -52,7 +52,7 @@ class QueueTextChunkEvent(AppQueueEvent):
     """
     QueueTextChunkEvent entity
     """
-    event = QueueEvent.TEXT_CHUNK
+    event: QueueEvent = QueueEvent.TEXT_CHUNK
     text: str
     metadata: Optional[dict] = None
 
@@ -61,7 +61,7 @@ class QueueAgentMessageEvent(AppQueueEvent):
     """
     QueueMessageEvent entity
     """
-    event = QueueEvent.AGENT_MESSAGE
+    event: QueueEvent = QueueEvent.AGENT_MESSAGE
     chunk: LLMResultChunk
 
     
@@ -69,7 +69,7 @@ class QueueMessageReplaceEvent(AppQueueEvent):
     """
     QueueMessageReplaceEvent entity
     """
-    event = QueueEvent.MESSAGE_REPLACE
+    event: QueueEvent = QueueEvent.MESSAGE_REPLACE
     text: str
 
 
@@ -77,7 +77,7 @@ class QueueRetrieverResourcesEvent(AppQueueEvent):
     """
     QueueRetrieverResourcesEvent entity
     """
-    event = QueueEvent.RETRIEVER_RESOURCES
+    event: QueueEvent = QueueEvent.RETRIEVER_RESOURCES
     retriever_resources: list[dict]
 
 
@@ -85,7 +85,7 @@ class QueueAnnotationReplyEvent(AppQueueEvent):
     """
     QueueAnnotationReplyEvent entity
     """
-    event = QueueEvent.ANNOTATION_REPLY
+    event: QueueEvent = QueueEvent.ANNOTATION_REPLY
     message_annotation_id: str
 
 
@@ -93,7 +93,7 @@ class QueueMessageEndEvent(AppQueueEvent):
     """
     QueueMessageEndEvent entity
     """
-    event = QueueEvent.MESSAGE_END
+    event: QueueEvent = QueueEvent.MESSAGE_END
     llm_result: Optional[LLMResult] = None
 
 
@@ -101,28 +101,28 @@ class QueueAdvancedChatMessageEndEvent(AppQueueEvent):
     """
     QueueAdvancedChatMessageEndEvent entity
     """
-    event = QueueEvent.ADVANCED_CHAT_MESSAGE_END
+    event: QueueEvent = QueueEvent.ADVANCED_CHAT_MESSAGE_END
 
 
 class QueueWorkflowStartedEvent(AppQueueEvent):
     """
     QueueWorkflowStartedEvent entity
     """
-    event = QueueEvent.WORKFLOW_STARTED
+    event: QueueEvent = QueueEvent.WORKFLOW_STARTED
 
 
 class QueueWorkflowSucceededEvent(AppQueueEvent):
     """
     QueueWorkflowSucceededEvent entity
     """
-    event = QueueEvent.WORKFLOW_SUCCEEDED
+    event: QueueEvent = QueueEvent.WORKFLOW_SUCCEEDED
 
 
 class QueueWorkflowFailedEvent(AppQueueEvent):
     """
     QueueWorkflowFailedEvent entity
     """
-    event = QueueEvent.WORKFLOW_FAILED
+    event: QueueEvent = QueueEvent.WORKFLOW_FAILED
     error: str
 
 
@@ -130,7 +130,7 @@ class QueueNodeStartedEvent(AppQueueEvent):
     """
     QueueNodeStartedEvent entity
     """
-    event = QueueEvent.NODE_STARTED
+    event: QueueEvent = QueueEvent.NODE_STARTED
 
     node_id: str
     node_type: NodeType
@@ -143,7 +143,7 @@ class QueueNodeSucceededEvent(AppQueueEvent):
     """
     QueueNodeSucceededEvent entity
     """
-    event = QueueEvent.NODE_SUCCEEDED
+    event: QueueEvent = QueueEvent.NODE_SUCCEEDED
 
     node_id: str
     node_type: NodeType
@@ -161,7 +161,7 @@ class QueueNodeFailedEvent(AppQueueEvent):
     """
     QueueNodeFailedEvent entity
     """
-    event = QueueEvent.NODE_FAILED
+    event: QueueEvent = QueueEvent.NODE_FAILED
 
     node_id: str
     node_type: NodeType
@@ -178,7 +178,7 @@ class QueueAgentThoughtEvent(AppQueueEvent):
     """
     QueueAgentThoughtEvent entity
     """
-    event = QueueEvent.AGENT_THOUGHT
+    event: QueueEvent = QueueEvent.AGENT_THOUGHT
     agent_thought_id: str
 
 
@@ -186,7 +186,7 @@ class QueueMessageFileEvent(AppQueueEvent):
     """
     QueueAgentThoughtEvent entity
     """
-    event = QueueEvent.MESSAGE_FILE
+    event: QueueEvent = QueueEvent.MESSAGE_FILE
     message_file_id: str
 
 
@@ -194,7 +194,7 @@ class QueueErrorEvent(AppQueueEvent):
     """
     QueueErrorEvent entity
     """
-    event = QueueEvent.ERROR
+    event: QueueEvent = QueueEvent.ERROR
     error: Any
 
 
@@ -202,7 +202,7 @@ class QueuePingEvent(AppQueueEvent):
     """
     QueuePingEvent entity
     """
-    event = QueueEvent.PING
+    event: QueueEvent = QueueEvent.PING
 
 
 class QueueStopEvent(AppQueueEvent):
@@ -218,7 +218,7 @@ class QueueStopEvent(AppQueueEvent):
         OUTPUT_MODERATION = "output-moderation"
         INPUT_MODERATION = "input-moderation"
 
-    event = QueueEvent.STOP
+    event: QueueEvent = QueueEvent.STOP
     stopped_by: StopBy
 
 

--- a/api/core/app/entities/queue_entities.py
+++ b/api/core/app/entities/queue_entities.py
@@ -195,7 +195,7 @@ class QueueErrorEvent(AppQueueEvent):
     QueueErrorEvent entity
     """
     event: QueueEvent = QueueEvent.ERROR
-    error: Any
+    error: Any = None
 
 
 class QueuePingEvent(AppQueueEvent):

--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMUsage
 from core.model_runtime.utils.encoders import jsonable_encoder
@@ -102,9 +102,7 @@ class ErrorStreamResponse(StreamResponse):
     """
     event: StreamEvent = StreamEvent.ERROR
     err: Exception
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class MessageStreamResponse(StreamResponse):

--- a/api/core/callback_handler/agent_tool_callback_handler.py
+++ b/api/core/callback_handler/agent_tool_callback_handler.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 class DifyAgentCallbackHandler(BaseCallbackHandler, BaseModel):
     """Callback Handler that prints to std out."""
     color: Optional[str] = ''
-    current_loop = 1
+    current_loop: Optional[int] = 1
 
     def __init__(self, color: Optional[str] = None) -> None:
         super().__init__()

--- a/api/core/entities/message_entities.py
+++ b/api/core/entities/message_entities.py
@@ -1,8 +1,8 @@
 import enum
-from typing import Any, cast
+from typing import Any, List, cast
 
 from langchain.schema import AIMessage, BaseMessage, FunctionMessage, HumanMessage, SystemMessage
-from pydantic import BaseModel
+from langchain_core.pydantic_v1 import BaseModel, ConfigDict
 
 from core.model_runtime.entities.message_entities import (
     AssistantPromptMessage,
@@ -15,7 +15,7 @@ from core.model_runtime.entities.message_entities import (
 )
 
 
-class PromptMessageFileType(enum.Enum):
+class PromptMessageFileType(str, enum.Enum):
     IMAGE = 'image'
 
     @staticmethod
@@ -29,9 +29,7 @@ class PromptMessageFileType(enum.Enum):
 class PromptMessageFile(BaseModel):
     type: PromptMessageFileType
     data: Any = None
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ImagePromptMessageFile(PromptMessageFile):
@@ -46,10 +44,8 @@ class ImagePromptMessageFile(PromptMessageFile):
 class LCHumanMessageWithFiles(HumanMessage):
     # content: Union[str, list[Union[str, Dict]]]
     content: str
-    files: list[PromptMessageFile]
-
-    class Config:
-        arbitrary_types_allowed = True
+    files: List[PromptMessageFile]
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 def lc_messages_to_prompt_messages(messages: list[BaseMessage]) -> list[PromptMessage]:

--- a/api/core/entities/message_entities.py
+++ b/api/core/entities/message_entities.py
@@ -28,7 +28,10 @@ class PromptMessageFileType(enum.Enum):
 
 class PromptMessageFile(BaseModel):
     type: PromptMessageFileType
-    data: Any
+    data: Any = None
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class ImagePromptMessageFile(PromptMessageFile):
@@ -44,6 +47,9 @@ class LCHumanMessageWithFiles(HumanMessage):
     # content: Union[str, list[Union[str, Dict]]]
     content: str
     files: list[PromptMessageFile]
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 def lc_messages_to_prompt_messages(messages: list[BaseMessage]) -> list[PromptMessage]:

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from json import JSONDecodeError
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from core.entities.model_entities import ModelStatus, ModelWithProviderEntity, SimpleModelProviderEntity
 from core.entities.provider_entities import CustomConfiguration, SystemConfiguration, SystemConfigurationStatus
@@ -791,8 +791,4 @@ class ProviderModelBundle(BaseModel):
     configuration: ProviderConfiguration
     provider_instance: ModelProvider
     model_type_instance: AIModel
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/api/core/extension/extensible.py
+++ b/api/core/extension/extensible.py
@@ -16,7 +16,7 @@ class ExtensionModule(enum.Enum):
 
 
 class ModuleExtension(BaseModel):
-    extension_class: Any
+    extension_class: Any = None
     name: str
     label: Optional[dict] = None
     form_schema: Optional[list] = None

--- a/api/core/helper/code_executor/code_executor.py
+++ b/api/core/helper/code_executor/code_executor.py
@@ -20,8 +20,8 @@ class CodeExecutionException(Exception):
 
 class CodeExecutionResponse(BaseModel):
     class Data(BaseModel):
-        stdout: Optional[str]
-        error: Optional[str]
+        stdout: Optional[str] = None
+        error: Optional[str] = None
 
     code: int
     message: str

--- a/api/core/model_runtime/entities/model_entities.py
+++ b/api/core/model_runtime/entities/model_entities.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from core.model_runtime.entities.common_entities import I18nObject
 
@@ -148,9 +148,7 @@ class ProviderModel(BaseModel):
     fetch_from: FetchFrom
     model_properties: dict[ModelPropertyKey, Any]
     deprecated: bool = False
-
-    class Config:
-        protected_namespaces = ()
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class ParameterRule(BaseModel):

--- a/api/core/model_runtime/entities/provider_entities.py
+++ b/api/core/model_runtime/entities/provider_entities.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, ModelType, ProviderModel
@@ -121,9 +121,7 @@ class ProviderEntity(BaseModel):
     models: list[ProviderModel] = []
     provider_credential_schema: Optional[ProviderCredentialSchema] = None
     model_credential_schema: Optional[ModelCredentialSchema] = None
-
-    class Config:
-        protected_namespaces = ()
+    model_config = ConfigDict(protected_namespaces=())
 
     def to_simple_provider(self) -> SimpleProviderEntity:
         """

--- a/api/core/model_runtime/model_providers/chatglm/llm/llm.py
+++ b/api/core/model_runtime/model_providers/chatglm/llm/llm.py
@@ -244,7 +244,7 @@ class ChatGLMLargeLanguageModel(LargeLanguageModel):
                 )
 
                 tool_call = AssistantPromptMessage.ToolCall(
-                    id=0,
+                    id="0",
                     type='function',
                     function=function
                 )

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.entities.provider_entities import ProviderConfig, ProviderEntity, SimpleProviderEntity
@@ -19,11 +19,7 @@ class ModelProviderExtension(BaseModel):
     provider_instance: ModelProvider
     name: str
     position: Optional[int] = None
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ModelProviderFactory:

--- a/api/core/model_runtime/model_providers/ollama/ollama.yaml
+++ b/api/core/model_runtime/model_providers/ollama/ollama.yaml
@@ -90,9 +90,9 @@ model_credential_schema:
       options:
         - value: 'true'
           label:
-            en_US: Yes
+            en_US: "Yes"
             zh_Hans: 是
         - value: 'false'
           label:
-            en_US: No
+            en_US: "No"
             zh_Hans: 否

--- a/api/core/model_runtime/model_providers/tongyi/llm/_client.py
+++ b/api/core/model_runtime/model_providers/tongyi/llm/_client.py
@@ -2,8 +2,8 @@ from typing import Any, Optional
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms import Tongyi
-from langchain.llms.tongyi import generate_with_retry, stream_generate_with_retry
 from langchain.schema import Generation, LLMResult
+from langchain_community.llms.tongyi import generate_with_retry, stream_generate_with_retry
 
 
 class EnhanceTongyi(Tongyi):

--- a/api/core/model_runtime/model_providers/tongyi/llm/llm.py
+++ b/api/core/model_runtime/model_providers/tongyi/llm/llm.py
@@ -11,7 +11,7 @@ from dashscope.common.error import (
     UnsupportedHTTPMethod,
     UnsupportedModel,
 )
-from langchain.llms.tongyi import generate_with_retry, stream_generate_with_retry
+from langchain_community.llms.tongyi import generate_with_retry, stream_generate_with_retry
 
 from core.model_runtime.callbacks.base_callback import Callback
 from core.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta

--- a/api/core/model_runtime/model_providers/triton_inference_server/triton_inference_server.yaml
+++ b/api/core/model_runtime/model_providers/triton_inference_server/triton_inference_server.yaml
@@ -43,7 +43,7 @@ model_credential_schema:
       placeholder:
         zh_Hans: 在此输入您的上下文大小
         en_US: Enter the context size
-      default: 2048
+      default: "2048"
     - variable: completion_type
       label:
         zh_Hans: 补全类型
@@ -69,16 +69,16 @@ model_credential_schema:
         en_US: Stream output
       type: select
       required: true
-      default: true
+      default: "true"
       placeholder:
         zh_Hans: 是否支持流式输出
         en_US: Whether to support stream output
       options:
         - label:
             zh_Hans: 是
-            en_US: Yes
-          value: true
+            en_US: "Yes"
+          value: "true"
         - label:
             zh_Hans: 否
-            en_US: No
-          value: false
+            en_US: "No"
+          value: "false"

--- a/api/core/model_runtime/utils/encoders.py
+++ b/api/core/model_runtime/utils/encoders.py
@@ -12,9 +12,9 @@ from typing import Any, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel
-from pydantic.color import Color
 from pydantic.networks import AnyUrl, NameEmail
 from pydantic.types import SecretBytes, SecretStr
+from pydantic_extra_types.color import Color
 
 from ._compat import PYDANTIC_V2, Url, _model_dump
 

--- a/api/core/moderation/output_moderation.py
+++ b/api/core/moderation/output_moderation.py
@@ -4,7 +4,7 @@ import time
 from typing import Any, Optional
 
 from flask import Flask, current_app
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.entities.queue_entities import QueueMessageReplaceEvent
@@ -33,9 +33,7 @@ class OutputModeration(BaseModel):
     buffer: str = ''
     is_final_chunk: bool = False
     final_output: Optional[str] = None
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def should_direct_output(self):
         return self.final_output is not None

--- a/api/core/rag/datasource/vdb/milvus/milvus_vector.py
+++ b/api/core/rag/datasource/vdb/milvus/milvus_vector.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 from pymilvus import MilvusClient, MilvusException, connections
 
 from core.rag.datasource.vdb.field import Field
@@ -21,7 +21,8 @@ class MilvusConfig(BaseModel):
     secure: bool = False
     batch_size: int = 100
 
-    @root_validator()
+    @model_validator()
+    @classmethod
     def validate_config(cls, values: dict) -> dict:
         if not values['host']:
             raise ValueError("config MILVUS_HOST is required")

--- a/api/core/rag/datasource/vdb/qdrant/qdrant_vector.py
+++ b/api/core/rag/datasource/vdb/qdrant/qdrant_vector.py
@@ -33,9 +33,9 @@ if TYPE_CHECKING:
 
 class QdrantConfig(BaseModel):
     endpoint: str
-    api_key: Optional[str]
+    api_key: Optional[str] = None
     timeout: float = 20
-    root_path: Optional[str]
+    root_path: Optional[str] = None
 
     def to_qdrant_params(self):
         if self.endpoint and self.endpoint.startswith('path:'):

--- a/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
+++ b/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 import requests
 import weaviate
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 
 from core.rag.datasource.vdb.field import Field
 from core.rag.datasource.vdb.vector_base import BaseVector
@@ -14,10 +14,11 @@ from models.dataset import Dataset
 
 class WeaviateConfig(BaseModel):
     endpoint: str
-    api_key: Optional[str]
+    api_key: Optional[str] = None
     batch_size: int = 100
 
-    @root_validator()
+    @model_validator()
+    @classmethod
     def validate_config(cls, values: dict) -> dict:
         if not values['endpoint']:
             raise ValueError("config WEAVIATE_ENDPOINT is required")

--- a/api/core/rag/extractor/blod/blod.py
+++ b/api/core/rag/extractor/blod/blod.py
@@ -14,7 +14,7 @@ from io import BufferedReader, BytesIO
 from pathlib import PurePath
 from typing import Any, Optional, Union
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 PathLike = Union[str, PurePath]
 
@@ -29,7 +29,7 @@ class Blob(BaseModel):
     Inspired by: https://developer.mozilla.org/en-US/docs/Web/API/Blob
     """
 
-    data: Union[bytes, str, None]  # Raw data
+    data: Union[bytes, str, None] = None  # Raw data
     mimetype: Optional[str] = None  # Not to be confused with a file extension
     encoding: str = "utf-8"  # Use utf-8 as default encoding, if decoding to string
     # Location where the original content was found
@@ -37,17 +37,15 @@ class Blob(BaseModel):
     # Useful for situations where downstream code assumes it must work with file paths
     # rather than in-memory content.
     path: Optional[PathLike] = None
-
-    class Config:
-        arbitrary_types_allowed = True
-        frozen = True
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
     @property
     def source(self) -> Optional[str]:
         """The source location of the blob as string if known otherwise none."""
         return str(self.path) if self.path else None
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def check_blob_is_valid(cls, values: Mapping[str, Any]) -> Mapping[str, Any]:
         """Verify that either data or path is provided."""
         if "data" not in values and "path" not in values:

--- a/api/core/rag/extractor/entity/extract_setting.py
+++ b/api/core/rag/extractor/entity/extract_setting.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from models.dataset import Document
 from models.model import UploadFile
@@ -13,9 +13,7 @@ class NotionInfo(BaseModel):
     notion_page_type: str
     document: Document = None
     tenant_id: str
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **data) -> None:
         super().__init__(**data)
@@ -29,9 +27,7 @@ class ExtractSetting(BaseModel):
     upload_file: UploadFile = None
     notion_info: NotionInfo = None
     document_model: str = None
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **data) -> None:
         super().__init__(**data)

--- a/api/core/rag/retrieval/agent/multi_dataset_router_agent.py
+++ b/api/core/rag/retrieval/agent/multi_dataset_router_agent.py
@@ -10,18 +10,18 @@ from langchain.schema import AgentAction, AgentFinish, AIMessage, SystemMessage
 from langchain.tools import BaseTool
 from pydantic import root_validator
 
-from core.entities.application_entities import ModelConfigEntity
+from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity
 from core.entities.message_entities import lc_messages_to_prompt_messages
-from core.features.dataset_retrieval.agent.fake_llm import FakeLLM
 from core.model_manager import ModelInstance
 from core.model_runtime.entities.message_entities import PromptMessageTool
+from core.rag.retrieval.agent.fake_llm import FakeLLM
 
 
 class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
     """
     An Multi Dataset Retrieve Agent driven by Router.
     """
-    model_config: ModelConfigEntity
+    model_config: ModelConfigWithCredentialsEntity
 
     class Config:
         """Configuration for this pydantic object."""
@@ -156,7 +156,7 @@ class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
     @classmethod
     def from_llm_and_tools(
             cls,
-            model_config: ModelConfigEntity,
+            model_config: ModelConfigWithCredentialsEntity,
             tools: Sequence[BaseTool],
             callback_manager: Optional[BaseCallbackManager] = None,
             extra_prompt_messages: Optional[list[BaseMessagePromptTemplate]] = None,

--- a/api/core/rag/retrieval/agent/multi_dataset_router_agent.py
+++ b/api/core/rag/retrieval/agent/multi_dataset_router_agent.py
@@ -10,18 +10,18 @@ from langchain.schema import AgentAction, AgentFinish, AIMessage, SystemMessage
 from langchain.tools import BaseTool
 from pydantic import root_validator
 
-from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity
+from core.entities.application_entities import ModelConfigEntity
 from core.entities.message_entities import lc_messages_to_prompt_messages
+from core.features.dataset_retrieval.agent.fake_llm import FakeLLM
 from core.model_manager import ModelInstance
 from core.model_runtime.entities.message_entities import PromptMessageTool
-from core.rag.retrieval.agent.fake_llm import FakeLLM
 
 
 class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
     """
     An Multi Dataset Retrieve Agent driven by Router.
     """
-    model_config: ModelConfigWithCredentialsEntity
+    model_config: ModelConfigEntity
 
     class Config:
         """Configuration for this pydantic object."""
@@ -156,7 +156,7 @@ class MultiDatasetRouterAgent(OpenAIFunctionsAgent):
     @classmethod
     def from_llm_and_tools(
             cls,
-            model_config: ModelConfigWithCredentialsEntity,
+            model_config: ModelConfigEntity,
             tools: Sequence[BaseTool],
             callback_manager: Optional[BaseCallbackManager] = None,
             extra_prompt_messages: Optional[list[BaseMessagePromptTemplate]] = None,

--- a/api/core/rag/retrieval/agent/structed_multi_dataset_router_agent.py
+++ b/api/core/rag/retrieval/agent/structed_multi_dataset_router_agent.py
@@ -11,6 +11,7 @@ from langchain.callbacks.manager import Callbacks
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate
 from langchain.schema import AgentAction, AgentFinish, OutputParserException
 from langchain.tools import BaseTool
+from pydantic import ConfigDict
 
 from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity
 from core.rag.retrieval.agent.llm_chain import LLMChain
@@ -50,11 +51,7 @@ Action:
 
 class StructuredMultiDatasetRouterAgent(StructuredChatAgent):
     dataset_tools: Sequence[BaseTool]
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def should_use_agent(self, query: str):
         """

--- a/api/core/rag/retrieval/agent_based_dataset_executor.py
+++ b/api/core/rag/retrieval/agent_based_dataset_executor.py
@@ -32,7 +32,6 @@ class AgentConfiguration(BaseModel):
     early_stopping_method: str = "generate"
     # `generate` will continue to complete the last inference after reaching the iteration limit or request time limit
 
-    agent_llm_callback: Optional[AgentLLMCallback] = None
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
 

--- a/api/core/tools/entities/user_entities.py
+++ b/api/core/tools/entities/user_entities.py
@@ -52,3 +52,10 @@ class UserToolProvider(BaseModel):
 
 class UserToolProviderCredentials(BaseModel):
     credentials: dict[str, ToolProviderCredentials]
+
+class UserTool(BaseModel):
+    author: str
+    name: str # identifier
+    label: I18nObject # label
+    description: I18nObject
+    parameters: Optional[list[ToolParameter]] = None

--- a/api/core/tools/entities/user_entities.py
+++ b/api/core/tools/entities/user_entities.py
@@ -13,7 +13,7 @@ class UserTool(BaseModel):
     name: str # identifier
     label: I18nObject # label
     description: I18nObject
-    parameters: Optional[list[ToolParameter]]
+    parameters: Optional[list[ToolParameter]] = None
 
 class UserToolProvider(BaseModel):
     class ProviderType(Enum):
@@ -52,10 +52,3 @@ class UserToolProvider(BaseModel):
 
 class UserToolProviderCredentials(BaseModel):
     credentials: dict[str, ToolProviderCredentials]
-
-class UserTool(BaseModel):
-    author: str
-    name: str # identifier
-    label: I18nObject # label
-    description: I18nObject
-    parameters: Optional[list[ToolParameter]] = None

--- a/api/core/tools/provider/builtin/aippt/tools/aippt.py
+++ b/api/core/tools/provider/builtin/aippt/tools/aippt.py
@@ -4,7 +4,7 @@ from hmac import new as hmac_new
 from json import loads as json_loads
 from threading import Lock
 from time import sleep, time
-from typing import Any
+from typing import Any, ClassVar
 
 from httpx import get, post
 from requests import get as requests_get
@@ -22,9 +22,9 @@ class AIPPTGenerateTool(BuiltinTool):
 
     _api_base_url = URL('https://co.aippt.cn/api')
     _api_token_cache = {}
-    _api_token_cache_lock = Lock()
+    _api_token_cache_lock: ClassVar[Any] = Lock()
     _style_cache = {}
-    _style_cache_lock = Lock()
+    _style_cache_lock: ClassVar[Any] = Lock()
 
     _task = {}
     _task_type_map = {

--- a/api/core/tools/provider/builtin/bing/tools/bing_web_search.py
+++ b/api/core/tools/provider/builtin/bing/tools/bing_web_search.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Optional, Union
 from urllib.parse import quote
 
 from requests import get
@@ -8,9 +8,9 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class BingSearchTool(BuiltinTool):
-    url = 'https://api.bing.microsoft.com/v7.0/search'
+    url: Optional[str] = 'https://api.bing.microsoft.com/v7.0/search'
 
-    def _invoke_bing(self, 
+    def _invoke_bing(self,
                      user_id: str,
                      subscription_key: str, query: str, limit: int, 
                      result_type: str, market: str, lang: str, 

--- a/api/core/tools/provider/builtin/bing/tools/bing_web_search.yaml
+++ b/api/core/tools/provider/builtin/bing/tools/bing_web_search.yaml
@@ -258,12 +258,12 @@ parameters:
           en_US: Netherlands
           zh_Hans: 荷兰
           pt_BR: Netherlands
-      - value: NZ
+      - value: "NZ"
         label:
           en_US: New Zealand
           zh_Hans: 新西兰
           pt_BR: New Zealand
-      - value: NO
+      - value: "NO"
         label:
           en_US: Norway
           zh_Hans: 挪威

--- a/api/core/tools/provider/builtin/qrcode/tools/qrcode_generator.py
+++ b/api/core/tools/provider/builtin/qrcode/tools/qrcode_generator.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import Any, Union
+from typing import Any, ClassVar, Union
 
 from qrcode.constants import ERROR_CORRECT_H, ERROR_CORRECT_L, ERROR_CORRECT_M, ERROR_CORRECT_Q
 from qrcode.image.base import BaseImage
@@ -12,7 +12,7 @@ from core.tools.tool.builtin_tool import BuiltinTool
 
 
 class QRCodeGeneratorTool(BuiltinTool):
-    error_correction_levels = {
+    error_correction_levels: ClassVar[dict] = {
         'L': ERROR_CORRECT_L,  # <=7%
         'M': ERROR_CORRECT_M,  # <=15%
         'Q': ERROR_CORRECT_Q,  # <=25%

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -23,6 +23,8 @@ class Tool(BaseModel, ABC):
     description: ToolDescription = None
     is_team_authorization: bool = False
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator('parameters', pre=True, always=True)
     def set_parameters(cls, v, values):
         if not v:

--- a/api/core/workflow/nodes/code/entities.py
+++ b/api/core/workflow/nodes/code/entities.py
@@ -12,7 +12,7 @@ class CodeNodeData(BaseNodeData):
     """
     class Output(BaseModel):
         type: Literal['string', 'number', 'object', 'array[string]', 'array[number]', 'array[object]']
-        children: Optional[dict[str, 'Output']]
+        children: Optional[dict[str, 'Output']] = {}
 
     variables: list[VariableSelector]
     code_language: Literal['python3', 'javascript']

--- a/api/core/workflow/nodes/code/entities.py
+++ b/api/core/workflow/nodes/code/entities.py
@@ -12,7 +12,7 @@ class CodeNodeData(BaseNodeData):
     """
     class Output(BaseModel):
         type: Literal['string', 'number', 'object', 'array[string]', 'array[number]', 'array[object]']
-        children: Optional[dict[str, 'Output']] = {}
+        children: Optional[dict[str, 'Output']] = None
 
     variables: list[VariableSelector]
     code_language: Literal['python3', 'javascript']

--- a/api/core/workflow/nodes/http_request/entities.py
+++ b/api/core/workflow/nodes/http_request/entities.py
@@ -10,14 +10,18 @@ class HttpRequestNodeData(BaseNodeData):
     Code Node Data.
     """
     class Authorization(BaseModel):
+        # TODO[pydantic]: The `Config` class inherits from another class, please create the `model_config` manually.
+        # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
         class Config(BaseModel):
             type: Literal[None, 'basic', 'bearer', 'custom']
-            api_key: Union[None, str]
-            header: Union[None, str]
+            api_key: Union[None, str] = None
+            header: Union[None, str] = None
 
         type: Literal['no-auth', 'api-key']
         config: Optional[Config]
 
+        # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+        # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
         @validator('config', always=True, pre=True)
         def check_config(cls, v, values):
             """
@@ -33,7 +37,7 @@ class HttpRequestNodeData(BaseNodeData):
 
     class Body(BaseModel):
         type: Literal['none', 'form-data', 'x-www-form-urlencoded', 'raw-text', 'json']
-        data: Union[None, str]
+        data: Union[None, str] = None
 
     method: Literal['get', 'post', 'put', 'patch', 'delete', 'head']
     url: str

--- a/api/core/workflow/nodes/if_else/entities.py
+++ b/api/core/workflow/nodes/if_else/entities.py
@@ -18,7 +18,7 @@ class IfElseNodeData(BaseNodeData):
             # for string or array
             "contains", "not contains", "start with", "end with", "is", "is not", "empty", "not empty",
             # for number
-            "=", "≠", ">", "<", "≥", "≤", "null", "not null"
+            "=" , "≠", ">", "<", "≥", "≤", "null", "not null"
         ]
         value: Optional[str] = None
 

--- a/api/core/workflow/nodes/knowledge_retrieval/entities.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/entities.py
@@ -18,7 +18,7 @@ class MultipleRetrievalConfig(BaseModel):
     Multiple Retrieval Config.
     """
     top_k: int
-    score_threshold: Optional[float]
+    score_threshold: Optional[float] = None
     reranking_model: RerankingModelConfig
 
 
@@ -47,5 +47,5 @@ class KnowledgeRetrievalNodeData(BaseNodeData):
     query_variable_selector: list[str]
     dataset_ids: list[str]
     retrieval_mode: Literal['single', 'multiple']
-    multiple_retrieval_config: Optional[MultipleRetrievalConfig]
-    single_retrieval_config: Optional[SingleRetrievalConfig]
+    multiple_retrieval_config: Optional[MultipleRetrievalConfig] = None
+    single_retrieval_config: Optional[SingleRetrievalConfig] = None

--- a/api/core/workflow/nodes/question_classifier/entities.py
+++ b/api/core/workflow/nodes/question_classifier/entities.py
@@ -32,5 +32,5 @@ class QuestionClassifierNodeData(BaseNodeData):
     type: str = 'question-classifier'
     model: ModelConfig
     classes: list[ClassConfig]
-    instruction: Optional[str]
-    memory: Optional[MemoryConfig]
+    instruction: Optional[str] = None
+    memory: Optional[MemoryConfig] = None

--- a/api/core/workflow/nodes/tool/entities.py
+++ b/api/core/workflow/nodes/tool/entities.py
@@ -19,6 +19,8 @@ class ToolNodeData(BaseNodeData, ToolEntity):
         value: Union[ToolParameterValue, list[str]]
         type: Literal['mixed', 'variable', 'constant']
 
+        # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+        # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
         @validator('type', pre=True, always=True)
         def check_type(cls, value, values):
             typ = value

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,7 +10,7 @@ flask-restful~=0.3.10
 flask-cors~=4.0.0
 gunicorn~=21.2.0
 gevent~=23.9.1
-langchain==0.0.250
+langchain==0.1.13
 openai~=1.13.3
 tiktoken~=0.6.0
 psycopg2-binary~=2.9.6
@@ -54,7 +54,7 @@ safetensors==0.3.2
 zhipuai==1.0.7
 werkzeug~=3.0.1
 pymilvus==2.3.0
-qdrant-client==1.7.3
+qdrant-client==1.8.2
 cohere~=4.44
 pyyaml~=6.0.1
 numpy~=1.25.2
@@ -76,3 +76,4 @@ qrcode~=7.4.2
 azure-storage-blob==12.9.0
 azure-identity==1.15.0
 lxml==5.1.0
+pydantic-extra-types==2.*

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,7 +10,7 @@ flask-restful~=0.3.10
 flask-cors~=4.0.0
 gunicorn~=21.2.0
 gevent~=23.9.1
-langchain==0.1.13
+langchain==0.1.14
 openai~=1.13.3
 tiktoken~=0.6.0
 psycopg2-binary~=2.9.6

--- a/api/test_pydantic.py
+++ b/api/test_pydantic.py
@@ -1,0 +1,17 @@
+from typing import Any, List
+from pydantic import BaseModel, ConfigDict
+from langchain_core.load.serializable import Serializable
+from langchain_core.pydantic_v1 import BaseModel, ConfigDict
+
+
+class PromptMessageFile(BaseModel):
+    data: Any = None
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class LCHumanMessageWithFiles(Serializable):
+    # content: Union[str, list[Union[str, Dict]]]
+    content: str
+    files: List[PromptMessageFile]
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+

--- a/api/tests/integration_tests/model_runtime/__mock/openai_chat.py
+++ b/api/tests/integration_tests/model_runtime/__mock/openai_chat.py
@@ -198,7 +198,7 @@ class MockChatClass(object):
 
     def chat_create(self: Completions, *,
         messages: List[ChatCompletionMessageParam],
-        model: Union[str,Literal[
+        model: Union[str, Literal[
             "gpt-4-1106-preview", "gpt-4-vision-preview", "gpt-4", "gpt-4-0314", "gpt-4-0613",
             "gpt-4-32k", "gpt-4-32k-0314", "gpt-4-32k-0613",
             "gpt-3.5-turbo-1106", "gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0301",


### PR DESCRIPTION
# Description

pydantic 2 introduced multiple enhancement, faster performance, and it was released 9 months ago, it's time to move forward and get better performance, more features.

summary of the changes:
1. upgrade langchain, inference-client qdrant-client to the latest, add pydantic-extra-types as it's a new package now
2. apply changes due to pydantic breaking changes, using `bump-pydantic  api`
3. fix a few type errors brought by YAML parse, those errors should exist before the upgrade, the strong type check by pydantic 2 exposed them.
4. rename `model_config` field in `AdvancedChatMessageEntity`, `MultiDatasetRouterAgent`, `AgentConfiguration` to `ai_model_config` because `model_config` is reserved by pydantic 2

This is a big update and could be harmful, I advise someone else set up a coverage report like `codecov`, then I can see which part of the code is not covered by tests and add more tests to bring us more confidence.

## Type of Change

Please delete options that are not relevant.

- [x] Dependency upgrade

# How Has This Been Tested?

- [x] Start a server that works

```
@LeoQuote ➜ /workspaces/dify/api (upgrade_pydantic) $ FLASK_APP=app.py flask run 
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_type" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
/home/vscode/.local/lib/python3.10/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
/home/vscode/.local/lib/python3.10/site-packages/langchain/llms/__init__.py:548: LangChainDeprecationWarning: Importing LLMs from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.llms import Tongyi`.

To install langchain-community run `pip install -U langchain-community`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_type_instance" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_schema" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
WARNING:root:Missing subclass of ExternalDataTool in /workspaces/dify/api/core/external_data_tool/api/api.py, Skip.
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:186: UserWarning: Field name "raise_error" shadows an attribute in parent "BaseCallbackHandler"; 
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:186: UserWarning: Field name "run_inline" shadows an attribute in parent "BaseCallbackHandler"; 
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_configuration" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/langchain/__init__.py:29: UserWarning: Importing BasePromptTemplate from langchain root module is no longer supported. Please use langchain_core.prompts.BasePromptTemplate instead.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/langchain/__init__.py:29: UserWarning: Importing PromptTemplate from langchain root module is no longer supported. Please use langchain_core.prompts.PromptTemplate instead.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/langchain/__init__.py:29: UserWarning: Importing LLMChain from langchain root module is no longer supported. Please use langchain.chains.LLMChain instead.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_credential_schema" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_type" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
 * Serving Flask app 'app.py'
 * Debug mode: off
INFO:werkzeug:WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:5000
INFO:werkzeug:Press CTRL+C to quit

```

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
