### PR TITLE
feat: add workflow editor shortcuts (#3382)

### DIFF
--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -779,7 +779,7 @@ export const useNodesInteractions = () => {
     return nodesToPaste
   }, [getNodesReadOnly, handleSyncWorkflowDraft, store, t, workflowStore])
 
-  const handleNodeCloneSelected = useCallback(() => {
+  const handleNodeDuplicateSelected = useCallback(() => {
     if (getNodesReadOnly())
       return
 
@@ -831,7 +831,7 @@ export const useNodesInteractions = () => {
     handleNodeDelete,
     handleNodeChange,
     handleNodeAdd,
-    handleNodeCloneSelected,
+    handleNodeDuplicateSelected,
     handleNodeCopySelected,
     handleNodeCut,
     handleNodeDeleteSelected,

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -728,7 +728,7 @@ export const useNodesInteractions = () => {
     } = store.getState()
 
     const nodes = getNodes()
-    const nodesToCopy = nodes.filter(node => node.selected)
+    const nodesToCopy = nodes.filter(node => node.data.selected)
 
     setClipboardElements(nodesToCopy)
 
@@ -808,7 +808,7 @@ export const useNodesInteractions = () => {
     } = store.getState()
 
     const nodes = getNodes()
-    const nodesToDelete = nodes.filter(node => node.selected)
+    const nodesToDelete = nodes.filter(node => node.data.selected)
 
     if (!nodesToDelete)
       return

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -797,10 +797,9 @@ export const useNodesInteractions = () => {
     if (!nodesToCut)
       return
 
-    for (const node of nodesToCut) {
+    for (const node of nodesToCut)
       handleNodeDelete(node.id)
-    }
-  }, [store, handleNodeCopySelected])
+  }, [getNodesReadOnly, handleNodeCopySelected, handleNodeDelete])
 
   const handleNodeDeleteSelected = useCallback(() => {
     if (getNodesReadOnly())
@@ -816,10 +815,9 @@ export const useNodesInteractions = () => {
     if (!nodesToDelete)
       return
 
-    for (const node of nodesToDelete) {
+    for (const node of nodesToDelete)
       handleNodeDelete(node.id)
-    }
-  }, [store])
+  }, [getNodesReadOnly, handleNodeDelete, store])
 
   return {
     handleNodeDragStart,

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -777,7 +777,7 @@ export const useNodesInteractions = () => {
     handleSyncWorkflowDraft()
 
     return nodesToPaste
-  }, [getNodesReadOnly, store, t, workflowStore])
+  }, [getNodesReadOnly, handleSyncWorkflowDraft, store, t, workflowStore])
 
   const handleNodeCloneSelected = useCallback(() => {
     if (getNodesReadOnly())
@@ -785,9 +785,7 @@ export const useNodesInteractions = () => {
 
     handleNodeCopySelected()
     handleNodePaste()
-
-    handleSyncWorkflowDraft()
-  }, [handleNodeCopySelected, handleNodePaste, handleSyncWorkflowDraft])
+  }, [getNodesReadOnly, handleNodeCopySelected, handleNodePaste])
 
   const handleNodeCut = useCallback(() => {
     if (getNodesReadOnly())
@@ -833,10 +831,10 @@ export const useNodesInteractions = () => {
     handleNodeDelete,
     handleNodeChange,
     handleNodeAdd,
-    handleNodeCut,
-    handleNodeCopySelected,
     handleNodeCloneSelected,
-    handleNodePaste,
+    handleNodeCopySelected,
+    handleNodeCut,
     handleNodeDeleteSelected,
+    handleNodePaste,
   }
 }

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -133,12 +133,12 @@ const Workflow: FC<WorkflowProps> = memo(({
     },
   })
 
-  useKeyPress('delete', handleEdgeDelete)
-  useKeyPress('delete', handleNodeDeleteSelected)
-  useKeyPress('ctrl.c', handleNodeCopySelected)
-  useKeyPress('ctrl.x', handleNodeCut)
-  useKeyPress('ctrl.v', handleNodePaste)
-  useKeyPress('ctrl.alt.d', handleNodeDuplicateSelected)
+  useKeyPress(['delete'], handleEdgeDelete)
+  useKeyPress(['delete'], handleNodeDeleteSelected)
+  useKeyPress(['ctrl.c', 'meta.c'], handleNodeCopySelected)
+  useKeyPress(['ctrl.x', 'meta.x'], handleNodeCut)
+  useKeyPress(['ctrl.v', 'meta.v'], handleNodePaste)
+  useKeyPress(['ctrl.alt.d', 'meta.shift.d'], handleNodeDuplicateSelected)
 
   return (
     <div

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -113,10 +113,10 @@ const Workflow: FC<WorkflowProps> = memo(({
     handleNodeConnect,
     handleNodeConnectStart,
     handleNodeConnectEnd,
-    handleNodeCut,
-    handleNodeDeleteSelected,
     handleNodeCloneSelected,
     handleNodeCopySelected,
+    handleNodeCut,
+    handleNodeDeleteSelected,
     handleNodePaste,
   } = useNodesInteractions()
   const {

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -113,7 +113,7 @@ const Workflow: FC<WorkflowProps> = memo(({
     handleNodeConnect,
     handleNodeConnectStart,
     handleNodeConnectEnd,
-    handleNodeCloneSelected,
+    handleNodeDuplicateSelected,
     handleNodeCopySelected,
     handleNodeCut,
     handleNodeDeleteSelected,
@@ -138,7 +138,7 @@ const Workflow: FC<WorkflowProps> = memo(({
   useKeyPress('ctrl.c', handleNodeCopySelected)
   useKeyPress('ctrl.x', handleNodeCut)
   useKeyPress('ctrl.v', handleNodePaste)
-  useKeyPress('ctrl.alt.d', handleNodeCloneSelected)
+  useKeyPress('ctrl.alt.d', handleNodeDuplicateSelected)
 
   return (
     <div

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -113,6 +113,11 @@ const Workflow: FC<WorkflowProps> = memo(({
     handleNodeConnect,
     handleNodeConnectStart,
     handleNodeConnectEnd,
+    handleNodeCut,
+    handleNodeDeleteSelected,
+    handleNodeCloneSelected,
+    handleNodeCopySelected,
+    handleNodePaste,
   } = useNodesInteractions()
   const {
     handleEdgeEnter,
@@ -128,7 +133,12 @@ const Workflow: FC<WorkflowProps> = memo(({
     },
   })
 
-  useKeyPress('Backspace', handleEdgeDelete)
+  useKeyPress('delete', handleEdgeDelete)
+  useKeyPress('delete', handleNodeDeleteSelected)
+  useKeyPress('ctrl.c', handleNodeCopySelected)
+  useKeyPress('ctrl.x', handleNodeCut)
+  useKeyPress('ctrl.v', handleNodePaste)
+  useKeyPress('ctrl.alt.d', handleNodeCloneSelected)
 
   return (
     <div

--- a/web/app/components/workflow/store.ts
+++ b/web/app/components/workflow/store.ts
@@ -63,6 +63,8 @@ type Shape = {
   setBuildInTools: (tools: ToolWithProvider[]) => void
   customTools: ToolWithProvider[]
   setCustomTools: (tools: ToolWithProvider[]) => void
+  clipboardElements: Node[]
+  setClipboardElements: (clipboardElements: Node[]) => void
 }
 
 export const createWorkflowStore = () => {
@@ -107,6 +109,8 @@ export const createWorkflowStore = () => {
     setBuildInTools: buildInTools => set(() => ({ buildInTools })),
     customTools: [],
     setCustomTools: customTools => set(() => ({ customTools })),
+    clipboardElements: [],
+    setClipboardElements: clipboardElements => set(() => ({ clipboardElements })),
   }))
 }
 


### PR DESCRIPTION
# Description
This PR brings shortcuts to the workflow editor as described in #3382. The following shortcuts are introduced:

| Keyboard Shortcut | Function | Hint |
| --- | --- | --- |
| `Delete` | Deletes the selected edge | **Hint**: This was previously the backspace key, but I found that delete is more intuitive. We should note this in the release. |
| `Delete` | Deletes the selected node | |
| `Ctrl + C` | Copies the selected node | |
| `Ctrl + X` | Cuts the selected node | |
| `Ctrl + V` | Pastes a copied or cut node | |
| `Ctrl + Alt + D` | Clones the selected node | |

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?
I tested it manually in the development mode with the following steps:

- [ ] Create Workflow or Chatflow
- [ ] Add a Classifier node, define two classes and change the model
- [ ] Assign two End/Answer nodes to the Classifier node
 - [ ] If you added Answer node, define a random word as answer so that we can publish the flow without issues 
- [ ] Select the Classifier node and press Ctrl + C
- [ ] Press Ctrl + V
  - [ ] The Node should be copied to the workflow, the name should have the number 2 at the end
  - [ ] The copied node should be selected
  - [ ] The copied node should show the plus icon for the ingoing and outgoing edges
  - [ ] The copied node should have the same classes and the same llm configured
  - [ ] The copied node should not connected to another node (no edges have beend added)
  - [ ] Press Ctrl + V again
  - [ ] Another node should be copied at the same place as the previously copied node
  - [ ] It should have a 3 at the end
  - [ ] Select the 3rd Classifier node and press Delete
  - [ ] The 3rd Classifier node should be deleted
  - [ ] Select the 2nd Classifier node and press Delete
  - [ ] The 2nd Classifier node should be deleted
  - [ ] Save the workflow, it should work without issues
- [ ] Select the Classifier node and press Ctrl + X
  - [ ] The classifier node should have been deleted, as well as the edges
  - [ ] Add a new Classifier node and connect all edges again
  - [ ] Save the workflow, it should work without issues
- [ ] Reload the page while the workflow editor is open
- [ ] Select the Clasifier node and press Delete
 - [ ] Reload the workflow
 - [ ] The node should still be deleted
 - [ ] Add a new Classifier node and connect the edges
- [ ] Select the Classifier node and press Ctrl + Shift + D
 - [ ] The Classifier node should have been duplicated
 - [ ] Reload the page the workflow editor is open
 - [ ] The duplicated Classifier node should still be there
 - [ ] Select the duplicated node and press Delete
 - [ ] Publish the workflow, it should work without issues
- [ ] Select the Classifier node
 - [ ] Press Ctrl + C and Ctrl + V
 - [ ] The Classifier node should have been duplicated
 - [ ] Reload the page the workflow editor is open
 - [ ] The duplicated Classifier node shuld still be there
 - [ ] Click on the Dropdown-Button (top right) to publish the flow
  - [ ] Click on the white button to restore the flow
  - [ ] A preview should be opened where the  duplicated Classifier node is not visible
  - [ ] Restore to this version
  - [ ] The duplicated Classifier node should no longer exist
 
# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
