### PR TITLE
fix: incorrect handling when http header value contain multiple colons.

### DIFF
--- a/api/core/workflow/nodes/http_request/http_executor.py
+++ b/api/core/workflow/nodes/http_request/http_executor.py
@@ -160,7 +160,9 @@ class HttpExecutor:
                 continue
 
             kv = kv.split(':', maxsplit=maxsplit)
-            if len(kv) == 2:
+            if len(kv) >= 3:
+                k, v = kv[0], ":".join(kv[1:])
+            elif len(kv) == 2:
                 k, v = kv
             elif len(kv) == 1:
                 k, v = kv[0], ''


### PR DESCRIPTION
… colons. #4573

Convert the string like `aa:bb:ee\n cc:dd` to dict `{aa:'bb:ee', cc:dd}`

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #4573 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After the issue has been fixed, I can now use the full URL in the Referer item in the Header, and it works properly. For example, I can set the Referer to http://google.com/.


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [x] `optional` I have made corresponding changes to the documentation 
- [x] `optional` I have added tests that prove my fix is effective or that my feature works
- [x] `optional` New and existing unit tests pass locally with my changes
