### PR TITLE
Add environment variables, you can manually enter the values of environment variables yourself

### DIFF
--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -11,6 +11,7 @@ from logging.handlers import RotatingFileHandler
 from configs import dify_config
 
 
+# 在顶级定义（函数）之前添加两个空行
 def replace_env_variables(text):
     def replace(match):
         var_name = match.group(1)

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -13,8 +13,8 @@ def replace_env_variables(text):
         var_name=math.group(1)
         var_value=os.getenv(var_name)
         return '' if var_value is None else var_value
-    pattern =r'\$\{([^}]+)\}'
-    return re.sub(pattern,replace,text)
+    pattern = r'\$\{([^}]+)\}'
+    return re.sub(pattern, replace, text)
 
 def init_app(app: Flask):
     log_handlers = None

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -1,10 +1,12 @@
-import logging
 import os
 import re
 import sys
-from logging.handlers import RotatingFileHandler
 
 from flask import Flask
+from logging.handlers import RotatingFileHandler
+
+import logging
+
 
 from configs import dify_config
 
@@ -13,9 +15,10 @@ def replace_env_variables(text):
         var_name = match.group(1)
         var_value = os.getenv(var_name)
         return '' if var_value is None else var_value
-    
+
     pattern = r'\$\{([^}]+)\}'
     return re.sub(pattern, replace, text)
+
 
 def init_app(app: Flask):
     log_handlers = None
@@ -31,7 +34,8 @@ def init_app(app: Flask):
                 backupCount=replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
             ),
             logging.StreamHandler(sys.stdout),
-        ] 
+        ]
+    
     logging.basicConfig(
         level=replace_env_variables(dify_config.LOG_LEVEL),
         format=replace_env_variables(dify_config.LOG_FORMAT),
@@ -39,6 +43,7 @@ def init_app(app: Flask):
         handlers=log_handlers,
         force=True,
     )
+    
     log_tz = replace_env_variables(dify_config.LOG_TZ)
     if log_tz:
         from datetime import datetime

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -1,40 +1,42 @@
 import logging
 import os
+import re
 import sys
 from logging.handlers import RotatingFileHandler
 
 from flask import Flask
 
 from configs import dify_config
-import re
 
 def replace_env_variables(text):
     def replace(match):
         var_name = match.group(1)
         var_value = os.getenv(var_name)
         return '' if var_value is None else var_value
+    
     pattern = r'\$\{([^}]+)\}'
     return re.sub(pattern, replace, text)
 
 def init_app(app: Flask):
     log_handlers = None
     log_file = replace_env_variables(dify_config.LOG_FILE)
+    
     if log_file:
         log_dir = os.path.dirname(log_file)
         os.makedirs(log_dir, exist_ok=True)
         log_handlers = [
             RotatingFileHandler(
-                filename = log_file,
-                maxBytes = replace_env_variables(dify_config.LOG_FILE_MAX_SIZE) * 1024 * 1024,
-                backupCount = replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
+                filename=log_file,
+                maxBytes=replace_env_variables(dify_config.LOG_FILE_MAX_SIZE) * 1024 * 1024,
+                backupCount=replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
             ),
             logging.StreamHandler(sys.stdout),
         ] 
     logging.basicConfig(
-        level = replace_env_variables(dify_config.LOG_LEVEL),
-        format = replace_env_variables(dify_config.LOG_FORMAT),
-        datefmt = replace_env_variables(dify_config.LOG_DATEFORMAT),
-        handlers = log_handlers,
+        level=replace_env_variables(dify_config.LOG_LEVEL),
+        format=replace_env_variables(dify_config.LOG_FORMAT),
+        datefmt=replace_env_variables(dify_config.LOG_DATEFORMAT),
+        handlers=log_handlers,
         force=True,
     )
     log_tz = replace_env_variables(dify_config.LOG_TZ)

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -13,9 +13,9 @@ def replace_env_variables(text):
     def replace(match):
         var_name = match.group(1)
         var_value = os.getenv(var_name)
-        return '' if var_value is None else var_value
+        return "" if var_value is None else var_value
 
-    pattern = r'\$\{([^}]+)\}'
+    pattern = r"\$\{([^}]+)\}"
     return re.sub(pattern, replace, text)
 
 
