### PR TITLE
fix: node.js sdk if request is a get data must not exist

### DIFF
--- a/sdks/nodejs-client/index.js
+++ b/sdks/nodejs-client/index.js
@@ -85,7 +85,7 @@ export class DifyClient {
       response = await axios({
         method,
         url,
-        data,
+        ...(method !== "GET" && { data }),
         params,
         headers,
         responseType: "json",

--- a/sdks/nodejs-client/index.test.js
+++ b/sdks/nodejs-client/index.test.js
@@ -42,7 +42,6 @@ describe('Send Requests', () => {
     expect(axios).toHaveBeenCalledWith({
       method,
       url: `${BASE_URL}${endpoint}`,
-      data: null,
       params: null,
       headers: {
         Authorization: `Bearer ${difyClient.apiKey}`,


### PR DESCRIPTION
# Description
When making HTTP requests, the sendRequest method currently includes a body even for GET requests. According to HTTP standards, GET requests should not have a body. Including a body in GET requests can lead to unexpected behavior and compatibility issues with servers that strictly adhere to HTTP specifications.

I noticed this problem using gcloud as host of my platform.

Fixes # (issue)
https://github.com/langgenius/dify/issues/4617

## Type of Change
I added a conditional check inside the sendRequest method. If the request method is GET, the request body is removed to ensure compliance with HTTP standards.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

I updated the related test  Send Requests. 
There is a test that checked the content of a GET request. 
Should be without data not with data:null

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
