### PR TITLE
fix: Change API key authentication failure response code from 404 to 401

### DIFF
--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -19,7 +19,7 @@ def inner_api_only(view):
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get('X-Inner-Api-Key')
         if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY:
-            abort(404)
+            abort(401)
 
         return view(*args, **kwargs)
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [X] Please open an issue before creating a PR or link to an existing issue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
When calling inner APIs, we use the @inner_api_only decorator. This decorator includes logic to compare the inner API key value provided in the API call with the value set on the server.

Currently, when the API keys do not match, a 404 status code is returned. However, for authentication failures, a 401 status code would be more appropriate and align with common practices.

The current 404 response led to confusion, causing developers to mistakenly believe the inner API URL was incorrectly set, resulting in significant time wasted on debugging.

**I propose modifying the response to return a 401 status code for inner api calling authentication failures**, which would more accurately represent the nature of the error and improve the developer experience.

⭐️Conclusion:
as-is: 404 for wrong inner api key
to-be: 401 for wrong inner api key

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

This PR literally changed only one character.



