### PR TITLE
fix: workflow_run_id not log_id in workflow api doc

### DIFF
--- a/web/app/components/develop/template/template_workflow.en.mdx
+++ b/web/app/components/develop/template/template_workflow.en.mdx
@@ -65,7 +65,7 @@ Workflow applications offers non-session support and is ideal for translation, a
 
     ### CompletionResponse
     Returns the App result, `Content-Type` is `application/json`.
-    - `log_id` (string) Unique log ID
+    - `workflow_run_id` (string) Unique ID of workflow execution
     - `task_id` (string) Task ID, used for request tracking and the below Stop Generate API
     - `data` (object) detail of result
       - `id` (string) ID of workflow execution
@@ -178,7 +178,7 @@ Workflow applications offers non-session support and is ideal for translation, a
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-        "log_id": "djflajgkldjgd",
+        "workflow_run_id": "djflajgkldjgd",
         "task_id": "9da23599-e713-473b-982c-4328d4f5c78a",
         "data": {
             "id": "fdlsjfjejkghjda",

--- a/web/app/components/develop/template/template_workflow.zh.mdx
+++ b/web/app/components/develop/template/template_workflow.zh.mdx
@@ -63,7 +63,7 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
 
     ### CompletionResponse
     返回完整的 App 结果，`Content-Type` 为 `application/json` 。
-    - `log_id` (string) 日志 ID
+    - `workflow_run_id` (string) workflow 执行 ID
     - `task_id` (string) 任务 ID，用于请求跟踪和下方的停止响应接口
     - `data` (object) 详细内容
       - `id` (string) workflow 执行 ID
@@ -174,7 +174,7 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-        "log_id": "djflajgkldjgd",
+        "workflow_run_id": "djflajgkldjgd",
         "task_id": "9da23599-e713-473b-982c-4328d4f5c78a",
         "data": {
             "id": "fdlsjfjejkghjda",


### PR DESCRIPTION
# Description

Workflow_run_id not log_id in workflow api doc.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
