### PR TITLE
fix: cannot change file uploader method

### DIFF
--- a/web/app/components/base/features/feature-panel/file-upload/param-config-content.tsx
+++ b/web/app/components/base/features/feature-panel/file-upload/param-config-content.tsx
@@ -38,7 +38,7 @@ const ParamConfigContent = ({
     } = featuresStore!.getState()
     const newFeatures = produce(features, (draft) => {
       if (draft.file?.image) {
-        if (TransferMethod.all)
+        if (value === TransferMethod.all)
           draft.file.image.transfer_methods = [TransferMethod.remote_url, TransferMethod.local_file]
         else
           draft.file.image.transfer_methods = [value]


### PR DESCRIPTION
fix: cannot change file uploader method

# Description

 Cannot change file uploader method while editing workflow image

![image](https://github.com/langgenius/dify/assets/42262072/c9c2ef06-a65f-4767-b9b8-b72cfe64d4ab)


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
