### PR TITLE
Typo on deepseek.yaml and yi.yaml 

### DIFF
--- a/api/core/model_runtime/model_providers/deepseek/deepseek.yaml
+++ b/api/core/model_runtime/model_providers/deepseek/deepseek.yaml
@@ -33,7 +33,7 @@ provider_credential_schema:
     - variable: endpoint_url
       label:
         zh_Hans: 自定义 API endpoint 地址
-        en_US: CUstom API endpoint URL
+        en_US: Custom API endpoint URL
       type: text-input
       required: false
       placeholder:

--- a/api/core/model_runtime/model_providers/yi/yi.yaml
+++ b/api/core/model_runtime/model_providers/yi/yi.yaml
@@ -33,7 +33,7 @@ provider_credential_schema:
     - variable: endpoint_url
       label:
         zh_Hans: 自定义 API endpoint 地址
-        en_US: CUstom API endpoint URL
+        en_US: Custom API endpoint URL
       type: text-input
       required: false
       placeholder:


### PR DESCRIPTION
# Description

I think C `U` stom is typo.

Fixes #4169

## Type of Change

Please delete options that are not relevant.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] confirming on the page of model provider
<img width="616" alt="スクリーンショット 2024-05-08 10 54 59" src="https://github.com/langgenius/dify/assets/50616781/502f6ef0-ec99-4398-a52c-27a323734969">
<img width="633" alt="スクリーンショット 2024-05-08 10 55 15" src="https://github.com/langgenius/dify/assets/50616781/cd1685fe-6dbb-44d5-9bce-914b26acf01f">