### PR TITLE
feat: Add support for custom Q&A in the knowledge base #10873

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -282,9 +282,12 @@ class IndexingRunner:
         if doc_form and doc_form == "qa_model":
             if len(preview_texts) > 0:
                 # qa model document
-                response = LLMGenerator.generate_qa_document(
-                    current_user.current_tenant_id, preview_texts[0], doc_language
-                )
+                if "Q00001:" in preview_texts[0] and "A00001:" in preview_texts[0]:
+                    response = preview_texts[0]
+                else:
+                    response = LLMGenerator.generate_qa_document(
+                        current_user.current_tenant_id, preview_texts[0], doc_language
+                    )
                 document_qa_list = self.format_split_text(response)
 
                 return {"total_segments": total_segments * 20, "qa_preview": document_qa_list, "preview": preview_texts}
@@ -501,7 +504,10 @@ class IndexingRunner:
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    document_node.page_content = remove_leading_symbols(page_content)
+                    if "Q00001:" in page_content and "A00001:" in page_content:
+                        document_node.page_content = page_content
+                    else:
+                        document_node.page_content = remove_leading_symbols(page_content)
 
                     if document_node.page_content:
                         split_documents.append(document_node)
@@ -536,7 +542,12 @@ class IndexingRunner:
         with flask_app.app_context():
             try:
                 # qa model document
-                response = LLMGenerator.generate_qa_document(tenant_id, document_node.page_content, document_language)
+                if "Q00001:" in document_node.page_content and "A00001:" in document_node.page_content:
+                    response = document_node.page_content
+                else:
+                    response = LLMGenerator.generate_qa_document(
+                        tenant_id, document_node.page_content, document_language
+                    )
                 document_qa_list = self.format_split_text(response)
                 qa_documents = []
                 for result in document_qa_list:

--- a/api/core/rag/extractor/csv_extractor.py
+++ b/api/core/rag/extractor/csv_extractor.py
@@ -25,6 +25,7 @@ class CSVExtractor(BaseExtractor):
         autodetect_encoding: bool = False,
         source_column: Optional[str] = None,
         csv_args: Optional[dict] = None,
+        document_model: Optional[str] = None,
     ):
         """Initialize with file path."""
         self._file_path = file_path
@@ -32,6 +33,7 @@ class CSVExtractor(BaseExtractor):
         self._autodetect_encoding = autodetect_encoding
         self.source_column = source_column
         self.csv_args = csv_args or {}
+        self.document_model = document_model
 
     def extract(self) -> list[Document]:
         """Load data into document objects."""
@@ -67,7 +69,10 @@ class CSVExtractor(BaseExtractor):
             # create document objects
 
             for i, row in df.iterrows():
-                content = ";".join(f"{col.strip()}: {str(row[col]).strip()}" for col in df.columns)
+                if len(df.columns) == 2 and "qa_model" == self.document_model:
+                    content = f"Q00001:{str(row[0]).strip()}\nA00001:{str(row[1]).strip()}"
+                else:
+                    content = ";".join(f"{col.strip()}: {str(row[col]).strip()}" for col in df.columns)
                 source = row[self.source_column] if self.source_column else ""
                 metadata = {"source": source, "row": i}
                 doc = Document(page_content=content, metadata=metadata)

--- a/api/core/rag/extractor/extract_processor.py
+++ b/api/core/rag/extractor/extract_processor.py
@@ -138,7 +138,7 @@ class ExtractProcessor:
                         )
                 else:
                     if file_extension in {".xlsx", ".xls"}:
-                        extractor = ExcelExtractor(file_path)
+                        extractor = ExcelExtractor(file_path, document_model=extract_setting.document_model)
                     elif file_extension == ".pdf":
                         extractor = PdfExtractor(file_path)
                     elif file_extension in {".md", ".markdown"}:
@@ -148,7 +148,9 @@ class ExtractProcessor:
                     elif file_extension == ".docx":
                         extractor = WordExtractor(file_path, upload_file.tenant_id, upload_file.created_by)
                     elif file_extension == ".csv":
-                        extractor = CSVExtractor(file_path, autodetect_encoding=True)
+                        extractor = CSVExtractor(
+                            file_path, autodetect_encoding=True, document_model=extract_setting.document_model
+                        )
                     elif file_extension == ".epub":
                         extractor = UnstructuredEpubExtractor(file_path)
                     else:

--- a/api/core/rag/index_processor/processor/qa_index_processor.py
+++ b/api/core/rag/index_processor/processor/qa_index_processor.py
@@ -54,7 +54,10 @@ class QAIndexProcessor(BaseIndexProcessor):
                     document_node.metadata["doc_hash"] = hash
                     # delete Splitter character
                     page_content = document_node.page_content
-                    document_node.page_content = remove_leading_symbols(page_content)
+                    if "Q00001:" in page_content and "A00001:" in page_content:
+                        document_node.page_content = page_content
+                    else:
+                        document_node.page_content = remove_leading_symbols(page_content)
                     split_documents.append(document_node)
             all_documents.extend(split_documents)
         for i in range(0, len(all_documents), 10):
@@ -143,7 +146,13 @@ class QAIndexProcessor(BaseIndexProcessor):
         with flask_app.app_context():
             try:
                 # qa model document
-                response = LLMGenerator.generate_qa_document(tenant_id, document_node.page_content, document_language)
+
+                if "Q00001:" in document_node.page_content and "A00001:" in document_node.page_content:
+                    response = document_node.page_content
+                else:
+                    response = LLMGenerator.generate_qa_document(
+                        tenant_id, document_node.page_content, document_language
+                    )
                 document_qa_list = self._format_split_text(response)
                 qa_documents = []
                 for result in document_qa_list:

--- a/api/core/rag/splitter/text_splitter.py
+++ b/api/core/rag/splitter/text_splitter.py
@@ -78,7 +78,12 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         documents = []
         for i, text in enumerate(texts):
             index = -1
-            for chunk in self.split_text(text):
+
+            if "Q00001:" in text and "A00001:" in text:
+                split_text_arr = [text]
+            else:
+                split_text_arr = self.split_text(text)
+            for chunk in split_text_arr:
                 metadata = copy.deepcopy(_metadatas[i])
                 if self._add_start_index:
                     index = text.find(chunk, index + 1)


### PR DESCRIPTION
# Summary

I need to import some Q&A text，not need LLM to generate results for me。
I modified the code to support excel and csv uploading qa files。
The processing logic is that when there are only two columns in csv or excel and qa mode is selected, the LLM will not be called。

Resolves #4664 
Resolves #6904     
Resolves #7735
Resolves #7430
Resolves #10873 

# Screenshots

<table>
  <tr>
  <td><img src="https://github.com/user-attachments/assets/c814457e-0c71-46e5-bb59-13c1989b70b1" />
</td>
  <td><img src="https://github.com/user-attachments/assets/8256dc59-5e33-40b2-ba28-1acfe5d11da5" />
</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

