### PR TITLE
fix: apply best practices for the latest buildkit

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM python:3.10-slim-bookworm as base
+FROM python:3.10-slim-bookworm AS base
 
 WORKDIR /app/api
 
@@ -14,7 +14,7 @@ ENV POETRY_NO_INTERACTION=1
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV POETRY_VIRTUALENVS_CREATE=true
 
-FROM base as packages
+FROM base AS packages
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc g++ libc-dev libffi-dev libgmp-dev libmpfr-dev libmpc-dev
@@ -27,18 +27,18 @@ RUN poetry install --sync --no-cache --no-root
 # production stage
 FROM base AS production
 
-ENV FLASK_APP app.py
-ENV EDITION SELF_HOSTED
-ENV DEPLOY_ENV PRODUCTION
-ENV CONSOLE_API_URL http://127.0.0.1:5001
-ENV CONSOLE_WEB_URL http://127.0.0.1:3000
-ENV SERVICE_API_URL http://127.0.0.1:5001
-ENV APP_WEB_URL http://127.0.0.1:3000
+ENV FLASK_APP=app.py
+ENV EDITION=SELF_HOSTED
+ENV DEPLOY_ENV=PRODUCTION
+ENV CONSOLE_API_URL=http://127.0.0.1:5001
+ENV CONSOLE_WEB_URL=http://127.0.0.1:3000
+ENV SERVICE_API_URL=http://127.0.0.1:5001
+ENV APP_WEB_URL=http://127.0.0.1:3000
 
 EXPOSE 5001
 
 # set timezone
-ENV TZ UTC
+ENV TZ=UTC
 
 WORKDIR /app/api
 
@@ -61,6 +61,6 @@ RUN chmod +x /entrypoint.sh
 
 
 ARG COMMIT_SHA
-ENV COMMIT_SHA ${COMMIT_SHA}
+ENV COMMIT_SHA=${COMMIT_SHA}
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache tzdata
 
 
 # install packages
-FROM base as packages
+FROM base AS packages
 
 WORKDIR /app/web
 
@@ -22,7 +22,7 @@ COPY yarn.lock .
 RUN yarn install --frozen-lockfile
 
 # build resources
-FROM base as builder
+FROM base AS builder
 WORKDIR /app/web
 COPY --from=packages /app/web/ .
 COPY . .
@@ -31,17 +31,17 @@ RUN yarn build
 
 
 # production stage
-FROM base as production
+FROM base AS production
 
-ENV NODE_ENV production
-ENV EDITION SELF_HOSTED
-ENV DEPLOY_ENV PRODUCTION
-ENV CONSOLE_API_URL http://127.0.0.1:5001
-ENV APP_API_URL http://127.0.0.1:5001
-ENV PORT 3000
+ENV NODE_ENV=production
+ENV EDITION=SELF_HOSTED
+ENV DEPLOY_ENV=PRODUCTION
+ENV CONSOLE_API_URL=http://127.0.0.1:5001
+ENV APP_API_URL=http://127.0.0.1:5001
+ENV PORT=3000
 
 # set timezone
-ENV TZ UTC
+ENV TZ=UTC
 RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone
 
@@ -59,7 +59,7 @@ COPY docker/pm2.json ./pm2.json
 COPY docker/entrypoint.sh ./entrypoint.sh
 
 ARG COMMIT_SHA
-ENV COMMIT_SHA ${COMMIT_SHA}
+ENV COMMIT_SHA=${COMMIT_SHA}
 
 EXPOSE 3000
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]


### PR DESCRIPTION
# Description

This PR fixes the lines in Dockerfile that does not follow the best practices.

The current Dockerfiles result following warnings due to newly introduced validation in BuildKit 0.14.0:

```bash
# build api with buildkit 0.14.1
$ docker buildx build --load .
...
 11 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 17)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 30)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 31)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 32)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 33)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 34)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 35)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 36)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 41)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 64)
...

# build web with buildkit 0.14.1
$ docker buildx build --load .
...
 11 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 12)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 25)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 34)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 36)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 37)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 38)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 39)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 40)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 41)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 44)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 62)
```

This also happened in the GHA:

- https://github.com/langgenius/dify/actions/runs/9626335852/job/26552194930#step:7:415
- https://github.com/langgenius/dify/actions/runs/9626335852/job/26552194791#step:7:500

We should follow:

- https://docs.docker.com/reference/build-checks/from-as-casing/
- https://docs.docker.com/reference/build-checks/legacy-key-value-format/

Fixes #5512 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] After applying this PR, ensure the command `docker buildx build --load .` does not show any warnings
- [x] After applying this PR, ensure the BuildKit 0.13.2, which is prior to 0.14.0, can be used to build without problems, means no side effects.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
