### PR TITLE
fix: Deprecated gemma2-9b model in Fireworks AI Provider

### DIFF
--- a/api/core/model_runtime/model_providers/fireworks/llm/gemma2-9b-it.yaml
+++ b/api/core/model_runtime/model_providers/fireworks/llm/gemma2-9b-it.yaml
@@ -43,3 +43,4 @@ pricing:
   output: '0.2'
   unit: '0.000001'
   currency: USD
+deprecated: true


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Deprecated gemma2-9b model in Fireworks AI Provider.
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/8482c694-d79d-42fe-a344-7f1b3f5f2368">

Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



