### PR TITLE
fix: files data missed for message

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -797,7 +797,7 @@ class Message(db.Model):
                 if message_file.transfer_method == 'local_file':
                     upload_file = (db.session.query(UploadFile)
                                    .filter(
-                        UploadFile.id == message_file.related_id
+                        UploadFile.id == message_file.upload_file_id
                     ).first())
 
                     url = UploadFileParser.get_image_data(


### PR DESCRIPTION
# Description

`message_files` is missed since https://github.com/langgenius/dify/pull/3160. it's initroduced by retrieving `UploadFile` by incorrect attribute `related_id`.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Tested the related endpoint, it previously respond with:
![image](https://github.com/langgenius/dify/assets/1320925/1af595ff-0195-45b0-ad7d-f66c4d0cd65b)

and it respond correctly now: 
![image](https://github.com/langgenius/dify/assets/1320925/fba7ef9f-a261-4e9d-b05d-be350ef90a82)


- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
