### PR TITLE
fix(Backend:http_executor): :wrench: prevent splitting JSON data as v…

### DIFF
--- a/api/core/workflow/nodes/http_request/http_executor.py
+++ b/api/core/workflow/nodes/http_request/http_executor.py
@@ -236,7 +236,7 @@ class HttpExecutor:
                 for kv in kv_paris:
                     if not kv.strip():
                         continue
-                    kv = kv.split(':')
+                    kv = kv.split(':', 1)
                     if len(kv) == 2:
                         body[kv[0].strip()] = kv[1]
                     elif len(kv) == 1:


### PR DESCRIPTION
# Description

HTTP Node had an issue evaluating JSON data as value when used with `form-data`

![image](https://github.com/langgenius/dify/assets/9155931/0480dc6e-38c5-487b-a76b-464febb63850)
![image](https://github.com/langgenius/dify/assets/9155931/4435a4cf-c0dc-4272-8d5f-3ead5249c0a0)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the HTTP node by sending couple different request to sandbox http receiver checking values of sent data.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
