### PR TITLE
fix: ExtractSetting optional value missing None as default val

### DIFF
--- a/api/core/rag/extractor/entity/extract_setting.py
+++ b/api/core/rag/extractor/entity/extract_setting.py
@@ -44,10 +44,10 @@ class ExtractSetting(BaseModel):
     Model class for provider response.
     """
     datasource_type: str
-    upload_file: Optional[UploadFile]
-    notion_info: Optional[NotionInfo]
-    website_info: Optional[WebsiteInfo]
-    document_model: Optional[str]
+    upload_file: Optional[UploadFile] = None
+    notion_info: Optional[NotionInfo] = None
+    website_info: Optional[WebsiteInfo] = None
+    document_model: Optional[str] = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **data) -> None:


### PR DESCRIPTION
# Description

fix: ExtractSetting optional value missing None as default val

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
