### PR TITLE
feat: Knowledge-base-api-get-post-method-text-error-#10836

### DIFF
--- a/web/app/(commonLayout)/datasets/template/template.en.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.en.mdx
@@ -329,7 +329,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
   <Col sticky>
     <CodeGroup
       title="Request"
-      tag="POST"
+      tag="GET"
       label="/datasets"
       targetCode={`curl --location --request GET '${props.apiBaseUrl}/datasets?page=1&limit=20' \\\n--header 'Authorization: Bearer {api_key}'`}
     >

--- a/web/app/(commonLayout)/datasets/template/template.zh.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.zh.mdx
@@ -329,7 +329,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
   <Col sticky>
     <CodeGroup
       title="Request"
-      tag="POST"
+      tag="GET"
       label="/datasets"
       targetCode={`curl --location --request GET '${props.apiBaseUrl}/datasets?page=1&limit=20' \\\n--header 'Authorization: Bearer {api_key}'`}
     >


### PR DESCRIPTION
# Summary

Knowledge base api get/post method text error
Fixes #10836 

# Screenshots

<table>
  <tr>
  <td>Before: 
![image](https://github.com/user-attachments/assets/b052ff9f-9794-49bc-80fa-a788b47cf769)
</td>
  <td>After:
![image](https://github.com/user-attachments/assets/a7608aa6-b3d7-44c7-a61b-e92746691850)
 </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [√] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [√] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [] I've updated the documentation accordingly.
- [] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

