### PR TITLE
chore: skip PLR6201 linter rule

### DIFF
--- a/api/core/tools/provider/builtin/firecrawl/tools/crawl.py
+++ b/api/core/tools/provider/builtin/firecrawl/tools/crawl.py
@@ -35,10 +35,10 @@ class CrawlTool(BuiltinTool):
         scrapeOptions["excludeTags"] = get_array_params(tool_parameters, "excludeTags")
         scrapeOptions["onlyMainContent"] = tool_parameters.get("onlyMainContent", False)
         scrapeOptions["waitFor"] = tool_parameters.get("waitFor", 0)
-        scrapeOptions = {k: v for k, v in scrapeOptions.items() if v not in {None, ""}}
+        scrapeOptions = {k: v for k, v in scrapeOptions.items() if v not in (None, "")}
         payload["scrapeOptions"] = scrapeOptions or None
 
-        payload = {k: v for k, v in payload.items() if v not in {None, ""}}
+        payload = {k: v for k, v in payload.items() if v not in (None, "")}
 
         crawl_result = app.crawl_url(url=tool_parameters["url"], wait=wait_for_results, **payload)
 

--- a/api/core/tools/provider/builtin/firecrawl/tools/scrape.py
+++ b/api/core/tools/provider/builtin/firecrawl/tools/scrape.py
@@ -29,10 +29,10 @@ class ScrapeTool(BuiltinTool):
         extract["schema"] = get_json_params(tool_parameters, "schema")
         extract["systemPrompt"] = tool_parameters.get("systemPrompt")
         extract["prompt"] = tool_parameters.get("prompt")
-        extract = {k: v for k, v in extract.items() if v not in {None, ""}}
+        extract = {k: v for k, v in extract.items() if v not in (None, "")}
         payload["extract"] = extract or None
 
-        payload = {k: v for k, v in payload.items() if v not in {None, ""}}
+        payload = {k: v for k, v in payload.items() if v not in (None, "")}
 
         crawl_result = app.scrape_url(url=tool_parameters["url"], **payload)
         markdown_result = crawl_result.get("data", {}).get("markdown", "")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -28,7 +28,6 @@ select = [
     "PLR0402", # manual-from-import
     "PLR1711", # useless-return
     "PLR1714", # repeated-equality-comparison
-    "PLR6201", # literal-membership
     "RUF019", # unnecessary-key-check
     "RUF100", # unused-noqa
     "RUF101", # redirected-noqa


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- fix comment in PR #8391 : https://github.com/langgenius/dify/pull/8391#issuecomment-2367347102
- skip PLR6201 linter rule, [literal-membership](https://docs.astral.sh/ruff/rules/literal-membership/), which could fail when testing an unhashable element value's membership in a literal set
- also reverting the changes in #8391

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



