### PR TITLE
feat: add start commands to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,8 @@
 			]
 		}
 	},
-	"postStartCommand": "chmod +x ./.devcontainer/post_start_command.sh; ./.devcontainer/post_start_command.sh",
-	"postCreateCommand": "chmod +x ./.devcontainer/post_create_command.sh; ./.devcontainer/post_create_command.sh"
+	"postStartCommand": "./.devcontainer/post_start_command.sh",
+	"postCreateCommand": "./.devcontainer/post_create_command.sh"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,8 @@
 			]
 		}
 	},
-	"postStartCommand": "cd api && pip install -r requirements.txt",
-	"postCreateCommand": "cd web && npm install"
+	"postStartCommand": "chmod +x ./.devcontainer/post_start_command.sh; ./.devcontainer/post_start_command.sh",
+	"postCreateCommand": "chmod +x ./.devcontainer/post_create_command.sh; ./.devcontainer/post_create_command.sh"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd web && npm install
+
+echo 'alias start-api="cd /workspaces/dify/api && flask run --host 0.0.0.0 --port=5001 --debug"' >> ~/.bashrc
+echo 'alias start-web="cd /workspaces/dify/web && npm run dev"' >> ~/.bashrc
+echo 'alias start-containers="cd /workspaces/dify/docker && docker-compose -f docker-compose.middleware.yaml -p dify up -d"' >> ~/.bashrc
+
+source ~/.bashrc

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -3,6 +3,7 @@
 cd web && npm install
 
 echo 'alias start-api="cd /workspaces/dify/api && flask run --host 0.0.0.0 --port=5001 --debug"' >> ~/.bashrc
+echo 'alias start-worker="cd /workspaces/dify/api && celery -A app.celery worker -P gevent -c 1 --loglevel INFO -Q dataset,generation,mail"' >> ~/.bashrc
 echo 'alias start-web="cd /workspaces/dify/web && npm run dev"' >> ~/.bashrc
 echo 'alias start-containers="cd /workspaces/dify/docker && docker-compose -f docker-compose.middleware.yaml -p dify up -d"' >> ~/.bashrc
 

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -7,4 +7,4 @@ echo 'alias start-worker="cd /workspaces/dify/api && celery -A app.celery worker
 echo 'alias start-web="cd /workspaces/dify/web && npm run dev"' >> ~/.bashrc
 echo 'alias start-containers="cd /workspaces/dify/docker && docker-compose -f docker-compose.middleware.yaml -p dify up -d"' >> ~/.bashrc
 
-source ~/.bashrc
+source /home/vscode/.bashrc

--- a/.devcontainer/post_start_command.sh
+++ b/.devcontainer/post_start_command.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd api && pip install -r requirements.txt


### PR DESCRIPTION
# Description

I work with the dify repo every week and every time I forget the whole command to start the api or the worker. I added these commands because they are intuitive and easy to remember.

This change just introduces shortcut commands to run services, which are made available via alias in the devcontainer:
- start-api: starts the flask app in debug mode
- start-worker: starts the worker 
- start-web: starts the nextjs web app in dev mode
- start-containers: runs docker compose for the middleware compose file to start containers like dbs and sandbox

## Type of Change
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement


# How Has This Been Tested?

- [ ] Open the dify workspace in a devcontainer
- [ ] Run the VS Code script "Rebuild Container"
- [ ] Watch the logs, after the container is created, it should run an npm install for web (as it did before)
- [ ] After the container has been created, it should run pip install for api (as it did before)
- [ ] run start-containers (just type it in the terminal and press enter)
  - [ ] this should run docker compose to run required containers for local development
- [ ] run start-api
  - [ ] this should start the dify api
- [ ] run start-worker
  - [ ] this should start the the dify worker
- [ ] run start-web
  - [ ] this should start the dify web
- [ ] open `~/.bashrc` you should see 4 commands defined at the end of the file
- [ ] close vs code and reopen it
- [ ] the devcontainer should run pip install but should not create the aliases again
- [ ] open `~/.bashrc` again
- [ ] it should still contain only the 4 commands once

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
