### PR TITLE
fix(web): copy button visible at chat page normally

### DIFF
--- a/web/app/components/app/chat/answer/index.tsx
+++ b/web/app/components/app/chat/answer/index.tsx
@@ -362,7 +362,7 @@ const Answer: FC<IAnswerProps> = ({
                 {!item.isOpeningStatement && (
                   <CopyBtn
                     value={content}
-                    className={cn(s.copyBtn, 'mr-1')}
+                    className='mr-1'
                   />
                 )}
                 {((isShowPromptLog && !isResponding) || (!item.isOpeningStatement && isShowTextToSpeech)) && (

--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -12,7 +12,6 @@ import cn from 'classnames'
 import CopyBtn from '@/app/components/app/chat/copy-btn'
 import SVGBtn from '@/app/components/app/chat/svg'
 import Flowchart from '@/app/components/app/chat/mermaid'
-import s from '@/app/components/app/chat/style.module.css'
 
 // Available language https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_HLJS.MD
 const capitalizationLanguageNameMap: Record<string, string> = {
@@ -113,7 +112,7 @@ export function Markdown(props: { content: string; className?: string }) {
                         />
                       }
                       <CopyBtn
-                        className={cn(s.copyBtn, 'mr-1')}
+                        className='mr-1'
                         value={String(children).replace(/\n$/, '')}
                         isPlain
                       />


### PR DESCRIPTION
# Description

copy button can not display at chat page now


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

