### PR TITLE
fix: correct http timeout configs‘ default values and ignorance by HttpRequestNode

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Optional
 
-from pydantic import AliasChoices, Field, HttpUrl, NegativeInt, NonNegativeInt, PositiveInt, computed_field, conint
+from pydantic import AliasChoices, Field, HttpUrl, NegativeInt, NonNegativeInt, PositiveInt, computed_field
 from pydantic_settings import BaseSettings
 
 from configs.feature.hosted_service import HostedServiceConfig

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1,8 +1,7 @@
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import AliasChoices, Field, HttpUrl, NegativeInt, NonNegativeInt, PositiveInt, computed_field, conint
 from pydantic_settings import BaseSettings
-from typing_extensions import Annotated
 
 from configs.feature.hosted_service import HostedServiceConfig
 
@@ -218,20 +217,29 @@ class HttpConfig(BaseSettings):
     def WEB_API_CORS_ALLOW_ORIGINS(self) -> list[str]:
         return self.inner_WEB_API_CORS_ALLOW_ORIGINS.split(",")
 
-    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[int, Field(ge=10)] = Field(
-        description="connect timeout in seconds for HTTP request, which should be no less than 60",
-        default=10,
-    )
+    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[int, Field(ge=10)] = Annotated[
+        int,
+        Field(
+            description="connect timeout in seconds for HTTP request, which should be no less than 60",
+            default=10,
+        ),
+    ]
 
-    HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[int, Field(ge=60)] = Field(
-        description="read timeout in seconds for HTTP request, which should be no less than 60",
-        default=60,
-    )
+    HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[int, Field(ge=60)] = Annotated[
+        int,
+        Field(
+            description="read timeout in seconds for HTTP request, which should be no less than 60",
+            default=60,
+        ),
+    ]
 
