### PR TITLE
fix: some image gen tool raise error

### DIFF
--- a/api/core/tools/utils/message_transformer.py
+++ b/api/core/tools/utils/message_transformer.py
@@ -25,7 +25,6 @@ class ToolFileMessageTransformer:
             elif (
                 message.type == ToolInvokeMessage.MessageType.IMAGE
                 and isinstance(message.message, str)
-                and conversation_id
             ):
                 # try to download image
                 try:


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

### To 0.10.0-beta

<img width="485" alt="0337c5413fcac966f1356fbb6d24e52" src="https://github.com/user-attachments/assets/87a47f9c-64cc-4e44-858a-bfb970c99904">

In a workflow app, seems it doesn't have a `conversation_id`,  so some tools use `create_image_message()` to create images will not be converted and downloaded in the 0.10.0 version. 

not coverted cause the error in the image,  the code [here](https://github.com/langgenius/dify/blob/2ab8bc679fb3f558c989745965b5299d229a2ef9/api/core/workflow/nodes/tool/tool_node.py#L169),  `response` doesn't have the `meta`.
not downloaded cause the url of node output is 404.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



