### PR TITLE
fix: refactor all 'or []' and 'or {}' logic to make code more clear

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -114,16 +114,9 @@ class BaseAgentRunner(AppRunner):
         # check if model supports stream tool call
         llm_model = cast(LargeLanguageModel, model_instance.model_type_instance)
         model_schema = llm_model.get_model_schema(model_instance.model, model_instance.credentials)
-        if model_schema and ModelFeature.STREAM_TOOL_CALL in (model_schema.features or []):
-            self.stream_tool_call = True
-        else:
-            self.stream_tool_call = False
-
-        # check if model supports vision
-        if model_schema and ModelFeature.VISION in (model_schema.features or []):
-            self.files = application_generate_entity.files
-        else:
-            self.files = []
+        features = model_schema.features if model_schema and model_schema.features else []
+        self.stream_tool_call = ModelFeature.STREAM_TOOL_CALL in features
+        self.files = application_generate_entity.files if ModelFeature.VISION in features else []
         self.query = None
         self._current_thoughts: list[PromptMessage] = []
 
@@ -250,7 +243,7 @@ class BaseAgentRunner(AppRunner):
         update prompt message tool
         """
         # try to get tool runtime parameters
-        tool_runtime_parameters = tool.get_runtime_parameters() or []
+        tool_runtime_parameters = tool.get_runtime_parameters()
 
         for parameter in tool_runtime_parameters:
             if parameter.form != ToolParameter.ToolParameterForm.LLM:

--- a/api/core/app/task_pipeline/workflow_cycle_manage.py
+++ b/api/core/app/task_pipeline/workflow_cycle_manage.py
@@ -381,7 +381,7 @@ class WorkflowCycleManage:
                 id=workflow_run.id,
                 workflow_id=workflow_run.workflow_id,
                 sequence_number=workflow_run.sequence_number,
-                inputs=workflow_run.inputs_dict or {},
+                inputs=workflow_run.inputs_dict,
                 created_at=int(workflow_run.created_at.timestamp()),
             ),
         )
@@ -428,7 +428,7 @@ class WorkflowCycleManage:
                 created_by=created_by,
                 created_at=int(workflow_run.created_at.timestamp()),
                 finished_at=int(workflow_run.finished_at.timestamp()),
-                files=self._fetch_files_from_node_outputs(workflow_run.outputs_dict or {}),
+                files=self._fetch_files_from_node_outputs(workflow_run.outputs_dict),
             ),
         )
 

--- a/api/core/model_runtime/model_providers/cohere/llm/llm.py
+++ b/api/core/model_runtime/model_providers/cohere/llm/llm.py
@@ -691,8 +691,8 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         base_model_schema = cast(AIModelEntity, base_model_schema)
 
         base_model_schema_features = base_model_schema.features or []
-        base_model_schema_model_properties = base_model_schema.model_properties or {}
-        base_model_schema_parameters_rules = base_model_schema.parameter_rules or []
+        base_model_schema_model_properties = base_model_schema.model_properties
+        base_model_schema_parameters_rules = base_model_schema.parameter_rules
 
         entity = AIModelEntity(
             model=model,

--- a/api/core/model_runtime/model_providers/openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai/llm/llm.py
@@ -1178,8 +1178,8 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         base_model_schema = model_map[base_model]
 
         base_model_schema_features = base_model_schema.features or []
-        base_model_schema_model_properties = base_model_schema.model_properties or {}
-        base_model_schema_parameters_rules = base_model_schema.parameter_rules or []
+        base_model_schema_model_properties = base_model_schema.model_properties
+        base_model_schema_parameters_rules = base_model_schema.parameter_rules
 
         entity = AIModelEntity(
             model=model,

--- a/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
@@ -106,7 +106,7 @@ class OpenLLMGenerate:
             timeout = 120
 
         data = {
-            "stop": stop or [],
+            "stop": stop,
             "prompt": "\n".join([message.content for message in prompt_messages]),
             "llm_config": default_llm_config,
         }

--- a/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
@@ -41,9 +41,9 @@ class OpenLLMGenerate:
         model_name: str,
         stream: bool,
         model_parameters: dict[str, Any],
-        stop: list[str],
-        prompt_messages: list[OpenLLMGenerateMessage],
-        user: str,
+        stop: list[str] | None = None,
+        prompt_messages: list[OpenLLMGenerateMessage] = [],
+        user: str | None = None,
     ) -> Union[Generator[OpenLLMGenerateMessage, None, None], OpenLLMGenerateMessage]:
         if not server_url:
             raise InvalidAuthenticationError("Invalid server URL")
@@ -106,7 +106,7 @@ class OpenLLMGenerate:
             timeout = 120
 
         data = {
-            "stop": stop,
+            "stop": stop or [],
             "prompt": "\n".join([message.content for message in prompt_messages]),
             "llm_config": default_llm_config,
         }

--- a/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
+++ b/api/core/model_runtime/model_providers/openllm/llm/openllm_generate.py
@@ -37,12 +37,13 @@ class OpenLLMGenerateMessage:
 class OpenLLMGenerate:
     def generate(
         self,
+        *,
         server_url: str,
         model_name: str,
         stream: bool,
         model_parameters: dict[str, Any],
         stop: list[str] | None = None,
-        prompt_messages: list[OpenLLMGenerateMessage] = [],
+        prompt_messages: list[OpenLLMGenerateMessage],
         user: str | None = None,
     ) -> Union[Generator[OpenLLMGenerateMessage, None, None], OpenLLMGenerateMessage]:
         if not server_url:

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -261,7 +261,7 @@ class Tool(BaseModel, ABC):
         """
         parameters = self.parameters or []
         parameters = parameters.copy()
