### PR TITLE
fix: optimize sticky header styles z-index in tools - ProviderList component

### DIFF
--- a/web/app/components/tools/provider-list.tsx
+++ b/web/app/components/tools/provider-list.tsx
@@ -69,7 +69,7 @@ const ProviderList = () => {
     <div className='relative flex overflow-hidden bg-gray-100 shrink-0 h-0 grow'>
       <div className='relative flex flex-col overflow-y-auto bg-gray-100 grow'>
         <div className={cn(
-          'z-20 sticky top-0 flex justify-between items-center pt-4 px-12 pb-2 leading-[56px] bg-gray-100 flex-wrap gap-y-2',
+          'sticky top-0 flex justify-between items-center pt-4 px-12 pb-2 leading-[56px] bg-gray-100 z-10 flex-wrap gap-y-2',
           currentProvider && 'pr-6',
         )}>
           <TabSliderNew


### PR DESCRIPTION
# Description
The sticky header used in the new Tools page is set to z-20, which remains at the top of the user menu. This PR changes it to z-10, which is consistent with the index of other headers on other pages and solves the display problem.

![Screenshot from 2024-05-28 10-22-32](https://github.com/langgenius/dify/assets/8712755/678cd450-0f44-4eee-ac75-90491eefa295)

Fixes #4723

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Tested with the fix:
![Screenshot from 2024-05-28 10-27-01](https://github.com/langgenius/dify/assets/8712755/9bee1df7-87d9-4c0b-ad79-f2daecf93d4e)


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
