### PR TITLE
fix: token count includes base64 string of input images

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/llm/llm.py
+++ b/api/core/model_runtime/model_providers/bedrock/llm/llm.py
@@ -489,7 +489,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         content = message.content
 
         if isinstance(message, UserPromptMessage):
-            message_text = f"{human_prompt_prefix} {content} {human_prompt_postfix}"
+            body = content
+            if (isinstance(content, list)):
+                body = "".join([c.data for c in content if c.type == PromptMessageContentType.TEXT])
+            message_text = f"{human_prompt_prefix} {body} {human_prompt_postfix}"
         elif isinstance(message, AssistantPromptMessage):
             message_text = f"{ai_prompt} {content}"
         elif isinstance(message, SystemPromptMessage):


### PR DESCRIPTION
# Description
When I send an image of a few megabytes to a chat bot powered by Bedrock Claude, I get the following error. 

> Query or prefix prompt is too long, you can reduce the prefix prompt, or shrink the max token, or switch to a llm with a larger token limit size.

which is thrown here:

https://github.com/langgenius/dify/blob/32d85fb89607ee3901a2f4492c8364e7bcaf9779/api/core/app/apps/base_app_runner.py#L79-L86

The root cause is that `prompt_messages` contains the entire base64 string of input images, which is passed directly into tokenizer, resulting the calculated token count incorrectly large.

So I changed `_convert_one_message_to_text` function, which is called when calculating a token count, to ignore image content.

https://github.com/langgenius/dify/blob/32d85fb89607ee3901a2f4492c8364e7bcaf9779/api/core/model_runtime/model_providers/bedrock/llm/llm.py#L404-L409

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run API and frontend locally and send a message with a large enough image to Bedrock claude chat bot to get a expected response. I also tested other models such as titan, llama, or command also works without breaking the previous behavior.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
