### PR TITLE
Duplicate embedding cache check

### DIFF
--- a/api/core/embedding/cached_embedding.py
+++ b/api/core/embedding/cached_embedding.py
@@ -60,14 +60,17 @@ class CacheEmbedding(Embeddings):
                             db.session.rollback()
                         except Exception as e:
                             logging.exception('Failed transform embedding: ', e)
+                cache_embeddings = []
                 for i, embedding in zip(embedding_queue_indices, embedding_queue_embeddings):
                     text_embeddings[i] = embedding
                     hash = helper.generate_text_hash(texts[i])
-                    embedding_cache = Embedding(model_name=self._model_instance.model,
-                                          hash=hash,
-                                          provider_name=self._model_instance.provider)
-                    embedding_cache.set_embedding(embedding)
-                    db.session.add(embedding_cache)
+                    if hash not in cache_embeddings:
+                        embedding_cache = Embedding(model_name=self._model_instance.model,
+                                              hash=hash,
+                                              provider_name=self._model_instance.provider)
+                        embedding_cache.set_embedding(embedding)
+                        db.session.add(embedding_cache)
+                        cache_embeddings.append(hash)
                 db.session.commit()
             except Exception as ex:
                 db.session.rollback()


### PR DESCRIPTION
# Description

Duplicate embedding cache check when doing the document  vector indexing

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
