### PR TITLE
fix: condition of list filter node not display

### DIFF
--- a/web/app/components/workflow/nodes/list-filter/components/filter-condition.tsx
+++ b/web/app/components/workflow/nodes/list-filter/components/filter-condition.tsx
@@ -48,12 +48,12 @@ const FilterCondition: FC<Props> = ({
       return []
     }
     return []
-  }, [condition.comparison_operator, condition.key, isSelect, t, isArrayValue])
+  }, [condition.comparison_operator, condition.key, isSelect, t])
   const handleChange = useCallback((key: string) => {
     return (value: any) => {
       onChange({
         ...condition,
-        [key]: isArrayValue ? [value] : value,
+        [key]: (isArrayValue && key === 'value') ? [value] : value,
       })
     }
   }, [condition, onChange, isArrayValue])


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

### To 0.10.0-beta

when the filter condition is `type`, choose `in`/`not in` not work.
<img width="287" alt="2a3fa6ab0486d1a14cc4627b4f79ad1" src="https://github.com/user-attachments/assets/5775f131-df1d-456e-9693-1fa22a3f4b7b">
 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



