### PR TITLE
chore(api): Use channel from UI as API query parameter

### DIFF
--- a/api/core/tools/provider/builtin/youtube/tools/videos.py
+++ b/api/core/tools/provider/builtin/youtube/tools/videos.py
@@ -36,7 +36,7 @@ class YoutubeVideosAnalyticsTool(BuiltinTool):
         youtube = build('youtube', 'v3', developerKey=self.runtime.credentials['google_api_key'])
 
         # try to get channel id
-        search_results = youtube.search().list(q='mrbeast', type='channel', order='relevance', part='id').execute()
+        search_results = youtube.search().list(q=channel, type='channel', order='relevance', part='id').execute()
         channel_id = search_results['items'][0]['id']['channelId']
 
         start_date, end_date = time_range


### PR DESCRIPTION
# Description

This PR addresses an issue where assigning a channel name to the Video statistics node in the YouTube section would incorrectly default to searching 'mrbeast' regardless of the input. The change ensures that the search is conducted based on the actual channel name assigned. This fix improves the accuracy and usability of the video statistics feature, aligning it with expected functionalities.

Fixes: #4561

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verified the functionality by inputting different channel names into the Video statistics node and confirming that the searches are correctly performed based on the provided names.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
