### PR TITLE
chore(ci): avoid reinstall pipx and pin poetry version aligned with in api dockerfile

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Install Poetry
       shell: bash
-      run: pipx install poetry==${{ inputs.poetry-version }}
+      run: pip install poetry==${{ inputs.poetry-version }}
 
     - name: Restore Poetry cache
       if: ${{ inputs.poetry-lockfile != '' }}

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,10 +1,34 @@
 name: Setup Poetry
 
+inputs:
+  python-version:
+    required: true
+    default: '3.10'
+  poetry-version:
+    required: true
+    default: '1.8.3'
+  poetry-lockfile:
+    required: true
+    default: ''
+
 runs:
   using: composite
   steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
     - name: Install Poetry
       shell: bash
       env:
         POETRY_VERSION: 1.8.3
-      run: pipx install poetry==${{ env.POETRY_VERSION }}
+      run: pipx install poetry==${{ inputs.poetry-version }}
+
+    - name: Poetry cache
+      if: ${{ inputs.poetry-lockfile != '' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: poetry
+        cache-dependency-path: ${{ inputs.poetry-lockfile }}

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -19,6 +19,7 @@ runs:
   steps:
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5
+      cache: pip
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,0 +1,9 @@
+name: Setup Poetry
+env:
+  POETRY_VERSION: 1.8.3
+runs:
+  using: composite
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry==${{ env.POETRY_VERSION }}

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,9 +1,10 @@
 name: Setup Poetry
-env:
-  POETRY_VERSION: 1.8.3
+
 runs:
   using: composite
   steps:
     - name: Install Poetry
       shell: bash
+      env:
+        POETRY_VERSION: 1.8.3
       run: pipx install poetry==${{ env.POETRY_VERSION }}

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -19,9 +19,9 @@ runs:
   steps:
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5
-      cache: pip
       with:
         python-version: ${{ inputs.python-version }}
+        cache: pip
 
     - name: Install Poetry
       shell: bash

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,13 +1,16 @@
-name: Setup Poetry
+name: Setup Poetry and Python
 
 inputs:
   python-version:
+    description: Python version to use and the Poetry installed with
     required: true
     default: '3.10'
   poetry-version:
+    description: Poetry version to set up
     required: true
     default: '1.8.3'
   poetry-lockfile:
+    description: Path to the Poetry lockfile to restore cache from
     required: true
     default: ''
 
@@ -21,11 +24,9 @@ runs:
 
     - name: Install Poetry
       shell: bash
-      env:
-        POETRY_VERSION: 1.8.3
       run: pipx install poetry==${{ inputs.poetry-version }}
 
-    - name: Poetry cache
+    - name: Restore Poetry cache
       if: ${{ inputs.poetry-lockfile != '' }}
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -8,7 +8,7 @@ inputs:
   poetry-version:
     description: Poetry version to set up
     required: true
-    default: '1.8.3'
+    default: '1.8.4'
   poetry-lockfile:
     description: Path to the Poetry lockfile to restore cache from
     required: true

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -28,15 +28,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Poetry
+      - name: Setup Poetry and Python ${{ matrix.python-version }}
         uses: ./.github/actions/setup-poetry
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
-          cache-dependency-path: api/poetry.lock
+          poetry-lockfile: api/poetry.lock
 
       - name: Check Poetry lockfile
         run: |

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v3
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/db-migration-test.yml
+++ b/.github/workflows/db-migration-test.yml
@@ -31,8 +31,8 @@ jobs:
             api/pyproject.toml
             api/poetry.lock
 
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v3
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
 
       - name: Install dependencies
         run: poetry install -C api

--- a/.github/workflows/db-migration-test.yml
+++ b/.github/workflows/db-migration-test.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - api/migrations/**
+      - .github/workflows/db-migration-test.yml
 
 concurrency:
   group: db-migration-test-${{ github.ref }}
@@ -14,25 +15,15 @@ concurrency:
 jobs:
   db-migration-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.10"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache-dependency-path: |
-            api/pyproject.toml
-            api/poetry.lock
-
-      - name: Setup Poetry
+      - name: Setup Poetry and Python
         uses: ./.github/actions/setup-poetry
+        with:
+          poetry-lockfile: api/poetry.lock
 
       - name: Install dependencies
         run: poetry install -C api

--- a/.github/workflows/db-migration-test.yml
+++ b/.github/workflows/db-migration-test.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - api/migrations/**
-      - .github/workflows/db-migration-test.yml
 
 concurrency:
   group: db-migration-test-${{ github.ref }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           files: api/**
 
-      - name: Install Poetry
+      - name: Setup Poetry
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: abatilo/actions-poetry@v3
+        uses: ./.github/actions/setup-poetry
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -30,7 +30,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/setup-poetry
 
-      - name: Install Python dependencies
+      - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: poetry install -C api --only lint
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,13 +28,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/setup-poetry
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          python-version: '3.10'
-
-      - name: Python dependencies
+      - name: Install Python dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: poetry install -C api --only lint
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -36,15 +36,13 @@ jobs:
 
       - name: Ruff check
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: poetry run -C api ruff check ./api
+        run: |
+          poetry run -C api ruff check ./api
+          poetry run -C api ruff format --check ./api
 
       - name: Dotenv check
         if: steps.changed-files.outputs.any_changed == 'true'
         run: poetry run -C api dotenv-linter ./api/.env.example ./web/.env.example
-
-      - name: Ruff formatter check
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: poetry run -C api ruff format --check ./api
 
       - name: Lint hints
         if: failure()

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           files: api/**
 
-      - name: Setup Poetry
+      - name: Setup Poetry and Python
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/setup-poetry
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,9 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: api/**
+          files: |
+            api/**
+            .github/workflows/style.yml
 
       - name: Setup Poetry and Python
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -28,15 +28,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Poetry
+      - name: Setup Poetry and Python ${{ matrix.python-version }}
         uses: ./.github/actions/setup-poetry
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
-          cache-dependency-path: api/poetry.lock
+          poetry-lockfile: api/poetry.lock
 
       - name: Check Poetry lockfile
         run: |

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v3
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -177,3 +177,4 @@ To protect your privacy, please avoid posting security issues on GitHub. Instead
 ## License
 
 This repository is available under the [Dify Open Source License](LICENSE), which is essentially Apache 2.0 with a few additional restrictions.
+

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10-slim-bookworm AS base
 WORKDIR /app/api
 
 # Install Poetry
-ENV POETRY_VERSION=1.8.3
+ENV POETRY_VERSION=1.8.4
 
 # if you located in China, you can use aliyun mirror to speed up
 # RUN pip install --no-cache-dir poetry==${POETRY_VERSION} -i https://mirrors.aliyun.com/pypi/simple/


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

- although pipx already shipped with runner image Ubuntu 24.04, install poetry directly on pip (not pipx) , with pip caching support
- pin poetry version aligned with used in dockerfile

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B



