### PR TITLE
Chores: add missing profile for middleware docker compose cmd and fix ssrf-proxy doc link

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -12,7 +12,7 @@
    ```bash
    cd ../docker
    cp middleware.env.example middleware.env
-   docker compose -f docker-compose.middleware.yaml -p dify up -d
+   docker compose -f docker-compose.middleware.yaml --profile weaviate -p dify up -d
    cd ../api
    ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -12,6 +12,7 @@
    ```bash
    cd ../docker
    cp middleware.env.example middleware.env
+   # change the profile to other vector database if you are not using weaviate
    docker compose -f docker-compose.middleware.yaml --profile weaviate -p dify up -d
    cd ../api
    ```

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -48,7 +48,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/getting-started/install-self-hosted/install-faq#id-16.-why-is-ssrf_proxy-needed
+  # https://docs.dify.ai/learn-more/faq/self-host-faq#id-18.-why-is-ssrf_proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

[PR 5754](https://github.com/langgenius/dify/pull/5754) refactored middleware docker-compose yaml which added profile for weaviate service, project beginner will not get a vector store instance to be running with previous docker compose cmd.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



