### PR TITLE
fix: not able to pass array of string/number/object into variable aggregator groups

### DIFF
--- a/api/core/workflow/nodes/variable_aggregator/entities.py
+++ b/api/core/workflow/nodes/variable_aggregator/entities.py
@@ -17,7 +17,7 @@ class AdvancedSettings(BaseModel):
         """
         Group.
         """
-        output_type: Literal['string', 'number', 'array', 'object']
+        output_type: Literal['string', 'number', 'object', 'array[string]', 'array[number]', 'array[object]']
         variables: list[list[str]]
         group_name: str
 


### PR DESCRIPTION

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes #6096 

The bug appears when using groups in variable aggregator node:

![2](https://github.com/user-attachments/assets/7d8ab9a7-61d5-403b-87a0-42b904194917)
![6](https://github.com/user-attachments/assets/31d45a00-6b2b-475f-81b3-e17d0d9447d7)



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



