### PR TITLE
fix: conversation variable may not change in the answer node

### DIFF
--- a/api/core/workflow/nodes/answer/answer_stream_generate_router.py
+++ b/api/core/workflow/nodes/answer/answer_stream_generate_router.py
@@ -153,6 +153,7 @@ class AnswerStreamGeneratorRouter:
                 NodeType.IF_ELSE,
                 NodeType.QUESTION_CLASSIFIER,
                 NodeType.ITERATION,
+                NodeType.CONVERSATION_VARIABLE_ASSIGNER,
             }:
                 answer_dependencies[answer_node_id].append(source_node_id)
             else:


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

### Reproduce
1. create a chatflow with three nodes: `start`, `variable assigner`, `answer`
2. create a conversation variable, in the `variable assigner` node change the variable,  in the `answer` node output the variable
3. in the debug and preview panel , will always output the previous variable value.  

![image](https://github.com/user-attachments/assets/36e8e1fa-f761-49bf-b05f-953119b45c93)
![4c9e365d46e221dde8a3038a414235d](https://github.com/user-attachments/assets/751e2809-a42b-4d1b-ab0f-4fc28d2b578e)

reproduce DSL:  [test.zip](https://github.com/user-attachments/files/17565381/test.zip)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

test locally

- [x] Test the reproduce DSL above
- [x] Test a  `variable assigner` node and a `LLM` node, and combine the results in the `answer` node



