### PR TITLE
fix: fetch page name of notion wiki

### DIFF
--- a/api/libs/oauth_data_source.py
+++ b/api/libs/oauth_data_source.py
@@ -153,23 +153,12 @@ class NotionOAuth(OAuthDataSource):
         # get page detail
         for page_result in page_results:
             page_id = page_result['id']
-            if 'Name' in page_result['properties']:
-                if len(page_result['properties']['Name']['title']) > 0:
-                    page_name = page_result['properties']['Name']['title'][0]['plain_text']
-                else:
-                    page_name = 'Untitled'
-            elif 'title' in page_result['properties']:
-                if len(page_result['properties']['title']['title']) > 0:
-                    page_name = page_result['properties']['title']['title'][0]['plain_text']
-                else:
-                    page_name = 'Untitled'
-            elif 'Title' in page_result['properties']:
-                if len(page_result['properties']['Title']['title']) > 0:
-                    page_name = page_result['properties']['Title']['title'][0]['plain_text']
-                else:
-                    page_name = 'Untitled'
-            else:
-                page_name = 'Untitled'
+            page_name = 'Untitled'
+            for key in ['Name', 'title', 'Title', 'Page']:
+                if key in page_result['properties']:
+                    if len(page_result['properties'][key].get('title', [])) > 0:
+                        page_name = page_result['properties'][key]['title'][0]['plain_text']
+                        break
             page_icon = page_result['icon']
             if page_icon:
                 icon_type = page_icon['type']


### PR DESCRIPTION
If you turn a page into wiki, the name of subpages will be placed in the `["properties"]["Page"]["title"]` field.

# Description

This pull request tries to fetch the page name in Notion wiki. [Notion's API document](https://developers.notion.com/reference/intro) does not mention "wiki". I found the pattern through experiments.

How to turn a page into wiki:
<img width="282" alt="image" src="https://github.com/badbye/dify/assets/3295865/58a26326-c624-4784-bf24-4f8889b14db8">
<img width="445" alt="image" src="https://github.com/badbye/dify/assets/3295865/19f111ca-60dd-427c-8025-c768d1f92e32">

After that, try the search API:
```
curl -X POST 'https://api.notion.com/v1/search' \
  -H 'Authorization: Bearer {your_notion_secret_key}' \
  -H "Notion-Version: 2022-06-28" \
-H 'Content-Type: application/json'
```

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested it in practice.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
