### PR TITLE
test: triggering tests on changes and allow cancelling in-progress CI test jobs

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - api/**
+
+concurrency:
+  group: api-tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   test:
+    name: API Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: style-check-${{ github.head_ref || github.run_id }}
+  group: style-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: dep-${{ github.head_ref || github.run_id }}
+  group: style-check-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tool-test-sdks.yaml
+++ b/.github/workflows/tool-test-sdks.yaml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+       - sdks/**
+
+concurrency:
+  group: sdk-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: unit test for Node.js SDK

--- a/.github/workflows/tool-test-sdks.yaml
+++ b/.github/workflows/tool-test-sdks.yaml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
     paths:
-       - sdks/**
+      - sdks/**
 
 concurrency:
-  group: sdk-test-${{ github.head_ref || github.run_id }}
+  group: sdk-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tool-test-sdks.yaml
+++ b/.github/workflows/tool-test-sdks.yaml
@@ -8,7 +8,7 @@ on:
        - sdks/**
 
 concurrency:
-  group: sdk-test-${{ github.ref }}
+  group: style-check-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tool-test-sdks.yaml
+++ b/.github/workflows/tool-test-sdks.yaml
@@ -8,7 +8,7 @@ on:
        - sdks/**
 
 concurrency:
-  group: style-check-${{ github.head_ref || github.run_id }}
+  group: sdk-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description

- allow cancelling in-progress testing jobs by setting `cancel-in-progress` to true and proper `concurrency.group`
- triggering tests on changes of relevant paths on demand, saving actions running time

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
