### PR TITLE
fix: front end error when same tool is called twice at once

### DIFF
--- a/web/app/components/app/chat/thought/index.tsx
+++ b/web/app/components/app/chat/thought/index.tsx
@@ -47,7 +47,7 @@ const Thought: FC<IThoughtProps> = ({
   const toolThoughtList = toolNames.map((toolName, index) => {
     return {
       name: toolName,
-      label: thought.tool_labels?.[toolName][language] ?? toolName,
+      label: thought.tool_labels?.toolName?.language ?? toolName,
       input: getValue(thought.tool_input, isValueArray, index),
       output: getValue(thought.observation, isValueArray, index),
       isFinished,


### PR DESCRIPTION
# Description

This simple fix removes the requirement for the language field of the tool name. In some model providers the model is able to return two tool calls for the same tool at the same time. This causes the tool name to be returned as tool_name;tool_name, for example google_search;google_search, which does not have a language field due to the name mismatch. 

While this doesn't fully address the root cause of the error, the frontend shouldn't fail like this, it should handle the backend output gracefully.

![Screenshot from 2024-06-10 23-16-38](https://github.com/langgenius/dify/assets/8712755/3951456d-08c0-4da9-9195-98b0f6be2f3e)

You can easily replicate this with the following DSL with Gemini 1.5 Pro:

```yml
app:
  description: ''
  icon: scream
  icon_background: '#FFEAD5'
  mode: agent-chat
  name: POC
model_config:
  agent_mode:
    enabled: true
    max_iteration: 5
    strategy: function_call
    tools:
    - enabled: true
      isDeleted: false
      notAuthor: false
      provider_id: jina
      provider_name: jina
      provider_type: builtin
      tool_label: JinaReader
      tool_name: jina_reader
      tool_parameters:
        summary: ''
        target_selector: ''
        url: ''
        wait_for_selector: ''
  annotation_reply:
    enabled: false
  chat_prompt_config: {}
  completion_prompt_config: {}
  dataset_configs:
    datasets:
      datasets: []
    retrieval_model: single
  dataset_query_variable: ''
  external_data_tools: []
  file_upload:
    image:
      detail: high
      enabled: false
      number_limits: 3
      transfer_methods:
      - remote_url
      - local_file
  model:
    completion_params:
      stop: []
    mode: chat
    name: gemini-1.5-pro-latest
    provider: google
  more_like_this:
    enabled: false
  opening_statement: What would you like to do?
  pre_prompt: 'Please follow the tasks below:


    ### Tasks:

    1. Use the jina_reader tool to gather relevant information about the latest news
    from the url: "https://www.cnn.com/".

    2. Use the jina_reader tool to gather relevant information about the latest news
    from the url: "https://www.bbc.com/".

    3. After the two tool calls are returned, answer the user''s query to the best
    of your abilities. '
  prompt_type: simple
  retriever_resource:
    enabled: true
  sensitive_word_avoidance:
    configs: []
    enabled: false
    type: ''
  speech_to_text:
    enabled: false
  suggested_questions:
  - Please perform the tasks.
  suggested_questions_after_answer:
    enabled: true
  text_to_speech:
    enabled: false
    language: ''
    voice: ''
  user_input_form: []
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested working without error locally.

![Screenshot from 2024-06-10 23-22-04](https://github.com/langgenius/dify/assets/8712755/c58a9d48-2160-4dc5-a911-a740f037a4ef)


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
