### PR TITLE
Fix: multi image preview sign

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -425,9 +425,9 @@ class DocumentSegment(db.Model):
     def get_sign_content(self):
         pattern = r"/files/([a-f0-9\-]+)/image-preview"
         text = self.content
-        match = re.search(pattern, text)
-
-        if match:
+        matches = re.finditer(pattern, text)
+        signed_urls = []
+        for match in matches:
             upload_file_id = match.group(1)
             nonce = os.urandom(16).hex()
             timestamp = str(int(time.time()))
@@ -437,8 +437,15 @@ class DocumentSegment(db.Model):
             encoded_sign = base64.urlsafe_b64encode(sign).decode()
 
             params = f"timestamp={timestamp}&nonce={nonce}&sign={encoded_sign}"
-            replacement = r"\g<0>?{params}".format(params=params)
-            text = re.sub(pattern, replacement, text)
+            signed_url = f"{match.group(0)}?{params}"
+            signed_urls.append((match.start(), match.end(), signed_url))
+
+        # Reconstruct the text with signed URLs
+        offset = 0
+        for start, end, signed_url in signed_urls:
+            text = text[:start + offset] + signed_url + text[end + offset:]
+            offset += len(signed_url) - (end - start)
+
         return text
 
 


### PR DESCRIPTION
# Description

Fix the image preview feature when the text includes multiple images. Currently, the code only matches the first pattern, it will cause all the image preview use the same sign.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
