### PR TITLE
Fixes #11065: tenant_id not found when login via ADMIN_KEY

### DIFF
--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -15,6 +15,7 @@ import json
 
 from flask import Flask, Response, request
 from flask_cors import CORS
+from flask_login import user_loaded_from_request, user_logged_in
 from werkzeug.exceptions import Unauthorized
 
 import contexts
@@ -120,9 +121,15 @@ def load_user_from_request(request_from_flask_login):
     user_id = decoded.get("user_id")
 
     logged_in_account = AccountService.load_logged_in_account(account_id=user_id)
-    if logged_in_account:
-        contexts.tenant_id.set(logged_in_account.current_tenant_id)
     return logged_in_account
+
+
+@user_logged_in.connect
+@user_loaded_from_request.connect
+def on_user_logged_in(_sender, user):
+    """Called when a user logged in."""
+    if user:
+        contexts.tenant_id.set(user.current_tenant_id)
 
 
 @login_manager.unauthorized_handler


### PR DESCRIPTION
# Summary

`load_user_from_request` is not called when logging in via ADMIN_KEY, which causes `contexts.tenant_id` to remain unset.

Close https://github.com/langgenius/dify/issues/11065


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

