### PR TITLE
Chore/remove extra docker middleware variables

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -1,5 +1,4 @@
 # standard import
-# standard import
 import base64
 import json
 import logging
@@ -7,7 +6,6 @@ import mimetypes
 from collections.abc import Generator
 from typing import Optional, Union, cast
 
-# 3rd import
 # 3rd import
 import boto3
 import requests
@@ -21,8 +19,6 @@ from botocore.exceptions import (
 )
 from cohere import ChatMessage
 
-# local import
-from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 # local import
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (

--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -69,7 +69,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :param user: unique user id
         :return: full response or stream response chunk generator result
         """
-        # invoke anthropic models via anthropic official SDK
+        # TODO: consolidate different invocation methods for models based on base model capabilities
+        # invoke anthropic models via boto3 client
         if "anthropic" in model:
             return self._generate_anthropic(model, credentials, prompt_messages, model_parameters, stop, stream, user)
         # invoke Cohere models via boto3 client

--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -1,4 +1,5 @@
 # standard import
+# standard import
 import base64
 import json
 import logging
@@ -6,6 +7,7 @@ import mimetypes
 from collections.abc import Generator
 from typing import Optional, Union, cast
 
+# 3rd import
 # 3rd import
 import boto3
 import requests
@@ -19,6 +21,8 @@ from botocore.exceptions import (
 )
 from cohere import ChatMessage
 
+# local import
+from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 # local import
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from core.model_runtime.entities.message_entities import (
@@ -65,8 +69,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :param user: unique user id
         :return: full response or stream response chunk generator result
         """
-        # TODO: consolidate different invocation methods for models based on base model capabilities
-        # invoke anthropic models via boto3 client
+        # invoke anthropic models via anthropic official SDK
         if "anthropic" in model:
             return self._generate_anthropic(model, credentials, prompt_messages, model_parameters, stop, stream, user)
         # invoke Cohere models via boto3 client

--- a/docker/middleware.env.example
+++ b/docker/middleware.env.example
@@ -11,12 +11,6 @@ PGDATA=/var/lib/postgresql/data/pgdata
 
 
 # ------------------------------
-# Environment Variables for qdrant Service
-# (only used when VECTOR_STORE is qdrant)
-# ------------------------------
-QDRANT_API_KEY=difyai123456
-
-# ------------------------------
 # Environment Variables for sandbox Service
 SANDBOX_API_KEY=dify-sandbox
 SANDBOX_GIN_MODE=release
@@ -37,7 +31,6 @@ SSRF_SANDBOX_HOST=sandbox
 
 # ------------------------------
 # Environment Variables for weaviate Service
-# (only used when VECTOR_STORE is weaviate)
 # ------------------------------
 WEAVIATE_QUERY_DEFAULTS_LIMIT=25
 WEAVIATE_AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true


### PR DESCRIPTION
# Description

Removes unnecessary variables that suggests `VECTOR_STORE` is configurable in `docker-compose.middleware.yaml`

Fixes #5792 

## Type of Change

Please delete options that are not relevant.

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
