### PR TITLE
Fix: Set Celery LOG_File only when available, always log to console

### DIFF
--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -46,7 +46,6 @@ def init_app(app: Flask) -> Celery:
         broker_connection_retry_on_startup=True,
         worker_log_format=dify_config.LOG_FORMAT,
         worker_task_log_format=dify_config.LOG_FORMAT,
-        worker_logfile=dify_config.LOG_FILE,
         worker_hijack_root_logger=False,
         timezone=pytz.timezone(dify_config.LOG_TZ),
     )
@@ -54,6 +53,11 @@ def init_app(app: Flask) -> Celery:
     if dify_config.BROKER_USE_SSL:
         celery_app.conf.update(
             broker_use_ssl=ssl_options,  # Add the SSL options to the broker configuration
+        )
+
+    if dify_config.LOG_FILE:
+        celery_app.conf.update(
+            worker_logfile=dify_config.LOG_FILE,
         )
 
     celery_app.set_default()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -9,19 +9,21 @@ from configs import dify_config
 
 
 def init_app(app: Flask):
-    log_handlers = None
+    log_handlers = []
     log_file = dify_config.LOG_FILE
     if log_file:
         log_dir = os.path.dirname(log_file)
         os.makedirs(log_dir, exist_ok=True)
-        log_handlers = [
+        log_handlers.append(
             RotatingFileHandler(
                 filename=log_file,
                 maxBytes=dify_config.LOG_FILE_MAX_SIZE * 1024 * 1024,
                 backupCount=dify_config.LOG_FILE_BACKUP_COUNT,
-            ),
-            logging.StreamHandler(sys.stdout),
-        ]
+            )
+        )
+
+    # Always add StreamHandler to log to console
+    log_handlers.append(logging.StreamHandler(sys.stdout))
 
     logging.basicConfig(
         level=dify_config.LOG_LEVEL,


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] Please open an issue before creating a PR or link to an existing issue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description

Fix [#10555](https://github.com/langgenius/dify/issues/10555)
Regarding Celery, only set the LOG_FILE variable to Difyconfig when its available. Besides, always log output to the console.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions

Fix the code, rebuild worker image, run docker compose.

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/53460202-ca40-4193-b546-9329facf2a9b">