@@ -34,7 +34,7 @@ def init_app(app: Flask):
             ),
             logging.StreamHandler(sys.stdout),
         ]
-    
+
     logging.basicConfig(
         level=dify_config.LOG_LEVEL,
         format=dify_config.LOG_FORMAT,
@@ -56,4 +56,3 @@ def init_app(app: Flask):
 
         for handler in logging.root.handlers:
             handler.formatter.converter = time_converter
-            

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -8,9 +8,13 @@ from flask import Flask
 from configs import dify_config
 
 
+
 def init_app(app: Flask):
     log_handlers = None
-    log_file = dify_config.LOG_FILE
+    # 获取环境变量 PYTHONPATH
+    python_path = os.getenv('PYTHONPATH', '')
+    # 将 PYTHONPATH 加入 log_file 路径
+    log_file = os.path.join(python_path, dify_config.LOG_FILE) if python_path else dify_config.LOG_FILE
     if log_file:
         log_dir = os.path.dirname(log_file)
         os.makedirs(log_dir, exist_ok=True)
@@ -21,8 +25,7 @@ def init_app(app: Flask):
                 backupCount=dify_config.LOG_FILE_BACKUP_COUNT,
             ),
             logging.StreamHandler(sys.stdout),
-        ]
-
+        ] 
     logging.basicConfig(
         level=dify_config.LOG_LEVEL,
         format=dify_config.LOG_FORMAT,
@@ -43,3 +46,8 @@ def init_app(app: Flask):
 
         for handler in logging.root.handlers:
             handler.formatter.converter = time_converter
+
+
+
+
+

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -13,9 +13,9 @@ def replace_env_variables(text):
     def replace(match):
         var_name = match.group(1)
         var_value = os.getenv(var_name)
-        return '' if var_value is None else var_value
+        return "" if var_value is None else var_value
 
-    pattern = r'\$\{([^}]+)\}'
+    pattern = r"\$\{([^}]+)\}"
     return re.sub(pattern, replace, text)
 
 
@@ -33,7 +33,7 @@ def init_app(app: Flask):
             ),
             logging.StreamHandler(sys.stdout),
         ]
-    
+
     logging.basicConfig(
         level=replace_env_variables(dify_config.LOG_LEVEL),
         format=replace_env_variables(dify_config.LOG_FORMAT),
@@ -54,4 +54,3 @@ def init_app(app: Flask):
 
         for handler in logging.root.handlers:
             handler.formatter.converter = time_converter
-            

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -13,9 +13,9 @@ def replace_env_variables(text):
     def replace(match):
         var_name = match.group(1)
         var_value = os.getenv(var_name)
-        return "" if var_value is None else var_value
+        return '' if var_value is None else var_value
 
-    pattern = r"\$\{([^}]+)\}"
+    pattern = r'\$\{([^}]+)\}'
     return re.sub(pattern, replace, text)
 
 
@@ -25,23 +25,25 @@ def init_app(app: Flask):
     if log_file:
         log_dir = os.path.dirname(log_file)
         os.makedirs(log_dir, exist_ok=True)
+
         log_handlers = [
             RotatingFileHandler(
                 filename=log_file,
-                maxBytes=replace_env_variables(dify_config.LOG_FILE_MAX_SIZE) * 1024 * 1024,
-                backupCount=replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
+                maxBytes=dify_config.LOG_FILE_MAX_SIZE * 1024 * 1024,
+                backupCount=dify_config.LOG_FILE_BACKUP_COUNT,
             ),
             logging.StreamHandler(sys.stdout),
         ]
-
+    
     logging.basicConfig(
-        level=replace_env_variables(dify_config.LOG_LEVEL),
-        format=replace_env_variables(dify_config.LOG_FORMAT),
-        datefmt=replace_env_variables(dify_config.LOG_DATEFORMAT),
+        level=dify_config.LOG_LEVEL,
+        format=dify_config.LOG_FORMAT,
+        datefmt=dify_config.LOG_DATEFORMAT,
         handlers=log_handlers,
         force=True,
     )
-    log_tz = replace_env_variables(dify_config.LOG_TZ)
+    log_tz = dify_config.LOG_TZ
+
     if log_tz:
         from datetime import datetime
 
@@ -54,3 +56,4 @@ def init_app(app: Flask):
 
         for handler in logging.root.handlers:
             handler.formatter.converter = time_converter
+            

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -22,7 +22,6 @@ def replace_env_variables(text):
 def init_app(app: Flask):
     log_handlers = None
     log_file = replace_env_variables(dify_config.LOG_FILE)
-    
     if log_file:
         log_dir = os.path.dirname(log_file)
         os.makedirs(log_dir, exist_ok=True)
@@ -42,7 +41,6 @@ def init_app(app: Flask):
         handlers=log_handlers,
         force=True,
     )
