### PR TITLE
fix: unnecessory data fetch when swithing apps category on explore page

### DIFF
--- a/web/hooks/use-tab-searchparams.ts
+++ b/web/hooks/use-tab-searchparams.ts
@@ -37,7 +37,7 @@ export const useTabSearchParams = ({
     setTab(newActiveTab)
     if (disableSearchParams)
       return
-    router[routingBehavior](`${pathName}?${searchParamName}=${newActiveTab}`)
+    history[`${routingBehavior}State`](null, '', `${pathName}?${searchParamName}=${newActiveTab}`)
   }
 
   return [activeTab, setActiveTab] as const

--- a/web/hooks/use-tab-searchparams.ts
+++ b/web/hooks/use-tab-searchparams.ts
@@ -1,4 +1,4 @@
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 
 type UseTabSearchParamsOptions = {
@@ -24,7 +24,6 @@ export const useTabSearchParams = ({
   searchParamName = 'category',
   disableSearchParams = false,
 }: UseTabSearchParamsOptions) => {
-  const router = useRouter()
   const pathName = usePathname()
   const searchParams = useSearchParams()
   const [activeTab, setTab] = useState<string>(


### PR DESCRIPTION
# Description

On the explore page, switching the apps category triggers a refetch of the allList data because the URL changes with the category as a search parameter via router push for sharing. Additionally, the category list sometimes renders in a different order.

To prevent page reload, it might be better to use the history API instead of route for changing the URL for sharing.

https://github.com/langgenius/dify/assets/3824431/6cc40514-8b13-4d28-a193-11863b65602a

## Type of Change

Please delete options that are not relevant.

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

1. on the explore page, apps category swith with the right data. No more data fetching. Url changed correctly with category search parameter.
2. open a new tab of the url with category search parameter, the correct category tab activated.
3. No error found on the studio page when add app with template.
4. No error found on the studio page and tools page when changing category or type.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
