### PR TITLE
fix: restore xinference secret field

### DIFF
--- a/api/core/model_runtime/model_providers/xinference/xinference.yaml
+++ b/api/core/model_runtime/model_providers/xinference/xinference.yaml
@@ -33,7 +33,7 @@ model_credential_schema:
       label:
         zh_Hans: 服务器URL
         en_US: Server url
-      type: text-input
+      type: secret-input
       required: true
       placeholder:
         zh_Hans: 在此输入Xinference的服务器地址，如 http://192.168.1.100:9997
@@ -51,7 +51,7 @@ model_credential_schema:
       label:
         zh_Hans: API密钥
         en_US: API key
-      type: text-input
+      type: secret-input
       required: false
       placeholder:
         zh_Hans: 在此输入您的API密钥

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
@@ -114,7 +114,7 @@ const Form: FC<FormProps> = ({
             validated={validatedSuccess}
             placeholder={placeholder?.[language] || placeholder?.en_US}
             disabled={disabed}
-            type={formSchema.type === FormTypeEnum.textNumber ? 'number' : formSchema.type === FormTypeEnum.secretInput ? 'password' : 'text'}
+            type={formSchema.type === FormTypeEnum.textNumber ? 'number' : 'text'}
             {...(formSchema.type === FormTypeEnum.textNumber ? { min: (formSchema as CredentialFormSchemaNumberInput).min, max: (formSchema as CredentialFormSchemaNumberInput).max } : {})}
           />
           {fieldMoreInfo?.(formSchema)}


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

In previous versions, while configuring the xinference model provider, the `server_url` in the model configuration was stored in an encrypted format. However, following the changes in [this issue](https://github.com/langgenius/dify/issues/6274), it is now stored in plaintext. This change can cause failures when accessing models that were previously configured to use the encrypted URL directly.

I made the following changes:
1. Reverted the `server_url` field type back to secret-input to ensure that previously configured models are not affected.
2. Changed the `api_key` field type to secret-input.
3. Updated the front-end `secret-input` to display as a text type input because the back-end has already sanitized the return of this field type. Displaying it as a password on the front-end is redundant, and it prevents users configuring the system from clearly seeing the current configuration.

Here is the screenshot showing the effect after the changes:
![image](https://github.com/user-attachments/assets/30bed0a1-caf4-4500-a5ff-19bd3c382378)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] For a model that was configured before with the xinference provider, after deleting the cache stored in Redis, the URL will be an encrypted string, which causes all chat interactions to fail.



