### PR TITLE
fix: allow special characters in email

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -25,7 +25,7 @@ class TimestampField(fields.Raw):
 
 def email(email):
     # Define a regex pattern for email addresses
-    pattern = r"^[\w\.-]+@([\w-]+\.)+[\w-]{2,}$"
+    pattern = r"^[\w\.!#$%&'*+\-/=?^_`{|}~]+@([\w-]+\.)+[\w-]{2,}$"
     # Check if the email matches the pattern
     if re.match(pattern, email) is not None:
         return email

--- a/api/tests/unit_tests/libs/test_email.py
+++ b/api/tests/unit_tests/libs/test_email.py
@@ -1,0 +1,25 @@
+from libs.helper import email
+
+
+def test_email_with_valid_email():
+    assert email("test@example.com") == "test@example.com"
+    assert email("TEST12345@example.com") == "TEST12345@example.com"
+    assert email("test+test@example.com") == "test+test@example.com"
+    assert email("!#$%&'*+-/=?^_{|}~`@example.com") == "!#$%&'*+-/=?^_{|}~`@example.com"
+
+
+def test_email_with_invalid_email():
+    try:
+        email("invalid_email")
+    except ValueError as e:
+        assert str(e) == "invalid_email is not a valid email."
+
+    try:
+        email("@example.com")
+    except ValueError as e:
+        assert str(e) == "@example.com is not a valid email."
+
+    try:
+        email("()@example.com")
+    except ValueError as e:
+        assert str(e) == "()@example.com is not a valid email."

--- a/web/app/signin/normalForm.tsx
+++ b/web/app/signin/normalForm.tsx
@@ -7,11 +7,10 @@ import useSWR from 'swr'
 import Link from 'next/link'
 import Toast from '../components/base/toast'
 import style from './page.module.css'
-import { IS_CE_EDITION, SUPPORT_MAIL_LOGIN, apiPrefix } from '@/config'
+import { IS_CE_EDITION, SUPPORT_MAIL_LOGIN, apiPrefix, emailRegex } from '@/config'
 import Button from '@/app/components/base/button'
 import { login, oauth } from '@/service/common'
 import { getPurifyHref } from '@/utils'
-const validEmailReg = /^[\w\.-]+@([\w-]+\.)+[\w-]{2,}$/
 
 type IState = {
   formValid: boolean
@@ -78,7 +77,7 @@ const NormalForm = () => {
 
   const [isLoading, setIsLoading] = useState(false)
   const handleEmailPasswordLogin = async () => {
-    if (!validEmailReg.test(email)) {
+    if (!emailRegex.test(email)) {
       Toast.notify({
         type: 'error',
         message: t('login.error.emailInValid'),

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -102,7 +102,7 @@ export const DEFAULT_PARAGRAPH_VALUE_MAX_LEN = 1000
 
 export const zhRegex = /^[\u4E00-\u9FA5]$/m
 export const emojiRegex = /^[\uD800-\uDBFF][\uDC00-\uDFFF]$/m
-export const emailRegex = /^[\w\.-]+@([\w-]+\.)+[\w-]{2,}$/m
+export const emailRegex = /^[\w.!#$%&'*+\-/=?^{|}~]+@([\w-]+\.)+[\w-]{2,}$/m
 const MAX_ZN_VAR_NAME_LENGHT = 8
 const MAX_EN_VAR_VALUE_LENGHT = 30
 export const getMaxVarNameLength = (value: string) => {


### PR DESCRIPTION
# Description

Fixes the issue where inviting email addresses with a "+" fails with an "Invalid Email Format" error. It also supports other allowed characters `!#$%&'*+-/=?^_\`{|}~`. This is not intended to fully support RFC 5322. For example, consecutive dots (..) are invalid email addresses according to RFC 5322, but the original behavior does not reject them, and this pull request does not address that issue either.

Fixes #5325

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] add unit test and ran test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [x] `optional` I have added tests that prove my fix is effective or that my feature works
- [x] `optional` New and existing unit tests pass locally with my changes
