### PR TITLE
fix: DuckDuckGo image search tool error

### DIFF
--- a/api/core/agent/cot_agent_runner.py
+++ b/api/core/agent/cot_agent_runner.py
@@ -316,17 +316,17 @@ class CotAgentRunner(BaseAgentRunner, ABC):
         )
 
         # publish files
-        for message_file, save_as in message_files:
+        for message_file_id, save_as in message_files:
             if save_as:
                 self.variables_pool.set_file(
-                    tool_name=tool_call_name, value=message_file.id, name=save_as)
+                    tool_name=tool_call_name, value=message_file_id, name=save_as)
 
             # publish message file
             self.queue_manager.publish(QueueMessageFileEvent(
-                message_file_id=message_file.id
+                message_file_id=message_file_id
             ), PublishFrom.APPLICATION_MANAGER)
             # add message file ids
-            message_file_ids.append(message_file.id)
+            message_file_ids.append(message_file_id)
 
         return tool_invoke_response, tool_invoke_meta
 

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -245,16 +245,16 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                         agent_tool_callback=self.agent_callback,
                     )
                     # publish files
-                    for message_file, save_as in message_files:
+                    for message_file_id, save_as in message_files:
                         if save_as:
-                            self.variables_pool.set_file(tool_name=tool_call_name, value=message_file.id, name=save_as)
+                            self.variables_pool.set_file(tool_name=tool_call_name, value=message_file_id, name=save_as)
 
                         # publish message file
                         self.queue_manager.publish(QueueMessageFileEvent(
-                            message_file_id=message_file.id
+                            message_file_id=message_file_id
                         ), PublishFrom.APPLICATION_MANAGER)
                         # add message file ids
-                        message_file_ids.append(message_file.id)
+                        message_file_ids.append(message_file_id)
                     
                     tool_response = {
                         "tool_call_id": tool_call_id,

--- a/api/core/app/task_pipeline/message_cycle_manage.py
+++ b/api/core/app/task_pipeline/message_cycle_manage.py
@@ -167,8 +167,11 @@ class MessageCycleManage:
                     extension = '.bin'
             else:
                 extension = '.bin'
-            # add sign url
-            url = ToolFileManager.sign_file(tool_file_id=tool_file_id, extension=extension)
+            # add sign url to local file
+            if message_file.url.startswith('http'):
+                url = message_file.url
+            else:
+                url = ToolFileManager.sign_file(tool_file_id=tool_file_id, extension=extension)
 
             return MessageFileStreamResponse(
                 task_id=self._application_generate_entity.task_id,

--- a/api/core/file/file_obj.py
+++ b/api/core/file/file_obj.py
@@ -65,6 +65,7 @@ class FileVar(BaseModel):
             'type': self.type.value,
             'transfer_method': self.transfer_method.value,
             'url': self.preview_url,
+            'remote_url': self.url,
             'related_id': self.related_id,
             'filename': self.filename,
             'extension': self.extension,

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
@@ -19,7 +19,11 @@ class DuckDuckGoImageSearchTool(BuiltinTool):
             "max_results": tool_parameters.get('max_results'),
         }
         response = DDGS().images(**query_dict)
-        results = []
+        result = []
         for res in response:
-            results.append(self.create_image_message(image=res.get("image")))
-        return results
+            msg = ToolInvokeMessage(type=ToolInvokeMessage.MessageType.IMAGE_LINK,
+                                    message=res.get('image'),
+                                    save_as='',
+                                    meta=res)
+            result.append(msg)
+        return result

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -2,7 +2,7 @@ import json
 from copy import deepcopy
 from datetime import datetime, timezone
 from mimetypes import guess_type
-from typing import Union
+from typing import Any, Union
 
 from yarl import URL
 
@@ -250,7 +250,7 @@ class ToolEngine:
         agent_message: Message,
         invoke_from: InvokeFrom,
         user_id: str
-    ) -> list[tuple[MessageFile, bool]]:
+    ) -> list[tuple[Any, str]]:
         """
         Create message file
 
@@ -291,7 +291,7 @@ class ToolEngine:
             db.session.refresh(message_file)
 
             result.append((
-                message_file,
+                message_file.id,
                 message.save_as
             ))
 

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -174,6 +174,7 @@ class ToolNode(BaseNode):
                     tenant_id=self.tenant_id,
                     type=FileType.IMAGE,
                     transfer_method=FileTransferMethod.TOOL_FILE,
+                    url=url,
                     related_id=tool_file_id,
                     filename=filename,
                     extension=ext,

--- a/web/app/components/base/image-gallery/index.tsx
+++ b/web/app/components/base/image-gallery/index.tsx
@@ -46,6 +46,7 @@ const ImageGallery: FC<Props> = ({
           src={src}
           alt=''
           onClick={() => setImagePreviewUrl(src)}
+          onError={e => e.currentTarget.remove()}
         />
       ))}
       {


### PR DESCRIPTION
# Description

1. Fixes https://github.com/langgenius/dify/issues/5244. As the [doc](https://github.com/langgenius/dify/blob/main/api/core/app/apps/README.md) described, we should pass IDs instead of Model objects to avoid DetachedInstanceError.
2. Now the image search results will not be downloaded. For agent mode, the images display well. For workflow mode, I add a `remote_url` field in the files response to avoid affect others.

![1719371661878](https://github.com/langgenius/dify/assets/25834719/b6e4b60c-9322-48bf-a540-a9ffe25d9f21)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

I test it locally.


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
