### PR TITLE
The firecrawl tool now supports self-hosting

### DIFF
--- a/api/core/tools/provider/builtin/firecrawl/firecrawl.yaml
+++ b/api/core/tools/provider/builtin/firecrawl/firecrawl.yaml
@@ -25,3 +25,12 @@ credentials_for_provider:
       en_US: Get your Firecrawl API key from your Firecrawl account settings.
       zh_CN: 从您的 Firecrawl 账户设置中获取 Firecrawl API 密钥。
     url: https://www.firecrawl.dev/account
+  base_url:
+    type: text-input
+    required: false
+    label:
+      en_US: Firecrawl server's Base URL
+      pt_BR: Firecrawl server's Base URL
+    placeholder:
+      en_US: https://www.firecrawl.dev
+      pt_BR: https://www.firecrawl.dev

--- a/api/core/tools/provider/builtin/firecrawl/firecrawl_appx.py
+++ b/api/core/tools/provider/builtin/firecrawl/firecrawl_appx.py
@@ -1,0 +1,96 @@
+import time
+import requests
+
+class FirecrawlApp:
+    def __init__(self, api_key=None, base_url=None):
+        self.api_key = api_key
+        self.base_url = base_url or 'https://api.firecrawl.dev'
+        if self.api_key is None and self.base_url == 'https://api.firecrawl.dev':
+            raise ValueError('No API key provided')
+
+    def scrape_url(self, url, params=None) -> dict:
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {self.api_key}'
+        }
+        json_data = {'url': url}
+        if params:
+            json_data.update(params)
+        response = requests.post(
+            f'{self.base_url}/v0/scrape',
+            headers=headers,
+            json=json_data
+        )
+        if response.status_code == 200:
+            response = response.json()
+            if response['success'] == True:
+                return response['data']
+            else:
+                raise Exception(f'Failed to scrape URL. Error: {response["error"]}')
+
+        elif response.status_code in [402, 409, 500]:
+            error_message = response.json().get('error', 'Unknown error occurred')
+            raise Exception(f'Failed to scrape URL. Status code: {response.status_code}. Error: {error_message}')
+        else:
+            raise Exception(f'Failed to scrape URL. Status code: {response.status_code}')
+
+    def crawl_url(self, url, params=None, wait_until_done=True, timeout=2) -> str:
+        headers = self._prepare_headers()
+        json_data = {'url': url}
+        if params:
+            json_data.update(params)
+        response = self._post_request(f'{self.base_url}/v0/crawl', json_data, headers)
+        if response.status_code == 200:
+            job_id = response.json().get('jobId')
+            if wait_until_done:
+                return self._monitor_job_status(job_id, headers, timeout)
+            else:
+                return {'jobId': job_id}
+        else:
+            self._handle_error(response, 'start crawl job')
+
+    def check_crawl_status(self, job_id) -> dict:
+        headers = self._prepare_headers()
+        response = self._get_request(f'{self.base_url}/v0/crawl/status/{job_id}', headers)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            self._handle_error(response, 'check crawl status')
+
+    def _prepare_headers(self):
+        return {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {self.api_key}'
+        }
+
+    def _post_request(self, url, data, headers):
+        return requests.post(url, headers=headers, json=data)
+
+    def _get_request(self, url, headers):
+        return requests.get(url, headers=headers)
+
+    def _monitor_job_status(self, job_id, headers, timeout):
+        while True:
+            status_response = self._get_request(f'{self.base_url}/v0/crawl/status/{job_id}', headers)
+            if status_response.status_code == 200:
+                status_data = status_response.json()
+                if status_data['status'] == 'completed':
+                    if 'data' in status_data:
+                        return status_data['data']
+                    else:
+                        raise Exception('Crawl job completed but no data was returned')
+                elif status_data['status'] in ['active', 'paused', 'pending', 'queued']:
+                    if timeout < 2:
+                        timeout = 2
+                    time.sleep(timeout)  # Wait for the specified timeout before checking again
+                else:
+                    raise Exception(f'Crawl job failed or was stopped. Status: {status_data["status"]}')
+            else:
+                self._handle_error(status_response, 'check crawl status')
+
+    def _handle_error(self, response, action):
+        if response.status_code in [402, 409, 500]:
+            error_message = response.json().get('error', 'Unknown error occurred')
+            raise Exception(f'Failed to {action}. Status code: {response.status_code}. Error: {error_message}')
+        else:
+            raise Exception(f'Unexpected error occurred while trying to {action}. Status code: {response.status_code}')

