### PR TITLE
chore: cleanup test_delete_by_document_id method in opensearch vdb test

### DIFF
--- a/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
+++ b/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
@@ -91,18 +91,6 @@ class TestOpenSearchVector:
         assert hits_by_vector[0].metadata['document_id'] == self.example_doc_id, \
             f"Expected document ID {self.example_doc_id}, got {hits_by_vector[0].metadata['document_id']}"
 
-        doc = Document(page_content="Test content to delete", metadata={"document_id": self.example_doc_id})
-        embedding = [0.1] * 128
-
-        with patch('opensearchpy.helpers.bulk') as mock_bulk:
-            mock_bulk.return_value = ([], [])
-            self.vector.add_texts([doc], [embedding])
-
-        self.vector._client.search.return_value = {'hits': {'total': {'value': 0}, 'hits': []}}
-
-        ids = self.vector.get_ids_by_metadata_field(key='document_id', value=self.example_doc_id)
-        assert ids is None or len(ids) == 0
-
     def test_get_ids_by_metadata_field(self):
         mock_response = {
             'hits': {


### PR DESCRIPTION
# Description

- as a follow-up for #5612, to cleanup the whole `test_delete_by_document_id` method in `test_opensearch.py` correctly.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
