### PR TITLE
Fix: fix load_yaml logging, Avoid setting the log level to warning

### DIFF
--- a/api/core/tools/utils/yaml_utils.py
+++ b/api/core/tools/utils/yaml_utils.py
@@ -4,6 +4,7 @@ import os
 import yaml
 from yaml import YAMLError
 
+logger = logging.getLogger(__name__)
 
 def load_yaml_file(file_path: str, ignore_error: bool = False) -> dict:
     """
@@ -24,11 +25,11 @@ def load_yaml_file(file_path: str, ignore_error: bool = False) -> dict:
             except Exception as e:
                 raise YAMLError(f'Failed to load YAML file {file_path}: {e}')
     except FileNotFoundError as e:
-        logging.debug(f'Failed to load YAML file {file_path}: {e}')
+        logger.debug(f'Failed to load YAML file {file_path}: {e}')
         return {}
     except Exception as e:
         if ignore_error:
-            logging.warning(f'Failed to load YAML file {file_path}: {e}')
+            logger.warning(f'Failed to load YAML file {file_path}: {e}')
             return {}
         else:
             raise e


### PR DESCRIPTION
# Description

logging.debug -> logger.debug. 
logging.debug is called at application startup, causing logging to execute an unexpected basic_config

```
def debug(msg, *args, **kwargs):
    """
    Log a message with severity 'DEBUG' on the root logger. If the logger has
    no handlers, call basicConfig() to add a console handler with a pre-defined
    format.
    """
    if len(root.handlers) == 0:
        basicConfig()
    root.debug(msg, *args, **kwargs)
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
