### PR TITLE
Add Azure OpenAI API version for GPT4o support

### DIFF
--- a/api/core/model_runtime/model_providers/azure_openai/azure_openai.yaml
+++ b/api/core/model_runtime/model_providers/azure_openai/azure_openai.yaml
@@ -59,6 +59,9 @@ model_credential_schema:
         - label:
             en_US: 2023-12-01-preview
           value: 2023-12-01-preview
+        - label:
+            en_US: '2024-02-01'
+          value: '2024-02-01'
       placeholder:
         zh_Hans: 在此选择您的 API 版本
         en_US: Select your API Version here


### PR DESCRIPTION
# Description

Azure OpenAI GPT4o only support 2024-02-01 but only 2024-02-15-preview and 2023-12-01-preview shown in Azure OpenAI Model Provider config. This change is to add API version 2024-02-01 as one of the option.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Just adding API Version into api/core/model_runtime/model_providers/azure_openai/azure_openai.yaml. Tested it locally and ran well

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
