### PR TITLE
fix: 'validation error for ToolInvokeMessage' when blob_message meta is None

### DIFF
--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -317,14 +317,14 @@ class Tool(BaseModel, ABC):
         """
         return ToolInvokeMessage(type=ToolInvokeMessage.MessageType.TEXT, message=text, save_as=save_as)
 
-    def create_blob_message(self, blob: bytes, meta: dict = {}, save_as: str = "") -> ToolInvokeMessage:
+    def create_blob_message(self, blob: bytes, meta: Optional[dict] = None, save_as: str = "") -> ToolInvokeMessage:
         """
         create a blob message
 
         :param blob: the blob
         :return: the blob message
         """
-        return ToolInvokeMessage(type=ToolInvokeMessage.MessageType.BLOB, message=blob, meta=meta, save_as=save_as)
+        return ToolInvokeMessage(type=ToolInvokeMessage.MessageType.BLOB, message=blob, meta=meta or {}, save_as=save_as)
 
     def create_json_message(self, object: dict) -> ToolInvokeMessage:
         """

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -317,7 +317,7 @@ class Tool(BaseModel, ABC):
         """
         return ToolInvokeMessage(type=ToolInvokeMessage.MessageType.TEXT, message=text, save_as=save_as)
 
-    def create_blob_message(self, blob: bytes, meta: Optional[dict] = None, save_as: str = "") -> ToolInvokeMessage:
+    def create_blob_message(self, blob: bytes, meta: dict = {}, save_as: str = "") -> ToolInvokeMessage:
         """
         create a blob message
 

--- a/api/core/tools/tool/tool.py
+++ b/api/core/tools/tool/tool.py
@@ -324,7 +324,12 @@ class Tool(BaseModel, ABC):
         :param blob: the blob
         :return: the blob message
         """
-        return ToolInvokeMessage(type=ToolInvokeMessage.MessageType.BLOB, message=blob, meta=meta or {}, save_as=save_as)
+        return ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.BLOB,
+            message=blob,
+            meta=meta or {},
+            save_as=save_as,
+        )
 
     def create_json_message(self, object: dict) -> ToolInvokeMessage:
         """


### PR DESCRIPTION

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

this change fix a issue when custom tool returns a blob message without metadata, a

 `validation error for ToolInvokeMessage\nmeta\n Input should be a valid dictionary`

will be throwed, because meta definition is `meta: dict[str, Any] = Field(default_factory=dict)` which can not be set to None.

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

