### PR TITLE
fix: get dict key indexing_technique in DocumentAddByFileApi

### DIFF
--- a/.github/workflows/api-workflow-tests.yaml
+++ b/.github/workflows/api-workflow-tests.yaml
@@ -12,6 +12,7 @@ jobs:
 
     env:
       MOCK_SWITCH: true
+      OPENAI_API_KEY: sk-IamNotARealKeyJustForMockTestKawaiiiiiiiiii
 
     steps:
       - name: Checkout code

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -174,7 +174,7 @@ class DocumentAddByFileApi(DatasetApiResource):
 
         if not dataset:
             raise ValueError('Dataset is not exist.')
-        if not dataset.indexing_technique and not args['indexing_technique']:
+        if not dataset.indexing_technique and not args.get('indexing_technique'):
             raise ValueError('indexing_technique is required.')
 
         # save file info


### PR DESCRIPTION
# Description

修复DocumentAddByFileApi.post方法中，对args字典indexing_technique这个键判断的取值方法。避免因indexing_technique不存在而抛出KeyError错误。

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

调用api:
/v1//datasets/uuid:dataset_id/document/create_by_file，json参数中不传indexing_technique这个字段即可复现该bug。

- [x] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
