### PR TITLE
Add maxLengthTip to web and increase max-chunk-size

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -682,7 +682,7 @@ SMTP_OPPORTUNISTIC_TLS=false
 # ------------------------------
 
 # Maximum length of segmentation tokens for indexing
-INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=1000
+INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=2048
 
 # Member invitation link valid time (hours),
 # Default: 72.

--- a/web/app/components/datasets/create/step-two/index.tsx
+++ b/web/app/components/datasets/create/step-two/index.tsx
@@ -665,7 +665,16 @@ const StepTwo = ({
                   </div>
                   <div className={s.formRow}>
                     <div className='w-full'>
-                      <div className={s.label}>{t('datasetCreation.stepTwo.maxLength')}</div>
+                      <div className={s.label}>
+                        {t('datasetCreation.stepTwo.maxLength')}
+                        <Tooltip
+                          popupContent={
+                            <div className='max-w-[200px]'>
+                              {t('datasetCreation.stepTwo.maxLengthTip')}
+                            </div>
+                          }
+                        />
+                      </div>
                       <Input
                         type="number"
                         className='h-9'

--- a/web/i18n/en-US/dataset-creation.ts
+++ b/web/i18n/en-US/dataset-creation.ts
@@ -103,6 +103,7 @@ const translation = {
     separatorTip: 'A delimiter is the character used to separate text. \\n\\n and \\n are commonly used delimiters for separating paragraphs and lines. Combined with commas (\\n\\n,\\n), paragraphs will be segmented by lines when exceeding the maximum chunk length. You can also use special delimiters defined by yourself (e.g. ***).',
     separatorPlaceholder: '\\n\\n for separating paragraphs; \\n for separating lines',
     maxLength: 'Maximum chunk length',
+    maxLengthTip: 'Maximum number of tokens per chunk. If no tokenizer provided, gpt2 tokenizer will be used',
     maxLengthCheck: 'Maximum chunk length should be less than 4000',
     overlap: 'Chunk overlap',
     overlapTip: 'Setting the chunk overlap can maintain the semantic relevance between them, enhancing the retrieve effect. It is recommended to set 10%-25% of the maximum chunk size.',

--- a/web/i18n/zh-Hans/dataset-creation.ts
+++ b/web/i18n/zh-Hans/dataset-creation.ts
@@ -103,6 +103,7 @@ const translation = {
     separatorTip: '分隔符是用于分隔文本的字符。\\n\\n 和 \\n 是常用于分隔段落和行的分隔符。用逗号连接分隔符（\\n\\n,\\n），当段落超过最大块长度时，会按行进行分割。你也可以使用自定义的特殊分隔符（例如 ***）。',
     separatorPlaceholder: '\\n\\n 用于分段；\\n 用于分行',
     maxLength: '分段最大长度',
+    maxLengthTip: '分段最大的token数目，如果对应模型没有提供tokenizer，默认会采用gpt2 tokenizer',
     maxLengthCheck: '分段最大长度不能大于 4000',
     overlap: '分段重叠长度',
     overlapTip: '设置分段之间的重叠长度可以保留分段之间的语义关系，提升召回效果。建议设置为最大分段长度的10%-25%',


### PR DESCRIPTION
# Summary


1. Add `maxLengthTip`: `Maximum chunk length` is ambiguous. It refers to the num of tokens, which could be confused with `string length`.
2. Increase `max-chunk-size`: With default gpt2-tokenizer, 1000 tokens is roughly equivalent to 400 CJK characters. It is not enough in most cases.

# Screenshots
<img width="227" alt="Screenshot 2024-11-22 at 17 04 06" src="https://github.com/user-attachments/assets/9ac05fec-e52a-4426-8796-6baaef388d69">


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

