### PR TITLE
Fix: setup google-storage client

### DIFF
--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -1,7 +1,7 @@
 import base64
+import io
 from collections.abc import Generator
 from contextlib import closing
-import io
 
 from flask import Flask
 from google.cloud import storage as GoogleCloudStorage

--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -4,6 +4,7 @@ from contextlib import closing
 
 from flask import Flask
 from google.cloud import storage as GoogleCloudStorage
+import json
 
 from extensions.storage.base_storage import BaseStorage
 
@@ -17,7 +18,7 @@ class GoogleStorage(BaseStorage):
         self.bucket_name = app_config.get('GOOGLE_STORAGE_BUCKET_NAME')
         service_account_json = base64.b64decode(app_config.get('GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64')).decode(
             'utf-8')
-        self.client = GoogleCloudStorage.Client().from_service_account_json(service_account_json)
+        self.client = GoogleCloudStorage.Client.from_service_account_info(json.loads(service_account_json))
 
     def save(self, filename, data):
         bucket = self.client.get_bucket(self.bucket_name)

--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -5,7 +5,6 @@ import io
 
 from flask import Flask
 from google.cloud import storage as GoogleCloudStorage
-import json
 
 from extensions.storage.base_storage import BaseStorage
 
@@ -20,7 +19,7 @@ class GoogleStorage(BaseStorage):
         service_account_json_str = app_config.get('GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64')
         # if service_account_json_str is empty, use Application Default Credentials
         if service_account_json_str:
-            service_account_json = json.loads(service_account_json_str)
+            service_account_json = base64.b64decode(service_account_json_str).decode('utf-8')
             self.client = GoogleCloudStorage.Client.from_service_account_info(service_account_json)
         else:
             self.client = GoogleCloudStorage.Client()

--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -16,9 +16,13 @@ class GoogleStorage(BaseStorage):
         super().__init__(app)
         app_config = self.app.config
         self.bucket_name = app_config.get('GOOGLE_STORAGE_BUCKET_NAME')
-        service_account_json = base64.b64decode(app_config.get('GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64')).decode(
-            'utf-8')
-        self.client = GoogleCloudStorage.Client.from_service_account_info(json.loads(service_account_json))
+        service_account_json_str = app_config.get('GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64')
+        # if service_account_json_str is empty, use Application Default Credentials
+        if service_account_json_str:
+            service_account_json = json.loads(service_account_json_str)
+            self.client = GoogleCloudStorage.Client.from_service_account_info(service_account_json)
+        else:
+            self.client = GoogleCloudStorage.Client()
 
     def save(self, filename, data):
         bucket = self.client.get_bucket(self.bucket_name)

--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -1,6 +1,7 @@
 import base64
 from collections.abc import Generator
 from contextlib import closing
+import io
 
 from flask import Flask
 from google.cloud import storage as GoogleCloudStorage
@@ -27,7 +28,8 @@ class GoogleStorage(BaseStorage):
     def save(self, filename, data):
         bucket = self.client.get_bucket(self.bucket_name)
         blob = bucket.blob(filename)
-        blob.upload_from_file(data)
+        with io.BytesIO(data) as stream:
+            blob.upload_from_file(stream)
 
     def load_once(self, filename: str) -> bytes:
         bucket = self.client.get_bucket(self.bucket_name)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -88,6 +88,7 @@ services:
       AZURE_BLOB_ACCOUNT_URL: 'https://<your_account_name>.blob.core.windows.net'
       # The Google storage configurations, only available when STORAGE_TYPE is `google-storage`.
       GOOGLE_STORAGE_BUCKET_NAME: 'yout-bucket-name'
+      # if you want to use Application Default Credentials, you can leave GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64 empty.
       GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: 'your-google-service-account-json-base64-string'
       # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`, `relyt`.
       VECTOR_STORE: weaviate
@@ -220,6 +221,7 @@ services:
       AZURE_BLOB_ACCOUNT_URL: 'https://<your_account_name>.blob.core.windows.net'
       # The Google storage configurations, only available when STORAGE_TYPE is `google-storage`.
       GOOGLE_STORAGE_BUCKET_NAME: 'yout-bucket-name'
+      # if you want to use Application Default Credentials, you can leave GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64 empty.
       GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64: 'your-google-service-account-json-base64-string'
       # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`, `relyt`, `pgvector`.
       VECTOR_STORE: weaviate


### PR DESCRIPTION
# Description

This PR addresses an issue where the `GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64` environment variable, which is expected to be in base64 format, was incorrectly processed. The `GoogleCloudStorage.Client().from_service_account_json(service_account_json)` method expects a JSON file path rather than the actual credentials. This change modifies the handling to correctly process the base64-encoded credentials.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Decoded the base64 string and passed it as `GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64` environment.
- [x] Verified that the service correctly authenticates using the decoded credentials.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes

---

Feel free to adjust any specifics or add any additional details as needed.