### PR TITLE
Fix: google storage init with sa and  download

### DIFF
--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -21,6 +21,7 @@ class GoogleStorage(BaseStorage):
         # if service_account_json_str is empty, use Application Default Credentials
         if service_account_json_str:
             service_account_json = base64.b64decode(service_account_json_str).decode('utf-8')
+            # convert str to object
             service_account_obj = json.loads(service_account_json)
             self.client = GoogleCloudStorage.Client.from_service_account_info(service_account_obj)
         else:

--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import io
 from collections.abc import Generator
 from contextlib import closing
@@ -20,7 +21,8 @@ class GoogleStorage(BaseStorage):
         # if service_account_json_str is empty, use Application Default Credentials
         if service_account_json_str:
             service_account_json = base64.b64decode(service_account_json_str).decode('utf-8')
-            self.client = GoogleCloudStorage.Client.from_service_account_info(service_account_json)
+            service_account_obj = json.loads(service_account_json)
+            self.client = GoogleCloudStorage.Client.from_service_account_info(service_account_obj)
         else:
             self.client = GoogleCloudStorage.Client()
 
@@ -48,9 +50,7 @@ class GoogleStorage(BaseStorage):
     def download(self, filename, target_filepath):
         bucket = self.client.get_bucket(self.bucket_name)
         blob = bucket.get_blob(filename)
-        with open(target_filepath, "wb") as my_blob:
-            blob_data = blob.download_blob()
-            blob_data.readinto(my_blob)
+        blob.download_to_filename(target_filepath)
 
     def exists(self, filename):
         bucket = self.client.get_bucket(self.bucket_name)

--- a/api/extensions/storage/google_storage.py
+++ b/api/extensions/storage/google_storage.py
@@ -1,6 +1,6 @@
 import base64
-import json
 import io
+import json
 from collections.abc import Generator
 from contextlib import closing
 


### PR DESCRIPTION
# Description

Fixed two problems when using Google Storage (STORAGE_TYPE=google-storage).
- When Service Account is specified, an error occurs when invoking init.
  - [from_service_account_info()](https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.client.Client#google_cloud_bigquery_client_Client_from_service_account_info) needs to specify a JSON object, not a JSON string
  - Change to pass after changing to a JSON object
- Error occurs when worker calls download when uploading files, etc.
  - Before the change, download_blob() does not exist.
  - Changed to use [download_to_filename()](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_download_to_filename)

Fixes # (issue)
 - none

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- [x] manual test

1. Create a Google Storage bucket
2. Create Service Account
3. Set a key to the created Service Account
4. Download and Base64 encode the key
5. Specify STORAGE_TYPE, GOOGLE_STORAGE_BUCKET_NAME, GOOGLE_STORAGE_SERVICE_ACCOUNT_JSON_BASE64 in environment variables

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
