### PR TITLE
fix: claude can not handle empty string

### DIFF
--- a/api/core/model_runtime/model_providers/anthropic/llm/llm.py
+++ b/api/core/model_runtime/model_providers/anthropic/llm/llm.py
@@ -483,6 +483,10 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 if isinstance(message, UserPromptMessage):
                     message = cast(UserPromptMessage, message)
                     if isinstance(message.content, str):
+                        # handle empty user prompt see #10013 #10520
+                        # responses, ignore user prompts containing only whitespace, the Claude API can't handle it.
+                        if not message.content.strip():
+                            continue
                         message_dict = {"role": "user", "content": message.content}
                         prompt_message_dicts.append(message_dict)
                     else:


### PR DESCRIPTION
# Summary

This patch try to fix claude api can not handle empty string problem. 
close #9366 
close #10013 
close #10520.

more: info -> we can check others face the problem 

https://github.com/dspinellis/ai-cli-lib/commit/0ddcaac500b19f3dd0b2d8effa9a2ad951a1bab7
https://github.com/dspinellis/ai-cli-lib/issues/16

https://github.com/karthink/gptel/commit/8b129c57bb78ce2c4d26e183a01bc28631c3c68a#diff-17f2ed0388d8bb8379b05dd47711d80f6b44463ff782876fc7084ae1df090fe6R97
https://github.com/karthink/gptel/issues/409

as a refer that fix it.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

