### PR TITLE
chore: add default title prefix to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: "🕷️ Bug report"
 description: Report errors or unexpected behavior
+title: "🕷️ [Bug]: "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/document_issue.yml
+++ b/.github/ISSUE_TEMPLATE/document_issue.yml
@@ -1,6 +1,6 @@
 name: "📚 Documentation Issue"
 description: Report issues in our documentation
-title: "📚 [Documentation]: ""
+title: "📚 [Documentation]: "
 labels:
   - documentation
 body:

--- a/.github/ISSUE_TEMPLATE/document_issue.yml
+++ b/.github/ISSUE_TEMPLATE/document_issue.yml
@@ -1,5 +1,6 @@
 name: "📚 Documentation Issue"
 description: Report issues in our documentation
+title: "📚 [Documentation]: ""
 labels:
   - documentation
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: "⭐ Feature or enhancement request"
 description: Propose something new.
+title: "✨ [Feature]: "
 labels:
   - enhancement
 body:

--- a/.github/ISSUE_TEMPLATE/translation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/translation_issue.yml
@@ -1,5 +1,6 @@
 name: "🌐 Localization/Translation issue"
 description: Report incorrect translations. [please use English :）]
+title: '🌐 [Localization/Translation]'
 labels:
   - translation
 body:

--- a/.github/ISSUE_TEMPLATE/translation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/translation_issue.yml
@@ -1,6 +1,6 @@
 name: "🌐 Localization/Translation issue"
 description: Report incorrect translations. [please use English :）]
-title: '🌐 [Localization/Translation]'
+title: '🌐 [Localization/Translation] '
 labels:
   - translation
 body:


### PR DESCRIPTION
# Description

Add a default title prefix to the issue template so that you can quickly locate the issue type when browsing.

Newly opened issues will be filled in with the default category prefix like this 👇 (This is how it works in other projects)
<img width="814" alt="image" src="https://github.com/langgenius/dify/assets/33956589/6abc1851-9027-4e4c-bb39-e2aaee398614">


## Type of Change

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods