### PR TITLE
Workflow TTS playback node filtering issue.

### DIFF
--- a/api/core/app/apps/advanced_chat/app_generator_tts_publisher.py
+++ b/api/core/app/apps/advanced_chat/app_generator_tts_publisher.py
@@ -5,7 +5,8 @@ import queue
 import re
 import threading
 
-from core.app.entities.queue_entities import QueueAgentMessageEvent, QueueLLMChunkEvent, QueueTextChunkEvent
+from core.app.entities.queue_entities import QueueAgentMessageEvent, QueueLLMChunkEvent, QueueTextChunkEvent, \
+    QueueNodeSucceededEvent
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 
@@ -88,6 +89,8 @@ class AppGeneratorTTSPublisher:
                     self.msg_text += message.event.chunk.delta.message.content
                 elif isinstance(message.event, QueueTextChunkEvent):
                     self.msg_text += message.event.text
+                elif isinstance(message.event, QueueNodeSucceededEvent):
+                    self.msg_text += message.event.outputs.get('output', '')
                 self.last_message = message
                 sentence_arr, text_tmp = self._extract_sentence(self.msg_text)
                 if len(sentence_arr) >= min(self.MAX_SENTENCE, 7):

--- a/api/core/app/apps/advanced_chat/app_generator_tts_publisher.py
+++ b/api/core/app/apps/advanced_chat/app_generator_tts_publisher.py
@@ -5,8 +5,12 @@ import queue
 import re
 import threading
 
-from core.app.entities.queue_entities import QueueAgentMessageEvent, QueueLLMChunkEvent, QueueTextChunkEvent, \
-    QueueNodeSucceededEvent
+from core.app.entities.queue_entities import (
+    QueueAgentMessageEvent,
+    QueueLLMChunkEvent,
+    QueueNodeSucceededEvent,
+    QueueTextChunkEvent,
+)
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
 

--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -244,8 +244,7 @@ class AdvancedChatAppGenerateTaskPipeline(BasedGenerateTaskPipeline, WorkflowCyc
         :return:
         """
         for message in self._queue_manager.listen():
-            if (isinstance(message.event, QueueTextChunkEvent)
-                    and message.event.metadata.get('is_answer_previous_node', False) and publisher):
+            if hasattr(message.event, 'metadata') and message.event.metadata.get('is_answer_previous_node', False) and publisher:
                 publisher.publish(message=message)
             event = message.event
 

--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -246,6 +246,11 @@ class AdvancedChatAppGenerateTaskPipeline(BasedGenerateTaskPipeline, WorkflowCyc
         for message in self._queue_manager.listen():
             if hasattr(message.event, 'metadata') and message.event.metadata.get('is_answer_previous_node', False) and publisher:
                 publisher.publish(message=message)
+            elif (hasattr(message.event, 'execution_metadata')
+                  and message.event.execution_metadata
+                  and message.event.execution_metadata.get('is_answer_previous_node', False)
+                  and publisher):
+                publisher.publish(message=message)
             event = message.event
 
             if isinstance(event, QueueErrorEvent):

--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -244,7 +244,8 @@ class AdvancedChatAppGenerateTaskPipeline(BasedGenerateTaskPipeline, WorkflowCyc
         :return:
         """
         for message in self._queue_manager.listen():
-            if publisher:
+            if (isinstance(message.event, QueueTextChunkEvent)
+                    and message.event.metadata.get('is_answer_previous_node', False) and publisher):
                 publisher.publish(message=message)
             event = message.event
 

--- a/api/core/workflow/nodes/base_node.py
+++ b/api/core/workflow/nodes/base_node.py
@@ -49,6 +49,8 @@ class BaseNode(ABC):
 
     callbacks: Sequence[WorkflowCallback]
 
+    is_answer_previous_node: bool = False
+
     def __init__(self, tenant_id: str,
                  app_id: str,
                  workflow_id: str,
@@ -110,6 +112,7 @@ class BaseNode(ABC):
                     text=text,
                     metadata={
                         "node_type": self.node_type,
+                        "is_answer_previous_node": self.is_answer_previous_node,
                         "value_selector": value_selector
                     }
                 )

--- a/api/core/workflow/workflow_engine_manager.py
+++ b/api/core/workflow/workflow_engine_manager.py
@@ -177,6 +177,19 @@ class WorkflowEngineManager:
         graph = workflow.graph_dict
 
         try:
+            answer_prov_node_ids = []
+            for node in graph.get('nodes', []):
+                if node.get('id', '') == 'answer':
+                    try:
+                        answer_prov_node_ids.append(node.get('data', {})
+                                                    .get('answer', '')
+                                                    .replace('#', '')
+                                                    .replace('.text', '')
+                                                    .replace('{{', '')
+                                                    .replace('}}', ''))
+                    except Exception as e:
+                        logger.error(e)
+
             predecessor_node: BaseNode | None = None
             current_iteration_node: BaseIterationNode | None = None
             has_entry_node = False
@@ -300,6 +313,9 @@ class WorkflowEngineManager:
                         continue
                     else:
                         next_node = self._get_node(workflow_run_state=workflow_run_state, graph=graph, node_id=next_node_id, callbacks=callbacks)
+
+                if next_node and next_node.node_id in answer_prov_node_ids:
+                    next_node.is_answer_previous_node = True
 
                 # run workflow, run multiple target nodes in the future
                 self._run_workflow_node(

--- a/api/core/workflow/workflow_engine_manager.py
+++ b/api/core/workflow/workflow_engine_manager.py
@@ -186,7 +186,7 @@ class WorkflowEngineManager:
                                                     .replace('#', '')
                                                     .replace('.text', '')
                                                     .replace('{{', '')
-                                                    .replace('}}', ''))
+                                                    .replace('}}', '').split('.')[0])
                     except Exception as e:
                         logger.error(e)
 
@@ -870,6 +870,10 @@ class WorkflowEngineManager:
 
             raise ValueError(f"Node {node.node_data.title} run failed: {node_run_result.error}")
 
+        if node.is_answer_previous_node and not isinstance(node, LLMNode):
+            if not node_run_result.metadata:
+                node_run_result.metadata = {}
+            node_run_result.metadata["is_answer_previous_node"]=True
         workflow_nodes_and_result.result = node_run_result
 
         # node run success


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

In the workflow chat, if a workflow contains multiple LLM nodes and the TTS auto-play feature is enabled, then the output of each LLM node will play the LLM. This may not be what the user needs. This fix is to ensure that TTS only plays the text content of the output from the end node, so that whatever the user sees, TTS will play.
eg.

<img width="2296" alt="image" src="https://github.com/user-attachments/assets/afd1735f-bb4c-460a-b2a0-5bcee5b77b7f">

In such cases, TTS should only play the output of the LLM2 node, because the final output of the Answer is the data from LLM2, and what the user sees is also the data output by LLM2. Therefore, TTS should only play the data output by LLM2.



Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



