### PR TITLE
feat: Add logging warning when MAIL_TYPE is not set

### DIFF
--- a/api/extensions/ext_mail.py
+++ b/api/extensions/ext_mail.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 import resend
@@ -16,7 +17,7 @@ class Mail:
         if app.config.get('MAIL_TYPE'):
             if app.config.get('MAIL_DEFAULT_SEND_FROM'):
                 self._default_send_from = app.config.get('MAIL_DEFAULT_SEND_FROM')
-
+            
             if app.config.get('MAIL_TYPE') == 'resend':
                 api_key = app.config.get('RESEND_API_KEY')
                 if not api_key:
@@ -42,6 +43,9 @@ class Mail:
                 )
             else:
                 raise ValueError('Unsupported mail type {}'.format(app.config.get('MAIL_TYPE')))
+        else:
+            logging.warning('MAIL_TYPE is not set')
+            
 
     def send(self, to: str, subject: str, html: str, from_: Optional[str] = None):
         if not self._client:


### PR DESCRIPTION
# Description

There was an issue where emails were not sent at all because the mail_type setting was forgotten during email configuration. I believe adding logs would have made it easier to notice this issue. Therefore, I added logging. This PR aims to improve the developer experience.

## Type of Change

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Start the api or worker with MAIL_TYPE set to “” in the .env. Check to see if there is a log that says MAIL_TYPE is not set.
![スクリーンショット 2024-05-29 18 16 33](https://github.com/langgenius/dify/assets/50980947/a39187a4-451e-4a42-94c9-0c0cac63bd92)
# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
