### PR TITLE
Fix issue with using an JSON object with single quote in a string when testing API tools.

### DIFF
--- a/api/core/tools/tool/api_tool.py
+++ b/api/core/tools/tool/api_tool.py
@@ -263,12 +263,14 @@ class ApiTool(Tool):
                 elif property["type"] == "object" or property["type"] == "array":
                     if isinstance(value, str):
                         try:
-                            # an array str like '[1,2]' also can convert to list [1,2] through json.loads
-                            # json not support single quote, but we can support it
-                            value = value.replace("'", '"')
-                            return json.loads(value)
+                            # an array str like '[1,2]' can also be converted to list [1,2] through json.loads
+                            # json does not support single quotes, but we can support it
+                            return json.loads(value.replace("'", '"'))
                         except ValueError:
-                            return value
+                            try:
+                                return json.loads(value)
+                            except ValueError:
+                                return value
                     elif isinstance(value, dict):
                         return value
                     else:


### PR DESCRIPTION
# Summary

Fix issue with using an JSON object with single quote in a string when testing API tools.

Simply replacing the single quote with double quote will cause issue if some string in the JSON object contains single quotes.  This fixes the issue.

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods