### PR TITLE
Fix : Add a process to fetch the mime type from the file name for signed url in remote_url

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -169,6 +169,7 @@ def _get_remote_file_info(url: str):
     mime_type = mimetypes.guess_type(url)[0] or ""
     file_size = -1
     filename = url.split("/")[-1].split("?")[0] or "unknown_file"
+    mime_type = mime_type or mimetypes.guess_type(filename)[0]
 
     resp = ssrf_proxy.head(url, follow_redirects=True)
     if resp.status_code == httpx.codes.OK:


### PR DESCRIPTION
Add a process to fetch the mime type from the file name for signed url in remote_url

# Summary

- Fixes [#10737](https://github.com/langgenius/dify/issues/10737)

- Fix the issue that the remote_url encounters an error due to the inability to retrieve the mime type when using an S3 signed URL.

- Add a process to fetch the mime type from the file name. This method is already implemented in api/controllers/common/helpers.py.

- Add the following line to line 172 of api/factories/file_factory.py:
"mime_type = mime_type or mimetypes.guess_type(filename)[0]".

- Confirmed that the MIME type is correctly retrieved in the local environment.


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

