### PR TITLE
refactor: improve handling of leading punctuation removal

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -500,8 +500,8 @@ class IndexingRunner:
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    if page_content.startswith(".") or page_content.startswith("。"):
-                        page_content = page_content[1:]
+                    if re.match(r"^[\p{P}\p{S}]+", page_content, re.UNICODE):
+                        page_content = re.sub(r"^[\p{P}\p{S}]+", "", page_content)
                     else:
                         page_content = page_content
                     document_node.page_content = page_content

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -29,6 +29,7 @@ from core.rag.splitter.fixed_text_splitter import (
     FixedRecursiveCharacterTextSplitter,
 )
 from core.rag.splitter.text_splitter import TextSplitter
+from core.tools.utils.text_processing_utils import remove_leading_symbols
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from extensions.ext_storage import storage
@@ -500,11 +501,7 @@ class IndexingRunner:
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    if re.match(r"^[\p{P}\p{S}]+", page_content, re.UNICODE):
-                        page_content = re.sub(r"^[\p{P}\p{S}]+", "", page_content)
-                    else:
-                        page_content = page_content
-                    document_node.page_content = page_content
+                    document_node.page_content = remove_leading_symbols(page_content)
 
                     if document_node.page_content:
                         split_documents.append(document_node)

--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -1,6 +1,5 @@
 """Paragraph index processor."""
 
-import re
 import uuid
 from typing import Optional
 
@@ -12,6 +11,7 @@ from core.rag.extractor.entity.extract_setting import ExtractSetting
 from core.rag.extractor.extract_processor import ExtractProcessor
 from core.rag.index_processor.index_processor_base import BaseIndexProcessor
 from core.rag.models.document import Document
+from core.tools.utils.text_processing_utils import remove_leading_symbols
 from libs import helper
 from models.dataset import Dataset
 
@@ -44,11 +44,7 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
                     document_node.metadata["doc_id"] = doc_id
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
-                    page_content = document_node.page_content
-                    if re.match(r"^[\p{P}\p{S}]+", page_content, re.UNICODE):
-                        page_content = re.sub(r"^[\p{P}\p{S}]+", "", page_content).strip()
-                    else:
-                        page_content = page_content
+                    page_content = remove_leading_symbols(document_node.page_content).strip()
                     if len(page_content) > 0:
                         document_node.page_content = page_content
                         split_documents.append(document_node)

--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -1,7 +1,7 @@
 """Paragraph index processor."""
 
-import uuid
 import re
+import uuid
 from typing import Optional
 
 from core.rag.cleaner.clean_processor import CleanProcessor

--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -1,6 +1,7 @@
 """Paragraph index processor."""
 
 import uuid
+import re
 from typing import Optional
 
 from core.rag.cleaner.clean_processor import CleanProcessor
@@ -44,8 +45,8 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    if page_content.startswith(".") or page_content.startswith("。"):
-                        page_content = page_content[1:].strip()
+                    if re.match(r"^[\p{P}\p{S}]+", page_content, re.UNICODE):
+                        page_content = re.sub(r"^[\p{P}\p{S}]+", "", page_content).strip()
                     else:
                         page_content = page_content
                     if len(page_content) > 0:

--- a/api/core/rag/index_processor/processor/qa_index_processor.py
+++ b/api/core/rag/index_processor/processor/qa_index_processor.py
@@ -53,8 +53,8 @@ class QAIndexProcessor(BaseIndexProcessor):
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    if page_content.startswith(".") or page_content.startswith("。"):
-                        page_content = page_content[1:]
+                    if re.match(r"^[\p{P}\p{S}]+", page_content, re.UNICODE):
+                        page_content = re.sub(r"^[\p{P}\p{S}]+", "", page_content)
                     else:
                         page_content = page_content
                     document_node.page_content = page_content

--- a/api/core/rag/index_processor/processor/qa_index_processor.py
+++ b/api/core/rag/index_processor/processor/qa_index_processor.py
@@ -18,6 +18,7 @@ from core.rag.extractor.entity.extract_setting import ExtractSetting
 from core.rag.extractor.extract_processor import ExtractProcessor
 from core.rag.index_processor.index_processor_base import BaseIndexProcessor
 from core.rag.models.document import Document
+from core.tools.utils.text_processing_utils import remove_leading_symbols
 from libs import helper
 from models.dataset import Dataset
 
@@ -53,11 +54,7 @@ class QAIndexProcessor(BaseIndexProcessor):
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    if re.match(r"^[\p{P}\p{S}]+", page_content, re.UNICODE):
-                        page_content = re.sub(r"^[\p{P}\p{S}]+", "", page_content)
-                    else:
-                        page_content = page_content
-                    document_node.page_content = page_content
+                    document_node.page_content = remove_leading_symbols(page_content)
                     split_documents.append(document_node)
             all_documents.extend(split_documents)
         for i in range(0, len(all_documents), 10):

--- a/api/core/tools/utils/text_processing_utils.py
+++ b/api/core/tools/utils/text_processing_utils.py
@@ -1,0 +1,16 @@
+import re
+
+
+def remove_leading_symbols(text: str) -> str:
+    """
+    Remove leading punctuation or symbols from the given text.
+
+    Args:
+        text (str): The input text to process.
+
+    Returns:
+        str: The text with leading punctuation or symbols removed.
+    """
+    # Match Unicode ranges for punctuation and symbols
+    pattern = r"^[\u2000-\u206F\u2E00-\u2E7F\u3000-\u303F!\"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~]+"
+    return re.sub(pattern, "", text)

--- a/api/tests/unit_tests/utils/test_text_processing.py
+++ b/api/tests/unit_tests/utils/test_text_processing.py
@@ -1,0 +1,20 @@
+from textwrap import dedent
+
+import pytest
+
+from core.tools.utils.text_processing_utils import remove_leading_symbols
+
+
+@pytest.mark.parametrize(
+    ("input_text", "expected_output"),
+    [
+        ("...Hello, World!", "Hello, World!"),
+        ("。测试中文标点", "测试中文标点"),
+        ("!@#Test symbols", "Test symbols"),
+        ("Hello, World!", "Hello, World!"),
+        ("", ""),
+        ("   ", "   "),
+    ],
+)
+def test_remove_leading_symbols(input_text, expected_output):
+    assert remove_leading_symbols(input_text) == expected_output


### PR DESCRIPTION
# Summary

This refactor improves the logic for trimming leading punctuation from text content. It replaces the use of `startswith` checks with a regular expression, enabling broader support for diverse punctuation and symbols. Additionally, `.strip()` has been incorporated to ensure removal of trailing whitespace for cleaner output.

**Motivation and Context:**
- Enhances flexibility for handling various punctuation cases, including multilingual and mixed-symbol text inputs.
- Improves code readability, maintainability, and robustness in preprocessing logic.

**Dependencies:**  
No additional dependencies were introduced with this change.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

