### PR TITLE
fix: error in agent mode while using models not supporting tools

### DIFF
--- a/api/tests/unit_tests/core/prompt/test_agent_history_prompt_transform.py
+++ b/api/tests/unit_tests/core/prompt/test_agent_history_prompt_transform.py
@@ -11,6 +11,7 @@ from core.model_runtime.entities.message_entities import (
     ToolPromptMessage,
     UserPromptMessage,
 )
+from core.model_runtime.entities.model_entities import AIModelEntity, ModelFeature
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.prompt.agent_history_prompt_transform import AgentHistoryPromptTransform
 from models.model import Conversation
@@ -25,13 +26,17 @@ def test_get_prompt():
         SystemPromptMessage(content='System Prompt 1'),
         UserPromptMessage(content='User Prompt 1'),
         AssistantPromptMessage(content='Assistant Thought 1'),
-        ToolPromptMessage(content='Tool 1-1', name='Tool 1-1', tool_call_id='1'),
-        ToolPromptMessage(content='Tool 1-2', name='Tool 1-2', tool_call_id='2'),
+        ToolPromptMessage(content='Tool 1-1',
+                          name='Tool 1-1', tool_call_id='1'),
+        ToolPromptMessage(content='Tool 1-2',
+                          name='Tool 1-2', tool_call_id='2'),
         SystemPromptMessage(content='System Prompt 2'),
         UserPromptMessage(content='User Prompt 2'),
         AssistantPromptMessage(content='Assistant Thought 2'),
-        ToolPromptMessage(content='Tool 2-1', name='Tool 2-1', tool_call_id='3'),
-        ToolPromptMessage(content='Tool 2-2', name='Tool 2-2', tool_call_id='4'),
+        ToolPromptMessage(content='Tool 2-1',
+                          name='Tool 2-1', tool_call_id='3'),
+        ToolPromptMessage(content='Tool 2-2',
+                          name='Tool 2-2', tool_call_id='4'),
         UserPromptMessage(content='User Prompt 3'),
         AssistantPromptMessage(content='Assistant Thought 3'),
     ]
@@ -40,15 +45,20 @@ def test_get_prompt():
     def side_effect_get_num_tokens(*args):
         return len(args[2])
     large_language_model_mock = MagicMock(spec=LargeLanguageModel)
-    large_language_model_mock.get_num_tokens = MagicMock(side_effect=side_effect_get_num_tokens)
+    large_language_model_mock.get_num_tokens = MagicMock(
+        side_effect=side_effect_get_num_tokens)
 
     provider_model_bundle_mock = MagicMock(spec=ProviderModelBundle)
     provider_model_bundle_mock.model_type_instance = large_language_model_mock
+
+    model_entity_mock = MagicMock(spec=AIModelEntity)
+    model_entity_mock.features = [ModelFeature.TOOL_CALL]
 
     model_config_mock = MagicMock(spec=ModelConfigWithCredentialsEntity)
     model_config_mock.model = 'openai'
     model_config_mock.credentials = {}
     model_config_mock.provider_model_bundle = provider_model_bundle_mock
+    model_config_mock.model_schema = model_entity_mock
 
     memory = TokenBufferMemory(
         conversation=Conversation(),


### PR DESCRIPTION
# Description

In the "ReAct Agent" mode, after executing a tool, a "ToolPromptMessage" is saved. Since the model in "ReAct" mode definitely does not support function calling, it is unable to calculate the token count of the "ToolPromptMessage." The fix is to determine whether to calculate the token count of the "ToolPromptMessage" based on whether the model's feature supports "tool calling."

Fixes #5055

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] manual test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
