### PR TITLE
fix: select field not work when it is not required

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -210,7 +210,7 @@ class ToolManager:
         if parameter_rule.type == ToolParameter.ToolParameterType.SELECT:
             # check if tool_parameter_config in options
             options = list(map(lambda x: x.value, parameter_rule.options))
-            if parameter_value not in options:
+            if parameter_value is not None and parameter_value not in options:
                 raise ValueError(
                     f"tool parameter {parameter_rule.name} value {parameter_value} not in options {options}")
 

--- a/web/app/components/base/select/index.tsx
+++ b/web/app/components/base/select/index.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import React, { Fragment, useEffect, useState } from 'react'
 import { Combobox, Listbox, Transition } from '@headlessui/react'
 import classNames from 'classnames'
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/20/solid'
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import { useTranslation } from 'react-i18next'
 import {
   PortalToFollowElem,
@@ -184,11 +184,24 @@ const SimpleSelect: FC<ISelectProps> = ({
       <div className={`relative h-9 ${wrapperClassName}`}>
         <Listbox.Button className={`w-full h-full rounded-lg border-0 bg-gray-100 py-1.5 pl-3 pr-10 sm:text-sm sm:leading-6 focus-visible:outline-none focus-visible:bg-gray-200 group-hover:bg-gray-200 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className}`}>
           <span className={classNames('block truncate text-left', !selectedItem?.name && 'text-gray-400')}>{selectedItem?.name ?? localPlaceholder}</span>
-          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-            <ChevronDownIcon
-              className="h-5 w-5 text-gray-400"
-              aria-hidden="true"
-            />
+          <span className="absolute inset-y-0 right-0 flex items-center pr-2">
+            {selectedItem
+              ? (
+                <XMarkIcon
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setSelectedItem(null)
+                  }}
+                  className="h-5 w-5 text-gray-400 cursor-pointer"
+                  aria-hidden="false"
+                />
+              )
+              : (
+                <ChevronDownIcon
+                  className="h-5 w-5 text-gray-400"
+                  aria-hidden="true"
+                />
+              )}
           </span>
         </Listbox.Button>
         {!disabled && (


### PR DESCRIPTION
# Description

when I added a tool and use a non-required select form field, found 2 issues:

1. when the user not make choice of this field, it will raise some error like  `Failed to get tool runtime: tool parameter size value None not in options ['Small', 'Medium', 'Large', 'Wallpaper']`
2. when the user select an option of this field, he can not select it to None again, But it's a non-required  field.

I fix the raise error and add a clear btn for the select field.
![image](https://github.com/langgenius/dify/assets/25834719/2dc711ca-f09c-494b-8077-5bc83b5572b9)



## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?
I test it locally.

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
