### PR TITLE
fix: modal z-index and cleanup

### DIFF
--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -235,7 +235,6 @@ const AppPublisher = ({
         onClose={() => setEmbeddingModalOpen(false)}
         appBaseUrl={appBaseURL}
         accessToken={accessToken}
-        className='z-50'
       />
     </PortalToFollowElem >
   )

--- a/web/app/components/app/configuration/dataset-config/params-config/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/index.tsx
@@ -84,7 +84,6 @@ const ParamsConfig: FC = () => {
               setOpen(false)
             }}
             className='sm:min-w-[528px]'
-            wrapperClassName='z-50'
             title={t('appDebug.datasetConfig.settingTitle')}
           >
             <ConfigContent

--- a/web/app/components/app/configuration/toolbox/annotation/config-param-modal.tsx
+++ b/web/app/components/app/configuration/toolbox/annotation/config-param-modal.tsx
@@ -78,7 +78,6 @@ const ConfigParamModal: FC<Props> = ({
       isShow={isShow}
       onClose={onHide}
       className='!p-8 !pb-6 !mt-14 !max-w-none !w-[640px]'
-      wrapperClassName='!z-50'
     >
       <div className='mb-2 text-xl font-semibold text-[#1D2939]'>
         {t(`appAnnotation.initSetup.${isInit ? 'title' : 'configTitle'}`)}

--- a/web/app/components/base/drawer/index.tsx
+++ b/web/app/components/base/drawer/index.tsx
@@ -14,7 +14,6 @@ export type IDrawerProps = {
   mask?: boolean
   positionCenter?: boolean
   isOpen: boolean
-  // closable: boolean
   showClose?: boolean
   clickOutsideNotOpen?: boolean
   onClose: () => void

--- a/web/app/components/base/modal/delete-confirm-modal/index.tsx
+++ b/web/app/components/base/modal/delete-confirm-modal/index.tsx
@@ -2,7 +2,6 @@
 import type { FC } from 'react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import cn from 'classnames'
 import s from './style.module.css'
 import Modal from '@/app/components/base/modal'
 import Button from '@/app/components/base/button'

--- a/web/app/components/base/modal/delete-confirm-modal/index.tsx
+++ b/web/app/components/base/modal/delete-confirm-modal/index.tsx
@@ -31,8 +31,7 @@ const DeleteConfirmModal: FC<Props> = ({
     <Modal
       isShow={isShow}
       onClose={onHide}
-      wrapperClassName='z-50'
-      className={cn(s.delModal, 'z-50')}
+      className={s.delModal}
       closable
     >
       <div onClick={(e) => {

--- a/web/app/components/base/modal/index.css
+++ b/web/app/components/base/modal/index.css
@@ -1,5 +1,5 @@
 .modal-dialog {
-  @apply relative z-10;
+  @apply relative z-50;
 }
 
 .modal-panel {

--- a/web/app/components/datasets/documents/rename-modal.tsx
+++ b/web/app/components/datasets/documents/rename-modal.tsx
@@ -57,7 +57,6 @@ const RenameModal: FC<Props> = ({
       title={t('datasetDocuments.list.table.rename')}
       isShow
       onClose={onClose}
-      wrapperClassName='!z-50'
     >
       <div className={'mt-6 font-medium text-sm leading-[21px] text-gray-900'}>{t('datasetDocuments.list.table.name')}</div>
       <input className={'mt-2 w-full rounded-lg h-10 box-border px-3 text-sm leading-10 bg-gray-100'}

--- a/web/app/components/share/chat/sidebar/rename-modal/index.tsx
+++ b/web/app/components/share/chat/sidebar/rename-modal/index.tsx
@@ -28,7 +28,6 @@ const RenameModal: FC<IRenameModalProps> = ({
       title={t('common.chat.renameConversation')}
       isShow={isShow}
       onClose={onClose}
-      wrapperClassName='!z-50'
     >
       <div className={'mt-6 font-medium text-sm leading-[21px] text-gray-900'}>{t('common.chat.conversationName')}</div>
       <input className={'mt-2 w-full rounded-lg h-10 box-border px-3 text-sm leading-10 bg-gray-100'}

--- a/web/app/components/workflow/nodes/http/components/authorization/index.tsx
+++ b/web/app/components/workflow/nodes/http/components/authorization/index.tsx
@@ -87,7 +87,6 @@ const Authorization: FC<Props> = ({
   return (
     <Modal
       title={t(`${i18nPrefix}.authorization`)}
-      wrapperClassName='z-50 w-400'
       isShow={isShow}
       onClose={onHide}
     >


### PR DESCRIPTION
# Description

This PR addresses the z-index of modal components being too small and causing display problems. It changes the default z-index for modal components from 10 to 50, and removes manual z-50 settings using Tailwind in components via Dify.

![Screenshot from 2024-06-05 13-28-56](https://github.com/langgenius/dify/assets/8712755/dee57252-7ea7-42c2-8f27-3821e02930fc)
![Screenshot from 2024-06-05 13-29-06](https://github.com/langgenius/dify/assets/8712755/467163d6-d0cb-4556-93ae-fe72cf953654)
![Screenshot from 2024-06-05 13-29-11](https://github.com/langgenius/dify/assets/8712755/099deeac-abe3-487a-8d19-4dc96258c77e)


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

- [x] Tested fixing the display issues for modals.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
