### PR TITLE
fix: stringify object while exporting batch result to csv

### DIFF
--- a/web/app/components/share/text-generation/index.tsx
+++ b/web/app/components/share/text-generation/index.tsx
@@ -174,7 +174,12 @@ const TextGeneration: FC<IMainProps> = ({
     promptConfig?.prompt_variables.forEach((v) => {
       res[v.name] = inputs[v.key]
     })
-    res[t('share.generation.completionResult')] = batchCompletionResLatest[task.id]
+    let result = batchCompletionResLatest[task.id]
+    // task might return multiple fields, should marshal object to string
+    if (typeof batchCompletionResLatest[task.id] === 'object')
+      result = JSON.stringify(result)
+
+    res[t('share.generation.completionResult')] = result
     return res
   })
   const checkBatchInputs = (data: string[][]) => {


### PR DESCRIPTION
# Description

When exporting result to CSV, only string field values are allowed. However, when there are multiple return values, the execution result of the task is an object. In this case, the object needs to be serialized in order to export it correctly.

Fixes #3323

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

tested in my local env

batch run detail
<img width="994" alt="image" src="https://github.com/langgenius/dify/assets/18367114/ca8cef6c-5164-457c-be22-e044e108cac8">

exported results
<img width="200" alt="截屏2024-04-15 12 57 40" src="https://github.com/langgenius/dify/assets/18367114/4a0a89d6-c0e1-426f-9bf6-e8aaf2180915">


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
