### PR TITLE
fix: ro-RO is not a valid language

### DIFF
--- a/api/constants/languages.py
+++ b/api/constants/languages.py
@@ -1,7 +1,3 @@
-
-
-languages = ['en-US', 'zh-Hans', 'zh-Hant', 'pt-BR', 'es-ES', 'fr-FR', 'de-DE', 'ja-JP', 'ko-KR', 'ru-RU', 'it-IT', 'uk-UA', 'vi-VN', 'pl-PL', 'hi-IN']
-
 language_timezone_mapping = {
     'en-US': 'America/New_York',
     'zh-Hans': 'Asia/Shanghai',
@@ -20,6 +16,8 @@ language_timezone_mapping = {
     'pl-PL': 'Europe/Warsaw',
     'hi-IN': 'Asia/Kolkata'
 }
+
+languages = language_timezone_mapping.keys()
 
 
 def supported_language(lang):


### PR DESCRIPTION
# Description
when you select  Romania in language setting,  will raise `ro-RO is not a valid language`. 
Because ro-RO is missing in languages, use language_timezone_mapping.keys() is not easy to forget.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

test locally


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
