### PR TITLE
Bugfix: Vertex AI vision model not support image

### DIFF
--- a/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
@@ -368,7 +368,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
                         metadata, data = c.data.split(',', 1)
                         mime_type = metadata.split(';', 1)[0].split(':')[1]
                         parts.append(glm.Part.from_data(mime_type=mime_type, data=data))
-                glm_content = glm.Content(role="user", parts=[parts])
+                glm_content = glm.Content(role="user", parts=parts)
             return glm_content
         elif isinstance(message, AssistantPromptMessage):
             if message.content:

--- a/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
@@ -367,9 +367,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
                     else:
                         metadata, data = c.data.split(',', 1)
                         mime_type = metadata.split(';', 1)[0].split(':')[1]
-                        blob = {"inline_data":{"mime_type":mime_type,"data":data}}
-                        parts.append(blob)
-                
+                        parts.append(glm.Part.from_data(mime_type=mime_type, data=data))
                 glm_content = glm.Content(role="user", parts=[parts])
             return glm_content
         elif isinstance(message, AssistantPromptMessage):


### PR DESCRIPTION
# Description

When the user selects the vision model in Vertex AI and the prompt contains an image, an error is returned: 
[vertex_ai] Error: module 'vertexai.generative_models' has no attribute 'Schema'. 
The code I submitted fixes this problem.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
