### PR TITLE
fix: tongyi json output

### DIFF
--- a/api/tests/integration_tests/model_runtime/tongyi/test_response_format.py
+++ b/api/tests/integration_tests/model_runtime/tongyi/test_response_format.py
@@ -1,0 +1,84 @@
+import json
+import os
+from collections.abc import Generator
+
+from core.model_runtime.entities.llm_entities import LLMResultChunk, LLMResultChunkDelta
+from core.model_runtime.entities.message_entities import AssistantPromptMessage, UserPromptMessage
+from core.model_runtime.model_providers.tongyi.llm.llm import TongyiLargeLanguageModel
+
+
+def test_invoke_model_with_json_response():
+    """
+    Test the invocation of a model with JSON response.
+    """
+    model_list = [
+        "qwen-max-0403",
+        "qwen-max-1201",
+        "qwen-max-longcontext",
+        "qwen-max",
+        "qwen-plus-chat",
+        "qwen-plus",
+        "qwen-turbo-chat",
+        "qwen-turbo",
+    ]
+    for model_name in model_list:
+        print("testing model: ", model_name)
+        invoke_model_with_json_response(model_name)
+
+
+def invoke_model_with_json_response(model_name="qwen-max-0403"):
+    """
+    Method to invoke the model with JSON response format.
+    Args:
+        model_name (str): The name of the model to invoke. Defaults to "qwen-max-0403".
+
+    Returns:
+        None
+    """
+    model = TongyiLargeLanguageModel()
+
+    response = model.invoke(
+        model=model_name,
+        credentials={
+            'dashscope_api_key': os.environ.get('TONGYI_DASHSCOPE_API_KEY')
+        },
+        prompt_messages=[
+            UserPromptMessage(
+                content='output json data with format `{"data": "test", "code": 200, "msg": "success"}'
+            )
+        ],
+        model_parameters={
+            'temperature': 0.5,
+            'max_tokens': 50,
+            'response_format': 'JSON',
+        },
+        stream=True,
+        user="abc-123"
+    )
+    print("=====================================")
+    print(response)
+    assert isinstance(response, Generator)
+    output = ""
+    for chunk in response:
+        assert isinstance(chunk, LLMResultChunk)
+        assert isinstance(chunk.delta, LLMResultChunkDelta)
+        assert isinstance(chunk.delta.message, AssistantPromptMessage)
+        output += chunk.delta.message.content
+    assert is_json(output)
+
+
+def is_json(s):
+    """
+    Check if a string is a valid JSON.
+
+    Args:
+        s (str): The string to check.
+
+    Returns:
+        bool: True if the string is a valid JSON, False otherwise.
+    """
+    try:
+        json.loads(s)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://github.com/langgenius/dify/issues/5397

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## api change
Accroding to [tongyi api docs](!https://help.aliyun.com/document_detail/2712576.html). There's no different between chat models and completaion models. 

original code: in `api/core/model_runtime/model_providers/tongyi/llm/llm.py` line 245, 249 will cause prompt missing when using json response format
```
        else:
            if mode == LLMMode.CHAT:
                params['messages'] = self._convert_prompt_messages_to_tongyi_messages(prompt_messages)
            else:
                params['prompt'] = prompt_messages[0].content.rstrip()
```

## json parse change
as comment in file `api/core/model_runtime/model_providers/__base/large_language_model.py`, some LLM with directly output json data without markdown block 


## test result with same prompt

```
请按以下格式输出json数据 `{"data": "test", "code": 200, "msg": "success"}`
```

### before change

![image](https://github.com/langgenius/dify/assets/1918195/31efe2ec-0cd2-476f-aea2-41a5263fc5c6)


### after change

![image](https://github.com/langgenius/dify/assets/1918195/4d3b986d-bea5-4778-acad-a6bd09575c54)

- [ ] TODO raise a error when json output did not satisfy 

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
