### PR TITLE
fix the .env and .yaml bugs

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,7 +10,7 @@
 # used to concatenate the authorization callback.
 # If empty, it is the same domain.
 # Example: https://api.console.dify.ai
-CONSOLE_API_URL=
+CONSOLE_API_URL=http://localhost:5001
 
 # The front-end URL of the console web,
 # used to concatenate some front-end addresses and for CORS configuration use.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -307,6 +307,8 @@ services:
     networks:
       - ssrf_proxy_network
       - default
+    ports:
+      - "5001:5001"
 
   # worker service
   # The Celery worker for processing the queue.


### PR DESCRIPTION
# Summary

When we run docker compose up -d on the server using the default .env and .yaml configurations and use vscode for port forwarding, we encounter a bug with http://localhost:3000/console/api/setup 404. After my research, it is a problem with the default configuration, which is only suitable for local deployment. When deploying on the server, CONSOLE_API_URL will default to http://localhost:3000, but in fact the backend should be on port 5001

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

![image](https://github.com/user-attachments/assets/167671e0-f8c0-4e08-a7d8-bf7da9ba4476)
![image](https://github.com/user-attachments/assets/30e35261-4df1-4dd4-816e-29a91001fd18)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

