### PR TITLE
fix: revert ref usage in handleFormChange to fix IME input issues

### DIFF
--- a/web/app/components/base/chat/chat-with-history/config-panel/form.tsx
+++ b/web/app/components/base/chat/chat-with-history/config-panel/form.tsx
@@ -11,16 +11,17 @@ const Form = () => {
   const {
     inputsForms,
     newConversationInputs,
+    newConversationInputsRef,
     handleNewConversationInputsChange,
     isMobile,
   } = useChatWithHistoryContext()
 
   const handleFormChange = useCallback((variable: string, value: any) => {
     handleNewConversationInputsChange({
-      ...newConversationInputs,
+      ...newConversationInputsRef.current,
       [variable]: value,
     })
-  }, [newConversationInputs, handleNewConversationInputsChange])
+  }, [newConversationInputsRef, handleNewConversationInputsChange])
 
   const renderField = (form: any) => {
     const {

--- a/web/app/components/base/chat/chat-with-history/config-panel/form.tsx
+++ b/web/app/components/base/chat/chat-with-history/config-panel/form.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useChatWithHistoryContext } from '../context'
 import Input from './form-input'
@@ -10,17 +11,16 @@ const Form = () => {
   const {
     inputsForms,
     newConversationInputs,
-    newConversationInputsRef,
     handleNewConversationInputsChange,
     isMobile,
   } = useChatWithHistoryContext()
 
-  const handleFormChange = (variable: string, value: any) => {
+  const handleFormChange = useCallback((variable: string, value: any) => {
     handleNewConversationInputsChange({
-      ...newConversationInputsRef.current,
+      ...newConversationInputs,
       [variable]: value,
     })
-  }
+  }, [newConversationInputs, handleNewConversationInputsChange])
 
   const renderField = (form: any) => {
     const {

--- a/web/app/components/base/chat/embedded-chatbot/config-panel/form.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/config-panel/form.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEmbeddedChatbotContext } from '../context'
 import Input from './form-input'
@@ -10,17 +11,16 @@ const Form = () => {
   const {
     inputsForms,
     newConversationInputs,
-    newConversationInputsRef,
     handleNewConversationInputsChange,
     isMobile,
   } = useEmbeddedChatbotContext()
 
-  const handleFormChange = (variable: string, value: any) => {
+  const handleFormChange = useCallback((variable: string, value: any) => {
     handleNewConversationInputsChange({
-      ...newConversationInputsRef.current,
+      ...newConversationInputs,
       [variable]: value,
     })
-  }
+  }, [newConversationInputs, handleNewConversationInputsChange])
 
   const renderField = (form: any) => {
     const {

--- a/web/app/components/base/chat/embedded-chatbot/config-panel/form.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/config-panel/form.tsx
@@ -11,16 +11,17 @@ const Form = () => {
   const {
     inputsForms,
     newConversationInputs,
+    newConversationInputsRef,
     handleNewConversationInputsChange,
     isMobile,
   } = useEmbeddedChatbotContext()
 
   const handleFormChange = useCallback((variable: string, value: any) => {
     handleNewConversationInputsChange({
-      ...newConversationInputs,
+      ...newConversationInputsRef.current,
       [variable]: value,
     })
-  }, [newConversationInputs, handleNewConversationInputsChange])
+  }, [newConversationInputsRef, handleNewConversationInputsChange])
 
   const renderField = (form: any) => {
     const {


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This PR partially reverts recent following two changes to the `handleFormChange` function on #9526 to fix issues with IME input, where typing would result in duplicated characters or premature confirmation of incomplete input.

- https://github.com/langgenius/dify/commit/7a1d6fe50984cb9b59a7f3275ace2eed49c98753#diff-92c707357704c4a775717f83fd603cfd38b31e9728714a26c33fc9451ab19e8aL16-L21
- https://github.com/langgenius/dify/commit/7a1d6fe50984cb9b59a7f3275ace2eed49c98753#diff-a77ab2b9e1dfac46a474c7abe9ee62abc94270b2f958d7bb719166c19bf1b75bL16-L21

In #9526, the `handleFormChange` function was updated:

- useCallback was removed
- ref (newConversationInputsRef.current) was used instead of state

After this change, IME input (e.g., for Japanese) started to behave incorrectly, with input duplication and issues during conversion.

Fixes #9671 
Fixes https://github.com/langgenius/dify/issues/9663

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] The variables of the published app can be input, and available in the chatbot
- [x] The variables of the embedded app can be input, and available in the chatbot
