### PR TITLE
Feat/add langsmith dotted order

### DIFF
--- a/api/core/ops/langsmith_trace/entities/langsmith_trace_entity.py
+++ b/api/core/ops/langsmith_trace/entities/langsmith_trace_entity.py
@@ -49,6 +49,7 @@ class LangSmithRunModel(LangSmithTokenUsage, LangSmithMultiModel):
     reference_example_id: Optional[str] = Field(None, description="Reference example ID associated with the run")
     input_attachments: Optional[dict[str, Any]] = Field(None, description="Input attachments of the run")
     output_attachments: Optional[dict[str, Any]] = Field(None, description="Output attachments of the run")
+    dotted_order: Optional[str] = Field(None, description="Dotted order of the run")
 
     @field_validator("inputs", "outputs")
     @classmethod

--- a/api/core/ops/langsmith_trace/langsmith_trace.py
+++ b/api/core/ops/langsmith_trace/langsmith_trace.py
@@ -276,11 +276,6 @@ class LangSmithDataTrace(BaseTraceInstance):
         self.add_run(llm_run)
 
     def moderation_trace(self, trace_info: ModerationTraceInfo):
-        parent_run_id = trace_info.message_id
-        parent_dotted_order = generate_dotted_order(parent_run_id, trace_info.start_time)
-        moderation_dotted_order = generate_dotted_order(
-            trace_info.message_id, trace_info.start_time, parent_dotted_order
-        )
         langsmith_run = LangSmithRunModel(
             name=TraceTaskName.MODERATION_TRACE.value,
             inputs=trace_info.inputs,
@@ -298,17 +293,11 @@ class LangSmithDataTrace(BaseTraceInstance):
             parent_run_id=trace_info.message_id,
             start_time=trace_info.start_time or trace_info.message_data.created_at,
             end_time=trace_info.end_time or trace_info.message_data.updated_at,
-            dotted_order=moderation_dotted_order,
         )
 
         self.add_run(langsmith_run)
 
     def suggested_question_trace(self, trace_info: SuggestedQuestionTraceInfo):
-        parent_run_id = trace_info.message_id
-        parent_dotted_order = generate_dotted_order(parent_run_id, trace_info.start_time)
-        suggested_question_dotted_order = generate_dotted_order(
-            trace_info.message_id, trace_info.start_time, parent_dotted_order
-        )
         message_data = trace_info.message_data
         suggested_question_run = LangSmithRunModel(
             name=TraceTaskName.SUGGESTED_QUESTION_TRACE.value,
@@ -322,17 +311,11 @@ class LangSmithDataTrace(BaseTraceInstance):
             parent_run_id=trace_info.message_id,
             start_time=trace_info.start_time or message_data.created_at,
             end_time=trace_info.end_time or message_data.updated_at,
-            dotted_order=suggested_question_dotted_order,
         )
 
         self.add_run(suggested_question_run)
 
     def dataset_retrieval_trace(self, trace_info: DatasetRetrievalTraceInfo):
-        parent_run_id = trace_info.message_id
-        parent_dotted_order = generate_dotted_order(parent_run_id, trace_info.start_time)
-        dataset_retrieval_dotted_order = generate_dotted_order(
-            trace_info.message_id, trace_info.start_time, parent_dotted_order
-        )
         dataset_retrieval_run = LangSmithRunModel(
             name=TraceTaskName.DATASET_RETRIEVAL_TRACE.value,
             inputs=trace_info.inputs,
@@ -345,15 +328,11 @@ class LangSmithDataTrace(BaseTraceInstance):
             parent_run_id=trace_info.message_id,
             start_time=trace_info.start_time or trace_info.message_data.created_at,
             end_time=trace_info.end_time or trace_info.message_data.updated_at,
-            dotted_order=dataset_retrieval_dotted_order,
         )
 
         self.add_run(dataset_retrieval_run)
 
     def tool_trace(self, trace_info: ToolTraceInfo):
