### PR TITLE
fix: stop event propagation when deleting selected workflow var node

### DIFF
--- a/web/app/components/base/prompt-editor/hooks.ts
+++ b/web/app/components/base/prompt-editor/hooks.ts
@@ -64,6 +64,7 @@ export const useSelectOrDelete: UseSelectOrDeleteHanlder = (nodeKey: string, com
             editor.dispatchCommand(command, undefined)
 
           node.remove()
+          return true
         }
       }
 

--- a/web/app/components/base/prompt-editor/plugins/workflow-variable-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/workflow-variable-block/component.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lexical'
 import { mergeRegister } from '@lexical/utils'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import cn from 'classnames'
 import { useSelectOrDelete } from '../../hooks'
 import type { WorkflowNodesMap } from './node'
 import { WorkflowVariableBlockNode } from './node'
@@ -61,11 +62,11 @@ const WorkflowVariableBlockComponent = ({
 
   const Item = (
     <div
-      className={`
-        mx-0.5 relative group/wrap flex items-center h-[18px] pl-0.5 pr-[3px] rounded-[5px] border
-        ${isSelected ? ' border-[#84ADFF] bg-[#F5F8FF]' : ' border-black/5 bg-white'}
-        ${!node && '!border-[#F04438] !bg-[#FEF3F2]'}
-      `}
+      className={cn(
+        'mx-0.5 relative group/wrap flex items-center h-[18px] pl-0.5 pr-[3px] rounded-[5px] border select-none',
+        isSelected ? ' border-[#84ADFF] bg-[#F5F8FF]' : ' border-black/5 bg-white',
+        !node && '!border-[#F04438] !bg-[#FEF3F2]',
+      )}
       ref={ref}
     >
       <div className='flex items-center'>


### PR DESCRIPTION
# Description

This pull request includes two changes:

- Stop event propagation when deleting the selected decorator node
  - When the selected workflow var node is deleted, the continuous workflow var node will be accidentally deleted.

https://github.com/langgenius/dify/assets/18554747/139a2616-5598-4733-a469-ec81874ab8d4

- Tweak workflow variable selected style
  - Now the text inside the workflow variable node can not be selected directly

Before

<img width="270" alt="Screenshot 2024-05-07 at 18 53 55" src="https://github.com/langgenius/dify/assets/18554747/08ab15e1-8dde-473a-952d-c7b303b7059e">

After

<img width="291" alt="Screenshot 2024-05-07 at 18 53 25" src="https://github.com/langgenius/dify/assets/18554747/811a1a60-ab6f-4241-90bc-317df02a1541">



## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] See the video

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
