### PR TITLE
fix: list filter node's url

### DIFF
--- a/api/core/file/file_manager.py
+++ b/api/core/file/file_manager.py
@@ -25,7 +25,7 @@ def get_attr(*, file: "File", attr: "FileAttribute"):
         case FileAttribute.TRANSFER_METHOD:
             return file.transfer_method.value
         case FileAttribute.URL:
-            return file.remote_url
+            return file.url
         case FileAttribute.EXTENSION:
             return file.extension
         case _:

--- a/api/core/file/models.py
+++ b/api/core/file/models.py
@@ -52,18 +52,21 @@ class File(BaseModel):
         data = self.model_dump()
         return {
             **data,
-            "url": self.generate_url(),
+            "url": self.url,
         }
 
     @property
     def markdown(self) -> str:
-        url = self.generate_url()
         if self.type == FileType.IMAGE:
-            text = f'![{self.filename or ""}]({url})'
+            text = f'![{self.filename or ""}]({self.url})'
         else:
-            text = f"[{self.filename or url}]({url})"
+            text = f"[{self.filename or self.url}]({self.url})"
 
         return text
+
+    @property
+    def url(self) -> str:
+        return self.generate_url()
 
     def generate_url(self) -> Optional[str]:
         if self.type == FileType.IMAGE:

--- a/api/core/workflow/nodes/list_filter/node.py
+++ b/api/core/workflow/nodes/list_filter/node.py
@@ -121,8 +121,8 @@ def _get_file_extract_string_func(*, key: str) -> Callable[[File], str]:
             return lambda x: x.mime_type or ""
         case "transfer_method":
             return lambda x: x.transfer_method
-        case "urL":
-            return lambda x: x.remote_url or ""
+        case "url":
+            return lambda x: x.url or ""
         case _:
             raise ValueError(f"Invalid key: {key}")
 
@@ -248,7 +248,7 @@ def _order_string(*, order: Literal["asc", "desc"], array: Sequence[str]):
 
 
 def _order_file(*, order: Literal["asc", "desc"], order_by: str = "", array: Sequence[File]):
-    if order_by in {"name", "type", "extension", "mime_type", "transfer_method", "urL"}:
+    if order_by in {"name", "type", "extension", "mime_type", "transfer_method", "url"}:
         extract_func = _get_file_extract_string_func(key=order_by)
         return sorted(array, key=lambda x: extract_func(x), reverse=order == "desc")
     elif order_by == "size":


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

### To 0.10.0-beta
#### 1. the order_by url not work
<img width="809" alt="610870609a533d44c711c442242bdcf" src="https://github.com/user-attachments/assets/2724a6b7-6ace-42cc-9343-4bca3a140070">


#### 2.  the next node's url input string is inconsistent with  the list filter node's output url
<img width="778" alt="f4ccdbd79bad0196bc9b60ca7f9a4dd" src="https://github.com/user-attachments/assets/f6d85505-9493-477c-b402-fe9ab822298a">


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



