### PR TITLE
Fix docker command

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -11,7 +11,7 @@
 
    ```bash
    cd ../docker
-   docker-compose -f docker-compose.middleware.yaml -p dify up -d
+   docker compose -f docker-compose.middleware.yaml -p dify up -d
    cd ../api
    ```
 


### PR DESCRIPTION
Noobs will struggle on this part a long time if they are using apt, since docker-compose actually is a package which is shown when you try to run `docker-compose -f docker-compose.middleware.yaml -p dify up -d`

![image](https://github.com/langgenius/dify/assets/131612909/e37f3c1a-2730-477f-b060-3d7b0d7d8aef)