### PR TITLE
chore: remove redundant version pinning for indirect dependencies

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -9502,4 +9502,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "65ba64d7ae9594fa275b5ea067ff6fd02ed0880922dc449e9991aa36dd6f742f"
+content-hash = "a8b61d74d9322302b7447b6f8728ad606abc160202a8a122a05a8ef3cec7055b"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -217,18 +217,6 @@ alibabacloud_tea_openapi = "~0.3.9"
 clickhouse-connect = "~0.7.16"
 
 ############################################################
-# Transparent dependencies required by main dependencies
-# for pinning versions
-############################################################
-
-[tool.poetry.group.transparent.dependencies]
-kaleido = "0.2.1"
-lxml = "5.1.0"
-sympy = "1.12"
-tenacity = "~8.3.0"
-xlrd = "~2.0.1"
-
-############################################################
 # Dev dependencies for running tests
 ############################################################
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- remove pinned versions for indirect transparent dependencies, as `poetry.lock` lockfile already had the same effect

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



