### PR TITLE
feat: allow answer node use chat_var and env_var

### DIFF
--- a/web/app/components/workflow/nodes/answer/panel.tsx
+++ b/web/app/components/workflow/nodes/answer/panel.tsx
@@ -23,8 +23,8 @@ const Panel: FC<NodePanelProps<AnswerNodeType>> = ({
 
   const { availableVars, availableNodesWithParent } = useAvailableVarList(id, {
     onlyLeafNodeVar: false,
-    hideChatVar: true,
-    hideEnv: true,
+    hideChatVar: false,
+    hideEnv: false,
     filterVar,
   })
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes  https://github.com/langgenius/dify/issues/9151
seems we don't need to hide the conversation var and environment var of answer node,  I tried each type of vars, except for `array[object]` not display in the choose panel, other types works well.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally.
![64cc9b73a79b4b7be5308ccc3388816](https://github.com/user-attachments/assets/34244872-a24a-410c-a03c-a7bb2c645040)


- [ ] Test A
- [ ] Test B



