### PR TITLE
fix: escape double quotation marks in the vector DB search query

### DIFF
--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -110,7 +110,7 @@ class RetrievalService:
                 )
 
                 documents = keyword.search(
-                    query,
+                    cls.escape_query_for_search(query),
                     top_k=top_k
                 )
                 all_documents.extend(documents)
@@ -132,7 +132,7 @@ class RetrievalService:
                 )
 
                 documents = vector.search_by_vector(
-                    query,
+                    cls.escape_query_for_search(query),
                     search_type='similarity_score_threshold',
                     top_k=top_k,
                     score_threshold=score_threshold,
@@ -170,7 +170,7 @@ class RetrievalService:
                 )
 
                 documents = vector_processor.search_by_full_text(
-                    query,
+                    cls.escape_query_for_search(query),
                     top_k=top_k
                 )
                 if documents:
@@ -186,3 +186,7 @@ class RetrievalService:
                         all_documents.extend(documents)
             except Exception as e:
                 exceptions.append(str(e))
+
+    @staticmethod
+    def escape_query_for_search(query: str) -> str:
+        return query.replace('"', '\\"')

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -40,7 +40,7 @@ class HitTestingService:
 
         all_documents = RetrievalService.retrieve(retrival_method=retrieval_model['search_method'],
                                                   dataset_id=dataset.id,
-                                                  query=query,
+                                                  query=cls.escape_query_for_search(query),
                                                   top_k=retrieval_model['top_k'],
                                                   score_threshold=retrieval_model['score_threshold']
                                                   if retrieval_model['score_threshold_enabled'] else None,
@@ -104,3 +104,7 @@ class HitTestingService:
 
         if not query or len(query) > 250:
             raise ValueError('Query is required and cannot exceed 250 characters')
+
+    @staticmethod
+    def escape_query_for_search(query: str) -> str:
+        return query.replace('"', '\\"')


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Close issue syntax: `Fixes #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes #5972 

Currently Dify returns the following error message if there are double quotations in the search query.

<img width="2079" alt="image" src="https://github.com/user-attachments/assets/27e4069e-67c0-460d-b083-31c696469832">

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Confirmed the retrieval testing returns relevant test results with double quotations in the search query.
- [x] Created three data sources as vector, full-text, and hybrid search. Confirmed all three data sources can be retrieved with double quotations in the search query.



