### PR TITLE
fix delete log annotation

### DIFF
--- a/web/app/components/app/chat/index.tsx
+++ b/web/app/components/app/chat/index.tsx
@@ -260,11 +260,7 @@ const Chat: FC<IChatProps> = ({
         return {
           ...item,
           content: item.content,
-          annotation: {
-            ...(item.annotation || {}),
-            id: '',
-            logAnnotation: undefined, // remove log
-          } as Annotation,
+          annotation: undefined,
         }
       }
       return item

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -137,8 +137,8 @@ const getFormattedChatList = (messages: ChatMessage[], conversationId: string, t
 
         if (item.annotation) {
           return {
-            id: '',
-            authorName: '',
+            id: item.annotation.id,
+            authorName: item.annotation.account.name,
             logAnnotation: item.annotation,
             created_at: 0,
           }

--- a/web/models/log.ts
+++ b/web/models/log.ts
@@ -57,6 +57,7 @@ export type ModelConfigDetail = {
 }
 
 export type LogAnnotation = {
+  id: string
   content: string
   account: {
     id: string


### PR DESCRIPTION
this is a fix of issue #4200 

1. changes of `web/app/components/app/log/list.tsx` make sure `remove annotation` can get the right annotation id
2. changes of `web/app/components/app/chat/index.tsx`make sure this annotation is properly removed. if not this message would still be tagged as annotated and the remove annotation button is still there
