### PR TITLE
fix(RunOnce): change to form submission instead of onKeyDown and onClick

### DIFF
--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import type { FC, FormEvent } from 'react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -39,11 +39,16 @@ const RunOnce: FC<IRunOnceProps> = ({
     onInputsChange(newInputs)
   }
 
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    onSend()
+  }
+
   return (
     <div className="">
       <section>
         {/* input form */}
-        <form>
+        <form onSubmit={onSubmit}>
           {promptConfig.prompt_variables.map(item => (
             <div className='w-full mt-4' key={item.key}>
               <label className='text-gray-900 text-sm font-medium'>{item.name}</label>
@@ -65,12 +70,6 @@ const RunOnce: FC<IRunOnceProps> = ({
                     placeholder={`${item.name}${!item.required ? `(${t('appDebug.variableTable.optional')})` : ''}`}
                     value={inputs[item.key]}
                     onChange={(e) => { onInputsChange({ ...inputs, [item.key]: e.target.value }) }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        onSend()
-                      }
-                    }}
                     maxLength={item.max_length || DEFAULT_VALUE_MAX_LEN}
                   />
                 )}
@@ -124,8 +123,8 @@ const RunOnce: FC<IRunOnceProps> = ({
                 <span className='text-[13px]'>{t('common.operation.clear')}</span>
               </Button>
               <Button
+                type='submit'
                 variant="primary"
-                onClick={onSend}
                 disabled={false}
               >
                 <PlayIcon className="shrink-0 w-4 h-4 mr-1" aria-hidden="true" />


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Fixes: https://github.com/langgenius/dify/issues/8092 

Solves the problem of the IME being sent during composing. There are several solutions, but the use of form submit events was considered the most appropriate.

|before|after|
| --- | --- |
|<video src="https://github.com/user-attachments/assets/63b240f0-f233-4fc3-b28f-27e612dea826" />|<video src="https://github.com/user-attachments/assets/8fddaa59-78b0-468f-b17b-bdc92e43efee" />|

<details><summary>reproducable workflow DSL</summary>
<p>

```yaml
app:
  description: ''
  icon: 🤖
  icon_background: '#FFEAD5'
  mode: workflow
  name: testtest
  use_icon_as_answer_icon: false
kind: app
version: 0.1.2
workflow:
  conversation_variables: []
  environment_variables: []
  features:
    file_upload:
      image:
        enabled: false
        number_limits: 3
        transfer_methods:
        - local_file
        - remote_url
    opening_statement: ''
    retriever_resource:
      enabled: true
    sensitive_word_avoidance:
      enabled: false
    speech_to_text:
      enabled: false
    suggested_questions: []
    suggested_questions_after_answer:
      enabled: false
    text_to_speech:
      enabled: false
      language: ''
      voice: ''
  graph:
    edges:
    - data:
        isInIteration: false
        sourceType: start
        targetType: end
      id: 1725801993255-source-1726369077052-target
      source: '1725801993255'
      sourceHandle: source
      target: '1726369077052'
      targetHandle: target
      type: custom
      zIndex: 0
    nodes:
    - data:
        desc: ''
        selected: true
        title: 開始
        type: start
        variables:
        - label: input
          max_length: 48
          options: []
          required: true
          type: text-input
          variable: input
        - label: paragraph
          max_length: 48
          options: []
          required: true
          type: paragraph
          variable: paragraph
        - label: select
          max_length: 48
          options:
          - option 1
          - option 2
          required: true
          type: select
          variable: select
        - label: number
          max_length: 48
          options: []
          required: true
          type: number
          variable: number
      height: 168
      id: '1725801993255'
      position:
        x: 80
        y: 282
      positionAbsolute:
        x: 80
        y: 282
      selected: true
      sourcePosition: right
      targetPosition: left
      type: custom
      width: 244
    - data:
        desc: ''
        outputs:
        - value_selector:
          - '1725801993255'
          - input
          variable: target
        selected: false
        title: 終了
        type: end
      height: 90
      id: '1726369077052'
      position:
        x: 384
        y: 282
      positionAbsolute:
        x: 384
        y: 282
      sourcePosition: right
      targetPosition: left
      type: custom
      width: 244
    viewport:
      x: 0
      y: 0
      zoom: 1
```

</p>
</details> 

## Another Solution

The first possible solution is to use `KeyboardEvent.isComposing`, but this does not work as expected in Safari.
ref: [Please do not implement `Enter key to Submit` behaviors by directly hooking into the raw keypress event.](https://dninomiya.github.io/form-guide/stop-enter-submit)
I initially considered implementing it: https://github.com/langgenius/dify/pull/8459

## Current Solution
I have implemented form submission using the onSubmit event of the form element. (This behavior is commonly referred to as [implicit submission](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission).)
This approach maintains the existing functionality of submitting the form via the submit button or by pressing enter in an input element, while simplifying the code and avoiding issues in browsers like Safari.




## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



