### PR TITLE
Fix/4742 ollama num gpu option not consistent with allowed values

### DIFF
--- a/api/core/model_runtime/model_providers/ollama/llm/llm.py
+++ b/api/core/model_runtime/model_providers/ollama/llm/llm.py
@@ -534,12 +534,14 @@ class OllamaLargeLanguageModel(LargeLanguageModel):
                 ),
                 ParameterRule(
                     name='num_gpu',
-                    label=I18nObject(en_US="Num GPU"),
+                    label=I18nObject(en_US="GPU Layers"),
                     type=ParameterType.INT,
-                    help=I18nObject(en_US="The number of layers to send to the GPU(s). "
-                                          "On macOS it defaults to 1 to enable metal support, 0 to disable."),
-                    min=0,
-                    max=1
+                    help=I18nObject(en_US="The number of layers to offload to the GPU(s). "
+                                          "On macOS it defaults to 1 to enable metal support, 0 to disable."
+                                          "As long as a model fits into one gpu it stays in one. "
+                                          "It does not set the number of GPUs. "),
+                    min=-1,
+                    default=1
                 ),
                 ParameterRule(
                     name='num_thread',

--- a/api/core/model_runtime/model_providers/ollama/llm/llm.py
+++ b/api/core/model_runtime/model_providers/ollama/llm/llm.py
@@ -539,7 +539,7 @@ class OllamaLargeLanguageModel(LargeLanguageModel):
                     help=I18nObject(en_US="The number of layers to offload to the GPU(s). "
                                           "On macOS it defaults to 1 to enable metal support, 0 to disable."
                                           "As long as a model fits into one gpu it stays in one. "
-                                          "It does not set the number of GPUs. "),
+                                          "It does not set the number of GPU(s). "),
                     min=-1,
                     default=1
                 ),


### PR DESCRIPTION
# Description

Change the label of `Num GPU` to `GPU Layers`.  

It will confuse the user when setting this parameter in Ollama model. => The number of GPU(s) might use.
Actually it is the layers offloaded to the GPU.

<img width="610" alt="image" src="https://github.com/langgenius/dify/assets/100913391/a11a6723-91f8-4b7c-8a88-90894696bf98">

Fixes #4742

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
