### PR TITLE
Fix VariableEntityType Bug external-data-tool -> external_data_tool

### DIFF
--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -92,7 +92,7 @@ class VariableEntityType(str, Enum):
     SELECT = "select"
     PARAGRAPH = "paragraph"
     NUMBER = "number"
-    EXTERNAL_DATA_TOOL = "external-data-tool"
+    EXTERNAL_DATA_TOOL = "external_data_tool"
 
 
 class VariableEntity(BaseModel):


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This pull request fixes a bug related to a constant definition error that caused `external_data_tool` to become unavailable. Specifically, the definition of `VariableEntityType` has been updated from `external-data-tool` to `external_data_tool`. This change ensures that the corresponding functionality works correctly and avoids issues caused by naming errors.

![external_data_tool_bug](https://github.com/user-attachments/assets/97fd1476-f980-4ee6-872e-514d1eb1e101)



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

1. Test that the related functionality now works correctly for `external_data_tool`.
2. Verify that the constant definition is properly resolved.
