### PR TITLE
fix: an issue of keyword search feature in application log list

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -173,21 +173,25 @@ class ChatConversationApi(Resource):
 
         if args["keyword"]:
             keyword_filter = "%{}%".format(args["keyword"])
-            query = (
-                query.join(
-                    Message,
-                    Message.conversation_id == Conversation.id,
-                )
-                .join(subquery, subquery.c.conversation_id == Conversation.id)
+            message_subquery = (
+                db.session.query(Message.conversation_id)
                 .filter(
                     or_(
                         Message.query.ilike(keyword_filter),
-                        Message.answer.ilike(keyword_filter),
-                        Conversation.name.ilike(keyword_filter),
-                        Conversation.introduction.ilike(keyword_filter),
-                        subquery.c.from_end_user_session_id.ilike(keyword_filter),
-                    ),
+                        Message.answer.ilike(keyword_filter)
+                    )
                 )
+                .subquery()
+            )
+            query = query.join(
+                subquery, subquery.c.conversation_id == Conversation.id
+            ).filter(
+                or_(
+                    Conversation.id.in_(message_subquery),
+                    Conversation.name.ilike(keyword_filter),
+                    Conversation.introduction.ilike(keyword_filter),
+                    subquery.c.from_end_user_session_id.ilike(keyword_filter)
+                ),
             )
 
         account = current_user

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -175,22 +175,15 @@ class ChatConversationApi(Resource):
             keyword_filter = "%{}%".format(args["keyword"])
             message_subquery = (
                 db.session.query(Message.conversation_id)
-                .filter(
-                    or_(
-                        Message.query.ilike(keyword_filter),
-                        Message.answer.ilike(keyword_filter)
-                    )
-                )
+                .filter(or_(Message.query.ilike(keyword_filter), Message.answer.ilike(keyword_filter)))
                 .subquery()
             )
-            query = query.join(
-                subquery, subquery.c.conversation_id == Conversation.id
-            ).filter(
+            query = query.join(subquery, subquery.c.conversation_id == Conversation.id).filter(
                 or_(
                     Conversation.id.in_(message_subquery),
                     Conversation.name.ilike(keyword_filter),
                     Conversation.introduction.ilike(keyword_filter),
-                    subquery.c.from_end_user_session_id.ilike(keyword_filter)
+                    subquery.c.from_end_user_session_id.ilike(keyword_filter),
                 ),
             )
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
If there are multiple records in the Message table associated with the same Conversation, and some of these records contain target keywords, it can lead to duplicate Conversation records in the final query results. This results in wrong data counts and pagination issues. The revised code employs `Conversation.id.in_(message_subquery)` as a filter condition to ensure that only unique Conversations with related Messages are returned. This approach prevents duplicate Conversation records from appearing in the query results, thereby ensuring the accuracy of the log list and the proper functioning of the pagination feature.
<img width="2560" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/ce20058e-7182-44e5-948b-2611fd072263">
<img width="1003" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/e352e594-4f17-42d0-ac86-928d4ba7e19e">


Fixes #7815 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



