### PR TITLE
fixed the Base URL usage issue in Podcast Generator tool verification

### DIFF
--- a/api/core/tools/provider/builtin/podcast_generator/podcast_generator.py
+++ b/api/core/tools/provider/builtin/podcast_generator/podcast_generator.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import openai
+from yarl import URL
 
 from core.tools.errors import ToolProviderCredentialValidationError
 from core.tools.provider.builtin_tool_provider import BuiltinToolProviderController
@@ -10,6 +11,7 @@ class PodcastGeneratorProvider(BuiltinToolProviderController):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         tts_service = credentials.get("tts_service")
         api_key = credentials.get("api_key")
+        base_url = credentials.get("openai_base_url")
 
         if not tts_service:
             raise ToolProviderCredentialValidationError("TTS service is not specified")
@@ -17,13 +19,16 @@ class PodcastGeneratorProvider(BuiltinToolProviderController):
         if not api_key:
             raise ToolProviderCredentialValidationError("API key is missing")
 
+        if base_url:
+            base_url = str(URL(base_url) / "v1")
+
         if tts_service == "openai":
-            self._validate_openai_credentials(api_key)
+            self._validate_openai_credentials(api_key, base_url)
         else:
             raise ToolProviderCredentialValidationError(f"Unsupported TTS service: {tts_service}")
 
-    def _validate_openai_credentials(self, api_key: str) -> None:
-        client = openai.OpenAI(api_key=api_key)
+    def _validate_openai_credentials(self, api_key: str, base_url: str | None) -> None:
+        client = openai.OpenAI(api_key=api_key, base_url=base_url)
         try:
             # We're using a simple API call to validate the credentials
             client.models.list()


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fixed the Base URL usage issue in Podcast Generator tool verification

Fixes #10696

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

