### PR TITLE
feat: support var auto rename in prompt editor

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -237,6 +237,9 @@ const replaceOldVarInText = (text: string, oldVar: ValueSelector, newVar: ValueS
   if (!text || typeof text !== 'string')
     return text
 
+  if (!newVar || newVar.length === 0)
+    return text
+
   return text.replaceAll(`{{#${oldVar.join('.')}#}}`, `{{#${newVar.join('.')}#}}`)
 }
 
@@ -422,30 +425,35 @@ export const updateNodeVars = (oldNode: Node, oldVarSelector: ValueSelector, new
         break
       }
       case BlockEnum.HttpRequest: {
-        // TODO: update in inputs
-        // const payload = data as HttpNodeType
-        // if (payload.variables) {
-        //   payload.variables = payload.variables.map((v) => {
-        //     if (v.value_selector.join('.') === oldVarSelector.join('.'))
-        //       v.value_selector = newVarSelector
-        //     return v
-        //   })
-        // }
+        const payload = data as HttpNodeType
+        payload.url = replaceOldVarInText(payload.url, oldVarSelector, newVarSelector)
+        payload.headers = replaceOldVarInText(payload.headers, oldVarSelector, newVarSelector)
+        payload.params = replaceOldVarInText(payload.params, oldVarSelector, newVarSelector)
+        payload.body.data = replaceOldVarInText(payload.body.data, oldVarSelector, newVarSelector)
         break
       }
       case BlockEnum.Tool: {
-        // TODO: update in inputs
-        // const payload = data as ToolNodeType
-        // if (payload.tool_parameters) {
-        //   payload.tool_parameters = payload.tool_parameters.map((v) => {
-        //     if (v.type === VarKindType.static)
-        //       return v
+        const payload = data as ToolNodeType
+        const hasShouldRenameVar = Object.keys(payload.tool_parameters)?.filter(key => payload.tool_parameters[key].type !== ToolVarType.constant)
+        if (hasShouldRenameVar) {
+          Object.keys(payload.tool_parameters).forEach((key) => {
+            const value = payload.tool_parameters[key]
+            const { type } = value
+            if (type === ToolVarType.variable) {
+              payload.tool_parameters[key] = {
+                ...value,
+                value: newVarSelector,
+              }
+            }
 
-        //     if (v.value_selector?.join('.') === oldVarSelector.join('.'))
-        //       v.value_selector = newVarSelector
-        //     return v
-        //   })
-        // }
+            if (type === ToolVarType.mixed) {
+              payload.tool_parameters[key] = {
+                ...value,
+                value: replaceOldVarInText(payload.tool_parameters[key].value as string, oldVarSelector, newVarSelector),
+              }
+            }
+          })
+        }
         break
       }
       case BlockEnum.VariableAssigner: {

--- a/web/app/components/workflow/nodes/start/use-config.ts
+++ b/web/app/components/workflow/nodes/start/use-config.ts
@@ -28,11 +28,13 @@ const useConfig = (id: string, payload: StartNodeType) => {
     setFalse: hideRemoveVarConfirm,
   }] = useBoolean(false)
   const [removedVar, setRemovedVar] = useState<ValueSelector>([])
+  const [removedIndex, setRemoveIndex] = useState(0)
   const handleVarListChange = useCallback((newList: InputVar[], moreInfo?: { index: number; payload: MoreInfo }) => {
     if (moreInfo?.payload?.type === ChangeType.remove) {
       if (isVarUsedInNodes([id, moreInfo?.payload?.payload?.beforeKey || ''])) {
         showRemoveVarConfirm()
         setRemovedVar([id, moreInfo?.payload?.payload?.beforeKey || ''])
+        setRemoveIndex(moreInfo?.index as number)
         return
       }
     }
@@ -48,9 +50,13 @@ const useConfig = (id: string, payload: StartNodeType) => {
   }, [handleOutVarRenameChange, id, inputs, isVarUsedInNodes, setInputs, showRemoveVarConfirm])
 
   const removeVarInNode = useCallback(() => {
+    const newInputs = produce(inputs, (draft) => {
+      draft.variables.splice(removedIndex, 1)
+    })
+    setInputs(newInputs)
     removeUsedVarInNodes(removedVar)
     hideRemoveVarConfirm()
-  }, [hideRemoveVarConfirm, removeUsedVarInNodes, removedVar])
+  }, [hideRemoveVarConfirm, inputs, removeUsedVarInNodes, removedIndex, removedVar, setInputs])
 
   const handleAddVariable = useCallback((payload: InputVar) => {
     const newInputs = produce(inputs, (draft: StartNodeType) => {


### PR DESCRIPTION
# Description

1. Support var auto rename in prompt editor.
2. Fix that if var used in other nodes, var can't be removed.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
