### PR TITLE
feat: Increase the number of Opening Questions in the Conversation Opener

### DIFF
--- a/web/app/components/app/configuration/features/chat-group/opening-statement/index.tsx
+++ b/web/app/components/app/configuration/features/chat-group/opening-statement/index.tsx
@@ -22,7 +22,7 @@ import { getNewVar } from '@/utils/var'
 import { varHighlightHTML } from '@/app/components/app/configuration/base/var-highlight'
 import Toast from '@/app/components/base/toast'
 
-const MAX_QUESTION_NUM = 5
+const MAX_QUESTION_NUM = 10
 
 export type IOpeningStatementProps = {
   value: string

--- a/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
@@ -22,7 +22,7 @@ type OpeningSettingModalProps = {
   onAutoAddPromptVariable?: (variable: PromptVariable[]) => void
 }
 
-const MAX_QUESTION_NUM = 5
+const MAX_QUESTION_NUM = 10
 
 const OpeningSettingModal = ({
   data,


### PR DESCRIPTION
# Summary

Currently, the number of Opening Questions that can be set in Chatflow's Conversation Opener is set to 5. This number may be a little low for some options. I don't think it's necessary to make it too high, but I suggest increasing it to around 10.

Fixes #11232


# Screenshots

![{800BA875-E7FD-480F-B9D5-695644388404}](https://github.com/user-attachments/assets/41df992a-d24d-46e8-9ede-c4bf2d403f82)

![{1DB833E9-4107-4BF5-95CE-93CB6FE8E0C3}](https://github.com/user-attachments/assets/08f3d6f3-6f7a-4e9f-abf4-4380943c64ed)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

