### PR TITLE
fix: download some remote files raise error

### DIFF
--- a/api/controllers/console/remote_files.py
+++ b/api/controllers/console/remote_files.py
@@ -45,7 +45,7 @@ class RemoteFileUploadApi(Resource):
 
         resp = ssrf_proxy.head(url=url)
         if resp.status_code != httpx.codes.OK:
-            resp = ssrf_proxy.get(url=url, timeout=3)
+            resp = ssrf_proxy.get(url=url, timeout=3, follow_redirects=True)
         resp.raise_for_status()
 
         file_info = helpers.guess_file_info_from_response(resp)


### PR DESCRIPTION
# Summary


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

the error is:
```
2024-11-16 20:50:26,250.250 INFO [Thread-207 (process_request_thread)] [_client.py:1038] - HTTP Request: HEAD https://cloud.video.taobao.com/vod/S8T54f_w1rkdfLdYjL3S5zKN9CrhkzuhRwOhF313tIQ.mp4 "HTTP/1.1 302 "
2024-11-16 20:50:26,762.762 INFO [Thread-207 (process_request_thread)] [_client.py:1038] - HTTP Request: GET https://cloud.video.taobao.com/vod/S8T54f_w1rkdfLdYjL3S5zKN9CrhkzuhRwOhF313tIQ.mp4 "HTTP/1.1 302 "
2024-11-16 20:50:26,763.763 ERROR [Thread-207 (process_request_thread)] [app.py:838] - Exception on /console/api/remote-files/upload [POST]
Traceback (most recent call last):
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\flask\app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\flask\app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\flask_restful\__init__.py", line 489, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\flask\views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\flask_restful\__init__.py", line 604, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\flask_restful\__init__.py", line 696, in wrapper
    resp = f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "C:\Users\hejl\PycharmProjects\dify\api\controllers\console\remote_files.py", line 49, in post
    resp.raise_for_status()
  File "C:\Users\hejl\PycharmProjects\dify\api\.venv\Lib\site-packages\httpx\_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Redirect response '302 ' for url 'https://cloud.video.taobao.com/vod/S8T54f_w1rkdfLdYjL3S5zKN9CrhkzuhRwOhF313tIQ.mp4'
Redirect location: 'https://tbexpand.alicdn.com/1724398134200/80d7b62dfe82d1e7.mp4?auth_key=1731821615-0-0-c36ebaa781aa6bc3a92df19ef4fd559d&biz=publish-662febf21aa149fd&t=2166e0db17318189152538525e13aa&t=2166e0db17318189152538525e13aa&b=publish&p=cloudvideo_http_video_extranet_notrans&i=478401527148' 
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
2024-11-16 20:50:26,766.766 INFO [Thread-207 (process_request_thread)] [_internal.py:97] - 127.0.0.1 - - [17/Nov/2024 12:50:26] "POST /console/api/remote-files/upload HTTP/1.1" 500 -
```

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

