### PR TITLE
fix: response_format of model_parameters will not be removed

### DIFF
--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -94,7 +94,7 @@ class LargeLanguageModel(AIModel):
         )
 
         try:
-            if "response_format" in model_parameters:
+            if "response_format" in model_parameters and model_parameters["response_format"] in {"JSON", "XML"}:
                 result = self._code_block_mode_wrapper(
                     model=model,
                     credentials=credentials,


### PR DESCRIPTION


# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes https://github.com/langgenius/dify/issues/8451

thanks for @tuoxiansp debug

the code [here](https://github.com/langgenius/dify/blob/b279d1904085d0265c4b0a0ef5843bc11b22c837/api/core/model_runtime/model_providers/__base/large_language_model.py#L205) will remove the `response_format` of `model_parameters `.  seems in earlier days,  we use a custom prompt to let the user get a JSON or XML response of LLM. But nowadays,  the `response_format` also will be used in lots of LLM's request parameters, we should not remove it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

use debug panel to check the params send to Azure.  I don't have a key, not check the response result.

- [ ] Test A
- [ ] Test B



