### PR TITLE
fix: Turn off SWR automatic revalidation when window is focused

### DIFF
--- a/web/app/components/swr-initor.tsx
+++ b/web/app/components/swr-initor.tsx
@@ -32,6 +32,7 @@ const SwrInitor = ({
     ? (
       <SWRConfig value={{
         shouldRetryOnError: false,
+        revalidateOnFocus: false,
       }}>
         {children}
       </SWRConfig>


### PR DESCRIPTION
# Description

[Issues#3048 Why do we always trigger many requests every time we focus on the page ?](https://github.com/langgenius/dify/issues/3084)

if using SWR to process data requests in React, set revalidateOnFocus=false in config is better.

Fixes #3048

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Open any page
2. Blur the page
3. Focus the page
4. See the network in browser's console

The network page of console is very refreshing

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
