### PR TITLE
fix(code_executor): surrogates not allowed error in jinja2 template

### DIFF
--- a/api/core/helper/code_executor/javascript_transformer.py
+++ b/api/core/helper/code_executor/javascript_transformer.py
@@ -29,16 +29,16 @@ class NodeJsTemplateTransformer(TemplateTransformer):
         :param inputs: inputs
         :return:
         """
-        
+
         # transform inputs to json string
-        inputs_str = json.dumps(inputs, indent=4)
+        inputs_str = json.dumps(inputs, indent=4, ensure_ascii=False)
 
         # replace code and inputs
         runner = NODEJS_RUNNER.replace('{{code}}', code)
         runner = runner.replace('{{inputs}}', inputs_str)
 
         return runner, NODEJS_PRELOAD
-    
+
     @classmethod
     def transform_response(cls, response: str) -> dict:
         """

--- a/api/core/helper/code_executor/jina2_transformer.py
+++ b/api/core/helper/code_executor/jina2_transformer.py
@@ -62,10 +62,10 @@ class Jinja2TemplateTransformer(TemplateTransformer):
 
         # transform jinja2 template to python code
         runner = PYTHON_RUNNER.replace('{{code}}', code)
-        runner = runner.replace('{{inputs}}', json.dumps(inputs, indent=4))
+        runner = runner.replace('{{inputs}}', json.dumps(inputs, indent=4, ensure_ascii=False))
 
         return runner, JINJA2_PRELOAD
-    
+
     @classmethod
     def transform_response(cls, response: str) -> dict:
         """

--- a/api/core/helper/code_executor/python_transformer.py
+++ b/api/core/helper/code_executor/python_transformer.py
@@ -34,7 +34,7 @@ class PythonTemplateTransformer(TemplateTransformer):
         """
         
         # transform inputs to json string
-        inputs_str = json.dumps(inputs, indent=4)
+        inputs_str = json.dumps(inputs, indent=4, ensure_ascii=False)
 
         # replace code and inputs
         runner = PYTHON_RUNNER.replace('{{code}}', code)


### PR DESCRIPTION
# Description

This commit fixes a bug related to "surrogates not allowed" error in Jinja2 template rendering by setting `ensure_ascii=False` in JSON dumps across various transformers. Ensures non-ASCII characters are correctly handled during the code execution process.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Dev env

### Before

![Xnip2024-03-25_09-36-21](https://github.com/langgenius/dify/assets/14071051/9da87a89-9091-4f93-9840-b1fbb91cf55f)

### After
![Capture-2024-03-25-093436](https://github.com/langgenius/dify/assets/14071051/513b2e2e-bd45-4281-a2bd-dd387cdbec98)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
