### PR TITLE
Revert "fix: an issue of keyword search feature in application log list"

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -173,18 +173,21 @@ class ChatConversationApi(Resource):
 
         if args["keyword"]:
             keyword_filter = "%{}%".format(args["keyword"])
-            message_subquery = (
-                db.session.query(Message.conversation_id)
-                .filter(or_(Message.query.ilike(keyword_filter), Message.answer.ilike(keyword_filter)))
-                .subquery()
-            )
-            query = query.join(subquery, subquery.c.conversation_id == Conversation.id).filter(
-                or_(
-                    Conversation.id.in_(message_subquery),
-                    Conversation.name.ilike(keyword_filter),
-                    Conversation.introduction.ilike(keyword_filter),
-                    subquery.c.from_end_user_session_id.ilike(keyword_filter),
-                ),
+            query = (
+                query.join(
+                    Message,
+                    Message.conversation_id == Conversation.id,
+                )
+                .join(subquery, subquery.c.conversation_id == Conversation.id)
+                .filter(
+                    or_(
+                        Message.query.ilike(keyword_filter),
+                        Message.answer.ilike(keyword_filter),
+                        Conversation.name.ilike(keyword_filter),
+                        Conversation.introduction.ilike(keyword_filter),
+                        subquery.c.from_end_user_session_id.ilike(keyword_filter),
+                    ),
+                )
             )
 
         account = current_user


### PR DESCRIPTION
Reverts langgenius/dify#7816 @realethanhsu

Due to the PR being modified to a full table scan statement, which resulted in a slow query, it could cause the database to go down.