### PR TITLE
fix: miss usage of os.path.join for URL assembly and add tests on yarl

### DIFF
--- a/api/core/model_runtime/model_providers/chatglm/llm/llm.py
+++ b/api/core/model_runtime/model_providers/chatglm/llm/llm.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Generator
-from os.path import join
 from typing import Optional, cast
 
 from httpx import Timeout
@@ -19,6 +18,7 @@ from openai import (
 )
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.chat_completion_message import FunctionCall
+from yarl import URL
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -265,7 +265,7 @@ class ChatGLMLargeLanguageModel(LargeLanguageModel):
         client_kwargs = {
             "timeout": Timeout(315.0, read=300.0, write=10.0, connect=5.0),
             "api_key": "1",
-            "base_url": join(credentials['api_base'], 'v1')
+            "base_url": str(URL(credentials['api_base']) / 'v1')
         }
 
         return client_kwargs

--- a/api/core/tools/provider/builtin/dalle/tools/dalle2.py
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle2.py
@@ -1,8 +1,8 @@
 from base64 import b64decode
-from os.path import join
 from typing import Any, Union
 
 from openai import OpenAI
+from yarl import URL
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
@@ -23,7 +23,7 @@ class DallE2Tool(BuiltinTool):
         if not openai_base_url:
             openai_base_url = None
         else:
-            openai_base_url = join(openai_base_url, 'v1')
+            openai_base_url = str(URL(openai_base_url) / 'v1')
 
         client = OpenAI(
             api_key=self.runtime.credentials['openai_api_key'],

--- a/api/core/tools/provider/builtin/dalle/tools/dalle3.py
+++ b/api/core/tools/provider/builtin/dalle/tools/dalle3.py
@@ -1,8 +1,8 @@
 from base64 import b64decode
-from os.path import join
 from typing import Any, Union
 
 from openai import OpenAI
+from yarl import URL
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
@@ -23,7 +23,7 @@ class DallE3Tool(BuiltinTool):
         if not openai_base_url:
             openai_base_url = None
         else:
-            openai_base_url = join(openai_base_url, 'v1')
+            openai_base_url = str(URL(openai_base_url) / 'v1')
 
         client = OpenAI(
             api_key=self.runtime.credentials['openai_api_key'],

--- a/api/tests/unit_tests/libs/test_yarl.py
+++ b/api/tests/unit_tests/libs/test_yarl.py
@@ -1,0 +1,23 @@
+import pytest
+from yarl import URL
+
+
+def test_yarl_urls():
+    expected_1 = 'https://dify.ai/api'
+    assert str(URL('https://dify.ai') / 'api') == expected_1
+    assert str(URL('https://dify.ai/') / 'api') == expected_1
+
+    expected_2 = 'http://dify.ai:12345/api'
+    assert str(URL('http://dify.ai:12345') / 'api') == expected_2
+    assert str(URL('http://dify.ai:12345/') / 'api') == expected_2
+
+    expected_3 = 'https://dify.ai/api/v1'
+    assert str(URL('https://dify.ai') / 'api' / 'v1') == expected_3
+    assert str(URL('https://dify.ai') / 'api/v1') == expected_3
+    assert str(URL('https://dify.ai/') / 'api/v1') == expected_3
+    assert str(URL('https://dify.ai/api') / 'v1') == expected_3
+    assert str(URL('https://dify.ai/api/') / 'v1') == expected_3
+
+    with pytest.raises(ValueError) as e1:
+        str(URL('https://dify.ai') / '/api')
+    assert str(e1.value) == "Appending path '/api' starting from slash is forbidden"


### PR DESCRIPTION
# Description

- fix the misusage of `os.path.join` for URL assembly , as `os.path.join` is OS dependent and it will cause "\\" seperator on Windows platform in URL instead of the correct '/'
- use and add test for  `yarl` package for safer URL assembly

## Type of Change

Please delete options that are not relevant.

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
