### PR TITLE
fix: update presence_penalty configuration for wenxin AI ernie-4.0-8k and ernie-3.5-8k models

### DIFF
--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie-3.5-8k.yaml
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie-3.5-8k.yaml
@@ -22,6 +22,9 @@ parameter_rules:
     max: 2048
   - name: presence_penalty
     use_template: presence_penalty
+    default: 1.0
+    min: 1.0
+    max: 2.0
   - name: frequency_penalty
     use_template: frequency_penalty
   - name: response_format

--- a/api/core/model_runtime/model_providers/wenxin/llm/ernie-4.0-8k.yaml
+++ b/api/core/model_runtime/model_providers/wenxin/llm/ernie-4.0-8k.yaml
@@ -22,6 +22,9 @@ parameter_rules:
     max: 2048
   - name: presence_penalty
     use_template: presence_penalty
+    default: 1.0
+    min: 1.0
+    max: 2.0
   - name: frequency_penalty
     use_template: frequency_penalty
   - name: response_format


### PR DESCRIPTION
fix: update presence_penalty configuration for wenxin AI ernie-4.0-8k and ernie-3.5-8k models

# Description

This change updates the `presence_penalty` configuration in the Wenxin AI models `ernie-4.0-8k` and `ernie-3.5-8k`.  The following fields have been added:

```
- name: presence_penalty
  use_template: presence_penalty
  default: 1.0
  min: 1.0
  max: 2.0
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tests to verify these changes are still pending.
- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes