### PR TITLE
fix: gitlab file url not correctly encoded

### DIFF
--- a/api/core/tools/provider/builtin/gitlab/tools/gitlab_files.py
+++ b/api/core/tools/provider/builtin/gitlab/tools/gitlab_files.py
@@ -69,14 +69,16 @@ class GitlabFilesTool(BuiltinTool):
                         self.fetch_files(site_url, access_token, identifier, branch, item_path, is_repository)
                     )
                 else:  # It's a file
+                    encoded_item_path = urllib.parse.quote(item_path, safe="")
                     if is_repository:
                         file_url = (
                             f"{domain}/api/v4/projects/{encoded_identifier}/repository/files"
-                            f"/{item_path}/raw?ref={branch}"
+                            f"/{encoded_item_path}/raw?ref={branch}"
                         )
                     else:
                         file_url = (
-                            f"{domain}/api/v4/projects/{project_id}/repository/files/{item_path}/raw?ref={branch}"
+                            f"{domain}/api/v4/projects/{project_id}/repository/files"
+                            f"{encoded_item_path}/raw?ref={branch}"
                         )
 
                     file_response = requests.get(file_url, headers=headers)


### PR DESCRIPTION
# Summary

Fixes #10995 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

