### PR TITLE
Revert "fix: hydration warning (#3897)"

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -42,7 +42,6 @@ const LocaleLayout = ({
         data-public-sentry-dsn={process.env.NEXT_PUBLIC_SENTRY_DSN}
         data-public-maintenance-notice={process.env.NEXT_PUBLIC_MAINTENANCE_NOTICE}
         data-public-site-about={process.env.NEXT_PUBLIC_SITE_ABOUT}
-        suppressHydrationWarning
       >
         <Topbar/>
         <BrowerInitor>


### PR DESCRIPTION
This reverts commit 08a65d74d56bd1666fa4e96e981faba65acc72af.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

We should not disable suppress hydration warning, I saw this error because of the influence of my Chrome extension
More details here https://github.com/huozhi/sugar-high/pull/97#discussion_r1582766252

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
