### PR TITLE
fix: wrong token usage in iteration node for streaming result

### DIFF
--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -367,7 +367,7 @@ class IterationNodeNextStreamResponse(StreamResponse):
 
 class IterationNodeCompletedStreamResponse(StreamResponse):
     """
-    NodeStartStreamResponse entity
+    NodeCompletedStreamResponse entity
     """
     class Data(BaseModel):
         """
@@ -385,6 +385,7 @@ class IterationNodeCompletedStreamResponse(StreamResponse):
         error: Optional[str] = None
         elapsed_time: float
         total_tokens: int
+        execution_metadata: Optional[dict] = None
         finished_at: int
         steps: int
 

--- a/api/core/app/task_pipeline/workflow_iteration_cycle_manage.py
+++ b/api/core/app/task_pipeline/workflow_iteration_cycle_manage.py
@@ -95,6 +95,9 @@ class WorkflowIterationCycleManage(WorkflowCycleStateManager):
                     error=None,
                     elapsed_time=time.perf_counter() - current_iteration.started_at,
                     total_tokens=current_iteration.total_tokens,
+                    execution_metadata={
+                        'total_tokens': current_iteration.total_tokens,
+                    },
                     finished_at=int(time.time()),
                     steps=current_iteration.current_index
                 )
@@ -276,6 +279,9 @@ class WorkflowIterationCycleManage(WorkflowCycleStateManager):
                     error=error,
                     elapsed_time=time.perf_counter() - current_iteration.started_at,
                     total_tokens=current_iteration.total_tokens,
+                    execution_metadata={
+                        'total_tokens': current_iteration.total_tokens,
+                    },
                     finished_at=int(time.time()),
                     steps=current_iteration.current_index
                 )


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #5323

The token usage of iteration node in run history is correct but not correct when the execution result is displayed via stream response.
The node component[ shows `execution_metadata.total_tokens` as the number of tokens](https://github.com/langgenius/dify/blob/main/web/app/components/workflow/run/node.tsx#L96) and task_pipeline stores [the accumulated token usage in the execution_metadata.total_tokens of iteration node](https://github.com/langgenius/dify/blob/d7213b12cc0998b83bb6b6c901549e57d43fa040/api/core/app/task_pipeline/workflow_iteration_cycle_manage.py#L225).  But it sets the token number t[o the top-level total_tokens field in stream response](https://github.com/langgenius/dify/blob/d7213b12cc0998b83bb6b6c901549e57d43fa040/api/core/app/task_pipeline/workflow_iteration_cycle_manage.py#L97) and lacks metadata_execution.

To fix the issue, this PR lets it respond token usage as execution_metadata in the stream response, as [in the LLM node](https://github.com/langgenius/dify/blob/d7213b12cc0998b83bb6b6c901549e57d43fa040/api/core/app/task_pipeline/workflow_cycle_manage.py#L387).
I didn't remove the existing total_tokens field as I'm not sure if it is not used.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I manually test it on local
![CleanShot 2024-06-18 at 01 37 48](https://github.com/langgenius/dify/assets/8503062/059d65f5-e5b0-48b0-87af-8adba11ab171)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
