### PR TITLE
fix: wrong param name

### DIFF
--- a/api/tasks/add_document_to_index_task.py
+++ b/api/tasks/add_document_to_index_task.py
@@ -18,9 +18,9 @@ from models.dataset import DocumentSegment
 def add_document_to_index_task(dataset_document_id: str):
     """
     Async Add document to index
-    :param document_id:
+    :param dataset_document_id:
 
-    Usage: add_document_to_index.delay(document_id)
+    Usage: add_document_to_index.delay(dataset_document_id)
     """
     logging.info(click.style("Start add document to index: {}".format(dataset_document_id), fg="green"))
     start_at = time.perf_counter()


### PR DESCRIPTION
# Summary

Fix a wrong param name in docs.


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

