### PR TITLE
fix: duckduckgo image search not work

### DIFF
--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
@@ -20,11 +20,9 @@ class DuckDuckGoImageSearchTool(BuiltinTool):
             "max_results": tool_parameters.get("max_results"),
         }
         response = DDGS().images(**query_dict)
-        result = []
+        markdown_result = "\n\n"
+        json_result = []
         for res in response:
-            res["transfer_method"] = FileTransferMethod.REMOTE_URL
-            msg = ToolInvokeMessage(
-                type=ToolInvokeMessage.MessageType.IMAGE_LINK, message=res.get("image"), save_as="", meta=res
-            )
-            result.append(msg)
-        return result
+            markdown_result += f"![{res.get('title') or ''}]({res.get('image') or ''})"
+            json_result.append(self.create_json_message(res))
+        return [self.create_text_message(markdown_result)] + json_result

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from duckduckgo_search import DDGS
 
-from core.file.models import FileTransferMethod
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fixes  https://github.com/langgenius/dify/issues/9778

caused by new version [here](https://github.com/langgenius/dify/blob/dd1750607814a9a3c31ae20de712f7bfadedbf20/api/core/workflow/nodes/tool/tool_node.py#L181) will validate the file of tool whether created

now changed the response to markdown can also display image result
![4ed2325126026f6e5e5432f12da7bce](https://github.com/user-attachments/assets/667900eb-7e09-43c5-8156-60e7d6c2076b)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [x] Test agent run tool
- [x] Test workflow run tool



