### PR TITLE
Feat/add admin check

### DIFF
--- a/api/models/account.py
+++ b/api/models/account.py
@@ -153,7 +153,7 @@ class TenantAccountRole(enum.StrEnum):
 
     @staticmethod
     def is_admin_role(role: str) -> bool:
-        return role and role in {TenantAccountRole.ADMIN}
+        return role and role == TenantAccountRole.ADMIN
 
     @staticmethod
     def is_non_owner_role(role: str) -> bool:

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -107,7 +107,7 @@ class Account(UserMixin, db.Model):
     @property
     def is_admin_or_owner(self):
         return TenantAccountRole.is_privileged_role(self._current_tenant.current_role)
-    
+
     @property
     def is_admin(self):
         return TenantAccountRole.is_admin_role(self._current_tenant.current_role)

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -107,6 +107,10 @@ class Account(UserMixin, db.Model):
     @property
     def is_admin_or_owner(self):
         return TenantAccountRole.is_privileged_role(self._current_tenant.current_role)
+    
+    @property
+    def is_admin(self):
+        return TenantAccountRole.is_admin_role(self._current_tenant.current_role)
 
     @property
     def is_editor(self):
@@ -146,6 +150,10 @@ class TenantAccountRole(enum.StrEnum):
     @staticmethod
     def is_privileged_role(role: str) -> bool:
         return role and role in {TenantAccountRole.OWNER, TenantAccountRole.ADMIN}
+
+    @staticmethod
+    def is_admin_role(role: str) -> bool:
+        return role and role in {TenantAccountRole.ADMIN}
 
     @staticmethod
     def is_non_owner_role(role: str) -> bool:


### PR DESCRIPTION
# Summary

This PR introduces a new is_admin property in the Account model and the corresponding utility method is_admin_role in the TenantAccountRole class. These changes enhance access control and ensure only administrators can manage critical application settings if required.

# Key Changes:

- Added is_admin property to the Account model to simplify admin checks.

- Added is_admin_role static method to TenantAccountRole to encapsulate role-specific logic.
# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
