### PR TITLE
fix: resolve issue with embedding model field visibility toggling on datasets page

### DIFF
--- a/web/app/components/datasets/settings/form/index.tsx
+++ b/web/app/components/datasets/settings/form/index.tsx
@@ -194,7 +194,7 @@ const Form = () => {
           </div>
         </>
       )}
-      {currentDataset && currentDataset.indexing_technique === 'high_quality' && (
+      {indexMethod === 'high_quality' && (
         <div className={rowClass}>
           <div className={labelClass}>
             <div>{t('datasetSettings.form.embeddingModel')}</div>


### PR DESCRIPTION
When I add a dataset and jump to config page to change `index model` from `Economical` to `High Quality`.
![企业微信截图_17188965443566](https://github.com/langgenius/dify/assets/13617900/641001cb-12ea-423e-8527-10a59c39beb3)
