### PR TITLE
fixed: web api remote urls error

### DIFF
--- a/api/controllers/web/remote_files.py
+++ b/api/controllers/web/remote_files.py
@@ -12,7 +12,7 @@ from services.file_service import FileService
 
 class RemoteFileInfoApi(WebApiResource):
     @marshal_with(remote_file_info_fields)
-    def get(self, url):
+    def get(self, app_model, end_user, url):
         decoded_url = urllib.parse.unquote(url)
         try:
             response = ssrf_proxy.head(decoded_url)


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

bug:
http://localhost:3000/api/remote-files/https:/public.bnbstatic.com/static/content/square/images/7b53b81a8bc14f0aa72feb82983dd66b.jpg

When adding a remote url using this interface, we get the following error.
After modifying the code, it is restored to normal.

<img width="805" alt="image" src="https://github.com/user-attachments/assets/ea4c956f-d3bc-4a92-92a4-716f04ddecc7">


Fixes 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



