### PR TITLE
fix: visioin model always with low quality

### DIFF
--- a/api/core/workflow/nodes/llm/llm_node.py
+++ b/api/core/workflow/nodes/llm/llm_node.py
@@ -12,7 +12,11 @@ from core.file.file_obj import FileVar
 from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_manager import ModelInstance, ModelManager
 from core.model_runtime.entities.llm_entities import LLMUsage
-from core.model_runtime.entities.message_entities import PromptMessage, PromptMessageContentType
+from core.model_runtime.entities.message_entities import (
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageContentType,
+)
 from core.model_runtime.entities.model_entities import ModelType
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.model_runtime.utils.encoders import jsonable_encoder
@@ -548,6 +552,7 @@ class LLMNode(BaseNode):
         stop = model_config.stop
 
         vision_enabled = node_data.vision.enabled
+        vision_detail = node_data.vision.configs.detail if node_data.vision.configs else None
         filtered_prompt_messages = []
         for prompt_message in prompt_messages:
             if prompt_message.is_empty():
@@ -556,7 +561,10 @@ class LLMNode(BaseNode):
             if not isinstance(prompt_message.content, str):
                 prompt_message_content = []
                 for content_item in prompt_message.content:
-                    if vision_enabled and content_item.type == PromptMessageContentType.IMAGE:
+                    if vision_enabled and content_item.type == PromptMessageContentType.IMAGE and isinstance(content_item, ImagePromptMessageContent):
+                        # Override vision config if LLM node has vision config
+                        if vision_detail:
+                            content_item.detail = ImagePromptMessageContent.DETAIL(vision_detail)
                         prompt_message_content.append(content_item)
                     elif content_item.type == PromptMessageContentType.TEXT:
                         prompt_message_content.append(content_item)


### PR DESCRIPTION
# Description

Fixes #5117 

The resolution parameter is stored in the LLM node's `node_data.vision.configs.detail`, but currently it's not used during prompt message generation.
The FileVar of the image is [generated using the `file_extra_config` ](https://github.com/langgenius/dify/blob/4f0488abb538944e8f7d317ff78d3dae34e5ad2f/api/core/file/message_file_parser.py#L145)created from [`workflow.features_dict` in the WorkflowAppGenerator](https://github.com/langgenius/dify/blob/4f0488abb538944e8f7d317ff78d3dae34e5ad2f/api/core/app/apps/workflow/app_generator.py#L55). I do not understand how the `detail` is set in this file_extra_config (perhaps it can be specified via the API?), but by default, the file_extra_config does not have a `detail` parameter, so[ the default LOW is set and always used](https://github.com/langgenius/dify/blob/4f0488abb538944e8f7d317ff78d3dae34e5ad2f/api/core/file/file_obj.py#L112).

In this PR, I have modified it to override with the detail of each node’s vision config during LLM Node execution. I wonder if this behavior is acceptable since the 'detail' in `file_extra_config` will never be used in the LLM node. 
Please let me know if any adjustments are needed, or feel free to close if this doesn't make sense.

Screenshot for verification:
![CleanShot 2024-06-15 at 18 06 17](https://github.com/langgenius/dify/assets/8503062/3d25a4a0-db01-4e19-b556-32d8bd2f8b17)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
