### PR TITLE
chore: remove the COPY instruction in .devcontainer/Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,5 @@
 FROM mcr.microsoft.com/devcontainers/python:3.10
 
-COPY . .
-
-
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>


### PR DESCRIPTION
# Description
Hello,

This PR makes a simple change to remove the `COPY` instruction in the `.devcontainer/Dockerfile` file.
It will copy the source files to `/` root, which seems unnecessary because devcontainer will auto mount the project workspace.
As we can see below:

<img width="1021" alt="Screenshot 2024-04-12 at 15 25 41" src="https://github.com/langgenius/dify/assets/3882561/86f9fcbf-a0e2-4c94-83c5-e699605dfccc">

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested from my local.

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
