### PR TITLE
chore: update package versions to 0.8.0-beta1

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           images: ${{ env[matrix.image_name_env] }}
           tags: |
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=ref,event=branch
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}

--- a/api/configs/packaging/__init__.py
+++ b/api/configs/packaging/__init__.py
@@ -9,7 +9,7 @@ class PackagingInfo(BaseSettings):
 
     CURRENT_VERSION: str = Field(
         description="Dify version",
-        default="0.7.3",
+        default="0.8.0-beta1",
     )
 
     COMMIT_SHA: str = Field(

--- a/docker-legacy/docker-compose.yaml
+++ b/docker-legacy/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.7.3
+    image: langgenius/dify-api:0.8.0-beta1
     restart: always
     environment:
       # Startup mode, 'api' starts the API server.
@@ -229,7 +229,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.7.3
+    image: langgenius/dify-api:0.8.0-beta1
     restart: always
     environment:
       CONSOLE_WEB_URL: ''
@@ -400,7 +400,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.7.3
+    image: langgenius/dify-web:0.8.0-beta1
     restart: always
     environment:
       # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -191,7 +191,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.7.3
+    image: langgenius/dify-api:0.8.0-beta1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -211,7 +211,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.7.3
+    image: langgenius/dify-api:0.8.0-beta1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -230,7 +230,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.7.3
+    image: langgenius/dify-web:0.8.0-beta1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "0.7.3",
+  "version": "0.8.0-beta1",
   "private": true,
   "engines": {
     "node": ">=18.17.0"


### PR DESCRIPTION
## ✨ What’s New in v0.8.0-beta1?✨

We are excited to announce the release of Dify 0.8.0-beta1! This version introduces a significant enhancement to workflow performance by enabling the parallel execution of nodes within workflows. This improvement allows workflows to run faster and more efficiently, optimizing the use of resources and reducing overall processing time.

### 🚀 Key Features

- **Parallel Execution of Nodes in Workflows**: Nodes can now be executed in parallel within a workflow, greatly increasing the execution speed. This feature is especially beneficial for complex workflows that involve multiple steps or processes, allowing for quicker completion times and improved performance.
  
  ![image](https://github.com/user-attachments/assets/98b209a1-d72e-4e8b-8bfe-7ca0babf27c4)


### Quick Start

To upgrade to this version, follow these steps:

1. Clone the repository using the following command:

   ```bash
   git clone https://github.com/langgenius/dify.git
   ```

2. Switch to the 0.8.0-beta1 branch:

   ```bash
   git checkout 0.8.0-beta1
   ```

3. Then following the [Deploy with Docker Compose > Starting Dify](https://docs.dify.ai/getting-started/install-self-hosted/docker-compose#starting-dify).

We hope you enjoy the new features and improvements in this release. As always, we welcome your feedback and contributions to make Dify even better!