### PR TITLE
fix: vertex ai remote url error(Error: not enough values to unpack)

### DIFF
--- a/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
@@ -3,6 +3,8 @@ import io
 import json
 import logging
 import time
+import requests
+
 from collections.abc import Generator
 from typing import Optional, Union, cast
 
@@ -653,9 +655,15 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
                     if c.type == PromptMessageContentType.TEXT:
                         parts.append(glm.Part.from_text(c.data))
                     else:
-                        metadata, data = c.data.split(",", 1)
-                        mime_type = metadata.split(";", 1)[0].split(":")[1]
-                        parts.append(glm.Part.from_data(mime_type=mime_type, data=data))
+                        message_content = cast(ImagePromptMessageContent, c)
+                        if not message_content.data.startswith("data:"):
+                            url_arr = message_content.data.split(".")
+                            mime_type = f"image/{url_arr[-1]}"
+                            parts.append(glm.Part.from_uri(mime_type=mime_type, uri=message_content.data))
+                        else:
+                            metadata, data = c.data.split(",", 1)
+                            mime_type = metadata.split(";", 1)[0].split(":")[1]
+                            parts.append(glm.Part.from_data(mime_type=mime_type, data=data))
                 glm_content = glm.Content(role="user", parts=parts)
             return glm_content
         elif isinstance(message, AssistantPromptMessage):

--- a/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/vertex_ai/llm/llm.py
@@ -3,12 +3,11 @@ import io
 import json
 import logging
 import time
-import requests
-
 from collections.abc import Generator
 from typing import Optional, Union, cast
 
 import google.auth.transport.requests
+import requests
 import vertexai.generative_models as glm
 from anthropic import AnthropicVertex, Stream
 from anthropic.types import (


### PR DESCRIPTION
fix: vertex ai remote url error（[vertex_ai] Error: not enough values to unpack (expected 2, got 1))

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

When I use the gemini model and upload remote image url, I get an error.
[vertex_ai] Error: not enough values to unpack (expected 2, got 1)
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/fbe9e7e2-3ffa-48b6-a01d-6fe007c1622d">


Fixed:
I changed some of the code to support remote urls

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/9a6cd697-6448-4542-9f1d-31456e54b584">


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [ ] Test B



