### PR TITLE
Feat: update app published time after clicking publish button

### DIFF
--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -62,6 +62,7 @@ const AppPublisher = ({
   const [published, setPublished] = useState(false)
   const [open, setOpen] = useState(false)
   const appDetail = useAppStore(state => state.appDetail)
+  const [publishedTime, setPublishedTime] = useState<number | undefined>(publishedAt)
   const { app_base_url: appBaseURL = '', access_token: accessToken = '' } = appDetail?.site ?? {}
   const appMode = (appDetail?.mode !== 'completion' && appDetail?.mode !== 'workflow') ? 'chat' : appDetail.mode
   const appURL = `${appBaseURL}/${appMode}/${accessToken}`
@@ -75,6 +76,7 @@ const AppPublisher = ({
     try {
       await onPublish?.(modelAndParameter)
       setPublished(true)
+      setPublishedTime(Date.now())
     }
     catch (e) {
       setPublished(false)
@@ -130,13 +132,13 @@ const AppPublisher = ({
         <div className='w-[336px] bg-white rounded-2xl border-[0.5px] border-gray-200 shadow-xl'>
           <div className='p-4 pt-3'>
             <div className='flex items-center h-6 text-xs font-medium text-gray-500 uppercase'>
-              {publishedAt ? t('workflow.common.latestPublished') : t('workflow.common.currentDraftUnpublished')}
+              {publishedTime ? t('workflow.common.latestPublished') : t('workflow.common.currentDraftUnpublished')}
             </div>
-            {publishedAt
+            {publishedTime
               ? (
                 <div className='flex justify-between items-center h-[18px]'>
                   <div className='flex items-center mt-[3px] mb-[3px] leading-[18px] text-[13px] font-medium text-gray-700'>
-                    {t('workflow.common.publishedAt')} {formatTimeFromNow(publishedAt)}
+                    {t('workflow.common.publishedAt')} {formatTimeFromNow(publishedTime)}
                   </div>
                   <Button
                     className={`
@@ -174,18 +176,18 @@ const AppPublisher = ({
                   {
                     published
                       ? t('workflow.common.published')
-                      : publishedAt ? t('workflow.common.update') : t('workflow.common.publish')
+                      : publishedTime ? t('workflow.common.update') : t('workflow.common.publish')
                   }
                 </Button>
               )
             }
           </div>
           <div className='p-4 pt-3 border-t-[0.5px] border-t-black/5'>
-            <SuggestedAction disabled={!publishedAt} link={appURL} icon={<PlayCircle />}>{t('workflow.common.runApp')}</SuggestedAction>
+            <SuggestedAction disabled={!publishedTime} link={appURL} icon={<PlayCircle />}>{t('workflow.common.runApp')}</SuggestedAction>
             {appDetail?.mode === 'workflow'
               ? (
                 <SuggestedAction
-                  disabled={!publishedAt}
+                  disabled={!publishedTime}
                   link={`${appURL}${appURL.includes('?') ? '&' : '?'}mode=batch`}
                   icon={<LeftIndent02 className='w-4 h-4' />}
                 >
@@ -198,16 +200,16 @@ const AppPublisher = ({
                     setEmbeddingModalOpen(true)
                     handleTrigger()
                   }}
-                  disabled={!publishedAt}
+                  disabled={!publishedTime}
                   icon={<CodeBrowser className='w-4 h-4' />}
                 >
                   {t('workflow.common.embedIntoSite')}
                 </SuggestedAction>
               )}
-            <SuggestedAction disabled={!publishedAt} link='./develop' icon={<FileText className='w-4 h-4' />}>{t('workflow.common.accessAPIReference')}</SuggestedAction>
+            <SuggestedAction disabled={!publishedTime} link='./develop' icon={<FileText className='w-4 h-4' />}>{t('workflow.common.accessAPIReference')}</SuggestedAction>
             {appDetail?.mode === 'workflow' && (
               <WorkflowToolConfigureButton
-                disabled={!publishedAt}
+                disabled={!publishedTime}
                 published={!!toolPublished}
                 detailNeedUpdate={!!toolPublished && published}
                 workflowAppId={appDetail?.id}


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

The component `App Publisher` always displays app published time info by `publishedAt` in initial props, and it won't update the published time even if our users click the publish button.
This PR adds a new state and uses `publishedAt` as the initial state value. Once our users succeed in publishing an App, the published time will get updated to the current time.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Click to publish an App
- [x] The published time gets updated
- [x] Do not refresh the page and toggle the publish modal several times, the published time displays correctly in the corresponding format. 

