### PR TITLE
fix: HTTP request header is overwritten when user set Content-Type

### DIFF
--- a/api/core/workflow/nodes/http_request/http_executor.py
+++ b/api/core/workflow/nodes/http_request/http_executor.py
@@ -168,9 +168,9 @@ class HttpExecutor:
             if body_data:
                 body_data, body_data_variable_selectors = self._format_template(body_data, variable_pool, is_valid_json)
 
-            if node_data.body.type == 'json':
+            if node_data.body.type == 'json' and self.headers.get('Content-Type') is None:
                 self.headers['Content-Type'] = 'application/json'
-            elif node_data.body.type == 'x-www-form-urlencoded':
+            elif node_data.body.type == 'x-www-form-urlencoded' and self.headers.get('Content-Type') is None:
                 self.headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
             if node_data.body.type in ['form-data', 'x-www-form-urlencoded']:

--- a/api/core/workflow/nodes/http_request/http_executor.py
+++ b/api/core/workflow/nodes/http_request/http_executor.py
@@ -168,9 +168,10 @@ class HttpExecutor:
             if body_data:
                 body_data, body_data_variable_selectors = self._format_template(body_data, variable_pool, is_valid_json)
 
-            if node_data.body.type == 'json' and self.headers.get('Content-Type') is None:
+            content_type_is_set = any(key.lower() == 'content-type' for key in self.headers)
+            if node_data.body.type == 'json' and not content_type_is_set:
                 self.headers['Content-Type'] = 'application/json'
-            elif node_data.body.type == 'x-www-form-urlencoded' and self.headers.get('Content-Type') is None:
+            elif node_data.body.type == 'x-www-form-urlencoded' and not content_type_is_set:
                 self.headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
             if node_data.body.type in ['form-data', 'x-www-form-urlencoded']:


### PR DESCRIPTION
# Description

Fixes https://github.com/langgenius/dify/issues/5611
If the user explicity sets the `Content-Type` field, we should not overwrite it.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

test locally

- [ ] TODO

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