-        user_parameters = self.get_runtime_parameters() or []
+        user_parameters = self.get_runtime_parameters()
         user_parameters = user_parameters.copy()
 
         # override parameters

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -55,7 +55,7 @@ class ToolEngine:
             # check if this tool has only one parameter
             parameters = [
                 parameter
-                for parameter in tool.get_runtime_parameters() or []
+                for parameter in tool.get_runtime_parameters()
                 if parameter.form == ToolParameter.ToolParameterForm.LLM
             ]
             if parameters and len(parameters) == 1:

--- a/api/core/tools/utils/configuration.py
+++ b/api/core/tools/utils/configuration.py
@@ -127,7 +127,7 @@ class ToolParameterConfigurationManager(BaseModel):
         # get tool parameters
         tool_parameters = self.tool_runtime.parameters or []
         # get tool runtime parameters
-        runtime_parameters = self.tool_runtime.get_runtime_parameters() or []
+        runtime_parameters = self.tool_runtime.get_runtime_parameters()
         # override parameters
         current_parameters = tool_parameters.copy()
         for runtime_parameter in runtime_parameters:

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -158,7 +158,7 @@ class AppService:
             model_config: AppModelConfig = app.app_model_config
             agent_mode = model_config.agent_mode_dict
             # decrypt agent tool parameters if it's secret-input
-            for tool in agent_mode.get("tools") or []:
+            for tool in agent_mode.get("tools", []):
                 if not isinstance(tool, dict) or len(tool.keys()) <= 3:
                     continue
                 agent_tool_entity = AgentToolEntity(**tool)
@@ -341,7 +341,7 @@ class AppService:
             if not app_model_config:
                 return meta
 
-            agent_config = app_model_config.agent_mode_dict or {}
+            agent_config = app_model_config.agent_mode_dict
 
             # get all tools
             tools = agent_config.get("tools", [])

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -158,7 +158,7 @@ class AppService:
             model_config: AppModelConfig = app.app_model_config
             agent_mode = model_config.agent_mode_dict
             # decrypt agent tool parameters if it's secret-input
-            for tool in agent_mode.get("tools", []):
+            for tool in agent_mode.get("tools") or []:
                 if not isinstance(tool, dict) or len(tool.keys()) <= 3:
                     continue
                 agent_tool_entity = AgentToolEntity(**tool)

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -242,7 +242,7 @@ class ToolTransformService:
             # get tool parameters
             parameters = tool.parameters or []
             # get tool runtime parameters
-            runtime_parameters = tool.get_runtime_parameters() or []
+            runtime_parameters = tool.get_runtime_parameters()
             # override parameters
             current_parameters = parameters.copy()
             for runtime_parameter in runtime_parameters:

--- a/api/services/website_service.py
+++ b/api/services/website_service.py
@@ -51,8 +51,8 @@ class WebsiteService:
                 excludes = options.get("excludes").split(",") if options.get("excludes") else []
                 params = {
                     "crawlerOptions": {
-                        "includes": includes or [],
-                        "excludes": excludes or [],
+                        "includes": includes,
+                        "excludes": excludes,
                         "generateImgAltText": True,
                         "limit": options.get("limit", 1),
                         "returnOnlyUrls": False,


### PR DESCRIPTION
# Summary

refactor most of the `or []` and `or {}` logic
main is as it
- since we use dict.get(xxx) can use default value
- some value is already [] by default there is no need to `or it` 


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

