### PR TITLE
generalize SDK client initialization method for model providers

### DIFF
--- a/api/core/model_runtime/model_providers/__base/model_client_provider.py
+++ b/api/core/model_runtime/model_providers/__base/model_client_provider.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+
+class ModelClientProvider:
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> Any:
+        """
+        Get an SDK client instance for model provider, if dedicate SDK available
+        """
+        raise NotImplementedError

--- a/api/core/model_runtime/model_providers/__base/model_client_provider.py
+++ b/api/core/model_runtime/model_providers/__base/model_client_provider.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Any, Optional
 
 
 class ModelClientProvider:
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> Any:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> Any:
         """
         Get an SDK client instance for model provider, if dedicate SDK available
         """

--- a/api/core/model_runtime/model_providers/anthropic/anthropic.py
+++ b/api/core/model_runtime/model_providers/anthropic/anthropic.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from anthropic import Anthropic
 
@@ -35,6 +35,6 @@ class AnthropicProvider(ModelProvider, ModelClientProvider):
             raise ex
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> Anthropic:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> Anthropic:
         client = Anthropic(**kwargs)
         return client

--- a/api/core/model_runtime/model_providers/anthropic/anthropic.py
+++ b/api/core/model_runtime/model_providers/anthropic/anthropic.py
@@ -1,13 +1,17 @@
 import logging
