### PR TITLE
fix: fish audio wrong validate credentials interface

### DIFF
--- a/api/core/model_runtime/model_providers/fishaudio/fishaudio.py
+++ b/api/core/model_runtime/model_providers/fishaudio/fishaudio.py
@@ -18,7 +18,8 @@ class FishAudioProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.TTS)
-            model_instance.validate_credentials(credentials=credentials)
+            # FIXME fish tts do not have model for now, so set it to empty string instead
+            model_instance.validate_credentials(model="", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/api/core/model_runtime/model_providers/fishaudio/tts/tts.py
+++ b/api/core/model_runtime/model_providers/fishaudio/tts/tts.py
@@ -66,7 +66,7 @@ class FishAudioText2SpeechModel(TTSModel):
             voice=voice,
         )
 
-    def validate_credentials(self, credentials: dict, user: Optional[str] = None) -> None:
+    def validate_credentials(self, model: str, credentials: dict, user: Optional[str] = None) -> None:
         """
         Validate credentials for text2speech model
 
@@ -76,7 +76,7 @@ class FishAudioText2SpeechModel(TTSModel):
 
         try:
             self.get_tts_model_voices(
-                None,
+                "",
                 credentials={
                     "api_key": credentials["api_key"],
                     "api_base": credentials["api_base"],


### PR DESCRIPTION
# Summary

Also found by https://github.com/langgenius/dify/pull/10921 and part of it.
the interface `validate_credentials` in FishAudioText2SpeechModel is different from others if seems forget the 
model name this pull request make them the same.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