-    
     log_tz = replace_env_variables(dify_config.LOG_TZ)
     if log_tz:
         from datetime import datetime
@@ -56,8 +54,4 @@ def init_app(app: Flask):
 
         for handler in logging.root.handlers:
             handler.formatter.converter = time_converter
-
-
-
-
-
+            

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -10,8 +10,8 @@ import re
 
 def replace_env_variables(text):
     def replace(match):
-        var_name=math.group(1)
-        var_value=os.getenv(var_name)
+        var_name = match.group(1)
+        var_value = os.getenv(var_name)
         return '' if var_value is None else var_value
     pattern = r'\$\{([^}]+)\}'
     return re.sub(pattern, replace, text)
@@ -24,17 +24,17 @@ def init_app(app: Flask):
         os.makedirs(log_dir, exist_ok=True)
         log_handlers = [
             RotatingFileHandler(
-                filename=log_file,
-                maxBytes=replace_env_variables(dify_config.LOG_FILE_MAX_SIZE) * 1024 * 1024,
-                backupCount=replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
+                filename = log_file,
+                maxBytes = replace_env_variables(dify_config.LOG_FILE_MAX_SIZE) * 1024 * 1024,
+                backupCount = replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
             ),
             logging.StreamHandler(sys.stdout),
         ] 
     logging.basicConfig(
-        level=replace_env_variables(dify_config.LOG_LEVEL),
-        format=replace_env_variables(dify_config.LOG_FORMAT),
-        datefmt=replace_env_variables(dify_config.LOG_DATEFORMAT),
-        handlers=log_handlers,
+        level = replace_env_variables(dify_config.LOG_LEVEL),
+        format = replace_env_variables(dify_config.LOG_FORMAT),
+        datefmt = replace_env_variables(dify_config.LOG_DATEFORMAT),
+        handlers = log_handlers,
         force=True,
     )
     log_tz = replace_env_variables(dify_config.LOG_TZ)

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -1,17 +1,17 @@
+# Standard library imports
 import os
 import re
 import sys
 import logging
-
-
+# Third-party imports
 from flask import Flask
 from logging.handlers import RotatingFileHandler
 
-
+# Local application/library imports
 from configs import dify_config
 
-
 # 在顶级定义（函数）之前添加两个空行
+
 def replace_env_variables(text):
     def replace(match):
         var_name = match.group(1)

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import logging
 
 
 from flask import Flask
@@ -8,9 +9,6 @@ from logging.handlers import RotatingFileHandler
 
 
 from configs import dify_config
-
-
-import logging
 
 
 def replace_env_variables(text):

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -6,34 +6,38 @@ from logging.handlers import RotatingFileHandler
 from flask import Flask
 
 from configs import dify_config
+import re
 
-
+def replace_env_variables(text):
+    def replace(match):
+        var_name=math.group(1)
+        var_value=os.getenv(var_name)
+        return '' if var_value is None else var_value
+    pattern =r'\$\{([^}]+)\}'
+    return re.sub(pattern,replace,text)
 
 def init_app(app: Flask):
     log_handlers = None
