### PR TITLE
doc: add clarification for length limit of init password

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -75,7 +75,8 @@ SECRET_KEY=sk-9f73s3ljTXVcMT3Blb3ljTqtsKiGHXVcMT3BlbkFJLK7U
 
 # Password for admin user initialization.
 # If left unset, admin user will not be prompted for a password
-# when creating the initial admin account.
+# when creating the initial admin account. 
+# The length of the password cannot exceed 30 charactors.
 INIT_PASSWORD=
 
 # Deployment environment.


### PR DESCRIPTION
Related code: https://github.com/langgenius/dify/blob/14f3d44c3788d07f6c95aeb592800a149e095d35/api/controllers/console/init_validate.py#L31

# Summary

The init password has an implicit length limit. It the user sets a password longer than 30 characters in the `.env` file, they will not be able to submit to the web server in the init process. It's better to explicitly clarify this limit. 

# Screenshots

None. Please see diff. 

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

