### PR TITLE
chore: code generator button should only display in code node

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/editor/base.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/base.tsx
@@ -29,6 +29,7 @@ type Props = {
   codeLanguages: CodeLanguage
   fileList?: FileEntity[]
   showFileList?: boolean
+  showCodeGenerator?: boolean
 }
 
 const Base: FC<Props> = ({
@@ -44,6 +45,7 @@ const Base: FC<Props> = ({
   codeLanguages,
   fileList = [],
   showFileList,
+  showCodeGenerator = false,
 }) => {
   const ref = useRef<HTMLDivElement>(null)
   const {
@@ -76,9 +78,11 @@ const Base: FC<Props> = ({
             e.stopPropagation()
           }}>
             {headerRight}
-            <div className='ml-1'>
-              <CodeGeneratorButton onGenerated={onGenerated} codeLanguages={codeLanguages}/>
-            </div>
+            {showCodeGenerator && (
+              <div className='ml-1'>
+                <CodeGeneratorButton onGenerated={onGenerated} codeLanguages={codeLanguages}/>
+              </div>
+            )}
             {!isCopied
               ? (
                 <Clipboard className='mx-1 w-3.5 h-3.5 text-gray-500 cursor-pointer' onClick={handleCopy} />

--- a/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
@@ -31,6 +31,7 @@ export type Props = {
   noWrapper?: boolean
   isExpand?: boolean
   showFileList?: boolean
+  showCodeGenerator?: boolean
 }
 
 export const languageMap = {
@@ -63,6 +64,7 @@ const CodeEditor: FC<Props> = ({
   noWrapper,
   isExpand,
   showFileList,
+  showCodeGenerator = false,
 }) => {
   const [isFocus, setIsFocus] = React.useState(false)
   const [isMounted, setIsMounted] = React.useState(false)
@@ -207,6 +209,7 @@ const CodeEditor: FC<Props> = ({
             codeLanguages={language}
             fileList={fileList}
             showFileList={showFileList}
+            showCodeGenerator={showCodeGenerator}
           >
             {main}
           </Base>

--- a/web/app/components/workflow/nodes/code/panel.tsx
+++ b/web/app/components/workflow/nodes/code/panel.tsx
@@ -92,6 +92,7 @@ const Panel: FC<NodePanelProps<CodeNodeType>> = ({
           language={inputs.code_language}
           value={inputs.code}
           onChange={handleCodeChange}
+          showCodeGenerator={true}
         />
       </div>
       <Split />


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

fix this:

![c90164afa49eb33b4fca7acc4fc9a40](https://github.com/user-attachments/assets/711fa27b-6d1a-4925-9673-627e932b954b)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [ ] Test A
- [ ] Test B



