### PR TITLE
fix: input vars not auto rename in list operator

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -739,6 +739,11 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
       res = [(data as IterationNodeType).iterator_selector]
       break
     }
+
+    case BlockEnum.ListFilter: {
+      res = [(data as ListFilterNodeType).variable]
+      break
+    }
   }
   return res || []
 }
@@ -995,6 +1000,12 @@ export const updateNodeVars = (oldNode: Node, oldVarSelector: ValueSelector, new
         if (payload.iterator_selector.join('.') === oldVarSelector.join('.'))
           payload.iterator_selector = newVarSelector
 
+        break
+      }
+      case BlockEnum.ListFilter: {
+        const payload = data as ListFilterNodeType
+        if (payload.variable.join('.') === oldVarSelector.join('.'))
+          payload.variable = newVarSelector
         break
       }
     }

--- a/web/app/components/workflow/nodes/list-operator/use-config.ts
+++ b/web/app/components/workflow/nodes/list-operator/use-config.ts
@@ -67,7 +67,7 @@ const useConfig = (id: string, payload: ListFilterNodeType) => {
   const itemVarTypeShowName = useMemo(() => {
     if (!inputs.variable)
       return '?'
-    return [itemVarType.substring(0, 1).toUpperCase(), itemVarType.substring(1)].join('')
+    return [(itemVarType || VarType.string).substring(0, 1).toUpperCase(), (itemVarType || VarType.string).substring(1)].join('')
   }, [inputs.variable, itemVarType])
 
   const hasSubVariable = [VarType.arrayFile].includes(varType)


### PR DESCRIPTION
# Description

Fix input vars not auto rename in list operator. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



