### PR TITLE
Ensure *.sh are LF-style, so that they can be used directly by Docker for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Ensure that .sh scripts use LF as line separator, even if they are checked out
+# to Windows(NTFS) file-system, by a user of Docker for Window. 
+# These .sh scripts will be run from the Container after `docker compose up -d`.
+# If they appear to be CRLF style, Dash from the Container will fail to execute
+# them.
+
+*.sh      text eol=lf


### PR DESCRIPTION
Before this fix, after running `docker compose up` on Docker Desktop 4.31 for Windows, the nginx-1 container fails to execute `nginx/docker-entrypoint.sh`. It repeatly spout error message:

```
sh: 1: /docker-entrypoint.sh: not found
sh: 1: /docker-entrypoint.sh: not found
sh: 1: /docker-entrypoint.sh: not found
```

![image](https://github.com/langgenius/dify/assets/38829153/e73fb844-e904-4697-ada0-d599733182a4)


That's due to docker-entrypoint.sh is having CRLF as line separator.

So, using a `.gitattributes` file at repo root dir solves the problem once and for all.

```
*.sh      text eol=lf
```
