### PR TITLE
fix: prevent http node overwrite on open

### DIFF
--- a/web/app/components/workflow/nodes/http/use-config.ts
+++ b/web/app/components/workflow/nodes/http/use-config.ts
@@ -29,8 +29,8 @@ const useConfig = (id: string, payload: HttpNodeType) => {
     const isReady = defaultConfig && Object.keys(defaultConfig).length > 0
     if (isReady) {
       setInputs({
-        ...inputs,
         ...defaultConfig,
+        ...inputs,
       })
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Description

We accidentally introduces a bug with #3854 which overwrites the http node with its default value when the node is opened.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue

# How Has This Been Tested?

- [ ] Open the HTTP node in workflow editor
- [ ] Set method to POST and define request body
- [ ] Close the node
- [ ] Open the node
- [ ] Values should still be there as configured

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
