### PR TITLE
fix: validateColorHex: cannot read properties of undefined (reading 'length')

### DIFF
--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -109,7 +109,7 @@ const SettingsModal: FC<ISettingsModalProps> = ({
     }
 
     const validateColorHex = (hex: string | null) => {
-      if (hex === null || hex.length === 0)
+      if (hex === null || hex?.length === 0)
         return true
 
       const regex = /#([A-Fa-f0-9]{6})/


### PR DESCRIPTION
# Description

Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'length')

Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


# Testing Instructions

Keep "Chat color theme" blank and click Save


