### PR TITLE
add name in docker-compose.yaml

### DIFF
--- a/docker-legacy/docker-compose.yaml
+++ b/docker-legacy/docker-compose.yaml
@@ -1,3 +1,4 @@
+name: dify
 version: '3'
 services:
   # API service


### PR DESCRIPTION
Fixes #8233 

Added `name: dify` in docker-compose.yaml file so that docker desktop shows "dify" instead of "docker".

Kindly review the PR.