### PR TITLE
Fix code scanning alert no. 89: DOM text reinterpreted as HTML

### DIFF
--- a/web/app/components/base/app-icon-picker/Uploader.tsx
+++ b/web/app/components/base/app-icon-picker/Uploader.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-
 import type { ChangeEvent, FC } from 'react'
 import { createRef, useEffect, useState } from 'react'
 import type { Area } from 'react-easy-crop'
@@ -11,6 +9,8 @@ import classNames from 'classnames'
 import { ImagePlus } from '../icons/src/vender/line/images'
 import { useDraggableUploader } from './hooks'
 import { ALLOW_FILE_EXTENSIONS } from '@/types/app'
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024
 
 type UploaderProps = {
   className?: string
@@ -40,9 +40,8 @@ const Uploader: FC<UploaderProps> = ({
 
   const handleLocalFileInput = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file && ALLOW_FILE_EXTENSIONS.includes(file.type.split('/').pop()?.toLowerCase() || '') && file.size <= MAX_FILE_SIZE) {
+    if (file && ALLOW_FILE_EXTENSIONS.includes(file.type.split('/').pop()?.toLowerCase() || '') && file.size <= MAX_FILE_SIZE)
       setInputImage({ file, url: URL.createObjectURL(file) })
-    }
   }
 
   const {

--- a/web/app/components/base/app-icon-picker/Uploader.tsx
+++ b/web/app/components/base/app-icon-picker/Uploader.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
 import type { ChangeEvent, FC } from 'react'
 import { createRef, useEffect, useState } from 'react'
 import type { Area } from 'react-easy-crop'
@@ -38,8 +40,9 @@ const Uploader: FC<UploaderProps> = ({
 
   const handleLocalFileInput = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file)
+    if (file && ALLOW_FILE_EXTENSIONS.includes(file.type.split('/').pop()?.toLowerCase() || '') && file.size <= MAX_FILE_SIZE) {
       setInputImage({ file, url: URL.createObjectURL(file) })
+    }
   }
 
   const {

--- a/web/app/components/base/app-icon-picker/utils.ts
+++ b/web/app/components/base/app-icon-picker/utils.ts
@@ -1,4 +1,4 @@
-export const createImage = (url: string) =>
+const createImage = (url: string) =>
   new Promise<HTMLImageElement>((resolve, reject) => {
     const image = new Image()
     image.addEventListener('load', () => resolve(image))


### PR DESCRIPTION
Fixes [https://github.com/langgenius/dify/security/code-scanning/89](https://github.com/langgenius/dify/security/code-scanning/89)

To fix the problem, we need to ensure that the `url` is properly validated or sanitized before being used as the `src` attribute of the `Image` object. One way to achieve this is by using a safe method to create the image URL, such as `URL.createObjectURL`, and ensuring that the input file is validated before creating the URL.

1. Validate the file type and size before creating the URL in `Uploader.tsx`.
2. Ensure that the `url` passed to `createImage` is always created using `URL.createObjectURL` and not directly from user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
