### PR TITLE
fix: Improve scrolling behavior for Conversation Opener

### DIFF
--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -109,7 +109,7 @@ const Chat: FC<ChatProps> = ({
   const userScrolledRef = useRef(false)
 
   const handleScrollToBottom = useCallback(() => {
-    if (chatContainerRef.current && !userScrolledRef.current)
+    if (chatList.length > 1 && chatContainerRef.current && !userScrolledRef.current)
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight
   }, [])
 

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -111,7 +111,7 @@ const Chat: FC<ChatProps> = ({
   const handleScrollToBottom = useCallback(() => {
     if (chatList.length > 1 && chatContainerRef.current && !userScrolledRef.current)
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight
-  }, [])
+  }, [chatList.length])
 
   const handleWindowResize = useCallback(() => {
     if (chatContainerRef.current)


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

fix: Improve scrolling behavior for Conversation Opener

- Before: Always scrolled to the bottom when accessing a conversation. Consequently, when users created a new conversation with a long Conversation Opener, the chat list would automatically scroll to the bottom, forcing users to scroll back up to read the Conversation Opener.
- After: Only scroll to the bottom if the conversation has more than one message.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

