### PR TITLE
fix: update show names for supported file types of xlsx and docx

### DIFF
--- a/web/app/components/datasets/create/file-uploader/index.tsx
+++ b/web/app/components/datasets/create/file-uploader/index.tsx
@@ -49,38 +49,20 @@ const FileUploader = ({
   const { data: supportFileTypesResponse } = useSWR({ url: '/files/support-type' }, fetchSupportFileTypes)
   const supportTypes = supportFileTypesResponse?.allowed_extensions || []
   const supportTypesShowNames = (() => {
-    let res = [...supportTypes]
-    if (res.includes('markdown') && res.includes('md'))
-      res = res.filter(item => item !== 'md')
+    const extensionMap: { [key: string]: string } = {
+      md: 'markdown',
+      pptx: 'pptx',
+      htm: 'html',
+      xlsx: 'xlsx',
+      docx: 'docx',
+    }
 
-    if (res.includes('pptx') && res.includes('ppt'))
-      res = res.filter(item => item !== 'ppt')
-
-    if (res.includes('html') && res.includes('htm'))
-      res = res.filter(item => item !== 'htm')
-
-    res = res.map((item) => {
-      if (item === 'md')
-        return 'markdown'
-
-      if (item === 'pptx')
-        return 'ppt'
-
-      if (item === 'htm')
-        return 'html'
-
-      if (item === 'xlsx')
-        return 'xls'
-
-      if (item === 'docx')
-        return 'doc'
-
-      return item
-    })
-    res = res.map(item => item.toLowerCase())
-    res = res.filter((item, index, self) => self.indexOf(item) === index)
-
-    return res.map(item => item.toUpperCase()).join(locale !== LanguagesSupported[1] ? ', ' : '、 ')
+    return [...supportTypes]
+      .map(item => extensionMap[item] || item) // map to standardized extension
+      .map(item => item.toLowerCase()) // convert to lower case
+      .filter((item, index, self) => self.indexOf(item) === index) // remove duplicates
+      .map(item => item.toUpperCase()) // convert to upper case
+      .join(locale !== LanguagesSupported[1] ? ', ' : '、 ')
   })()
   const ACCEPTS = supportTypes.map((ext: string) => `.${ext}`)
   const fileUploadConfig = useMemo(() => fileUploadConfigResponse ?? {


### PR DESCRIPTION
# Description
- Fix the outdated show names of `xls` and `doc`, updated with `xlsx` and `docx`
- Before:
<img width="676" alt="企业微信截图_9e3da39c-1083-40bc-9dfa-0985ef0fd1b4" src="https://github.com/langgenius/dify/assets/1935105/d8c1795a-e44e-4b0f-a424-0451afdf0bee">

- After:
<img width="663" alt="企业微信截图_712c3e78-f9e1-43ab-a196-dc02e314495c" src="https://github.com/langgenius/dify/assets/1935105/f99500ea-5183-492d-8f37-c003b23461ec">

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
