### PR TITLE
chore: skip explicit installing jinja2 as testing dependency

### DIFF
--- a/api/requirements-dev.txt
+++ b/api/requirements-dev.txt
@@ -3,4 +3,3 @@ pytest~=8.1.1
 pytest-benchmark~=4.0.0
 pytest-env~=1.1.3
 pytest-mock~=3.14.0
-jinja2~=3.1.2


### PR DESCRIPTION
# Description

- skip explict installing jinja2 as testing dependencies from `api/requirments-dev.txt`, as jinja2 has been already required by flask in `api/requirements.txt`
```
Collecting Jinja2>=3.1.2 (from flask~=3.0.1->-r ./api/requirements.txt (line 2))
  Downloading jinja2-3.1.4-py3-none-any.whl.metadata (2.6 kB)
```

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
