### PR TITLE
Update i18n/ja-JP/dataset-documents.ts "embeddedSpend" value.

### DIFF
--- a/web/i18n/ja-JP/dataset-documents.ts
+++ b/web/i18n/ja-JP/dataset-documents.ts
@@ -221,7 +221,7 @@ const translation = {
         paragraphs: '段落',
         hitCount: '検索回数',
         embeddingTime: '埋め込み時間',
-        embeddedSpend: '埋め込み時間',
+        embeddedSpend: '埋め込みコスト',
       },
     },
     languageMap: {


### PR DESCRIPTION
Update i18n/ja-JP/dataset-documents.ts "embeddedSpend" value.

# Checklist:
> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.
- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
This PR updates the Japanese translation for the "embeddedSpend" field in the dataset-documents.ts file. The translation has been changed from "埋め込み時間" to "埋め込みコスト" to more accurately reflect the meaning of "Embedded spend".

This change is related to the issue of i18n translations not being reflected in the Docker environment, which is being tracked separately in issue #7123. While this PR addresses the translation update itself, the visibility of this change in the Docker environment is still under investigation.

Fixes #(issue number for the translation update, if one exists)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions
To verify this change:

1. Navigate to the `web/i18n/ja-JP/dataset-documents.ts` file.
2. Confirm that the "embeddedSpend" field is now translated as "埋め込みコスト".
3. Run the following commands to build the project:
   ```
   cd /path/to/dify/
   npm ci
   cd web/
   npm ci
   npm run build
   ```
4. Check the built files to ensure the change is included:
   ```
   cd /path/to/dify/web/.next/server
   grep -r "埋め込みコスト" .
   ```
5. Launch the application and navigate to the relevant UI section to visually confirm the change.

Note: As mentioned in issue #7123, there may be discrepancies between the built files and the Docker environment. However, since `npm build` succeeds and the updated string can be found in `/path/to/dify/web/.next/server`, I believe this PR sufficiently addresses the `.ts` file syntax update. The Docker-related discrepancy would be investigated separately and should not block this translation update.
