### PR TITLE
improvement: speed up dependency installation in docker image rebuilds by mounting cache layer

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update \
 
 COPY requirements.txt /requirements.txt
 
-RUN pip install --prefix=/pkg -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/pkg -r requirements.txt
 
 # production stage
 FROM base AS production

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /app/web
 COPY package.json .
 COPY yarn.lock .
 
-RUN yarn install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn \
+    yarn install --frozen-lockfile
 
 
 # build resources


### PR DESCRIPTION
# Description

- shrink down the build time for rebuilding Docker images in the case of unhit build cache, eg. `2000s` to `200s` for api image (limited 10Mbps bandwidth)
- mounting cache layer for Python and Yarn dependencies


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
