### PR TITLE
fix: [azure_openai] Error: 'NoneType' object has no attribute 'content'

### DIFF
--- a/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
@@ -343,8 +343,12 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
             delta = chunk.choices[0]
 
-            if delta.finish_reason is None and (delta.delta.content is None or delta.delta.content == '') and \
-                delta.delta.function_call is None:
+            # Handling exceptions when content filters' streaming mode is set to asynchronous modified filter
+            if delta.delta is None or (
+                delta.finish_reason is None
+                and (delta.delta.content is None or delta.delta.content == '')
+                and delta.delta.function_call is None
+            ):
                 continue
             
             # assistant_message_tool_calls = delta.delta.tool_calls


### PR DESCRIPTION
# Description

After enabling Streaming Mode as Asynchronous Modified Filter in Azure OpenAI, the returned results will throw an error, it appears that the response has additional content filter data added after the stop sign, handle this exception.

Fixes #3384 

additional content filter after stop:
<img width="864" alt="async_choice" src="https://github.com/langgenius/dify/assets/5120456/0349d522-97ef-434e-8ca0-2fd63c956c7f">

normal response:
<img width="905" alt="default_choice" src="https://github.com/langgenius/dify/assets/5120456/a7121d05-a1c3-40e2-ba9c-d3ad69a39aa2">


## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X]  Switch the default/asynchronous modified filter Streaming Mode in Azure OpenAI, then test the streaming response.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [X] `optional` New and existing unit tests pass locally with my changes

response body after fix:
<img width="1492" alt="end" src="https://github.com/langgenius/dify/assets/5120456/668dfac8-419a-4065-86a9-b1c72e91042c">

ruff check:
![image](https://github.com/langgenius/dify/assets/5120456/4e249c53-7a3f-4b47-9cdf-a7f7071a30c1)

local fix compare the same model with the cloud version (identify the online version by the mark of the upgrade icon)
<img width="913" alt="线下与线上对比" src="https://github.com/langgenius/dify/assets/5120456/9e8e513c-8dbd-4c5a-ac41-b7aacaf7226b">
