### PR TITLE
fix: add timeout to SMTPClient to prevent worker blocking

### DIFF
--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -1,7 +1,7 @@
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-
+import logging
 
 class SMTPClient:
     def __init__(self, server: str, port: int, username: str, password: str, _from: str, use_tls=False):
@@ -13,15 +13,30 @@ class SMTPClient:
         self._use_tls = use_tls
 
     def send(self, mail: dict):
-        smtp = smtplib.SMTP(self.server, self.port)
-        if self._use_tls:
-            smtp.starttls()
-        if self.username and self.password:
-            smtp.login(self.username, self.password)
-        msg = MIMEMultipart()
-        msg['Subject'] = mail['subject']
-        msg['From'] = self._from
-        msg['To'] = mail['to']
-        msg.attach(MIMEText(mail['html'], 'html'))
-        smtp.sendmail(self.username, mail['to'], msg.as_string())
-        smtp.quit()
+        smtp = None
+        try:
+            smtp = smtplib.SMTP(self.server, self.port, timeout=10)
+            if self._use_tls:
+                smtp.starttls()
+            if self.username and self.password:
+                smtp.login(self.username, self.password)
+
+            msg = MIMEMultipart()
+            msg['Subject'] = mail['subject']
+            msg['From'] = self._from
+            msg['To'] = mail['to']
+            msg.attach(MIMEText(mail['html'], 'html'))
+
+            smtp.sendmail(self._from, mail['to'], msg.as_string())
+        except smtplib.SMTPException as e:
+            logging.error(f"SMTP error occurred: {str(e)}")
+            raise
+        except TimeoutError as e:
+            logging.error(f"Timeout occurred while sending email: {str(e)}")
+            raise
+        except Exception as e:
+            logging.error(f"Unexpected error occurred while sending email: {str(e)}")
+            raise
+        finally:
+            if smtp:
+                smtp.quit()

--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -1,7 +1,8 @@
+import logging
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import logging
+
 
 class SMTPClient:
     def __init__(self, server: str, port: int, username: str, password: str, _from: str, use_tls=False):


### PR DESCRIPTION
# Description

This PR adds a timeout parameter to the `SMTP` constructor in the `SMTPClient` class to prevent the worker from blocking indefinitely when the SMTP server becomes unresponsive. Currently, if the server hangs, the worker blocks permanently, causing reduced system responsiveness and potential disruptions.

The `SMTPClient` will wait for a maximum of 10 seconds for the server to respond. If no response is received within that time, a `TimeoutError` exception is raised, allowing the worker to gracefully handle the situation and proceed with other tasks.

The PR also includes improved error handling by catching specific exceptions (`SMTPException`, `TimeoutError`, and unexpected exceptions) and logging error messages for better visibility and debugging.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested SMTPClient with a valid SMTP server, verifying emails are sent within the specified timeout.
- [x] Simulated an unresponsive SMTP server scenario, confirming TimeoutError is raised and worker doesn't block indefinitely.
- [x] Verified caught exceptions are properly logged using the logging module.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
