### PR TITLE
fixbug tts(stream) not work on ios safari(17.1+)

### DIFF
--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -33,7 +33,7 @@ export default class AudioPlayer {
     this.callback = callback
 
     // Compatible with iphone ios17 ManagedMediaSource
-    const MediaSource = window.ManagedMediaSource || window.MediaSource  //if has ManagedMediaSource first use
+    const MediaSource = window.ManagedMediaSource || window.MediaSource
     if (!MediaSource) {
       Toast.notify({
         message: 'Your browser does not support audio streaming, if you are using an iPhone, please update to iOS 17.1 or later.',
@@ -43,9 +43,9 @@ export default class AudioPlayer {
     this.mediaSource = MediaSource ? new MediaSource() : null
     this.audio = new Audio()
     this.setCallback(callback)
-    if(!window.MediaSource){//if use  ManagedMediaSource 
-      this.audio.disableRemotePlayback = true;
-      this.audio.controls = true;
+    if (!window.MediaSource) { // if use  ManagedMediaSource
+      this.audio.disableRemotePlayback = true
+      this.audio.controls = true
     }
     this.audio.src = this.mediaSource ? URL.createObjectURL(this.mediaSource) : ''
     this.audio.autoplay = true

--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -12,7 +12,7 @@ export default class AudioPlayer {
   mediaSource: MediaSource | null
   audio: HTMLAudioElement
   audioContext: AudioContext
-  sourceBuffer?: SourceBuffer
+  sourceBuffer?: any
   cacheBuffers: ArrayBuffer[] = []
   pauseTimer: number | null = null
   msgId: string | undefined
@@ -33,7 +33,7 @@ export default class AudioPlayer {
     this.callback = callback
 
     // Compatible with iphone ios17 ManagedMediaSource
-    const MediaSource = window.MediaSource || window.ManagedMediaSource
+    const MediaSource = window.ManagedMediaSource || window.MediaSource  //if has ManagedMediaSource first use
     if (!MediaSource) {
       Toast.notify({
         message: 'Your browser does not support audio streaming, if you are using an iPhone, please update to iOS 17.1 or later.',
@@ -43,6 +43,10 @@ export default class AudioPlayer {
     this.mediaSource = MediaSource ? new MediaSource() : null
     this.audio = new Audio()
     this.setCallback(callback)
+    if(!window.MediaSource){//if use  ManagedMediaSource 
+      this.audio.disableRemotePlayback = true;
+      this.audio.controls = true;
+    }
     this.audio.src = this.mediaSource ? URL.createObjectURL(this.mediaSource) : ''
     this.audio.autoplay = true
 


### PR DESCRIPTION
when work on  tts stream model,the ManagedMediaSource(ios 17.1+).  the audio api must set  disableRemotePlayback = true
controls = true

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

when TTS(stream) work on ios safari webkit the audio cannot play .

Fixes 

## Type of Change

 Bug fix (non-breaking change which fixes an issue)


# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B



