### PR TITLE
fix(api/configs): Ignore empty environment variables when loading config.

### DIFF
--- a/api/configs/app_config.py
+++ b/api/configs/app_config.py
@@ -36,6 +36,7 @@ class DifyConfig(
         # read from dotenv format config file
         env_file='.env',
         env_file_encoding='utf-8',
+        env_ignore_empty=True,
 
         # ignore extra attributes
         extra='ignore',


### PR DESCRIPTION
# Description

Ensure that default values in the configuration items are correctly loaded by ignoring potential null values in the environment variables.

[Ref](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#parsing-environment-variable-values)

Fixes #5640 (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
