### PR TITLE
fix: copy button is always displayed on the chat logs page

### DIFF
--- a/web/app/components/app/chat/answer/index.tsx
+++ b/web/app/components/app/chat/answer/index.tsx
@@ -362,7 +362,7 @@ const Answer: FC<IAnswerProps> = ({
                 {!item.isOpeningStatement && (
                   <CopyBtn
                     value={content}
-                    className='mr-1'
+                    className={cn(s.copyBtn, 'mr-1')}
                   />
                 )}
                 {((isShowPromptLog && !isResponding) || (!item.isOpeningStatement && isShowTextToSpeech)) && (


### PR DESCRIPTION
# Description

![chrome_oTbnMRyCE7](https://github.com/langgenius/dify/assets/3364975/cda574c4-b725-4872-b359-e2396aae89d7)
.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