--- a/api/core/tools/provider/builtin/firecrawl/firecrawl_appx.py
+++ b/api/core/tools/provider/builtin/firecrawl/firecrawl_appx.py
@@ -1,5 +1,7 @@
-import requests
 import time
+
+import requests
+
 
 class FirecrawlApp:
     def __init__(self, api_key=None, base_url=None):

--- a/api/core/tools/provider/builtin/firecrawl/firecrawl_appx.py
+++ b/api/core/tools/provider/builtin/firecrawl/firecrawl_appx.py
@@ -1,5 +1,5 @@
-import time
 import requests
+import time
 
 class FirecrawlApp:
     def __init__(self, api_key=None, base_url=None):

--- a/api/core/tools/provider/builtin/firecrawl/tools/crawl.py
+++ b/api/core/tools/provider/builtin/firecrawl/tools/crawl.py
@@ -1,7 +1,7 @@
 from typing import Any, Union
 
-from core.tools.provider.builtin.firecrawl.firecrawl_appx import FirecrawlApp
 from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.provider.builtin.firecrawl.firecrawl_appx import FirecrawlApp
 from core.tools.tool.builtin_tool import BuiltinTool
 
 

--- a/api/core/tools/provider/builtin/firecrawl/tools/crawl.py
+++ b/api/core/tools/provider/builtin/firecrawl/tools/crawl.py
@@ -1,7 +1,6 @@
 from typing import Any, Union
 
-from firecrawl import FirecrawlApp
-
+from core.tools.provider.builtin.firecrawl.firecrawl_appx import FirecrawlApp
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 
@@ -9,7 +8,7 @@ from core.tools.tool.builtin_tool import BuiltinTool
 class CrawlTool(BuiltinTool):
     def _invoke(self, user_id: str, tool_parameters: dict[str, Any]) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
         # initialize the app object with the api key
-        app = FirecrawlApp(api_key=self.runtime.credentials['firecrawl_api_key'])
+        app = FirecrawlApp(api_key=self.runtime.credentials['firecrawl_api_key'], base_url=self.runtime.credentials['base_url'])
 
         options = {
             'crawlerOptions': {


### PR DESCRIPTION
# Description
Fixed to allow the base url to be entered into the firecrawl tool to use a self-hosted built firecrawl.
※ Similar pull request　[https://github.com/langgenius/dify/pull/5519](https://github.com/langgenius/dify/pull/5519)

## Type of change

Remove any options that are not relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes an existing feature to stop working as expected)
- [ ] This change requires an update to the following documentation: [Dify documentation](https://github.com/langgenius/dify-docs)
- [x] Improvements, including but not limited to code refactoring, performance optimizations, and UI/UX improvements
- [ ] Dependency upgrade

# How was it tested?
The following tests were performed on WSL on Windows.

## How the firecrawl tool works
- [ ] Verify that you can connect to https://api.firecrawl.dev with the apiKey and no base_url
- [ ] Verify that you can connect to the self-hosted firecrawl with the apiKey and base_url (self-hosted firecrawl)

# Recommended checklist:

- [x] I self-reviewed my code
- [x] I commented my code, especially in the parts that were hard to understand
- [x] The change did not generate any new warnings
- [ ] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
- [ ] I made the corresponding change to the `optional` documentation
- [] I added a test that proves that the `optional` fix is ​​valid or that the feature works
- [] `optional` The change caused new and existing unit tests to pass locally