### PR TITLE
feat: Optimize usability during debugging #10641

### DIFF
--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useRef,
   useState,
 } from 'react'
 import Textarea from 'rc-textarea'
@@ -73,7 +74,8 @@ const ChatInputArea = ({
     isDragActive,
   } = useFile(visionConfig!)
   const { checkInputsForm } = useCheckInputsForms()
-
+  const historyRef = useRef([''])
+  const [currentIndex, setCurrentIndex] = useState(-1)
   const handleSend = () => {
     if (onSend) {
       const { files, setFiles } = filesStore.getState()
@@ -92,12 +94,32 @@ const ChatInputArea = ({
       }
     }
   }
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       setQuery(query.replace(/\n$/, ''))
+      historyRef.current.push(query)
+      setCurrentIndex(historyRef.current.length)
       handleSend()
+    }
+    else if (e.key === 'ArrowUp' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      // When the up key is pressed, output the previous element
+      if (currentIndex > 0) {
+        setCurrentIndex(currentIndex - 1)
+        setQuery(historyRef.current[currentIndex - 1])
+      }
+    }
+    else if (e.key === 'ArrowDown' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      // When the down key is pressed, output the next element
+      if (currentIndex < historyRef.current.length - 1) {
+        setCurrentIndex(currentIndex + 1)
+        setQuery(historyRef.current[currentIndex + 1])
+      }
+      else if (currentIndex === historyRef.current.length - 1) {
+        // If it is the last element, clear the input box
+        setCurrentIndex(historyRef.current.length)
+        setQuery('')
+      }
     }
   }
 


### PR DESCRIPTION
# Summary

Ease of use optimization.Fixes #10641.

During debugging, you need to ask the same group question repeatedly, and it is very troublesome to press ctrl+c, ctrl+v every time.

This is the change:
 - When the up ⬆️ key is pressed, output the previous element
 - When the down ⬇️ key is pressed, output the next element

# Screenshots

![image](https://github.com/user-attachments/assets/8bf79ed3-d00d-4d09-9dec-402887bcce16)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

