### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -177,6 +177,7 @@ services:
     image: langgenius/dify-api:0.6.7
     restart: always
     environment:
+      CONSOLE_WEB_URL: ''
       # Startup mode, 'worker' starts the Celery worker for processing the queue.
       MODE: worker
 
@@ -251,6 +252,11 @@ services:
       MAIL_TYPE: ''
       # default send from email address, if not specified
       MAIL_DEFAULT_SEND_FROM: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
+      SMTP_SERVER: ''
+      SMTP_PORT: 587
+      SMTP_USERNAME: ''
+      SMTP_PASSWORD: ''
+      SMTP_USE_TLS: 'true'
       # the api-key for resend (https://resend.com)
       RESEND_API_KEY: ''
       RESEND_API_URL: https://api.resend.com


### PR DESCRIPTION
It is recommended to include the Email-related ENV configurations in the worker as well, otherwise the worker cannot access the necessary variables for sending emails when executing the email action. Having these SMTP configurations set only in the API is ineffective. Additionally, the CONSOLE_WEB_URL should also be set in the worker's ENV to ensure that the login URL in the emails received by users is correct.

# Description
After deploying according to the official documentation, emails cannot be sent.
After reviewing the source code, it was discovered that the email sending function is executed only within the worker. Therefore, the email variables need to be added to the worker's ENV.



