### PR TITLE
fix: prompt-editor regex.lastIndex needed to reset

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/workflow-variable-block/workflow-variable-block-replacement-block.tsx
+++ b/web/app/components/base/prompt-editor/plugins/workflow-variable-block/workflow-variable-block-replacement-block.tsx
@@ -12,7 +12,7 @@ import type { WorkflowVariableBlockType } from '../../types'
 import { CustomTextNode } from '../custom-text/node'
 import { $createWorkflowVariableBlockNode } from './node'
 import { WorkflowVariableBlockNode } from './index'
-import { VAR_REGEX as REGEX } from '@/config'
+import { VAR_REGEX as REGEX, resetReg } from '@/config'
 
 const WorkflowVariableBlockReplacementBlock = ({
   workflowNodesMap,
@@ -48,11 +48,12 @@ const WorkflowVariableBlockReplacementBlock = ({
   }, [])
 
   const transformListener = useCallback((textNode: any) => {
+    resetReg()
     return decoratorTransform(textNode, getMatch, createWorkflowVariableBlockNode)
   }, [createWorkflowVariableBlockNode, getMatch])
 
   useEffect(() => {
-    REGEX.lastIndex = 0
+    resetReg()
     return mergeRegister(
       editor.registerNodeTransform(CustomTextNode, transformListener),
     )

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -158,28 +158,28 @@ export const DEFAULT_AGENT_SETTING = {
 }
 
 export const DEFAULT_AGENT_PROMPT = {
-  chat: `Respond to the human as helpfully and accurately as possible. 
+  chat: `Respond to the human as helpfully and accurately as possible.
 
   {{instruction}}
-  
+
   You have access to the following tools:
-  
+
   {{tools}}
-  
+
   Use a json blob to specify a tool by providing an {{TOOL_NAME_KEY}} key (tool name) and an {{ACTION_INPUT_KEY}} key (tool input).
   Valid "{{TOOL_NAME_KEY}}" values: "Final Answer" or {{tool_names}}
-  
+
   Provide only ONE action per $JSON_BLOB, as shown:
-  
+
   \`\`\`
   {
     "{{TOOL_NAME_KEY}}": $TOOL_NAME,
     "{{ACTION_INPUT_KEY}}": $ACTION_INPUT
   }
   \`\`\`
-  
+
   Follow this format:
-  
+
   Question: input question to answer
   Thought: consider previous and subsequent steps
   Action:
@@ -196,10 +196,10 @@ export const DEFAULT_AGENT_PROMPT = {
     "{{ACTION_INPUT_KEY}}": "Final response to human"
   }
   \`\`\`
-  
+
   Begin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:\`\`\`$JSON_BLOB\`\`\`then Observation:.`,
   completion: `
-  Respond to the human as helpfully and accurately as possible. 
+  Respond to the human as helpfully and accurately as possible.
 
 {{instruction}}
 
@@ -245,6 +245,8 @@ Thought: {{agent_scratchpad}}
 }
 
 export const VAR_REGEX = /\{\{(#[a-zA-Z0-9_-]{1,50}(\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}/gi
+
+export const resetReg = () => VAR_REGEX.lastIndex = 0
 
 export let textGenerationTimeoutMs = 60000
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

The variable in the prompt-editor occasionally displays incorrectly. 

Fixes  #9096 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



