### PR TITLE
chore: set logging level to debug when reading YAML files and falling back to default value in case of None

### DIFF
--- a/api/core/tools/utils/yaml_utils.py
+++ b/api/core/tools/utils/yaml_utils.py
@@ -12,7 +12,7 @@ def load_yaml_file(file_path: str, ignore_error: bool = True, default_value: Any
     Safe loading a YAML file
     :param file_path: the path of the YAML file
     :param ignore_error:
-        if True, return default_value if error occurs and the error will be logged in warning level
+        if True, return default_value if error occurs and the error will be logged in debug level
         if False, raise error if error occurs
     :param default_value: the value returned when errors ignored
     :return: an object of the YAML content
@@ -20,12 +20,13 @@ def load_yaml_file(file_path: str, ignore_error: bool = True, default_value: Any
     try:
         with open(file_path, encoding='utf-8') as yaml_file:
             try:
-                return yaml.safe_load(yaml_file)
+                yaml_content = yaml.safe_load(yaml_file)
+                return yaml_content if yaml_content else default_value
             except Exception as e:
                 raise YAMLError(f'Failed to load YAML file {file_path}: {e}')
     except Exception as e:
         if ignore_error:
-            logger.warning(f'Failed to load YAML file {file_path}: {e}')
+            logger.debug(f'Failed to load YAML file {file_path}: {e}')
             return default_value
         else:
             raise e


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- as the follow-up PR of #6541, to reduce warning logging when parsing empty or non-existed YAML files
- fallback to default value when None result read from YAML file

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



