### PR TITLE
Update dify-sandbox version to 0.2.10

### DIFF
--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -41,7 +41,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.9
+    image: langgenius/dify-sandbox:0.2.10
     restart: always
     environment:
       # The DifySandbox configurations

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -313,7 +313,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.9
+    image: langgenius/dify-sandbox:0.2.10
     restart: always
     environment:
       # The DifySandbox configurations


### PR DESCRIPTION
Dependency upgrade: Modify the image version of the sandbox in docker/docker-compose.yaml and docker/docker-compose.middleware.yaml to 0.2.10