### PR TITLE
Fix: HTTP request node PARAMS parameters, if ':' appears in the value…

### DIFF
--- a/web/app/components/workflow/nodes/http/hooks/use-key-value-list.ts
+++ b/web/app/components/workflow/nodes/http/hooks/use-key-value-list.ts
@@ -6,11 +6,11 @@ import type { KeyValue } from '../types'
 const UNIQUE_ID_PREFIX = 'key-value-'
 const strToKeyValueList = (value: string) => {
   return value.split('\n').map((item) => {
-    const [key, value] = item.split(':')
+    const [key, ...others] = item.split(':')
     return {
       id: uniqueId(UNIQUE_ID_PREFIX),
       key: key.trim(),
-      value: value?.trim(),
+      value: others.join(':').trim(),
     }
   })
 }


### PR DESCRIPTION
# Description

When I expect to add a key-value value in the PARAMS on the HTTP Node, such as key: 'url' and value: 'http://xxxx.com', I find that when I close the edit box and reopen the edit box, the value becomes http, and the content after ':' will be lost.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Enter key: 'url' and value: 'http://xxxx.com' in the PARAMS of the http node. Close the edit drawer and reopen it. The content of the value will not change.

- [ ] TODO key has same issue

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
