### PR TITLE
fix: Incorrect iteration log display in workflow with multiple parallel mode iteartaion nodes

### DIFF
--- a/web/app/components/workflow/hooks/use-workflow-run.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run.ts
@@ -158,7 +158,7 @@ export const useWorkflowRun = () => {
       else
         ttsUrl = `/apps/${params.appId}/text-to-audio`
     }
-    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', (_: any): any => { })
+    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', (_: any): any => {})
 
     ssePost(
       url,

--- a/web/app/components/workflow/hooks/use-workflow-run.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run.ts
@@ -158,7 +158,7 @@ export const useWorkflowRun = () => {
       else
         ttsUrl = `/apps/${params.appId}/text-to-audio`
     }
-    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', (_: any): any => {})
+    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', (_: any): any => { })
 
     ssePost(
       url,
@@ -271,13 +271,18 @@ export const useWorkflowRun = () => {
                 } as any)
               }
               else {
-                if (!iterParallelLogMap.has(data.parallel_run_id))
-                  iterParallelLogMap.set(data.parallel_run_id, [{ ...data, status: NodeRunningStatus.Running } as any])
+                const nodeId = iterations?.node_id as string
+                if (!iterParallelLogMap.has(nodeId as string))
+                  iterParallelLogMap.set(iterations?.node_id as string, new Map())
+
+                const currentIterLogMap = iterParallelLogMap.get(nodeId)!
+                if (!currentIterLogMap.has(data.parallel_run_id))
+                  currentIterLogMap.set(data.parallel_run_id, [{ ...data, status: NodeRunningStatus.Running } as any])
                 else
-                  iterParallelLogMap.get(data.parallel_run_id)!.push({ ...data, status: NodeRunningStatus.Running } as any)
+                  currentIterLogMap.get(data.parallel_run_id)!.push({ ...data, status: NodeRunningStatus.Running } as any)
                 setIterParallelLogMap(iterParallelLogMap)
                 if (iterations)
-                  iterations.details = Array.from(iterParallelLogMap.values())
+                  iterations.details = Array.from(currentIterLogMap.values())
               }
             }))
           }
@@ -373,7 +378,7 @@ export const useWorkflowRun = () => {
                 if (iterations && iterations.details) {
                   const iterRunID = data.execution_metadata?.parallel_mode_run_id
 
-                  const currIteration = iterParallelLogMap.get(iterRunID)
+                  const currIteration = iterParallelLogMap.get(iterations.node_id)?.get(iterRunID)
                   const nodeIndex = currIteration?.findIndex(node =>
                     node.node_id === data.node_id && (
                       node?.parallel_run_id === data.execution_metadata?.parallel_mode_run_id),
@@ -392,7 +397,9 @@ export const useWorkflowRun = () => {
                     }
                   }
                   setIterParallelLogMap(iterParallelLogMap)
-                  iterations.details = Array.from(iterParallelLogMap.values())
+                  const iterLogMap = iterParallelLogMap.get(iterations.node_id)
+                  if (iterLogMap)
+                    iterations.details = Array.from(iterLogMap.values())
                 }
               }))
             }

--- a/web/app/components/workflow/run/index.tsx
+++ b/web/app/components/workflow/run/index.tsx
@@ -62,7 +62,7 @@ const RunPanel: FC<RunProps> = ({ hideResult, activeTab = 'RESULT', runID, getRe
   const formatNodeList = useCallback((list: NodeTracing[]) => {
     const allItems = [...list].reverse()
     const result: NodeTracing[] = []
-    const groupMap = new Map<string, NodeTracing[]>()
+    const nodeGroupMap = new Map<string, Map<string, NodeTracing[]>>()
 
     const processIterationNode = (item: NodeTracing) => {
       result.push({
@@ -70,11 +70,19 @@ const RunPanel: FC<RunProps> = ({ hideResult, activeTab = 'RESULT', runID, getRe
         details: [],
       })
     }
+
     const updateParallelModeGroup = (runId: string, item: NodeTracing, iterationNode: NodeTracing) => {
+      if (!nodeGroupMap.has(iterationNode.node_id))
+        nodeGroupMap.set(iterationNode.node_id, new Map())
+
+      const groupMap = nodeGroupMap.get(iterationNode.node_id)!
+
       if (!groupMap.has(runId))
         groupMap.set(runId, [item])
+
       else
         groupMap.get(runId)!.push(item)
+
       if (item.status === 'failed') {
         iterationNode.status = 'failed'
         iterationNode.error = item.error

--- a/web/app/components/workflow/store.ts
+++ b/web/app/components/workflow/store.ts
@@ -169,8 +169,8 @@ type Shape = {
   setShowTips: (showTips: string) => void
   iterTimes: number
   setIterTimes: (iterTimes: number) => void
-  iterParallelLogMap: Map<string, NodeTracing[]>
-  setIterParallelLogMap: (iterParallelLogMap: Map<string, NodeTracing[]>) => void
+  iterParallelLogMap: Map<string, Map<string, NodeTracing[]>>
+  setIterParallelLogMap: (iterParallelLogMap: Map<string, Map<string, NodeTracing[]>>) => void
 }
 
 export const createWorkflowStore = () => {
@@ -288,7 +288,7 @@ export const createWorkflowStore = () => {
     setShowTips: showTips => set(() => ({ showTips })),
     iterTimes: 1,
     setIterTimes: iterTimes => set(() => ({ iterTimes })),
-    iterParallelLogMap: new Map<string, NodeTracing[]>(),
+    iterParallelLogMap: new Map<string, Map<string, NodeTracing[]>>(),
     setIterParallelLogMap: iterParallelLogMap => set(() => ({ iterParallelLogMap })),
 
   }))


### PR DESCRIPTION
Incorrect iteration log display in workflow with multiple parallel mode iteartaion nodes

# Summary

When there are two or more iteration nodes in the workflow, the logs for iteration nodes other than the first one will be incorrect because the state for each iteration node was not categorized correctly before. This issue has now been resolved.

Fixes #11117 


# Screenshots

<table>
  <tr>
  <td>Before: 
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/26adb029-f5db-4e3d-b250-d5fdd3d600e2">
</td>
  <td>After: 
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/b7b4837e-28db-489d-a44d-1b4f1feebac0">
</td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

