### PR TITLE
fix audio not working during development due to react's useEffect wil be triggered twice

### DIFF
--- a/web/app/components/base/voice-input/index.tsx
+++ b/web/app/components/base/voice-input/index.tsx
@@ -152,6 +152,10 @@ const VoiceInput = ({
   useEffect(() => {
     initCanvas()
     handleStartRecord()
+    const recorderRef = recorder?.current
+    return () => {
+      recorderRef?.stop()
+    }
   }, [])
 
   const minutes = parseInt(`${parseInt(`${originDuration}`) / 60}`)


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

During development, React will call useEffect twice which leads to handleStartRecord() been called twice without stop. See more detail in this issue:

Fixes https://github.com/langgenius/dify/issues/3060

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A start dify middleware using docker; start dify backend and frontend locally; enable speech to text in your agent; click on *microphone* button. 



