### PR TITLE
compatible xinference reranker server

### DIFF
--- a/api/core/model_runtime/model_providers/xinference/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/xinference/rerank/rerank.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from xinference_client.client.restful.restful_client import Client, RESTfulRerankModelHandle
 
@@ -51,17 +51,22 @@ class XinferenceRerankModel(RerankModel):
             server_url = server_url[:-1]
         auth_headers = {'Authorization': f'Bearer {api_key}'} if api_key else {}
 
+        params = {
+            'documents': docs,
+            'query': query,
+            'top_n': top_n,
+            'return_documents': True
+        }
         try:
             handle = RESTfulRerankModelHandle(model_uid, server_url, auth_headers)
-            response = handle.rerank(
-                documents=docs,
-                query=query,
-                top_n=top_n,
-                return_documents=True
-            )
+            response = handle.rerank(**params)
         except RuntimeError as e:
-            raise InvokeServerUnavailableError(str(e))
+            if "rerank hasn't support extra parameter" not in str(e):
+                raise InvokeServerUnavailableError(str(e))
 
+            # compatible xinference server between v0.10.1 - v0.12.1, not support 'return_len'
+            handle = RESTfulRerankModelHandleWithoutExtraParameter(model_uid, server_url, auth_headers)
+            response = handle.rerank(**params)
 
         rerank_documents = []
         for idx, result in enumerate(response['results']):
@@ -167,8 +172,40 @@ class XinferenceRerankModel(RerankModel):
             ),
             fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
             model_type=ModelType.RERANK,
-            model_properties={ },
+            model_properties={},
             parameter_rules=[]
         )
 
         return entity
+
+
+class RESTfulRerankModelHandleWithoutExtraParameter(RESTfulRerankModelHandle):
+
+    def rerank(
+            self,
+            documents: List[str],
+            query: str,
+            top_n: Optional[int] = None,
+            max_chunks_per_doc: Optional[int] = None,
+            return_documents: Optional[bool] = None,
+            **kwargs
+    ):
+        url = f"{self._base_url}/v1/rerank"
+        request_body = {
+            "model": self._model_uid,
+            "documents": documents,
+            "query": query,
+            "top_n": top_n,
+            "max_chunks_per_doc": max_chunks_per_doc,
+            "return_documents": return_documents,
+        }
+
+        import requests
+
+        response = requests.post(url, json=request_body, headers=self.auth_headers)
+        if response.status_code != 200:
+            raise InvokeServerUnavailableError(
+                f"Failed to rerank documents, detail: {response.json()['detail']}"
+            )
+        response_data = response.json()
+        return response_data

--- a/api/core/model_runtime/model_providers/xinference/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/xinference/rerank/rerank.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 from xinference_client.client.restful.restful_client import Client, RESTfulRerankModelHandle
 
@@ -183,7 +183,7 @@ class RESTfulRerankModelHandleWithoutExtraParameter(RESTfulRerankModelHandle):
 
     def rerank(
             self,
-            documents: List[str],
+            documents: list[str],
             query: str,
             top_n: Optional[int] = None,
             max_chunks_per_doc: Optional[int] = None,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
error:
```json
{
    "code": "invalid_param",
    "message": "[xinference] Server Unavailable Error, Failed to rerank documents, detail: [address=0.0.0.0:35815, pid=74] rerank hasn't support extra parameter.",
    "status": 400
}
```

throw error after commit https://github.com/xorbitsai/inference/commit/6ef2815e1b3e58485528146eafe0190b41b4aedb#diff-8836e2c94d14cb4a5c30cca682e04289976b198470dd4ad3ca0e58efe5543d13


this error will be occurred at xinference server v0.10.1 -> v0.12.1

xinference 


![344d7892edadee8ac394df095493a5f2](https://github.com/user-attachments/assets/cd2df382-8177-46df-8049-f8f3378ae521)

![image](https://github.com/user-attachments/assets/715f16cb-bced-4e65-bf31-21c31b7ea3ca)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

I test xinference rerank at v0.12.0 server and v0.14.0 server 

