### PR TITLE
Feat: Invitation link automatically completes domain name

### DIFF
--- a/web/app/components/header/account-setting/members-page/invited-modal/invitation-link.tsx
+++ b/web/app/components/header/account-setting/members-page/invited-modal/invitation-link.tsx
@@ -18,7 +18,7 @@ const InvitationLink = ({
   const selector = useRef(`invite-link-${randomString(4)}`)
 
   const copyHandle = useCallback(() => {
-    copy(value.url)
+    copy(window.location.origin + value.url)
     setIsCopied(true)
   }, [value])
 


### PR DESCRIPTION
# Description

When adding a member to generate an invitation link, the current domain name is automatically spliced to generate a valid URL.

# Type of Change
New feature (non-breaking change which adds functionality)

<img width="503" alt="image" src="https://github.com/langgenius/dify/assets/9191067/961813c3-943c-43b3-a424-413ee77ae679">
