### PR TITLE
fix: ignore all files except for .gitkeep under docker/nginx/ssl by gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,8 @@ docker/volumes/pgvector/data/*
 docker/volumes/pgvecto_rs/data/*
 
 docker/nginx/conf.d/default.conf
+docker/nginx/ssl/*
+!docker/nginx/ssl/.gitkeep
 docker/middleware.env
 
 sdks/python-client/build


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

To enable HTTPS in a self-hosted environment, we need to place the certificate and key files in the `docker/nginx/ssl` directory. However, with the current `.gitignore` settings, there is a possibility that these files could accidentally be tracked by Git.

This PR prevents sensitive information, such as private keys, from being mistakenly added to the repository.

Fixes #9519

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Place any files under `docker/nginx/ssl` and invoke `git status`. Ensure no changes are detected (means no files are listed as untracked files)

