### PR TITLE
fix(api): throw error when notion block can not find

### DIFF
--- a/api/libs/oauth_data_source.py
+++ b/api/libs/oauth_data_source.py
@@ -253,6 +253,8 @@ class NotionOAuth(OAuthDataSource):
         }
         response = requests.get(url=f"{self._NOTION_BLOCK_SEARCH}/{block_id}", headers=headers)
         response_json = response.json()
+        if response.status_code != 200:
+            raise ValueError(f"Error fetching block parent page ID: {response_json.message}")
         parent = response_json["parent"]
         parent_type = parent["type"]
         if parent_type == "block_id":


### PR DESCRIPTION
# Summary

This pull request focuses on give an error tips when notion do not have enough permisson to find page parents block,that may cause`Internal Server Error`

 Resolves #6300 


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

