### PR TITLE
fix: handle redis authentication for healthcheck command

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,7 @@ Welcome to the new `docker` directory for deploying Dify using Docker Compose. T
     - Navigate to the `docker` directory.
     - Ensure the `middleware.env` file is created by running `cp middleware.env.example middleware.env` (refer to the `middleware.env.example` file).
 2. **Running Middleware Services**:
-    - Execute `docker-compose -f docker-compose.middleware.yaml up -d` to start the middleware services.
+    - Execute `docker-compose -f docker-compose.middleware.yaml up --env-file middleware.env -d` to start the middleware services.
 
 ### Migration for Existing Users
 

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -29,11 +29,13 @@ services:
   redis:
     image: redis:6-alpine
     restart: always
+    environment:
+      REDISCLI_AUTH: ${REDIS_PASSWORD:-difyai123456}
     volumes:
       # Mount the redis data directory to the container.
       - ${REDIS_HOST_VOLUME:-./volumes/redis/data}:/data
     # Set the redis password when startup redis server.
-    command: redis-server --requirepass difyai123456
+    command: redis-server --requirepass ${REDIS_PASSWORD:-difyai123456}
     ports:
       - "${EXPOSE_REDIS_PORT:-6379}:6379"
     healthcheck:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -366,6 +366,8 @@ services:
   redis:
     image: redis:6-alpine
     restart: always
+    environment:
+      REDISCLI_AUTH: ${REDIS_PASSWORD:-difyai123456}
     volumes:
       # Mount the redis data directory to the container.
       - ./volumes/redis/data:/data

--- a/docker/middleware.env.example
+++ b/docker/middleware.env.example
@@ -42,11 +42,13 @@ POSTGRES_EFFECTIVE_CACHE_SIZE=4096MB
 
 # -----------------------------
 # Environment Variables for redis Service
-REDIS_HOST_VOLUME=./volumes/redis/data
 # -----------------------------
+REDIS_HOST_VOLUME=./volumes/redis/data
+REDIS_PASSWORD=difyai123456
 
 # ------------------------------
 # Environment Variables for sandbox Service
+# ------------------------------
 SANDBOX_API_KEY=dify-sandbox
 SANDBOX_GIN_MODE=release
 SANDBOX_WORKER_TIMEOUT=15
@@ -54,7 +56,6 @@ SANDBOX_ENABLE_NETWORK=true
 SANDBOX_HTTP_PROXY=http://ssrf_proxy:3128
 SANDBOX_HTTPS_PROXY=http://ssrf_proxy:3128
 SANDBOX_PORT=8194
-# ------------------------------
 
 # ------------------------------
 # Environment Variables for ssrf_proxy Service


### PR DESCRIPTION
# Summary

Fixes #10898

This PR includes the following changes:

* Resolved the issue in #10898 by adding the `REDISCLI_AUTH` parameter
* Aligned the separator position in `env.example` with the overall format
* And one update with Readme: Modified `docker-compose` command parameters to ensure proper variable substitution,  according to:
  * [Environment variables precedence in Docker Compose](https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/)
  * [Substitute with --env-file](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#substitute-with---env-file)

Brief explanation: The `env_file` parameter is used to pass environment variables to containers, while variables in the docker compose yaml file like `${REDIS_PASSWORD:-difyai123456}` require environment variables during `docker-compose` command execution. Since the middleware env file in the documentation won't be automatically loaded as a `.env` file, the `--env-file` flag is necessary for docker-compose commands to properly substitute default values with the complete environment variables.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