+from typing import Any
+
+from anthropic import Anthropic
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)
 
 
-class AnthropicProvider(ModelProvider):
+class AnthropicProvider(ModelProvider, ModelClientProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -29,3 +33,8 @@ class AnthropicProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
             raise ex
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> Anthropic:
+        client = Anthropic(**kwargs)
+        return client

--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -42,6 +42,7 @@ from core.model_runtime.errors.invoke import (
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.anthropic.anthropic import AnthropicProvider
 
 ANTHROPIC_BLOCK_MODE_PROMPT = """You should always follow the instructions and output a valid {{block}} object.
 The structure of the {{block}} object you can found in the instructions, use {"answer": "$your_answer"} as the default structure
@@ -76,7 +77,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         return self._chat_generate(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
 
     def _chat_generate(self, model: str, credentials: dict,
-                       prompt_messages: list[PromptMessage], model_parameters: dict, 
+                       prompt_messages: list[PromptMessage], model_parameters: dict,
                        tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None,
                        stream: bool = True, user: Optional[str] = None) -> Union[LLMResult, Generator]:
         """
@@ -215,7 +216,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         """
         prompt = self._convert_messages_to_prompt_anthropic(prompt_messages)
 
-        client = Anthropic(api_key="")
+        client = AnthropicProvider.get_service_client(api_key="")
         tokens = client.count_tokens(prompt)
 
         tool_call_inner_prompts_tokens_map = {
@@ -465,7 +466,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                             "type": "text",
                             "text": message.content
                         })
-                    
+
                     if prompt_message_dicts[-1]["role"] == "assistant":
                         prompt_message_dicts[-1]["content"].extend(content)
                     else:

--- a/api/core/model_runtime/model_providers/baichuan/baichuan.py
+++ b/api/core/model_runtime/model_providers/baichuan/baichuan.py
@@ -1,12 +1,15 @@
 import logging
+from typing import Any
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
+from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo import BaichuanModel
 
 logger = logging.getLogger(__name__)
 
-class BaichuanProvider(ModelProvider):
+class BaichuanProvider(ModelProvider,ModelClientProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -28,3 +31,11 @@ class BaichuanProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
             raise ex
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> BaichuanModel:
+        client = BaichuanModel(
+            api_key=credentials.get('api_key'),
+            secret_key=credentials.get('secret_key', '')
+        )
+        return client

--- a/api/core/model_runtime/model_providers/baichuan/baichuan.py
+++ b/api/core/model_runtime/model_providers/baichuan/baichuan.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
@@ -33,7 +33,7 @@ class BaichuanProvider(ModelProvider,ModelClientProvider):
             raise ex
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> BaichuanModel:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> BaichuanModel:
         client = BaichuanModel(
             api_key=credentials.get('api_key'),
             secret_key=credentials.get('secret_key', '')

--- a/api/core/model_runtime/model_providers/baichuan/llm/llm.py
+++ b/api/core/model_runtime/model_providers/baichuan/llm/llm.py
@@ -19,8 +19,9 @@ from core.model_runtime.errors.invoke import (
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.baichuan.baichuan import BaichuanProvider
 from core.model_runtime.model_providers.baichuan.llm.baichuan_tokenizer import BaichuanTokenizer
-from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo import BaichuanMessage, BaichuanModel
+from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo import BaichuanMessage
 from core.model_runtime.model_providers.baichuan.llm.baichuan_turbo_errors import (
     BadRequestError,
     InsufficientAccountBalance,
@@ -92,10 +93,7 @@ class BaichuanLarguageModel(LargeLanguageModel):
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         # ping
-        instance = BaichuanModel(
-            api_key=credentials['api_key'],
-            secret_key=credentials.get('secret_key', '')
-        )
+        instance = BaichuanProvider.get_service_client(credentials=credentials)
 
         try:
             instance.generate(model=model, stream=False, messages=[
@@ -113,10 +111,7 @@ class BaichuanLarguageModel(LargeLanguageModel):
         if tools is not None and len(tools) > 0:
             raise InvokeBadRequestError("Baichuan model doesn't support tools")
         
-        instance = BaichuanModel(
-            api_key=credentials['api_key'],
-            secret_key=credentials.get('secret_key', '')
-        )
+        instance = BaichuanProvider.get_service_client(credentials=credentials)
 
         # convert prompt messages to baichuan messages
         messages = [

--- a/api/core/model_runtime/model_providers/bedrock/bedrock.py
+++ b/api/core/model_runtime/model_providers/bedrock/bedrock.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from anthropic import AnthropicBedrock
 
@@ -36,7 +36,7 @@ class BedrockProvider(ModelProvider, ModelClientProvider):
             raise ex
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> AnthropicBedrock:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> AnthropicBedrock:
         client = AnthropicBedrock(
             aws_access_key=credentials["aws_access_key_id"],
             aws_secret_key=credentials["aws_secret_access_key"],

--- a/api/core/model_runtime/model_providers/bedrock/bedrock.py
+++ b/api/core/model_runtime/model_providers/bedrock/bedrock.py
@@ -1,12 +1,17 @@
 import logging
+from typing import Any
+
+from anthropic import AnthropicBedrock
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)
 
-class BedrockProvider(ModelProvider):
+
+class BedrockProvider(ModelProvider, ModelClientProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -29,3 +34,12 @@ class BedrockProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
             raise ex
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> AnthropicBedrock:
+        client = AnthropicBedrock(
+            aws_access_key=credentials["aws_access_key_id"],
+            aws_secret_key=credentials["aws_secret_access_key"],
+            aws_region=credentials["aws_region"],
+        )
+        return client

--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -8,7 +8,7 @@ from typing import Optional, Union, cast
 
 import boto3
 import requests
-from anthropic import AnthropicBedrock, Stream
+from anthropic import Stream
 from anthropic.types import (
     ContentBlockDeltaEvent,
     Message,
@@ -48,6 +48,7 @@ from core.model_runtime.errors.invoke import (
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.bedrock.bedrock import BedrockProvider
 
 logger = logging.getLogger(__name__)
 
@@ -94,11 +95,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # use Anthropic official SDK references
         # - https://docs.anthropic.com/claude/reference/claude-on-amazon-bedrock
         # - https://github.com/anthropics/anthropic-sdk-python
-        client = AnthropicBedrock(
-            aws_access_key=credentials["aws_access_key_id"],
-            aws_secret_key=credentials["aws_secret_access_key"],
-            aws_region=credentials["aws_region"],
-        )
+        client = BedrockProvider.get_service_client(credentials=credentials)
 
         extra_model_kwargs = {}
         if stop:

--- a/api/core/model_runtime/model_providers/chatglm/chatglm.py
+++ b/api/core/model_runtime/model_providers/chatglm/chatglm.py
@@ -6,7 +6,6 @@ from core.model_runtime.model_providers.__base.model_provider import ModelProvid
 
 logger = logging.getLogger(__name__)
 
-
 class ChatGLMProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """

--- a/api/core/model_runtime/model_providers/cohere/cohere.py
+++ b/api/core/model_runtime/model_providers/cohere/cohere.py
@@ -1,13 +1,17 @@
 import logging
+from typing import Any
+
+import cohere
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)
 
 
-class CohereProvider(ModelProvider):
+class CohereProvider(ModelProvider, ModelClientProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -29,3 +33,10 @@ class CohereProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
             raise ex
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> cohere.Client:
+        client = cohere.Client(
+            api_key=credentials.get('api_key'),
+        )
+        return client

--- a/api/core/model_runtime/model_providers/cohere/cohere.py
+++ b/api/core/model_runtime/model_providers/cohere/cohere.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import cohere
 
@@ -35,7 +35,7 @@ class CohereProvider(ModelProvider, ModelClientProvider):
             raise ex
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> cohere.Client:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> cohere.Client:
         client = cohere.Client(
             api_key=credentials.get('api_key'),
         )

--- a/api/core/model_runtime/model_providers/cohere/llm/llm.py
+++ b/api/core/model_runtime/model_providers/cohere/llm/llm.py
@@ -46,6 +46,7 @@ from core.model_runtime.errors.invoke import (
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.model_runtime.model_providers.cohere.cohere import CohereProvider
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +174,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         :return: full response or stream response chunk generator result
         """
         # initialize client
-        client = cohere.Client(credentials.get('api_key'))
+        client = CohereProvider.get_service_client(credentials)
 
         if stop:
             model_parameters['end_sequences'] = stop
@@ -317,7 +318,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         :return: full response or stream response chunk generator result
         """
         # initialize client
-        client = cohere.Client(credentials.get('api_key'))
+        client = CohereProvider.get_service_client(credentials)
 
         if stop:
             model_parameters['stop_sequences'] = stop
@@ -636,7 +637,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         :return: number of tokens
         """
         # initialize client
-        client = cohere.Client(credentials.get('api_key'))
+        client = CohereProvider.get_service_client(credentials)
 
         response = client.tokenize(
             text=text,

--- a/api/core/model_runtime/model_providers/cohere/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/cohere/rerank/rerank.py
@@ -14,6 +14,7 @@ from core.model_runtime.errors.invoke import (
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.rerank_model import RerankModel
+from core.model_runtime.model_providers.cohere.cohere import CohereProvider
 
 
 class CohereRerankModel(RerankModel):
@@ -44,7 +45,7 @@ class CohereRerankModel(RerankModel):
             )
 
         # initialize client
-        client = cohere.Client(credentials.get('api_key'))
+        client = CohereProvider.get_service_client(credentials)
         response = client.rerank(
             query=query,
             documents=docs,

--- a/api/core/model_runtime/model_providers/cohere/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/cohere/text_embedding/text_embedding.py
@@ -17,6 +17,7 @@ from core.model_runtime.errors.invoke import (
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
+from core.model_runtime.model_providers.cohere.cohere import CohereProvider
 
 
 class CohereTextEmbeddingModel(TextEmbeddingModel):
@@ -141,7 +142,7 @@ class CohereTextEmbeddingModel(TextEmbeddingModel):
             return []
 
         # initialize client
-        client = cohere.Client(credentials.get('api_key'))
+        client = CohereProvider.get_service_client(credentials)
 
         response = client.tokenize(
             text=text,
@@ -180,7 +181,7 @@ class CohereTextEmbeddingModel(TextEmbeddingModel):
         :return: embeddings and used tokens
         """
         # initialize client
-        client = cohere.Client(credentials.get('api_key'))
+        client = CohereProvider.get_service_client(credentials)
 
         # call embedding model
         response = client.embed(

--- a/api/core/model_runtime/model_providers/google/google.py
+++ b/api/core/model_runtime/model_providers/google/google.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import google.generativeai.client as GoogleGenerativeAiClient
 
@@ -35,7 +35,7 @@ class GoogleProvider(ModelProvider, ModelClientProvider):
             raise ex
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> Any:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> Any:
         new_client_manager = GoogleGenerativeAiClient._ClientManager()
         new_client_manager.configure(
             api_key=credentials["google_api_key"],

--- a/api/core/model_runtime/model_providers/google/google.py
+++ b/api/core/model_runtime/model_providers/google/google.py
@@ -1,13 +1,17 @@
 import logging
+from typing import Any
+
+import google.generativeai.client as GoogleGenerativeAiClient
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)
 
 
-class GoogleProvider(ModelProvider):
+class GoogleProvider(ModelProvider, ModelClientProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -29,3 +33,12 @@ class GoogleProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
             raise ex
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> Any:
+        new_client_manager = GoogleGenerativeAiClient._ClientManager()
+        new_client_manager.configure(
+            api_key=credentials["google_api_key"],
+        )
+        client = new_client_manager.make_client(name=kwargs['name'])
+        return client

--- a/api/core/model_runtime/model_providers/huggingface_hub/huggingface_hub.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/huggingface_hub.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from huggingface_hub import InferenceClient
 
@@ -15,7 +15,7 @@ class HuggingfaceHubProvider(ModelProvider, ModelClientProvider):
         pass
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> InferenceClient:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> InferenceClient:
         client = InferenceClient(
             token=credentials['huggingfacehub_api_token'],
         )

--- a/api/core/model_runtime/model_providers/huggingface_hub/huggingface_hub.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/huggingface_hub.py
@@ -1,11 +1,22 @@
 import logging
+from typing import Any
 
+from huggingface_hub import InferenceClient
+
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)
 
 
-class HuggingfaceHubProvider(ModelProvider):
+class HuggingfaceHubProvider(ModelProvider, ModelClientProvider):
 
     def validate_provider_credentials(self, credentials: dict) -> None:
         pass
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> InferenceClient:
+        client = InferenceClient(
+            token=credentials['huggingfacehub_api_token'],
+        )
+        return client

--- a/api/core/model_runtime/model_providers/huggingface_hub/llm/llm.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/llm/llm.py
@@ -1,7 +1,6 @@
 from collections.abc import Generator
 from typing import Optional, Union
 
-from huggingface_hub import InferenceClient
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import BadRequestError
 
@@ -26,6 +25,7 @@ from core.model_runtime.entities.model_entities import (
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.huggingface_hub._common import _CommonHuggingfaceHub
+from core.model_runtime.model_providers.huggingface_hub.huggingface_hub import HuggingfaceHubProvider
 
 
 class HuggingfaceHubLargeLanguageModel(_CommonHuggingfaceHub, LargeLanguageModel):
@@ -33,7 +33,7 @@ class HuggingfaceHubLargeLanguageModel(_CommonHuggingfaceHub, LargeLanguageModel
                 tools: Optional[list[PromptMessageTool]] = None, stop: Optional[list[str]] = None, stream: bool = True,
                 user: Optional[str] = None) -> Union[LLMResult, Generator]:
 
-        client = InferenceClient(token=credentials['huggingfacehub_api_token'])
+        client = HuggingfaceHubProvider.get_service_client(credentials=credentials)
 
         if credentials['huggingfacehub_api_type'] == 'inference_endpoints':
             model = credentials['huggingfacehub_endpoint_url']
@@ -84,7 +84,7 @@ class HuggingfaceHubLargeLanguageModel(_CommonHuggingfaceHub, LargeLanguageModel
                 raise CredentialsValidateFailedError('Huggingface Hub Task Type must be one of text2text-generation, '
                                                      'text-generation.')
 
-            client = InferenceClient(token=credentials['huggingfacehub_api_token'])
+            client = HuggingfaceHubProvider.get_service_client(credentials=credentials)
 
             if credentials['huggingfacehub_api_type'] == 'inference_endpoints':
                 model = credentials['huggingfacehub_endpoint_url']

--- a/api/core/model_runtime/model_providers/huggingface_hub/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/huggingface_hub/text_embedding/text_embedding.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 import requests
-from huggingface_hub import HfApi, InferenceClient
+from huggingface_hub import HfApi
 
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelType, PriceType
@@ -12,6 +12,7 @@ from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, 
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.huggingface_hub._common import _CommonHuggingfaceHub
+from core.model_runtime.model_providers.huggingface_hub.huggingface_hub import HuggingfaceHubProvider
 
 HUGGINGFACE_ENDPOINT_API = 'https://api.endpoints.huggingface.cloud/v2/endpoint/'
 
@@ -20,7 +21,7 @@ class HuggingfaceHubTextEmbeddingModel(_CommonHuggingfaceHub, TextEmbeddingModel
 
     def _invoke(self, model: str, credentials: dict, texts: list[str],
                 user: Optional[str] = None) -> TextEmbeddingResult:
-        client = InferenceClient(token=credentials['huggingfacehub_api_token'])
+        client = HuggingfaceHubProvider.get_service_client(credentials=credentials)
 
         execute_model = model
 
@@ -85,7 +86,7 @@ class HuggingfaceHubTextEmbeddingModel(_CommonHuggingfaceHub, TextEmbeddingModel
             else:
                 raise CredentialsValidateFailedError('Huggingface Hub Endpoint Type is invalid.')
 
-            client = InferenceClient(token=credentials['huggingfacehub_api_token'])
+            client = HuggingfaceHubProvider.get_service_client(credentials=credentials)
             client.feature_extraction(text='hello world', model=model)
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))

--- a/api/core/model_runtime/model_providers/replicate/llm/llm.py
+++ b/api/core/model_runtime/model_providers/replicate/llm/llm.py
@@ -1,7 +1,6 @@
 from collections.abc import Generator
 from typing import Optional, Union
 
-from replicate import Client as ReplicateClient
 from replicate.exceptions import ReplicateError
 from replicate.prediction import Prediction
 
@@ -25,6 +24,7 @@ from core.model_runtime.entities.model_entities import (
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.replicate._common import _CommonReplicate
+from core.model_runtime.model_providers.replicate.replicate import ReplicateProvider
 
 
 class ReplicateLargeLanguageModel(_CommonReplicate, LargeLanguageModel):
@@ -35,7 +35,7 @@ class ReplicateLargeLanguageModel(_CommonReplicate, LargeLanguageModel):
 
         version = credentials['model_version']
 
-        client = ReplicateClient(api_token=credentials['replicate_api_token'], timeout=30)
+        client = ReplicateProvider.get_service_client(credentials)
         model_info = client.models.get(model)
         model_info_version = model_info.versions.get(version)
 
@@ -75,7 +75,7 @@ class ReplicateLargeLanguageModel(_CommonReplicate, LargeLanguageModel):
         version = credentials['model_version']
 
         try:
-            client = ReplicateClient(api_token=credentials['replicate_api_token'], timeout=30)
+            client = ReplicateProvider.get_service_client(credentials)
             model_info = client.models.get(model)
             model_info_version = model_info.versions.get(version)
 
@@ -115,7 +115,7 @@ class ReplicateLargeLanguageModel(_CommonReplicate, LargeLanguageModel):
     def _get_customizable_model_parameter_rules(cls, model: str, credentials: dict) -> list[ParameterRule]:
         version = credentials['model_version']
 
-        client = ReplicateClient(api_token=credentials['replicate_api_token'], timeout=30)
+        client = ReplicateProvider.get_service_client(credentials)
         model_info = client.models.get(model)
         model_info_version = model_info.versions.get(version)
 

--- a/api/core/model_runtime/model_providers/replicate/replicate.py
+++ b/api/core/model_runtime/model_providers/replicate/replicate.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from httpx import Timeout
 from replicate import Client as ReplicateClient
@@ -16,7 +16,7 @@ class ReplicateProvider(ModelProvider,ModelClientProvider):
         pass
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> ReplicateClient:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> ReplicateClient:
         client = ReplicateClient(
             api_token=credentials['replicate_api_token'],
             timeout=Timeout(30),

--- a/api/core/model_runtime/model_providers/replicate/replicate.py
+++ b/api/core/model_runtime/model_providers/replicate/replicate.py
@@ -1,11 +1,24 @@
 import logging
+from typing import Any
 
+from httpx import Timeout
+from replicate import Client as ReplicateClient
+
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
 
 logger = logging.getLogger(__name__)
 
 
-class ReplicateProvider(ModelProvider):
+class ReplicateProvider(ModelProvider,ModelClientProvider):
 
     def validate_provider_credentials(self, credentials: dict) -> None:
         pass
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> ReplicateClient:
+        client = ReplicateClient(
+            api_token=credentials['replicate_api_token'],
+            timeout=Timeout(30),
+        )
+        return client

--- a/api/core/model_runtime/model_providers/replicate/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/replicate/text_embedding/text_embedding.py
@@ -10,13 +10,14 @@ from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, 
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.replicate._common import _CommonReplicate
+from core.model_runtime.model_providers.replicate.replicate import ReplicateProvider
 
 
 class ReplicateEmbeddingModel(_CommonReplicate, TextEmbeddingModel):
     def _invoke(self, model: str, credentials: dict, texts: list[str],
                 user: Optional[str] = None) -> TextEmbeddingResult:
 
-        client = ReplicateClient(api_token=credentials['replicate_api_token'], timeout=30)
+        client = ReplicateProvider.get_service_client(credentials)
         replicate_model_version = f'{model}:{credentials["model_version"]}'
 
         text_input_key = self._get_text_input_key(model, credentials['model_version'], client)
@@ -47,7 +48,7 @@ class ReplicateEmbeddingModel(_CommonReplicate, TextEmbeddingModel):
             raise CredentialsValidateFailedError('Replicate Model Version must be provided.')
 
         try:
-            client = ReplicateClient(api_token=credentials['replicate_api_token'], timeout=30)
+            client = ReplicateProvider.get_service_client(credentials)
             replicate_model_version = f'{model}:{credentials["model_version"]}'
 
             text_input_key = self._get_text_input_key(model, credentials['model_version'], client)

--- a/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
@@ -15,7 +15,7 @@ from core.model_runtime.entities.message_entities import (
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.model_providers.zhipuai._common import _CommonZhipuaiAI
-from core.model_runtime.model_providers.zhipuai.zhipuai_sdk._client import ZhipuAI
+from core.model_runtime.model_providers.zhipuai.zhipuai import ZhipuaiProvider
 from core.model_runtime.model_providers.zhipuai.zhipuai_sdk.types.chat.chat_completion import Completion
 from core.model_runtime.model_providers.zhipuai.zhipuai_sdk.types.chat.chat_completion_chunk import ChatCompletionChunk
 from core.model_runtime.utils import helper
@@ -155,9 +155,7 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
         if stop:
             extra_model_kwargs['stop'] = stop
 
-        client = ZhipuAI(
-            api_key=credentials_kwargs['api_key']
-        )
+        client = ZhipuaiProvider.get_service_client(credentials=credentials_kwargs)
 
         if len(prompt_messages) == 0:
             raise ValueError('At least one message is required')

--- a/api/core/model_runtime/model_providers/zhipuai/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/zhipuai/text_embedding/text_embedding.py
@@ -6,6 +6,7 @@ from core.model_runtime.entities.text_embedding_entities import EmbeddingUsage, 
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.text_embedding_model import TextEmbeddingModel
 from core.model_runtime.model_providers.zhipuai._common import _CommonZhipuaiAI
+from core.model_runtime.model_providers.zhipuai.zhipuai import ZhipuaiProvider
 from core.model_runtime.model_providers.zhipuai.zhipuai_sdk._client import ZhipuAI
 
 
@@ -27,9 +28,7 @@ class ZhipuAITextEmbeddingModel(_CommonZhipuaiAI, TextEmbeddingModel):
         :return: embeddings result
         """
         credentials_kwargs = self._to_credential_kwargs(credentials)
-        client = ZhipuAI(
-            api_key=credentials_kwargs['api_key']
-        )
+        client = ZhipuaiProvider.get_service_client(credentials=credentials_kwargs)
 
         embeddings, embedding_used_tokens = self.embed_documents(model, client, texts)
 
@@ -68,9 +67,7 @@ class ZhipuAITextEmbeddingModel(_CommonZhipuaiAI, TextEmbeddingModel):
         try:
             # transform credentials to kwargs for model instance
             credentials_kwargs = self._to_credential_kwargs(credentials)
-            client = ZhipuAI(
-                api_key=credentials_kwargs['api_key']
-            )
+            client = ZhipuaiProvider.get_service_client(credentials=credentials_kwargs)
 
             # call embedding model
             self.embed_documents(

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai.py
@@ -1,13 +1,16 @@
 import logging
+from typing import Any
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.model_runtime.model_providers.__base.model_client_provider import ModelClientProvider
 from core.model_runtime.model_providers.__base.model_provider import ModelProvider
+from core.model_runtime.model_providers.zhipuai.zhipuai_sdk import ZhipuAI
 
 logger = logging.getLogger(__name__)
 
 
-class ZhipuaiProvider(ModelProvider):
+class ZhipuaiProvider(ModelProvider, ModelClientProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -28,3 +31,10 @@ class ZhipuaiProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f'{self.get_provider_schema().provider} credentials validate failed')
             raise ex
+
+    @staticmethod
+    def get_service_client(credentials: dict = None, **kwargs: Any) -> ZhipuAI:
+        client = ZhipuAI(
+            api_key=credentials['api_key'],
+        )
+        return client

--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
@@ -33,7 +33,7 @@ class ZhipuaiProvider(ModelProvider, ModelClientProvider):
             raise ex
 
     @staticmethod
-    def get_service_client(credentials: dict = None, **kwargs: Any) -> ZhipuAI:
+    def get_service_client(credentials: Optional[dict] = None, **kwargs: Any) -> ZhipuAI:
         client = ZhipuAI(
             api_key=credentials['api_key'],
         )


### PR DESCRIPTION
# Description

- prevent init service provider's SDK clients in raw code, use generalized static method `get_client` in each model provider instead
- minimize the impact from future changes for client initialization

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
