### PR TITLE
fix: chat history might be empty in log detail view

### DIFF
--- a/web/app/components/base/chat/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/web/app/components/base/chat/__tests__/__snapshots__/utils.spec.ts.snap
@@ -1812,6 +1812,83 @@ exports[`build chat item tree and get thread messages should work with partial m
         "agent_thoughts": [
           {
             "chain_id": null,
+            "created_at": 1726105799,
+            "files": [],
+            "id": "9730d587-9268-4683-9dd9-91a1cab9510b",
+            "message_id": "4c5d0841-1206-463e-95d8-71f812877658",
+            "observation": "",
+            "position": 1,
+            "thought": "I'll go with 112. Your turn!",
+            "tool": "",
+            "tool_input": "",
+            "tool_labels": {},
+          },
+        ],
+        "children": [],
+        "content": "I'll go with 112. Your turn!",
+        "conversationId": "dd6c9cfd-2656-48ec-bd51-2139c1790d80",
+        "feedbackDisabled": false,
+        "id": "4c5d0841-1206-463e-95d8-71f812877658",
+        "input": {
+          "inputs": {},
+          "query": "99",
+        },
+        "isAnswer": true,
+        "log": [
+          {
+            "files": [],
+            "role": "user",
+            "text": "Let's play a game, I say a number , and you response me with another bigger, yet randomly number. I'll start first, 38",
+          },
+          {
+            "files": [],
+            "role": "assistant",
+            "text": "Sure, I'll play! My number is 57. Your turn!",
+          },
+          {
+            "files": [],
+            "role": "user",
+            "text": "58",
+          },
+          {
+            "files": [],
+            "role": "assistant",
+            "text": "I choose 83. What's your next number?",
+          },
+          {
+            "files": [],
+            "role": "user",
+            "text": "99",
+          },
+          {
+            "files": [],
+            "role": "assistant",
+            "text": "I'll go with 112. Your turn!",
+          },
+        ],
+        "message_files": [],
+        "more": {
+          "latency": "1.49",
+          "time": "09/11/2024 09:50 PM",
+          "tokens": 86,
+        },
+        "parentMessageId": "question-4c5d0841-1206-463e-95d8-71f812877658",
+        "siblingIndex": 0,
+        "workflow_run_id": null,
+      },
+    ],
+    "content": "99",
+    "id": "question-4c5d0841-1206-463e-95d8-71f812877658",
+    "isAnswer": false,
+    "message_files": [],
+    "parentMessageId": "73bbad14-d915-499d-87bf-0df14d40779d",
+  },
+  {
+    "children": [
+      {
+        "agent_thoughts": [
+          {
+            "chain_id": null,
             "created_at": 1726105809,
             "files": [],
             "id": "1019cd79-d141-4f9f-880a-fc1441cfd802",

--- a/web/app/components/base/chat/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/web/app/components/base/chat/__tests__/__snapshots__/utils.spec.ts.snap
@@ -1804,7 +1804,7 @@ exports[`build chat item tree and get thread messages should get thread messages
 ]
 `;
 
-exports[`build chat item tree and get thread messages should work with partial messages 1`] = `
+exports[`build chat item tree and get thread messages should work with partial messages 1 1`] = `
 [
   {
     "children": [
@@ -2151,6 +2151,178 @@ exports[`build chat item tree and get thread messages should work with partial m
     "id": "question-cd5affb0-7bc2-4a6f-be7e-25e74595c9dd",
     "isAnswer": false,
     "message_files": [],
