### PR TITLE
feat: add retry mechanism for zhipuai

### DIFF
--- a/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_http_client.py
+++ b/api/core/model_runtime/model_providers/zhipuai/zhipuai_sdk/core/_http_client.py
@@ -7,6 +7,8 @@ from typing import Any, Union, cast
 import httpx
 import pydantic
 from httpx import URL, Timeout
+from tenacity import retry
+from tenacity.stop import stop_after_attempt
 
 from . import _errors
 from ._base_type import NOT_GIVEN, Body, Data, Headers, NotGiven, Query, RequestFiles, ResponseT
@@ -221,6 +223,7 @@ class HttpClient:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    @retry(stop=stop_after_attempt(ZHIPUAI_DEFAULT_MAX_RETRIES))
     def request(
             self,
             *,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

I've discovered that the ZHIPUAI_DEFAULT_MAX_RETRIES parameter is not functioning as expected in the current codebase. This oversight means that zhipuai actually lacks any retry mechanism. To resolve this issue, I implemented a tenacity retry approach, which successfully restored functionality.

Fixes #5925 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

- [x] After disconnecting from the network for a few seconds, reconnect and continue observing the response
- [x] Keep disconnecting from the network, you can see the newly introduced RetryError in the log.
![微信截图_20240703152745](https://github.com/langgenius/dify/assets/5905773/4a7320b0-87f0-4552-b7da-0764f82a2cc3)




