### PR TITLE
fix(variable_pool): handle invalid attributes in variable lookup

### DIFF
--- a/api/core/workflow/entities/variable_pool.py
+++ b/api/core/workflow/entities/variable_pool.py
@@ -124,11 +124,14 @@ class VariablePool(BaseModel):
 
         if value is None:
             selector, attr = selector[:-1], selector[-1]
+            if attr not in FileAttribute:
+                return None
             value = self.get(selector)
-            if isinstance(value, FileSegment):
-                attr = FileAttribute(attr)
-                attr_value = file_manager.get_attr(file=value.value, attr=attr)
-                return variable_factory.build_segment(attr_value)
+            if not isinstance(value, FileSegment):
+                return None
+            attr = FileAttribute(attr)
+            attr_value = file_manager.get_attr(file=value.value, attr=attr)
+            return variable_factory.build_segment(attr_value)
 
         return value
 

--- a/api/core/workflow/entities/variable_pool.py
+++ b/api/core/workflow/entities/variable_pool.py
@@ -124,7 +124,8 @@ class VariablePool(BaseModel):
 
         if value is None:
             selector, attr = selector[:-1], selector[-1]
-            if attr not in FileAttribute:
+            # Python support `attr in FileAttribute` after 3.12
+            if attr not in {item.value for item in FileAttribute}:
                 return None
             value = self.get(selector)
             if not isinstance(value, FileSegment):

--- a/api/tests/unit_tests/core/workflow/test_variable_pool.py
+++ b/api/tests/unit_tests/core/workflow/test_variable_pool.py
@@ -33,8 +33,8 @@ def test_get_file_attribute(pool, file):
     assert result.value == file.filename
 
     # Test getting a non-existent attribute
-    with pytest.raises(ValueError):
-        pool.get(("node_1", "file_var", "non_existent_attr"))
+    result = pool.get(("node_1", "file_var", "non_existent_attr"))
+    assert result is None
 
 
 def test_use_long_selector(pool):


### PR DESCRIPTION

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Return None if attribute is not in FileAttribute when fetching a variable.
- Prevent errors by checking FileSegment instance before processing attributes.

Fixes #9397

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



