### PR TITLE
chore: separate style checks into multiple jobs triggering on file changes

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,57 +15,89 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: api/**
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           python-version: '3.10'
 
       - name: Python dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: pip install ruff dotenv-linter
 
       - name: Ruff check
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: ruff check ./api
 
       - name: Dotenv check
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: dotenv-linter ./api/.env.example ./web/.env.example
 
       - name: Lint hints
         if: failure()
         run: echo "Please run 'dev/reformat' to fix the fixable linting errors."
 
-  test:
-    name: ESLint and SuperLinter
+  web-style:
+    name: Web Style
     runs-on: ubuntu-latest
-    needs: python-style
+    defaults:
+      run:
+        working-directory: ./web
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
         with:
-          fetch-depth: 0
+          files: web/**
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           node-version: 20
           cache: yarn
           cache-dependency-path: ./web/package.json
 
       - name: Web dependencies
-        run: |
-          cd ./web
-          yarn install --frozen-lockfile
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: yarn install --frozen-lockfile
 
       - name: Web style check
-        run: |
-          cd ./web
-          yarn run lint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: yarn run lint
+
+
+  superlinter:
+    name: SuperLinter
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            **.sh
+            **.yaml
+            **.yml
+            Dockerfile
 
       - name: Super-linter
         uses: super-linter/super-linter/slim@v6
+        if: steps.changed-files.outputs.any_changed == 'true'
         env:
           BASH_SEVERITY: warning
           DEFAULT_BRANCH: main

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Check changed files
         id: changed-files
@@ -53,7 +54,8 @@ jobs:
         working-directory: ./web
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Check changed files
         id: changed-files
@@ -83,7 +85,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Check changed files
         id: changed-files


### PR DESCRIPTION
# Description

- seperate style check into jobs for Python, Web and general purpose
- speed up ci jobs by skipping linting jobs , which helps to reduce SuperLinter runtime saving ~1.5min execution time, if no changed files hit by path filters

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
