### PR TITLE
fix: remove the latest message from the user that does not have any answer yet

### DIFF
--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -60,8 +60,8 @@ class TokenBufferMemory:
         thread_messages = extract_thread_messages(messages)
 
         # for newly created message, its answer is temporarily empty, we don't need to add it to memory
-        if thread_messages and not thread_messages[-1].answer:
-            thread_messages.pop()
+        if thread_messages and not thread_messages[0].answer:
+            thread_messages.pop(0)
 
         messages = list(reversed(thread_messages))
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

To resolve issue #9041, #9122 was merged, but #9122 is not functioning as expected.

#9122 is attempting to remove only the user's latest message (one that has not yet received a answer) using `pop()`.

https://github.com/langgenius/dify/pull/9122/files#diff-32253f22ce6d4d0b26560678c8de9dc9fe3d1b11bc4f912b008152c8ed9b4380R63-R64

However, the latest message in `thread_messages` is at the beginning (`[0]`), not at the end (`[-1]`). Therefore, to check for an answer and `pop()`, it should be for the beginning (`[0]`), not for the end (`[-1]`).

Fixes #9296

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] The chat can continue for more than two rounds with Gemini
- [x] By enabling the follow-up feature, suggestions related to the initial answer will be provided

# Context

- The regenerate feature was introduced in #7661
- This caused a new issue #9041
- The fix for the #9041 was made in #9122
- This caused a new issue #9296

