### PR TITLE
fix: wrong link to web app repo in chatflow mode

### DIFF
--- a/web/app/components/app/overview/customize/index.tsx
+++ b/web/app/components/app/overview/customize/index.tsx
@@ -44,7 +44,7 @@ const CustomizeModal: FC<IShareLinkProps> = ({
 }) => {
   const { t } = useTranslation()
   const { locale } = useContext(I18n)
-  const isChatApp = mode === 'chat'
+  const isChatApp = mode === 'chat' || mode === 'advanced-chat'
 
   return <Modal
     title={t(`${prefixCustomize}.title`)}


### PR DESCRIPTION
# Description

The link to the Dify Web Client is wrong for Chatflow Apps.
![image](https://github.com/langgenius/dify/assets/11357019/c7a1a3cf-b248-4bd3-b3d1-401b47410ba8)


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested it locally. To test it:
- [ ] Go to the overview page of a chatflow app
- [ ] Click the "Customize" button
- [ ] In the dialog, click the "Dify-WebClient" button
- [ ] The conversation app repo should open in a new tab: https://github.com/langgenius/webapp-conversation

Doing the same for workflow should send you to https://github.com/langgenius/webapp-text-generator

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
