### PR TITLE
fix: update the default model to gpt-4o-mini for duckduckgo ai chat

### DIFF
--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_ai.yaml
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_ai.yaml
@@ -37,7 +37,7 @@ parameters:
       - value: mixtral-8x7b
         label:
           en_US: Mixtral
-    default: gpt-3.5
+    default: gpt-4o-mini
     label:
       en_US: Choose Model
       zh_Hans: 选择模型


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
1. Update the default model to gpt-4o-mini for duckduckgo ai chat，because there is no option for gpt-3.5 in the list of AI chat models

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



