### PR TITLE
chore: replace outdated config in vscode debug settings

### DIFF
--- a/api/.vscode/launch.json
+++ b/api/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Python: Celery",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "celery",
             "justMyCode": true,
@@ -21,7 +21,7 @@
         },
         {
             "name": "Python: Flask",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "flask",
             "env": {


### PR DESCRIPTION
# Description

quote from https://devblogs.microsoft.com/python/python-in-visual-studio-code-february-2024-release/
>  To ensure you are using the new Python Debugger extension, replace "type": "python" with "type": "debugpy" in your launch.json configuration file. In the future, the Python extension will no longer offer debugging support, and we will transition all debugging support to the Python Debugger extension.
