### PR TITLE
fix: status query not stop when leaving document embedding detail page

### DIFF
--- a/web/app/components/datasets/documents/detail/embedding/index.tsx
+++ b/web/app/components/datasets/documents/detail/embedding/index.tsx
@@ -126,17 +126,13 @@ const EmbeddingDetail: FC<Props> = ({ detail, stopPosition = 'top', datasetId: d
     return status
   }
 
-  const [isStopQuery, setIsStopQuery] = useState(false)
-  const isStopQueryRef = useRef(isStopQuery)
-  useEffect(() => {
-    isStopQueryRef.current = isStopQuery
-  }, [isStopQuery])
+  const isStopQuery = useRef(false)
   const stopQueryStatus = () => {
-    setIsStopQuery(true)
+    isStopQuery.current = true
   }
 
   const startQueryStatus = async () => {
-    if (isStopQueryRef.current)
+    if (isStopQuery.current)
       return
 
     try {
@@ -146,6 +142,7 @@ const EmbeddingDetail: FC<Props> = ({ detail, stopPosition = 'top', datasetId: d
         detailUpdate()
         return
       }
+
       await sleep(2500)
       await startQueryStatus()
     }
@@ -156,12 +153,11 @@ const EmbeddingDetail: FC<Props> = ({ detail, stopPosition = 'top', datasetId: d
   }
 
   useEffect(() => {
-    setIsStopQuery(false)
+    isStopQuery.current = false
     startQueryStatus()
     return () => {
       stopQueryStatus()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const { data: indexingEstimateDetail, error: indexingEstimateErr } = useSWR({

--- a/web/app/components/datasets/documents/detail/embedding/index.tsx
+++ b/web/app/components/datasets/documents/detail/embedding/index.tsx
@@ -127,11 +127,11 @@ const EmbeddingDetail: FC<Props> = ({ detail, stopPosition = 'top', datasetId: d
   }
 
   const isStopQuery = useRef(false)
-  const stopQueryStatus = () => {
+  const stopQueryStatus = useCallback(() => {
     isStopQuery.current = true
-  }
+  }, [])
 
-  const startQueryStatus = async () => {
+  const startQueryStatus = useCallback(async () => {
     if (isStopQuery.current)
       return
 
@@ -150,7 +150,7 @@ const EmbeddingDetail: FC<Props> = ({ detail, stopPosition = 'top', datasetId: d
       await sleep(2500)
       await startQueryStatus()
     }
-  }
+  }, [stopQueryStatus])
 
   useEffect(() => {
     isStopQuery.current = false
@@ -158,7 +158,7 @@ const EmbeddingDetail: FC<Props> = ({ detail, stopPosition = 'top', datasetId: d
     return () => {
       stopQueryStatus()
     }
-  }, [])
+  }, [startQueryStatus, stopQueryStatus])
 
   const { data: indexingEstimateDetail, error: indexingEstimateErr } = useSWR({
     action: 'fetchIndexingEstimate',


### PR DESCRIPTION
# Description

Use isStopQuery Ref update Immediately  to ensure the query stop on leaving detail page.

Fixes #4753 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Open the document detail page which document status is 'waiting', then back to the list.
In the detail page, the query called every 2500ms, then back to the list page, query stop.

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
