### PR TITLE
fix: json parse err when http node send request

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -108,7 +108,7 @@ class Executor:
                     self.content = self.variable_pool.convert_template(data[0].value).text
                 case "json":
                     json_string = self.variable_pool.convert_template(data[0].value).text
-                    json_object = json.loads(json_string)
+                    json_object = json.loads(json_string, strict=False)
                     self.json = json_object
                     # self.json = self._parse_object_contains_variables(json_object)
                 case "binary":


### PR DESCRIPTION
When the node sends an http request parameter with \n\t\r, the json conversion error ValueError: Invalid control character at: line 1 column 8363 (char 8362)

# Summary

When the request parameter carries '\t', '\n', '\r' and is sent in application/json format, an error "ValueError: Invalid control character at: line 1 column 8363 (char 8362)" will be reported.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

