### PR TITLE
send linting hints to comment when style check fails

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
+      contents: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,10 +13,7 @@ jobs:
   python-style:
     name: Python Style
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-      contents: write
+    permissions: write-all
 
     steps:
       - name: Checkout code

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,19 +31,19 @@ jobs:
 
       - name: Ruff hints
         if: failure()
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            Please run 'dev/reformat' to fix the fixable linting errors.
-#        uses: actions/github-script@v7
+#        uses: thollander/actions-comment-pull-request@v2
 #        with:
-#          script: |
-#            github.rest.issues.createComment({
-#              issue_number: context.issue.number,
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              body: "Please run 'dev/reformat' to fix the fixable linting errors."
-#            })
+#          message: |
+#            Please run 'dev/reformat' to fix the fixable linting errors.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Please run 'dev/reformat' to fix the fixable linting errors."
+            })
 
       - name: Dotenv check
         run: dotenv-linter ./api/.env.example ./web/.env.example

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,6 +41,7 @@ jobs:
 #            Please run 'dev/reformat' to fix the fixable linting errors.
         uses: actions/github-script@v7
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,15 +31,19 @@ jobs:
 
       - name: Ruff hints
         if: failure()
-        uses: actions/github-script@v7
+        uses: thollander/actions-comment-pull-request@v2
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "Please run 'dev/reformat' to fix the fixable linting errors."
-            })
+          message: |
+            Please run 'dev/reformat' to fix the fixable linting errors.
+#        uses: actions/github-script@v7
+#        with:
+#          script: |
+#            github.rest.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: "Please run 'dev/reformat' to fix the fixable linting errors."
+#            })
 
       - name: Dotenv check
         run: dotenv-linter ./api/.env.example ./web/.env.example

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,6 +13,8 @@ jobs:
   python-style:
     name: Python Style
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,12 +29,21 @@ jobs:
       - name: Ruff check
         run: ruff check ./api
 
+      - name: Ruff hints
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Please run 'dev/reformat' to fix the fixable linting errors."
+            })
+
       - name: Dotenv check
         run: dotenv-linter ./api/.env.example ./web/.env.example
 
-      - name: Lint hints
-        if: failure()
-        run: echo "Please run 'dev/reformat' to fix the fixable linting errors."
 
   test:
     name: ESLint and SuperLinter

--- a/api/core/rag/datasource/vdb/milvus/milvus_vector.py
+++ b/api/core/rag/datasource/vdb/milvus/milvus_vector.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Any, Optional
 from uuid import uuid4
+from typing import Any, Optional
 
 from pydantic import BaseModel, root_validator
 from pymilvus import MilvusClient, MilvusException, connections


### PR DESCRIPTION
# Description

- send linting hits to PR's comment when Ruff check fails

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
