### PR TITLE
fix(api): Code-Based Extension cause error on position map sorting

### DIFF
--- a/api/core/extension/extensible.py
+++ b/api/core/extension/extensible.py
@@ -65,7 +65,7 @@ class Extensible:
                     if os.path.exists(builtin_file_path):
                         with open(builtin_file_path, encoding='utf-8') as f:
                             position = int(f.read().strip())
-                position_map[extension_name] = position
+                    position_map[extension_name] = position
 
                 if (extension_name + '.py') not in file_names:
                     logging.warning(f"Missing {extension_name}.py file in {subdir_path}, Skip.")


### PR DESCRIPTION
Fixes #3981 and should continue to track the remain issue at #6528.

**Note: The Code-Based Extension still does not appear on the interface.**

I am submitting this PR mainly to explain my findings in the error, in order to save time for the next developer fixing the Code-Based Extension.


# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

The issue is because there is None in the `position_map`.

This piece of code assigns None to `position` and stores it in `position_map[extension_name]` when not entering the if statement.
https://github.com/langgenius/dify/blob/main/api/core/extension/extensible.py#L60-L68

This implementation ensures that when no value is get from the `position_map`, it uses infinity as the default value.
But there's None inside the `position_map`.
Then it was taken out for comparison, and the error occurred.
https://github.com/langgenius/dify/blob/main/api/core/helper/position_helper.py#L120


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

This error occurs at startup and causes the program to exit immediately when you have Code-Based Extension in the external_data_tool folder.
After the correction, the error message disappeared and the api started normally.
(But the Code-Based Extension still doesn't show up at frontend.)