### PR TITLE
Update and fix the model param of Deepseek

### DIFF
--- a/api/core/model_runtime/model_providers/deepseek/llm/deepseek-chat.yaml
+++ b/api/core/model_runtime/model_providers/deepseek/llm/deepseek-chat.yaml
@@ -23,7 +23,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 32000
+    max: 4096
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.

--- a/api/core/model_runtime/model_providers/deepseek/llm/deepseek-coder.yaml
+++ b/api/core/model_runtime/model_providers/deepseek/llm/deepseek-coder.yaml
@@ -7,7 +7,7 @@ features:
   - agent-thought
 model_properties:
   mode: chat
-  context_size: 16000
+  context_size: 32000
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -22,5 +22,5 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     min: 1
-    max: 32000
+    max: 4096
     default: 1024


### PR DESCRIPTION
# Description

Deepseek just announce [their new models](https://mp.weixin.qq.com/s/XvDMVZmynO5MxxdpEo9hFg), and it claims that the backend models have been updated. However, after reviewing the code related to these two models, I found out that the max number of max_token is larger that what's set in [the official docs](https://platform.deepseek.com/api-docs/#token--token-usage:~:text=(1)%20The%20backend,32K%20context%20window.).

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The previous max_token setting could break the usage.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings