### PR TITLE
chore: set build system to Poetry and remove unnecessary settings with package mode disabled 

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,10 @@
 [project]
 requires-python = ">=3.10"
 
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.ruff]
 exclude = [
 ]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -77,17 +77,9 @@ MOCK_SWITCH = "true"
 CODE_MAX_STRING_LENGTH = "80000"
 CODE_EXECUTION_ENDPOINT="http://127.0.0.1:8194"
 CODE_EXECUTION_API_KEY="dify-sandbox"
-
 FIRECRAWL_API_KEY = "fc-"
 
-
-
 [tool.poetry]
-name = "dify-api"
-version = "0.6.11"
-description = ""
-authors = ["Dify <hello@dify.ai>"]
-readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -84,6 +84,7 @@ CODE_EXECUTION_API_KEY="dify-sandbox"
 FIRECRAWL_API_KEY = "fc-"
 
 [tool.poetry]
+name = "dify-api"
 package-mode = false
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
# Description

- set Poetry in `[build-system]` to follow PEP 517 with official guidance: https://python-poetry.org/docs/pyproject/#poetry-and-pep-517. This has no impact on other tools like `pip install`.
- As the operating mode of Poetry is set via `package-mode = false`, the version , name , readme and authors are not required for the pre-checks during running `poetry install`.
- By skipping the version setting in `[tool.poetry]` section, it helps reduce the manual maintenance in this dedicated unused settings in `pyproject.tml` for Poetry.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
