### PR TITLE
fix: zhipuai pytest correction

### DIFF
--- a/api/tests/integration_tests/model_runtime/zhipuai/test_llm.py
+++ b/api/tests/integration_tests/model_runtime/zhipuai/test_llm.py
@@ -152,4 +152,4 @@ def test_get_tools_num_tokens():
         ]
     )
 
-    assert num_tokens == 108
+    assert num_tokens == 88


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

The current test code is being tested using chatglm_turbo, but chatglm_turbo is outdated. Zhipu may have already pointed chatglm_turbo to glm-4-air, and glm-4 is a new series of model. The token count may be different from the previous model. The numbers need to be corrected.

Fixes #5933

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

- [x] pytest api/tests/integration_tests/model_runtime/zhipuai

![微信截图_20240703175137](https://github.com/langgenius/dify/assets/5905773/4c733b6f-ee47-4f72-a633-3eb61c9df37f)



