### PR TITLE
chore: add shortcut keys and hints for the shortcuts

### DIFF
--- a/web/app/components/workflow/header/undo-redo.tsx
+++ b/web/app/components/workflow/header/undo-redo.tsx
@@ -30,7 +30,7 @@ const UndoRedo: FC<UndoRedoProps> = ({ handleUndo, handleRedo }) => {
 
   return (
     <div className='flex items-center p-0.5 rounded-lg border-[0.5px] border-gray-100 bg-white shadow-lg text-gray-500'>
-      <TipPopup title={t('workflow.common.undo')!} >
+      <TipPopup title={t('workflow.common.undo')!} shortcuts={['ctrl', 'z']}>
         <div
           data-tooltip-id='workflow.undo'
           className={`
@@ -43,7 +43,7 @@ const UndoRedo: FC<UndoRedoProps> = ({ handleUndo, handleRedo }) => {
           <RiArrowGoBackLine className='h-4 w-4' />
         </div>
       </TipPopup>
-      <TipPopup title={t('workflow.common.redo')!} >
+      <TipPopup title={t('workflow.common.redo')!} shortcuts={['ctrl', 'y']}>
         <div
           data-tooltip-id='workflow.redo'
           className={`

--- a/web/app/components/workflow/operator/control.tsx
+++ b/web/app/components/workflow/operator/control.tsx
@@ -83,23 +83,18 @@ const Control = () => {
     goLayout()
   }, { exactMatch: true, useCapture: true })
 
-  const addNote = (e?: MouseEvent<HTMLDivElement>) => {
+  const addNote = (e: MouseEvent<HTMLDivElement>) => {
     if (getNodesReadOnly())
       return
 
-    e?.stopPropagation()
+    e.stopPropagation()
     handleAddNote()
   }
-
-  useKeyPress('n', (e) => {
-    e.preventDefault()
-    addNote()
-  }, { exactMatch: true, useCapture: true })
 
   return (
     <div className='flex items-center p-0.5 rounded-lg border-[0.5px] border-gray-100 bg-white shadow-lg text-gray-500'>
       <AddBlock />
-      <TipPopup title={t('workflow.nodes.note.addNote')} shortcuts={['n']}>
+      <TipPopup title={t('workflow.nodes.note.addNote')}>
         <div
           className={cn(
             'flex items-center justify-center ml-[1px] w-8 h-8 rounded-lg hover:bg-black/5 hover:text-gray-700 cursor-pointer',

--- a/web/app/components/workflow/operator/control.tsx
+++ b/web/app/components/workflow/operator/control.tsx
@@ -16,7 +16,7 @@ import {
   useSelectionInteractions,
   useWorkflow,
 } from '../hooks'
-import { isEventTargetInputArea } from '../utils'
+import { getKeyboardKeyCodeBySystem, isEventTargetInputArea } from '../utils'
 import { useStore } from '../store'
 import AddBlock from './add-block'
 import TipPopup from './tip-popup'
@@ -78,18 +78,28 @@ const Control = () => {
     handleLayout()
   }
 
-  const addNote = (e: MouseEvent<HTMLDivElement>) => {
+  useKeyPress(`${getKeyboardKeyCodeBySystem('ctrl')}.o`, (e) => {
+    e.preventDefault()
+    goLayout()
+  }, { exactMatch: true, useCapture: true })
+
+  const addNote = (e?: MouseEvent<HTMLDivElement>) => {
     if (getNodesReadOnly())
       return
 
-    e.stopPropagation()
+    e?.stopPropagation()
     handleAddNote()
   }
+
+  useKeyPress('n', (e) => {
+    e.preventDefault()
+    addNote()
+  }, { exactMatch: true, useCapture: true })
 
   return (
     <div className='flex items-center p-0.5 rounded-lg border-[0.5px] border-gray-100 bg-white shadow-lg text-gray-500'>
       <AddBlock />
-      <TipPopup title={t('workflow.nodes.note.addNote')}>
+      <TipPopup title={t('workflow.nodes.note.addNote')} shortcuts={['n']}>
         <div
           className={cn(
             'flex items-center justify-center ml-[1px] w-8 h-8 rounded-lg hover:bg-black/5 hover:text-gray-700 cursor-pointer',
@@ -101,7 +111,7 @@ const Control = () => {
         </div>
       </TipPopup>
       <div className='mx-[3px] w-[1px] h-3.5 bg-gray-200'></div>
-      <TipPopup title={t('workflow.common.pointerMode')}>
+      <TipPopup title={t('workflow.common.pointerMode')} shortcuts={['v']}>
         <div
           className={cn(
             'flex items-center justify-center mr-[1px] w-8 h-8 rounded-lg cursor-pointer',
@@ -113,7 +123,7 @@ const Control = () => {
           <RiCursorLine className='w-4 h-4' />
         </div>
       </TipPopup>
-      <TipPopup title={t('workflow.common.handMode')}>
+      <TipPopup title={t('workflow.common.handMode')} shortcuts={['h']}>
         <div
           className={cn(
             'flex items-center justify-center w-8 h-8 rounded-lg cursor-pointer',
@@ -126,7 +136,7 @@ const Control = () => {
         </div>
       </TipPopup>
       <div className='mx-[3px] w-[1px] h-3.5 bg-gray-200'></div>
-      <TipPopup title={t('workflow.panel.organizeBlocks')}>
+      <TipPopup title={t('workflow.panel.organizeBlocks')} shortcuts={['ctrl', 'o']}>
         <div
           className={cn(
             'flex items-center justify-center w-8 h-8 rounded-lg hover:bg-black/5 hover:text-gray-700 cursor-pointer',

--- a/web/app/components/workflow/panel-contextmenu.tsx
+++ b/web/app/components/workflow/panel-contextmenu.tsx
@@ -71,7 +71,6 @@ const PanelContextmenu = () => {
           }}
         >
           {t('workflow.nodes.note.addNote')}
-          <ShortcutsName keys={['n']} />
         </div>
         <div
           className='flex items-center justify-between px-3 h-8 text-sm text-gray-700 rounded-lg cursor-pointer hover:bg-gray-50'

--- a/web/app/components/workflow/panel-contextmenu.tsx
+++ b/web/app/components/workflow/panel-contextmenu.tsx
@@ -71,6 +71,7 @@ const PanelContextmenu = () => {
           }}
         >
           {t('workflow.nodes.note.addNote')}
+          <ShortcutsName keys={['n']} />
         </div>
         <div
           className='flex items-center justify-between px-3 h-8 text-sm text-gray-700 rounded-lg cursor-pointer hover:bg-gray-50'


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

![image](https://github.com/user-attachments/assets/2f454fd3-0400-4afb-a12e-e7b92b54bdbb)

1. when you mouseover these icons,  only the `zoom in` and `zoom out` has shortcut hints, I add hints for other icons
2. add `ctrl+o` shortcut key for organize nodes

btw, add note operate also should have a shortcut for convience, but `ctrl+n` will blocked by the browser, a single `n` will affect textarea of user input. maybe `ctrl+s` for `add sticky note`?

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



