### PR TITLE
fix(i18n): handle key naming error

### DIFF
--- a/web/i18n/pt-BR/app-log.ts
+++ b/web/i18n/pt-BR/app-log.ts
@@ -86,8 +86,8 @@ const translation = {
   agenteLogDetail: {
     agentMode: 'Modo Agente',
     toolUsed: 'Ferramenta usada',
-    iterações: 'Iterações',
-    iteração: 'Iteração',
+    iterations: 'Iterações',
+    iteration: 'Iteração',
     finalProcessing: 'Processamento Final',
   },
   agentLogDetail: {


### PR DESCRIPTION
# Summary

Compile error caused by this translation key when I run in development mode


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>
<img width="467" alt="image" src="https://github.com/user-attachments/assets/68b2bcac-6a16-4bdc-b6b0-6da51dde48b0">
</td>
  <td>OK</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

