### PR TITLE
chore: rename vdb tests for PGVector and PGvectoRS

### DIFF
--- a/api/tests/integration_tests/vdb/pgvecto_rs/test_pgvecto_rs.py
+++ b/api/tests/integration_tests/vdb/pgvecto_rs/test_pgvecto_rs.py
@@ -6,7 +6,7 @@ from tests.integration_tests.vdb.test_vector_store import (
 )
 
 
-class TestPgvectoRSVector(AbstractVectorTest):
+class PGVectoRSVectorTest(AbstractVectorTest):
     def __init__(self):
         super().__init__()
         self.vector = PGVectoRS(
@@ -34,4 +34,4 @@ class TestPgvectoRSVector(AbstractVectorTest):
         assert len(ids) == 1
 
 def test_pgvecot_rs(setup_mock_redis):
-    TestPgvectoRSVector().run_all_tests()
+    PGVectoRSVectorTest().run_all_tests()

--- a/api/tests/integration_tests/vdb/pgvector/test_pgvector.py
+++ b/api/tests/integration_tests/vdb/pgvector/test_pgvector.py
@@ -7,7 +7,7 @@ from tests.integration_tests.vdb.test_vector_store import (
 )
 
 
-class TestPGVector(AbstractVectorTest):
+class PGVectorTest(AbstractVectorTest):
     def __init__(self):
         super().__init__()
         self.vector = PGVector(
@@ -27,4 +27,4 @@ class TestPGVector(AbstractVectorTest):
 
 
 def test_pgvector(setup_mock_redis):
-    TestPGVector().run_all_tests()
+    PGVectorTest().run_all_tests()


### PR DESCRIPTION
# Description

- to avoid warning messages in CI tests, by removing `Test` prefix in vdb tests' class name:
```
api/tests/integration_tests/vdb/pgvecto_rs/test_pgvecto_rs.py:9
  /home/runner/work/dify/dify/api/tests/integration_tests/vdb/pgvecto_rs/test_pgvecto_rs.py:9: PytestCollectionWarning: cannot collect test class 'TestPgvectoRSVector' because it has a __init__ constructor (from: tests/integration_tests/vdb/pgvecto_rs/test_pgvecto_rs.py)
    class TestPgvectoRSVector(AbstractVectorTest):
api/tests/integration_tests/vdb/pgvector/test_pgvector.py:10
  /home/runner/work/dify/dify/api/tests/integration_tests/vdb/pgvector/test_pgvector.py:10: PytestCollectionWarning: cannot collect test class 'TestPGVector' because it has a __init__ constructor (from: tests/integration_tests/vdb/pgvector/test_pgvector.py)
    class TestPGVector(AbstractVectorTest):
```
- logs: https://github.com/langgenius/dify/actions/runs/9386204004/job/25846210222?pr=4965#step:11:31

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
