### PR TITLE
chore(ci): separate vector store tests into new workflow

### DIFF
--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -1,11 +1,11 @@
-name: Run Pytest
+name: Run VDB Tests
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - api/**
+      - api/core/rag/datasource/**
       - docker/**
 
 concurrency:
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    name: API Tests
+    name: VDB Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,18 +46,6 @@ jobs:
       - name: Install dependencies
         run: poetry install -C api --with dev
 
-      - name: Check dependencies in pyproject.toml
-        run: poetry run -C api bash dev/pytest/pytest_artifacts.sh
-
-      - name: Run Unit tests
-        run: poetry run -C api bash dev/pytest/pytest_unit_tests.sh
-
-      - name: Run ModelRuntime
-        run: poetry run -C api bash dev/pytest/pytest_model_runtime.sh
-
-      - name: Run Tool
-        run: poetry run -C api bash dev/pytest/pytest_tools.sh
-
       - name: Set up dotenvs
         run: |
           cp docker/.env.example docker/.env
@@ -66,14 +54,22 @@ jobs:
       - name: Expose Service Ports
         run: sh .github/workflows/expose_service_ports.sh
 
-      - name: Set up Sandbox
+      - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
         uses: hoverkraft-tech/compose-action@v2.0.0
         with:
           compose-file: |
-            docker/docker-compose.middleware.yaml
+            docker/docker-compose.yaml
           services: |
-            sandbox
-            ssrf_proxy
+            weaviate
+            qdrant
+            couchbase-server
+            etcd
+            minio
+            milvus-standalone
+            pgvecto-rs
+            pgvector
+            chroma
+            elasticsearch
 
-      - name: Run Workflow
-        run: poetry run -C api bash dev/pytest/pytest_workflow.sh
+      - name: Test Vector Stores
+        run: poetry run -C api bash dev/pytest/pytest_vdb.sh


### PR DESCRIPTION

# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- Moved vector store setup and tests from `api-tests.yml` to a new `vdb-tests.yml`.
- Isolated tests to run only on specific path changes to `api/core/rag/datasource` and `docker`.
- Introduced concurrent job execution with version matrix for Python 3.10, 3.11, and 3.12.
- Ensured concurrent test execution by cancelling in-progress runs of the same workflow.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



