### PR TITLE
chore: make prompt generator max tokens configurable

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -183,6 +183,7 @@ UPLOAD_IMAGE_FILE_SIZE_LIMIT=10
 
 # Model Configuration
 MULTIMODAL_SEND_IMAGE_FORMAT=base64
+PROMPT_GENERATION_MAX_TOKENS=512
 
 # Mail configuration, support: resend, smtp
 MAIL_TYPE=

--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -1,3 +1,5 @@
+import os
+
 from flask_login import current_user
 from flask_restful import Resource, reqparse
 
@@ -28,13 +30,15 @@ class RuleGenerateApi(Resource):
         args = parser.parse_args()
 
         account = current_user
+        PROMPT_GENERATION_MAX_TOKENS = int(os.getenv('PROMPT_GENERATION_MAX_TOKENS', '512'))
 
         try:
             rules = LLMGenerator.generate_rule_config(
                 tenant_id=account.current_tenant_id,
                 instruction=args['instruction'],
                 model_config=args['model_config'],
-                no_variable=args['no_variable']
+                no_variable=args['no_variable'],
+                rule_config_max_tokens=PROMPT_GENERATION_MAX_TOKENS
             )
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -118,7 +118,7 @@ class LLMGenerator:
         return questions
 
     @classmethod
-    def generate_rule_config(cls, tenant_id: str, instruction: str, model_config: dict, no_variable: bool) -> dict:
+    def generate_rule_config(cls, tenant_id: str, instruction: str, model_config: dict, no_variable: bool, rule_config_max_tokens: int = 512) -> dict:
         output_parser = RuleConfigGeneratorOutputParser()
 
         error = ""
@@ -130,7 +130,7 @@ class LLMGenerator:
             "error": ""
         }
         model_parameters = {
-            "max_tokens": 512,
+            "max_tokens": rule_config_max_tokens,
             "temperature": 0.01
         }
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Close issue syntax: `Fixes #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes #6692 

The value of PROMPT_GENERATION_MAX_TOKENS is set to 512, which is same as prior to this PR. Thus, it will not change the current system's behaviour. What this PR allows is to give users a way to modify the length of prompt that is created by Prompt Generator.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Set the PROMPT_GENERATION_MAX_TOKENS to 512 in the .env file
The prompt generation got stopped at 2570 characters and not completed.

<img width="2178" alt="image" src="https://github.com/user-attachments/assets/788e8639-6afb-444b-b575-7be7afdc4d73">

- [x] Set the PROMPT_GENERATION_MAX_TOKENS to 1024 in the .env file
The prompt generator successfully created a 3776 characters long prompt.

<img width="2178" alt="image" src="https://github.com/user-attachments/assets/2d21d759-ebe9-405e-b869-66ab1a51ec87">



