### PR TITLE
fix: ignore empty outputs in Tool node

### DIFF
--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -253,6 +253,7 @@ class ToolNode(BaseNode[ToolNodeData]):
                 if message.type == ToolInvokeMessage.MessageType.LINK
                 else ""
                 for message in tool_response
+                if message.type in {ToolInvokeMessage.MessageType.TEXT, ToolInvokeMessage.MessageType.LINK}
             ]
         )
 

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -250,8 +250,6 @@ class ToolNode(BaseNode[ToolNodeData]):
                 f"{message.message}"
                 if message.type == ToolInvokeMessage.MessageType.TEXT
                 else f"Link: {message.message}"
-                if message.type == ToolInvokeMessage.MessageType.LINK
-                else ""
                 for message in tool_response
                 if message.type in {ToolInvokeMessage.MessageType.TEXT, ToolInvokeMessage.MessageType.LINK}
             ]


### PR DESCRIPTION
# Summary

Modify _extract_tool_response_text to avoid adding empty elements to the list. Handle only tool_response messages of types TEXT and LINK, ensuring no empty elements are created in the list for other types of messages.

Fixes #10987

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

