### PR TITLE
fix: glm models prices and max_tokens correction

### DIFF
--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm-4-flash.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm-4-flash.yaml
@@ -38,7 +38,7 @@ parameter_rules:
     min: 1
     max: 8192
 pricing:
-  input: '0.0001'
-  output: '0.0001'
+  input: '0'
+  output: '0'
   unit: '0.001'
   currency: RMB

--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm_3_turbo.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm_3_turbo.yaml
@@ -37,3 +37,8 @@ parameter_rules:
     default: 1024
     min: 1
     max: 8192
+pricing:
+  input: '0.001'
+  output: '0.001'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm_4.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm_4.yaml
@@ -37,3 +37,8 @@ parameter_rules:
     default: 1024
     min: 1
     max: 8192
+pricing:
+  input: '0.1'
+  output: '0.1'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm_4_long.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm_4_long.yaml
@@ -30,4 +30,9 @@ parameter_rules:
     use_template: max_tokens
     default: 1024
     min: 1
-    max: 4096
+    max: 8192
+pricing:
+  input: '0.001'
+  output: '0.001'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm_4_plus.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm_4_plus.yaml
@@ -37,3 +37,8 @@ parameter_rules:
     default: 1024
     min: 1
     max: 8192
+pricing:
+  input: '0.05'
+  output: '0.05'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm_4v.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm_4v.yaml
@@ -34,4 +34,9 @@ parameter_rules:
     use_template: max_tokens
     default: 1024
     min: 1
-    max: 8192
+    max: 1024
+pricing:
+  input: '0.05'
+  output: '0.05'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/zhipuai/llm/glm_4v_plus.yaml
+++ b/api/core/model_runtime/model_providers/zhipuai/llm/glm_4v_plus.yaml
@@ -34,4 +34,9 @@ parameter_rules:
     use_template: max_tokens
     default: 1024
     min: 1
-    max: 8192
+    max: 1024
+pricing:
+  input: '0.01'
+  output: '0.01'
+  unit: '0.001'
+  currency: RMB


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Close issue syntax: `Fixes #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Change the max_tokens value of glm4v models to 1024.
Add the price info for some glm4 models.

Fixes #7880

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] pytest zhipuai
- [x] Try to set the max_tokens value
![image](https://github.com/user-attachments/assets/a871cd5b-4a9a-48d5-9861-ccd3976d17a8)




