### PR TITLE
fix organize agent's history messages without recalculating tokens

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -42,7 +42,6 @@ from core.tools.tool_manager import ToolManager
 from extensions.ext_database import db
 from models.model import Conversation, Message, MessageAgentThought
 from models.tools import ToolConversationVariables
-from core.prompt.agent_history_prompt_transform import AgentHistoryPromptTransform
 
 logger = logging.getLogger(__name__)
 
@@ -85,14 +84,9 @@ class BaseAgentRunner(AppRunner):
         self.message = message
         self.user_id = user_id
         self.memory = memory
-        self.history_prompt_messages = AgentHistoryPromptTransform(
-            tenant_id=tenant_id,
-            app_config=app_config,
-            model_config=model_config,
-            message=message,
-            prompt_messages=prompt_messages or [],
-            memory=memory
-        ).get_prompt()
+        self.history_prompt_messages = self.organize_agent_history(
+            prompt_messages=prompt_messages or []
+        )
         self.variables_pool = variables_pool
         self.db_variables_pool = db_variables
         self.model_instance = model_instance
@@ -451,4 +445,103 @@ class BaseAgentRunner(AppRunner):
         db_variables.variables_str = json.dumps(jsonable_encoder(tool_variables.pool))
         db.session.commit()
         db.session.close()
-        
+
+    def organize_agent_history(self, prompt_messages: list[PromptMessage]) -> list[PromptMessage]:
+        """
+        Organize agent history
+        """
+        result = []
+        # check if there is a system message in the beginning of the conversation
+        for prompt_message in prompt_messages:
+            if isinstance(prompt_message, SystemPromptMessage):
+                result.append(prompt_message)
+
+        messages: list[Message] = db.session.query(Message).filter(
+            Message.conversation_id == self.message.conversation_id,
+        ).order_by(Message.created_at.asc()).all()
+
+        for message in messages:
+            if message.id == self.message.id:
+                continue
+
+            result.append(self.organize_agent_user_prompt(message))
+            agent_thoughts: list[MessageAgentThought] = message.agent_thoughts
+            if agent_thoughts:
+                for agent_thought in agent_thoughts:
+                    tools = agent_thought.tool
+                    if tools:
+                        tools = tools.split(';')
+                        tool_calls: list[AssistantPromptMessage.ToolCall] = []
+                        tool_call_response: list[ToolPromptMessage] = []
+                        try:
+                            tool_inputs = json.loads(agent_thought.tool_input)
+                        except Exception as e:
+                            tool_inputs = { tool: {} for tool in tools }
+                        try:
+                            tool_responses = json.loads(agent_thought.observation)
+                        except Exception as e:
+                            tool_responses = { tool: agent_thought.observation for tool in tools }
+
+                        for tool in tools:
+                            # generate a uuid for tool call
+                            tool_call_id = str(uuid.uuid4())
+                            tool_calls.append(AssistantPromptMessage.ToolCall(
+                                id=tool_call_id,
+                                type='function',
+                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                    name=tool,
+                                    arguments=json.dumps(tool_inputs.get(tool, {})),
+                                )
+                            ))
+                            tool_call_response.append(ToolPromptMessage(
+                                content=tool_responses.get(tool, agent_thought.observation),
+                                name=tool,
+                                tool_call_id=tool_call_id,
+                            ))
+
+                        result.extend([
+                            AssistantPromptMessage(
+                                content=agent_thought.thought,
+                                tool_calls=tool_calls,
+                            ),
+                            *tool_call_response
+                        ])
+                    if not tools:
+                        result.append(AssistantPromptMessage(content=agent_thought.thought))
+            else:
+                if message.answer:
+                    result.append(AssistantPromptMessage(content=message.answer))
+
+        db.session.close()
+
+        return result
+
+    def organize_agent_user_prompt(self, message: Message) -> UserPromptMessage:
+        message_file_parser = MessageFileParser(
+            tenant_id=self.tenant_id,
+            app_id=self.app_config.app_id,
+        )
+
+        files = message.message_files
+        if files:
+            file_extra_config = FileUploadConfigManager.convert(message.app_model_config.to_dict())
+
+            if file_extra_config:
+                file_objs = message_file_parser.transform_message_files(
+                    files,
+                    file_extra_config
+                )
+            else:
+                file_objs = []
+
+            if not file_objs:
+                return UserPromptMessage(content=message.query)
+            else:
+                prompt_message_contents = [TextPromptMessageContent(data=message.query)]
+                for file_obj in file_objs:
+                    prompt_message_contents.append(file_obj.prompt_message_content)
+
+                return UserPromptMessage(content=prompt_message_contents)
+        else:
+            return UserPromptMessage(content=message.query)
+         

