### PR TITLE
style: fix annotation panel display misalignment

### DIFF
--- a/web/app/components/app/annotation/header-opts/index.tsx
+++ b/web/app/components/app/annotation/header-opts/index.tsx
@@ -150,7 +150,7 @@ const HeaderOptions: FC<Props> = ({
             s.actionIconWrapper,
           )
         }
-        className={'!w-[154px] h-fit !z-20'}
+        className={'!w-[155px] h-fit !z-20'}
         popupClassName='!w-full !overflow-visible'
         manualClose
       />


### PR DESCRIPTION
# Description

fix this by just 1px wider:
![20240529100108](https://github.com/langgenius/dify/assets/25834719/392d5288-faae-4ad2-8c15-ce15a9cbb487)


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
