### PR TITLE
fix: respect the interface language specified by the user on the activation success screen

### DIFF
--- a/web/app/activate/activateForm.tsx
+++ b/web/app/activate/activateForm.tsx
@@ -86,7 +86,7 @@ const ActivateForm = () => {
           timezone,
         },
       })
-      setLocaleOnClient(language.startsWith('en') ? 'en-US' : 'zh-Hans', false)
+      setLocaleOnClient(language, false)
       setShowSuccess(true)
     }
     catch {


### PR DESCRIPTION
# Description

This PR changes activation success screen to display message in the user-provided interface language.

The implementation of fallback to `zh-Hans` if the specified language is not in `en-US` seems to have been introduced in #942.
At the time of #942, it seems that the only interface languages were `zh` or `en`, so that implementation was appropriate.

Now that a wide variety of languages are supported, it is more appropriate to simply use the language specified by the user instead of falling back to `zh`.

Fixes #5256

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Activate new user with non-`en` nor `zh` language. Ensure the success screen is displayed in the selected language instead of `zh`

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
