### PR TITLE
fix: The url output by the list_operator is null

### DIFF
--- a/api/core/workflow/nodes/list_operator/node.py
+++ b/api/core/workflow/nodes/list_operator/node.py
@@ -176,7 +176,7 @@ def _get_file_extract_string_func(*, key: str) -> Callable[[File], str]:
         case "transfer_method":
             return lambda x: x.transfer_method
         case "url":
-            return lambda x: x.remote_url or ""
+            return lambda x: x.generate_url() or ""
         case _:
             raise InvalidKeyError(f"Invalid key: {key}")
 


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [ ] Please open an issue before creating a PR or link to an existing issue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# Description
Fixes #10590 
Close https://github.com/langgenius/dify/pull/10513
The url can be output in the first or last data obtained by list_operator. After reference, url is not a field of File model, but a field processed by self.generate_url(). However, the code uses the direct output of remote_url, which is often an incomplete field or null, so it is more reasonable to replace it with a field generated by generate_url()

Fixes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# Testing Instructions

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


