### PR TITLE
Add Cloudflare Workers script for proxying Dify Chat API to OpenAI format

### DIFF
--- a/sdks/cloudflare-workers/README.md
+++ b/sdks/cloudflare-workers/README.md
@@ -1,0 +1,81 @@
+# Dify Chat API Proxy for Cloudflare Workers
+
+This is a Cloudflare Workers script that proxies the Dify conversational application API and transforms the output format to match the OpenAI Chat Completions API. By deploying this script to your Cloudflare Workers, you can immediately start using the Dify API with the familiar OpenAI API format.
+
+## Features
+
+- Proxies the Dify conversational application API
+- Converts the Dify API response format to match the OpenAI Chat Completions API
+- Supports both streaming and non-streaming responses
+- Handles CORS (Cross-Origin Resource Sharing) headers for seamless integration with web applications
+
+## Prerequisites
+
+- A Cloudflare account with the Workers feature enabled
+- A Dify API key
+
+## Installation
+
+1. Create a new Cloudflare Worker:
+   - Log in to your Cloudflare account
+   - Navigate to the "Workers" section
+   - Click on "Create a Service"
+   - Choose a name for your worker and select a starter template (e.g., "HTTP Handler")
+
+2. Replace the default code in the worker's script editor with the provided code from `workers.js`.
+
+3. Configure the API key:
+   - Replace the placeholder API key check logic in the `handleRequest` function with your own authorization logic.
+   - For example, you can check if the API key is defined in the environment variables, like `DifyAPIKey = app-xxxxxxxxxxxxxxxxxx`.
+
+4. Deploy the worker:
+   - Click on "Save and Deploy" to deploy your worker.
+
+## Usage
+
+To use the Dify Chat API Proxy, make a POST request to your worker's URL with the following parameters:
+
+- URL: `https://your-worker-url.workers.dev/v1/chat/completions`
+- Method: POST
+- Headers:
+  - `Content-Type: application/json`
+  - `Authorization: Bearer YOUR_API_KEY`
+- Body (JSON):
+  ```json
+  {
+    "messages": [
+      {
+        "content": "Your message content"
+      }
+    ],
+    "stream": true
+  }
+  ```
+
+Replace `YOUR_API_KEY` with your actual Dify API key.
+
+The `messages` array should contain the message objects with the `content` property representing the message content. The `stream` parameter is optional and can be set to `true` for streaming responses or `false` (or omitted) for non-streaming responses.
+
+The proxy will forward the request to the Dify API, transform the response format to match the OpenAI Chat Completions API, and return the response.
+
+## Example
+
+Here's an example of how to make a request to the Dify Chat API Proxy using the standard HTTP/1.1 protocol:
+
+```http
+POST /v1/chat/completions HTTP/1.1
+Host: your-worker-url.workers.dev
+Content-Type: application/json
+Authorization: Bearer YOUR_API_KEY
+
+{
+  "messages": [
+    {
+      "content": "Hello, how are you?"
+    }
+  ],
+  "stream": true
+}
+```
+
+Make sure to replace `YOUR_API_KEY` with your actual Dify API key and `your-worker-url` with your deployed worker's URL.

