### PR TITLE
fix ja-JP translation of secret values

### DIFF
--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -94,9 +94,9 @@ const translation = {
     },
     export: {
       title: 'シークレット環境変数をエクスポートしますか？',
-      checkbox: 'シクレート値をエクスポート',
+      checkbox: 'シークレット値をエクスポート',
       ignore: 'DSLをエクスポート',
-      export: 'シクレート値を含むDSLをエクスポート',
+      export: 'シークレット値を含むDSLをエクスポート',
     },
   },
   changeHistory: {


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

The Japanese translation of "secret" has been corrected from "シクレート" to "シークレット".

Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



