### PR TITLE
fix: external dataset missing score_threshold_enabled 

### DIFF
--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -41,6 +41,7 @@ dataset_retrieval_model_fields = {
 external_retrieval_model_fields = {
     "top_k": fields.Integer,
     "score_threshold": fields.Float,
+    "score_threshold_enabled": fields.Boolean,
 }
 
 tag_fields = {"id": fields.String, "name": fields.String, "type": fields.String}


### PR DESCRIPTION
fix:  when external dataset  setting change score_threshold_enabled from false to true,  response missing score_threshold_enabled  value.  

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