--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -128,6 +128,8 @@ class BaseAgentRunner(AppRunner):
             self.files = application_generate_entity.files
         else:
             self.files = []
+        self.query = None
+        self._current_thoughts: list[PromptMessage] = []
 
     def _repack_app_generate_entity(self, app_generate_entity: AgentChatAppGenerateEntity) \
             -> AgentChatAppGenerateEntity:

--- a/api/core/agent/cot_agent_runner.py
+++ b/api/core/agent/cot_agent_runner.py
@@ -374,7 +374,7 @@ class CotAgentRunner(BaseAgentRunner, ABC):
 
         return message
 
-    def _organize_historic_prompt_messages(self, prompt_messages: list[PromptMessage] = []) -> list[PromptMessage]:
+    def _organize_historic_prompt_messages(self, current_session_messages: list[PromptMessage] = None) -> list[PromptMessage]:
         """
             organize historic prompt messages
         """
@@ -384,7 +384,7 @@ class CotAgentRunner(BaseAgentRunner, ABC):
 
         self.history_prompt_messages = AgentHistoryPromptTransform(
             model_config=self.model_config,
-            prompt_messages=prompt_messages,
+            prompt_messages=current_session_messages or [],
             history_messages=self.history_prompt_messages,
             memory=self.memory
         ).get_prompt()

--- a/api/core/agent/cot_agent_runner.py
+++ b/api/core/agent/cot_agent_runner.py
@@ -15,6 +15,7 @@ from core.model_runtime.entities.message_entities import (
     ToolPromptMessage,
     UserPromptMessage,
 )
+from core.prompt.agent_history_prompt_transform import AgentHistoryPromptTransform
 from core.tools.entities.tool_entities import ToolInvokeMeta
 from core.tools.tool.tool import Tool
 from core.tools.tool_engine import ToolEngine
@@ -373,13 +374,20 @@ class CotAgentRunner(BaseAgentRunner, ABC):
 
         return message
 
-    def _organize_historic_prompt_messages(self) -> list[PromptMessage]:
+    def _organize_historic_prompt_messages(self, prompt_messages: list[PromptMessage] = []) -> list[PromptMessage]:
         """
             organize historic prompt messages
         """
         result: list[PromptMessage] = []
         scratchpad: list[AgentScratchpadUnit] = []
         current_scratchpad: AgentScratchpadUnit = None
+
+        self.history_prompt_messages = AgentHistoryPromptTransform(
+            model_config=self.model_config,
+            prompt_messages=prompt_messages,
+            history_messages=self.history_prompt_messages,
+            memory=self.memory
+        ).get_prompt()
 
         for message in self.history_prompt_messages:
             if isinstance(message, AssistantPromptMessage):

--- a/api/core/agent/cot_chat_agent_runner.py
+++ b/api/core/agent/cot_chat_agent_runner.py
@@ -32,9 +32,6 @@ class CotChatAgentRunner(CotAgentRunner):
         # organize system prompt
         system_message = self._organize_system_prompt()
 
-        # organize historic prompt messages
-        historic_messages = self._historic_prompt_messages
-
         # organize current assistant messages
         agent_scratchpad = self._agent_scratchpad
         if not agent_scratchpad:
@@ -57,6 +54,13 @@ class CotChatAgentRunner(CotAgentRunner):
         query_messages = UserPromptMessage(content=self._query)
 
         if assistant_messages:
