### PR TITLE
chore: modify tools/JinaReader label to Jina

### DIFF
--- a/api/core/tools/provider/builtin/jina/jina.yaml
+++ b/api/core/tools/provider/builtin/jina/jina.yaml
@@ -2,9 +2,9 @@ identity:
   author: Dify
   name: jina
   label:
-    en_US: JinaReader
-    zh_Hans: JinaReader
-    pt_BR: JinaReader
+    en_US: Jina
+    zh_Hans: Jina
+    pt_BR: Jina
   description:
     en_US: Convert any URL to an LLM-friendly input or perform searches on the web for grounding information. Experience improved output for your agent and RAG systems at no cost.
     zh_Hans: 将任何URL转换为LLM易读的输入或在网页上搜索引擎上搜索引擎。


### PR DESCRIPTION
# Description

In Tools list page, the Jina's label is JinaReader, but when search 'Reader' cannot get the correct result which make the user confused.
Modify the label from JinaReader to Jina  which configured in tools/provider/builtin/jina.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After reload the flask api, the Jina's Lable is Jina.
Search 'reader', get no result, search 'jina' get 'Jina'.

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
