### PR TITLE
fix: downgrade pymilvus==2.3.6

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -55,7 +55,7 @@ xinference-client==0.9.4
 safetensors~=0.4.3
 zhipuai==1.0.7
 werkzeug~=3.0.1
-pymilvus~=2.3.0
+pymilvus==2.3.6
 qdrant-client==1.7.3
 cohere~=5.2.4
 pyyaml~=6.0.1


### PR DESCRIPTION
# Description

- quick fix by downgrading pymilvus to 2.3.6, for the method `create_collection_with_schema` which is removed from 2.3.7
- code ref in 2.3.6: https://github.com/milvus-io/pymilvus/blob/v2.3.6/pymilvus/milvus_client/milvus_client.py#L495

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
