### PR TITLE
fix: update DocumentIsPausedError

### DIFF
--- a/api/tasks/external_document_indexing_task.py
+++ b/api/tasks/external_document_indexing_task.py
@@ -5,7 +5,7 @@ import time
 import click
 from celery import shared_task
 
-from core.indexing_runner import DocumentIsPausedException
+from core.indexing_runner import DocumentIsPausedError
 from extensions.ext_database import db
 from extensions.ext_storage import storage
 from models.dataset import Dataset, ExternalKnowledgeApis
@@ -86,7 +86,7 @@ def external_document_indexing_task(
                 fg="green",
             )
         )
-    except DocumentIsPausedException as ex:
+    except DocumentIsPausedError as ex:
         logging.info(click.style(str(ex), fg="yellow"))
 
     except Exception:


### PR DESCRIPTION
# Summary

The external_document_indexing_task imports an undeclared exception class named DocumentIsPausedException, which was renamed to DocumentIsPausedError on September 11, 2024. Therefore, the reference needs to be updated to the latest version.

Close https://github.com/langgenius/dify/issues/11403

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<table>
  <tr>
  <td>Before: </td>
  <td>After: </td>
  </tr>
  <tr>
  <td>...</td>
  <td>...</td>
  </tr>
</table>

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

