### PR TITLE
chore: improve validation and handler of logging timezone with TimezoneName

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -10,6 +10,7 @@ from pydantic import (
     PositiveInt,
     computed_field,
 )
+from pydantic_extra_types.timezone_name import TimeZoneName
 from pydantic_settings import BaseSettings
 
 from configs.feature.hosted_service import HostedServiceConfig
@@ -329,8 +330,9 @@ class LoggingConfig(BaseSettings):
         default=None,
     )
 
-    LOG_TZ: Optional[str] = Field(
-        description="Timezone for log timestamps (e.g., 'America/New_York')",
+    LOG_TZ: Optional[TimeZoneName] = Field(
+        description="Timezone for log timestamps. Allowed timezone values can be referred to IANA Time Zone Database,"
+        " e.g., 'America/New_York')",
         default=None,
     )
 

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import sys
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
+import pytz
 from flask import Flask
 
 from configs import dify_config
@@ -30,16 +32,10 @@ def init_app(app: Flask):
         handlers=log_handlers,
         force=True,
     )
+
     log_tz = dify_config.LOG_TZ
     if log_tz:
-        from datetime import datetime
-
-        import pytz
-
-        timezone = pytz.timezone(log_tz)
-
-        def time_converter(seconds):
-            return datetime.utcfromtimestamp(seconds).astimezone(timezone).timetuple()
-
         for handler in logging.root.handlers:
-            handler.formatter.converter = time_converter
+            handler.formatter.converter = lambda seconds: (
+                datetime.fromtimestamp(seconds, tz=pytz.UTC).astimezone(log_tz).timetuple()
+            )


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- replace deprecated Python datetime API `datetime.utcfromtimestamp()`
- make use of Pydantic's TimezoneName type (https://docs.pydantic.dev/latest/api/pydantic_extra_types_timezone_name/) for validation of timezone name allowing the names in IANA Time Zone Database (eg. https://data.iana.org/time-zones/tzdb-2024b/zone.tab), without manually timezone parsing

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



