### PR TITLE
fix: node shortcuts active in input fields

### DIFF
--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -721,7 +721,11 @@ export const useNodesInteractions = () => {
 
     const {
       setClipboardElements,
+      shortcutsDisabled,
     } = workflowStore.getState()
+
+    if (shortcutsDisabled)
+      return
 
     const {
       getNodes,
@@ -741,7 +745,11 @@ export const useNodesInteractions = () => {
 
     const {
       clipboardElements,
+      shortcutsDisabled,
     } = workflowStore.getState()
+
+    if (shortcutsDisabled)
+      return
 
     const {
       getNodes,
@@ -804,6 +812,13 @@ export const useNodesInteractions = () => {
       return
 
     const {
+      shortcutsDisabled,
+    } = workflowStore.getState()
+
+    if (shortcutsDisabled)
+      return
+
+    const {
       getNodes,
     } = store.getState()
 
@@ -815,7 +830,7 @@ export const useNodesInteractions = () => {
 
     for (const node of nodesToDelete)
       handleNodeDelete(node.id)
-  }, [getNodesReadOnly, handleNodeDelete, store])
+  }, [getNodesReadOnly, handleNodeDelete, store, workflowStore])
 
   return {
     handleNodeDragStart,

--- a/web/app/components/workflow/hooks/use-workflow.ts
+++ b/web/app/components/workflow/hooks/use-workflow.ts
@@ -331,6 +331,16 @@ export const useWorkflow = () => {
     return nodes.find(node => node.id === nodeId) || nodes.find(node => node.data.type === BlockEnum.Start)
   }, [store])
 
+  const enableShortcuts = useCallback(() => {
+    const { setShortcutsDisabled } = workflowStore.getState()
+    setShortcutsDisabled(false)
+  }, [workflowStore])
+
+  const disableShortcuts = useCallback(() => {
+    const { setShortcutsDisabled } = workflowStore.getState()
+    setShortcutsDisabled(true)
+  }, [workflowStore])
+
   return {
     handleLayout,
     getTreeLeafNodes,
@@ -345,6 +355,8 @@ export const useWorkflow = () => {
     renderTreeFromRecord,
     getNode,
     getBeforeNodeById,
+    enableShortcuts,
+    disableShortcuts,
   }
 }
 

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -125,7 +125,11 @@ const Workflow: FC<WorkflowProps> = memo(({
     handleEdgeDelete,
     handleEdgesChange,
   } = useEdgesInteractions()
-  const { isValidConnection } = useWorkflow()
+  const {
+    isValidConnection,
+    enableShortcuts,
+    disableShortcuts,
+  } = useWorkflow()
 
   useOnViewportChange({
     onEnd: () => {
@@ -161,6 +165,8 @@ const Workflow: FC<WorkflowProps> = memo(({
         edgeTypes={edgeTypes}
         nodes={nodes}
         edges={edges}
+        onPointerDown={enableShortcuts}
+        onMouseLeave={disableShortcuts}
         onNodeDragStart={handleNodeDragStart}
         onNodeDrag={handleNodeDrag}
         onNodeDragStop={handleNodeDragStop}

--- a/web/app/components/workflow/store.ts
+++ b/web/app/components/workflow/store.ts
@@ -65,6 +65,8 @@ type Shape = {
   setCustomTools: (tools: ToolWithProvider[]) => void
   clipboardElements: Node[]
   setClipboardElements: (clipboardElements: Node[]) => void
+  shortcutsDisabled: boolean
+  setShortcutsDisabled: (shortcutsDisabled: boolean) => void
 }
 
 export const createWorkflowStore = () => {
@@ -111,6 +113,8 @@ export const createWorkflowStore = () => {
     setCustomTools: customTools => set(() => ({ customTools })),
     clipboardElements: [],
     setClipboardElements: clipboardElements => set(() => ({ clipboardElements })),
+    shortcutsDisabled: false,
+    setShortcutsDisabled: shortcutsDisabled => set(() => ({ shortcutsDisabled })),
   }))
 }
 


### PR DESCRIPTION
# Description

With #3390 I added shortcuts for interacting with nodes. These shortcuts are hadled even if you use them to manipulate text in inputs.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Go to the workflow editor of a workflow or chatflow
- [x] Add a LLM node
- [x] Go to the instructions input, write text, select it and press delete
 - [x] the text should be deleted from the input field, the node is still there. without this fix pressing delete would have deleted the llm node

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
