### PR TITLE
fix: embedding job fails using IAM role

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/bedrock.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/bedrock.yaml
@@ -23,7 +23,7 @@ provider_credential_schema:
     - variable: aws_access_key_id
       required: false
       label:
-        en_US: Access Key (If not provided, credentials are obtained from your running environment. e.g. IAM role)
+        en_US: Access Key (If not provided, credentials are obtained from the running environment.)
         zh_Hans: Access Key
       type: secret-input
       placeholder:

--- a/api/core/model_runtime/model_providers/bedrock/text_embedding/text_embedding.py
+++ b/api/core/model_runtime/model_providers/bedrock/text_embedding/text_embedding.py
@@ -49,8 +49,8 @@ class BedrockTextEmbeddingModel(TextEmbeddingModel):
         bedrock_runtime = boto3.client(
             service_name='bedrock-runtime',
             config=client_config,
-            aws_access_key_id=credentials["aws_access_key_id"],
-            aws_secret_access_key=credentials["aws_secret_access_key"]
+            aws_access_key_id=credentials.get("aws_access_key_id", None),
+            aws_secret_access_key=credentials.get("aws_secret_access_key", None)
         )
 
         embeddings = []


### PR DESCRIPTION
# Description

Related to #5188

Although we can now uses IAM role credentials when registering Bedrock models, the async embedding job fails due to a missing credential error.

The reason is that there is another code that references aws credentials, which this PR fixes. I confirmed there is no more place that uses these credentials by grep-ing `aws_access_key_id`.

I also edited the label a bit to make it fit with the component width.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] run embedding job locally and it sucesses.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
