### PR TITLE
fix: add event handler to delete the site when the related app deleted

### DIFF
--- a/api/events/event_handlers/__init__.py
+++ b/api/events/event_handlers/__init__.py
@@ -5,6 +5,7 @@ from .create_installed_app_when_app_created import handle
 from .create_site_record_when_app_created import handle
 from .deduct_quota_when_messaeg_created import handle
 from .delete_installed_app_when_app_deleted import handle
+from .delete_site_record_when_app_deleted import handle
 from .delete_tool_parameters_cache_when_sync_draft_workflow import handle
 from .delete_workflow_as_tool_when_app_deleted import handle
 from .update_app_dataset_join_when_app_model_config_updated import handle

--- a/api/events/event_handlers/delete_site_record_when_app_deleted.py
+++ b/api/events/event_handlers/delete_site_record_when_app_deleted.py
@@ -1,0 +1,11 @@
+from events.app_event import app_was_deleted
+from extensions.ext_database import db
+from models.model import Site
+
+
+@app_was_deleted.connect
+def handle(sender, **kwargs):
+    app = sender
+    site = db.session.query(Site).filter(Site.app_id == app.id).first()
+    db.session.delete(site)
+    db.session.commit()


### PR DESCRIPTION
# Description

This PR adds new event handler to delete the site record when the related app deleted.

**NOTE**: In my understanding, the current design allows only one site per app, so this PR uses `.first()` to find the site record to be deleted.

If there is a possibility that more than one site exists for a single app (currently, or in the future), and I would prefer to use `.all()`, please let me know so I can modify it.

Fixes #5280

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create and publish new app, then delete the app. Ensure the related site record is deleted from `sites` table

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
