### PR TITLE
fix: remove conversation_id description in completion-messages docs

### DIFF
--- a/web/app/components/develop/template/template.en.mdx
+++ b/web/app/components/develop/template/template.en.mdx
@@ -60,9 +60,6 @@ The text generation application offers non-session support and is ideal for tran
           User identifier, used to define the identity of the end-user for retrieval and statistics.
           Should be uniquely defined by the developer within the application.
       </Property>
-      <Property name='conversation_id' type='string' key='conversation_id'>
-      Converation ID, to continue the conversation based on previous chat records, it is necessary to pass the previous message's conversation_id.
-      </Property>
       <Property name='files' type='array[object]' key='files'>
           File list, suitable for inputting files (images) combined with text understanding and answering questions, available only when the model supports Vision capability.
           - `type` (string) Supported type: `image` (currently only supports image type)
@@ -79,7 +76,6 @@ The text generation application offers non-session support and is ideal for tran
     ### ChatCompletionResponse
     Returns the complete App result, `Content-Type` is `application/json`.
     - `message_id` (string) Unique message ID
-    - `conversation_id` (string) Conversation ID
     - `mode` (string) App mode, fixed as `chat`
     - `answer` (string) Complete response content
     - `metadata` (object) Metadata
@@ -99,13 +95,11 @@ The text generation application offers non-session support and is ideal for tran
     - `event: message` LLM returns text chunk event, i.e., the complete text is output in a chunked fashion.
       - `task_id` (string) Task ID, used for request tracking and the below Stop Generate API
       - `message_id` (string) Unique message ID
-      - `conversation_id` (string) Conversation ID
       - `answer` (string) LLM returned text chunk content
       - `created_at` (int) Creation timestamp, e.g., 1705395332
     - `event: message_end` Message end event, receiving this event means streaming has ended.
       - `task_id` (string) Task ID, used for request tracking and the below Stop Generate API
       - `message_id` (string) Unique message ID
-      - `conversation_id` (string) Conversation ID
       - `metadata` (object) Metadata
         - `usage` (Usage) Model usage information
         - `retriever_resources` (array[RetrieverResource]) Citation and Attribution List
@@ -113,7 +107,6 @@ The text generation application offers non-session support and is ideal for tran
       When output content moderation is enabled, if the content is flagged, then the message content will be replaced with a preset reply through this event.
       - `task_id` (string) Task ID, used for request tracking and the below Stop Generate API
       - `message_id` (string) Unique message ID
-      - `conversation_id` (string) Conversation ID
       - `answer` (string) Replacement content (directly replaces all LLM reply text)
       - `created_at` (int) Creation timestamp, e.g., 1705395332
     - `event: error`

--- a/web/app/components/develop/template/template.zh.mdx
+++ b/web/app/components/develop/template/template.zh.mdx
@@ -57,9 +57,6 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
         用户标识，用于定义终端用户的身份，方便检索、统计。
         由开发者定义规则，需保证用户标识在应用内唯一。
       </Property>
-      <Property name='conversation_id' type='string' key='conversation_id'>
-      （选填）会话 ID，需要基于之前的聊天记录继续对话，必须传之前消息的 conversation_id。
-      </Property>
       <Property name='files' type='array[object]' key='files'>
           上传的文件。
           - `type` (string) 支持类型：图片 `image`（目前仅支持图片格式） 。
@@ -79,7 +76,6 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     ### ChatCompletionResponse
     返回完整的 App 结果，`Content-Type` 为 `application/json`。
     - `message_id` (string) 消息唯一 ID
-    - `conversation_id` (string) 会话 ID
     - `mode` (string) App 模式，固定为 chat
     - `answer` (string) 完整回复内容
     - `metadata` (object) 元数据
@@ -99,13 +95,11 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     - `event: message` LLM 返回文本块事件，即：完整的文本以分块的方式输出。
       - `task_id` (string) 任务 ID，用于请求跟踪和下方的停止响应接口
       - `message_id` (string) 消息唯一 ID
-      - `conversation_id` (string) 会话 ID
       - `answer` (string) LLM 返回文本块内容
       - `created_at` (int) 创建时间戳，如：1705395332
     - `event: message_end` 消息结束事件，收到此事件则代表流式返回结束。
       - `task_id` (string) 任务 ID，用于请求跟踪和下方的停止响应接口
       - `message_id` (string) 消息唯一 ID
-      - `conversation_id` (string) 会话 ID
       - `metadata` (object) 元数据
         - `usage` (Usage) 模型用量信息
         - `retriever_resources` (array[RetrieverResource]) 引用和归属分段列表
@@ -113,7 +107,6 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       开启内容审查和审查输出内容时，若命中了审查条件，则会通过此事件替换消息内容为预设回复。
       - `task_id` (string) 任务 ID，用于请求跟踪和下方的停止响应接口
       - `message_id` (string) 消息唯一 ID
-      - `conversation_id` (string) 会话 ID
       - `answer` (string) 替换内容（直接替换 LLM 所有回复文本）
       - `created_at` (int) 创建时间戳，如：1705395332
     - `event: error`


### PR DESCRIPTION
# Description

remove `conversation_id` description in `completion-messages` mdx docs

Fixes https://github.com/langgenius/dify/issues/5356
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
