### PR TITLE
feat(api): add generic file size limit parameter

### DIFF
--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -25,6 +25,7 @@ class AppParameterApi(InstalledAppResource):
         "image_file_size_limit": fields.Integer,
         "video_file_size_limit": fields.Integer,
         "audio_file_size_limit": fields.Integer,
+        "file_size_limit": fields.Integer,
     }
 
     parameters_fields = {
@@ -90,6 +91,7 @@ class AppParameterApi(InstalledAppResource):
                 "image_file_size_limit": dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
                 "video_file_size_limit": dify_config.UPLOAD_VIDEO_FILE_SIZE_LIMIT,
                 "audio_file_size_limit": dify_config.UPLOAD_AUDIO_FILE_SIZE_LIMIT,
+                "file_size_limit": dify_config.UPLOAD_FILE_SIZE_LIMIT,
             },
         }
 

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -22,9 +22,10 @@ class AppParameterApi(Resource):
     }
 
     system_parameters_fields = {
-        "image_file_size_limit": fields.String,
+        "image_file_size_limit": fields.Integer,
         "video_file_size_limit": fields.Integer,
         "audio_file_size_limit": fields.Integer,
+        "file_size_limit": fields.Integer,
     }
 
     parameters_fields = {
@@ -89,6 +90,7 @@ class AppParameterApi(Resource):
                 "image_file_size_limit": dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
                 "video_file_size_limit": dify_config.UPLOAD_VIDEO_FILE_SIZE_LIMIT,
                 "audio_file_size_limit": dify_config.UPLOAD_AUDIO_FILE_SIZE_LIMIT,
+                "file_size_limit": dify_config.UPLOAD_FILE_SIZE_LIMIT,
             },
         }
 

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -25,6 +25,7 @@ class AppParameterApi(WebApiResource):
         "image_file_size_limit": fields.Integer,
         "video_file_size_limit": fields.Integer,
         "audio_file_size_limit": fields.Integer,
+        "file_size_limit": fields.Integer,
     }
 
     parameters_fields = {
@@ -88,6 +89,7 @@ class AppParameterApi(WebApiResource):
                 "image_file_size_limit": dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
                 "video_file_size_limit": dify_config.UPLOAD_VIDEO_FILE_SIZE_LIMIT,
                 "audio_file_size_limit": dify_config.UPLOAD_AUDIO_FILE_SIZE_LIMIT,
+                "file_size_limit": dify_config.UPLOAD_FILE_SIZE_LIMIT,
             },
         }
 


### PR DESCRIPTION


# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Introduced a new parameter for a generic file size limit across multiple API endpoints.
- Updated data structures and configurations to support the new `file_size_limit`.
- Changed `image_file_size_limit` field type from String to Integer for consistency.

Follow up #9797

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



