### PR TITLE
fix users had already joined a workspace, but the system still first …

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -505,7 +505,6 @@ class TenantService:
     def create_owner_tenant_if_not_exist(
         account: Account, name: Optional[str] = None, is_setup: Optional[bool] = False
     ):
-
         """Check if user have a workspace or not"""
         available_ta = (
             TenantAccountJoin.query.filter_by(account_id=account.id).order_by(TenantAccountJoin.id.asc()).first()

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -505,15 +505,18 @@ class TenantService:
     def create_owner_tenant_if_not_exist(
         account: Account, name: Optional[str] = None, is_setup: Optional[bool] = False
     ):
-        """Create owner tenant if not exist"""
-        if not FeatureService.get_system_features().is_allow_create_workspace and not is_setup:
-            raise WorkSpaceNotAllowedCreateError()
+
+        """Check if user have a workspace or not"""
         available_ta = (
             TenantAccountJoin.query.filter_by(account_id=account.id).order_by(TenantAccountJoin.id.asc()).first()
         )
 
         if available_ta:
             return
+
+        """Create owner tenant if not exist"""
+        if not FeatureService.get_system_features().is_allow_create_workspace and not is_setup:
+            raise WorkSpaceNotAllowedCreateError()
 
         if name:
             tenant = TenantService.create_tenant(name=name, is_setup=is_setup)


### PR DESCRIPTION
### Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods.

### Description

When updating the project from version 0.6.14 to 0.10.1, users who previously logged in via OAuth encountered the error "Workspace not found, please contact system admin to invite you to join in a workspace" upon logging in again. These users have already joined a workspace, but the system first checks if they can create their own workspace, leading to login failures when this check fails. I believe this sequence is incorrect. If a user is already linked to a workspace, it should return immediately without checking `is_allow_create_workspace`. This PR aims to fix this bug.

Fixes #9833

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

### Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B