### PR TITLE
Add grok-vision-beta to xAI + Update grok-beta Features

### DIFF
--- a/api/core/model_runtime/model_providers/x/llm/grok-vision-beta.yaml
+++ b/api/core/model_runtime/model_providers/x/llm/grok-vision-beta.yaml
@@ -1,15 +1,13 @@
-model: grok-beta
+model: grok-vision-beta
 label:
-  en_US: Grok Beta
+  en_US: Grok Vision Beta
 model_type: llm
 features:
   - agent-thought
-  - tool-call
-  - multi-tool-call
-  - stream-tool-call
+  - vision
 model_properties:
   mode: chat
-  context_size: 131072
+  context_size: 8192
 parameter_rules:
   - name: temperature
     label:

--- a/api/core/model_runtime/model_providers/x/llm/llm.py
+++ b/api/core/model_runtime/model_providers/x/llm/llm.py
@@ -35,3 +35,5 @@ class XAILargeLanguageModel(OAIAPICompatLargeLanguageModel):
         credentials["endpoint_url"] = str(URL(credentials["endpoint_url"])) or "https://api.x.ai/v1"
         credentials["mode"] = LLMMode.CHAT.value
         credentials["function_calling_type"] = "tool_call"
+        credentials["stream_function_calling"] = "support"
+        credentials["vision_support"] = "support"


### PR DESCRIPTION
# Summary
This PR adds grok-vision-beta to the xAI provider.
It also updates the grok-beta model with more features.

# Screenshots
<img width="637" alt="image" src="https://github.com/user-attachments/assets/a0b85cb3-b7c1-4bcd-b48a-9c3b7921e99e">

<img width="610" alt="image" src="https://github.com/user-attachments/assets/7fe6e499-639c-449d-933a-48bab0783ae4">

<img width="607" alt="image" src="https://github.com/user-attachments/assets/d3cb8c04-761b-4d47-9228-34a578ecaa74">
