### PR TITLE
fix: some base models cannot be selected in Azure OpenAI Service setting page

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -302,7 +302,7 @@ const ModelModal: FC<ModelModalProps> = ({
                 configurationMethod: configurateMethod,
               }} />
 
-              <div className='sticky bottom-0 flex justify-between items-center mt-2 -mx-2 pt-4 px-2 pb-6 flex-wrap gap-y-2 bg-white z-10'>
+              <div className='sticky bottom-0 flex justify-between items-center mt-2 -mx-2 pt-4 px-2 pb-6 flex-wrap gap-y-2 bg-white'>
                 {
                   (provider.help && (provider.help.title || provider.help.url))
                     ? (


### PR DESCRIPTION
# Description

In Model Provider setting page, when add Azure OpenAI Service model, some base models cannot be selected because of coverd by the bottom action div.
Fixed by removing the incorrect z-index of the bottom action div.

![20240606025628](https://github.com/langgenius/dify/assets/3824431/17859401-5ce9-47d6-bd5c-28931cdfc635)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After fix this, the base models can be selected correctly in Azure OpenAi and VolcanoEngine.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
