### PR TITLE
Feat/6725 can not get image url from cogview tool

### DIFF
--- a/api/core/tools/provider/builtin/cogview/tools/cogview3.py
+++ b/api/core/tools/provider/builtin/cogview/tools/cogview3.py
@@ -30,7 +30,6 @@ class CogView3Tool(BuiltinTool):
         if not prompt:
             return self.create_text_message('Please input prompt')
         # get size
-        print(tool_parameters.get('prompt', 'square'))
         size = size_mapping[tool_parameters.get('size', 'square')]
         # get n
         n = tool_parameters.get('n', 1)
@@ -58,8 +57,10 @@ class CogView3Tool(BuiltinTool):
         result = []
         for image in response.data:
             result.append(self.create_image_message(image=image.url))
-        result.append(self.create_text_message(
-            f'\nGenerate image source to Seed ID: {seed_id}'))
+            result.append(self.create_json_message({
+                "url": image.url,
+            }))
+            result.append(self.create_text_message(f'{image.url}'))
         return result
 
     @staticmethod

--- a/api/core/tools/provider/builtin/cogview/tools/cogview3.py
+++ b/api/core/tools/provider/builtin/cogview/tools/cogview3.py
@@ -60,7 +60,6 @@ class CogView3Tool(BuiltinTool):
             result.append(self.create_json_message({
                 "url": image.url,
             }))
-            result.append(self.create_text_message(f'{image.url}'))
         return result
 
     @staticmethod


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This aims to get image url from CogView tools. Currently, it only renders the image in agent chat, but not in the workflow.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



