### PR TITLE
fix: populate app configs to system environment variables

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -87,7 +87,7 @@ def create_flask_app_with_configs() -> Flask:
     for key, value in dify_app.config.items():
         if isinstance(value, str):
             os.environ[key] = value
-        elif isinstance(value, (int, float, bool)):
+        elif isinstance(value, int | float | bool):
             os.environ[key] = str(value)
         elif value is None:
             os.environ[key] = ''

--- a/api/app.py
+++ b/api/app.py
@@ -84,7 +84,7 @@ def create_flask_app_with_configs() -> Flask:
     dify_app.config.from_mapping(DifyConfig().model_dump())
 
     # populate configs into system environment variables
-    for key, value in app.config.items():
+    for key, value in dify_app.config.items():
         if isinstance(value, str):
             os.environ[key] = value
         elif isinstance(value, (int, float, bool)):

--- a/api/app.py
+++ b/api/app.py
@@ -82,6 +82,16 @@ def create_flask_app_with_configs() -> Flask:
     """
     dify_app = DifyApp(__name__)
     dify_app.config.from_mapping(DifyConfig().model_dump())
+
+    # populate configs into system environment variables
+    for key, value in app.config.items():
+        if isinstance(value, str):
+            os.environ[key] = value
+        elif isinstance(value, (int, float, bool)):
+            os.environ[key] = str(value)
+        elif value is None:
+            os.environ[key] = ''
+
     return dify_app
 
 


### PR DESCRIPTION
# Description

- set the configs read from `.env` to system env variables, for the packages relies on  env variables rather than reading configs from flask app's config.


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
