### PR TITLE
Fix content-type header case sensitivity

### DIFF
--- a/api/core/workflow/nodes/http_request/entities.py
+++ b/api/core/workflow/nodes/http_request/entities.py
@@ -94,7 +94,7 @@ class Response:
     @property
     def is_file(self):
         content_type = self.content_type
-        content_disposition = self.response.headers.get("Content-Disposition", "")
+        content_disposition = self.response.headers.get("content-disposition", "")
 
         return "attachment" in content_disposition or (
             not any(non_file in content_type for non_file in NON_FILE_CONTENT_TYPES)
@@ -103,7 +103,7 @@ class Response:
 
     @property
     def content_type(self) -> str:
-        return self.headers.get("Content-Type", "")
+        return self.headers.get("content-type", "")
 
     @property
     def text(self) -> str:

--- a/api/core/workflow/nodes/http_request/node.py
+++ b/api/core/workflow/nodes/http_request/node.py
@@ -147,7 +147,6 @@ class HttpRequestNode(BaseNode[HttpRequestNodeData]):
         content = response.content
 
         if is_file and content_type:
-        if content_type:
             # extract filename from url
             filename = path.basename(url)
             # extract extension if possible

--- a/api/core/workflow/nodes/http_request/node.py
+++ b/api/core/workflow/nodes/http_request/node.py
@@ -142,9 +142,11 @@ class HttpRequestNode(BaseNode[HttpRequestNodeData]):
         Extract files from response
         """
         files = []
+        is_file = response.is_file
         content_type = response.content_type
         content = response.content
 
+        if is_file and content_type:
         if content_type:
             # extract filename from url
             filename = path.basename(url)

--- a/api/tests/integration_tests/workflow/nodes/test_http.py
+++ b/api/tests/integration_tests/workflow/nodes/test_http.py
@@ -430,3 +430,37 @@ def test_multi_colons_parse(setup_http_mock):
     assert urlencode({"Redirect": "http://example2.com"}) in result.process_data.get("request", "")
     assert 'form-data; name="Redirect"\r\n\r\nhttp://example6.com' in result.process_data.get("request", "")
     # assert "http://example3.com" == resp.get("headers", {}).get("referer")
+
+
+def test_image_file(monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        "core.tools.tool_file_manager.ToolFileManager.create_file_by_raw",
+        lambda *args, **kwargs: SimpleNamespace(id="1"),
+    )
+
+    node = init_http_node(
+        config={
+            "id": "1",
+            "data": {
+                "title": "http",
+                "desc": "",
+                "method": "get",
+                "url": "https://cloud.dify.ai/logo/logo-site.png",
+                "authorization": {
+                    "type": "no-auth",
+                    "config": None,
+                },
+                "params": "",
+                "headers": "",
+                "body": None,
+            },
+        }
+    )
+
+    result = node._run()
+    assert result.process_data is not None
+    assert result.outputs is not None
+    resp = result.outputs
+    assert len(resp.get("files", [])) == 1


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

All dictionary keys in `self.headers` are stored in lowercase, so the keys are corrected to lowercase when retrieving them.

Fixes #9896

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade




