### PR TITLE
Concurrent calls to the Wenxin model, and the exception problem when obtaining the token is fixed

### DIFF
--- a/api/core/model_runtime/model_providers/wenxin/_common.py
+++ b/api/core/model_runtime/model_providers/wenxin/_common.py
@@ -79,11 +79,13 @@ class BaiduAccessToken:
             # if access token not in cache, request it
             token = BaiduAccessToken(api_key)
             baidu_access_tokens[api_key] = token
-            # release it to enhance performance
-            # btw, _get_access_token will raise exception if failed, release lock here to avoid deadlock
-            baidu_access_tokens_lock.release()
-            # try to get access token
-            token_str = BaiduAccessToken._get_access_token(api_key, secret_key)
+            try:
+                # try to get access token
+                token_str = BaiduAccessToken._get_access_token(api_key, secret_key)
+            finally:
+                # release it to enhance performance
+                # btw, _get_access_token will raise exception if failed, release lock here to avoid deadlock
+                baidu_access_tokens_lock.release()
             token.access_token = token_str
             token.expires = now + timedelta(days=3)
             return token


### PR DESCRIPTION
第一个请求获取到BaiduAccessToken对象就释放了锁，此时对象中的access_token还是空。第二个请求马上进来直接拿走这个对象，导致获取到的access_token为空，进而导致请求模型报错

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Close issue syntax: `Fixes #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



