### PR TITLE
chore: Hide the copy button when there is no content to copy

### DIFF
--- a/web/app/components/workflow/panel/workflow-preview.tsx
+++ b/web/app/components/workflow/panel/workflow-preview.tsx
@@ -119,20 +119,21 @@ const WorkflowPreview = () => {
                 error={workflowRunningData?.result?.error}
                 onClick={() => switchTab('DETAIL')}
               />
-              <SimpleBtn
-                isDisabled={workflowRunningData?.result.status !== WorkflowRunningStatus.Succeeded}
-                className={cn('ml-4 mb-4 inline-flex space-x-1')}
-                onClick={() => {
-                  const content = workflowRunningData?.resultText
-                  if (typeof content === 'string')
-                    copy(content)
-                  else
-                    copy(JSON.stringify(content))
-                  Toast.notify({ type: 'success', message: t('common.actionMsg.copySuccessfully') })
-                }}>
-                <Clipboard className='w-3.5 h-3.5' />
-                <div>{t('common.operation.copy')}</div>
-              </SimpleBtn>
+              {(workflowRunningData?.result.status !== WorkflowRunningStatus.Succeeded || !workflowRunningData?.resultText) && (
+                <SimpleBtn
+                  className={cn('ml-4 mb-4 inline-flex space-x-1')}
+                  onClick={() => {
+                    const content = workflowRunningData?.resultText
+                    if (typeof content === 'string')
+                      copy(content)
+                    else
+                      copy(JSON.stringify(content))
+                    Toast.notify({ type: 'success', message: t('common.actionMsg.copySuccessfully') })
+                  }}>
+                  <Clipboard className='w-3.5 h-3.5' />
+                  <div>{t('common.operation.copy')}</div>
+                </SimpleBtn>
+              )}
             </>
           )}
           {currentTab === 'DETAIL' && (


### PR DESCRIPTION
# Description
In the result panel of the workflow, the `copy` button is always avaliable. And when you click it, It always prompts "Copy Successful" but in reality, nothing has been copied.

I hide the button when there is no content to copy.

![20240521153935](https://github.com/langgenius/dify/assets/25834719/9b59e2e5-68e6-4852-9549-e2212815490f)



## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?
I test it locally

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
