### PR TITLE
feat: add a meta(mac) ctrl(windows) key

### DIFF
--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -102,21 +102,21 @@ const ChatInputArea = ({
       setCurrentIndex(historyRef.current.length)
       handleSend()
     }
-    else if (e.key === 'ArrowUp' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      // When the up key is pressed, output the previous element
+    else if (e.key === 'ArrowUp' && !e.shiftKey && !e.nativeEvent.isComposing && e.metaKey) {
+      // When the cmd + up key is pressed, output the previous element
       if (currentIndex > 0) {
         setCurrentIndex(currentIndex - 1)
         setQuery(historyRef.current[currentIndex - 1])
       }
     }
-    else if (e.key === 'ArrowDown' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      // When the down key is pressed, output the next element
+    else if (e.key === 'ArrowDown' && !e.shiftKey && !e.nativeEvent.isComposing && e.metaKey) {
+      // When the cmd + down key is pressed, output the next element
       if (currentIndex < historyRef.current.length - 1) {
         setCurrentIndex(currentIndex + 1)
         setQuery(historyRef.current[currentIndex + 1])
       }
       else if (currentIndex === historyRef.current.length - 1) {
-        // If it is the last element, clear the input box
+      // If it is the last element, clear the input box
         setCurrentIndex(historyRef.current.length)
         setQuery('')
       }


### PR DESCRIPTION
# Summary

We introduced the ability to reuse previous by using `Key Up` and `Key Down`.
Now we change it to 
- `Ctrl + Key Up` or `Meta + Key Up`
- `Ctrl + Key Down` or `Meta + Key Down`

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

