### PR TITLE
fix: chart tool chinese font display and raise error

### DIFF
--- a/api/core/tools/provider/builtin/chart/chart.py
+++ b/api/core/tools/provider/builtin/chart/chart.py
@@ -1,3 +1,4 @@
+import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.font_manager import FontProperties, fontManager
 
@@ -5,7 +6,7 @@ from core.tools.provider.builtin_tool_provider import BuiltinToolProviderControl
 
 
 def set_chinese_font():
-    font_list = [
+    to_find_fonts = [
         "PingFang SC",
         "SimHei",
         "Microsoft YaHei",
@@ -15,16 +16,16 @@ def set_chinese_font():
         "Noto Sans CJK SC",
         "Noto Sans CJK JP",
     ]
-
-    for font in font_list:
-        if font in fontManager.ttflist:
-            chinese_font = FontProperties(font)
-            if chinese_font.get_name() == font:
-                return chinese_font
+    installed_fonts = frozenset(fontInfo.name for fontInfo in fontManager.ttflist)
+    for font in to_find_fonts:
+        if font in installed_fonts:
+            return FontProperties(font)
 
     return FontProperties()
 
 
+# use non-interactive backend to prevent `RuntimeError: main thread is not in main loop`
+matplotlib.use("Agg")
 # use a business theme
 plt.style.use("seaborn-v0_8-darkgrid")
 plt.rcParams["axes.unicode_minus"] = False


### PR DESCRIPTION
# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fixed 2 errors:

1. fix https://github.com/langgenius/dify/issues/10777
2. when you run the tool to generate a bar,  then change params to generate another bar will raise:
```
[on_tool_start] ToolCall:bar_chart
{'data': '15000', 'x_axis': '测试汉字'}
C:\Users\hejl\PycharmProjects\dify\api\core\tools\provider\builtin\chart\tools\bar.py:31: UserWarning: Starting a Matplotlib GUI outside of the main thread will likely fail.
  flg, ax = plt.subplots(figsize=(10, 8))
C:\Users\hejl\PycharmProjects\dify\api\core\tools\provider\builtin\chart\tools\bar.py:35: UserWarning: set_ticklabels() should only be used with a fixed number of ticks, i.e. after set_ticks() or using a FixedLocator.
  ax.set_xticklabels(axis, rotation=45, ha="right")
Exception ignored in: <function Image.__del__ at 0x0000018D0AC99080>
Traceback (most recent call last):
  File "C:\Users\hejl\.pyenv\pyenv-win\versions\3.12.0\Lib\tkinter\__init__.py", line 4081, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
2024-11-24 21:31:55,681.681 INFO [Thread-9 (process_request_thread)] [_internal.py:97] - 127.0.0.1 - - [25/Nov/2024 13:31:55] "OPTIONS /console/api/apps/d0f351d8-946d-4a62-a074-dc8ac0bf2e11/workflows/draft HTTP/1.1" 200 -
2024-11-24 21:31:55,710.710 INFO [Thread-11 (process_request_thread)] [_internal.py:97] - 127.0.0.1 - - [25/Nov/2024 13:31:55] "POST /console/api/apps/d0f351d8-946d-4a62-a074-dc8ac0bf2e11/workflows/draft HTTP/1.1" 200 -
Exception ignored in: <function Variable.__del__ at 0x0000018D0AC02AC0>
Traceback (most recent call last):
  File "C:\Users\hejl\.pyenv\pyenv-win\versions\3.12.0\Lib\tkinter\__init__.py", line 410, in __del__
    if self._tk.getboolean(self._tk.call("info", "exists", self._name)):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: main thread is not in main loop
Exception ignored in: <function Variable.__del__ at 0x0000018D0AC02AC0>
Traceback (most recent call last):
  File "C:\Users\hejl\.pyenv\pyenv-win\versions\3.12.0\Lib\tkinter\__init__.py", line 410, in __del__
    if self._tk.getboolean(self._tk.call("info", "exists", self._name)):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: main thread is not in main loop
Exception ignored in: <function Variable.__del__ at 0x0000018D0AC02AC0>
Traceback (most recent call last):
  File "C:\Users\hejl\.pyenv\pyenv-win\versions\3.12.0\Lib\tkinter\__init__.py", line 410, in __del__
    if self._tk.getboolean(self._tk.call("info", "exists", self._name)):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: main thread is not in main loop
Exception ignored in: <function Variable.__del__ at 0x0000018D0AC02AC0>
Traceback (most recent call last):
  File "C:\Users\hejl\.pyenv\pyenv-win\versions\3.12.0\Lib\tkinter\__init__.py", line 410, in __del__
    if self._tk.getboolean(self._tk.call("info", "exists", self._name)):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: main thread is not in main loop
Tcl_AsyncDelete: async handler deleted by the wrong thread
```

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td> <img src="https://github.com/user-attachments/assets/f5779cb9-ce7d-4107-997d-a12f8a799ca6" />
</td>
  <td><img src="https://github.com/user-attachments/assets/0c56c936-d121-4976-b2d2-188cbf9370e1" /></td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

