### PR TITLE
chore: make doc extractor node also can extract text by file extension

### DIFF
--- a/api/core/workflow/nodes/document_extractor/document_extractor_node.py
+++ b/api/core/workflow/nodes/document_extractor/document_extractor_node.py
@@ -77,7 +77,7 @@ class DocumentExtractorNode(BaseNode):
             )
 
 
-def _extract_text(*, file_content: bytes, mime_type: str) -> str:
+def _extract_text(*, file_content: bytes, mime_type: str, file_extension: str = "") -> str:
     """Extract text from a file based on its MIME type."""
     if mime_type.startswith("text/plain") or mime_type in {"text/html", "text/htm", "text/markdown", "text/xml"}:
         return _extract_text_from_plain_text(file_content)
@@ -106,7 +106,37 @@ def _extract_text(*, file_content: bytes, mime_type: str) -> str:
     elif mime_type == "application/vnd.ms-outlook":
         return _extract_text_from_msg(file_content)
     else:
+        extract_result = _extract_text_by_file_extension(file_content, file_extension)
+        if extract_result:
+            return extract_result
         raise UnsupportedFileTypeError(f"Unsupported MIME type: {mime_type}")
+
+
+def _extract_text_by_file_extension(file_content: bytes, file_extension: str) -> str:
+    """Extract text from a file based on its file extension."""
+    match file_extension:
+        case "txt" | "markdown" | "md" | "html" | "htm" | "xml":
+            return _extract_text_from_plain_text(file_content)
+        case "pdf":
+            return _extract_text_from_pdf(file_content)
+        case "doc" | "docx":
+            return _extract_text_from_doc(file_content)
+        case "csv":
+            return _extract_text_from_csv(file_content)
+        case "xls" | "xlsx":
+            return _extract_text_from_excel(file_content)
+        case "ppt":
+            return _extract_text_from_ppt(file_content)
+        case "pptx":
+            return _extract_text_from_pptx(file_content)
+        case "epub":
+            return _extract_text_from_epub(file_content)
+        case "eml":
+            return _extract_text_from_eml(file_content)
+        case "msg":
+            return _extract_text_from_msg(file_content)
+        case _:
+            return ""
 
 
 def _extract_text_from_plain_text(file_content: bytes) -> str:
@@ -163,7 +193,7 @@ def _extract_text_from_file(file: File):
     if file.mime_type is None:
         raise UnsupportedFileTypeError("Unable to determine file type: MIME type is missing")
     file_content = _download_file_content(file)
-    extracted_text = _extract_text(file_content=file_content, mime_type=file.mime_type)
+    extracted_text = _extract_text(file_content=file_content, mime_type=file.mime_type, file_extension=file.extension)
     return extracted_text
 
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

### To 0.10.0-beta

when upload a `markdown` file, the doc extractor node will raise:
![1fcf2a087089ffa52e917f88cccdd58](https://github.com/user-attachments/assets/e869a1eb-40c3-46b7-af72-a2a8c1993d59)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



