### PR TITLE
fix: milvus_vector default dataset index_struct type from weaviate to milvus

### DIFF
--- a/api/core/rag/datasource/vdb/milvus/milvus_vector.py
+++ b/api/core/rag/datasource/vdb/milvus/milvus_vector.py
@@ -279,7 +279,7 @@ class MilvusVectorFactory(AbstractVectorFactory):
             dataset_id = dataset.id
             collection_name = Dataset.gen_collection_name_by_id(dataset_id)
             dataset.index_struct = json.dumps(
-                self.gen_index_struct_dict(VectorType.WEAVIATE, collection_name))
+                self.gen_index_struct_dict(VectorType.MILVUS, collection_name))
 
         config = current_app.config
         return MilvusVector(


### PR DESCRIPTION
# Description

The 'weaviate' vector type should not appear in milvus vector file, might be due to code reuse. vdb not working as expected.

![IMG_20240612_130609](https://github.com/langgenius/dify/assets/5120456/c2e2ecef-736a-4449-9881-1a7f4396eb75)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Set vector db to milvus, default dataset index_struct type now working as expected

- [X] Fix has been verified on the self-hosted version.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
