### PR TITLE
feat: export with fixed-api-key

### DIFF
--- a/web/app/components/develop/secret-key/secret-key-modal.tsx
+++ b/web/app/components/develop/secret-key/secret-key-modal.tsx
@@ -1,5 +1,5 @@
 'use client'
-import {
+import React, {
   useEffect,
   useState,
 } from 'react'
@@ -51,7 +51,7 @@ const SecretKeyModal = ({
     : { url: '/datasets/api-keys', params: {} }
   const fetchApiKeysList = appId ? fetchAppApiKeysList : fetchDatasetApiKeysList
   const { data: apiKeysList } = useSWR(commonParams, fetchApiKeysList)
-
+  const [apikey, setApikey] = useState('')
   const [delKeyID, setDelKeyId] = useState('')
 
   const [copyValue, setCopyValue] = useState('')
@@ -83,8 +83,8 @@ const SecretKeyModal = ({
 
   const onCreate = async () => {
     const params = appId
-      ? { url: `/apps/${appId}/api-keys`, body: {} }
-      : { url: '/datasets/api-keys', body: {} }
+      ? { url: `/apps/${appId}/api-keys?apikey=${apikey}`, body: {} }
+      : { url: `/datasets/api-keys?apikey=${apikey}`, body: {} }
     const createApikey = appId ? createAppApikey : createDatasetApikey
     const res = await createApikey(params)
     setVisible(true)
@@ -141,6 +141,14 @@ const SecretKeyModal = ({
           </div>
         )
       }
+      <input
+        id="apikey"
+        type="text"
+        value={ apikey }
+        onChange={e => setApikey(e.target.value)}
+        placeholder={t('appApi.apiKeyModal.customSecretKey') || ''}
+        className={'appearance-none block w-full rounded-lg pl-[14px] px-3 py-2 border border-gray-200 hover:border-gray-300 hover:shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 placeholder-gray-400 caret-primary-600 sm:text-sm pr-10'}
+      />
       <div className='flex'>
         <Button className={`flex flex-shrink-0 mt-4 ${s.autoWidth}`} onClick={onCreate} disabled={!currentWorkspace || !isCurrentWorkspaceEditor}>
           <PlusIcon className='flex flex-shrink-0 w-4 h-4' />

--- a/web/i18n/en-US/app-api.ts
+++ b/web/i18n/en-US/app-api.ts
@@ -23,6 +23,7 @@ const translation = {
     created: 'CREATED',
     lastUsed: 'LAST USED',
     generateTips: 'Keep this key in a secure and accessible place.',
+    customSecretKey: 'Custom API key. If empty, a random key will be generated.',
   },
   actionMsg: {
     deleteConfirmTitle: 'Delete this secret key?',

--- a/web/i18n/zh-Hans/app-api.ts
+++ b/web/i18n/zh-Hans/app-api.ts
@@ -23,6 +23,7 @@ const translation = {
     created: '创建时间',
     lastUsed: '最后使用',
     generateTips: '请将此密钥保存在安全且可访问的地方。',
+    customSecretKey: '自定义API密钥，如果为空，则生成随机密钥。',
   },
   actionMsg: {
     deleteConfirmTitle: '删除此密钥？',


### PR DESCRIPTION
# Summary

A fixed api-key keeps the api-key of app services unchanged when we import, export or upgrade the dsl.

Resolves #10632
Resolves #9559 


# Screenshots

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/14def667-e821-4e11-ad7f-b7761f986ea2" alt="image"></td>
    <td><img src="https://github.com/user-attachments/assets/ef02e798-e7b4-40b4-92cb-855bc356e0d9" alt="image"></td>
  </tr>
  <tr>
    <td>test-app-apikey:<br><img src="https://github.com/user-attachments/assets/0deafc83-ac95-4334-8ba1-1b268dfaaf80" alt="image"></td>
    <td>test-app-apikey:<br><img src="https://github.com/user-attachments/assets/0ad9a0b2-3774-48c1-8fb3-b01b443b352d" alt="image"></td>
    <td>test-dataset-appkey:<br><img src="https://github.com/user-attachments/assets/850576da-0c27-4f17-bed0-ea2916401596" alt="image"></td>
    <td>test-pk-check:<br><img src="https://github.com/user-attachments/assets/f46c10e9-dd90-4805-9533-e819ffc45d38" alt="image"></td>
    <td>test-api:<br><img src="https://github.com/user-attachments/assets/2c108e46-bb30-4683-8c22-16aeb5f982ea" alt="image"></td>
    <td>test-api:<br><img src="https://github.com/user-attachments/assets/280c13d4-bca5-4856-8c0d-9e8619f2cf18" alt="image"></td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

