### PR TITLE
fix: show exception message when sandbox execution fails

### DIFF
--- a/api/core/helper/code_executor/code_executor.py
+++ b/api/core/helper/code_executor/code_executor.py
@@ -99,7 +99,9 @@ class CodeExecutor:
         except CodeExecutionException as e:
             raise e
         except Exception as e:
-            raise CodeExecutionException('Failed to execute code, this is likely a network issue, please check if the sandbox service is running')
+            raise CodeExecutionException('Failed to execute code, which is likely a network issue,'
+                                         ' please check if the sandbox service is running.'
+                                         f' Error: str{e}')
         
         try:
             response = response.json()

--- a/api/core/helper/code_executor/code_executor.py
+++ b/api/core/helper/code_executor/code_executor.py
@@ -101,7 +101,7 @@ class CodeExecutor:
         except Exception as e:
             raise CodeExecutionException('Failed to execute code, which is likely a network issue,'
                                          ' please check if the sandbox service is running.'
-                                         f' Error: {str(e)}')
+                                         f' ( Error: {str(e)} )')
         
         try:
             response = response.json()

--- a/api/core/helper/code_executor/code_executor.py
+++ b/api/core/helper/code_executor/code_executor.py
@@ -101,7 +101,7 @@ class CodeExecutor:
         except Exception as e:
             raise CodeExecutionException('Failed to execute code, which is likely a network issue,'
                                          ' please check if the sandbox service is running.'
-                                         f' Error: str{e}')
+                                         f' Error: {str(e)}')
         
         try:
             response = response.json()


### PR DESCRIPTION
# Description

- show the exception message when sandbox execution fails

eg. when using an incorrect API key , error message helps to trace and fix the problem.

<img width="468" alt="测试运行 代码执行" src="https://github.com/langgenius/dify/assets/1935105/4461b746-5b51-4316-a169-fcdf1c29b7f8">

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
