### PR TITLE
Fix the situation where output_tokens/input_tokens may be None in response.usage

### DIFF
--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -325,11 +325,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 assistant_prompt_message.tool_calls.append(tool_call)
 
         # calculate num tokens
-        prompt_tokens = (response.usage and response.usage.input_tokens) or \
-            self.get_num_tokens(model, credentials, prompt_messages)
-            
-        completion_tokens = (response.usage and response.usage.output_tokens) or \
-            self.get_num_tokens(model, credentials, [assistant_prompt_message])
+        prompt_tokens = (response.usage and response.usage.input_tokens) or self.get_num_tokens(
+            model, credentials, prompt_messages
+        )
+
+        completion_tokens = (response.usage and response.usage.output_tokens) or self.get_num_tokens(
+            model, credentials, [assistant_prompt_message]
+        )
 
         # transform usage
         usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)

--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -331,7 +331,6 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         completion_tokens = (response.usage and response.usage.output_tokens) or \
             self.get_num_tokens(model, credentials, [assistant_prompt_message])
 
-
         # transform usage
         usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
 

--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -325,14 +325,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 assistant_prompt_message.tool_calls.append(tool_call)
 
         # calculate num tokens
-        if response.usage:
-            # transform usage
-            prompt_tokens = response.usage.input_tokens
-            completion_tokens = response.usage.output_tokens
-        else:
-            # calculate num tokens
-            prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
-            completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
+        prompt_tokens = (response.usage and response.usage.input_tokens) or \
+            self.get_num_tokens(model, credentials, prompt_messages)
+            
+        completion_tokens = (response.usage and response.usage.output_tokens) or \
+            self.get_num_tokens(model, credentials, [assistant_prompt_message])
+
 
         # transform usage
         usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)


### PR DESCRIPTION
# Summary

The usage information returned by some 3rd-party API service providers may be `None`, which will affect the calculation of the `get_price` function and lead to errors `unsupported operand type(s) for *: 'NoneType' and 'decimal.Decimal' ` during multiplication.

The usage information returned by some 3rd-party API service providers :
"usage":{"input_tokens":0,"output_tokens":None}


# Screenshots

Before:
![Snipaste_2024-11-15_11-13-43](https://github.com/user-attachments/assets/e8c11b14-6f7f-48f6-8810-715194848b4b)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

