### PR TITLE
fix: correct gpt-4o-mini max token

### DIFF
--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini-2024-07-18.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini-2024-07-18.yaml
@@ -24,7 +24,7 @@ parameter_rules:
     use_template: max_tokens
     default: 512
     min: 1
-    max: 16000
+    max: 16384
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini-2024-07-18.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini-2024-07-18.yaml
@@ -24,7 +24,7 @@ parameter_rules:
     use_template: max_tokens
     default: 512
     min: 1
-    max: 4096
+    max: 16000
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini.yaml
@@ -24,7 +24,7 @@ parameter_rules:
     use_template: max_tokens
     default: 512
     min: 1
-    max: 16000
+    max: 16384
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/gpt-4o-mini.yaml
@@ -24,7 +24,7 @@ parameter_rules:
     use_template: max_tokens
     default: 512
     min: 1
-    max: 4096
+    max: 16000
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openrouter/llm/gpt-4o-mini.yaml
+++ b/api/core/model_runtime/model_providers/openrouter/llm/gpt-4o-mini.yaml
@@ -23,7 +23,7 @@ parameter_rules:
     use_template: max_tokens
     default: 512
     min: 1
-    max: 4096
+    max: 16000
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/api/core/model_runtime/model_providers/openrouter/llm/gpt-4o-mini.yaml
+++ b/api/core/model_runtime/model_providers/openrouter/llm/gpt-4o-mini.yaml
@@ -23,7 +23,7 @@ parameter_rules:
     use_template: max_tokens
     default: 512
     min: 1
-    max: 16000
+    max: 16384
   - name: response_format
     label:
       zh_Hans: 回复格式


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

According to https://openrouter.ai/models/openai/gpt-4o-mini, the max_tokens for the GPT-4o-mini is 16k.

Fixes https://github.com/langgenius/dify/issues/6474

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



