### PR TITLE
fix TypeError: catch_warnings.__init__() got an unexpected keyword argument 'action'

### DIFF
--- a/api/core/tools/provider/builtin/podcast_generator/tools/podcast_audio_generator.py
+++ b/api/core/tools/provider/builtin/podcast_generator/tools/podcast_audio_generator.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import io
 import random
 from typing import Any, Literal, Optional, Union
-from warnings import catch_warnings
+from warnings import catch_warnings, simplefilter
 
 import openai
 
@@ -10,7 +10,8 @@ from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolParameterValidationError, ToolProviderCredentialValidationError
 from core.tools.tool.builtin_tool import BuiltinTool
 
-with catch_warnings(action="ignore", category=RuntimeWarning):
+with catch_warnings():
+    simplefilter("ignore", category=RuntimeWarning)
     from pydub import AudioSegment
 
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

1.execute command
`poetry shell`
`flask db upgrade`

2.error information

Traceback (most recent call last):
File "F:\Dify资料\ai408_dify\api\core\helper\module_import_helper.py", line 29, in import_module_from_source
spec.loader.exec_module(module)
File "", line 883, in exec_module
File "", line 241, in _call_with_frames_removed
File "F:\Dify资料\ai408_dify\api\core\tools\provider\builtin\podcast_generator\tools\podcast_audio_generator.py", line 13, in
with catch_warnings(action="ignore", category=RuntimeWarning):
TypeError: catch_warnings.init() got an unexpected keyword argument 'action'
ERROR:core.tools.tool_manager:load builtin provider identity=ToolProviderIdentity(author='Dify', name='podcast_generator', description=I18nObject(en_US='Generate podcast audio using Text-to-Speech services', zh_Hans='使用文字转语音服务生成播客 音频', pt_BR='Generate podcast audio using Text-to-Speech services', ja_JP='Generate podcast audio using Text-to-Speech services'), icon='icon.svg', label=I18nObject(en_US='Podcast Generator', zh_Hans='播客生成器', pt_BR='Podcast Generator', jadcast Generator'), tags=[]) tools=None credentials_schema={'tts_service': ToolProviderCredentials(name='tts_service', type=<CredentialsType.SELECT: 'select'>, required=True, default=None, options=[ToolCredentialsOption(value='openai', label=I18nObject(en_US='OpenAI TTS', zh_Hans='OpenAI TTS', pt_BR='OpenAI TTS', ja_JP='OpenAI TTS'))], label=I18nObject(en_US='TTS Service', zh_Hans='TTS 服务', pt_BR='TTS Service', ja_JP='TTS Service'), help=None, url=None, placeholder=I18nObject(en_US=elect a TTS service', zh_Hans='选择一个 TTS 服务', pt_BR='Select a TTS service', ja_JP='Select a TTS service')), 'api_key': ToolProviderCredentials(name='api_key', type=<CredentialsType.SECRET_INPUT: 'secret-input'>, required=True, default=Noneons=None, label=I18nObject(en_US='API Key', zh_Hans='API 密钥', pt_BR='API Key', ja_JP='API Key'), help=None, url=None, placeholder=I18nObject(en_US='Enter your TTS service API key', zh_Hans='输入您的 TTS 服务 API 密钥', pt_BR='Enter your TTS s key', ja_JP='Enter your TTS service API key'))} error: catch_warnings.init() got an unexpected keyword argument 'action'

Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

