### PR TITLE
fix: draft run workflow node with image will raise error

### DIFF
--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -289,7 +289,7 @@ class WorkflowEntry:
                             new_value.append(file)
 
                 if new_value:
-                    value = new_value
+                    input_value = new_value
 
             # append variable and value to variable pool
             variable_pool.add([variable_node_id] + variable_key_list, input_value)


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Reproduce Steps:
1. choose a model which support vision in the workflow's LLM node
2. upload an image or input an image url
3. just run this node

<img width="752" alt="a21de84c0f9dba41b662520425f2357" src="https://github.com/user-attachments/assets/eedf3f94-2959-4b8f-aaa5-eb0f41535bfe">

because the file object from `dict` transform to the `FileVar` object, but not assign to the variable_pool


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



