### PR TITLE
🔧 fix docker-compose ssrf_proxy service WARNING: You should probably remove '::/0' from the ACL named 'all' 

### DIFF
--- a/docker/volumes/ssrf_proxy/squid.conf
+++ b/docker/volumes/ssrf_proxy/squid.conf
@@ -46,5 +46,5 @@ logfile_rotate 0
 ################################## Reverse Proxy To Sandbox ################################
 http_port 8194 accel vhost
 cache_peer sandbox parent 8194 0 no-query originserver
-acl all src all
-http_access allow all
+acl src_all src all
+http_access allow src_all


### PR DESCRIPTION
🔧 fix(squid.conf): change ACL name from 'all' to 'src_all' to avoid conflict

Renamed the ACL name from 'all' to 'src_all'. This avoids conflicts with predefined keywords. It fixed "WARNING: You should probably remove '::/0' from the ACL named 'all'"

# Description

The ssrf_proxy serivce in docker-compose.yaml occrured waring.
```
ssrf_proxy-1  | 2024/06/06 16:47:51| Processing Configuration File: /etc/squid/squid.conf (depth 0)
ssrf_proxy-1  | 2024/06/06 16:47:51| WARNING: (B) '::/0' is a subnetwork of (A) '::/0'
ssrf_proxy-1  | 2024/06/06 16:47:51| WARNING: because of this '::/0' is ignored to keep splay tree searching predictable
ssrf_proxy-1  | 2024/06/06 16:47:51| WARNING: You should probably remove '::/0' from the ACL named 'all'
ssrf_proxy-1  | 2024/06/06 16:47:51| Created PID file (/run/squid.pid)
```
This is because, ACL 'all' is predefined in squid. 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I restarted and confirmed that the warning was gone.
``` shell
$ docker compose up ssrf_proxy 
Attaching to ssrf_proxy-1
ssrf_proxy-1  | 2024/06/06 16:50:12| Processing Configuration File: /etc/squid/squid.conf (depth 0)
ssrf_proxy-1  | 2024/06/06 16:50:12| Created PID file (/run/squid.pid)
ssrf_proxy-1  | 2024/06/06 16:50:12| Set Current Directory to /var/spool/squid
ssrf_proxy-1  | 2024/06/06 16:50:12| Creating missing swap directories
```

# Suggested Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