-        parent_run_id = trace_info.message_id
-        parent_dotted_order = generate_dotted_order(parent_run_id, trace_info.start_time)
-        tool_dotted_order = generate_dotted_order(trace_info.message_id, trace_info.start_time, parent_dotted_order)
         tool_run = LangSmithRunModel(
             name=trace_info.tool_name,
             inputs=trace_info.tool_inputs,
@@ -367,17 +346,11 @@ class LangSmithDataTrace(BaseTraceInstance):
             start_time=trace_info.start_time,
             end_time=trace_info.end_time,
             file_list=[trace_info.file_url],
-            dotted_order=tool_dotted_order,
         )
 
         self.add_run(tool_run)
 
     def generate_name_trace(self, trace_info: GenerateNameTraceInfo):
-        parent_run_id = trace_info.message_id
-        parent_dotted_order = generate_dotted_order(parent_run_id, trace_info.start_time)
-        generate_name_dotted_order = generate_dotted_order(
-            trace_info.message_id, trace_info.start_time, parent_dotted_order
-        )
         name_run = LangSmithRunModel(
             name=TraceTaskName.GENERATE_NAME_TRACE.value,
             inputs=trace_info.inputs,
@@ -389,7 +362,6 @@ class LangSmithDataTrace(BaseTraceInstance):
             tags=["generate_name"],
             start_time=trace_info.start_time or datetime.now(),
             end_time=trace_info.end_time or datetime.now(),
-            dotted_order=generate_name_dotted_order,
         )
 
         self.add_run(name_run)

--- a/api/core/ops/langsmith_trace/langsmith_trace.py
+++ b/api/core/ops/langsmith_trace/langsmith_trace.py
@@ -234,7 +234,6 @@ class LangSmithDataTrace(BaseTraceInstance):
                 end_user_id = end_user_data.session_id
                 metadata["end_user_id"] = end_user_id
 
-        dotted_order = generate_dotted_order(message_id, trace_info.start_time)
         message_run = LangSmithRunModel(
             input_tokens=trace_info.message_tokens,
             output_tokens=trace_info.answer_tokens,
@@ -252,12 +251,10 @@ class LangSmithDataTrace(BaseTraceInstance):
             tags=["message", str(trace_info.conversation_mode)],
             error=trace_info.error,
             file_list=file_list,
-            dotted_order=dotted_order,
         )
         self.add_run(message_run)
 
         # create llm run parented to message run
-        llm_dotted_order = generate_dotted_order(message_id, trace_info.start_time, dotted_order)
         llm_run = LangSmithRunModel(
             input_tokens=trace_info.message_tokens,
             output_tokens=trace_info.answer_tokens,
@@ -275,7 +272,6 @@ class LangSmithDataTrace(BaseTraceInstance):
             tags=["llm", str(trace_info.conversation_mode)],
             error=trace_info.error,
             file_list=file_list,
-            dotted_order=llm_dotted_order,
         )
         self.add_run(llm_run)
 

--- a/api/core/ops/utils.py
+++ b/api/core/ops/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime
+from typing import Optional
 
 from extensions.ext_database import db
 from models.model import Message
@@ -43,3 +44,16 @@ def replace_text_with_content(data):
         return [replace_text_with_content(item) for item in data]
     else:
         return data
+
+
+def generate_dotted_order(run_id: str, start_time: datetime, parent_dotted_order: Optional[str] = None) -> str:
+    """
+    generate dotted_order for langsmith
+    """
+    timestamp = start_time.strftime("%Y%m%dT%H%M%S%f")[:-3] + "Z"
+    current_segment = f"{timestamp}{run_id}"
+
+    if parent_dotted_order is None:
+        return current_segment
+
+    return f"{parent_dotted_order}.{current_segment}"

--- a/api/core/ops/utils.py
+++ b/api/core/ops/utils.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from extensions.ext_database import db
 from models.model import Message
@@ -46,10 +46,13 @@ def replace_text_with_content(data):
         return data
 
 
-def generate_dotted_order(run_id: str, start_time: datetime, parent_dotted_order: Optional[str] = None) -> str:
+def generate_dotted_order(
+    run_id: str, start_time: Union[str, datetime], parent_dotted_order: Optional[str] = None
+) -> str:
     """
     generate dotted_order for langsmith
     """
+    start_time = datetime.fromisoformat(start_time) if isinstance(start_time, str) else start_time
     timestamp = start_time.strftime("%Y%m%dT%H%M%S%f")[:-3] + "Z"
     current_segment = f"{timestamp}{run_id}"
 


### PR DESCRIPTION
# Summary

Add trace_id and dotted_order for LangSmith integration to enable batch processing

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

