### PR TITLE
feat: Output custom parameters at the message_end node #11078

### DIFF
--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -125,7 +125,7 @@ const translation = {
   },
   chatVariable: {
     panelTitle: 'Conversation Variables',
-    panelDescription: 'Conversation Variables are used to store interactive information that LLM needs to remember, including conversation history, uploaded files, user preferences. They are read-write. ',
+    panelDescription: 'Conversation Variables are used to store interactive information that LLM needs to remember, including conversation history, uploaded files, user preferences. They are read-write. Variables starting with answer_ will also be output to the caller through the API.',
     docLink: 'Visit our docs to learn more.',
     button: 'Add Variable',
     modal: {

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -125,7 +125,7 @@ const translation = {
   },
   chatVariable: {
     panelTitle: '会话变量',
-    panelDescription: '会话变量用于存储 LLM 需要的上下文信息，如用户偏好、对话历史等。它是可读写的。',
+    panelDescription: '会话变量用于存储 LLM 需要的上下文信息，如用户偏好、对话历史等。它是可读写的。answer_开头的变量还将通过api输出给调用方。',
     docLink: '查看文档了解更多。',
     button: '添加变量',
     modal: {


### PR DESCRIPTION
# Summary

You can customize the output of some parameters in the streaming interface and non-streaming interface. For example: customized knowledge sources, recommended questions, some flags, etc.

I modified the meesage_end node to output the specified session variable.

Resolves #11078 


# Screenshots

![image](https://github.com/user-attachments/assets/fc7a4092-08b2-479e-86d3-bd6a01b7df29)
![image](https://github.com/user-attachments/assets/bf9e2e40-4032-4962-a39d-0b262b38952d)
![image](https://github.com/user-attachments/assets/10b125a2-5b0f-4b10-bd27-194ed0bf4b91)
![image](https://github.com/user-attachments/assets/c80e52df-b2fa-4ed8-96b9-a609eb28843f)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

