### PR TITLE
DatasetService Submitting document indexing tasks in a loop

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -916,10 +916,12 @@ class DocumentService:
                 db.session.commit()
 
                 # trigger async task
-                if document_ids:
-                    document_indexing_task.delay(dataset.id, document_ids)
-                if duplicate_document_ids:
-                    duplicate_document_indexing_task.delay(dataset.id, duplicate_document_ids)
+            if document_ids:
+                for dociment_id in document_ids:
+                    document_indexing_task.delay(dataset.id, [dociment_id])
+            if duplicate_document_ids:
+                for duplicate_document_id in duplicate_document_ids:
+                    duplicate_document_indexing_task.delay(dataset.id, [duplicate_document_id])
 
             return documents, batch
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
In the current version, if a large number of files are uploaded at a time and multiple batches are uploaded simultaneously, there may be repeated indexing of documents in some batches, which will not stop.

Modified approach: Use a `for loop` to iterate over multiple documents in a batch and send them to Celery one by one, processing one document at a time.

After modification:

1. It can prevent the occurrence of repeated indexing issues;
2. If there are multiple nodes, it can avoid load imbalance caused by significant differences in the number of documents uploaded in different batches;
3. If a document is lost in a batch, multiple documents in the batch may have indexing issues. The modification can prevent this problem.



Fixes #9986 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



