### PR TITLE
fix: when http request body is raw or json, if there are line breaks and double quotes, the request will fail

### DIFF
--- a/api/core/workflow/utils/variable_template_parser.py
+++ b/api/core/workflow/utils/variable_template_parser.py
@@ -91,6 +91,7 @@ class VariableTemplateParser:
         def replacer(match):
             key = match.group(1)
             value = inputs.get(key, match.group(0))  # return original matched string if key not found
+            value = value.replace('\n', '\\n').replace('"', '\\"')  # replace the line breaks in the content with /n and the double quotes with /"
             # convert the value to string
             if isinstance(value, list | dict | bool | int | float):
                 value = str(value)


### PR DESCRIPTION
# Description

My workflow is to send the output of the large model to an external API via http request node，when http request body is raw or json, if there are line breaks and double quotes, the request will fail.

<img width="522" alt="image" src="https://github.com/langgenius/dify/assets/8756642/d344b562-7136-405f-8d16-9d92b92ca91c">

<img width="342" alt="image" src="https://github.com/langgenius/dify/assets/8756642/4926203f-169b-40c8-8152-787d441ac94f">

I found that the error was caused by multi-line text or double quotes
<img width="524" alt="image" src="https://github.com/langgenius/dify/assets/8756642/6645cdee-3be5-4f79-9bee-f72a2ffea539">


# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade



