### PR TITLE
Modify slack webhook url validation to allow workflow (#6041)

### DIFF
--- a/api/core/tools/provider/builtin/slack/tools/slack_webhook.py
+++ b/api/core/tools/provider/builtin/slack/tools/slack_webhook.py
@@ -20,7 +20,7 @@ class SlackWebhookTool(BuiltinTool):
 
         webhook_url = tool_parameters.get('webhook_url', '')
 
-        if not webhook_url.startswith('https://hooks.slack.com/services/'):
+        if not webhook_url.startswith('https://hooks.slack.com/'):
             return self.create_text_message(
                 f'Invalid parameter webhook_url ${webhook_url}, not a valid Slack webhook URL')
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes #6041.  
In order for slack_webhook to allow using workflow-based incoming webhook URL, I changed url validation string.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Since this is only tiny modification for validation URL string, no specific tests are required.
