### PR TITLE
Fixing #11005: Incorrect max_tokens in yaml file for AWS Bedrock US Cross Region Inference version of 3.5 Sonnet v2 and 3.5 Haiku

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/llm/us.anthropic.claude-3-5-haiku-v1.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/us.anthropic.claude-3-5-haiku-v1.yaml
@@ -15,9 +15,9 @@ parameter_rules:
     use_template: max_tokens
     required: true
     type: int
-    default: 4096
+    default: 8192
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 停止前生成的最大令牌数。请注意，Anthropic Claude 模型可能会在达到 max_tokens 的值之前停止生成令牌。不同的 Anthropic Claude 模型对此参数具有不同的最大值。
       en_US: The maximum number of tokens to generate before stopping. Note that Anthropic Claude models might stop generating tokens before reaching the value of max_tokens. Different Anthropic Claude models have different maximum values for this parameter.

--- a/api/core/model_runtime/model_providers/bedrock/llm/us.anthropic.claude-3-sonnet-v2.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/us.anthropic.claude-3-sonnet-v2.yaml
@@ -16,9 +16,9 @@ parameter_rules:
     use_template: max_tokens
     required: true
     type: int
-    default: 4096
+    default: 8192
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 停止前生成的最大令牌数。请注意，Anthropic Claude 模型可能会在达到 max_tokens 的值之前停止生成令牌。不同的 Anthropic Claude 模型对此参数具有不同的最大值。
       en_US: The maximum number of tokens to generate before stopping. Note that Anthropic Claude models might stop generating tokens before reaching the value of max_tokens. Different Anthropic Claude models have different maximum values for this parameter.


### PR DESCRIPTION
# Summary

This PR Fixes #11005 .
This is to fix maximum number of configurable Max Tokens on model configuration UI for the case: bedrock claude 3.5 sonnet v2 cross region and claude 3.5 haiku cross region.

Those number right now is 4096, To-Be is 8192.

# Screenshots

<table>
  <tr>
  <td>Before: 

![image](https://github.com/user-attachments/assets/8ec9986f-d29f-4237-9317-d0ae59e81b2e)

![image](https://github.com/user-attachments/assets/392d6ac9-a7c7-4fcb-8236-411b66ad416d)

</td>
  <td>After: 

![image](https://github.com/user-attachments/assets/0cf58014-df8d-4f3b-8cd9-17465f1f0b84)

![image](https://github.com/user-attachments/assets/047497ba-d8c1-4a96-802a-8b4b213e7409)

</td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

NA as this is just to change the yaml file for UI displaying. 
As clarified in previous section, yaml fixes where reflected to UI expectedly where I confirmed chat application worked as expected for both of Cross Region bedrock claude 3.5 sonnet v2 cross region/cladue 3.5 haiku cross region.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

