### PR TITLE
fix: fix tran list issue

### DIFF
--- a/api/core/rag/splitter/fixed_text_splitter.py
+++ b/api/core/rag/splitter/fixed_text_splitter.py
@@ -63,7 +63,7 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
         if self._fixed_separator:
             chunks = text.split(self._fixed_separator)
         else:
-            chunks = list(text)
+            chunks = [text]
 
         final_chunks = []
         for chunk in chunks:


### PR DESCRIPTION
list("abc") = ["a", "b", "c"]

Without specifying a delimiter, the existing implementation converts the text to a list of letters, which is not expected


