### PR TITLE
fix: bump twilio to 9.0.4 skipping yanked versions

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -72,7 +72,7 @@ numexpr~=2.9.0
 duckduckgo-search==5.2.2
 arxiv==2.1.0
 yarl~=1.9.4
-twilio==9.0.0
+twilio~=9.0.4
 qrcode~=7.4.2
 azure-storage-blob==12.9.0
 azure-identity==1.15.0


### PR DESCRIPTION
# Description
- twilio 9.0.0 and 9.0.1 are yanked versions, according to https://pypi.org/project/twilio/#history
- fix the warning when running `pip install`
```
WARNING: The candidate selected for download or install is a yanked version: 'twilio' candidate (version 9.0.0 at https://files.pythonhosted.org/packages/1c/d6/7ba1e2fc5b5695cfef2b5f943e687ed0b4a4e3b92973cf4d7cde6b5668de/twilio-9.0.0-py2.py3-none-any.whl (from https://pypi.org/simple/twilio/) (requires-python:>=3.7.0))
Reason for being yanked: All inequality(eg date_after, date_before) fields are not present in this version.
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
