### PR TITLE
fix: wrong nginx listen port in container

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -293,7 +293,7 @@ services:
       NGINX_SERVER_NAME: ${NGINX_SERVER_NAME:-_}
       NGINX_HTTPS_ENABLED: ${NGINX_HTTPS_ENABLED:-false}
       NGINX_SSL_PORT: ${NGINX_SSL_PORT:-443}
-      NGINX_PORT: ${NGINX_PORT:-80}
+      NGINX_PORT: ${EXPOSE_NGINX_PORT:-80}
       # You're required to add your own SSL certificates/keys to the `./nginx/ssl` directory
       # and modify the env vars below in .env if HTTPS_ENABLED is true.
       NGINX_SSL_CERT_FILENAME: ${NGINX_SSL_CERT_FILENAME:-dify.crt}


### PR DESCRIPTION
# Description
Nginx in container should listen to EXPOSE_NGINX_PORT instead of NGINX_PORT.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Self-Tested on my own server

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
