### PR TITLE
[Pixtral] Add new model ; add vision

### DIFF
--- a/api/core/model_runtime/model_providers/mistralai/llm/_position.yaml
+++ b/api/core/model_runtime/model_providers/mistralai/llm/_position.yaml
@@ -1,3 +1,5 @@
+- pixtral-large-latest
+- pixtral-large-2411
 - pixtral-12b-2409
 - codestral-latest
 - mistral-embed

--- a/api/core/model_runtime/model_providers/mistralai/llm/pixtral-large-2411.yaml
+++ b/api/core/model_runtime/model_providers/mistralai/llm/pixtral-large-2411.yaml
@@ -1,7 +1,7 @@
-model: pixtral-12b-2409
+model: pixtral-large-2411
 label:
-  zh_Hans: pixtral-12b-2409
-  en_US: pixtral-12b-2409
+  zh_Hans: pixtral-large-2411
+  en_US: pixtral-large-2411
 model_type: llm
 features:
   - agent-thought

--- a/api/core/model_runtime/model_providers/mistralai/llm/pixtral-large-latest.yaml
+++ b/api/core/model_runtime/model_providers/mistralai/llm/pixtral-large-latest.yaml
@@ -1,7 +1,7 @@
-model: pixtral-12b-2409
+model: pixtral-large-latest
 label:
-  zh_Hans: pixtral-12b-2409
-  en_US: pixtral-12b-2409
+  zh_Hans: pixtral-large-latest
+  en_US: pixtral-large-latest
 model_type: llm
 features:
   - agent-thought


### PR DESCRIPTION
# Summary
This PR adds support for new Mistral AI models, specifically adding configuration for Pixtral models (pixtral-large-latest and pixtral-large-2411) to the model runtime. These models support vision and agent-thought features with a large context window of 128K tokens.

https://mistral.ai/fr/news/pixtral-large/

Changes include:
- Added new models to `_position.yaml`
- Created configuration files for pixtral-large-2411 and pixtral-large-latest
- Models support vision and agent-thought capabilities
- Configured with standard parameter rules (temperature, top_p, max_tokens, safe_prompt, random_seed)
- Set pricing at $0.008/1K tokens for input and $0.024/1K tokens for output

Close https://github.com/langgenius/dify/issues/10896

# Screenshots
<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>No Pixtral large models available in model selection</td>
  <td>Pixtral large models available with vision capabilities</td>
  </tr>
</table>

![image](https://github.com/user-attachments/assets/a3283b70-c46e-4fb2-8c42-9c272c909939)

![image](https://github.com/user-attachments/assets/0bb9f61c-b3aa-4f0f-80d2-1fb55d702c6e)

![image](https://github.com/user-attachments/assets/8963607e-e05c-4661-866e-c61e5e905985)

![image](https://github.com/user-attachments/assets/658c4ec2-f65f-423a-83a4-fcb92db956f0)

# Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods