### PR TITLE
chore: apply HttpUrl type to configs

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AliasChoices, Field, NonNegativeInt, PositiveInt, computed_field, HttpUrl
+from pydantic import AliasChoices, Field, HttpUrl, NonNegativeInt, PositiveInt, computed_field
 from pydantic_settings import BaseSettings
 
 from configs.feature.hosted_service import HostedServiceConfig

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AliasChoices, Field, NonNegativeInt, PositiveInt, computed_field
+from pydantic import AliasChoices, Field, NonNegativeInt, PositiveInt, computed_field, HttpUrl
 from pydantic_settings import BaseSettings
 
 from configs.feature.hosted_service import HostedServiceConfig
@@ -41,7 +41,7 @@ class CodeExecutionSandboxConfig(BaseSettings):
     """
     Code Execution Sandbox configs
     """
-    CODE_EXECUTION_ENDPOINT: str = Field(
+    CODE_EXECUTION_ENDPOINT: HttpUrl = Field(
         description='endpoint URL of code execution servcie',
         default='http://sandbox:8194',
     )
@@ -228,7 +228,7 @@ class UpdateConfig(BaseSettings):
     """
     Update configs
     """
-    CHECK_UPDATE_URL: str = Field(
+    CHECK_UPDATE_URL: HttpUrl = Field(
         description='url for checking updates',
         default='https://updates.dify.ai',
     )

--- a/api/configs/feature/hosted_service/__init__.py
+++ b/api/configs/feature/hosted_service/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field, NonNegativeInt, HttpUrl
+from pydantic import Field, HttpUrl, NonNegativeInt
 from pydantic_settings import BaseSettings
 
 

--- a/api/configs/feature/hosted_service/__init__.py
+++ b/api/configs/feature/hosted_service/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field, NonNegativeInt
+from pydantic import Field, NonNegativeInt, HttpUrl
 from pydantic_settings import BaseSettings
 
 
@@ -187,7 +187,7 @@ class HostedFetchAppTemplateConfig(BaseSettings):
         default='remote',
     )
 
-    HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN: str = Field(
+    HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN: HttpUrl = Field(
         description='the domain for fetching remote app templates',
         default='https://tmpl.dify.ai',
     )

--- a/api/controllers/console/version.py
+++ b/api/controllers/console/version.py
@@ -15,7 +15,7 @@ class VersionApi(Resource):
         parser = reqparse.RequestParser()
         parser.add_argument('current_version', type=str, required=True, location='args')
         args = parser.parse_args()
-        check_update_url = current_app.config['CHECK_UPDATE_URL']
+        check_update_url = str(current_app.config['CHECK_UPDATE_URL'])
 
         result = {
             'version': current_app.config['CURRENT_VERSION'],

--- a/api/core/helper/code_executor/code_executor.py
+++ b/api/core/helper/code_executor/code_executor.py
@@ -168,7 +168,7 @@ class CodeExecutor:
         """
         List dependencies
         """
-        url = URL(CODE_EXECUTION_ENDPOINT) / 'v1' / 'sandbox' / 'dependencies'
+        url = URL(str(CODE_EXECUTION_ENDPOINT)) / 'v1' / 'sandbox' / 'dependencies'
 
         headers = {
             'X-Api-Key': CODE_EXECUTION_API_KEY


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Pydantic's HttpUrl type is more suitable for some of the configs.
  - https://docs.pydantic.dev/latest/api/networks/#pydantic.networks.HttpUrl
  - the default allowed schemas are http and https

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