-    HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[int, Field(ge=10)] = Field(
-        description="read timeout in seconds for HTTP request, which should be no less than 10",
-        default=20,
-    )
+    HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[int, Field(ge=10)] = Annotated[
+        int,
+        Field(
+            description="read timeout in seconds for HTTP request, which should be no less than 10",
+            default=20,
+        ),
+    ]
 
     HTTP_REQUEST_NODE_MAX_BINARY_SIZE: PositiveInt = Field(
         description="",

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -217,29 +217,25 @@ class HttpConfig(BaseSettings):
     def WEB_API_CORS_ALLOW_ORIGINS(self) -> list[str]:
         return self.inner_WEB_API_CORS_ALLOW_ORIGINS.split(",")
 
-    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[int, Field(ge=10)] = Annotated[
-        int,
-        Field(
-            description="connect timeout in seconds for HTTP request, which should be no less than 60",
-            default=10,
-        ),
-    ]
+    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[
+        int, Field(ge=10, description="connect timeout in seconds for HTTP request, which should be no less than 60")
+    ] = 10
 
-    HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[int, Field(ge=60)] = Annotated[
+    HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[
         int,
         Field(
+            ge=60,
             description="read timeout in seconds for HTTP request, which should be no less than 60",
-            default=60,
         ),
-    ]
+    ] = 60
 
-    HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[int, Field(ge=10)] = Annotated[
+    HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[
         int,
         Field(
+            ge=10,
             description="read timeout in seconds for HTTP request, which should be no less than 10",
-            default=20,
         ),
-    ]
+    ] = 20
 
     HTTP_REQUEST_NODE_MAX_BINARY_SIZE: PositiveInt = Field(
         description="",

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -219,17 +219,17 @@ class HttpConfig(BaseSettings):
 
     HTTP_REQUEST_MAX_CONNECT_TIMEOUT: conint(ge=10) = Field(
         description="connect timeout in seconds for HTTP request, which should be no less than 60",
-        default=300,
+        default=10,
     )
 
     HTTP_REQUEST_MAX_READ_TIMEOUT: conint(ge=60) = Field(
         description="read timeout in seconds for HTTP request, which should be no less than 60",
-        default=600,
+        default=60,
     )
 
     HTTP_REQUEST_MAX_WRITE_TIMEOUT: conint(ge=10) = Field(
         description="read timeout in seconds for HTTP request, which should be no less than 10",
-        default=600,
+        default=20,
     )
 
     HTTP_REQUEST_NODE_MAX_BINARY_SIZE: PositiveInt = Field(

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -218,15 +218,15 @@ class HttpConfig(BaseSettings):
         return self.inner_WEB_API_CORS_ALLOW_ORIGINS.split(",")
 
     HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[
-        int, Field(ge=10, description="connect timeout in seconds for HTTP request")
+        PositiveInt, Field(ge=10, description="connect timeout in seconds for HTTP request")
     ] = 10
 
     HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[
-        int, Field(ge=60, description="read timeout in seconds for HTTP request")
+        PositiveInt, Field(ge=60, description="read timeout in seconds for HTTP request")
     ] = 60
 
     HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[
-        int, Field(ge=10, description="read timeout in seconds for HTTP request")
+        PositiveInt, Field(ge=10, description="read timeout in seconds for HTTP request")
     ] = 20
 
     HTTP_REQUEST_NODE_MAX_BINARY_SIZE: PositiveInt = Field(

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from pydantic import AliasChoices, Field, HttpUrl, NegativeInt, NonNegativeInt, PositiveInt, computed_field, conint
 from pydantic_settings import BaseSettings
+from typing_extensions import Annotated
 
 from configs.feature.hosted_service import HostedServiceConfig
 
@@ -217,17 +218,17 @@ class HttpConfig(BaseSettings):
     def WEB_API_CORS_ALLOW_ORIGINS(self) -> list[str]:
         return self.inner_WEB_API_CORS_ALLOW_ORIGINS.split(",")
 
-    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: conint(ge=10) = Field(
+    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[int, Field(ge=10)] = Field(
         description="connect timeout in seconds for HTTP request, which should be no less than 60",
         default=10,
     )
 
-    HTTP_REQUEST_MAX_READ_TIMEOUT: conint(ge=60) = Field(
+    HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[int, Field(ge=60)] = Field(
         description="read timeout in seconds for HTTP request, which should be no less than 60",
         default=60,
     )
 
-    HTTP_REQUEST_MAX_WRITE_TIMEOUT: conint(ge=10) = Field(
+    HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[int, Field(ge=10)] = Field(
         description="read timeout in seconds for HTTP request, which should be no less than 10",
         default=20,
     )

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -218,23 +218,15 @@ class HttpConfig(BaseSettings):
         return self.inner_WEB_API_CORS_ALLOW_ORIGINS.split(",")
 
     HTTP_REQUEST_MAX_CONNECT_TIMEOUT: Annotated[
-        int, Field(ge=10, description="connect timeout in seconds for HTTP request, which should be no less than 60")
+        int, Field(ge=10, description="connect timeout in seconds for HTTP request")
     ] = 10
 
     HTTP_REQUEST_MAX_READ_TIMEOUT: Annotated[
-        int,
-        Field(
-            ge=60,
-            description="read timeout in seconds for HTTP request, which should be no less than 60",
-        ),
+        int, Field(ge=60, description="read timeout in seconds for HTTP request")
     ] = 60
 
     HTTP_REQUEST_MAX_WRITE_TIMEOUT: Annotated[
-        int,
-        Field(
-            ge=10,
-            description="read timeout in seconds for HTTP request, which should be no less than 10",
-        ),
+        int, Field(ge=10, description="read timeout in seconds for HTTP request")
     ] = 20
 
     HTTP_REQUEST_NODE_MAX_BINARY_SIZE: PositiveInt = Field(

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AliasChoices, Field, HttpUrl, NegativeInt, NonNegativeInt, PositiveInt, computed_field
+from pydantic import AliasChoices, Field, HttpUrl, NegativeInt, NonNegativeInt, PositiveInt, computed_field, conint
 from pydantic_settings import BaseSettings
 
 from configs.feature.hosted_service import HostedServiceConfig
@@ -217,18 +217,18 @@ class HttpConfig(BaseSettings):
     def WEB_API_CORS_ALLOW_ORIGINS(self) -> list[str]:
         return self.inner_WEB_API_CORS_ALLOW_ORIGINS.split(",")
 
-    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: NonNegativeInt = Field(
-        description="",
+    HTTP_REQUEST_MAX_CONNECT_TIMEOUT: conint(ge=10) = Field(
+        description="connect timeout in seconds for HTTP request, which should be no less than 60",
         default=300,
     )
 
-    HTTP_REQUEST_MAX_READ_TIMEOUT: NonNegativeInt = Field(
-        description="",
+    HTTP_REQUEST_MAX_READ_TIMEOUT: conint(ge=60) = Field(
+        description="read timeout in seconds for HTTP request, which should be no less than 60",
         default=600,
     )
 
-    HTTP_REQUEST_MAX_WRITE_TIMEOUT: NonNegativeInt = Field(
-        description="",
+    HTTP_REQUEST_MAX_WRITE_TIMEOUT: conint(ge=10) = Field(
+        description="read timeout in seconds for HTTP request, which should be no less than 10",
         default=600,
     )
 

--- a/api/core/workflow/nodes/http_request/http_request_node.py
+++ b/api/core/workflow/nodes/http_request/http_request_node.py
@@ -19,9 +19,9 @@ from core.workflow.nodes.http_request.http_executor import HttpExecutor, HttpExe
 from models.workflow import WorkflowNodeExecutionStatus
 
 HTTP_REQUEST_DEFAULT_TIMEOUT = HttpRequestNodeTimeout(
-    connect=min(10, dify_config.HTTP_REQUEST_MAX_CONNECT_TIMEOUT),
-    read=min(60, dify_config.HTTP_REQUEST_MAX_READ_TIMEOUT),
-    write=min(20, dify_config.HTTP_REQUEST_MAX_WRITE_TIMEOUT),
+    connect=dify_config.HTTP_REQUEST_MAX_CONNECT_TIMEOUT,
+    read=dify_config.HTTP_REQUEST_MAX_READ_TIMEOUT,
+    write=dify_config.HTTP_REQUEST_MAX_WRITE_TIMEOUT,
 )
 
 
@@ -96,12 +96,9 @@ class HttpRequestNode(BaseNode):
         if timeout is None:
             return HTTP_REQUEST_DEFAULT_TIMEOUT
 
-        timeout.connect = min(timeout.connect or HTTP_REQUEST_DEFAULT_TIMEOUT.connect,
-                              dify_config.HTTP_REQUEST_MAX_CONNECT_TIMEOUT)
-        timeout.read = min(timeout.read or HTTP_REQUEST_DEFAULT_TIMEOUT.read,
-                           dify_config.HTTP_REQUEST_MAX_READ_TIMEOUT)
-        timeout.write = min(timeout.write or HTTP_REQUEST_DEFAULT_TIMEOUT.write,
-                            dify_config.HTTP_REQUEST_MAX_WRITE_TIMEOUT)
+        timeout.connect = timeout.connect or HTTP_REQUEST_DEFAULT_TIMEOUT.connect
+        timeout.read = timeout.read or HTTP_REQUEST_DEFAULT_TIMEOUT.read
+        timeout.write = timeout.write or HTTP_REQUEST_DEFAULT_TIMEOUT.write
         return timeout
 
     @classmethod

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -19,7 +19,7 @@ def example_env_file(tmp_path, monkeypatch) -> str:
             """
         CONSOLE_API_URL=https://example.com
         CONSOLE_WEB_URL=https://example.com
-        HTTP_REQUEST_MAX_WRITE_TIMEOUT=20
+        HTTP_REQUEST_MAX_WRITE_TIMEOUT=30
         """
         )
     )
@@ -53,7 +53,7 @@ def test_dify_config(example_env_file):
     assert config.HTTP_REQUEST_MAX_READ_TIMEOUT == 60
 
     # annotated field with configured value
-    assert config.HTTP_REQUEST_MAX_WRITE_TIMEOUT == 20
+    assert config.HTTP_REQUEST_MAX_WRITE_TIMEOUT == 30
 
 
 # NOTE: If there is a `.env` file in your Workspace, this test might not succeed as expected.

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -19,6 +19,7 @@ def example_env_file(tmp_path, monkeypatch) -> str:
             """
         CONSOLE_API_URL=https://example.com
         CONSOLE_WEB_URL=https://example.com
+        HTTP_REQUEST_MAX_WRITE_TIMEOUT=20
         """
         )
     )
@@ -47,6 +48,12 @@ def test_dify_config(example_env_file):
     assert config.EDITION == "SELF_HOSTED"
     assert config.API_COMPRESSION_ENABLED is False
     assert config.SENTRY_TRACES_SAMPLE_RATE == 1.0
+
+    # annotated field with default value
+    assert config.HTTP_REQUEST_MAX_READ_TIMEOUT == 60
+
+    # annotated field with configured value
+    assert config.HTTP_REQUEST_MAX_WRITE_TIMEOUT == 20
 
 
 # NOTE: If there is a `.env` file in your Workspace, this test might not succeed as expected.


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- the `min` operator causes the explicitly set http timeout configs are ignored
- replace `min` by using `Annotated[int, Field(ge=10,)]` to check http timeouts minimum
- correct default timeouts

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] annotated field with default value
- [x] annotated field with configured value



