### PR TITLE
fix: app_count of dataset is error when apps was deleted

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -76,7 +76,8 @@ class Dataset(db.Model):
 
     @property
     def app_count(self):
-        return db.session.query(func.count(AppDatasetJoin.id)).filter(AppDatasetJoin.dataset_id == self.id).scalar()
+        return db.session.query(func.count(AppDatasetJoin.id)).filter(AppDatasetJoin.dataset_id == self.id,
+                                                                      App.id == AppDatasetJoin.app_id).scalar()
 
     @property
     def document_count(self):


### PR DESCRIPTION
# Description

When an app is deleted, the statistics of the count of apps associated with the dataset will be incorrect, and the deleted app will also be counted.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

1. Create a dataset and upload documents
2. Create an app and associate it with the dataset
3. Check that the count of apps associated with the dataset is 1
4. Delete the dataset and check that the count of apps associated with the dataset is still 1
5. After repair, check that the count of applications associated with the dataset is 0


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

