### PR TITLE
change "Import from text file" to "Import from file"

### DIFF
--- a/web/i18n/en-US/dataset-creation.ts
+++ b/web/i18n/en-US/dataset-creation.ts
@@ -15,12 +15,12 @@ const translation = {
     filePreview: 'File Preview',
     pagePreview: 'Page Preview',
     dataSourceType: {
-      file: 'Import from text file',
+      file: 'Import from file',
       notion: 'Sync from Notion',
       web: 'Sync from website',
     },
     uploader: {
-      title: 'Upload text file',
+      title: 'Upload file',
       button: 'Drag and drop file, or',
       browse: 'Browse',
       tip: 'Supports {{supportTypes}}. Max {{size}}MB each.',


### PR DESCRIPTION
# Description

Given the supported file formats are more than text file, the label should be import from file instead of import from text file. 
<img width="730" alt="Screenshot 2024-06-04 at 2 27 36 PM" src="https://github.com/langgenius/dify/assets/595772/62bd755a-f057-48a9-b47e-f63540fe0faf">

# How Has This Been Tested?

simple label text change.
