### PR TITLE
Fix authorization header validation to handle bearer types correctly - "authorization config header is required" error

### DIFF
--- a/api/core/workflow/nodes/http_request/http_executor.py
+++ b/api/core/workflow/nodes/http_request/http_executor.py
@@ -212,7 +212,7 @@ class HttpExecutor:
                 raise ValueError('self.authorization config is required')
             if authorization.config is None:
                 raise ValueError('authorization config is required')
-            if authorization.config.header is None:
+            if authorization.config.type != 'bearer' and authorization.config.header is None:
                 raise ValueError('authorization config header is required')
 
             if self.authorization.config.api_key is None:


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This pull request fixes the issue with authorization header validation to handle bearer types correctly. The validation logic is modified to check for the authorization config header only for non-bearer types. This ensures that the bearer authorization configurations are handled properly.

Fixes #6033

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

To verify the changes, please follow these steps:

- Configure an HTTP node with Bearer authorization and ensure it works as expected.
- Configure an HTTP node with a non-bearer authorization type and ensure the appropriate error message is displayed if the header is missing.

