### PR TITLE
chore: allow download audio/video through HTTP node

### DIFF
--- a/api/core/workflow/nodes/http_request/http_request_node.py
+++ b/api/core/workflow/nodes/http_request/http_request_node.py
@@ -133,9 +133,6 @@ class HttpRequestNode(BaseNode):
         """
         files = []
         mimetype, file_binary = response.extract_file()
-        # if not image, return directly
-        if 'image' not in mimetype:
-            return files
 
         if mimetype:
             # extract filename from url


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

At present, we only allow images download through HTTP node. I don't know why,  I think we should allow more types to download.  The code [here](https://github.com/langgenius/dify/blob/13d061911b6ccd823ab3e5c85c8f2b680cd5a1fb/api/core/workflow/nodes/http_request/http_executor.py#L41) limit image/audio/video in content-type can get the mimetype and can be downloaded.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test url `https://cdn.pixabay.com/download/audio/2023/08/05/audio_145e6bad08.mp3?filename=usb-connect-160911.mp3`

- [ ] Test A
- [ ] Test B



