### PR TITLE
add：save_model_credentials error log

### DIFF
--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -156,6 +156,7 @@ class ModelProviderModelApi(Resource):
                         credentials=args['credentials']
                     )
                 except CredentialsValidateFailedError as ex:
+                    logging.exception(f"save model credentials error: {ex}")
                     raise ValueError(str(ex))
 
         return {'result': 'success'}, 200


### PR DESCRIPTION
# Checklist:
> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.
- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
This PR enhances the error logging for the `save_model_credentials` method in the `ModelProviderModelApi` class. By adding a detailed stack trace log when a `CredentialsValidateFailedError` occurs, we improve our ability to debug and quickly identify the root cause of credential validation failures, especially in complex model validation scenarios.

This change does not alter the existing functionality but significantly improves observability, which is crucial for troubleshooting in production environments.

Fixes #[Issue number] (Please replace with the actual issue number if one exists)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions
To verify this change:
- [ ] Intentionally trigger a `CredentialsValidateFailedError` in the `save_model_credentials` method
- [ ] Check the logs to ensure the full stack trace is present
- [ ] Run existing unit tests to confirm no regression