### PR TITLE
enhance: improve empty data display for detail panel

### DIFF
--- a/web/app/components/workflow/run/meta.tsx
+++ b/web/app/components/workflow/run/meta.tsx
@@ -16,7 +16,7 @@ type Props = {
 const MetaData: FC<Props> = ({
   status,
   executor,
-  startTime = 0,
+  startTime,
   time,
   tokens,
   steps = 1,
@@ -64,7 +64,7 @@ const MetaData: FC<Props> = ({
               <div className='my-[5px] w-[72px] h-2 rounded-sm bg-[rgba(0,0,0,0.05)]'/>
             )}
             {status !== 'running' && (
-              <span>{formatTime(startTime, t('appLog.dateTimeFormat') as string)}</span>
+              <span>{startTime ? formatTime(startTime, t('appLog.dateTimeFormat') as string) : '-'}</span>
             )}
           </div>
         </div>
@@ -75,7 +75,7 @@ const MetaData: FC<Props> = ({
               <div className='my-[5px] w-[72px] h-2 rounded-sm bg-[rgba(0,0,0,0.05)]'/>
             )}
             {status !== 'running' && (
-              <span>{`${time?.toFixed(3)}s`}</span>
+              <span>{time ? `${time.toFixed(3)}s` : '-'}</span>
             )}
           </div>
         </div>

--- a/web/app/components/workflow/run/status.tsx
+++ b/web/app/components/workflow/run/status.tsx
@@ -71,7 +71,7 @@ const StatusPanel: FC<ResultProps> = ({
               <div className='w-16 h-2 rounded-sm bg-[rgba(0,0,0,0.05)]' />
             )}
             {status !== 'running' && (
-              <span>{`${time?.toFixed(3)}s`}</span>
+              <span>{time ? `${time?.toFixed(3)}s` : '-'}</span>
             )}
           </div>
         </div>


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

I noticed that when a failure occurs, the details panel displays `1970-01-01 08:00` or `undefineds`. This seems to be a display issue. This PR addresses the problem by ensuring that empty values are not formatted and are instead replaced with `-`.

### Before Fix
![image](https://github.com/user-attachments/assets/5aded180-5bcd-457a-b8bf-5aeb184b5f15)

### After Fix
![image](https://github.com/user-attachments/assets/7911f711-6f22-4a0c-aaf6-6133b41b4373)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



