### PR TITLE
Ensure consistent float type for cached embedding return values

### DIFF
--- a/api/core/rag/embedding/cached_embedding.py
+++ b/api/core/rag/embedding/cached_embedding.py
@@ -102,7 +102,8 @@ class CacheEmbedding(Embeddings):
         embedding = redis_client.get(embedding_cache_key)
         if embedding:
             redis_client.expire(embedding_cache_key, 600)
-            return list(np.frombuffer(base64.b64decode(embedding), dtype="float"))
+            decoded_embedding = np.frombuffer(base64.b64decode(embedding), dtype="float")
+            return [float(x) for x in decoded_embedding]
         try:
             embedding_result = self._model_instance.invoke_text_embedding(
                 texts=[text], user=self._user, input_type=EmbeddingInputType.QUERY


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

This PR ensures that the return values of embeddings retrieved from the cache are consistently in float type. This change prevents potential issues caused by type mismatches (`float` vs `float64`) during serialization, especially when using Chroma as the vector database.

Fixes #7213

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

- Test
    - Set up Chroma as the vector database
    - Run a Retrieval Testing
        - Results are retrieved successfully.
    - Run the same search again
        - Before Fix: Prior to this fix, running the search twice would result in an error: `Type is not JSON serializable: numpy.float64`.
        - After Fix: After applying this fix, the same search should succeed without errors, and the results should be retrieved consistently.


