### PR TITLE
Urgent Correction: Resolving Critical License Documentation Error in Dify's Japanese README

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -242,4 +242,4 @@ docker compose up -d
 
 ## ライセンス
 
-このリポジトリは、Apache 2.0にいくつかの追加制限を加えた[Difyオープンソースライセンス](LICENSE)の下で利用可能です。
+このリポジトリは、Dify Open Source License にいくつかの追加制限を加えた[Difyオープンソースライセンス](LICENSE)の下で利用可能です。

--- a/README_JA.md
+++ b/README_JA.md
@@ -242,4 +242,4 @@ docker compose up -d
 
 ## ライセンス
 
-プロジェクトはMITライセンスの下で利用可能です。[LICENSE](LICENSE)をご参照ください。
+このリポジトリは、Apache 2.0にいくつかの追加制限を加えた[Difyオープンソースライセンス](LICENSE)の下で利用可能です。


### PR DESCRIPTION
# Description

This pull request addresses a discrepancy found in the licensing information stated in the project documentation. The current document erroneously states that the project is available under the MIT License, which is not accurate according to the intended licensing.

This change corrects the license documentation to reflect the actual license under which the project is distributed, specifically pointing out that the repository is available under the Dify Open Source License, an adaptation of Apache 2.0 with additional restrictions. This correction ensures that all users and contributors have correct and reliable licensing information.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)

# How Has This Been Tested?

- [x] The corrected documentation does not require tests beyond verification by the project maintainers to ensure the updated license text accurately reflects the intended licensing structure.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation