### PR TITLE
fix: var assigner input node can not find caused error

### DIFF
--- a/web/app/components/workflow/utils.ts
+++ b/web/app/components/workflow/utils.ts
@@ -214,14 +214,19 @@ export const getNodesConnectedSourceOrTargetHandleIdsMap = (changes: ConnectedSo
       type,
     } = change
     const sourceNode = nodes.find(node => node.id === edge.source)!
-    nodesConnectedSourceOrTargetHandleIdsMap[sourceNode.id] = nodesConnectedSourceOrTargetHandleIdsMap[sourceNode.id] || {
-      _connectedSourceHandleIds: [...(sourceNode?.data._connectedSourceHandleIds || [])],
-      _connectedTargetHandleIds: [...(sourceNode?.data._connectedTargetHandleIds || [])],
+    if (sourceNode) {
+      nodesConnectedSourceOrTargetHandleIdsMap[sourceNode.id] = nodesConnectedSourceOrTargetHandleIdsMap[sourceNode.id] || {
+        _connectedSourceHandleIds: [...(sourceNode?.data._connectedSourceHandleIds || [])],
+        _connectedTargetHandleIds: [...(sourceNode?.data._connectedTargetHandleIds || [])],
+      }
     }
+
     const targetNode = nodes.find(node => node.id === edge.target)!
-    nodesConnectedSourceOrTargetHandleIdsMap[targetNode.id] = nodesConnectedSourceOrTargetHandleIdsMap[targetNode.id] || {
-      _connectedSourceHandleIds: [...(targetNode?.data._connectedSourceHandleIds || [])],
-      _connectedTargetHandleIds: [...(targetNode?.data._connectedTargetHandleIds || [])],
+    if (targetNode) {
+      nodesConnectedSourceOrTargetHandleIdsMap[targetNode.id] = nodesConnectedSourceOrTargetHandleIdsMap[targetNode.id] || {
+        _connectedSourceHandleIds: [...(targetNode?.data._connectedSourceHandleIds || [])],
+        _connectedTargetHandleIds: [...(targetNode?.data._connectedTargetHandleIds || [])],
+      }
     }
 
     if (sourceNode) {


### PR DESCRIPTION
# Description

Var assigner input node can not find caused error.

Fixes # (issue)
https://github.com/langgenius/dify/issues/3246

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
