### PR TITLE
fix: UP031 style rule violation

### DIFF
--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -29,8 +29,7 @@ class WordExtractor(BaseExtractor):
 
             if r.status_code != 200:
                 raise ValueError(
-                    "Check the url of your file; returned status code %s"
-                    % r.status_code
+                    f"Check the url of your file; returned status code {r.status_code}"
                 )
 
             self.web_path = self.file_path
@@ -38,7 +37,7 @@ class WordExtractor(BaseExtractor):
             self.temp_file.write(r.content)
             self.file_path = self.temp_file.name
         elif not os.path.isfile(self.file_path):
-            raise ValueError("File path %s is not a valid file or url" % self.file_path)
+            raise ValueError(f"File path {self.file_path} is not a valid file or url")
 
     def __del__(self) -> None:
         if hasattr(self, "temp_file"):


### PR DESCRIPTION
# Description

- fix style violation of `UP031 printf-string-formatting` (https://docs.astral.sh/ruff/rules/printf-string-formatting/), checked by `ruff` 0.4.2

```
Run ruff check ./api
api/core/rag/extractor/word_extractor.py:32:21: UP031 Use format specifiers instead of percent format
api/core/rag/extractor/word_extractor.py:41:30: UP031 Use format specifiers instead of percent format
Found 2 errors.
```

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
