### PR TITLE
fix(onebot): use yarl to format url

### DIFF
--- a/api/core/tools/provider/builtin/onebot/tools/send_group_msg.py
+++ b/api/core/tools/provider/builtin/onebot/tools/send_group_msg.py
@@ -1,6 +1,7 @@
 from typing import Any, Union
 
 import requests
+from yarl import URL
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
@@ -29,9 +30,10 @@ class SendGroupMsg(BuiltinTool):
         auto_escape = tool_parameters.get('auto_escape', False)
 
         try:
+            url = URL(self.runtime.credentials['ob11_http_url']) / 'send_group_msg'
 
             resp = requests.post(
-                f'{self.runtime.credentials['ob11_http_url']}/send_group_msg',
+                url,
                 json={
                     'group_id': send_group_id,
                     'message': message,

--- a/api/core/tools/provider/builtin/onebot/tools/send_private_msg.py
+++ b/api/core/tools/provider/builtin/onebot/tools/send_private_msg.py
@@ -1,6 +1,7 @@
 from typing import Any, Union
 
 import requests
+from yarl import URL
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
@@ -29,8 +30,10 @@ class SendPrivateMsg(BuiltinTool):
         auto_escape = tool_parameters.get('auto_escape', False)
 
         try:
+            url = URL(self.runtime.credentials['ob11_http_url']) / 'send_private_msg'
+
             resp = requests.post(
-                f'{self.runtime.credentials['ob11_http_url']}/send_private_msg',
+                url,
                 json={
                     'user_id': send_user_id,
                     'message': message,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Use yarl to format in stead of f-str to fix a url formatting bug in #7583 

Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



