### PR TITLE
update lite8k/speed8k/128k max_token to newest

### DIFF
--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie-lite-8k-0308.yaml
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie-lite-8k-0308.yaml
@@ -22,7 +22,7 @@ parameter_rules:
     use_template: max_tokens
     default: 1024
     min: 2
-    max: 1024
+    max: 2048
   - name: presence_penalty
     use_template: presence_penalty
     default: 1.0

--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie-speed-128k.yaml
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie-speed-128k.yaml
@@ -20,9 +20,9 @@ parameter_rules:
     default: 0.7
   - name: max_tokens
     use_template: max_tokens
-    default: 1024
+    default: 4096
     min: 2
-    max: 1024
+    max: 4096
   - name: presence_penalty
     use_template: presence_penalty
     default: 1.0

--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie-speed-8k.yaml
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie-speed-8k.yaml
@@ -22,7 +22,7 @@ parameter_rules:
     use_template: max_tokens
     default: 1024
     min: 2
-    max: 1024
+    max: 2048
   - name: presence_penalty
     use_template: presence_penalty
     default: 1.0


### PR DESCRIPTION
# Description
Attempted to use Baidu's free model API, and casually confirmed the model's max output tokens.

Use baidu [doc](https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Alp0kdm0n)  update models max output token


