### PR TITLE
update the discord Invalid invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,4 +155,4 @@ And that's it! Once your PR is merged, you will be featured as a contributor in 
 
 ## Getting Help
 
-If you ever get stuck or got a burning question while contributing, simply shoot your queries our way via the related GitHub issue, or hop onto our [Discord](https://discord.gg/AhzKf7dNgk) for a quick chat. 
+If you ever get stuck or got a burning question while contributing, simply shoot your queries our way via the related GitHub issue, or hop onto our [Discord](https://discord.gg/8Tpq4AcN9c) for a quick chat. 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -152,4 +152,4 @@ Dify的后端使用Python编写，使用[Flask](https://flask.palletsprojects.co
 
 ## 获取帮助
 
-如果你在贡献过程中遇到困难或者有任何问题，可以通过相关的 GitHub 问题提出你的疑问，或者加入我们的 [Discord](https://discord.gg/AhzKf7dNgk) 进行快速交流。
+如果你在贡献过程中遇到困难或者有任何问题，可以通过相关的 GitHub 问题提出你的疑问，或者加入我们的 [Discord](https://discord.gg/8Tpq4AcN9c) 进行快速交流。

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ At the same time, please consider supporting Dify by sharing it on social media 
 
 ### Translations
 
-We are looking for contributors to help with translating Dify to languages other than Mandarin or English. If you are interested in helping, please see the [i18n README](https://github.com/langgenius/dify/blob/main/web/i18n/README.md) for more information, and leave us a comment in the `global-users` channel of our [Discord Community Server](https://discord.gg/AhzKf7dNgk).
+We are looking for contributors to help with translating Dify to languages other than Mandarin or English. If you are interested in helping, please see the [i18n README](https://github.com/langgenius/dify/blob/main/web/i18n/README.md) for more information, and leave us a comment in the `global-users` channel of our [Discord Community Server](https://discord.gg/8Tpq4AcN9c).
 
 ## Community & Support
 


### PR DESCRIPTION
# Description

When I looked for CONTRIBUTING_CN.md on github, at the bottom of the file, I found the discord invite link.But the link is Invalid like the image

![image](https://github.com/langgenius/dify/assets/124553455/5ce03dac-e7ef-4002-9d57-0eea113beae3)

This fix was made to allow other contributors to correctly find discord community invitation links
Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)


# How Has This Been Tested?

use the invite link from [Dify Document Support](https://docs.dify.ai/community/support)

like the below
![image](https://github.com/langgenius/dify/assets/124553455/7bc57cee-26c6-4186-b90a-883a76f7ba71)

- [ ] TODO

# Suggested Checklist:

-  I have made corresponding changes to the documentation 

