### PR TITLE
Revert "fix: parameter rule"

### DIFF
--- a/api/core/model_runtime/model_providers/spark/llm/spark-1.5.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-1.5.yaml
@@ -26,7 +26,7 @@ parameter_rules:
     type: int
     default: 4
     min: 1
-    max: 10
+    max: 6
     help:
       zh_Hans: 从 k 个候选中随机选择一个（非等概率）。
       en_US: Randomly select one from k candidates (non-equal probability).

--- a/api/core/model_runtime/model_providers/spark/llm/spark-2.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-2.yaml
@@ -27,7 +27,7 @@ parameter_rules:
     type: int
     default: 4
     min: 1
-    max: 10
+    max: 6
     help:
       zh_Hans: 从 k 个候选中随机选择一个（非等概率）。
       en_US: Randomly select one from k candidates (non-equal probability).

--- a/api/core/model_runtime/model_providers/spark/llm/spark-3.5.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-3.5.yaml
@@ -26,7 +26,7 @@ parameter_rules:
     type: int
     default: 4
     min: 1
-    max: 10
+    max: 6
     help:
       zh_Hans: 从 k 个候选中随机选择一个（非等概率）。
       en_US: Randomly select one from k candidates (non-equal probability).

--- a/api/core/model_runtime/model_providers/spark/llm/spark-3.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-3.yaml
@@ -26,7 +26,7 @@ parameter_rules:
     type: int
     default: 4
     min: 1
-    max: 10
+    max: 6
     help:
       zh_Hans: 从 k 个候选中随机选择一个（非等概率）。
       en_US: Randomly select one from k candidates (non-equal probability).

--- a/api/core/model_runtime/model_providers/spark/llm/spark-4.yaml
+++ b/api/core/model_runtime/model_providers/spark/llm/spark-4.yaml
@@ -26,7 +26,7 @@ parameter_rules:
     type: int
     default: 4
     min: 1
-    max: 10
+    max: 6
     help:
       zh_Hans: 从 k 个候选中随机选择一个（非等概率）。
       en_US: Randomly select one from k candidates (non-equal probability).


### PR DESCRIPTION
Reverts langgenius/dify#8064
The official has not modified the range of top_k.
 [official documentation](https://www.xfyun.cn/doc/spark/Web.html#_1-%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E)
The bug I reported is that the step setting in the front end is incorrect. It should be set to step="1".
`<input class="shrink-0 block ml-4 pl-3 w-16 h-8 appearance-none outline-none rounded-lg bg-gray-100 text-[13px] text-gra-900" max="6" min="1" step="0.1" type="number" data-tabindex="" tabindex="-1">`
