### PR TITLE
fix(rag):Fix document deduplication logic

### DIFF
--- a/api/core/rag/rerank/weight_rerank.py
+++ b/api/core/rag/rerank/weight_rerank.py
@@ -37,11 +37,11 @@ class WeightRerankRunner(BaseRerankRunner):
         :return:
         """
         unique_documents = []
-        doc_id = set()
+        doc_ids = set()
         for document in documents:
             doc_id = document.metadata.get("doc_id")
-            if doc_id not in doc_id:
-                doc_id.add(doc_id)
+            if doc_id not in doc_ids:
+                doc_ids.add(doc_id)
                 unique_documents.append(document)
 
         documents = unique_documents


### PR DESCRIPTION
# Summary

After the knowledge base hybrid retrieval selection weight is set, the recalled content is an empty array.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>
<img width="1855" alt="image" src="https://github.com/user-attachments/assets/95bbc26f-e9ec-4bc2-bef4-301c483e0bac">
</td>
  <td>
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/1abec20e-e21b-41be-94e8-553fc8eed61a">
</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

