### PR TITLE
Provide output data also in json property of workflow tool (#6924)

### DIFF
--- a/api/core/tools/tool/workflow_tool.py
+++ b/api/core/tools/tool/workflow_tool.py
@@ -72,6 +72,7 @@ class WorkflowTool(Tool):
             result.append(self.create_file_var_message(file))
         
         result.append(self.create_text_message(json.dumps(outputs, ensure_ascii=False)))
+        result.append(self.create_json_message(outputs))
 
         return result
 


### PR DESCRIPTION
# Checklist:

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This patch will change the output behaviour of workflow tools, so the output data of a workflow block will also be provided via `json` property. This simplifies further usage of this data, because you do not need to transform the stringified output data from `text` property to access certain properties of this data in following tools. This issue is described in more detail in 
Close #6924.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

- [x] Create a simple workflow (A), which takes a text input and provides this as an output in the end
- [x] Create a second workflow (B), which takes a text input, passes this into workflow (A), receives the output of this embedded workflow and finally provides this data in the end
- [x] Expect: If you run the parent workflow (B), the `json` property in the end finally contains the output data from the emebedded workflow (A).