+            # organize historic prompt messages
+            historic_messages = self._organize_historic_prompt_messages([
+                system_message,
+                query_messages,
+                *assistant_messages,
+                UserPromptMessage(content='continue')
+            ])            
             messages = [
                 system_message,
                 *historic_messages,
@@ -65,6 +69,8 @@ class CotChatAgentRunner(CotAgentRunner):
                 UserPromptMessage(content='continue')
             ]
         else:
+            # organize historic prompt messages
+            historic_messages = self._organize_historic_prompt_messages([system_message, query_messages])
             messages = [system_message, *historic_messages, query_messages]
 
         # join all messages

--- a/api/core/agent/cot_completion_agent_runner.py
+++ b/api/core/agent/cot_completion_agent_runner.py
@@ -19,11 +19,11 @@ class CotCompletionAgentRunner(CotAgentRunner):
         
         return system_prompt
 
-    def _organize_historic_prompt(self) -> str:
+    def _organize_historic_prompt(self, prompt_message: list[PromptMessage] = []) -> str:
         """
         Organize historic prompt
         """
-        historic_prompt_messages = self._historic_prompt_messages
+        historic_prompt_messages = self._organize_historic_prompt_messages(prompt_message)
         historic_prompt = ""
 
         for message in historic_prompt_messages:

--- a/api/core/agent/cot_completion_agent_runner.py
+++ b/api/core/agent/cot_completion_agent_runner.py
@@ -19,11 +19,11 @@ class CotCompletionAgentRunner(CotAgentRunner):
         
         return system_prompt
 
-    def _organize_historic_prompt(self, prompt_message: list[PromptMessage] = []) -> str:
+    def _organize_historic_prompt(self, current_session_messages: list[PromptMessage] = None) -> str:
         """
         Organize historic prompt
         """
-        historic_prompt_messages = self._organize_historic_prompt_messages(prompt_message)
+        historic_prompt_messages = self._organize_historic_prompt_messages(current_session_messages)
         historic_prompt = ""
 
         for message in historic_prompt_messages:

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -25,9 +25,6 @@ from models.model import Message
 logger = logging.getLogger(__name__)
 
 class FunctionCallAgentRunner(BaseAgentRunner):
