### PR TITLE
edited Tools > Google > description

### DIFF
--- a/api/core/tools/provider/builtin/google/google.yaml
+++ b/api/core/tools/provider/builtin/google/google.yaml
@@ -6,9 +6,9 @@ identity:
     zh_Hans: Google
     pt_BR: Google
   description:
-    en_US: Google
-    zh_Hans: GoogleSearch
-    pt_BR: Google
+    en_US: Google Search
+    zh_Hans: Google 搜索
+    pt_BR: Google Search
   icon: icon.svg
   tags:
     - search


### PR DESCRIPTION
# Description

改进了 `工具 > Google > 描述` 的格式不统一

原始的描述：
![](https://cdn.statically.io/gh/stvlynn/cloudimg@master/blog/2310/截屏2024-09-29-17.25.51.t45zkjk1xio.webp)

改进如下：

简体中文：
`GoogleSearch` -> `Google 搜索`

English & Portuguese
`Google` -> `Google Search`