### PR TITLE
Fix the issue of obtaining an empty file upload URL variable.

### DIFF
--- a/api/core/file/file_manager.py
+++ b/api/core/file/file_manager.py
@@ -31,7 +31,7 @@ def get_attr(*, file: File, attr: FileAttribute):
         case FileAttribute.TRANSFER_METHOD:
             return file.transfer_method.value
         case FileAttribute.URL:
-            return file.remote_url
+            return file.generate_url()
         case FileAttribute.EXTENSION:
             return file.extension
 


### PR DESCRIPTION
# Summary

When obtaining the file's URL variable, the remote_url's URL can be retrieved, but the URL of the locally uploaded file cannot be obtained. Moreover, even the remote_url gets converted to local_file mode. Therefore, it should return the URL generated by file.generate_url().

# Screenshots
before fixed: 
![image](https://github.com/user-attachments/assets/8f0cd766-388a-461d-b3f9-178524019938)
![image](https://github.com/user-attachments/assets/0b1b1984-f6bd-471e-813e-75b7d85527b6)

after fixed: 
![image](https://github.com/user-attachments/assets/a3b52586-7507-418f-85c6-f1a10a997c9d)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

