### PR TITLE
fix: workflow as tool always outdated

### DIFF
--- a/web/app/components/tools/workflow-tool/configure-button.tsx
+++ b/web/app/components/tools/workflow-tool/configure-button.tsx
@@ -65,7 +65,7 @@ const WorkflowToolConfigureButton = ({
         else {
           if (item.type === 'paragraph' && param.type !== 'string')
             return true
-          if (param.type !== item.type && !(param.type === 'string' && item.type === 'paragraph'))
+          if (item.type === 'text-input' && param.type !== 'string')
             return true
         }
       }


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description


https://github.com/user-attachments/assets/9f79a9f6-d803-4df8-8e05-ba6601b66200

reproduce:
1. create a simple workflow with an text-input field
2. publish it and click the `workflow as tool` button, it will always `outdated`


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [x] Test the 4 kinds of input-fields worked 



