### PR TITLE
fix: default max_chunks set to 1 as other providers

### DIFF
--- a/api/core/model_runtime/model_providers/volcengine_maas/text_embedding/models.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/text_embedding/models.py
@@ -22,7 +22,7 @@ def get_model_config(credentials: dict) -> ModelConfig:
         return ModelConfig(
             properties=ModelProperties(
                 context_size=int(credentials.get("context_size", 0)),
-                max_chunks=int(credentials.get("max_chunks", 0)),
+                max_chunks=int(credentials.get("max_chunks", 1)),
             )
         )
     return model_configs


### PR DESCRIPTION
# Summary

set default max_chunks to 1 as others close #10936


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

