### PR TITLE
🌟add docker-compose.yaml container_name.

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   # API service
   api:
+    container_name: api
     image: langgenius/dify-api:0.6.5
     restart: always
     environment:
@@ -159,6 +160,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
+    container_name: worker
     image: langgenius/dify-api:0.6.5
     restart: always
     environment:
@@ -247,6 +249,7 @@ services:
 
   # Frontend web application.
   web:
+    container_name: web
     image: langgenius/dify-web:0.6.5
     restart: always
     environment:
@@ -289,6 +292,7 @@ services:
 
   # The redis cache.
   redis:
+    container_name: redis
     image: redis:6-alpine
     restart: always
     volumes:
@@ -304,6 +308,7 @@ services:
 
   # The Weaviate vector store.
   weaviate:
+    container_name: weaviate
     image: semitechnologies/weaviate:1.19.0
     restart: always
     volumes:
@@ -328,6 +333,7 @@ services:
 
   # The DifySandbox
   sandbox:
+    container_name: sandbox
     image: langgenius/dify-sandbox:latest
     restart: always
     cap_add:
@@ -358,6 +364,7 @@ services:
   # The nginx reverse proxy.
   # used for reverse proxying the API service and Web service.
   nginx:
+    container_name: nginx
     image: nginx:latest
     restart: always
     volumes:


### PR DESCRIPTION
# Description

When I was helping others deploy, I found that none of the services in Docker-compose do specify container_name, which results in docker automatically assigning a container name when Docker-Compose starts the container, which is usually "service name -1". This will misunderstand many people and cause them to misunderstand the problem

## Type of Change

Please delete options that are not relevant.
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

run "docker-compose up -d && docker ps -a"
You can view the service name without a suffix

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] `optional` I have added tests that prove my fix is effective or that my feature works
- [x] `optional` New and existing unit tests pass locally with my changes
