### PR TITLE
doc: docker-compose won't start due to wrong README

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -11,6 +11,7 @@
 
    ```bash
    cd ../docker
+   cp .middleware.env.example .middleware.env
    docker compose -f docker-compose.middleware.yaml -p dify up -d
    cd ../api
    ```


### PR DESCRIPTION
# Description

When I followed the instructions in api/README.md, docker-compose.middleware won't start due to the below error.


> env file /home/ec2-user/dify/docker/middleware.env not found: stat /home/ec2-user/dify/docker/middleware.env: no such file or directory

I added a step to create a .middleware.env.

## Type of Change

- [X] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement

# How Has This Been Tested?

I ran the instructions locally.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
