### PR TITLE
feat: opportunistic tls flag for smtp

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -127,10 +127,11 @@ RESEND_API_KEY=
 RESEND_API_URL=https://api.resend.com
 # smtp configuration
 SMTP_SERVER=smtp.gmail.com
-SMTP_PORT=587
+SMTP_PORT=465
 SMTP_USERNAME=123
 SMTP_PASSWORD=abc
-SMTP_USE_TLS=false
+SMTP_USE_TLS=true
+SMTP_OPPORTUNISTIC_TLS=false
 
 # Sentry configuration
 SENTRY_DSN=

--- a/api/config.py
+++ b/api/config.py
@@ -294,6 +294,7 @@ class Config:
         self.SMTP_USERNAME = get_env('SMTP_USERNAME')
         self.SMTP_PASSWORD = get_env('SMTP_PASSWORD')
         self.SMTP_USE_TLS = get_bool_env('SMTP_USE_TLS')
+        self.SMTP_OPPORTUNISTIC_TLS = get_bool_env('SMTP_OPPORTUNISTIC_TLS')
 
         # ------------------------
         # Workspace Configurations.

--- a/api/extensions/ext_mail.py
+++ b/api/extensions/ext_mail.py
@@ -32,13 +32,16 @@ class Mail:
                 from libs.smtp import SMTPClient
                 if not app.config.get('SMTP_SERVER') or not app.config.get('SMTP_PORT'):
                     raise ValueError('SMTP_SERVER and SMTP_PORT are required for smtp mail type')
+                if not app.config.get('SMTP_USE_TLS') and app.config.get('SMTP_OPPORTUNISTIC_TLS'):
+                    raise ValueError('SMTP_OPPORTUNISTIC_TLS is not supported without enabling SMTP_USE_TLS')
                 self._client = SMTPClient(
                     server=app.config.get('SMTP_SERVER'),
                     port=app.config.get('SMTP_PORT'),
                     username=app.config.get('SMTP_USERNAME'),
                     password=app.config.get('SMTP_PASSWORD'),
                     _from=app.config.get('MAIL_DEFAULT_SEND_FROM'),
-                    use_tls=app.config.get('SMTP_USE_TLS')
+                    use_tls=app.config.get('SMTP_USE_TLS'),
+                    opportunistic_tls=app.config.get('SMTP_OPPORTUNISTIC_TLS')
                 )
             else:
                 raise ValueError('Unsupported mail type {}'.format(app.config.get('MAIL_TYPE')))

--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -5,20 +5,27 @@ from email.mime.text import MIMEText
 
 
 class SMTPClient:
-    def __init__(self, server: str, port: int, username: str, password: str, _from: str, use_tls=False):
+    def __init__(self, server: str, port: int, username: str, password: str, _from: str, use_tls=False, opportunistic_tls=False):
         self.server = server
         self.port = port
         self._from = _from
         self.username = username
         self.password = password
-        self._use_tls = use_tls
+        self.use_tls = use_tls
+        self.opportunistic_tls = opportunistic_tls
 
     def send(self, mail: dict):
         smtp = None
         try:
-            smtp = smtplib.SMTP(self.server, self.port, timeout=10)
-            if self._use_tls:
-                smtp.starttls()
+            if self.use_tls:
+                if self.opportunistic_tls:
+                    smtp = smtplib.SMTP(self.server, self.port, timeout=10)
+                    smtp.starttls()
+                else:
+                    smtp = smtplib.SMTP_SSL(self.server, self.port, timeout=10)
+            else:
+                smtp = smtplib.SMTP(self.server, self.port, timeout=10)
+                
             if self.username and self.password:
                 smtp.login(self.username, self.password)
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -139,10 +139,11 @@ services:
       # default send from email address, if not specified
       MAIL_DEFAULT_SEND_FROM: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
       SMTP_SERVER: ''
-      SMTP_PORT: 587
+      SMTP_PORT: 465
       SMTP_USERNAME: ''
       SMTP_PASSWORD: ''
       SMTP_USE_TLS: 'true'
+      SMTP_OPPORTUNISTIC_TLS: 'false'
       # the api-key for resend (https://resend.com)
       RESEND_API_KEY: ''
       RESEND_API_URL: https://api.resend.com
@@ -268,10 +269,11 @@ services:
       # default send from email address, if not specified
       MAIL_DEFAULT_SEND_FROM: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
       SMTP_SERVER: ''
-      SMTP_PORT: 587
+      SMTP_PORT: 465
       SMTP_USERNAME: ''
       SMTP_PASSWORD: ''
       SMTP_USE_TLS: 'true'
+      SMTP_OPPORTUNISTIC_TLS: 'false'
       # the api-key for resend (https://resend.com)
       RESEND_API_KEY: ''
       RESEND_API_URL: https://api.resend.com


### PR DESCRIPTION
# Description

This pull request introduces an opportunistic TLS flag for the SMTP configuration in Dify and changes the default SMTP port from 587 to 465.

Currently, the existing TLS flag in Dify does not support port 465 (It will hang and then timeout), which is more commonly used nowadays due to its higher security. Port 465 is used for SMTP connections secured with SSL/TLS encryption from the start, establishing a secure connection before any SMTP commands are sent. SSL/TLS encryption is enabled by default on this port, providing a higher level of security compared to port 587.

Port 587, on the other hand, is used for SMTP connections with STARTTLS, where the connection starts as a plain-text SMTP connection and can be upgraded to a secure connection using the STARTTLS command. It allows the client and server to negotiate the use of encryption during the SMTP conversation.

To address the limitation of the current TLS flag and enhance the security of email communication, this pull request introduces an opportunistic TLS flag. This flag provides the option to enable opportunistic TLS encryption for SMTP connections, allowing the flexibility to use either port 587 with STARTTLS or port 465 with SSL/TLS, depending on the email server's requirements and support.

Furthermore, the pull request changes the default SMTP port in the example configs from 587 to 465. This ensures that the SMTP connection is encrypted from the beginning by default, providing a higher level of security out of the box.

The changes include updates to the configuration files, environment variables, and the SMTPClient class to support this new feature and the default port change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Verified that the SMTP configuration updates are reflected in the `api/.env.example` and `docker/docker-compose.yaml` files.
- [x] Tested the SMTPClient class with different combinations of `use_tls` and `opportunistic_tls` flags to ensure the correct behavior.
- [x] Validated that email sending functionality works as expected with the new opportunistic TLS option enabled with port 587.
- [x] Validated that email sending functionality works as expected with the new opportunistic TLS option disabled with port 465.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes