### PR TITLE
fix image files not deleted on indexing_estimate #9541

### DIFF
--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -78,6 +78,7 @@ def clean_dataset_task(
                             "Delete image_files failed when storage deleted, \
                                           image_upload_file_is: {}".format(upload_file_id)
                         )
+                    db.session.delete(image_file)
                 db.session.delete(segment)
 
         db.session.query(DatasetProcessRule).filter(DatasetProcessRule.dataset_id == dataset_id).delete()

--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -51,6 +51,7 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
                             "Delete image_files failed when storage deleted, \
                                           image_upload_file_is: {}".format(upload_file_id)
                         )
+                    db.session.delete(image_file)
                 db.session.delete(segment)
 
             db.session.commit()


### PR DESCRIPTION
This pr fixes two problems:
1. https://github.com/langgenius/dify/pull/10465 deletes image files while deleteing documents but not UploadFile records. We delete UploadFile record either.
2. On indexing estimate, image files will be extracted from documents and saved. We delete them after estimating.