### PR TITLE
feat: return page number of pdf documents upon retrieval

### DIFF
--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -30,7 +30,7 @@ class AbstractVectorFactory(ABC):
 class Vector:
     def __init__(self, dataset: Dataset, attributes: list = None):
         if attributes is None:
-            attributes = ['doc_id', 'dataset_id', 'document_id', 'doc_hash']
+            attributes = ['doc_id', 'dataset_id', 'document_id', 'doc_hash', 'page']
         self._dataset = dataset
         self._embeddings = self._get_embeddings()
         self._attributes = attributes
@@ -107,6 +107,7 @@ class Vector:
     def add_texts(self, documents: list[Document], **kwargs):
         if kwargs.get('duplicate_check', False):
             documents = self._filter_duplicate_texts(documents)
+
         embeddings = self._embeddings.embed_documents([document.page_content for document in documents])
         self._vector_processor.create(
             texts=documents,

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+
 from sqlalchemy import func
 
 from core.app.app_config.entities import DatasetRetrieveConfigEntity

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -1,5 +1,4 @@
 from typing import Any, cast
-
 from sqlalchemy import func
 
 from core.app.app_config.entities import DatasetRetrieveConfigEntity
@@ -173,9 +172,13 @@ class KnowledgeRetrievalNode(BaseNode):
         context_list = []
         if all_documents:
             document_score_list = {}
+            page_number_list = {}
             for item in all_documents:
                 if item.metadata.get('score'):
                     document_score_list[item.metadata['doc_id']] = item.metadata['score']
+                # both 'page' and 'score' are metadata fields
+                if item.metadata.get('page'):
+                    page_number_list[item.metadata['doc_id']] = item.metadata['page']
 
             index_node_ids = [document.metadata['doc_id'] for document in all_documents]
             segments = DocumentSegment.query.filter(
@@ -199,9 +202,9 @@ class KnowledgeRetrievalNode(BaseNode):
                                                      Document.enabled == True,
                                                      Document.archived == False,
                                                      ).first()
+
                     resource_number = 1
                     if dataset and document:
-
                         source = {
                             'metadata': {
                                 '_source': 'knowledge',
@@ -211,6 +214,7 @@ class KnowledgeRetrievalNode(BaseNode):
                                 'document_id': document.id,
                                 'document_name': document.name,
                                 'document_data_source_type': document.data_source_type,
+                                'page': page_number_list.get(segment.index_node_id, None),
                                 'segment_id': segment.id,
                                 'retriever_from': 'workflow',
                                 'score': document_score_list.get(segment.index_node_id, None),

--- a/api/core/workflow/nodes/llm/llm_node.py
+++ b/api/core/workflow/nodes/llm/llm_node.py
@@ -1,4 +1,5 @@
 import json
+
 from collections.abc import Generator
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, cast
@@ -400,6 +401,7 @@ class LLMNode(BaseNode):
         if ('metadata' in context_dict and '_source' in context_dict['metadata']
                 and context_dict['metadata']['_source'] == 'knowledge'):
             metadata = context_dict.get('metadata', {})
+
             source = {
                 'position': metadata.get('position'),
                 'dataset_id': metadata.get('dataset_id'),
@@ -415,6 +417,7 @@ class LLMNode(BaseNode):
                 'segment_position': metadata.get('segment_position'),
                 'index_node_hash': metadata.get('segment_index_node_hash'),
                 'content': context_dict.get('content'),
+                'page': metadata.get('page'),
             }
 
             return source

--- a/api/core/workflow/nodes/llm/llm_node.py
+++ b/api/core/workflow/nodes/llm/llm_node.py
@@ -1,5 +1,4 @@
 import json
-
 from collections.abc import Generator
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, cast


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Return the original page number of an uploaded pdf file when retrieving knowledge. 
    - the value will be `None` if `page` is not in the knowledge base 
- Closes #7738 
- Closes https://github.com/langgenius/dify/issues/7944

Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on different local files besides pdf and it works
- [x] page number is returned when querying a pdf file
 
<img width="231" alt="Screenshot 2024-08-28 at 4 00 40 PM" src="https://github.com/user-attachments/assets/e2457e91-7d99-41b7-90f9-7eaaf4728b50">
