### PR TITLE
Fix language setting not success

### DIFF
--- a/web/app/components/header/account-setting/language-page/index.tsx
+++ b/web/app/components/header/account-setting/language-page/index.tsx
@@ -30,8 +30,8 @@ export default function LanguagePage() {
     setEditing(true)
     try {
       await updateUserProfile({ url, body: { [bodyKey]: item.value } })
-
       notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })
+
       setLocaleOnClient(item.value.toString())
     }
     catch (e) {
@@ -50,6 +50,7 @@ export default function LanguagePage() {
     try {
       await updateUserProfile({ url, body: { [bodyKey]: item.value } })
       notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })
+
       mutateUserProfile()
     }
     catch (e) {

--- a/web/app/components/header/account-setting/language-page/index.tsx
+++ b/web/app/components/header/account-setting/language-page/index.tsx
@@ -22,27 +22,40 @@ export default function LanguagePage() {
   const { notify } = useContext(ToastContext)
   const [editing, setEditing] = useState(false)
   const { t } = useTranslation()
-  const handleSelect = async (type: string, item: Item) => {
-    let url = ''
-    let bodyKey = ''
-    if (type === 'language') {
-      url = '/account/interface-language'
-      bodyKey = 'interface_language'
-      setLocaleOnClient(item.value.toString())
-    }
-    if (type === 'timezone') {
-      url = '/account/timezone'
-      bodyKey = 'timezone'
-    }
+
+  const handleSelectLanguage = async (item: Item) => {
+    const url = '/account/interface-language'
+    const bodyKey = 'interface_language'
+
+    setEditing(true)
     try {
-      setEditing(true)
       await updateUserProfile({ url, body: { [bodyKey]: item.value } })
+
       notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })
-      mutateUserProfile()
-      setEditing(false)
+      setLocaleOnClient(item.value.toString())
     }
     catch (e) {
       notify({ type: 'error', message: (e as Error).message })
+    }
+    finally {
+      setEditing(false)
+    }
+  }
+
+  const handleSelectTimezone = async (item: Item) => {
+    const url = '/account/timezone'
+    const bodyKey = 'timezone'
+
+    setEditing(true)
+    try {
+      await updateUserProfile({ url, body: { [bodyKey]: item.value } })
+      notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })
+      mutateUserProfile()
+    }
+    catch (e) {
+      notify({ type: 'error', message: (e as Error).message })
+    }
+    finally {
       setEditing(false)
     }
   }
@@ -54,7 +67,7 @@ export default function LanguagePage() {
         <SimpleSelect
           defaultValue={locale || userProfile.interface_language}
           items={languages.filter(item => item.supported)}
-          onSelect={item => handleSelect('language', item)}
+          onSelect={item => handleSelectLanguage(item)}
           disabled={editing}
         />
       </div>
@@ -63,7 +76,7 @@ export default function LanguagePage() {
         <SimpleSelect
           defaultValue={userProfile.timezone}
           items={timezones}
-          onSelect={item => handleSelect('timezone', item)}
+          onSelect={item => handleSelectTimezone(item)}
           disabled={editing}
         />
       </div>


### PR DESCRIPTION
# Description

I can reproduce the issue with my local code, but changing the language works fine on cloud.dify.ai. However, I believe there are still some areas for improvement.

On the language settings page, when changing the language, a request is posted to update the user profile. Before this request, the 'setLocaleOnClient' function is called, which reloads the page. In my local environment, the request to update the user profile does not get sent correctly.

As a result, the local context locale and the user profile in the database become inconsistent. For example, the local context locale is set to 'Chinese', but the user profile in the database remains 'English', this discrepancy causes issues such as the Explore page displaying the app list in English while other parts of the interface are in Chinese.

Additionally, since changing the language reloads the page, there is no need to call 'mutateUserProfile'.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
