### PR TITLE
chore: apply and fix flake8-bugbear lint rules

### DIFF
--- a/api/core/model_runtime/callbacks/base_callback.py
+++ b/api/core/model_runtime/callbacks/base_callback.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from typing import Optional
 
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
@@ -14,7 +13,7 @@ _TEXT_COLOR_MAPPING = {
 }
 
 
-class Callback(ABC):
+class Callback:
     """
     Base class for callbacks.
     Only for LLM.

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -361,7 +361,6 @@ class ToolManager:
 
             :return: the label of the tool
         """
-        cls._builtin_tools_labels
         if len(cls._builtin_tools_labels) == 0:
             # init the builtin providers
             cls.load_builtin_providers_cache()

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -39,7 +39,6 @@ class ToolNode(BaseNode):
         parameters = self._generate_parameters(variable_pool, node_data)
         # get tool runtime
         try:
-            self.app_id
             tool_runtime = ToolManager.get_workflow_tool_runtime(self.tenant_id, self.app_id, self.node_id, node_data)
         except Exception as e:
             return NodeRunResult(

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -9,9 +9,9 @@ line-length = 120
 [tool.ruff.lint]
 ignore-init-module-imports = true
 select = [
+    "B", # flake8-bugbear rules
     "F", # pyflakes rules
-    "I001", # unsorted-imports
-    "I002", # missing-required-import
+    "I", # isort rules
     "UP",   # pyupgrade rules
     "RUF019", # unnecessary-key-check
 ]
@@ -22,6 +22,12 @@ ignore = [
     "F841", # unused-variable
     "UP007", # non-pep604-annotation
     "UP032", # f-string
+    "B005", # strip-with-multi-characters
+    "B006", # mutable-argument-default
+    "B007", # unused-loop-control-variable
+    "B026", # star-arg-unpacking-after-keyword-arg
+    "B904", # raise-without-from-inside-except
+    "B905", # zip-without-explicit-strict
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
# Description

- apply `flake-bugbear` rules to prevent and reduce likely bugs and usages
  - ruff rules list: https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
  - PyCQA/flake8-bugbear: https://github.com/PyCQA/flake8-bugbear
- fixed the violations in the following list:
  - B033 duplicate value in set values in `Python3TemplateTransformer`
  - B024 marked abstract base class but no abstract methods in the class `Callback`
  - B018 touching the existed fields but never assigned or used in `ToolManager` and `ToolNode`

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
