### PR TITLE
fix: workspace member's last_active should be last_active_time, but not last_login_time

### DIFF
--- a/api/fields/member_fields.py
+++ b/api/fields/member_fields.py
@@ -28,6 +28,7 @@ account_with_role_fields = {
     'avatar': fields.String,
     'email': fields.String,
     'last_login_at': TimestampField,
+    'last_active_at': TimestampField,
     'created_at': TimestampField,
     'role': fields.String,
     'status': fields.String,

--- a/web/app/components/header/account-setting/members-page/index.tsx
+++ b/web/app/components/header/account-setting/members-page/index.tsx
@@ -104,7 +104,7 @@ const MembersPage = () => {
                       <div className='text-xs text-gray-500 leading-[18px]'>{account.email}</div>
                     </div>
                   </div>
-                  <div className='shrink-0 flex items-center w-[104px] py-2 text-[13px] text-gray-700'>{dayjs(Number((account.last_login_at || account.created_at)) * 1000).locale(locale === 'zh-Hans' ? 'zh-cn' : 'en').fromNow()}</div>
+                  <div className='shrink-0 flex items-center w-[104px] py-2 text-[13px] text-gray-700'>{dayjs(Number((account.last_active_at || account.created_at)) * 1000).locale(locale === 'zh-Hans' ? 'zh-cn' : 'en').fromNow()}</div>
                   <div className='shrink-0 w-[96px] flex items-center'>
                     {
                       (owner && account.role !== 'owner')

--- a/web/models/common.ts
+++ b/web/models/common.ts
@@ -27,6 +27,7 @@ export type UserProfileResponse = {
   interface_theme?: string
   timezone?: string
   last_login_at?: string
+  last_active_at?: string
   last_login_ip?: string
   created_at?: string
 }
@@ -61,7 +62,7 @@ export type TenantInfoResponse = {
   trial_end_reason: null | 'trial_exceeded' | 'using_custom'
 }
 
-export type Member = Pick<UserProfileResponse, 'id' | 'name' | 'email' | 'last_login_at' | 'created_at'> & {
+export type Member = Pick<UserProfileResponse, 'id' | 'name' | 'email' | 'last_login_at' | 'last_login_at' | 'created_at'> & {
   avatar: string
   status: 'pending' | 'active' | 'banned' | 'closed'
   role: 'owner' | 'admin' | 'normal'


### PR DESCRIPTION
# Description

Workspace member's last_active now set to be last_login_time, which is wrong。It should be set to the value of last_active_time.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. before fix, lastActive shows the value of last_login_time, which is '18天前'
2. after fix，lastActive shows the value of last_active_time, which is '几秒前'

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
