### PR TITLE
feat: Add hyperlink parsing to the DOCX document.

### DIFF
--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -1,9 +1,12 @@
 """Abstract interface for document loader implementations."""
 import datetime
+import logging
 import mimetypes
 import os
+import re
 import tempfile
 import uuid
+import xml.etree.ElementTree as ET
 from urllib.parse import urlparse
 
 import requests
@@ -16,6 +19,7 @@ from extensions.ext_database import db
 from extensions.ext_storage import storage
 from models.model import UploadFile
 
+logger = logging.getLogger(__name__)
 
 class WordExtractor(BaseExtractor):
     """Load docx files.
@@ -152,6 +156,31 @@ class WordExtractor(BaseExtractor):
         content = []
 
         image_map = self._extract_images_from_docx(doc, image_folder)
+
+        hyperlinks_url = None
+        url_pattern = re.compile(r'http://[^\s+]+//|https://[^\s+]+')
+        for para in doc.paragraphs:
+            # 检查段落中是否有超链接
+            for run in para.runs:
+                if run.text and hyperlinks_url:
+                    result = f'  [{run.text}]({hyperlinks_url})  '
+                    run.text = result
+                    hyperlinks_url = None
+                if 'HYPERLINK' in run.element.xml:
+                    try:
+                        xml = ET.XML(run.element.xml)
+                        x_child = [c for c in xml.iter() if c is not None]
+                        for x in x_child:
+                            if x_child is None:
+                                continue
+                            if x.tag.endswith('instrText'):
+                                for i in url_pattern.findall(x.text):
+                                    hyperlinks_url = str(i)
+                    except Exception as e:
+                        logger.error(e)
+
+
+
 
         def parse_paragraph(paragraph):
             paragraph_content = []

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -160,7 +160,6 @@ class WordExtractor(BaseExtractor):
         hyperlinks_url = None
         url_pattern = re.compile(r'http://[^\s+]+//|https://[^\s+]+')
         for para in doc.paragraphs:
-            # 检查段落中是否有超链接
             for run in para.runs:
                 if run.text and hyperlinks_url:
                     result = f'  [{run.text}]({hyperlinks_url})  '


### PR DESCRIPTION
…rving the hyperlink address functionality.

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

<img width="878" alt="image" src="https://github.com/user-attachments/assets/5131dc4a-aafd-4cd7-b6c1-f99170493f09">

I have a Word document content as shown in the figure that needs to be extract. bug i got 

``` txt
this is HyperLink case: YOUTUB VEDIO
```
I hope to get is

```txt
this is HyperLink case: [YOUTUB VEDIO ](https://www.youtube.com/)

```



Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Find the same document for testing and that will do.

- [ ] Test A
- [ ] Test B



