### PR TITLE
feat: allow to use IAM Role for Bedrock

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/bedrock.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/bedrock.yaml
@@ -21,16 +21,16 @@ configurate_methods:
 provider_credential_schema:
   credential_form_schemas:
     - variable: aws_access_key_id
-      required: true
+      required: false
       label:
-        en_US: Access Key
+        en_US: Access Key (If not provided, credentials are obtained from your running environment. e.g. IAM role)
         zh_Hans: Access Key
       type: secret-input
       placeholder:
         en_US: Enter your Access Key
         zh_Hans: 在此输入您的 Access Key
     - variable: aws_secret_access_key
-      required: true
+      required: false
       label:
         en_US: Secret Access Key
         zh_Hans: Secret Access Key

--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -95,8 +95,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # - https://docs.anthropic.com/claude/reference/claude-on-amazon-bedrock
         # - https://github.com/anthropics/anthropic-sdk-python
         client = AnthropicBedrock(
-            aws_access_key=credentials["aws_access_key_id"],
-            aws_secret_key=credentials["aws_secret_access_key"],
+            aws_access_key=credentials.get("aws_access_key_id", None),
+            aws_secret_key=credentials.get("aws_secret_access_key", None),
             aws_region=credentials["aws_region"],
         )
 
@@ -568,8 +568,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         runtime_client = boto3.client(
             service_name='bedrock-runtime',
             config=client_config,
-            aws_access_key_id=credentials["aws_access_key_id"],
-            aws_secret_access_key=credentials["aws_secret_access_key"]
+            aws_access_key_id=credentials.get("aws_access_key_id", None),
+            aws_secret_access_key=credentials.get("aws_secret_access_key", None)
         )
 
         model_prefix = model.split('.')[0]

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -205,7 +205,7 @@ const ModelModal: FC<ModelModalProps> = ({
   const encodeSecretValues = useCallback((v: FormValue) => {
     const result = { ...v }
     extendedSecretFormSchemas.forEach(({ variable }) => {
-      if (result[variable] === formSchemasValue?.[variable])
+      if (result[variable] === formSchemasValue?.[variable] && result[variable] !== undefined)
         result[variable] = '[__HIDDEN__]'
     })
     return result


### PR DESCRIPTION
# Description

Fixes #3471 

This PR makes `aws_access_key_id` and `aws_secret_access_key` optional, and let boto to retrieve credentials from its execution environment.

## Type of Change

- [X] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

- [X] Run web and api locally, and confirmed it successfully uses credentials from running environment when access key is not provided.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
