### PR TITLE
fix: Validate file only when file type is set to custom

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -243,7 +243,7 @@ def _is_file_valid_with_config(
 
     if (
         input_file_type == FileType.CUSTOM
-        and config.allowed_file_extensions
+        and config.allowed_file_extensions is not None
         and file_extension not in config.allowed_file_extensions
     ):
         return False

--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -241,7 +241,11 @@ def _is_file_valid_with_config(
     ):
         return False
 
-    if config.allowed_file_extensions and file_extension not in config.allowed_file_extensions:
+    if (
+        input_file_type == FileType.CUSTOM
+        and config.allowed_file_extensions
+        and file_extension not in config.allowed_file_extensions
+    ):
         return False
 
     if config.allowed_file_upload_methods and file_transfer_method not in config.allowed_file_upload_methods:


### PR DESCRIPTION

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

