### PR TITLE
fix: correct typo in ETL type comment in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -562,7 +562,7 @@ UPLOAD_FILE_SIZE_LIMIT=15
 # The maximum number of files that can be uploaded at a time, default 5.
 UPLOAD_FILE_BATCH_LIMIT=5
 
-# ETl type, support: `dify`, `Unstructured`
+# ETL type, support: `dify`, `Unstructured`
 # `dify` Dify's proprietary file extraction scheme
 # `Unstructured` Unstructured.io file extraction scheme
 ETL_TYPE=dify


### PR DESCRIPTION
# Summary

This is a simple typo fix of the example environment file. 


# Screenshots

None. See diff. 

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

