### PR TITLE
fix: correct typos in the icons for microsoft

### DIFF
--- a/api/core/model_runtime/model_providers/azure_openai/_assets/icon_s_en.svg
+++ b/api/core/model_runtime/model_providers/azure_openai/_assets/icon_s_en.svg
@@ -1,5 +1,5 @@
 <svg width="21" height="22" viewBox="0 0 21 22" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="Microsfot">
+<g id="Microsoft">
 <rect id="Rectangle 1010" y="0.5" width="10" height="10" fill="#EF4F21"/>
 <rect id="Rectangle 1012" y="11.5" width="10" height="10" fill="#03A4EE"/>
 <rect id="Rectangle 1011" x="11" y="0.5" width="10" height="10" fill="#7EB903"/>

--- a/web/app/components/base/icons/assets/public/llm/microsoft.svg
+++ b/web/app/components/base/icons/assets/public/llm/microsoft.svg
@@ -1,5 +1,5 @@
 <svg width="21" height="22" viewBox="0 0 21 22" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="Microsfot">
+<g id="Microsoft">
 <rect id="Rectangle 1010" y="0.5" width="10" height="10" fill="#EF4F21"/>
 <rect id="Rectangle 1012" y="11.5" width="10" height="10" fill="#03A4EE"/>
 <rect id="Rectangle 1011" x="11" y="0.5" width="10" height="10" fill="#7EB903"/>

--- a/web/app/components/base/icons/src/public/llm/Microsoft.json
+++ b/web/app/components/base/icons/src/public/llm/Microsoft.json
@@ -15,7 +15,7 @@
 				"type": "element",
 				"name": "g",
 				"attributes": {
-					"id": "Microsfot"
+					"id": "Microsoft"
 				},
 				"children": [
 					{


### PR DESCRIPTION
# Description

Replace typoed `Microsfot` with `Microsoft` in some icons.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Not tested as I can't display any MS icons in any pages since I don't have any active subscriptions for Azure OpenAI Service (but I believe this PR breaks nothing).

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
