### PR TITLE
fix: remote image not display in answer node

### DIFF
--- a/api/core/file/file_obj.py
+++ b/api/core/file/file_obj.py
@@ -130,9 +130,6 @@ class FileVar(BaseModel):
                 )
             elif self.transfer_method == FileTransferMethod.TOOL_FILE:
                 extension = self.extension
-                # this url is remote url, we have not downloaded it to local server, so we don't need to sign it
-                if self.url:
-                    return self.url
                 # add sign url
                 return ToolFileParser.get_tool_file_manager().sign_file(tool_file_id=self.related_id, extension=extension)
 

--- a/api/core/file/file_obj.py
+++ b/api/core/file/file_obj.py
@@ -130,6 +130,9 @@ class FileVar(BaseModel):
                 )
             elif self.transfer_method == FileTransferMethod.TOOL_FILE:
                 extension = self.extension
+                # this url is remote url, we have not downloaded it to local server, so we don't need to sign it
+                if self.url:
+                    return self.url
                 # add sign url
                 return ToolFileParser.get_tool_file_manager().sign_file(tool_file_id=self.related_id, extension=extension)
 

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from duckduckgo_search import DDGS
 
+from core.file.file_obj import FileTransferMethod
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 
@@ -21,6 +22,7 @@ class DuckDuckGoImageSearchTool(BuiltinTool):
         response = DDGS().images(**query_dict)
         result = []
         for res in response:
+            res['transfer_method'] = FileTransferMethod.REMOTE_URL
             msg = ToolInvokeMessage(type=ToolInvokeMessage.MessageType.IMAGE_LINK,
                                     message=res.get('image'),
                                     save_as='',

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -174,13 +174,14 @@ class ToolNode(BaseNode):
                 ext = path.splitext(url)[1]
                 mimetype = response.meta.get('mime_type', 'image/jpeg')
                 filename = response.save_as or url.split('/')[-1]
+                transfer_method = response.meta.get('transfer_method', FileTransferMethod.TOOL_FILE)
 
                 # get tool file id
                 tool_file_id = url.split('/')[-1].split('.')[0]
                 result.append(FileVar(
                     tenant_id=self.tenant_id,
                     type=FileType.IMAGE,
-                    transfer_method=FileTransferMethod.TOOL_FILE,
+                    transfer_method=transfer_method,
                     url=url,
                     related_id=tool_file_id,
                     filename=filename,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes  https://github.com/langgenius/dify/issues/6857

Here the reason is the answer node use the `FileVar` object's `data` as input. If it's `transfer_method` attr is `REMOTE_URL`, it will use the remote url, otherwise it will sign it to localurl

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally
![0b5f13bf34476314f63873e627cf846](https://github.com/user-attachments/assets/bd74c541-365b-4acd-ab2e-8d48f3a87083)

![8ba551a41e6f8ac9ae80a87bda2858a](https://github.com/user-attachments/assets/f667a471-0081-4e1a-a6e5-1c30a9189724)

