### PR TITLE
chore: make comfy workflow can generate image with a random seed

### DIFF
--- a/api/core/tools/provider/builtin/comfyui/tools/comfyui_client.py
+++ b/api/core/tools/provider/builtin/comfyui/tools/comfyui_client.py
@@ -76,9 +76,9 @@ class ComfyUiClient:
         if seed_id not in prompt:
             raise Exception("Not a valid seed node")
         if "seed" in prompt[seed_id]["inputs"]:
-            prompt[seed_id]["inputs"]["seed"] = random.randint(10 ** 14, 10 ** 15 - 1)
+            prompt[seed_id]["inputs"]["seed"] = random.randint(10**14, 10**15 - 1)
         elif "noise_seed" in prompt[seed_id]["inputs"]:
-            prompt[seed_id]["inputs"]["noise_seed"] = random.randint(10 ** 14, 10 ** 15 - 1)
+            prompt[seed_id]["inputs"]["noise_seed"] = random.randint(10**14, 10**15 - 1)
         else:
             raise Exception("Not a valid seed node")
         return prompt

--- a/api/core/tools/provider/builtin/comfyui/tools/comfyui_client.py
+++ b/api/core/tools/provider/builtin/comfyui/tools/comfyui_client.py
@@ -48,7 +48,6 @@ class ComfyUiClient:
         prompt = origin_prompt.copy()
         id_to_class_type = {id: details["class_type"] for id, details in prompt.items()}
         k_sampler = [key for key, value in id_to_class_type.items() if value == "KSampler"][0]
-        prompt.get(k_sampler)["inputs"]["seed"] = random.randint(10**14, 10**15 - 1)
         positive_input_id = prompt.get(k_sampler)["inputs"]["positive"][0]
         prompt.get(positive_input_id)["inputs"]["text"] = positive_prompt
 
@@ -70,6 +69,18 @@ class ComfyUiClient:
         load_image_nodes = [key for key, value in id_to_class_type.items() if value == "LoadImage"]
         for load_image, image_name in zip(load_image_nodes, image_names):
             prompt.get(load_image)["inputs"]["image"] = image_name
+        return prompt
+
+    def set_prompt_seed_by_id(self, origin_prompt: dict, seed_id: str) -> dict:
+        prompt = origin_prompt.copy()
+        if seed_id not in prompt:
+            raise Exception("Not a valid seed node")
+        if "seed" in prompt[seed_id]["inputs"]:
+            prompt[seed_id]["inputs"]["seed"] = random.randint(10 ** 14, 10 ** 15 - 1)
+        elif "noise_seed" in prompt[seed_id]["inputs"]:
+            prompt[seed_id]["inputs"]["noise_seed"] = random.randint(10 ** 14, 10 ** 15 - 1)
+        else:
+            raise Exception("Not a valid seed node")
         return prompt
 
     def track_progress(self, prompt: dict, ws: WebSocket, prompt_id: str):

--- a/api/core/tools/provider/builtin/comfyui/tools/comfyui_workflow.py
+++ b/api/core/tools/provider/builtin/comfyui/tools/comfyui_workflow.py
@@ -70,6 +70,9 @@ class ComfyUIWorkflowTool(BuiltinTool):
             else:
                 prompt = comfyui.set_prompt_images_by_default(prompt, image_names)
 
+        if seed_id := tool_parameters.get("seed_id"):
+            prompt = comfyui.set_prompt_seed_by_id(prompt, seed_id)
+
         images = comfyui.generate_image_by_prompt(prompt)
         result = []
         for img in images:

--- a/api/core/tools/provider/builtin/comfyui/tools/comfyui_workflow.yaml
+++ b/api/core/tools/provider/builtin/comfyui/tools/comfyui_workflow.yaml
@@ -52,3 +52,12 @@ parameters:
       en_US: When the workflow has multiple image nodes, enter the ID list of these nodes, and the images will be passed to ComfyUI in the order of the list.
       zh_Hans: 当工作流有多个图片节点时，输入这些节点的ID列表，图片将按列表顺序传给ComfyUI
     form: form
+  - name: seed_id
+    type: string
+    label:
+      en_US: Seed Node Id
+      zh_Hans: 种子节点ID
+    human_description:
+      en_US: If you need to generate different images each time, you need to enter the ID of the seed node.
+      zh_Hans: 如果需要每次生成时使用不同的种子，需要输入包含种子的节点的ID
+    form: form


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
Fixes https://github.com/langgenius/dify/issues/10304
require use choose which node need to use random seed

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions


- [x] Test same prompt without seed node config will generate same image
- [x] Test same prompt with seed node config will generate different image
- [x] Test node id incorrect will raise error



