### PR TITLE
fix: env SMTP_PORT is empty caused err when launching

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -405,7 +405,7 @@ RESEND_API_KEY=your-resend-api-key
 
 # SMTP server configuration, used when MAIL_TYPE is `smtp`
 SMTP_SERVER=
-SMTP_PORT=
+SMTP_PORT=465
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_USE_TLS=true


### PR DESCRIPTION
# Description

fix: env SMTP_PORT is empty caused err when launching

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual test

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
