### PR TITLE
fix: cannot send message when debug with multiple model with conversa…

### DIFF
--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/chat-item.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/chat-item.tsx
@@ -29,6 +29,7 @@ import { useAppContext } from '@/context/app-context'
 import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useFeatures } from '@/app/components/base/features/hooks'
 import type { InputForm } from '@/app/components/base/chat/chat/type'
+import { getLastAnswer } from '@/app/components/base/chat/utils'
 
 type ChatItemProps = {
   modelAndParameter: ModelAndParameter
@@ -101,7 +102,7 @@ const ChatItem: FC<ChatItemProps> = ({
       query: message,
       inputs,
       model_config: configData,
-      parent_message_id: chatListRef.current.at(-1)?.id || null,
+      parentMessageId: getLastAnswer(chatListRef.current)?.id || null,
     }
 
     if ((config.file_upload as any).enabled && files?.length && supportVision)

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/chat-item.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/chat-item.tsx
@@ -102,7 +102,7 @@ const ChatItem: FC<ChatItemProps> = ({
       query: message,
       inputs,
       model_config: configData,
-      parentMessageId: getLastAnswer(chatListRef.current)?.id || null,
+      parent_message_id: getLastAnswer(chatListRef.current)?.id || null,
     }
 
     if ((config.file_upload as any).enabled && files?.length && supportVision)


### PR DESCRIPTION
…tion opener

# Summary

This PR follows up https://github.com/langgenius/dify/pull/8627 and https://github.com/langgenius/dify/pull/8682, resolves cannot sending first message in multi-model debug panel if Conversation Opener is enabled. 

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td><video src="https://github.com/user-attachments/assets/7da25ac1-b36c-43a7-b5c6-da64d32ecc3d
"/></td>
  <td><video src="https://github.com/user-attachments/assets/24f02e8d-61e0-4e0f-954e-bd834dd40b80"/></td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