-    _query: str = None
-    _current_thoughts: list[PromptMessage] = []
-
 
     def run(self, 
             message: Message, query: str, **kwargs: Any
@@ -35,7 +32,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
         """
         Run FunctionCall agent application
         """
-        self._query = query
+        self.query = query
         app_generate_entity = self.application_generate_entity
 
         app_config = self.app_config
@@ -417,7 +414,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
     def _organize_prompt_messages(self):
         prompt_template = self.app_config.prompt_template.simple_prompt_template or ''
         self.history_prompt_messages = self._init_system_message(prompt_template, self.history_prompt_messages)
-        query_prompt_messages = self._organize_user_query(self._query, [])
+        query_prompt_messages = self._organize_user_query(self.query, [])
 
         self.history_prompt_messages = AgentHistoryPromptTransform(
             model_config=self.model_config,

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -17,6 +17,7 @@ from core.model_runtime.entities.message_entities import (
     ToolPromptMessage,
     UserPromptMessage,
 )
+from core.prompt.agent_history_prompt_transform import AgentHistoryPromptTransform
 from core.tools.entities.tool_entities import ToolInvokeMeta
 from core.tools.tool_engine import ToolEngine
 from models.model import Message
@@ -24,20 +25,20 @@ from models.model import Message
 logger = logging.getLogger(__name__)
 
 class FunctionCallAgentRunner(BaseAgentRunner):
+    _query: str = None
+    _current_thoughts: list[PromptMessage] = []
+
+
     def run(self, 
             message: Message, query: str, **kwargs: Any
     ) -> Generator[LLMResultChunk, None, None]:
         """
         Run FunctionCall agent application
         """
+        self._query = query
         app_generate_entity = self.application_generate_entity
 
         app_config = self.app_config
-
-        prompt_template = app_config.prompt_template.simple_prompt_template or ''
-        prompt_messages = self.history_prompt_messages
-        prompt_messages = self._init_system_message(prompt_template, prompt_messages)
-        prompt_messages = self._organize_user_query(query, prompt_messages)
 
         # convert tools into ModelRuntime Tool format
         tool_instances, prompt_messages_tools = self._init_prompt_tools()
@@ -81,6 +82,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
             )
 
             # recalc llm max tokens
+            prompt_messages = self._organize_prompt_messages()
             self.recalc_llm_max_tokens(self.model_config, prompt_messages)
             # invoke model
             chunks: Union[Generator[LLMResultChunk, None, None], LLMResult] = model_instance.invoke_llm(
@@ -203,7 +205,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
             else:
                 assistant_message.content = response
             
-            prompt_messages.append(assistant_message)
+            self._current_thoughts.append(assistant_message)
 
             # save thought
             self.save_agent_thought(
@@ -265,12 +267,14 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                     }
                 
                 tool_responses.append(tool_response)
-                prompt_messages = self._organize_assistant_message(
-                    tool_call_id=tool_call_id,
-                    tool_call_name=tool_call_name,
-                    tool_response=tool_response['tool_response'],
-                    prompt_messages=prompt_messages,
-                )
+                if tool_response['tool_response'] is not None:
+                    self._current_thoughts.append(
+                        ToolPromptMessage(
+                            content=tool_response['tool_response'],
+                            tool_call_id=tool_call_id,
+                            name=tool_call_name,
+                        )
+                    ) 
 
             if len(tool_responses) > 0:
                 # save agent thought
@@ -299,8 +303,6 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                 self.update_prompt_message_tool(tool_instances[prompt_tool.name], prompt_tool)
 
             iteration_step += 1
-
-            prompt_messages = self._clear_user_prompt_image_messages(prompt_messages)
 
         self.update_db_variables(self.variables_pool, self.db_variables_pool)
         # publish end event
@@ -393,24 +395,6 @@ class FunctionCallAgentRunner(BaseAgentRunner):
 
         return prompt_messages
     
-    def _organize_assistant_message(self, tool_call_id: str = None, tool_call_name: str = None, tool_response: str = None, 
-                                    prompt_messages: list[PromptMessage] = None) -> list[PromptMessage]:
-        """
-        Organize assistant message
-        """
-        prompt_messages = deepcopy(prompt_messages)
-
-        if tool_response is not None:
-            prompt_messages.append(
-                ToolPromptMessage(
-                    content=tool_response,
-                    tool_call_id=tool_call_id,
-                    name=tool_call_name,
-                )
-            )
-
-        return prompt_messages
-    
     def _clear_user_prompt_image_messages(self, prompt_messages: list[PromptMessage]) -> list[PromptMessage]:
         """
         As for now, gpt supports both fc and vision at the first iteration.
@@ -428,4 +412,26 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                         for content in prompt_message.content 
                     ])
 
+        return prompt_messages
+
+    def _organize_prompt_messages(self):
+        prompt_template = self.app_config.prompt_template.simple_prompt_template or ''
+        self.history_prompt_messages = self._init_system_message(prompt_template, self.history_prompt_messages)
+        query_prompt_messages = self._organize_user_query(self._query, [])
+
+        self.history_prompt_messages = AgentHistoryPromptTransform(
+            model_config=self.model_config,
+            prompt_messages=[*query_prompt_messages, *self._current_thoughts],
+            history_messages=self.history_prompt_messages,
+            memory=self.memory
+        ).get_prompt()
+
+        prompt_messages = [
+            *self.history_prompt_messages,
+            *query_prompt_messages,
+            *self._current_thoughts
+        ]
+        if len(self._current_thoughts) != 0:
+            # clear messages after the first iteration
+            prompt_messages = self._clear_user_prompt_image_messages(prompt_messages)
         return prompt_messages

--- a/api/core/prompt/agent_history_prompt_transform.py
+++ b/api/core/prompt/agent_history_prompt_transform.py
@@ -1,0 +1,165 @@
+import json
+import uuid
+from typing import Optional
+
+from core.app.entities.app_invoke_entities import (
+    AgentChatAppGenerateEntity,
+    ModelConfigWithCredentialsEntity,
+)
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from extensions.ext_database import db
+from core.model_runtime.model_providers import model_provider_factory
+from core.model_runtime.entities.model_entities import ModelType
+from core.prompt.prompt_transform import PromptTransform
+from core.file.message_file_parser import MessageFileParser
+from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
+from core.app.apps.agent_chat.app_config_manager import AgentChatAppConfig
+from core.memory.token_buffer_memory import TokenBufferMemory
+from models.model import Conversation, Message, MessageAgentThought
+
+
+class AgentHistoryPromptTransform(PromptTransform):
+    """
+    History Prompt Transform for Agent App
+    """
+    def __init__(self,
+                 tenant_id: str,
+                 app_config: AgentChatAppConfig,
+                 model_config: ModelConfigWithCredentialsEntity,
+                 message: Message,
+                 prompt_messages: Optional[list[PromptMessage]] = None,
+                 memory: Optional[TokenBufferMemory] = None,
+                 ):
+        self.tenant_id = tenant_id
+        self.app_config = app_config
+        self.model_config = model_config
+        self.message = message
+        self.prompt_messages = prompt_messages or []
+        self.memory = memory
+
+    def get_prompt(self) -> list[PromptMessage]:
+        prompt_messages = []
+        # check if there is a system message in the beginning of the conversation
+        for prompt_message in self.prompt_messages:
+            if isinstance(prompt_message, SystemPromptMessage):
+                prompt_messages.append(prompt_message)
+
+        if not self.memory:
+            return prompt_messages
+
+        max_token_limit = self._calculate_rest_token(self.prompt_messages, self.model_config)
+
+        provider_instance = model_provider_factory.get_provider_instance(self.memory.model_instance.provider)
+        model_type_instance = provider_instance.get_model_instance(ModelType.LLM)
+
+        messages: list[Message] = db.session.query(Message).filter(
+            Message.conversation_id == self.memory.conversation.id,
+        ).order_by(Message.created_at.desc()).all()
+
+        for message in messages:
+            if message.id == self.message.id:
+                continue
+
+            prompt_messages.append(self._organize_agent_user_prompt(message))
+            # number of appended prompts
+            num_prompt = 1
+            agent_thoughts: list[MessageAgentThought] = message.agent_thoughts
+            if agent_thoughts:
+                for agent_thought in agent_thoughts:
+                    tools = agent_thought.tool
+                    if tools:
+                        tools = tools.split(';')
+                        tool_calls: list[AssistantPromptMessage.ToolCall] = []
+                        tool_call_response: list[ToolPromptMessage] = []
+                        try:
+                            tool_inputs = json.loads(agent_thought.tool_input)
+                        except Exception as e:
+                            tool_inputs = {tool: {} for tool in tools}
+                        try:
+                            tool_responses = json.loads(agent_thought.observation)
+                        except Exception as e:
+                            tool_responses = {tool: agent_thought.observation for tool in tools}
+
+                        for tool in tools:
+                            # generate a uuid for tool call
+                            tool_call_id = str(uuid.uuid4())
+                            tool_calls.append(AssistantPromptMessage.ToolCall(
+                                id=tool_call_id,
+                                type='function',
+                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                    name=tool,
+                                    arguments=json.dumps(tool_inputs.get(tool, {})),
+                                )
+                            ))
+                            tool_call_response.append(ToolPromptMessage(
+                                content=tool_responses.get(tool, agent_thought.observation),
+                                name=tool,
+                                tool_call_id=tool_call_id,
+                            ))
+
+                        prompt_messages.extend([
+                            AssistantPromptMessage(
+                                content=agent_thought.thought,
+                                tool_calls=tool_calls,
+                            ),
+                            *tool_call_response
+                        ])
+                        num_prompt += 1 + len(tool_call_response)
+                    if not tools:
+                        prompt_messages.append(AssistantPromptMessage(content=agent_thought.thought))
+                        num_prompt += 1
+            else:
+                if message.answer:
+                    prompt_messages.append(AssistantPromptMessage(content=message.answer))
+                    num_prompt += 1
+
+            curr_message_tokens = model_type_instance.get_num_tokens(
+                self.memory.model_instance.model,
+                self.memory.model_instance.credentials,
+                prompt_messages
+            )
+            # If tokens is overflow, drop all appended prompts in current message and break
+            if curr_message_tokens > max_token_limit:
+                prompt_messages = prompt_messages[:-num_prompt]
+                break
+
+        db.session.close()
+
+        return prompt_messages
+
+    def _organize_agent_user_prompt(self, message: Message) -> UserPromptMessage:
+        message_file_parser = MessageFileParser(
+            tenant_id=self.tenant_id,
+            app_id=self.app_config.app_id,
+        )
+
+        files = message.message_files
+        if files:
+            file_extra_config = FileUploadConfigManager.convert(message.app_model_config.to_dict())
+
+            if file_extra_config:
+                file_objs = message_file_parser.transform_message_files(
+                    files,
+                    file_extra_config
+                )
+            else:
+                file_objs = []
+
+            if not file_objs:
+                return UserPromptMessage(content=message.query)
+            else:
+                prompt_message_contents = [TextPromptMessageContent(data=message.query)]
+                for file_obj in file_objs:
+                    prompt_message_contents.append(file_obj.prompt_message_content)
+
+                return UserPromptMessage(content=prompt_message_contents)
+        else:
+            return UserPromptMessage(content=message.query)

--- a/api/core/prompt/agent_history_prompt_transform.py
+++ b/api/core/prompt/agent_history_prompt_transform.py
@@ -1,29 +1,16 @@
-import json
-import uuid
-from typing import Optional
+from typing import Optional, cast
 
 from core.app.entities.app_invoke_entities import (
-    AgentChatAppGenerateEntity,
     ModelConfigWithCredentialsEntity,
 )
+from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_runtime.entities.message_entities import (
-    AssistantPromptMessage,
     PromptMessage,
-    PromptMessageTool,
     SystemPromptMessage,
-    TextPromptMessageContent,
-    ToolPromptMessage,
     UserPromptMessage,
 )
-from extensions.ext_database import db
-from core.model_runtime.model_providers import model_provider_factory
-from core.model_runtime.entities.model_entities import ModelType
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.prompt.prompt_transform import PromptTransform
-from core.file.message_file_parser import MessageFileParser
-from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
-from core.app.apps.agent_chat.app_config_manager import AgentChatAppConfig
-from core.memory.token_buffer_memory import TokenBufferMemory
-from models.model import Conversation, Message, MessageAgentThought
 
 
 class AgentHistoryPromptTransform(PromptTransform):
@@ -31,135 +18,65 @@ class AgentHistoryPromptTransform(PromptTransform):
     History Prompt Transform for Agent App
     """
     def __init__(self,
-                 tenant_id: str,
-                 app_config: AgentChatAppConfig,
                  model_config: ModelConfigWithCredentialsEntity,
-                 message: Message,
-                 prompt_messages: Optional[list[PromptMessage]] = None,
+                 prompt_messages: list[PromptMessage],
+                 history_messages: list[PromptMessage],
                  memory: Optional[TokenBufferMemory] = None,
                  ):
-        self.tenant_id = tenant_id
-        self.app_config = app_config
         self.model_config = model_config
-        self.message = message
-        self.prompt_messages = prompt_messages or []
+        self.prompt_messages = prompt_messages
+        self.history_messages = history_messages
         self.memory = memory
 
     def get_prompt(self) -> list[PromptMessage]:
         prompt_messages = []
-        # check if there is a system message in the beginning of the conversation
-        for prompt_message in self.prompt_messages:
+        num_system = 0
+        for prompt_message in self.history_messages:
             if isinstance(prompt_message, SystemPromptMessage):
                 prompt_messages.append(prompt_message)
+                num_system += 1
 
         if not self.memory:
             return prompt_messages
 
         max_token_limit = self._calculate_rest_token(self.prompt_messages, self.model_config)
 
-        provider_instance = model_provider_factory.get_provider_instance(self.memory.model_instance.provider)
-        model_type_instance = provider_instance.get_model_instance(ModelType.LLM)
+        model_type_instance = self.model_config.provider_model_bundle.model_type_instance
+        model_type_instance = cast(LargeLanguageModel, model_type_instance)
 
-        messages: list[Message] = db.session.query(Message).filter(
-            Message.conversation_id == self.memory.conversation.id,
-        ).order_by(Message.created_at.desc()).all()
-
-        for message in messages:
-            if message.id == self.message.id:
-                continue
-
-            prompt_messages.append(self._organize_agent_user_prompt(message))
-            # number of appended prompts
-            num_prompt = 1
-            agent_thoughts: list[MessageAgentThought] = message.agent_thoughts
-            if agent_thoughts:
-                for agent_thought in agent_thoughts:
-                    tools = agent_thought.tool
-                    if tools:
-                        tools = tools.split(';')
-                        tool_calls: list[AssistantPromptMessage.ToolCall] = []
-                        tool_call_response: list[ToolPromptMessage] = []
-                        try:
-                            tool_inputs = json.loads(agent_thought.tool_input)
-                        except Exception as e:
-                            tool_inputs = {tool: {} for tool in tools}
-                        try:
-                            tool_responses = json.loads(agent_thought.observation)
-                        except Exception as e:
-                            tool_responses = {tool: agent_thought.observation for tool in tools}
-
-                        for tool in tools:
-                            # generate a uuid for tool call
-                            tool_call_id = str(uuid.uuid4())
-                            tool_calls.append(AssistantPromptMessage.ToolCall(
-                                id=tool_call_id,
-                                type='function',
-                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                                    name=tool,
-                                    arguments=json.dumps(tool_inputs.get(tool, {})),
-                                )
-                            ))
-                            tool_call_response.append(ToolPromptMessage(
-                                content=tool_responses.get(tool, agent_thought.observation),
-                                name=tool,
-                                tool_call_id=tool_call_id,
-                            ))
-
-                        prompt_messages.extend([
-                            AssistantPromptMessage(
-                                content=agent_thought.thought,
-                                tool_calls=tool_calls,
-                            ),
-                            *tool_call_response
-                        ])
-                        num_prompt += 1 + len(tool_call_response)
-                    if not tools:
-                        prompt_messages.append(AssistantPromptMessage(content=agent_thought.thought))
-                        num_prompt += 1
-            else:
-                if message.answer:
-                    prompt_messages.append(AssistantPromptMessage(content=message.answer))
-                    num_prompt += 1
-
-            curr_message_tokens = model_type_instance.get_num_tokens(
-                self.memory.model_instance.model,
-                self.memory.model_instance.credentials,
-                prompt_messages
-            )
-            # If tokens is overflow, drop all appended prompts in current message and break
-            if curr_message_tokens > max_token_limit:
-                prompt_messages = prompt_messages[:-num_prompt]
-                break
-
-        db.session.close()
-
-        return prompt_messages
-
-    def _organize_agent_user_prompt(self, message: Message) -> UserPromptMessage:
-        message_file_parser = MessageFileParser(
-            tenant_id=self.tenant_id,
-            app_id=self.app_config.app_id,
+        curr_message_tokens = model_type_instance.get_num_tokens(
+            self.memory.model_instance.model,
+            self.memory.model_instance.credentials,
+            self.history_messages
         )
+        if curr_message_tokens <= max_token_limit:
+            return self.history_messages
 
-        files = message.message_files
-        if files:
-            file_extra_config = FileUploadConfigManager.convert(message.app_model_config.to_dict())
-
-            if file_extra_config:
-                file_objs = message_file_parser.transform_message_files(
-                    files,
-                    file_extra_config
+        # number of prompt has been appended in current message
+        num_prompt = 0
+        # append prompt messages in desc order
+        for prompt_message in self.history_messages[::-1]:
+            if isinstance(prompt_message, SystemPromptMessage):
+                continue
+            prompt_messages.append(prompt_message)
+            num_prompt += 1
+            # a message is start with UserPromptMessage
+            if isinstance(prompt_message, UserPromptMessage):
+                curr_message_tokens = model_type_instance.get_num_tokens(
+                    self.memory.model_instance.model,
+                    self.memory.model_instance.credentials,
+                    prompt_messages
                 )
-            else:
-                file_objs = []
+                # if current message token is overflow, drop all the prompts in current message and break
+                if curr_message_tokens > max_token_limit:
+                    prompt_messages = prompt_messages[:-num_prompt]
+                    break
+                num_prompt = 0
+        # return prompt messages in asc order
+        message_prompts = prompt_messages[num_system:]
+        message_prompts.reverse()
 
-            if not file_objs:
-                return UserPromptMessage(content=message.query)
-            else:
-                prompt_message_contents = [TextPromptMessageContent(data=message.query)]
-                for file_obj in file_objs:
-                    prompt_message_contents.append(file_obj.prompt_message_content)
-
-                return UserPromptMessage(content=prompt_message_contents)
-        else:
-            return UserPromptMessage(content=message.query)
+        # merge system and message prompt
+        prompt_messages = prompt_messages[:num_system]
+        prompt_messages.extend(message_prompts)
+        return prompt_messages

--- a/api/tests/unit_tests/core/prompt/test_agent_history_prompt_transform.py
+++ b/api/tests/unit_tests/core/prompt/test_agent_history_prompt_transform.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+
+from core.app.entities.app_invoke_entities import (
+    ModelConfigWithCredentialsEntity,
+)
+from core.entities.provider_configuration import ProviderModelBundle
+from core.memory.token_buffer_memory import TokenBufferMemory
+from core.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.prompt.agent_history_prompt_transform import AgentHistoryPromptTransform
+from models.model import Conversation
+
+
+def test_get_prompt():
+    prompt_messages = [
+        SystemPromptMessage(content='System Template'),
+        UserPromptMessage(content='User Query'),
+    ]
+    history_messages = [
+        SystemPromptMessage(content='System Prompt 1'),
+        UserPromptMessage(content='User Prompt 1'),
+        AssistantPromptMessage(content='Assistant Thought 1'),
+        ToolPromptMessage(content='Tool 1-1', name='Tool 1-1', tool_call_id='1'),
+        ToolPromptMessage(content='Tool 1-2', name='Tool 1-2', tool_call_id='2'),
+        SystemPromptMessage(content='System Prompt 2'),
+        UserPromptMessage(content='User Prompt 2'),
+        AssistantPromptMessage(content='Assistant Thought 2'),
+        ToolPromptMessage(content='Tool 2-1', name='Tool 2-1', tool_call_id='3'),
+        ToolPromptMessage(content='Tool 2-2', name='Tool 2-2', tool_call_id='4'),
+        UserPromptMessage(content='User Prompt 3'),
+        AssistantPromptMessage(content='Assistant Thought 3'),
+    ]
+
+    # use message number instead of token for testing
+    def side_effect_get_num_tokens(*args):
+        return len(args[2])
+    large_language_model_mock = MagicMock(spec=LargeLanguageModel)
+    large_language_model_mock.get_num_tokens = MagicMock(side_effect=side_effect_get_num_tokens)
+
+    provider_model_bundle_mock = MagicMock(spec=ProviderModelBundle)
+    provider_model_bundle_mock.model_type_instance = large_language_model_mock
+
+    model_config_mock = MagicMock(spec=ModelConfigWithCredentialsEntity)
+    model_config_mock.model = 'openai'
+    model_config_mock.credentials = {}
+    model_config_mock.provider_model_bundle = provider_model_bundle_mock
+
+    memory = TokenBufferMemory(
+        conversation=Conversation(),
+        model_instance=model_config_mock
+    )
+
+    transform = AgentHistoryPromptTransform(
+        model_config=model_config_mock,
+        prompt_messages=prompt_messages,
+        history_messages=history_messages,
+        memory=memory
+    )
+
+    max_token_limit = 5
+    transform._calculate_rest_token = MagicMock(return_value=max_token_limit)
+    result = transform.get_prompt()
+
+    assert len(result) <= max_token_limit
+    assert len(result) == 4
+
+    max_token_limit = 20
+    transform._calculate_rest_token = MagicMock(return_value=max_token_limit)
+    result = transform.get_prompt()
+
+    assert len(result) <= max_token_limit
+    assert len(result) == 12


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2932

Add token recalculation when organize agent's history messages.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested locally

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
