### PR TITLE
fix: remove obsoleted 'version' elements in compose files

### DIFF
--- a/docker/docker-compose.chroma.yaml
+++ b/docker/docker-compose.chroma.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # Chroma vector store.
   chroma:

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # The postgres database.
   db:

--- a/docker/docker-compose.opensearch.yml
+++ b/docker/docker-compose.opensearch.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   opensearch: # This is also the hostname of the container within the Docker network (i.e. https://opensearch/)
     image: opensearchproject/opensearch:latest # Specifying the latest available image - modify if you want a specific version

--- a/docker/docker-compose.oracle.yaml
+++ b/docker/docker-compose.oracle.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # oracle 23 ai vector store.
   oracle:

--- a/docker/docker-compose.pgvecto-rs.yaml
+++ b/docker/docker-compose.pgvecto-rs.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # The pgvecto—rs database.
   pgvecto-rs:

--- a/docker/docker-compose.pgvector.yaml
+++ b/docker/docker-compose.pgvector.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # Qdrant vector store.
   pgvector:

--- a/docker/docker-compose.qdrant.yaml
+++ b/docker/docker-compose.qdrant.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # Qdrant vector store.
   qdrant:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # API service
   api:


### PR DESCRIPTION
# Description

This PR removes the line `version: '3'` from all `docker-compose*.yaml` files.

The `version` element is already obsoleted, and causes warning to be shown in the newer compose plugin:

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative and you'll receive a warning message that it is obsolete if used.
> https://docs.docker.com/compose/compose-file/04-version-and-name/

Example warnings are here; the same warning will be shown on any other `docker compose` commands:

```bash
$ docker compose up -d
WARN[0000] /home/********/dify/docker/docker-compose.yaml: `version` is obsolete      👈👈👈👈👈
[+] Running 12/12
 ✔ Network docker_ssrf_proxy_network  Created                                                                                                                                                                   0.1s 
 ✔ Network docker_default             Created                                                                                                                                                                   0.1s 
 ✔ Container docker-sandbox-1         Started                                                                                                                                                                   0.5s 
 ✔ Container docker-weaviate-1        Started                                                                                                                                                                   0.8s 
 ✔ Container docker-web-1             Started                                                                                                                                                                   0.6s 
 ✔ Container docker-db-1              Started                                                                                                                                                                   0.7s 
 ✔ Container docker-ssrf_proxy-1      Started                                                                                                                                                                   0.9s 
 ✔ Container docker-redis-1           Started                                                                                                                                                                   0.6s 
 ✔ Container docker-bot-1             Started                                                                                                                                                                   0.7s 
 ✔ Container docker-worker-1          Started                                                                                                                                                                   1.5s 
 ✔ Container docker-api-1             Started                                                                                                                                                                   1.4s 
 ✔ Container docker-nginx-1           Started        

$ docker compose logs api --tail=5
WARN[0000] /home/********/dify/docker/docker-compose.yaml: `version` is obsolete       👈👈👈👈👈
api-1  | None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
api-1  | [2024-06-24 12:57:14 +0000] [22] [INFO] Starting gunicorn 22.0.0
api-1  | [2024-06-24 12:57:14 +0000] [22] [INFO] Listening at: http://0.0.0.0:5001 (22)
api-1  | [2024-06-24 12:57:14 +0000] [22] [INFO] Using worker: gevent
api-1  | [2024-06-24 12:57:14 +0000] [37] [INFO] Booting worker with pid: 37

$ docker compose exec api flask db history
WARN[0000] /home/********/dify/docker/docker-compose.yaml: `version` is obsolete        👈👈👈👈👈
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
4e99a8df00ff -> 7b45942e39bb (head), add-api-key-auth-binding
64a70a7aab8b -> 4e99a8df00ff, add load balancing
03f98355ba0e -> 64a70a7aab8b, add workflow run index
9e98fbaffb88 -> 03f98355ba0e, add workflow tool label and tool bindings idx
.....
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tried invoking `docker compose` commands such as `down`, `up`, `logs`, `ps`, `pull`, `start`, `stop` and confirmed that there is no warning

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
