### PR TITLE
feat: add a minimal separator between pinned apps and unpinned apps in the explore page

### DIFF
--- a/web/app/components/explore/sidebar/index.tsx
+++ b/web/app/components/explore/sidebar/index.tsx
@@ -11,6 +11,7 @@ import cn from '@/utils/classnames'
 import { fetchInstalledAppList as doFetchInstalledAppList, uninstallApp, updatePinStatus } from '@/service/explore'
 import ExploreContext from '@/context/explore-context'
 import Confirm from '@/app/components/base/confirm'
+import Divider from '@/app/components/base/divider'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 
 const SelectedDiscoveryIcon = () => (
@@ -89,6 +90,7 @@ const SideBar: FC<IExploreSideBarProps> = ({
     fetchInstalledAppList()
   }, [controlUpdateInstalledApps])
 
+  const pinnedAppsCount = installedApps.filter(({ is_pinned }) => is_pinned).length
   return (
     <div className='w-fit sm:w-[216px] shrink-0 pt-6 px-4 border-gray-200 cursor-pointer'>
       <div>
@@ -109,10 +111,9 @@ const SideBar: FC<IExploreSideBarProps> = ({
               height: 'calc(100vh - 250px)',
             }}
           >
-            {installedApps.map(({ id, is_pinned, uninstallable, app: { name, icon_type, icon, icon_url, icon_background } }) => {
-              return (
+            {installedApps.map(({ id, is_pinned, uninstallable, app: { name, icon_type, icon, icon_url, icon_background } }, index) => (
+              <React.Fragment key={id}>
                 <Item
-                  key={id}
                   isMobile={isMobile}
                   name={name}
                   icon_type={icon_type}
@@ -129,8 +130,9 @@ const SideBar: FC<IExploreSideBarProps> = ({
                     setShowConfirm(true)
                   }}
                 />
-              )
-            })}
+                {index === pinnedAppsCount - 1 && index !== installedApps.length - 1 && <Divider />}
+              </React.Fragment>
+            ))}
           </div>
         </div>
       )}


### PR DESCRIPTION
# Summary

This PR adds a minimal separator between Pinned Apps and Unpinned Apps in the Explore page. The separator is displayed only if there are both pinned apps and unpinned apps.

Tested as follows:

- Pin one or more apps and then ensure the separator is displayed
- Unpin all apps and then ensure the separator is not displayed
- Pill all apps and then ensure the separator is not displayed

Fixes #10869

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

There are 5 pinned apps on the top.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/a2928069-ce84-4e55-b7d2-f10714c0d474) | ![image](https://github.com/user-attachments/assets/395c578e-f026-46bb-9ef2-e344205aac59) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

