### PR TITLE
Fixed http_request response class to ignore case when getting content…

### DIFF
--- a/api/core/workflow/nodes/http_request/entities.py
+++ b/api/core/workflow/nodes/http_request/entities.py
@@ -94,7 +94,7 @@ class Response:
     @property
     def is_file(self):
         content_type = self.content_type
-        content_disposition = self.response.headers.get("Content-Disposition", "")
+        content_disposition = next((value for key, value in self.headers.items() if key.lower() == "content-disposition"), "")
 
         return "attachment" in content_disposition or (
             not any(non_file in content_type for non_file in NON_FILE_CONTENT_TYPES)
@@ -103,7 +103,7 @@ class Response:
 
     @property
     def content_type(self) -> str:
-        return self.headers.get("Content-Type", "")
+        return next((value for key, value in self.headers.items() if key.lower() == "content-type"), "")
 
     @property
     def text(self) -> str:

--- a/api/core/workflow/nodes/http_request/entities.py
+++ b/api/core/workflow/nodes/http_request/entities.py
@@ -95,8 +95,7 @@ class Response:
     def is_file(self):
         content_type = self.content_type
         content_disposition = next(
-            (value for key, value in self.headers.items() if key.lower() == "content-disposition"), 
-            ""
+            (value for key, value in self.headers.items() if key.lower() == "content-disposition"), ""
         )
 
         return "attachment" in content_disposition or (

--- a/api/core/workflow/nodes/http_request/entities.py
+++ b/api/core/workflow/nodes/http_request/entities.py
@@ -94,7 +94,10 @@ class Response:
     @property
     def is_file(self):
         content_type = self.content_type
-        content_disposition = next((value for key, value in self.headers.items() if key.lower() == "content-disposition"), "")
+        content_disposition = next(
+            (value for key, value in self.headers.items() if key.lower() == "content-disposition"), 
+            ""
+        )
 
         return "attachment" in content_disposition or (
             not any(non_file in content_type for non_file in NON_FILE_CONTENT_TYPES)


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

In the HTTP Request node, the `Content-Disposition` and `Content-Type` headers are used to determine whether the response is a file or not. However, since case is not ignored, if these headers are returned in lower case, it is mistakenly determined that the response is not a file.

Fixes #9896

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade




