### PR TITLE
feat: make Citations and Attributions display enable default

### DIFF
--- a/api/constants/model_template.py
+++ b/api/constants/model_template.py
@@ -22,7 +22,7 @@ default_app_templates = {
         'model_config': {
             'model': {
                 "provider": "openai",
-                "name": "gpt-4",
+                "name": "gpt-4o",
                 "mode": "chat",
                 "completion_params": {}
             },
@@ -51,7 +51,7 @@ default_app_templates = {
         'model_config': {
             'model': {
                 "provider": "openai",
-                "name": "gpt-4",
+                "name": "gpt-4o",
                 "mode": "chat",
                 "completion_params": {}
             }
@@ -77,7 +77,7 @@ default_app_templates = {
         'model_config': {
             'model': {
                 "provider": "openai",
-                "name": "gpt-4",
+                "name": "gpt-4o",
                 "mode": "chat",
                 "completion_params": {}
             }

--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -84,6 +84,10 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
             workflow=workflow
         )
 
+        if invoke_from == InvokeFrom.DEBUGGER:
+            # always enable retriever resource in debugger mode
+            app_config.additional_features.show_retrieve_source = True
+
         # init application generate entity
         application_generate_entity = AdvancedChatAppGenerateEntity(
             task_id=str(uuid.uuid4()),

--- a/api/core/app/apps/agent_chat/app_generator.py
+++ b/api/core/app/apps/agent_chat/app_generator.py
@@ -82,6 +82,11 @@ class AgentChatAppGenerator(MessageBasedAppGenerator):
                 config=args.get('model_config')
             )
 
+            # always enable retriever resource in debugger mode
+            override_model_config_dict["retriever_resource"] = {
+                "enabled": True
+            }
+
         # parse files
         files = args['files'] if args.get('files') else []
         message_file_parser = MessageFileParser(tenant_id=app_model.tenant_id, app_id=app_model.id)

--- a/api/core/app/apps/chat/app_config_manager.py
+++ b/api/core/app/apps/chat/app_config_manager.py
@@ -50,6 +50,9 @@ class ChatAppConfigManager(BaseAppConfigManager):
             app_model_config_dict = app_model_config.to_dict()
             config_dict = app_model_config_dict.copy()
         else:
+            if not override_config_dict:
+                raise Exception('override_config_dict is required when config_from is ARGS')
+
             config_dict = override_config_dict
 
         app_mode = AppMode.value_of(app_model.mode)

--- a/api/core/app/apps/chat/app_generator.py
+++ b/api/core/app/apps/chat/app_generator.py
@@ -79,6 +79,11 @@ class ChatAppGenerator(MessageBasedAppGenerator):
                 config=args.get('model_config')
             )
 
+            # always enable retriever resource in debugger mode
+            override_model_config_dict["retriever_resource"] = {
+                "enabled": True
+            }
+
         # parse files
         files = args['files'] if args.get('files') else []
         message_file_parser = MessageFileParser(tenant_id=app_model.tenant_id, app_id=app_model.id)

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -265,7 +265,7 @@ class AppModelConfig(db.Model):
     @property
     def retriever_resource_dict(self) -> dict:
         return json.loads(self.retriever_resource) if self.retriever_resource \
-            else {"enabled": False}
+            else {"enabled": True}
 
     @property
     def annotation_reply_dict(self) -> dict:

--- a/web/app/components/workflow/hooks/use-workflow.ts
+++ b/web/app/components/workflow/hooks/use-workflow.ts
@@ -485,7 +485,9 @@ export const useWorkflowInit = () => {
                   nodes: nodesTemplate,
                   edges: edgesTemplate,
                 },
-                features: {},
+                features: {
+                  retriever_resource: { enabled: true },
+                },
               },
             }).then((res) => {
               workflowStore.getState().setDraftUpdatedAt(res.updated_at)


### PR DESCRIPTION
# Description

1. Default opens the `Citations and Attributions` display when debugging in agent and chatbot app.
2. When creating a new app for the agent and chatbot, the `Citations and Attributions` display is default enabled.

## Type of Change

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

- [x] Manual test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
