### PR TITLE
fix: annotation id not pass to update setting

### DIFF
--- a/web/app/components/app/annotation/index.tsx
+++ b/web/app/components/app/annotation/index.tsx
@@ -41,6 +41,7 @@ const Annotation: FC<Props> = ({
   const fetchAnnotationConfig = async () => {
     const res = await doFetchAnnotationConfig(appDetail.id)
     setAnnotationConfig(res as AnnotationReplyConfig)
+    return (res as AnnotationReplyConfig).id
   }
   useEffect(() => {
     const isChatApp = appDetail.mode !== 'completion'
@@ -284,9 +285,9 @@ const Annotation: FC<Props> = ({
                 const { job_id: jobId }: any = await updateAnnotationStatus(appDetail.id, AnnotationEnableStatus.enable, embeddingModel, score)
                 await ensureJobCompleted(jobId, AnnotationEnableStatus.enable)
               }
-
+              const annotationId = await fetchAnnotationConfig()
               if (score !== annotationConfig?.score_threshold)
-                await updateAnnotationScore(appDetail.id, annotationConfig?.id || '', score)
+                await updateAnnotationScore(appDetail.id, annotationId, score)
 
               await fetchAnnotationConfig()
               Toast.notify({

--- a/web/app/components/app/configuration/toolbox/annotation/config-param.tsx
+++ b/web/app/components/app/configuration/toolbox/annotation/config-param.tsx
@@ -14,7 +14,8 @@ import TooltipPlus from '@/app/components/base/tooltip-plus'
 import { LinkExternal02, Settings04 } from '@/app/components/base/icons/src/vender/line/general'
 import ConfigContext from '@/context/debug-configuration'
 import type { EmbeddingModelConfig } from '@/app/components/app/annotation/type'
-import { updateAnnotationScore } from '@/service/annotation'
+import { fetchAnnotationConfig, updateAnnotationScore } from '@/service/annotation'
+import type { AnnotationReplyConfig as AnnotationReplyConfigType } from '@/models/debug'
 
 type Props = {
   onEmbeddingChange: (embeddingModel: EmbeddingModelConfig) => void
@@ -98,6 +99,7 @@ const AnnotationReplyConfig: FC<Props> = ({
             setIsShowEdit(false)
           }}
           onSave={async (embeddingModel, score) => {
+            const annotationConfig = await fetchAnnotationConfig(appId) as AnnotationReplyConfigType
             let isEmbeddingModelChanged = false
             if (
               embeddingModel.embedding_model_name !== annotationConfig.embedding_model.embedding_model_name


### PR DESCRIPTION
# Description

Annotation id not pass to update setting when first enable.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
