### PR TITLE
chore: support line break of tooltip content

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import type { FC } from 'react'
 import { ValidatingTip } from '../../key-validator/ValidateStatus'
 import type {
@@ -67,6 +67,15 @@ const Form: FC<FormProps> = ({
     onChange({ ...value, [key]: val, ...shouldClearVariable })
   }
 
+  // convert tooltip '\n' to <br />
+  const renderTooltipContent = (content: string) => {
+    return content.split('\n').map((line, index, array) => (
+      <Fragment key={index}>
+        {line}
+        {index < array.length - 1 && <br />}
+      </Fragment>
+    ))
+  }
   const renderField = (formSchema: CredentialFormSchema) => {
     const tooltip = formSchema.tooltip
     const tooltipContent = (tooltip && (
@@ -74,7 +83,7 @@ const Form: FC<FormProps> = ({
         <Tooltip
           popupContent={
             <div className='w-[200px]'>
-              {tooltip[language] || tooltip.en_US}
+              {renderTooltipContent(tooltip[language] || tooltip.en_US)}
             </div>}
           triggerClassName='w-4 h-4'
         />


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Re-add support line break of tooltip content (#7424) due to #8055

Before
<img width="529" alt="Screenshot 2024-09-06 at 9 56 52 PM" src="https://github.com/user-attachments/assets/6023c6eb-3a6f-41b9-9e90-388c3d7e3677">

After
<img width="373" alt="Screenshot 2024-09-06 at 9 59 19 PM" src="https://github.com/user-attachments/assets/93bd00af-c673-4146-956b-d3e230bf2891">


## Type of Change

- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement