### PR TITLE
fix: zhipu tool calling, this PR fixes the bug described in issue #5496

### DIFF
--- a/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
@@ -10,8 +10,8 @@ from core.model_runtime.entities.message_entities import (
     PromptMessageRole,
     PromptMessageTool,
     SystemPromptMessage,
+    ToolPromptMessage,
     UserPromptMessage,
-    ToolPromptMessage
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel

--- a/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/llm.py
@@ -11,6 +11,7 @@ from core.model_runtime.entities.message_entities import (
     PromptMessageTool,
     SystemPromptMessage,
     UserPromptMessage,
+    ToolPromptMessage
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
@@ -462,6 +463,8 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
         elif isinstance(message, AssistantPromptMessage):
             message_text = f"{ai_prompt} {content}"
         elif isinstance(message, SystemPromptMessage):
+            message_text = content
+        elif isinstance(message, ToolPromptMessage):
             message_text = content
         else:
             raise ValueError(f"Got unknown type {message}")


### PR DESCRIPTION
# Description

Agent App with Zhipu GLM-4 Model and workflow tool always fails to get the response when asking the second question after the first tool calling is done.

reproduce steps:
1. select chat model to ZhiPu GLM-4 model
2. Create a agent app with a tool published by a workflow
3. Ask a question to the agent and it MUST invoke a tool for the question and the answer is feedbacked by the agent.
4. In the save conversation, then you ask the second question, the UI will pop an error message like 'Got unknown type role=<PromptMessageRole.TOOL: 'tool'> content='{"company_info": "[]", "register_info": "{\"company_info\": \"[]\"}"}' name='getCompanyInfo' tool_call_id='47e36eb3-a484-4eb9-955c-3122655d9143'

Fixes #5496 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please follow with the reproduce steps 

