### PR TITLE
Solution/role based app setting[WIP]

### DIFF
--- a/api/models/account.py
+++ b/api/models/account.py
@@ -107,6 +107,10 @@ class Account(UserMixin, db.Model):
     @property
     def is_admin_or_owner(self):
         return TenantAccountRole.is_privileged_role(self._current_tenant.current_role)
+    
+    @property
+    def is_admin(self):
+        return TenantAccountRole.is_admin_role(self._current_tenant.current_role)
 
     @property
     def is_editor(self):
@@ -146,6 +150,10 @@ class TenantAccountRole(str, enum.Enum):
     @staticmethod
     def is_privileged_role(role: str) -> bool:
         return role and role in {TenantAccountRole.OWNER, TenantAccountRole.ADMIN}
+
+    @staticmethod
+    def is_admin_role(role: str) -> bool:
+        return role and role in {TenantAccountRole.ADMIN}
 
     @staticmethod
     def is_non_owner_role(role: str) -> bool:

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -75,6 +75,17 @@ class App(db.Model):
     workflow_id = db.Column(StringUUID, nullable=True)
     status = db.Column(db.String(255), nullable=False, server_default=db.text("'normal'::character varying"))
     enable_site = db.Column(db.Boolean, nullable=False)
+    # to enable/disable public site URL
+    # _enable_site = db.Column("enable_site", db.Boolean, nullable=False, server_default=db.text("false"))
+
+    # @property
+    # def enable_site(self) -> Literal[False]:
+    #     return False
+
+    # @enable_site.setter
+    # def enable_site(self, value: bool) -> None:
+    #     self._enable_site = value
+
     enable_api = db.Column(db.Boolean, nullable=False)
     api_rpm = db.Column(db.Integer, nullable=False, server_default=db.text("0"))
     api_rph = db.Column(db.Integer, nullable=False, server_default=db.text("0"))

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -268,6 +268,10 @@ class AppService:
         :param enable_site: enable site status
         :return: App instance
         """
+
+        if not current_user.is_admin:
+            return app
+
         if enable_site == app.enable_site:
             return app
 


### PR DESCRIPTION
# Summary

This PR introduces a new is_admin property in the Account model and the corresponding utility method is_admin_role in the TenantAccountRole class. Additionally, it updates the AppService logic to prevent non-admin users from modifying the enable_site property. These changes enhance access control and ensure only administrators can manage critical application settings.

# Key Changes:

- Added is_admin property to the Account model to simplify admin checks.

- Added is_admin_role static method to TenantAccountRole to encapsulate role-specific logic.

- Updated AppService to include a check for current_user.is_admin before updating the enable_site property.

- Included commented-out alternative implementation for handling the enable_site property for potential future use.

	Fixes # (replace with the relevant issue number or remove if not applicable).
