### PR TITLE
dep: bump pandas from 1.x to 2.x

### DIFF
--- a/api/core/rag/extractor/csv_extractor.py
+++ b/api/core/rag/extractor/csv_extractor.py
@@ -57,7 +57,7 @@ class CSVExtractor(BaseExtractor):
         docs = []
         try:
             # load csv file into pandas dataframe
-            df = pd.read_csv(csvfile, error_bad_lines=False, **self.csv_args)
+            df = pd.read_csv(csvfile, on_bad_lines='skip', **self.csv_args)
 
             # check source column exists
             if self.source_column and self.source_column not in df.columns:

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -26,7 +26,6 @@ sympy==1.12
 jieba==0.42.1
 celery~=5.3.6
 redis[hiredis]~=5.0.3
-openpyxl==3.1.2
 chardet~=5.1.0
 python-docx~=1.1.0
 pypdfium2~=4.17.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -77,7 +77,6 @@ qrcode~=7.4.2
 azure-storage-blob==12.9.0
 azure-identity==1.15.0
 lxml==5.1.0
-xlrd~=2.0.1
 pydantic~=1.10.0
 pgvecto-rs==0.1.4
 firecrawl-py==0.0.5

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -51,7 +51,7 @@ dashscope[tokenizer]~=1.17.0
 huggingface_hub~=0.16.4
 transformers~=4.35.0
 tokenizers~=0.15.0
-pandas==1.5.3
+pandas[performance]~=2.2.2
 xinference-client==0.9.4
 safetensors~=0.4.3
 zhipuai==1.0.7

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -51,7 +51,7 @@ dashscope[tokenizer]~=1.17.0
 huggingface_hub~=0.16.4
 transformers~=4.35.0
 tokenizers~=0.15.0
-pandas[performance]~=2.2.2
+pandas[performance,excel]~=2.2.2
 xinference-client==0.9.4
 safetensors~=0.4.3
 zhipuai==1.0.7

--- a/api/tests/unit_tests/libs/test_pandas.py
+++ b/api/tests/unit_tests/libs/test_pandas.py
@@ -12,7 +12,7 @@ def test_pandas_csv(tmp_path, monkeypatch):
     df1.to_csv(csv_file_path, index=False)
 
     # read from csv file
-    df2 = pd.read_csv(csv_file_path)
+    df2 = pd.read_csv(csv_file_path, on_bad_lines='skip')
     assert df2[df2.columns[0]].to_list() == data['col1']
     assert df2[df2.columns[1]].to_list() == data['col2']
 

