### PR TITLE
fix: fix azure open-4o-08-06 when enable json schema cant process content = ""

### DIFF
--- a/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
+++ b/api/core/model_runtime/model_providers/azure_openai/llm/llm.py
@@ -598,6 +598,9 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             # message = cast(AssistantPromptMessage, message)
             message_dict = {"role": "assistant", "content": message.content}
             if message.tool_calls:
+                # fix azure when enable json schema cant process content = "" in assistant fix with None
+                if not message.content:
+                    message_dict["content"] = None
                 message_dict["tool_calls"] = [helper.dump_model(tool_call) for tool_call in message.tool_calls]
         elif isinstance(message, SystemPromptMessage):
             message = cast(SystemPromptMessage, message)


### PR DESCRIPTION
# Summary

The bug caused by Azure model changes first occurred on November 18, 2024. When using the Azure OpenAI GPT-4o-08-06 model with JSON schema format output, if a tool is invoked and the assistant message content is an empty string, the model fails to respond properly, ultimately resulting in a 500 error. To ensure compatibility, it is necessary to detect when the assistant message involves a tool invocation and replace an empty message content with None to enable proper responses.

# Screenshots

## debug wiht azure py code

before:
![image](https://github.com/user-attachments/assets/9acb8e84-6d52-4fb0-bd82-ae1b58b5ac50)
![image](https://github.com/user-attachments/assets/5ac7bc96-eac6-4fc0-be54-0e526e0406bb)

after:
![image](https://github.com/user-attachments/assets/a6b8dd8c-171b-4961-94af-b9ff01a027e3)
![image](https://github.com/user-attachments/assets/67eab7e9-bbc2-41e0-9355-74fe592b7dcc)



## debug with dify backend code:

before:

<img width="1637" alt="image" src="https://github.com/user-attachments/assets/0e710e91-af6f-47bd-a995-e72bc5051142">

after：

<img width="1643" alt="image" src="https://github.com/user-attachments/assets/961098a3-b149-4d4b-925a-40a944b87c03">


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

