### PR TITLE
chore: make text generation timeout duration configurable

### DIFF
--- a/web/app/components/share/text-generation/result/index.tsx
+++ b/web/app/components/share/text-generation/result/index.tsx
@@ -19,6 +19,7 @@ import { NodeRunningStatus, WorkflowRunningStatus } from '@/app/components/workf
 import type { WorkflowProcess } from '@/app/components/base/chat/types'
 import { sleep } from '@/utils'
 import type { SiteInfo } from '@/models/share'
+import { TEXT_GENERATION_TIMEOUT_MS } from '@/config'
 
 export type IResultProps = {
   isWorkflow: boolean
@@ -186,7 +187,7 @@ const Result: FC<IResultProps> = ({
     let isEnd = false
     let isTimeout = false;
     (async () => {
-      await sleep(1000 * 60) // 1min timeout
+      await sleep(TEXT_GENERATION_TIMEOUT_MS) // 1min timeout
       if (!isEnd) {
         setRespondingFalse()
         onCompleted(getCompletionRes(), taskId, false)

--- a/web/app/components/share/text-generation/result/index.tsx
+++ b/web/app/components/share/text-generation/result/index.tsx
@@ -187,7 +187,7 @@ const Result: FC<IResultProps> = ({
     let isEnd = false
     let isTimeout = false;
     (async () => {
-      await sleep(TEXT_GENERATION_TIMEOUT_MS) // 1min timeout
+      await sleep(TEXT_GENERATION_TIMEOUT_MS)
       if (!isEnd) {
         setRespondingFalse()
         onCompleted(getCompletionRes(), taskId, false)

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -245,3 +245,5 @@ Thought: {{agent_scratchpad}}
 }
 
 export const VAR_REGEX = /\{\{(#[a-zA-Z0-9_-]{1,50}(\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}/gi
+
+export const TEXT_GENERATION_TIMEOUT_MS = 60000


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Close issue syntax: `Fixes #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes #6449 

It will not directly resolve the issue with text not being rendered in Workflow. However, this PR will provide more flexible way of handling the issue. More detailed discussion can be found in the following [Discord thread](https://discord.com/channels/1082486657678311454/1261378430780571808).



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Set TEXT_GENERATION_TIMEOUT_MS to 30000 and the text generation took 33 seconds

Text generation took 33 seconds.
<img width="1575" alt="image" src="https://github.com/user-attachments/assets/5f1c6906-28b1-4b24-a1b9-fcc24daaa6a1">

As expected, the output is not shown.

<img width="1575" alt="image" src="https://github.com/user-attachments/assets/152cbd8f-b8a6-45ec-b2c6-4c6a483db7c7">

- [x] Set TEXT_GENERATION_TIMEOUT_MS to 30000 and the text generation took 16 seconds.

Text generation took 16 seconds.
<img width="1575" alt="image" src="https://github.com/user-attachments/assets/c8536426-8ddc-46e7-835a-e9e43336a2b2">

Output is correctly displayed.
<img width="1575" alt="image" src="https://github.com/user-attachments/assets/7a8cd548-1066-4b94-811b-57554541a7b8">


