### PR TITLE
fix:position error when creating segments

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1458,6 +1458,7 @@ class SegmentService:
             pre_segment_data_list = []
             segment_data_list = []
             keywords_list = []
+            position = max_position + 1 if max_position else 1
             for segment_item in segments:
                 content = segment_item["content"]
                 doc_id = str(uuid.uuid4())
@@ -1475,7 +1476,7 @@ class SegmentService:
                     document_id=document.id,
                     index_node_id=doc_id,
                     index_node_hash=segment_hash,
-                    position=max_position + 1 if max_position else 1,
+                    position=position,
                     content=content,
                     word_count=len(content),
                     tokens=tokens,
@@ -1490,6 +1491,7 @@ class SegmentService:
                 increment_word_count += segment_document.word_count
                 db.session.add(segment_document)
                 segment_data_list.append(segment_document)
+                position += 1
 
                 pre_segment_data_list.append(segment_document)
                 if "keywords" in segment_item:


### PR DESCRIPTION
# Summary

In the original code, the position of the segments was set using max_position + 1, which could lead to incorrect position calculation in scenarios with multiple concurrent requests or different datasets. Specifically, in a single request, the value of max_position might not have been correctly updated, resulting in an inaccurate calculation of the position for new segments.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

