### PR TITLE
Got dify running on Mac 14.1.2 (23B92) with colima

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -386,7 +386,7 @@ services:
       # postgres data directory
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
-      - ./volumes/db/data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     # uncomment to expose db(postgresql) port to host
     # ports:
     #   - "5432:5432"
@@ -402,7 +402,7 @@ services:
     restart: always
     volumes:
       # Mount the redis data directory to the container.
-      - ./volumes/redis/data:/data
+      - redis_data:/data
     # Set the redis password when startup redis server.
     command: redis-server --requirepass difyai123456
     healthcheck:
@@ -524,6 +524,9 @@ services:
     ports:
       - "80:80"
       #- "443:443"
+volumes:
+  postgres_data:
+  redis_data:
 networks:
   # create a network between sandbox, api and ssrf_proxy, and can not access outside.
   ssrf_proxy_network:

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,38 +1,33 @@
+upstream api {
+    server docker-api-1:5001;
+}
+
 server {
     listen 80;
     server_name _;
 
     location /console/api {
-      proxy_pass http://api:5001;
-      include proxy.conf;
+        proxy_pass http://api;
+        include proxy.conf;
     }
 
     location /api {
-      proxy_pass http://api:5001;
-      include proxy.conf;
+        proxy_pass http://api;
+        include proxy.conf;
     }
 
     location /v1 {
-      proxy_pass http://api:5001;
-      include proxy.conf;
+        proxy_pass http://api;
+        include proxy.conf;
     }
 
     location /files {
-      proxy_pass http://api:5001;
-      include proxy.conf;
+        proxy_pass http://api;
+        include proxy.conf;
     }
 
     location / {
-      proxy_pass http://web:3000;
-      include proxy.conf;
+        proxy_pass http://web:3000;
+        include proxy.conf;
     }
-
-    # If you want to support HTTPS, please uncomment the code snippet below
-    #listen 443 ssl;
-    #ssl_certificate ./../ssl/your_cert_file.cer;
-    #ssl_certificate_key ./../ssl/your_cert_key.key;
-    #ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
-    #ssl_prefer_server_ciphers on;
-    #ssl_session_cache shared:SSL:10m;
-    #ssl_session_timeout 10m;
 }


### PR DESCRIPTION
# Description

I ran into some problems getting dify to run on Mac Sonoma. 
## Permission denied errors with `docker-redis-` and `docker-db-1` that were solved by using docker volumes

db: `docker logs docker-db-1`

`chown: /var/lib/postgresql/data/pgdata: Permission denied`

redis: `docker logs docker-redis-1`

`permission denied`

## Connection refused when the console tried to connect to the port 5001 service

`docker logs docker-nginx-1`

```
2024/06/17 17:38:47 [error] 29#29: *3 connect() failed (111: Connection refused) while connecting to upstream, client: 172.30.0.1, server: _, request: "GET /console/api/setup HTTP/1.1", upstream: "http://172.30.0.8:5001/console/api/setup", host: "localhost", referrer: "http://localhost/install"
```


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

the sign-in page successfully appeared and I was able to create an account and go to the app. 


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes

# Environment
```
➜  docker git:(main) ✗ docker version
Client: Docker Engine - Community
 Version:           26.1.4
 API version:       1.45
 Go version:        go1.22.4
 Git commit:        5650f9b102
 Built:             Wed Jun  5 10:47:13 2024
 OS/Arch:           darwin/arm64
 Context:           colima

Server: Docker Engine - Community
 Engine:
  Version:          26.1.1
  API version:      1.45 (minimum version 1.24)
  Go version:       go1.21.9
  Git commit:       ac2de55
  Built:            Tue Apr 30 11:48:47 2024
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.6.31
  GitCommit:        e377cd56a71523140ca6ae87e30244719194a521
 runc:
  Version:          1.1.12
  GitCommit:        v1.1.12-0-g51d5e94
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```