### PR TITLE
chore: fix invalid escape sequences by applying W605 rule

### DIFF
--- a/api/core/splitter/text_splitter.py
+++ b/api/core/splitter/text_splitter.py
@@ -701,7 +701,7 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 # Split along section titles
                 "\n=+\n",
                 "\n-+\n",
-                "\n\*+\n",
+                "\n\\*+\n",
                 # Split along directive markers
                 "\n\n.. *\n\n",
                 # Split by the normal type of lines
@@ -800,7 +800,7 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 # End of code block
                 "```\n",
                 # Horizontal lines
-                "\n\*\*\*+\n",
+                "\n\\*\\*\\*+\n",
                 "\n---+\n",
                 "\n___+\n",
                 # Note that this splitter doesn't handle horizontal lines defined
@@ -813,10 +813,10 @@ class RecursiveCharacterTextSplitter(TextSplitter):
         elif language == Language.LATEX:
             return [
                 # First, try to split along Latex sections
-                "\n\\\chapter{",
-                "\n\\\section{",
-                "\n\\\subsection{",
-                "\n\\\subsubsection{",
+                "\n\\\\chapter{",
+                "\n\\\\section{",
+                "\n\\\\subsection{",
+                "\n\\\\subsubsection{",
                 # Now split by environments
                 "\n\\\begin{enumerate}",
                 "\n\\\begin{itemize}",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ select = [
     "UP",   # pyupgrade rules
     "RUF019", # unnecessary-key-check
     "S506", # unsafe-yaml-load
+    "W605", # invalid-escape-sequence
 ]
 ignore = [
     "F403", # undefined-local-with-import-star

--- a/api/services/workflow/workflow_converter.py
+++ b/api/services/workflow/workflow_converter.py
@@ -305,7 +305,7 @@ class WorkflowConverter:
             }
 
             request_body_json = json.dumps(request_body)
-            request_body_json = request_body_json.replace('\{\{', '{{').replace('\}\}', '}}')
+            request_body_json = request_body_json.replace(r'\{\{', '{{').replace(r'\}\}', '}}')
 
             http_request_node = {
                 "id": f"http_request_{index}",


### PR DESCRIPTION
# Description

-  applying W605 rule (https://docs.astral.sh/ruff/rules/invalid-escape-sequence/) to auto-fix invalid escape sequences causing warning messages when running unit tests in CI jobs:
```
api/services/workflow/workflow_converter.py:308
  /home/runner/work/dify/dify/api/services/workflow/workflow_converter.py:308: DeprecationWarning: invalid escape sequence '\{'
    request_body_json = request_body_json.replace('\{\{', '{{').replace('\}\}', '}}')

api/services/workflow/workflow_converter.py:308
  /home/runner/work/dify/dify/api/services/workflow/workflow_converter.py:308: DeprecationWarning: invalid escape sequence '\}'
    request_body_json = request_body_json.replace('\{\{', '{{').replace('\}\}', '}}')

api/core/splitter/text_splitter.py:704
  /home/runner/work/dify/dify/api/core/splitter/text_splitter.py:704: DeprecationWarning: invalid escape sequence '\*'
    "\n\*+\n",

api/core/splitter/text_splitter.py:803
  /home/runner/work/dify/dify/api/core/splitter/text_splitter.py:803: DeprecationWarning: invalid escape sequence '\*'
    "\n\*\*\*+\n",

api/core/splitter/text_splitter.py:816
  /home/runner/work/dify/dify/api/core/splitter/text_splitter.py:816: DeprecationWarning: invalid escape sequence '\c'
    "\n\\\chapter{",

api/core/splitter/text_splitter.py:817
  /home/runner/work/dify/dify/api/core/splitter/text_splitter.py:817: DeprecationWarning: invalid escape sequence '\s'
    "\n\\\section{",

api/core/splitter/text_splitter.py:818
  /home/runner/work/dify/dify/api/core/splitter/text_splitter.py:818: DeprecationWarning: invalid escape sequence '\s'
    "\n\\\subsection{",

api/core/splitter/text_splitter.py:819
  /home/runner/work/dify/dify/api/core/splitter/text_splitter.py:819: DeprecationWarning: invalid escape sequence '\s'
    "\n\\\subsubsection{",
```

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

- [x] pass the `test_text_splitter` tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
