### PR TITLE
chore: address security alerts on braces escape and KaTeX

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/variable-value-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/variable-value-block/index.tsx
@@ -31,7 +31,7 @@ const VariableValueBlock = () => {
     if (matchArr === null)
       return null
 
-    const hashtagLength = matchArr[3].length + 4
+    const hashtagLength = matchArr[0].length
     const startOffset = matchArr.index
     const endOffset = startOffset + hashtagLength
     return {

--- a/web/app/components/base/prompt-editor/plugins/variable-value-block/utils.ts
+++ b/web/app/components/base/prompt-editor/plugins/variable-value-block/utils.ts
@@ -1,5 +1,5 @@
 export function getHashtagRegexString(): string {
-  const hashtag = '(\{)(\{)([a-zA-Z_][a-zA-Z0-9_]{0,29})(\})(\})'
+  const hashtag = '\\{\\{[a-zA-Z_][a-zA-Z0-9_]{0,29}\\}\\}'
 
   return hashtag
 }

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,7 @@
     "immer": "^9.0.19",
     "js-audio-recorder": "^1.0.7",
     "js-cookie": "^3.0.1",
-    "katex": "^0.16.7",
+    "katex": "^0.16.10",
     "lamejs": "^1.2.1",
     "lexical": "^0.12.2",
     "lodash-es": "^4.17.21",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4092,10 +4092,17 @@ jsonc-eslint-parser@^2.0.4, jsonc-eslint-parser@^2.1.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-katex@^0.16.0, katex@^0.16.7:
+katex@^0.16.0:
   version "0.16.8"
   resolved "https://registry.npmjs.org/katex/-/katex-0.16.8.tgz"
   integrity sha512-ftuDnJbcbOckGY11OO+zg3OofESlbR5DRl2cmN8HeWeeFIV7wTXvAOx8kEjZjobhA+9wh2fbKeO6cdcA9Mnovg==
+  dependencies:
+    commander "^8.3.0"
+
+katex@^0.16.10:
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.10.tgz#6f81b71ac37ff4ec7556861160f53bc5f058b185"
+  integrity sha512-ZiqaC04tp2O5utMsl2TEZTXxa6WSC4yo0fv5ML++D3QZv/vx2Mct0mTlRx3O+uUkjfuAgOkzsCmq5MiUEsDDdA==
   dependencies:
     commander "^8.3.0"
 


### PR DESCRIPTION
# Description

Fix security alerts on braces escape and `katex` package.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] self-tested

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
