### PR TITLE
fix: delete tool parameters cache when sync draft workflow for run workflow use new parameter change in draft workflow 

### DIFF
--- a/api/events/app_event.py
+++ b/api/events/app_event.py
@@ -11,3 +11,6 @@ app_model_config_was_updated = signal('app-model-config-was-updated')
 
 # sender: app, kwargs: published_workflow
 app_published_workflow_was_updated = signal('app-published-workflow-was-updated')
+
+# sender: app, kwargs: synced_draft_workflow
+app_draft_workflow_was_synced = signal('app-draft-workflow-was-synced')

--- a/api/events/event_handlers/__init__.py
+++ b/api/events/event_handlers/__init__.py
@@ -5,7 +5,7 @@ from .create_installed_app_when_app_created import handle
 from .create_site_record_when_app_created import handle
 from .deduct_quota_when_messaeg_created import handle
 from .delete_installed_app_when_app_deleted import handle
+from .delete_tool_parameters_cache_when_sync_draft_workflow import handle
 from .update_app_dataset_join_when_app_model_config_updated import handle
 from .update_app_dataset_join_when_app_published_workflow_updated import handle
 from .update_provider_last_used_at_when_messaeg_created import handle
-from .delete_tool_parameters_cache_when_sync_draft_workflow import handle

--- a/api/events/event_handlers/__init__.py
+++ b/api/events/event_handlers/__init__.py
@@ -8,3 +8,4 @@ from .delete_installed_app_when_app_deleted import handle
 from .update_app_dataset_join_when_app_model_config_updated import handle
 from .update_app_dataset_join_when_app_published_workflow_updated import handle
 from .update_provider_last_used_at_when_messaeg_created import handle
+from .delete_tool_parameters_cache_when_sync_draft_workflow import handle

--- a/api/events/event_handlers/delete_tool_parameters_cache_when_sync_draft_workflow.py
+++ b/api/events/event_handlers/delete_tool_parameters_cache_when_sync_draft_workflow.py
@@ -1,0 +1,26 @@
+from core.workflow.entities.node_entities import NodeType
+from events.app_event import app_draft_workflow_was_synced
+from core.tools.utils.configuration import ToolParameterConfigurationManager
+from core.workflow.nodes.tool.entities import ToolEntity
+from core.tools.tool_manager import ToolManager
+
+
+@app_draft_workflow_was_synced.connect
+def handle(sender, **kwargs):
+    app = sender
+    for node_data in kwargs.get('synced_draft_workflow').graph_dict.get('nodes', []):
+        if node_data.get('data', {}).get('type') == NodeType.TOOL.value:
+            tool_entity = ToolEntity(**node_data["data"])
+            tool_runtime = ToolManager.get_tool_runtime(
+                provider_type=tool_entity.provider_type,
+                provider_name=tool_entity.provider_id,
+                tool_name=tool_entity.tool_name,
+                tenant_id=app.tenant_id,
+            )
+            manager = ToolParameterConfigurationManager(
+                tenant_id=app.tenant_id,
+                tool_runtime=tool_runtime,
+                provider_name=tool_entity.provider_name,
+                provider_type=tool_entity.provider_type,
+            )
+            manager.delete_tool_parameters_cache()

--- a/api/events/event_handlers/delete_tool_parameters_cache_when_sync_draft_workflow.py
+++ b/api/events/event_handlers/delete_tool_parameters_cache_when_sync_draft_workflow.py
@@ -1,8 +1,8 @@
-from core.workflow.entities.node_entities import NodeType
-from events.app_event import app_draft_workflow_was_synced
-from core.tools.utils.configuration import ToolParameterConfigurationManager
-from core.workflow.nodes.tool.entities import ToolEntity
 from core.tools.tool_manager import ToolManager
+from core.tools.utils.configuration import ToolParameterConfigurationManager
+from core.workflow.entities.node_entities import NodeType
+from core.workflow.nodes.tool.entities import ToolEntity
+from events.app_event import app_draft_workflow_was_synced
 
 
 @app_draft_workflow_was_synced.connect

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -9,7 +9,7 @@ from core.model_runtime.utils.encoders import jsonable_encoder
 from core.workflow.entities.node_entities import NodeType
 from core.workflow.errors import WorkflowNodeRunFailedError
 from core.workflow.workflow_engine_manager import WorkflowEngineManager
-from events.app_event import app_published_workflow_was_updated, app_draft_workflow_was_synced
+from events.app_event import app_draft_workflow_was_synced, app_published_workflow_was_updated
 from extensions.ext_database import db
 from models.account import Account
 from models.model import App, AppMode

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -9,7 +9,7 @@ from core.model_runtime.utils.encoders import jsonable_encoder
 from core.workflow.entities.node_entities import NodeType
 from core.workflow.errors import WorkflowNodeRunFailedError
 from core.workflow.workflow_engine_manager import WorkflowEngineManager
-from events.app_event import app_published_workflow_was_updated
+from events.app_event import app_published_workflow_was_updated, app_draft_workflow_was_synced
 from extensions.ext_database import db
 from models.account import Account
 from models.model import App, AppMode
@@ -97,6 +97,9 @@ class WorkflowService:
 
         # commit db session changes
         db.session.commit()
+
+        # trigger app workflow events
+        app_draft_workflow_was_synced.send(app_model, synced_draft_workflow=workflow)
 
         # return draft workflow
         return workflow


### PR DESCRIPTION
# Description
在更新draft workflow时增加了删除工具的参数缓存逻辑，不然在实际使用中出现了无法使用最新参数而是使用缓存参数的问题，comments中给出了具体问题截图

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
