### PR TITLE
fix: kill signal is not passed to the main process

### DIFF
--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -8,15 +8,15 @@ if [[ "${MIGRATION_ENABLED}" == "true" ]]; then
 fi
 
 if [[ "${MODE}" == "worker" ]]; then
-  celery -A app.celery worker -P ${CELERY_WORKER_CLASS:-gevent} -c ${CELERY_WORKER_AMOUNT:-1} --loglevel INFO \
+  exec celery -A app.celery worker -P ${CELERY_WORKER_CLASS:-gevent} -c ${CELERY_WORKER_AMOUNT:-1} --loglevel INFO \
     -Q ${CELERY_QUEUES:-dataset,generation,mail,ops_trace,app_deletion}
 elif [[ "${MODE}" == "beat" ]]; then
-  celery -A app.celery beat --loglevel INFO
+  exec celery -A app.celery beat --loglevel INFO
 else
   if [[ "${DEBUG}" == "true" ]]; then
-    flask run --host=${DIFY_BIND_ADDRESS:-0.0.0.0} --port=${DIFY_PORT:-5001} --debug
+    exec flask run --host=${DIFY_BIND_ADDRESS:-0.0.0.0} --port=${DIFY_PORT:-5001} --debug
   else
-    gunicorn \
+    exec gunicorn \
       --bind "${DIFY_BIND_ADDRESS:-0.0.0.0}:${DIFY_PORT:-5001}" \
       --workers ${SERVER_WORKER_AMOUNT:-1} \
       --worker-class ${SERVER_WORKER_CLASS:-gevent} \


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [X] Please open an issue before creating a PR or link to an existing issue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes #6158 

The root cause is that the main process is not PID=1, and kill signal is not passed to it. To make the main process PID=1, this PR addede `exec` when calling the main process.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Build an api container image and confirmed it runs and shut down successfully.

```sh
cd api
docker build -t api .
docker run api # then Ctrl+C
docker run -e MODE=beat api # then Ctrl+C
docker run -e MODE=worker api # then Ctrl+C
docker run -e DEBUG=true api # then Ctrl+C
```