--- a/api/tests/unit_tests/libs/test_pandas.py
+++ b/api/tests/unit_tests/libs/test_pandas.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+
+def test_pandas_csv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data = {'col1': [1, 2.2, -3.3, 4.0, 5],
+            'col2': ['A', 'B', 'C', 'D', 'E']}
+    df1 = pd.DataFrame(data)
+
+    # write to csv file
+    csv_file_name = 'example.csv'
+    file_path = tmp_path.joinpath(csv_file_name)
+    df1.to_csv(file_path, index=False)
+
+    # read from csv file
+    df2 = pd.read_csv(csv_file_name)
+    assert len(df2.index) == len(data['col1'])
+    assert df2[df2.columns[0]].to_list() == data['col1']
+    assert df2[df2.columns[1]].to_list() == data['col2']
+
+
+def test_pandas_xlsx(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data = {'col1': [1, 2.2, -3.3, 4.0, 5],
+            'col2': ['A', 'B', 'C', 'D', 'E']}
+    df1 = pd.DataFrame(data)
+
+    # write to xlsx file
+    xlsx_file_name = 'example.xlsx'
+    file_path = tmp_path.joinpath(xlsx_file_name)
+    df1.to_excel(file_path, index=False)
+
+    # read from xlsx file
+    df2 = pd.read_excel(xlsx_file_name)
+    assert len(df2.index) == len(data['col1'])
+    assert df2[df2.columns[0]].to_list() == data['col1']
+    assert df2[df2.columns[1]].to_list() == data['col2']
+
+
+def test_pandas_xlsx_with_sheets(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data1 = {'col1': [1, 2, 3, 4, 5],
+             'col2': ['A', 'B', 'C', 'D', 'E']}
+    df1 = pd.DataFrame(data1)
+
+    data2 = {'col1': [6, 7, 8, 9, 10],
+             'col2': ['F', 'G', 'H', 'I', 'J']}
+    df2 = pd.DataFrame(data2)
+
+    # write to xlsx file with sheets
+    xlsx_file_name = 'example_with_sheets.xlsx'
+    file_path = tmp_path.joinpath(xlsx_file_name)
+    sheet1 = 'Sheet1'
+    sheet2 = 'Sheet2'
+    with pd.ExcelWriter(file_path) as excel_writer:
+        df1.to_excel(excel_writer, sheet_name=sheet1, index=False)
+        df2.to_excel(excel_writer, sheet_name=sheet2, index=False)
+
+    # read from xlsx file with sheets
+    with pd.ExcelFile(file_path) as excel_file:
+        df1 = pd.read_excel(excel_file, sheet_name=sheet1)
+        assert len(df1.index) == len(data1['col1'])
+        assert df1[df1.columns[0]].to_list() == data1['col1']
+        assert df1[df1.columns[1]].to_list() == data1['col2']
+
+        df2 = pd.read_excel(excel_file, sheet_name=sheet2)
+        assert len(df2.index) == len(data2['col1'])
+        assert df2[df2.columns[0]].to_list() == data2['col1']
+        assert df2[df2.columns[1]].to_list() == data2['col2']

--- a/api/tests/unit_tests/libs/test_pandas.py
+++ b/api/tests/unit_tests/libs/test_pandas.py
@@ -8,13 +8,11 @@ def test_pandas_csv(tmp_path, monkeypatch):
     df1 = pd.DataFrame(data)
 
     # write to csv file
-    csv_file_name = 'example.csv'
-    file_path = tmp_path.joinpath(csv_file_name)
-    df1.to_csv(file_path, index=False)
+    csv_file_path = tmp_path.joinpath('example.csv')
+    df1.to_csv(csv_file_path, index=False)
 
     # read from csv file
-    df2 = pd.read_csv(csv_file_name)
-    assert len(df2.index) == len(data['col1'])
+    df2 = pd.read_csv(csv_file_path)
     assert df2[df2.columns[0]].to_list() == data['col1']
     assert df2[df2.columns[1]].to_list() == data['col2']
 
@@ -26,13 +24,11 @@ def test_pandas_xlsx(tmp_path, monkeypatch):
     df1 = pd.DataFrame(data)
 
     # write to xlsx file
-    xlsx_file_name = 'example.xlsx'
-    file_path = tmp_path.joinpath(xlsx_file_name)
-    df1.to_excel(file_path, index=False)
+    xlsx_file_path = tmp_path.joinpath('example.xlsx')
+    df1.to_excel(xlsx_file_path, index=False)
 
     # read from xlsx file
-    df2 = pd.read_excel(xlsx_file_name)
-    assert len(df2.index) == len(data['col1'])
+    df2 = pd.read_excel(xlsx_file_path)
     assert df2[df2.columns[0]].to_list() == data['col1']
     assert df2[df2.columns[1]].to_list() == data['col2']
 
@@ -48,22 +44,19 @@ def test_pandas_xlsx_with_sheets(tmp_path, monkeypatch):
     df2 = pd.DataFrame(data2)
 
     # write to xlsx file with sheets
-    xlsx_file_name = 'example_with_sheets.xlsx'
-    file_path = tmp_path.joinpath(xlsx_file_name)
+    xlsx_file_path = tmp_path.joinpath('example_with_sheets.xlsx')
     sheet1 = 'Sheet1'
     sheet2 = 'Sheet2'
-    with pd.ExcelWriter(file_path) as excel_writer:
+    with pd.ExcelWriter(xlsx_file_path) as excel_writer:
         df1.to_excel(excel_writer, sheet_name=sheet1, index=False)
         df2.to_excel(excel_writer, sheet_name=sheet2, index=False)
 
     # read from xlsx file with sheets
-    with pd.ExcelFile(file_path) as excel_file:
+    with pd.ExcelFile(xlsx_file_path) as excel_file:
         df1 = pd.read_excel(excel_file, sheet_name=sheet1)
-        assert len(df1.index) == len(data1['col1'])
         assert df1[df1.columns[0]].to_list() == data1['col1']
         assert df1[df1.columns[1]].to_list() == data1['col2']
 
         df2 = pd.read_excel(excel_file, sheet_name=sheet2)
-        assert len(df2.index) == len(data2['col1'])
         assert df2[df2.columns[0]].to_list() == data2['col1']
         assert df2[df2.columns[1]].to_list() == data2['col2']


### PR DESCRIPTION
# Description

- pandas 2.x is released in early 2023, and the 3.x is under development. It's time to migrate pandas to 2.x
- no breaking changes in usage of pandas in Dify
- proper tests for reading and writing xlsx file and csv files
- using `pandas[performance]` as officially encouraged, referring docs: https://pandas.pydata.org/docs/dev/getting_started/install.html#performance-dependencies-recommended
- installing `pandas[excel]` package for excel file processing, and skipping explicit pinning the transparent dependencies including openpyxl and xlrd
```
openpyxl>=3.1.0 in /lib/python3.10/site-packages (from pandas[excel,performance]~=2.2.2->-r api/requirements.txt (line 53)) (3.1.2)
xlrd>=2.0.1 in /lib/python3.10/site-packages (from pandas[excel,performance]~=2.2.2->-r api/requirements.txt (line 53)) (2.0.1)
```
- migrate the deprecated `error_bad_lines` option in `read_csv` to `on_bad_lines` option, referring:
  - docs: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
  - https://stackoverflow.com/questions/69513799/pandas-read-csv-the-error-bad-lines-argument-has-been-deprecated-and-will-be-re  

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [x] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
