### PR TITLE
fix(core): use CreatedByRole enum for role consistency

### DIFF
--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -18,6 +18,7 @@ from core.rag.extractor.extractor_base import BaseExtractor
 from core.rag.models.document import Document
 from extensions.ext_database import db
 from extensions.ext_storage import storage
+from models.enums import CreatedByRole
 from models.model import UploadFile
 
 logger = logging.getLogger(__name__)
@@ -109,9 +110,10 @@ class WordExtractor(BaseExtractor):
                     key=file_key,
                     name=file_key,
                     size=0,
-                    extension=image_ext,
-                    mime_type=mime_type,
+                    extension=str(image_ext),
+                    mime_type=mime_type or "",
                     created_by=self.user_id,
+                    created_by_role=CreatedByRole.ACCOUNT,
                     created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
                     used=True,
                     used_by=self.user_id,

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1391,7 +1391,7 @@ class UploadFile(db.Model):
         size: int,
         extension: str,
         mime_type: str,
-        created_by_role: str,
+        created_by_role: CreatedByRole,
         created_by: str,
         created_at: datetime,
         used: bool,
@@ -1406,7 +1406,7 @@ class UploadFile(db.Model):
         self.size = size
         self.extension = extension
         self.mime_type = mime_type
-        self.created_by_role = created_by_role
+        self.created_by_role = created_by_role.value
         self.created_by = created_by
         self.created_at = created_at
         self.used = used

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -20,6 +20,7 @@ from core.rag.extractor.extract_processor import ExtractProcessor
 from extensions.ext_database import db
 from extensions.ext_storage import storage
 from models.account import Account
+from models.enums import CreatedByRole
 from models.model import EndUser, UploadFile
 from services.errors.file import FileNotExistsError, FileTooLargeError, UnsupportedFileTypeError
 
@@ -85,7 +86,7 @@ class FileService:
             size=file_size,
             extension=extension,
             mime_type=file.mimetype,
-            created_by_role=("account" if isinstance(user, Account) else "end_user"),
+            created_by_role=(CreatedByRole.ACCOUNT if isinstance(user, Account) else CreatedByRole.END_USER),
             created_by=user.id,
             created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             used=False,
@@ -118,6 +119,7 @@ class FileService:
             extension="txt",
             mime_type="text/plain",
             created_by=current_user.id,
+            created_by_role=CreatedByRole.ACCOUNT,
             created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             used=True,
             used_by=current_user.id,


### PR DESCRIPTION


# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Replace string role identifiers with CreatedByRole enum to ensure consistency.
- Update WordExtractor and FileService to use the enum for specifying user roles.
- Modify UploadFile model to handle enum values correctly.

Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



