### PR TITLE
Update Code Generator to use the currently configured model.

### DIFF
--- a/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
+++ b/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
@@ -17,6 +17,8 @@ import Confirm from '@/app/components/base/confirm'
 import type { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import { useModelListAndDefaultModelAndCurrentProviderAndModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
+import ModelIcon from '@/app/components/header/account-setting/model-provider-page/model-icon'
+import ModelName from '@/app/components/header/account-setting/model-provider-page/model-name'
 export type IGetCodeGeneratorResProps = {
   mode: AppType
   isShow: boolean
@@ -116,6 +118,19 @@ export const GetCodeGeneratorResModal: FC<IGetCodeGeneratorResProps> = (
           <div className='mb-8'>
             <div className={'leading-[28px] text-lg font-bold'}>{t('appDebug.codegen.title')}</div>
             <div className='mt-1 text-[13px] font-normal text-gray-500'>{t('appDebug.codegen.description')}</div>
+          </div>
+          <div className='flex items-center'>
+            <ModelIcon
+              className='shrink-0 mr-1.5'
+              provider={currentProvider}
+              modelName={currentModel?.model}
+            />
+            <ModelName
+              className='grow'
+              modelItem={currentModel!}
+              showMode
+              showFeatures
+            />
           </div>
           <div className='mt-6'>
             <div className='text-[0px]'>

--- a/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
+++ b/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
@@ -7,8 +7,7 @@ import ConfigPrompt from '../../config-prompt'
 import { languageMap } from '../../../../workflow/nodes/_base/components/editor/code-editor/index'
 import { generateRuleCode } from '@/service/debug'
 import type { CodeGenRes } from '@/service/debug'
-import { ModelModeType } from '@/types/app'
-import type { AppType, Model } from '@/types/app'
+import { type AppType, type Model, ModelModeType } from '@/types/app'
 import Modal from '@/app/components/base/modal'
 import Button from '@/app/components/base/button'
 import { Generator } from '@/app/components/base/icons/src/vender/other'
@@ -16,6 +15,8 @@ import Toast from '@/app/components/base/toast'
 import Loading from '@/app/components/base/loading'
 import Confirm from '@/app/components/base/confirm'
 import type { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
+import { useModelListAndDefaultModelAndCurrentProviderAndModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
+import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 export type IGetCodeGeneratorResProps = {
   mode: AppType
   isShow: boolean
@@ -31,9 +32,12 @@ export const GetCodeGeneratorResModal: FC<IGetCodeGeneratorResProps> = (
     codeLanguages,
     onClose,
     onFinished,
-
   },
 ) => {
+  const {
+    currentProvider,
+    currentModel,
+  } = useModelListAndDefaultModelAndCurrentProviderAndModel(ModelTypeEnum.textGeneration)
   const { t } = useTranslation()
   const [instruction, setInstruction] = React.useState<string>('')
   const [isLoading, { setTrue: setLoadingTrue, setFalse: setLoadingFalse }] = useBoolean(false)
@@ -51,9 +55,10 @@ export const GetCodeGeneratorResModal: FC<IGetCodeGeneratorResProps> = (
     return true
   }
   const model: Model = {
-    provider: 'openai',
-    name: 'gpt-4o-mini',
+    provider: currentProvider?.provider || '',
+    name: currentModel?.model || '',
     mode: ModelModeType.chat,
+    // This is a fixed parameter
     completion_params: {
       temperature: 0.7,
       max_tokens: 0,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
The code generator could only use gpt4-o-mini, which was inconvenient because it required users to have a ChatGPT API key configured. This update allows the code generator to utilize the currently configured model, making it more flexible and user-friendly.

Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

You can verify this by setting a system model other than ChatGPT and then running the Code Generator. It will clearly display which model the Code Generator is using, making it easy to confirm.
<img width="627" alt="スクリーンショット 2024-10-23 23 41 42" src="https://github.com/user-attachments/assets/87bcd165-a19b-4780-a8f6-2f54aef842f9">

