### PR TITLE
fix: do nothing if switch to current app

### DIFF
--- a/web/app/components/header/nav/nav-selector/index.tsx
+++ b/web/app/components/header/nav/nav-selector/index.tsx
@@ -73,6 +73,8 @@ const NavSelector = ({ curNav, navs, createText, isApp, onCreate, onLoadmore }: 
                   navs.map(nav => (
                     <Menu.Item key={nav.id}>
                       <div className='flex items-center w-full px-3 py-[6px] text-gray-700 text-[14px] rounded-lg font-normal hover:bg-gray-100 cursor-pointer truncate' onClick={() => {
+                        if (curNav?.id === nav.id)
+                          return
                         setAppDetail()
                         router.push(nav.link)
                       }} title={nav.name}>


### PR DESCRIPTION
# Description

bug reproduction steps: 
1. enter any app detail page
2. click header app switch nav button to show the app droplist
3. try switch to the currently active app
4. page rendering stuck at loading state

![image](https://github.com/langgenius/dify/assets/4371697/4feab734-0ef0-4c88-a854-1ac51e92f6e4)
![image](https://github.com/langgenius/dify/assets/4371697/88aa4840-74af-4e1e-a787-282f0f90640d)

reason:
web/app/components/header/nav/nav-selector/index.tsx - switch app click handler set app as emptry by calling `setAppDetail()`
web/app/components/app/configuration/index.tsx - useEffect won't rerun coz the dependency [appId] hasn't change

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

switch to current selected app in header nav menu, the page can be rendered properly.

- [x] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