--- a/sdks/cloudflare-workers/openai-to-dify.js
+++ b/sdks/cloudflare-workers/openai-to-dify.js
@@ -1,0 +1,167 @@
+addEventListener('fetch', event => {
+    if (event.request.method === 'OPTIONS') {
+        event.respondWith(handleOptions(event.request))
+    } else if (event.request.method === 'POST') {
+        event.respondWith(handleRequest(event.request))
+    } else {
+        event.respondWith(new Response('Method Not Allowed', { status: 405 }))
+    }
+})
+
+async function handleOptions(request) {
+    const headers = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': '*',
+        'Access-Control-Allow-Headers': '*',
+        'Access-Control-Allow-Credentials': 'true',
+    }
+    return new Response(null, { headers })
+}
+
+class LineBreakTransformer {
+    constructor() {
+        this.container = ''
+    }
+
+    transform(chunk, controller) {
+        // chunk is a Uint8Array, needs to be converted to a string
+        chunk = new TextDecoder("utf-8").decode(chunk)
+        this.container += chunk
+        const lines = this.container.split('\n\n')
+        // If there is only one line, it means it's incomplete, wait for the next chunk
+        if (lines.length === 1) {
+            return
+        }
+        // If there are multiple lines, the last line is incomplete and needs to be preserved
+        this.container = lines.pop()
+        console.log(lines)
+        for (const line of lines) {
+            if (line.startsWith('data: ')) {
+                // I don't know why, but the first line is always 'data: ping' or 'data: pong'
+                if(line == 'data: ping' || line == 'data: pong'){
+                    continue
+                }
+                const difyResponse = JSON.parse(line.slice(6))
+                if (difyResponse.event === 'message' || difyResponse.event === 'agent_message') {
+                    const completionChunk = {
+                        id: difyResponse.message_id,
+                        object: 'chat.completion.chunk',
+                        created: difyResponse.created_at,
+                        model: 'gpt-3.5-turbo',
+                        choices: [
+                            {
+                                delta: {
+                                    content: difyResponse.answer,
+                                },
+                                finish_reason: null,
+                            },
+                        ],
+                    }
+                    controller.enqueue(new TextEncoder().encode("data: " + JSON.stringify(completionChunk) + '\n\n'))
+                }else if (difyResponse.event === 'agent_thought') {
+                    const completionChunk = {
+                        id: difyResponse.message_id,
+                        object: 'chat.completion.chunk',
+                        created: difyResponse.created_at,
+                        model: 'gpt-3.5-turbo',
+                        choices: [
+                            {
+                                delta: {
+                                    content: (difyResponse.thought ? difyResponse.thought + '\n' : "")
+                                        + difyResponse.observation,
+                                },
+                                finish_reason: null,
+                            },
+                        ],
+                    }
+                    controller.enqueue(new TextEncoder().encode("data: " + JSON.stringify(completionChunk) + '\n\n'))
+
+                }else if (difyResponse.event === 'message_end') {
+                    const completionChunk = {
+                        id: difyResponse.message_id,
+                        object: 'chat.completion.chunk',
+                        created: difyResponse.created_at,
+                        model: 'gpt-3.5-turbo',
+                        choices: [
+                            {
+                                delta: {},
+                                finish_reason: 'stop',
+                            },
+                        ],
+                    }
+                    controller.enqueue(new TextEncoder().encode("data: " + JSON.stringify(completionChunk) + '\n\n'))
+                }
+            }
+        }
+    }
+
+    flush(controller) {
+        controller.terminate()
+    }
+}
+
+async function handleRequest(request) {
+    const url = new URL(request.url)
+    if (url.pathname === '/v1/chat/completions') {
+        const { messages, stream, ...rest } = await request.json()
+        const apiKey = request.headers.get('Authorization')?.split(' ')[1]
+        /**
+         * You can replace the following block with your own authorization logic
+         * For example, you can check if the API key is defined in the environment variables, like: DifyAPIKey = app-xxxxxxxxxxxxxxxxxx
+         * if (apiKey !== DifyAPIKey) { return new Response('Unauthorized', { status: 401 })
+         */
+        if (!apiKey) {
+            return new Response('Unauthorized', { status: 401 })
+        }
+        const difyRequestBody = {
+            inputs: {},
+            query: messages.map(message => message.content).join('\n\n'), // In this example, the content of each message is concatenated with '\n\n', replace it with the actual message content when using it in practice
+            user: 'default', // In this example, 'default' is used as the user identifier, replace it with the actual user identifier when using it in practice
+            conversation_id: '', // In this example, an empty string is used as the conversation ID, replace it with the actual conversation ID when using it in practice
+            response_mode: stream ? 'streaming' : 'blocking',
+        }
+        const difyRequest = new Request('https://api.dify.ai/v1/chat-messages', {
+            method: 'POST',
+            body: JSON.stringify(difyRequestBody),
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`,
+            },
+        })
+        let difyResponse = await fetch(difyRequest)
+        if (stream) {
+            difyResponse = new Response(difyResponse.body.pipeThrough(new TransformStream(new LineBreakTransformer())), difyResponse)
+            difyResponse.headers.set('Content-Type', 'text/event-stream')
+        } else {
+            const difyResponseBody = await difyResponse.json()
+            const completionResponse = {
+                id: difyResponseBody.message_id,
+                object: 'chat.completion',
+                created: difyResponseBody.created_at,
+                model: 'gpt-3.5-turbo',
+                choices: [
+                    {
+                        message: {
+                            role: 'assistant',
+                            content: difyResponseBody.answer,
+                        },
+                        finish_reason: 'stop',
+                    },
+                ],
+            }
+            difyResponse = new Response(JSON.stringify(completionResponse), difyResponse)
+            difyResponse.headers.set('Content-Type', 'application/json')
+
+
+        }
+        // Allow cross-origin access
+        difyResponse.headers.set('Access-Control-Allow-Origin', '*')
+        difyResponse.headers.set('Access-Control-Allow-Methods', '*')
+        difyResponse.headers.set('Access-Control-Allow-Headers', '*')
+        difyResponse.headers.set('Access-Control-Allow-Credentials', 'true')
+
+        return difyResponse
+    } else {
+        return new Response('Not Found', { status: 404 })
+    }
+}


### PR DESCRIPTION
# Description

This pull request adds a new feature that allows users to easily deploy a Cloudflare Workers script for proxying the Dify conversational application API and transforming the output format to match the OpenAI Chat Completions API. By providing this script, users can quickly set up a proxy to use the Dify API with the familiar OpenAI API format.

Fixes # (issue) none

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

- [x] Tested the Cloudflare Workers script by deploying it to a Cloudflare Worker and making requests to the proxy endpoint. Verified that the responses match the expected OpenAI Chat Completions API format.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes