### PR TITLE
Add explanatory comment to NGINX_ENABLE_CERTBOT_CHALLENGE key in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -657,6 +657,7 @@ NGINX_KEEPALIVE_TIMEOUT=65
 NGINX_PROXY_READ_TIMEOUT=3600s
 NGINX_PROXY_SEND_TIMEOUT=3600s
 
+# Set true to accept requests for /.well-known/acme-challenge/
 NGINX_ENABLE_CERTBOT_CHALLENGE=false
 
 # ------------------------------


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This pull request adds an appropriate comment to the NGINX_ENABLE_CERTBOT_CHALLENGE key in the `.env.example` file to enhance clarity and provide guidance on this specific configuration option. The comment starts with `#` and is intended to make the function of this key more user-friendly and easier to understand.

## Fixes

Before:
NGINX_ENABLE_CERTBOT_CHALLENGE=false

After:
# Set true to accept requests for /.well-known/acme-challenge/
NGINX_ENABLE_CERTBOT_CHALLENGE=false

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `cp .env.example .env` and executed `docker-compose up --force-recreate`. Then check if the server accepts a request to `localhost/apps` from a browser.
