### PR TITLE
fix: broken link to knowledge base guide

### DIFF
--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout.tsx
@@ -166,7 +166,7 @@ const ExtraInfo = ({ isMobile, relatedApps }: IExtraInfoProps) => {
             className='inline-flex items-center text-xs text-primary-600 mt-2 cursor-pointer'
             href={
               locale === LanguagesSupported[1]
-                ? 'https://docs.dify.ai/v/zh-hans/guides/knowledge-base/integrate_knowledge_within_application'
+                ? 'https://docs.dify.ai/v/zh-hans/guides/knowledge-base/integrate-knowledge-within-application'
                 : 'https://docs.dify.ai/guides/knowledge-base/integrate-knowledge-within-application'
             }
             target='_blank' rel='noopener noreferrer'


### PR DESCRIPTION
# Summary

Just fix a broken link to knowledge base guide when I explored the knowledge base.

<img width="318" alt="image" src="https://github.com/user-attachments/assets/032d9877-f9ca-4195-968d-5fee5448e1fb">

# Screenshots

<table>
  <tr>
  <td>Before: 
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/f34171ee-cfe5-44d8-a179-e3de98de2844">
</td>
  <td>After: 
<img width="993" alt="image" src="https://github.com/user-attachments/assets/427dd518-2878-439d-a4a0-13ccb99dff3f">
</td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

