### PR TITLE
Fix/input-value-type-in-moderation

### DIFF
--- a/api/core/moderation/keywords/keywords.py
+++ b/api/core/moderation/keywords/keywords.py
@@ -1,3 +1,4 @@
+from typing import Any, Sequence
 from core.moderation.base import Moderation, ModerationAction, ModerationInputsResult, ModerationOutputsResult
 
 
@@ -62,5 +63,5 @@ class KeywordsModeration(Moderation):
     def _is_violated(self, inputs: dict, keywords_list: list) -> bool:
         return any(self._check_keywords_in_value(keywords_list, value) for value in inputs.values())
 
-    def _check_keywords_in_value(self, keywords_list, value) -> bool:
-        return any(keyword.lower() in value.lower() for keyword in keywords_list)
+    def _check_keywords_in_value(self, keywords_list: Sequence[str], value: Any) -> bool:
+        return any(keyword.lower() in str(value).lower() for keyword in keywords_list)

--- a/api/core/moderation/keywords/keywords.py
+++ b/api/core/moderation/keywords/keywords.py
@@ -1,4 +1,6 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
+
 from core.moderation.base import Moderation, ModerationAction, ModerationInputsResult, ModerationOutputsResult
 
 


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes #10865

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td><img width="626" alt="image" src="https://github.com/user-attachments/assets/e5de0532-87ca-4d49-8e45-3b9222bdb241"></td>
  <td><img width="625" alt="image" src="https://github.com/user-attachments/assets/f3d5c197-cac4-46bd-a53e-de39b86df7b7"></td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