-    # 获取环境变量 PYTHONPATH
-    python_path = os.getenv('PYTHONPATH', '')
-    # 将 PYTHONPATH 加入 log_file 路径
-    log_file = os.path.join(python_path, dify_config.LOG_FILE) if python_path else dify_config.LOG_FILE
+    log_file = replace_env_variables(dify_config.LOG_FILE)
     if log_file:
         log_dir = os.path.dirname(log_file)
         os.makedirs(log_dir, exist_ok=True)
         log_handlers = [
             RotatingFileHandler(
                 filename=log_file,
-                maxBytes=dify_config.LOG_FILE_MAX_SIZE * 1024 * 1024,
-                backupCount=dify_config.LOG_FILE_BACKUP_COUNT,
+                maxBytes=replace_env_variables(dify_config.LOG_FILE_MAX_SIZE) * 1024 * 1024,
+                backupCount=replace_env_variables(dify_config.LOG_FILE_BACKUP_COUNT),
             ),
             logging.StreamHandler(sys.stdout),
         ] 
     logging.basicConfig(
-        level=dify_config.LOG_LEVEL,
-        format=dify_config.LOG_FORMAT,
-        datefmt=dify_config.LOG_DATEFORMAT,
+        level=replace_env_variables(dify_config.LOG_LEVEL),
+        format=replace_env_variables(dify_config.LOG_FORMAT),
+        datefmt=replace_env_variables(dify_config.LOG_DATEFORMAT),
         handlers=log_handlers,
         force=True,
     )
-    log_tz = dify_config.LOG_TZ
+    log_tz = replace_env_variables(dify_config.LOG_TZ)
     if log_tz:
         from datetime import datetime
 

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -1,16 +1,13 @@
-# Standard library imports
+import logging
 import os
 import re
 import sys
-import logging
-# Third-party imports
-from flask import Flask
 from logging.handlers import RotatingFileHandler
 
-# Local application/library imports
+from flask import Flask
+
 from configs import dify_config
 
-# 在顶级定义（函数）之前添加两个空行
 
 def replace_env_variables(text):
     def replace(match):

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -2,13 +2,16 @@ import os
 import re
 import sys
 
+
 from flask import Flask
 from logging.handlers import RotatingFileHandler
 
-import logging
-
 
 from configs import dify_config
+
+
+import logging
+
 
 def replace_env_variables(text):
     def replace(match):

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -132,14 +132,14 @@ class AppAnnotationService:
                         MessageAnnotation.content.ilike("%{}%".format(keyword)),
                     )
                 )
-                .order_by(MessageAnnotation.created_at.desc(),MessageAnnotation.id.desc())
+                .order_by(MessageAnnotation.created_at.desc(), MessageAnnotation.id.desc())
                 .paginate(page=page, per_page=limit, max_per_page=100, error_out=False)
             )
         else:
             annotations = (
                 db.session.query(MessageAnnotation)
                 .filter(MessageAnnotation.app_id == app_id)
-                .order_by(MessageAnnotation.created_at.desc(),MessageAnnotation.id.desc())
+                .order_by(MessageAnnotation.created_at.desc(), MessageAnnotation.id.desc())
                 .paginate(page=page, per_page=limit, max_per_page=100, error_out=False)
             )
         return annotations.items, annotations.total

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -132,14 +132,14 @@ class AppAnnotationService:
                         MessageAnnotation.content.ilike("%{}%".format(keyword)),
                     )
                 )
-                .order_by(MessageAnnotation.created_at.desc())
+                .order_by(MessageAnnotation.created_at.desc(),MessageAnnotation.id.desc())
                 .paginate(page=page, per_page=limit, max_per_page=100, error_out=False)
             )
         else:
             annotations = (
                 db.session.query(MessageAnnotation)
                 .filter(MessageAnnotation.app_id == app_id)
-                .order_by(MessageAnnotation.created_at.desc())
+                .order_by(MessageAnnotation.created_at.desc(),MessageAnnotation.id.desc())
                 .paginate(page=page, per_page=limit, max_per_page=100, error_out=False)
             )
         return annotations.items, annotations.total


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
       At present, the path in the ext_logging.py file cannot be changed, and it is impossible to determine the complete path by passing the value in the path environment variable parameter by yourself.
       Now you can define a replace_env_variables() function by yourself,Add environment variables to achieve this function, which is to match the specific environment variable to where the specific environment variable is through regular expressions, and the matched environment variable value needs to be manually replaced with the actual value. At this point, the path to the LOG_FILE file becomes a complete path.
       This environment variable substitution function only works in the LOG_FILE file, and files elsewhere in the code do not use this environment variable substitution function.


Fixes 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



