### PR TITLE
fix: initialize site with customized icon and icon_background

### DIFF
--- a/api/events/event_handlers/create_site_record_when_app_created.py
+++ b/api/events/event_handlers/create_site_record_when_app_created.py
@@ -11,6 +11,8 @@ def handle(sender, **kwargs):
     site = Site(
         app_id=app.id,
         title=app.name,
+        icon = app.icon,
+        icon_background = app.icon_background,
         default_language=account.interface_language,
         customize_token_strategy='not_allow',
         code=Site.generate_code(16)


### PR DESCRIPTION
# Description

This PR ensures that the icon settings specified when creating the app are also reflected in its web app.

Related #5180

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create new app with default icon and default icon background, then publish the app. Ensure that the web app has default icon and there is no side effect of this PR.
- [x] Create new app with customized icon and icon background, then publish the app. Ensure that the web app has the same icon and background as the bot.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
