### PR TITLE
fix: update email validation regex to allow periods in local part

### DIFF
--- a/api/core/tools/provider/builtin/email/tools/send_mail.py
+++ b/api/core/tools/provider/builtin/email/tools/send_mail.py
@@ -17,7 +17,7 @@ class SendMailTool(BuiltinTool):
         invoke tools
         """
         sender = self.runtime.credentials.get("email_account", "")
-        email_rgx = re.compile(r"^[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$")
+        email_rgx = re.compile(r"^[a-zA-Z0-9._-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$")
         password = self.runtime.credentials.get("email_password", "")
         smtp_server = self.runtime.credentials.get("smtp_server", "")
         if not smtp_server:

--- a/api/core/tools/provider/builtin/email/tools/send_mail_batch.py
+++ b/api/core/tools/provider/builtin/email/tools/send_mail_batch.py
@@ -18,7 +18,7 @@ class SendMailTool(BuiltinTool):
         invoke tools
         """
         sender = self.runtime.credentials.get("email_account", "")
-        email_rgx = re.compile(r"^[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$")
+        email_rgx = re.compile(r"^[a-zA-Z0-9._-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$")
         password = self.runtime.credentials.get("email_password", "")
         smtp_server = self.runtime.credentials.get("smtp_server", "")
         if not smtp_server:


### PR DESCRIPTION
# Summary

Fixed email validation regex to properly handle periods in email addresses' local part. The previous regex pattern didn't allow periods before the @ symbol, which made it reject valid email addresses like "a.a@gmail.com".

Changes made:
- Added period (.) to the allowed characters in the local part of email regex pattern
- Changed `[a-zA-Z0-9_-]` to `[a-zA-Z0-9._-]` before the @ symbol

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods