### PR TITLE
fix: remove escape characters from strings in api

### DIFF
--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -293,7 +293,8 @@ class ApiTool(Tool):
                 elif property['type'] == 'object':
                     if isinstance(value, str):
                         try:
-                            return json.loads(value)
+                            unescaped_string = value.replace("\\", "")  # 移除字符串中的转义字符
+                            return json.loads(unescaped_string)
                         except ValueError:
                             return value
                     elif isinstance(value, dict):


### PR DESCRIPTION
# Description

When setting the API swagger, the interface request is post, and the value corresponding to the submitted parameter key is object type. When converting the job string to object, # remove the escape character from the string, otherwise an error will be reported

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)