### PR TITLE
fix: wrong convert in PromptTemplateConfigManager

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/prompt_template/manager.py
+++ b/api/core/app/app_config/easy_ui_based_app/prompt_template/manager.py
@@ -1,4 +1,5 @@
 from core.app.app_config.entities import (
+    AdvancedChatMessageEntity,
     AdvancedChatPromptTemplateEntity,
     AdvancedCompletionPromptTemplateEntity,
     PromptTemplateEntity,
@@ -25,7 +26,9 @@ class PromptTemplateConfigManager:
                 chat_prompt_messages = []
                 for message in chat_prompt_config.get("prompt", []):
                     chat_prompt_messages.append(
-                        {"text": message["text"], "role": PromptMessageRole.value_of(message["role"])}
+                        AdvancedChatMessageEntity(
+                            **{"text": message["text"], "role": PromptMessageRole.value_of(message["role"])}
+                        )
                     )
 
                 advanced_chat_prompt_template = AdvancedChatPromptTemplateEntity(messages=chat_prompt_messages)


### PR DESCRIPTION
# Summary

still found by https://github.com/langgenius/dify/pull/10921 and part of it.
AdvancedChatPromptTemplateEntity(messages=chat_prompt_messages) chat_prompt_messages type seems wrong here

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