+  },
+]
+`;
+
+exports[`build chat item tree and get thread messages should work with partial messages 2 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "content": "237.",
+        "id": "ebb73fe2-15de-46dd-aab5-75416d8448eb",
+        "isAnswer": true,
+        "parentMessageId": "question-ebb73fe2-15de-46dd-aab5-75416d8448eb",
+        "siblingIndex": 0,
+      },
+    ],
+    "content": "123",
+    "id": "question-ebb73fe2-15de-46dd-aab5-75416d8448eb",
+    "isAnswer": false,
+    "parentMessageId": "57c989f9-3fa4-4dec-9ee5-c3568dd27418",
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "content": "My number is 256.",
+        "id": "3553d508-3850-462e-8594-078539f940f9",
+        "isAnswer": true,
+        "parentMessageId": "question-3553d508-3850-462e-8594-078539f940f9",
+        "siblingIndex": 1,
+      },
+    ],
+    "content": "123",
+    "id": "question-3553d508-3850-462e-8594-078539f940f9",
+    "isAnswer": false,
+    "parentMessageId": "57c989f9-3fa4-4dec-9ee5-c3568dd27418",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "children": [],
+                                                                "content": "My number is 3e (approximately 8.15).",
+                                                                "id": "9eac3bcc-8d3b-4e56-a12b-44c34cebc719",
+                                                                "isAnswer": true,
+                                                                "parentMessageId": "question-9eac3bcc-8d3b-4e56-a12b-44c34cebc719",
+                                                                "siblingIndex": 0,
+                                                              },
+                                                            ],
+                                                            "content": "e",
+                                                            "id": "question-9eac3bcc-8d3b-4e56-a12b-44c34cebc719",
+                                                            "isAnswer": false,
+                                                            "parentMessageId": "5c56a2b3-f057-42a0-9b2c-52a35713cd8c",
+                                                          },
+                                                        ],
+                                                        "content": "My number is 2π (approximately 6.28).",
+                                                        "id": "5c56a2b3-f057-42a0-9b2c-52a35713cd8c",
+                                                        "isAnswer": true,
+                                                        "parentMessageId": "question-5c56a2b3-f057-42a0-9b2c-52a35713cd8c",
+                                                        "siblingIndex": 0,
+                                                      },
+                                                    ],
+                                                    "content": "π",
+                                                    "id": "question-5c56a2b3-f057-42a0-9b2c-52a35713cd8c",
+                                                    "isAnswer": false,
+                                                    "parentMessageId": "46a49bb9-0881-459e-8c6a-24d20ae48d2f",
+                                                  },
+                                                ],
+                                                "content": "My number is 145.",
+                                                "id": "46a49bb9-0881-459e-8c6a-24d20ae48d2f",
+                                                "isAnswer": true,
+                                                "parentMessageId": "question-46a49bb9-0881-459e-8c6a-24d20ae48d2f",
+                                                "siblingIndex": 0,
+                                              },
+                                            ],
+                                            "content": "78",
+                                            "id": "question-46a49bb9-0881-459e-8c6a-24d20ae48d2f",
+                                            "isAnswer": false,
+                                            "parentMessageId": "3cded945-855a-4a24-aab7-43c7dd54664c",
+                                          },
+                                        ],
+                                        "content": "My number is 7.89.",
+                                        "id": "3cded945-855a-4a24-aab7-43c7dd54664c",
+                                        "isAnswer": true,
+                                        "parentMessageId": "question-3cded945-855a-4a24-aab7-43c7dd54664c",
+                                        "siblingIndex": 0,
+                                      },
+                                    ],
+                                    "content": "3.11",
+                                    "id": "question-3cded945-855a-4a24-aab7-43c7dd54664c",
+                                    "isAnswer": false,
+                                    "parentMessageId": "a956de3d-ef95-4d90-84fe-f7a26ef28cd7",
+                                  },
+                                ],
+                                "content": "My number is 22.",
+                                "id": "a956de3d-ef95-4d90-84fe-f7a26ef28cd7",
+                                "isAnswer": true,
+                                "parentMessageId": "question-a956de3d-ef95-4d90-84fe-f7a26ef28cd7",
+                                "siblingIndex": 0,
+                              },
+                            ],
+                            "content": "-5",
+                            "id": "question-a956de3d-ef95-4d90-84fe-f7a26ef28cd7",
+                            "isAnswer": false,
+                            "parentMessageId": "93bac05d-1470-4ac9-b090-fe21cd7c3d55",
+                          },
+                        ],
+                        "content": "My number is 4782.",
+                        "id": "93bac05d-1470-4ac9-b090-fe21cd7c3d55",
+                        "isAnswer": true,
+                        "parentMessageId": "question-93bac05d-1470-4ac9-b090-fe21cd7c3d55",
+                        "siblingIndex": 0,
+                      },
+                    ],
+                    "content": "3306",
+                    "id": "question-93bac05d-1470-4ac9-b090-fe21cd7c3d55",
+                    "isAnswer": false,
+                    "parentMessageId": "9e51a13b-7780-4565-98dc-f2d8c3b1758f",
+                  },
+                ],
+                "content": "My number is 2048.",
+                "id": "9e51a13b-7780-4565-98dc-f2d8c3b1758f",
+                "isAnswer": true,
+                "parentMessageId": "question-9e51a13b-7780-4565-98dc-f2d8c3b1758f",
+                "siblingIndex": 0,
+              },
+            ],
+            "content": "1024",
+            "id": "question-9e51a13b-7780-4565-98dc-f2d8c3b1758f",
+            "isAnswer": false,
+            "parentMessageId": "507f9df9-1f06-4a57-bb38-f00228c42c22",
+          },
+        ],
+        "content": "My number is 259.",
+        "id": "507f9df9-1f06-4a57-bb38-f00228c42c22",
+        "isAnswer": true,
+        "parentMessageId": "question-507f9df9-1f06-4a57-bb38-f00228c42c22",
+        "siblingIndex": 2,
+      },
+    ],
+    "content": "123",
+    "id": "question-507f9df9-1f06-4a57-bb38-f00228c42c22",
+    "isAnswer": false,
+    "parentMessageId": "57c989f9-3fa4-4dec-9ee5-c3568dd27418",
   },
 ]
 `;

--- a/web/app/components/base/chat/__tests__/partialMessages.json
+++ b/web/app/components/base/chat/__tests__/partialMessages.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "question-ebb73fe2-15de-46dd-aab5-75416d8448eb",
+    "content": "123",
+    "isAnswer": false,
+    "parentMessageId": "57c989f9-3fa4-4dec-9ee5-c3568dd27418"
+  },
+  {
+    "id": "ebb73fe2-15de-46dd-aab5-75416d8448eb",
+    "content": "237.",
+    "isAnswer": true,
+    "parentMessageId": "question-ebb73fe2-15de-46dd-aab5-75416d8448eb"
+  },
+  {
+    "id": "question-3553d508-3850-462e-8594-078539f940f9",
+    "content": "123",
+    "isAnswer": false,
+    "parentMessageId": "57c989f9-3fa4-4dec-9ee5-c3568dd27418"
+  },
+  {
+    "id": "3553d508-3850-462e-8594-078539f940f9",
+    "content": "My number is 256.",
+    "isAnswer": true,
+    "parentMessageId": "question-3553d508-3850-462e-8594-078539f940f9"
+  },
+  {
+    "id": "question-507f9df9-1f06-4a57-bb38-f00228c42c22",
+    "content": "123",
+    "isAnswer": false,
+    "parentMessageId": "57c989f9-3fa4-4dec-9ee5-c3568dd27418"
+  },
+  {
+    "id": "507f9df9-1f06-4a57-bb38-f00228c42c22",
+    "content": "My number is 259.",
+    "isAnswer": true,
+    "parentMessageId": "question-507f9df9-1f06-4a57-bb38-f00228c42c22"
+  },
+  {
+    "id": "question-9e51a13b-7780-4565-98dc-f2d8c3b1758f",
+    "content": "1024",
+    "isAnswer": false,
+    "parentMessageId": "507f9df9-1f06-4a57-bb38-f00228c42c22"
+  },
+  {
+    "id": "9e51a13b-7780-4565-98dc-f2d8c3b1758f",
+    "content": "My number is 2048.",
+    "isAnswer": true,
+    "parentMessageId": "question-9e51a13b-7780-4565-98dc-f2d8c3b1758f"
+  },
+  {
+    "id": "question-93bac05d-1470-4ac9-b090-fe21cd7c3d55",
+    "content": "3306",
+    "isAnswer": false,
+    "parentMessageId": "9e51a13b-7780-4565-98dc-f2d8c3b1758f"
+  },
+  {
+    "id": "93bac05d-1470-4ac9-b090-fe21cd7c3d55",
+    "content": "My number is 4782.",
+    "isAnswer": true,
+    "parentMessageId": "question-93bac05d-1470-4ac9-b090-fe21cd7c3d55"
+  },
+  {
+    "id": "question-a956de3d-ef95-4d90-84fe-f7a26ef28cd7",
+    "content": "-5",
+    "isAnswer": false,
+    "parentMessageId": "93bac05d-1470-4ac9-b090-fe21cd7c3d55"
+  },
+  {
+    "id": "a956de3d-ef95-4d90-84fe-f7a26ef28cd7",
+    "content": "My number is 22.",
+    "isAnswer": true,
+    "parentMessageId": "question-a956de3d-ef95-4d90-84fe-f7a26ef28cd7"
+  },
+  {
+    "id": "question-3cded945-855a-4a24-aab7-43c7dd54664c",
+    "content": "3.11",
+    "isAnswer": false,
+    "parentMessageId": "a956de3d-ef95-4d90-84fe-f7a26ef28cd7"
+  },
+  {
+    "id": "3cded945-855a-4a24-aab7-43c7dd54664c",
+    "content": "My number is 7.89.",
+    "isAnswer": true,
+    "parentMessageId": "question-3cded945-855a-4a24-aab7-43c7dd54664c"
+  },
+  {
+    "id": "question-46a49bb9-0881-459e-8c6a-24d20ae48d2f",
+    "content": "78",
+    "isAnswer": false,
+    "parentMessageId": "3cded945-855a-4a24-aab7-43c7dd54664c"
+  },
+  {
+    "id": "46a49bb9-0881-459e-8c6a-24d20ae48d2f",
+    "content": "My number is 145.",
+    "isAnswer": true,
+    "parentMessageId": "question-46a49bb9-0881-459e-8c6a-24d20ae48d2f"
+  },
+  {
+    "id": "question-5c56a2b3-f057-42a0-9b2c-52a35713cd8c",
+    "content": "π",
+    "isAnswer": false,
+    "parentMessageId": "46a49bb9-0881-459e-8c6a-24d20ae48d2f"
+  },
+  {
+    "id": "5c56a2b3-f057-42a0-9b2c-52a35713cd8c",
+    "content": "My number is 2π (approximately 6.28).",
+    "isAnswer": true,
+    "parentMessageId": "question-5c56a2b3-f057-42a0-9b2c-52a35713cd8c"
+  },
+  {
+    "id": "question-9eac3bcc-8d3b-4e56-a12b-44c34cebc719",
+    "content": "e",
+    "isAnswer": false,
+    "parentMessageId": "5c56a2b3-f057-42a0-9b2c-52a35713cd8c"
+  },
+  {
+    "id": "9eac3bcc-8d3b-4e56-a12b-44c34cebc719",
+    "content": "My number is 3e (approximately 8.15).",
+    "isAnswer": true,
+    "parentMessageId": "question-9eac3bcc-8d3b-4e56-a12b-44c34cebc719"
+  }
+]

--- a/web/app/components/base/chat/__tests__/utils.spec.ts
+++ b/web/app/components/base/chat/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import mixedTestMessages from './mixedTestMessages.json'
 import multiRootNodesMessages from './multiRootNodesMessages.json'
 import multiRootNodesWithLegacyTestMessages from './multiRootNodesWithLegacyTestMessages.json'
 import realWorldMessages from './realWorldMessages.json'
+import partialMessages from './partialMessages.json'
 
 function visitNode(tree: ChatItemInTree | ChatItemInTree[], path: string): ChatItemInTree {
   return get(tree, path)
@@ -256,9 +257,15 @@ describe('build chat item tree and get thread messages', () => {
     expect(threadMessages6_2).toMatchSnapshot()
   })
 
-  const partialMessages = (realWorldMessages as ChatItemInTree[]).slice(-10)
-  const tree7 = buildChatItemTree(partialMessages)
-  it('should work with partial messages', () => {
+  const partialMessages1 = (realWorldMessages as ChatItemInTree[]).slice(-10)
+  const tree7 = buildChatItemTree(partialMessages1)
+  it('should work with partial messages 1', () => {
     expect(tree7).toMatchSnapshot()
+  })
+
+  const partialMessages2 = (partialMessages as ChatItemInTree[])
+  const tree8 = buildChatItemTree(partialMessages2)
+  it('should work with partial messages 2', () => {
+    expect(tree8).toMatchSnapshot()
   })
 })

--- a/web/app/components/base/chat/utils.ts
+++ b/web/app/components/base/chat/utils.ts
@@ -127,7 +127,10 @@ function buildChatItemTree(allMessages: IChatItem[]): ChatItemInTree[] {
       lastAppendedLegacyAnswer = answerNode
     }
     else {
-      if (!parentMessageId || !allMessages.some(item => item.id === parentMessageId))
+      if (
+        !parentMessageId
+        || !allMessages.some(item => item.id === parentMessageId) // parent message might not be fetched yet, in this case we will append the question to the root nodes
+      )
         rootNodes.push(questionNode)
       else
         map[parentMessageId]?.children!.push(questionNode)

--- a/web/app/components/base/chat/utils.ts
+++ b/web/app/components/base/chat/utils.ts
@@ -127,18 +127,12 @@ function buildChatItemTree(allMessages: IChatItem[]): ChatItemInTree[] {
       lastAppendedLegacyAnswer = answerNode
     }
     else {
-      if (!parentMessageId)
+      if (!parentMessageId || !allMessages.some(item => item.id === parentMessageId))
         rootNodes.push(questionNode)
       else
         map[parentMessageId]?.children!.push(questionNode)
     }
   }
-
-  // If no messages have parentMessageId=null (indicating a root node),
-  // then we likely have a partial chat history. In this case,
-  // use the first available message as the root node.
-  if (rootNodes.length === 0 && allMessages.length > 0)
-    rootNodes.push(map[allMessages[0]!.id]!)
 
   return rootNodes
 }


### PR DESCRIPTION
# Summary

**Screenshots**

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td><img width="1699" alt="image" src="https://github.com/user-attachments/assets/2aae14a2-0957-4222-8df4-e47562bcf1c9"></td>
  <td><img width="1709" alt="image" src="https://github.com/user-attachments/assets/4dd343b5-8ef9-41c9-990f-7e529d8f248d"></td>
  </tr>
</table>

**How did this happen?**

When the fetched message list (10 items) is partial, and in the fetched list, there are more than one messages whose `parent_message_id` are temporarily unknown, the view will not display any records.

See message tree diagram below: the `93156a` node is not yet fetched from backend, and there are multiple messages depend on it.

![6051732094444_ pic](https://github.com/user-attachments/assets/cc4a74ea-b3ee-4b99-8e42-50e92be83337)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

