### PR TITLE
fix: workflow auto layout nodes offset & delete node shortcuts

### DIFF
--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -138,7 +138,7 @@ const Workflow: FC<WorkflowProps> = memo(({
   })
 
   useKeyPress(['delete'], handleEdgeDelete)
-  useKeyPress(['delete'], handleNodeDeleteSelected)
+  useKeyPress(['delete', 'backspace'], handleNodeDeleteSelected)
   useKeyPress(['ctrl.c', 'meta.c'], handleNodeCopySelected)
   useKeyPress(['ctrl.x', 'meta.x'], handleNodeCut)
   useKeyPress(['ctrl.v', 'meta.v'], handleNodePaste)

--- a/web/app/components/workflow/utils.ts
+++ b/web/app/components/workflow/utils.ts
@@ -175,8 +175,8 @@ export const getLayoutByDagre = (originNodes: Node[], originEdges: Edge[]) => {
   dagreGraph.setGraph({
     rankdir: 'LR',
     align: 'UL',
-    nodesep: 64,
-    ranksep: 40,
+    nodesep: 40,
+    ranksep: 60,
   })
   nodes.forEach((node) => {
     dagreGraph.setNode(node.id, { width: node.width, height: node.height })


### PR DESCRIPTION
# Description

fix: workflow auto layout nodes offset & delete node shortcuts

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
