### PR TITLE
fix: firecrawl apikey not start with fc-

### DIFF
--- a/web/app/components/header/account-setting/data-source-page/data-source-website/config-firecrawl-modal.tsx
+++ b/web/app/components/header/account-setting/data-source-page/data-source-website/config-firecrawl-modal.tsx
@@ -51,9 +51,6 @@ const ConfigFirecrawlModal: FC<Props> = ({
           field: 'API Key',
         })
       }
-      else if (!config.api_key.startsWith('fc-')) {
-        errorMsg = t(`${I18N_PREFIX}.apiKeyFormatError`)
-      }
     }
 
     if (errorMsg) {

--- a/web/i18n/en-US/dataset-creation.ts
+++ b/web/i18n/en-US/dataset-creation.ts
@@ -13,8 +13,7 @@ const translation = {
   },
   firecrawl: {
     configFirecrawl: 'Configure 🔥Firecrawl',
-    apiKeyPlaceholder: 'API key from firecrawl.dev, starting with "fc-"',
-    apiKeyFormatError: 'API key should start with "fc-"',
+    apiKeyPlaceholder: 'API key from firecrawl.dev',
     getApiKeyLinkText: 'Get your API key from firecrawl.dev',
   },
   stepOne: {

--- a/web/i18n/hi-IN/dataset-creation.ts
+++ b/web/i18n/hi-IN/dataset-creation.ts
@@ -13,8 +13,7 @@ const translation = {
   },
   firecrawl: {
     configFirecrawl: '🔥फायरक्रॉल को कॉन्फ़िगर करें',
-    apiKeyPlaceholder: 'firecrawl.dev से API कुंजी, "fc-" से शुरू होती है',
-    apiKeyFormatError: 'API कुंजी "fc-" से शुरू होनी चाहिए',
+    apiKeyPlaceholder: 'firecrawl.dev से API कुंजी',
     getApiKeyLinkText: 'firecrawl.dev से अपनी API कुंजी प्राप्त करें',
   },
   stepOne: {

--- a/web/i18n/zh-Hans/dataset-creation.ts
+++ b/web/i18n/zh-Hans/dataset-creation.ts
@@ -13,8 +13,7 @@ const translation = {
   },
   firecrawl: {
     configFirecrawl: '配置 🔥Firecrawl',
-    apiKeyPlaceholder: '从 firecrawl.dev 获取 API Key，以 "fc-" 开头',
-    apiKeyFormatError: 'API Key 应以 "fc-" 开头',
+    apiKeyPlaceholder: '从 firecrawl.dev 获取 API Key',
     getApiKeyLinkText: '从 firecrawl.dev 获取您的 API Key',
   },
   stepOne: {


### PR DESCRIPTION
# Description

Firecrawl apikey not start with fc- anymore.So change the check rule.

Fixes https://github.com/langgenius/dify/issues/5497


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
