### PR TITLE
fix: remove redundant props

### DIFF
--- a/web/app/components/i18n-server.tsx
+++ b/web/app/components/i18n-server.tsx
@@ -7,7 +7,7 @@ export type II18NServerProps = {
   children: React.ReactNode
 }
 
-const I18NServer = async ({
+const I18NServer = ({
   children,
 }: II18NServerProps) => {
   const locale = getLocaleOnServer()

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -47,7 +47,7 @@ const LocaleLayout = ({
         <BrowerInitor>
           <SentryInitor>
             {/* @ts-expect-error Async Server Component */}
-            <I18nServer locale={locale}>{children}</I18nServer>
+            <I18nServer>{children}</I18nServer>
           </SentryInitor>
         </BrowerInitor>
       </body>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -46,7 +46,6 @@ const LocaleLayout = ({
         <Topbar/>
         <BrowerInitor>
           <SentryInitor>
-            {/* @ts-expect-error Async Server Component */}
             <I18nServer>{children}</I18nServer>
           </SentryInitor>
         </BrowerInitor>


### PR DESCRIPTION
# Description

This PR includes two fixes:

- Remove redundant props in the root layout component.
- Remove the `async` keyword from the `I18NServer` component and fix the ts error in the root layout component.

Because the `getLocaleOnserver` function isn't an async function, the server component also doesn't need the `async` keyword.




## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?



# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
