### PR TITLE
fix: run agent with Vertex AI Gemini models

### DIFF
--- a/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.0-pro-vision.yaml
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.0-pro-vision.yaml
@@ -3,9 +3,8 @@ label:
   en_US: Gemini 1.0 Pro Vision
 model_type: llm
 features:
+  - agent-thought
   - vision
-  - tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 16384

--- a/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.0-pro.yaml
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.0-pro.yaml
@@ -4,8 +4,6 @@ label:
 model_type: llm
 features:
   - agent-thought
-  - tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 32760

--- a/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.5-flash.yaml
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.5-flash.yaml
@@ -1,11 +1,10 @@
-model: gemini-1.5-flash-preview-0514
+model: gemini-1.5-flash-001
 label:
   en_US: Gemini 1.5 Flash
 model_type: llm
 features:
+  - agent-thought
   - vision
-  - tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 1048576

--- a/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.5-pro.yaml
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/gemini-1.5-pro.yaml
@@ -1,12 +1,10 @@
-model: gemini-1.5-pro-preview-0514
+model: gemini-1.5-pro-001
 label:
   en_US: Gemini 1.5 Pro
 model_type: llm
 features:
   - agent-thought
   - vision
-  - tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 1048576


### PR DESCRIPTION
# Description
When agent uses the Vertex AI Gemini models, if `tool-call` and `stream-tool-call` are enabled,  Errors will occur: "[vertex_ai] Error: module 'vertexai.generative_models' has no attribute 'Schema'". Use `agent-thought` to resolve this issue.


Fixes #4981 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
