### PR TITLE
add generate conversation name error log

### DIFF
--- a/api/core/app/task_pipeline/message_cycle_manage.py
+++ b/api/core/app/task_pipeline/message_cycle_manage.py
@@ -82,8 +82,8 @@ class MessageCycleManage:
                 try:
                     name = LLMGenerator.generate_conversation_name(app_model.tenant_id, query)
                     conversation.name = name
-                except:
-                    pass
+                except Exception as e:
+                    logging.exception(f"generate conversation name failed: {e}")
 
                 db.session.merge(conversation)
                 db.session.commit()


### PR DESCRIPTION
# Checklist:
> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.
- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
This pull request addresses an issue where exceptions during conversation name generation were being silently caught and ignored. This made it difficult to identify and diagnose problems in this process. The change implements proper exception logging to improve visibility and debugging capabilities.

The main change is in the `_generate_conversation_name_worker` method of the `MessageCycleManage` class. We've replaced the generic `except: pass` block with a specific exception catch that logs the error details.

Fixes #[Issue Number] <!-- Replace with the actual issue number -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions
To verify this change, please follow these steps:

- [ ] Run the application in a development environment
- [ ] Trigger a conversation name generation process
- [ ] Intentionally cause an error in the `LLMGenerator.generate_conversation_name` method (e.g., by passing invalid parameters)
- [ ] Check the application logs for an error message starting with "generate conversate name failed: " followed by exception details
- [ ] Verify that the application continues to function normally despite the error in name generation