### PR TITLE
fix: autoHeightTextarea dimensions in Firefox

### DIFF
--- a/web/app/components/base/auto-height-textarea/common.tsx
+++ b/web/app/components/base/auto-height-textarea/common.tsx
@@ -38,7 +38,7 @@ const AutoHeightTextarea = forwardRef<HTMLTextAreaElement, AutoHeightTextareaPro
           <textarea
             ref={ref}
             placeholder={placeholder}
-            className={cn(className, 'disabled:bg-transparent absolute inset-0 outline-none border-none appearance-none resize-none')}
+            className={cn(className, 'disabled:bg-transparent absolute inset-0 outline-none border-none appearance-none resize-none w-full h-full')}
             value={value}
             disabled={disabled}
             {...rest}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in Firefox

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [x] `optional` I have made corresponding changes to the documentation 
- [x] `optional` I have added tests that prove my fix is effective or that my feature works
- [x] `optional` New and existing unit tests pass locally with my changes
