### PR TITLE
fix: yarn install extract package err when using GitHub Cache in amd6…

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -99,7 +99,7 @@ class Config:
         # ------------------------
         # General Configurations.
         # ------------------------
-        self.CURRENT_VERSION = "0.6.2-fix1"
+        self.CURRENT_VERSION = "0.6.2"
         self.COMMIT_SHA = get_env('COMMIT_SHA')
         self.EDITION = "SELF_HOSTED"
         self.DEPLOY_ENV = get_env('DEPLOY_ENV')

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.6.2-fix1-fix1
+    image: langgenius/dify-api:0.6.2
     restart: always
     environment:
       # Startup mode, 'api' starts the API server.
@@ -150,7 +150,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.6.2-fix1
+    image: langgenius/dify-api:0.6.2
     restart: always
     environment:
       # Startup mode, 'worker' starts the Celery worker for processing the queue.
@@ -232,7 +232,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.6.2-fix1
+    image: langgenius/dify-web:0.6.2
     restart: always
     environment:
       EDITION: SELF_HOSTED

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,12 +13,10 @@ WORKDIR /app/web
 COPY package.json .
 COPY yarn.lock .
 
-RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn \
-    yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile
 
 # if you located in China, you can use taobao registry to speed up
-# RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn \
-#     yarn install --frozen-lockfile --registry https://registry.npm.taobao.org/
+# RUN yarn install --frozen-lockfile --registry https://registry.npm.taobao.org/
 
 
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "0.6.2-fix1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Description

fix: yarn install extract package err when using GitHub Cache in amd64/arm64 matrix building

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
