### PR TITLE
fix: skip Celery warning by setting broker_connection_retry_on_startup config

### DIFF
--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -28,6 +28,7 @@ def init_app(app: Flask) -> Celery:
 
     celery_app.conf.update(
         result_backend=app.config["CELERY_RESULT_BACKEND"],
+        broker_connection_retry_on_startup=True,
     )
 
     if app.config["BROKER_USE_SSL"]:


### PR DESCRIPTION
# Description

- explicitly set Celery config `broker_connection_retry_on_startup` to true, to skip warning message on startup:

```
...
[2024-04-09 01:53:26,197: INFO/MainProcess] Connected to redis://:**@localhost:6379/1
[2024-04-09 01:53:26,198: WARNING/MainProcess] /opt/homebrew/Caskroom/miniforge/base/envs/dify/lib/python3.10/site-packages/celery/worker/consumer/consumer.py:507: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
whether broker connection retries are made during startup in Celery 6.0 and above.
If you wish to retain the existing behavior for retrying connections on startup,
you should set broker_connection_retry_on_startup to True.
  warnings.warn(
...
```
- warning tips in docs for `broker_connection_retry`: https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-connection-retry
- config docs for `broker_connection_retry_on_startup `:https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-connection-retry-on-startup


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
