### PR TITLE
bump to 0.6.12-fix1

### DIFF
--- a/api/configs/packaging/__init__.py
+++ b/api/configs/packaging/__init__.py
@@ -8,7 +8,7 @@ class PackagingInfo(BaseModel):
 
     CURRENT_VERSION: str = Field(
         description='Dify version',
-        default='0.6.12',
+        default='0.6.12-fix1',
     )
 
     COMMIT_SHA: str = Field(

--- a/docker-legacy/docker-compose.yaml
+++ b/docker-legacy/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.6.12
+    image: langgenius/dify-api:0.6.12-fix1
     restart: always
     environment:
       # Startup mode, 'api' starts the API server.
@@ -222,7 +222,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.6.12
+    image: langgenius/dify-api:0.6.12-fix1
     restart: always
     environment:
       CONSOLE_WEB_URL: ''
@@ -388,7 +388,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.6.12
+    image: langgenius/dify-web:0.6.12-fix1
     restart: always
     environment:
       # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -259,7 +259,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.6.12
+    image: langgenius/dify-api:0.6.12-fix1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -282,7 +282,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.6.12
+    image: langgenius/dify-api:0.6.12-fix1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -301,7 +301,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.6.12
+    image: langgenius/dify-web:0.6.12-fix1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "0.6.12",
+  "version": "0.6.12-fix1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Fixed the issue where the WebApp URL was incorrect and the problem where the model and tools icons weren’t showing up after starting from Docker Compose