### PR TITLE
fix: segement settings of documents raise error

### DIFF
--- a/web/app/components/datasets/documents/detail/settings/index.tsx
+++ b/web/app/components/datasets/documents/detail/settings/index.tsx
@@ -5,7 +5,7 @@ import { useBoolean } from 'ahooks'
 import { useContext } from 'use-context-selector'
 import { useRouter } from 'next/navigation'
 import DatasetDetailContext from '@/context/dataset-detail'
-import type { FullDocumentDetail } from '@/models/datasets'
+import type { CrawlOptions, CustomFile, FullDocumentDetail } from '@/models/datasets'
 import type { MetadataType } from '@/service/datasets'
 import { fetchDocumentDetail } from '@/service/datasets'
 
@@ -15,6 +15,7 @@ import AccountSetting from '@/app/components/header/account-setting'
 import AppUnavailable from '@/app/components/base/app-unavailable'
 import { useDefaultModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
+import type { NotionPage } from '@/models/common'
 
 type DocumentSettingsProps = {
   datasetId: string
@@ -40,7 +41,7 @@ const DocumentSettings = ({ datasetId, documentId }: DocumentSettingsProps) => {
       page_id: documentDetail?.data_source_info.notion_page_id,
       page_name: documentDetail?.name,
       page_icon: documentDetail?.data_source_info.notion_page_icon,
-      type: documentDetail?.data_source_info.type,
+      type: documentDetail?.data_source_type,
     }
   }, [documentDetail])
   useEffect(() => {
@@ -72,7 +73,7 @@ const DocumentSettings = ({ datasetId, documentId }: DocumentSettingsProps) => {
             onSetting={showSetAPIKey}
             datasetId={datasetId}
             dataSourceType={documentDetail.data_source_type}
-            notionPages={[currentPage]}
+            notionPages={[currentPage as unknown as NotionPage]}
             websitePages={[
               {
                 title: documentDetail.name,
@@ -81,12 +82,13 @@ const DocumentSettings = ({ datasetId, documentId }: DocumentSettingsProps) => {
                 description: '',
               },
             ]}
-            fireCrawlJobId={documentDetail.data_source_info?.job_id}
-            crawlOptions={documentDetail.data_source_info}
+            websiteCrawlProvider={documentDetail.data_source_info?.provider}
+            websiteCrawlJobId={documentDetail.data_source_info?.job_id}
+            crawlOptions={documentDetail.data_source_info as unknown as CrawlOptions}
             indexingType={indexingTechnique || ''}
             isSetting
             documentDetail={documentDetail}
-            files={[documentDetail.data_source_info.upload_file]}
+            files={[documentDetail.data_source_info.upload_file as CustomFile]}
             onSave={saveHandler}
             onCancel={cancelHandler}
           />

--- a/web/models/datasets.ts
+++ b/web/models/datasets.ts
@@ -1,4 +1,4 @@
-import type { DataSourceNotionPage } from './common'
+import type { DataSourceNotionPage, DataSourceProvider } from './common'
 import type { AppIconType, AppMode, RetrievalConfig } from '@/types/app'
 import type { Tag } from '@/app/components/base/tag-management/constant'
 
@@ -230,6 +230,9 @@ export type DataSourceInfo = {
     extension: string
   }
   notion_page_icon?: string
+  notion_workspace_id?: string
+  notion_page_id?: string
+  provider?: DataSourceProvider
   job_id: string
   url: string
 }


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

### Reproduce:
1. use the jina to crawl any page to your datasets
2. then click the `segement setting` button of any document

the `http://localhost:5001/console/api/datasets/indexing-estimate` will raise error:
```
{
    "code": "indexing_estimate_error",
    "message": "Expecting value: line 1 column 1 (char 0)",
    "status": 500
}
```

caused by the `job_id` and `provider` not sent:
![9ff5690a4f7229bae396d37ac902306](https://github.com/user-attachments/assets/467600dc-e93c-48d8-bccc-41952757643b)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



