### PR TITLE
fix: allow the name and icon of the web app to be set independently of that of the bot itself

### DIFF
--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -65,13 +65,6 @@ class AppSite(Resource):
             if value is not None:
                 setattr(site, attr_name, value)
 
-                if attr_name == 'title':
-                    app_model.name = value
-                elif attr_name == 'icon':
-                    app_model.icon = value
-                elif attr_name == 'icon_background':
-                    app_model.icon_background = value
-
         db.session.commit()
 
         return site


### PR DESCRIPTION
# Description

This PR allows users to change name and icon of the web app without changing that of the bot itself.

The name, icon, and description appear to be designed so that the bot and its web app can be configured to differ from each other. Currently we have following behavior:

- "Edit App Info" can change only the bot settings, as expected
- "WebApp Settings" change, contrary to expectations, change not only the web app but also the bot settings

This is introduced in #857, but this forces users to do the following three steps when they want to set different names or icons for the bot and its web app:

1. Changing the bot settings
2. Change web app settings
3. Undo changes to the bot that were made unintentionally

Related #5180, this PR partially reverts #857. I don't know the intent or purpose of #857, so if this PR is inappropriate, feel free to close it. Thanks.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create new app with customized name, icon, and background, then change the name, icon, and its background for the web app by `WebApp Settings` screen. Ensure the web app is updated as expected, and the name, icon, and its background for the bot is kept unchanged as expected.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
