### PR TITLE
fix: the date is incorrect if the db field is timestamp and the TZ is not the UTC

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -177,7 +177,8 @@ class Config:
             'pool_size': int(get_env('SQLALCHEMY_POOL_SIZE')),
             'max_overflow': int(get_env('SQLALCHEMY_MAX_OVERFLOW')),
             'pool_recycle': int(get_env('SQLALCHEMY_POOL_RECYCLE')),
-            'pool_pre_ping': get_bool_env('SQLALCHEMY_POOL_PRE_PING')
+            'pool_pre_ping': get_bool_env('SQLALCHEMY_POOL_PRE_PING'),
+            'connect_args': {'options': '-c timezone=UTC'},
         }
 
         self.SQLALCHEMY_ECHO = get_bool_env('SQLALCHEMY_ECHO')


### PR DESCRIPTION
… not UTC

# Description

fix the date is incorrect if the db field is timestamp and the TZ is not the UT](fix: the date is incorrect if the db field is timestamp and the TZ is not the UTC)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

prepare a postgre instance with the TZ=Asia/Shanghai or you can execute the following sql to change the TZ for current session
```sql

show timezone;
SET TIME ZONE 'Asia/Shanghai'

# this two column should be equals
select EXTRACT(EPOCH from current_timestamp(0)), EXTRACT(EPOCH from current_timestamp(0)::timestamp);

# prepare the test data
INSERT INTO public.messages
(id, app_id, model_provider, model_id, override_model_configs, conversation_id, inputs, query, message, message_tokens, message_unit_price, answer, answer_tokens, answer_unit_price, provider_response_latency, total_price, currency, from_source, from_end_user_id, from_account_id, agent_based, message_price_unit, answer_price_unit, workflow_run_id, status, error, message_metadata, invoke_from)
VALUES('1d3554b9-3ee4-4426-9aa7-7194056b5811'::uuid, '4c665659-1115-4ed7-9cfb-0964d0a0a6ba'::uuid, 'xinference', 'qwen1.5-chat', '{"provider": "", "model_id": "", "configs": {}, "opening_statement": "", "suggested_questions": [], "suggested_questions_after_answer": {"enabled": false}, "speech_to_text": {"enabled": false}, "text_to_speech": {"enabled": false, "voice": "", "language": ""}, "retriever_resource": {"enabled": false}, "annotation_reply": {"id": "89b68b4f-afd9-40c4-87c7-8e80802274ce", "enabled": true, "score_threshold": 0.8, "embedding_model": {"embedding_provider_name": "xinference", "embedding_model_name": "bge-m3"}}, "more_like_this": {"enabled": false}, "sensitive_word_avoidance": {"enabled": false, "type": "", "configs": []}, "external_data_tools": [], "model": {"provider": "xinference", "name": "qwen1.5-chat", "mode": "chat", "completion_params": {"temperature": 0, "top_p": 1, "max_tokens": 512}}, "user_input_form": [{"paragraph": {"label": "prompt", "variable": "prompt", "required": false, "default": ""}}], "dataset_query_variable": "", "pre_prompt": "{{prompt}}", "agent_mode": {"enabled": false, "max_iteration": 5, "strategy": "function_call", "tools": []}, "prompt_type": "simple", "chat_prompt_config": {}, "completion_prompt_config": {}, "dataset_configs": {"retrieval_model": "single", "datasets": {"datasets": []}}, "file_upload": {"image": {"enabled": false, "number_limits": 3, "detail": "high", "transfer_methods": ["remote_url", "local_file"]}}}', 'b940f904-5343-4c92-98d5-3c91d51c3c68'::uuid, '{"prompt": ""}'::json, '你是谁？', '[{"role": "user", "text": "\u4f60\u662f\u8c01\uff1f", "files": []}]'::json, 16, 0.0000, '我是xxx', 125, 0.0000, 1.9694188218563795, 0.0000000, 'USD', 'console', NULL, '351604d8-9320-44b3-92ba-9d4ba1a1f2e7'::uuid, false, 0.0000000, 0.0000000, NULL, 'normal', NULL, NULL, NULL);
```

# check if the timestamp equals to current timestamp.
select EXTRACT(EPOCH FROM created_at) from public.messages where id = '1d3554b9-3ee4-4426-9aa7-7194056b5811';

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
