### PR TITLE
use pymilvus 2.3.7

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -55,7 +55,7 @@ xinference-client==0.9.4
 safetensors~=0.4.3
 zhipuai==1.0.7
 werkzeug~=3.0.1
-pymilvus~=2.3.0
+pymilvus~=2.3.7
 qdrant-client==1.7.3
 cohere~=5.2.4
 pyyaml~=6.0.1


### PR DESCRIPTION
# Description

- as #3683 uses `create_collection` for creating collection with schema, which is API changed since `pymilvus` 2.3.2+, set pymilvus to 2.3.7 preventing accidently falling to previously cached or installed  `pymilvus` 2.3.1 and below.
- `pymilvus` 2.3.7 is currently recommended officially to connect Milvus 2.3 used in `milvus-standalone-docker-compose.yml`, refer docs: https://github.com/milvus-io/pymilvus?tab=readme-ov-file#compatibility

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
