### PR TITLE
fix(files): update Content-Length handling for tool and remote files

### DIFF
--- a/api/controllers/files/tool_files.py
+++ b/api/controllers/files/tool_files.py
@@ -42,10 +42,10 @@ class ToolFilePreviewApi(Resource):
             stream,
             mimetype=tool_file.mimetype,
             direct_passthrough=True,
-            headers={
-                "Content-Length": str(tool_file.size),
-            },
+            headers={},
         )
+        if tool_file.size > 0:
+            response.headers["Content-Length"] = str(tool_file.size)
         if args["as_attachment"]:
             response.headers["Content-Disposition"] = f"attachment; filename={tool_file.name}"
 

--- a/api/controllers/web/file.py
+++ b/api/controllers/web/file.py
@@ -46,7 +46,7 @@ class RemoteFileInfoApi(WebApiResource):
             response = ssrf_proxy.head(decoded_url)
             return {
                 "file_type": response.headers.get("Content-Type", "application/octet-stream"),
-                "file_length": int(response.headers.get("Content-Length", 0)),
+                "file_length": int(response.headers.get("Content-Length", -1)),
             }
         except Exception as e:
             return {"error": str(e)}, 400


### PR DESCRIPTION


# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Handle non-existent Content-Length header safely by checking tool file size before setting it.
- Change default remote file length to -1 when Content-Length header is absent.

Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



