### PR TITLE
fix: crawl options max length can not set 0

### DIFF
--- a/web/app/components/datasets/create/website/firecrawl/base/field.tsx
+++ b/web/app/components/datasets/create/website/firecrawl/base/field.tsx
@@ -38,7 +38,7 @@ const Field: FC<Props> = ({
             popupContent={
               <div className='w-[200px]'>{tooltip}</div>
             }
-            popupClassName='relative top-[3px] w-3 h-3 ml-1'
+            triggerClassName='ml-0.5 w-4 h-4'
           />
         )}
       </div>

--- a/web/app/components/datasets/create/website/firecrawl/base/input.tsx
+++ b/web/app/components/datasets/create/website/firecrawl/base/input.tsx
@@ -9,7 +9,7 @@ type Props = {
   isNumber?: boolean
 }
 
-const MIN_VALUE = 1
+const MIN_VALUE = 0
 
 const Input: FC<Props> = ({
   value,


### PR DESCRIPTION
# Description

Fix crawl options max length can not set 0 and tooltip problems.

Fixes https://github.com/langgenius/dify/issues/7755

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



