### PR TITLE
fix: list filter node some operator raise error

### DIFF
--- a/api/core/workflow/nodes/list_operator/entities.py
+++ b/api/core/workflow/nodes/list_operator/entities.py
@@ -8,18 +8,18 @@ from core.workflow.nodes.base import BaseNodeData
 _Condition = Literal[
     # string conditions
     "contains",
-    "startswith",
-    "endswith",
+    "start with",
+    "end with",
     "is",
     "in",
     "empty",
     "not contains",
-    "not is",
+    "is not",
     "not in",
     "not empty",
     # number conditions
     "=",
-    "!=",
+    "≠",
     "<",
     ">",
     "≥",

--- a/api/core/workflow/nodes/list_operator/node.py
+++ b/api/core/workflow/nodes/list_operator/node.py
@@ -132,9 +132,9 @@ def _get_string_filter_func(*, condition: str, value: str) -> Callable[[str], bo
     match condition:
         case "contains":
             return _contains(value)
-        case "startswith":
+        case "start with":
             return _startswith(value)
-        case "endswith":
+        case "end with":
             return _endswith(value)
         case "is":
             return _is(value)
@@ -144,7 +144,7 @@ def _get_string_filter_func(*, condition: str, value: str) -> Callable[[str], bo
             return lambda x: x == ""
         case "not contains":
             return lambda x: not _contains(value)(x)
-        case "not is":
+        case "is not":
             return lambda x: not _is(value)(x)
         case "not in":
             return lambda x: not _in(value)(x)
@@ -168,7 +168,7 @@ def _get_number_filter_func(*, condition: str, value: int | float) -> Callable[[
     match condition:
         case "=":
             return _eq(value)
-        case "!=":
+        case "≠":
             return _ne(value)
         case "<":
             return _lt(value)


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

when use some operator like `start with` to filter the list will raise error:

![5cce14b26bbb00701e85bc99b2cb7a2](https://github.com/user-attachments/assets/027d15a4-b93b-41e4-a0ed-6fff12f4d8d0)

these operators between frontend and backend are not consistent 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



