### PR TITLE
Fix: Preserve tag input state on blur

### DIFF
--- a/web/app/components/base/tag-input/index.tsx
+++ b/web/app/components/base/tag-input/index.tsx
@@ -63,7 +63,6 @@ const TagInput: FC<TagInputProps> = ({
   }
 
   const handleBlur = () => {
-    setValue('')
     setFocused(false)
   }
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This PR addresses the issue where the tag input field loses its state when the mouse leaves the area during tag addition. The fix preserves the input state by modifying the `handleBlur` function in the TagInput component to only set the focus state without clearing the input value.

This change improves the user experience by allowing users to move their mouse away from the input area (e.g., to copy a tag name from another source) without losing their input.

Fixes #7471

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

To verify this change:

1. Create a new application in the system.
2. Hover over the tag addition area to make the tag input field appear.
3. Begin typing a tag name.
4. Move the mouse cursor away from the tag input area.
5. Move the mouse cursor back to the tag input area.
6. Verify that the previously entered text is still present in the input field.

Additional tests:
- Test with multiple tag input fields on the same page to ensure they function independently.
- Test rapid mouse movements in and out of the tag input area to ensure stability.