### PR TITLE
fix: resolve scrolling issue in workflow-log table

### DIFF
--- a/web/app/components/app/workflow-log/index.tsx
+++ b/web/app/components/app/workflow-log/index.tsx
@@ -76,7 +76,7 @@ const Logs: FC<ILogsProps> = ({ appDetail }) => {
     <div className='flex flex-col h-full'>
       <h1 className='text-text-primary system-xl-semibold'>{t('appLog.workflowTitle')}</h1>
       <p className='text-text-tertiary system-sm-regular'>{t('appLog.workflowSubtitle')}</p>
-      <div className='flex flex-col py-4 flex-1'>
+      <div className='flex flex-col py-4 flex-1 max-h-[calc(100%-16px)]'>
         <Filter queryParams={queryParams} setQueryParams={setQueryParams} />
         {/* workflow log */}
         {total === undefined


### PR DESCRIPTION
# Summary

On the workflow-log page, when the page size (limit) is set to a large value that exceeds one page, the table should display a scrollbar to prevent the paginator from being pushed out of view.

This PR addresses the issue by adding a maximum height to the workflow-log table wrapper, enabling scrolling.

# Screenshots

| Before:|After: |
|---|---|
| ![image](https://github.com/user-attachments/assets/059939a8-98e9-4676-9780-bd8920fd6386) | ![image](https://github.com/user-attachments/assets/0e3e7228-ebf9-40a0-9ea7-e42b2b087832) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

