### PR TITLE
fix: key-value-table styles

### DIFF
--- a/web/app/components/base/prompt-editor/index.tsx
+++ b/web/app/components/base/prompt-editor/index.tsx
@@ -142,7 +142,7 @@ const PromptEditor: FC<PromptEditorProps> = ({
 
   return (
     <LexicalComposer initialConfig={{ ...initialConfig, editable }}>
-      <div className='relative'>
+      <div className='relative h-full'>
         <RichTextPlugin
           contentEditable={<ContentEditable className={`${className} outline-none ${compact ? 'leading-5 text-[13px]' : 'leading-6 text-sm'} text-gray-700`} style={style || {}} />}
           placeholder={<Placeholder value={placeholder} className={placeholderClassName} compact={compact} />}

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
@@ -49,7 +49,7 @@ const InputItem: FC<Props> = ({
   }, [onRemove])
 
   return (
-    <div className={cn(className, 'hover:bg-gray-50 hover:cursor-text', 'relative flex h-full items-center')}>
+    <div className={cn(className, 'hover:bg-gray-50 hover:cursor-text', 'relative flex items-center')}>
       {(!readOnly)
         ? (
           <Input

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
@@ -49,7 +49,7 @@ const InputItem: FC<Props> = ({
   }, [onRemove])
 
   return (
-    <div className={cn(className, 'hover:bg-gray-50 hover:cursor-text', 'relative flex items-center')}>
+    <div className={cn(className, 'hover:bg-gray-50 hover:cursor-text', 'relative flex h-full')}>
       {(!readOnly)
         ? (
           <Input
@@ -63,6 +63,7 @@ const InputItem: FC<Props> = ({
             onFocusChange={setIsFocus}
             placeholder={t('workflow.nodes.http.insertVarPlaceholder')!}
             placeholderClassName='!leading-[21px]'
+            promptMinHeightClassName='h-full'
           />
         )
         : <div
@@ -81,6 +82,7 @@ const InputItem: FC<Props> = ({
               onFocusChange={setIsFocus}
               placeholder={t('workflow.nodes.http.insertVarPlaceholder')!}
               placeholderClassName='!leading-[21px]'
+              promptMinHeightClassName='h-full'
             />
           )}
 

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
@@ -49,8 +49,8 @@ const KeyValueItem: FC<Props> = ({
 
   return (
     // group class name is for hover row show remove button
-    <div className={cn(className, 'group flex items-start h-min-7 border-t border-gray-200')}>
-      <div className='w-1/2 h-full border-r border-gray-200'>
+    <div className={cn(className, 'group flex h-min-7 border-t border-gray-200')}>
+      <div className='w-1/2 border-r border-gray-200'>
         <InputItem
           instanceId={`http-key-${instanceId}`}
           nodeId={nodeId}
@@ -61,7 +61,7 @@ const KeyValueItem: FC<Props> = ({
           readOnly={readonly}
         />
       </div>
-      <div className='w-1/2  h-full'>
+      <div className='w-1/2'>
         <InputItem
           instanceId={`http-value-${instanceId}`}
           nodeId={nodeId}


### PR DESCRIPTION
# Description

There is a problem with the left side of the input box 
1. when the right side of the content is larger, the left line is missing a part.
2. the prompt-input does not fill up the parent element,  causing the click area not work.

![image](https://github.com/langgenius/dify/assets/58675561/c4e7b88f-13de-4be3-b3f9-105868cbe4a1)

after the fix:

![image](https://github.com/langgenius/dify/assets/58675561/6594459d-6e67-4151-aaab-877ef57d02c2)

## Type of Change


- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement


# How Has This Been Tested?


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
