### PR TITLE
fix: missing dataset patch parameters in settings modal

### DIFF
--- a/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
@@ -100,6 +100,8 @@ const SettingsModal: FC<SettingsModalProps> = ({
           permission,
           indexing_technique: indexMethod,
           retrieval_model: postRetrievalConfig,
+          embedding_model: localeCurrentDataset.embedding_model,
+          embedding_model_provider: localeCurrentDataset.embedding_model_provider,
         },
       })
       notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })


### PR DESCRIPTION
# Description
This PR fixes an issue in the dataset settings modal where unnecessary updates were being triggered when the embedding model provider or model changed, even if the indexing technique remained the same. In addition, this was causing problems with the Milvus database when such update tasks were sent.

The changes include:
- Added `embedding_model` and `embedding_model_provider` fields to the dataset settings modal in the frontend, allowing them to be passed along with the PATCH request.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement 
- [ ] Dependency upgrade

# How Has This Been Tested?
- Manually tested the dataset settings modal to ensure embedding model and provider changes no longer trigger unnecessary updates
- Verified that the Milvus database no longer encounters issues due to these unneeded update tasks

# Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran dev/reformat(backend) and cd web && npx lint-staged(frontend) to appease the lint gods
- [ ] optional I have made corresponding changes to the documentation
- [ ] optional I have added tests that prove my fix is effective or that my feature works 
- [ ] optional New and existing unit tests pass locally with my changes