### PR TITLE
fix: avoid occurring at least one message error when there was no user message for Claude llm

### DIFF
--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -538,6 +538,10 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 else:
                     raise ValueError(f"Got unknown type {message}")
 
+        # if no user message, add a system message as the user message to avoid at least one message error
+        if not prompt_message_dicts:
+            prompt_message_dicts.append({"role": "user", "content": system})
+
         return system, prompt_message_dicts
 
     def _convert_one_message_to_text(self, message: PromptMessage) -> str:


### PR DESCRIPTION
fix: avoid occurring at least one message error when there was no user message for Claude llm

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

The issue related is here 

Fixes #8788 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Use Claude model without user message provided to run on workflow



