### PR TITLE
Fixes devcontainers so they can be ran on Apple Silicon.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.10
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/python:3.10
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
 {
 	"name": "Python 3.10",
-	"build": { 
+	"build": {
 		"context": "..",
 		"dockerfile": "Dockerfile"
 	},
@@ -33,8 +33,10 @@
 		}
 	},
 	"postStartCommand": "./.devcontainer/post_start_command.sh",
-	"postCreateCommand": "./.devcontainer/post_create_command.sh"
-
+	"postCreateCommand": "./.devcontainer/post_create_command.sh",
+	"runArgs": [
+		"--platform=linux/amd64"
+	]
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 


### PR DESCRIPTION
# Summary

This PR adds platform-specific configurations to the devcontainer setup to ensure compatibility with Apple Silicon (M1/M2) Macs. The changes explicitly set the platform to `linux/amd64` to prevent architecture-related issues when running devcontainers on ARM-based machines.

Without this fix gmpy2 can't find `mpfr.h` when the post start command is ran.

```
 In file included from src/gmpy2.c:112:
  src/gmpy2.h:77:10: fatal error: mpfr.h: No such file or directory
     77 | #include <mpfr.h>
        |          ^~~~~~~~
  compilation terminated.
  error: command '/usr/bin/gcc' failed with exit code 1
  

  at /usr/local/py-utils/venvs/poetry/lib/python3.10/site-packages/poetry/installation/chef.py:164 in _prepare
      160│ 
      161│                 error = ChefBuildError("\n\n".join(message_parts))
      162│ 
      163│             if error is not None:
    → 164│                 raise error from None
      165│ 
      166│             return path
      167│ 
      168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:

Note: This error originates from the build backend, and is likely not a problem with poetry but with gmpy2 (2.2.1) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "gmpy2 (==2.2.1)"'.
```

Changes include:
- Added platform specification in Dockerfile using `--platform=amd64`
- Added `runArgs` with platform configuration in devcontainer.json

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>N/A - Development environment configuration change</td>
  <td>N/A - Development environment configuration change</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods