### PR TITLE
feat: add 'Open in Explore' link for each apps on studio

### DIFF
--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 
+from flask import request
 from flask_login import current_user
 from flask_restful import Resource, inputs, marshal_with, reqparse
 from sqlalchemy import and_
@@ -20,8 +21,17 @@ class InstalledAppsListApi(Resource):
     @account_initialization_required
     @marshal_with(installed_app_list_fields)
     def get(self):
+        app_id = request.args.get("app_id", default=None, type=str)
         current_tenant_id = current_user.current_tenant_id
-        installed_apps = db.session.query(InstalledApp).filter(InstalledApp.tenant_id == current_tenant_id).all()
+
+        if app_id:
+            installed_apps = (
+                db.session.query(InstalledApp)
+                .filter(and_(InstalledApp.tenant_id == current_tenant_id, InstalledApp.app_id == app_id))
+                .all()
+            )
+        else:
+            installed_apps = db.session.query(InstalledApp).filter(InstalledApp.tenant_id == current_tenant_id).all()
 
         current_user.role = TenantService.get_user_role(current_user, current_user.current_tenant)
         installed_apps = [

--- a/web/app/(commonLayout)/apps/AppCard.tsx
+++ b/web/app/(commonLayout)/apps/AppCard.tsx
@@ -217,11 +217,10 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
       e.preventDefault()
       try {
         const { installed_apps }: any = await fetchInstalledAppList(app.id) || {}
-        if (installed_apps?.length > 0) {
-          window.open(`/explore/installed/${installed_apps[0].id}`, '_blank');
-        } else {
+        if (installed_apps?.length > 0)
+          window.open(`/explore/installed/${installed_apps[0].id}`, '_blank')
+        else
           throw new Error('No app found in Explore')
-        }
       }
       catch (e: any) {
         Toast.notify({ type: 'error', message: `${e.message || e}` })

--- a/web/app/(commonLayout)/apps/AppCard.tsx
+++ b/web/app/(commonLayout)/apps/AppCard.tsx
@@ -9,6 +9,7 @@ import s from './style.module.css'
 import cn from '@/utils/classnames'
 import type { App } from '@/types/app'
 import Confirm from '@/app/components/base/confirm'
+import Toast from '@/app/components/base/toast'
 import { ToastContext } from '@/app/components/base/toast'
 import { copyApp, deleteApp, exportAppConfig, updateAppInfo } from '@/service/apps'
 import DuplicateAppModal from '@/app/components/app/duplicate-modal'
@@ -31,6 +32,7 @@ import TagSelector from '@/app/components/base/tag-management/selector'
 import type { EnvironmentVariable } from '@/app/components/workflow/types'
 import DSLExportConfirmModal from '@/app/components/workflow/dsl-export-confirm-modal'
 import { fetchWorkflowDraft } from '@/service/workflow'
+import { fetchInstalledAppList } from '@/service/explore'
 
 export type AppCardProps = {
   app: App
@@ -209,6 +211,22 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
       e.preventDefault()
       setShowConfirmDelete(true)
     }
+    const onClickInstalledApp = async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      props.onClick?.()
+      e.preventDefault()
+      try {
+        const { installed_apps }: any = await fetchInstalledAppList(app.id) || {}
+        if (installed_apps?.length > 0) {
+          window.open(`/explore/installed/${installed_apps[0].id}`, '_blank');
+        } else {
+          throw new Error('No app found in Explore')
+        }
+      }
+      catch (e: any) {
+        Toast.notify({ type: 'error', message: `${e.message || e}` })
+      }
+    }
     return (
       <div className="relative w-full py-1" onMouseLeave={onMouseLeave}>
         <button className={s.actionItem} onClick={onClickSettings}>
@@ -232,6 +250,10 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
             </div>
           </>
         )}
+        <Divider className="!my-1" />
+        <button className={s.actionItem} onClick={onClickInstalledApp}>
+          <span className={s.actionName}>{t('app.openInExplore')}</span>
+        </button>
         <Divider className="!my-1" />
         <div
           className={cn(s.actionItem, s.deleteActionItem, 'group')}
@@ -353,10 +375,10 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
                   }
                   popupClassName={
                     (app.mode === 'completion' || app.mode === 'chat')
-                      ? '!w-[238px] translate-x-[-110px]'
-                      : ''
+                      ? '!w-[256px] translate-x-[-224px]'
+                      : '!w-[160px] translate-x-[-128px]'
                   }
-                  className={'!w-[128px] h-fit !z-20'}
+                  className={'h-fit !z-20'}
                 />
               </div>
             </>

--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -110,11 +110,10 @@ const AppPublisher = ({
   const handleOpenInExplore = useCallback(async () => {
     try {
       const { installed_apps }: any = await fetchInstalledAppList(appDetail?.id) || {}
-      if (installed_apps?.length > 0) {
+      if (installed_apps?.length > 0)
         window.open(`/explore/installed/${installed_apps[0].id}`, '_blank')
-      } else {
+      else
         throw new Error('No app found in Explore')
-      }
     }
     catch (e: any) {
       Toast.notify({ type: 'error', message: `${e.message || e}` })

--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -5,7 +5,8 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import dayjs from 'dayjs'
-import { RiArrowDownSLine } from '@remixicon/react'
+import { RiArrowDownSLine, RiPlanetLine } from '@remixicon/react'
+import Toast from '../../base/toast'
 import type { ModelAndParameter } from '../configuration/debug/types'
 import SuggestedAction from './suggested-action'
 import PublishWithMultipleModel from './publish-with-multiple-model'
@@ -15,6 +16,7 @@ import {
   PortalToFollowElemContent,
   PortalToFollowElemTrigger,
 } from '@/app/components/base/portal-to-follow-elem'
+import { fetchInstalledAppList } from '@/service/explore'
 import EmbeddedModal from '@/app/components/app/overview/embedded'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useGetLanguage } from '@/context/i18n'
@@ -104,6 +106,20 @@ const AppPublisher = ({
     if (state)
       setPublished(false)
   }, [disabled, onToggle, open])
+
+  const handleOpenInExplore = useCallback(async () => {
+    try {
+      const { installed_apps }: any = await fetchInstalledAppList(appDetail?.id) || {}
+      if (installed_apps?.length > 0) {
+        window.open(`/explore/installed/${installed_apps[0].id}`, '_blank')
+      } else {
+        throw new Error('No app found in Explore')
+      }
+    }
+    catch (e: any) {
+      Toast.notify({ type: 'error', message: `${e.message || e}` })
+    }
+  }, [appDetail?.id])
 
   const [embeddingModalOpen, setEmbeddingModalOpen] = useState(false)
 
@@ -205,6 +221,15 @@ const AppPublisher = ({
                   {t('workflow.common.embedIntoSite')}
                 </SuggestedAction>
               )}
+            <SuggestedAction
+              onClick={() => {
+                handleOpenInExplore()
+              }}
+              disabled={!publishedAt}
+              icon={<RiPlanetLine className='w-4 h-4' />}
+            >
+              {t('workflow.common.openInExplore')}
+            </SuggestedAction>
             <SuggestedAction disabled={!publishedAt} link='./develop' icon={<FileText className='w-4 h-4' />}>{t('workflow.common.accessAPIReference')}</SuggestedAction>
             {appDetail?.mode === 'workflow' && (
               <WorkflowToolConfigureButton

--- a/web/i18n/en-US/app.ts
+++ b/web/i18n/en-US/app.ts
@@ -101,6 +101,7 @@ const translation = {
   switchLabel: 'The app copy to be created',
   removeOriginal: 'Delete the original app',
   switchStart: 'Start switch',
+  openInExplore: 'Open in Explore',
   typeSelector: {
     all: 'ALL Types',
     chatbot: 'Chatbot',

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -32,6 +32,7 @@ const translation = {
     restore: 'Restore',
     runApp: 'Run App',
     batchRunApp: 'Batch Run App',
+    openInExplore: 'Open in Explore',
     accessAPIReference: 'Access API Reference',
     embedIntoSite: 'Embed Into Site',
     addTitle: 'Add title...',

--- a/web/i18n/ja-JP/app.ts
+++ b/web/i18n/ja-JP/app.ts
@@ -93,6 +93,7 @@ const translation = {
   switchLabel: '作成されるアプリのコピー',
   removeOriginal: '元のアプリを削除する',
   switchStart: '切り替えを開始する',
+  openInExplore: '"探索" で開く',
   typeSelector: {
     all: 'すべてのタイプ',
     chatbot: 'チャットボット',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -32,6 +32,7 @@ const translation = {
     restore: '復元',
     runApp: 'アプリを実行',
     batchRunApp: 'バッチでアプリを実行',
+    openInExplore: '"探索" で開く',
     accessAPIReference: 'APIリファレンスにアクセス',
     embedIntoSite: 'サイトに埋め込む',
     addTitle: 'タイトルを追加...',

--- a/web/service/explore.ts
+++ b/web/service/explore.ts
@@ -12,8 +12,8 @@ export const fetchAppDetail = (id: string): Promise<any> => {
   return get(`/explore/apps/${id}`)
 }
 
-export const fetchInstalledAppList = () => {
-  return get('/installed-apps')
+export const fetchInstalledAppList = (app_id?: string | null) => {
+  return get(`/installed-apps${app_id ? `?app_id=${app_id}` : ''}`);
 }
 
 export const installApp = (id: string) => {

--- a/web/service/explore.ts
+++ b/web/service/explore.ts
@@ -13,7 +13,7 @@ export const fetchAppDetail = (id: string): Promise<any> => {
 }
 
 export const fetchInstalledAppList = (app_id?: string | null) => {
-  return get(`/installed-apps${app_id ? `?app_id=${app_id}` : ''}`);
+  return get(`/installed-apps${app_id ? `?app_id=${app_id}` : ''}`)
 }
 
 export const installApp = (id: string) => {


### PR DESCRIPTION
# Summary

This PR adds an "Open in Explore" link to the menu of each app in the app list in Studio, and the menu under `Publish` button in Studio.
Clicking this link will open the target app in Explore in a new tab.
Also, to prevent the items in the pop-up menu from containing line break, I will slightly widen its width.

To achieve this, following changes are made by this PR:

- **API**
  - Update `/console/api/installed-apps` to allow querying installed apps by `app_id`
- **Web**
  - Add `Open in Explore` menu for each apps in the app list on studio
  - Add 'Open in Explore' in the publish menu on studio

Closes #11401 

# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>

![image](https://github.com/user-attachments/assets/3d35837b-0167-4f65-a7d5-85b49b8e3e4a)
![image](https://github.com/user-attachments/assets/ed01d358-6c10-4351-a54e-ce7c89daf1a1)
![image](https://github.com/user-attachments/assets/01330277-5a84-4240-9871-749056f58af8)

</td>
  <td>

![image](https://github.com/user-attachments/assets/e18bd46e-dc4d-4630-a120-f8b27b4a8b70)
![image](https://github.com/user-attachments/assets/9d64c4f5-c3cc-4a12-86b8-fc65f16b1034)
![image](https://github.com/user-attachments/assets/b75d74ec-27d0-4147-b851-bfe0f39e9367)
![image](https://github.com/user-attachments/assets/19b6d2dd-e68e-4606-af8a-38562bfee1d8)

</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

