### PR TITLE
chore: use posixpath to wrapper filepath

### DIFF
--- a/api/extensions/storage/aliyun_oss_storage.py
+++ b/api/extensions/storage/aliyun_oss_storage.py
@@ -1,3 +1,4 @@
+import posixpath
 from collections.abc import Generator
 
 import oss2 as aliyun_s3
@@ -50,9 +51,4 @@ class AliyunOssStorage(BaseStorage):
         self.client.delete_object(self.__wrapper_folder_filename(filename))
 
     def __wrapper_folder_filename(self, filename) -> str:
-        if self.folder:
-            if self.folder.endswith("/"):
-                filename = self.folder + filename
-            else:
-                filename = self.folder + "/" + filename
-        return filename
+        return posixpath.join(self.folder, filename) if self.folder else filename


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Use posixpath to join the filepath, ensures that paths always use `/` as the separator

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



