### PR TITLE
Fix problem with scroll inside chat window

### DIFF
--- a/web/app/styles/globals.css
+++ b/web/app/styles/globals.css
@@ -76,7 +76,7 @@
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
# Description

Fixes #3569 (issue)

I noticed a problem with the chat window when using the embedding method. When the window is opened, an additional scroll appears for the full height of the window (regardless of the browser). I changed the code here:

```
body, html {
max-width: 100vw;
overflow-x: hidden;
}
```

New param is without "x":

`overflow: hidden;`


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Browser: Chrome, Opera, Edge, Safari, Firefox (MacOs 14)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
