### PR TITLE
fix: Page may lock if user close the page when refresh access_token

### DIFF
--- a/web/service/refresh-token.ts
+++ b/web/service/refresh-token.ts
@@ -1,7 +1,7 @@
 import { apiPrefix } from '@/config'
 import { fetchWithRetry } from '@/utils'
 
-const LOCAL_STORAGE_KEY = 'is_refreshing'
+const LOCAL_STORAGE_KEY = 'is_other_tab_refreshing'
 
 let isRefreshing = false
 function waitUntilTokenRefreshed() {

--- a/web/service/refresh-token.ts
+++ b/web/service/refresh-token.ts
@@ -1,11 +1,13 @@
 import { apiPrefix } from '@/config'
 import { fetchWithRetry } from '@/utils'
 
+const LOCAL_STORAGE_KEY = 'is_refreshing'
+
 let isRefreshing = false
 function waitUntilTokenRefreshed() {
   return new Promise<void>((resolve, reject) => {
     function _check() {
-      const isRefreshingSign = localStorage.getItem('is_refreshing')
+      const isRefreshingSign = globalThis.localStorage.getItem(LOCAL_STORAGE_KEY)
       if ((isRefreshingSign && isRefreshingSign === '1') || isRefreshing) {
         setTimeout(() => {
           _check()
@@ -22,13 +24,14 @@ function waitUntilTokenRefreshed() {
 // only one request can send
 async function getNewAccessToken(): Promise<void> {
   try {
-    const isRefreshingSign = localStorage.getItem('is_refreshing')
+    const isRefreshingSign = globalThis.localStorage.getItem(LOCAL_STORAGE_KEY)
     if ((isRefreshingSign && isRefreshingSign === '1') || isRefreshing) {
       await waitUntilTokenRefreshed()
     }
     else {
-      globalThis.localStorage.setItem('is_refreshing', '1')
       isRefreshing = true
+      globalThis.localStorage.setItem(LOCAL_STORAGE_KEY, '1')
+      globalThis.addEventListener('beforeunload', releaseRefreshLock)
       const refresh_token = globalThis.localStorage.getItem('refresh_token')
 
       // Do not use baseFetch to refresh tokens.
@@ -61,15 +64,21 @@ async function getNewAccessToken(): Promise<void> {
     return Promise.reject(error)
   }
   finally {
+    releaseRefreshLock()
+  }
+}
+
+function releaseRefreshLock() {
+  if (isRefreshing) {
     isRefreshing = false
-    globalThis.localStorage.removeItem('is_refreshing')
+    globalThis.localStorage.removeItem(LOCAL_STORAGE_KEY)
+    globalThis.removeEventListener('beforeunload', releaseRefreshLock)
   }
 }
 
 export async function refreshAccessTokenOrRelogin(timeout: number) {
   return Promise.race([new Promise<void>((resolve, reject) => setTimeout(() => {
-    isRefreshing = false
-    globalThis.localStorage.removeItem('is_refreshing')
+    releaseRefreshLock()
     reject(new Error('request timeout'))
   }, timeout)), getNewAccessToken()])
 }


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

listen beforeunload event when it start refresh access_token, release the is_refreshing if refresh completed (success \ fail \ timeout)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade
