### PR TITLE
fix: slidespeak text output is not the download link

### DIFF
--- a/api/core/tools/provider/builtin/slidespeak/tools/slides_generator.py
+++ b/api/core/tools/provider/builtin/slidespeak/tools/slides_generator.py
@@ -149,7 +149,7 @@ class SlidesGeneratorTool(BuiltinTool):
                     presentation_bytes = await self._fetch_presentation(session, download_url)
 
                 return [
-                    self.create_text_message("Presentation generated successfully"),
+                    self.create_text_message(download_url),
                     self.create_blob_message(
                         blob=presentation_bytes,
                         meta={"mime_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation"},


### PR DESCRIPTION
# Summary

![image](https://github.com/user-attachments/assets/2e3cdfef-b1d2-4c5a-8ea5-162fc2eb9df8)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

