### PR TITLE
fix: simplify Enter key handling and remove unused ref

### DIFF
--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -1,6 +1,5 @@
 import {
   useCallback,
-  useRef,
   useState,
 } from 'react'
 import Textarea from 'rc-textarea'
@@ -63,7 +62,6 @@ const ChatInputArea = ({
     isMultipleLine,
   } = useTextAreaHeight()
   const [query, setQuery] = useState('')
-  const isUseInputMethod = useRef(false)
   const [showVoiceInput, setShowVoiceInput] = useState(false)
   const filesStore = useFileStore()
   const {
@@ -95,20 +93,11 @@ const ChatInputArea = ({
     }
   }
 
-  const handleKeyUp = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      // prevent send message when using input method enter
-      if (!e.shiftKey && !isUseInputMethod.current)
-        handleSend()
-    }
-  }
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    isUseInputMethod.current = e.nativeEvent.isComposing
-    if (e.key === 'Enter' && !e.shiftKey) {
-      setQuery(query.replace(/\n$/, ''))
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
+      setQuery(query.replace(/\n$/, ''))
+      handleSend()
     }
   }
 
@@ -165,7 +154,6 @@ const ChatInputArea = ({
                   setQuery(e.target.value)
                   handleTextareaResize()
                 }}
-                onKeyUp={handleKeyUp}
                 onKeyDown={handleKeyDown}
                 onPaste={handleClipboardPasteFile}
                 onDragEnter={handleDragFileEnter}


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fix #9295

> There are times when input is mistakenly sent by pressing enter after completing IME input. When inserting a line break with shift + enter, mistaken sending occurs if you:
> 
> 1. press down shift and enter
> 2. release shift
> 3. release enter

The issue described above has been resolved.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Create a sample chatbot
- [ ] Use IME in the chat-input section within the preview
- [ ] Confirm that after inserting a line break with Shift + Enter, releasing Shift first and then releasing Enter with a slight delay does not send the chat message.