### PR TITLE
Add query_prefix + Return TED Transcript URL for Downstream Scraping Tasks

### DIFF
--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.py
@@ -18,6 +18,12 @@ class DuckDuckGoImageSearchTool(BuiltinTool):
             "size": tool_parameters.get("size"),
             "max_results": tool_parameters.get("max_results"),
         }
+
+        # Add query_prefix handling
+        query_prefix = tool_parameters.get("query_prefix", "").strip()
+        final_query = f"{query_prefix} {query_dict['keywords']}".strip()
+        query_dict["keywords"] = final_query
+
         response = DDGS().images(**query_dict)
         markdown_result = "\n\n"
         json_result = []

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.yaml
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_img.yaml
@@ -86,3 +86,14 @@ parameters:
       en_US: The size of the image to be searched.
       zh_Hans: 要搜索的图片的大小
     form: form
+  - name: query_prefix
+    label:
+      en_US: Query Prefix
+      zh_Hans: 查询前缀
+    type: string
+    required: false
+    default: ""
+    form: form
+    human_description:
+      en_US: Specific Search e.g. "site:unsplash.com"
+      zh_Hans: 定向搜索 e.g. "site:unsplash.com"

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_news.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_news.py
@@ -7,7 +7,7 @@ from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 
 SUMMARY_PROMPT = """
-User's query: 
+User's query:
 {query}
 
 Here are the news results:
@@ -30,6 +30,12 @@ class DuckDuckGoNewsSearchTool(BuiltinTool):
             "safesearch": "moderate",
             "region": "wt-wt",
         }
+
+        # Add query_prefix handling
+        query_prefix = tool_parameters.get("query_prefix", "").strip()
+        final_query = f"{query_prefix} {query_dict['keywords']}".strip()
+        query_dict["keywords"] = final_query
+
         try:
             response = list(DDGS().news(**query_dict))
             if not response:

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_news.yaml
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_news.yaml
@@ -69,3 +69,14 @@ parameters:
       en_US: Whether to pass the news results to llm for summarization.
       zh_Hans: 是否需要将新闻结果传给大模型总结
     form: form
+  - name: query_prefix
+    label:
+      en_US: Query Prefix
+      zh_Hans: 查询前缀
+    type: string
+    required: false
+    default: ""
+    form: form
+    human_description:
+      en_US: Specific Search e.g. "site:msn.com"
+      zh_Hans: 定向搜索 e.g. "site:msn.com"

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_search.py
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_search.py
@@ -7,7 +7,7 @@ from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool.builtin_tool import BuiltinTool
 
 SUMMARY_PROMPT = """
-User's query: 
+User's query:
 {query}
 
 Here is the search engine result:
@@ -26,7 +26,12 @@ class DuckDuckGoSearchTool(BuiltinTool):
         query = tool_parameters.get("query")
         max_results = tool_parameters.get("max_results", 5)
         require_summary = tool_parameters.get("require_summary", False)
-        response = DDGS().text(query, max_results=max_results)
+
+        # Add query_prefix handling
+        query_prefix = tool_parameters.get("query_prefix", "").strip()
+        final_query = f"{query_prefix} {query}".strip()
+
+        response = DDGS().text(final_query, max_results=max_results)
         if require_summary:
             results = "\n".join([res.get("body") for res in response])
             results = self.summary_results(user_id=user_id, content=results, query=query)

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_search.yaml
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_search.yaml
@@ -39,3 +39,14 @@ parameters:
       en_US: Whether to pass the search results to llm for summarization.
       zh_Hans: 是否需要将搜索结果传给大模型总结
     form: form
+  - name: query_prefix
+    label:
+      en_US: Query Prefix
+      zh_Hans: 查询前缀
+    type: string
+    required: false
+    default: ""
+    form: form
+    human_description:
+      en_US: Specific Search e.g. "site:wikipedia.org"
+      zh_Hans: 定向搜索 e.g. "site:wikipedia.org"

--- a/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_video.yaml
+++ b/api/core/tools/provider/builtin/duckduckgo/tools/ddgo_video.yaml
@@ -95,3 +95,14 @@ parameters:
       en_US: Proxy URL
       zh_Hans: 视频代理地址
     form: form
+  - name: query_prefix
+    label:
+      en_US: Query Prefix
+      zh_Hans: 查询前缀
+    type: string
+    required: false
+    default: ""
+    form: form
+    human_description:
+      en_US: Specific Search e.g. "site:www.ted.com"
+      zh_Hans: 定向搜索 e.g. "site:www.ted.com"


### PR DESCRIPTION
# Summary

This PR adds an advanced search feature to the duckduckgo tool with a query_prefix parameter.

It also makes the video search tool return transcript URLs for ted videos. 
Downstream tools like firecrawl and jina reader can be used to scrape transcripts.

# Screenshots
<img width="396" alt="image" src="https://github.com/user-attachments/assets/0adf1628-d607-4b92-800e-44d6a560d177">
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/06383038-fe60-455e-ada0-6474fc2f21e6">
