### PR TITLE
chore: LOCAL_FILE also try to use remote_url as Prompt message

### DIFF
--- a/api/core/file/file_manager.py
+++ b/api/core/file/file_manager.py
@@ -141,7 +141,7 @@ def _to_url(f: File, /):
     elif f.transfer_method == FileTransferMethod.LOCAL_FILE:
         if f.related_id is None:
             raise ValueError("Missing file related_id")
-        return helpers.get_signed_file_url(upload_file_id=f.related_id)
+        return f.remote_url or helpers.get_signed_file_url(upload_file_id=f.related_id)
     elif f.transfer_method == FileTransferMethod.TOOL_FILE:
         # add sign url
         if f.related_id is None or f.extension is None:


### PR DESCRIPTION
# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Because of the CSP, all the remote file upload as `LOCAL_FILE `.  But for the LLM prompt message, we can try to use `remote_url`.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

