### PR TITLE
Fix if_else node compatibility with historical workflows.

### DIFF
--- a/api/core/workflow/nodes/if_else/if_else_node.py
+++ b/api/core/workflow/nodes/if_else/if_else_node.py
@@ -60,6 +60,8 @@ class IfElseNode(BaseNode):
 
                 final_result = all(group_result) if node_data.logical_operator == "and" else any(group_result)
 
+                selected_case_id = "true" if final_result else "false"
+
                 process_datas["condition_results"].append(
                     {
                         "group": "default",
@@ -78,11 +80,7 @@ class IfElseNode(BaseNode):
                 error=str(e)
             )
 
-        outputs = {
-            "result": final_result
-        }
-        if node_data.cases:
-            outputs["selected_case_id"] = selected_case_id
+        outputs = {"result": final_result, "selected_case_id": selected_case_id}
 
         data = NodeRunResult(
             status=WorkflowNodeExecutionStatus.SUCCEEDED,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes
if_else nodes are not compatible with historical workflow configurations, causing if_else that have not been republished to go to the else branch by default.

 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



