### PR TITLE
Added tools for Azure Bing Search API v7

### DIFF
--- a/api/core/tools/provider/builtin/azure_bing_search_v7/_assets/icon.svg
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/_assets/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="none">
+  <defs>
+    <radialGradient id="ea8ddd8a-48ba-441c-8311-10e5bddbfbfb" cx="10.629" cy="7.175" r="6.675" gradientUnits="userSpaceOnUse">
+      <stop offset="0.225" stop-color="#32d4f5"/>
+      <stop offset="0.59" stop-color="#32d2f2"/>
+      <stop offset="0.825" stop-color="#32caea"/>
+      <stop offset="1" stop-color="#32bedd"/>
+    </radialGradient>
+  </defs>
+  <title>MsPortalFx.base.images-56</title>
+  <g id="e958cf41-a31a-426c-90ab-58b20591ece8">
+    <g>
+      <rect x="-0.375" y="12.598" width="9.73" height="2.216" rx="1.036" transform="translate(-8.376 7.19) rotate(-45)" fill="#198ab3"/>
+      <circle cx="10.629" cy="7.175" r="6.675" fill="url(#ea8ddd8a-48ba-441c-8311-10e5bddbfbfb)"/>
+      <circle cx="10.615" cy="7.056" r="5.243" fill="#fff"/>
+      <path d="M5.535,8.353S6.97,1.171,13.676,2.8a5.14,5.14,0,0,0-6.186.047A5.121,5.121,0,0,0,5.535,8.353Z" fill="#c3f1ff"/>
+    </g>
+  </g>
+</svg>

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/azure_bing_search_v7.py
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/azure_bing_search_v7.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from core.tools.errors import ToolProviderCredentialValidationError
+from core.tools.provider.builtin.azure_bing_search_v7.tools.azure_bing_search_v7 import AzureBingSearchTool
+from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
+
+
+class AzureBingSearchProvider(BuiltinToolProviderController):
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
+        try:
+            AzureBingSearchTool().fork_tool_runtime(
+                runtime={
+                    "credentials": credentials,
+                }
+            ).invoke(
+                user_id='',
+                tool_parameters={
+                    "query": "test",
+                    "count": 1,
+                    "freshness": "Unspecified",
+                    "market": "ja-JP"
+                },
+            )
+        except Exception as e:
+            raise ToolProviderCredentialValidationError(str(e))
+    

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/azure_bing_search_v7.yaml
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/azure_bing_search_v7.yaml
@@ -1,0 +1,21 @@
+identity:
+  author: keita69
+  name: azure_bing_search_v7
+  label:
+    en_US: Azure Being Search v7
+  description:
+    en_US: Azure Being Search v7
+  icon: icon.svg
+  tags:
+    - search
+credentials_for_provider:
+  bing_search_api_key:
+    type: secret-input
+    required: true
+    label:
+      en_US: Azure Being Search v7 API key
+    placeholder:
+      en_US: Please input your Azure Being Search v7 API key
+    help:
+      en_US: Get your Azure Being Search v7 API key from Azure Being Search
+    url: https://learn.microsoft.com/en-us/azure/search/search-security-api-keys?tabs=rest-use%2Cportal-find%2Cportal-query#find-existing-keys

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.py
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.py
@@ -1,0 +1,89 @@
+from typing import Any, Union
+
+import requests
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool.builtin_tool import BuiltinTool
+
+BING_SEARCH_API_URL = "https://api.bing.microsoft.com/v7.0/search"
+
+
+class AzureBingSearchAPI:
+    """
+    AzureBingSearchAPI tool provider.
+    """
+    def __init__(self, api_key: str) -> None:
+        """Initialize AzureBingSearchAPI tool provider."""
+        self.bing_search_api_key = api_key
+
+    def run(self, query: str, count: int, freshness: str, market: str, api_key: str) -> str:
+        """Run query through AzureBingSearchAPI and parse result."""
+        return self._process_response(self.results(query, count, freshness, market, api_key))
+
+    def results(self, query: str, count: int, freshness: str, market: str, api_key: str) -> dict:
+        """Run query through AzureBingSearchAPI and return the raw result."""
+        headers = self.get_headers(api_key)
+        params = self.get_params(query, count, freshness, market)
+        response = requests.get(url=BING_SEARCH_API_URL, params=params, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    def get_headers(self, api_key: str) -> dict[str, str]:
+        """Get parameters for AzureBingSearchAPI."""
+        return {"Ocp-Apim-Subscription-Key": api_key}
+
+    def get_params(self, query: str, count: int, freshness: str, market: str) -> dict[str, str]:
+        """Get parameters for AzureBingSearchAPI."""
+        params = {
+            "q": query,
+            "count": count,
+            "freshness": freshness,
+            "freshness": freshness if freshness != "Unspecified" else None,
+            "market": market,
+            "textDecorations": False,
+            "textFormat": "HTML"
+        }
+        return params
+
+    @staticmethod
+    def _process_response(response: dict) -> str:
+        """
+        Process response from AzureBingSearchAPI.
+        AzureBingSearchAPI doc: https://learn.microsoft.com/en-us/bing/search-apis/bing-web-search/
+        Bing search main results are called organic results
+        """
+        if "error" in response:
+            raise ValueError(f"Got error from AzureBingSearchAPI: {response['error']}")
+
+        result = {}
+        if "value" in response["webPages"]:
+            items = []
+            for item in response["webPages"]["value"]:
+                items.append({
+                    "name": item.get("name", ""),
+                    "url": item.get("url", ""),
+                    "snippet": item.get("snippet", ""),
+                    "language": item.get("language", ""),
+                    "datePublished": item.get("datePublished", "")
+                })
+            result["webPages"] = {"value": items}
+        return result
+
+
+class AzureBingSearchTool(BuiltinTool):
+
+    def _invoke(self,
+                user_id: str,
+                tool_parameters: dict[str, Any],
+                ) -> Union[ToolInvokeMessage, list[ToolInvokeMessage]]:
+        """
+            invoke tools
+        """
+        query = tool_parameters['query']
+        count = tool_parameters['count']
+        freshness = tool_parameters['freshness']
+        market = tool_parameters['market']
+        api_key = self.runtime.credentials['bing_search_api_key']
+        assert api_key
+        result = AzureBingSearchAPI(api_key).run(query, count, freshness, market, api_key)
+        return self.create_text_message(text=result)

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.py
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.py
@@ -37,7 +37,6 @@ class AzureBingSearchAPI:
         params = {
             "q": query,
             "count": count,
-            "freshness": freshness,
             "freshness": freshness if freshness != "Unspecified" else None,
             "market": market,
             "textDecorations": False,

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.yaml
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.yaml
@@ -168,7 +168,7 @@ parameters:
     default: ja-JP
     required: false
     label:
-      en_US: Market 
+      en_US: Market
     human_description:
-      en_US: The market where the results come from. Typically, mkt is the country where the user is making the request from. 
+      en_US: The market where the results come from. Typically, mkt is the country where the user is making the request from.
     form: form

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.yaml
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.yaml
@@ -28,7 +28,7 @@ parameters:
     form: llm
   - name: freshness
     type: select
-    options: # 選択ボックスオプション
+    options:
       - value: Unspecified
         label:
           en_US: Unspecified
@@ -50,7 +50,7 @@ parameters:
     form: form
   - name: market
     type: select
-    options: # 選択ボックスオプション
+    options:
       - value: es-AR
         label:
           en_US: Argentina

--- a/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.yaml
+++ b/api/core/tools/provider/builtin/azure_bing_search_v7/tools/azure_bing_search_v7.yaml
@@ -1,0 +1,174 @@
+identity:
+  name: azure_bing_Search_v7
+  author: keita69
+  label:
+    en_US: Azure Bing Search V7
+description:
+  human:
+    en_US: A tool for performing an Azure Bing Search v7 search and extracting snippets and webpages.Input should be a search query.
+  llm: A tool for performing an Azure Bing Search v7 search and extracting snippets and webpages.Input should be a search query.
+parameters:
+  - name: query
+    type: string
+    required: true
+    label:
+      en_US: Query string
+    human_description:
+      en_US: used for searching
+    llm_description: key words for searching
+    form: llm
+  - name: count
+    type: number
+    required: true
+    label:
+      en_US: Results Count
+    human_description:
+      en_US: The number of search results to return in the response. The default is 10 and the maximum value is 50. The actual number delivered may be less than requested.
+    llm_description: number of search results
+    form: llm
+  - name: freshness
+    type: select
+    options: # 選択ボックスオプション
+      - value: Unspecified
+        label:
+          en_US: Unspecified
+      - value: Day
+        label:
+          en_US: Day (last 24 hours)
+      - value: Week
+        label:
+          en_US: Week (last 7 days)
+      - value: Month
+        label:
+          en_US: Month (last 30 days)
+    default: null
+    required: false
+    label:
+      en_US: Filter search results by age
+    human_description:
+      en_US: Filter search results by the following case-insensitive age values. Day:last 24 hours / Week:last 7 days / Month:last 30 days
+    form: form
+  - name: market
+    type: select
+    options: # 選択ボックスオプション
+      - value: es-AR
+        label:
+          en_US: Argentina
+      - value: en-AU
+        label:
+          en_US: Australia
+      - value: de-AT
+        label:
+          en_US: Austria
+      - value: nl-BE
+        label:
+          en_US: Belgium (Dutch)
+      - value: fr-BE
+        label:
+          en_US: Belgium (French)
+      - value: pt-BR
+        label:
+          en_US: Brazil
+      - value: en-CA
+        label:
+          en_US: Canada (English)
+      - value: fr-CA
+        label:
+          en_US: Canada (French)
+      - value: es-CL
+        label:
+          en_US: Chile
+      - value: da-DK
+        label:
+          en_US: Denmark
+      - value: fi-FI
+        label:
+          en_US: Finland
+      - value: fr-FR
+        label:
+          en_US: France
+      - value: de-DE
+        label:
+          en_US: Germany
+      - value: zh-HK
+        label:
+          en_US: Hong Kong SAR
+      - value: en-IN
+        label:
+          en_US: India
+      - value: en-ID
+        label:
+          en_US: Indonesia
+      - value: it-IT
+        label:
+          en_US: Italy
+      - value: ja-JP
+        label:
+          en_US: Japan
+      - value: ko-KR
+        label:
+          en_US: Korea
+      - value: en-MY
+        label:
+          en_US: Malaysia
+      - value: es-MX
+        label:
+          en_US: Mexico
+      - value: nl-NL
+        label:
+          en_US: Netherlandsk
+      - value: en-NZ
+        label:
+          en_US: New Zealand
+      - value: no-NO
+        label:
+          en_US: Norway
+      - value: zh-CN
+        label:
+          en_US: People's Republic of China
+      - value: pl-PL
+        label:
+          en_US: Poland
+      - value: en-PH
+        label:
+          en_US: Republic of the Philippines
+      - value: ru-RU
+        label:
+          en_US: Russia
+      - value: en-ZA
+        label:
+          en_US: South Africa
+      - value: es-ES
+        label:
+          en_US: Spaink
+      - value: sv-SE
+        label:
+          en_US: Sweden
+      - value: fr-CH
+        label:
+          en_US: Switzerland (French)
+      - value: de-CH
+        label:
+          en_US: Switzerland (German)
+      - value: zh-TW
+        label:
+          en_US: Taiwan
+      - value: tr-TR
+        label:
+          en_US: Türkiye
+      - value: en-GB
+        label:
+          en_US: United Kingdom
+      - value: en-US
+        label:
+          en_US: United States (English)
+      - value: es-US
+        label:
+          en_US: United States (Spanish)
+    default: ja-JP
+    required: false
+    label:
+      en_US: Market 
+    human_description:
+      en_US: The market where the results come from. Typically, mkt is the country where the user is making the request from. 
+    form: form


### PR DESCRIPTION
# Description
Created tools for Azure Bing Search API v7.

## Related Motivation and Background
I created this tool because I didn't want to call external services from Dify on Azure. (I don't want to use external services such as SerpAPI for security reasons)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

# How was this tested?
I used a tool added locally (WSL) and confirmed its operation with a chat flow.

- [ ] Tool certification
- [ ] Change the settings of each tool parameter randomly and check the operation (not all patterns have been tried)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
