### PR TITLE
fix: unit tests env will need clear too

### DIFF
--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -37,7 +37,11 @@ def test_dify_config_undefined_entry(example_env_file):
         assert config["LOG_LEVEL"] == "INFO"
 
 
+# NOTE: If there is a `.env` file in your Workspace, this test might not succeed as expected.
+# This is due to `pymilvus` loading all the variables from the `.env` file into `os.environ`.
 def test_dify_config(example_env_file):
+    # clear system environment variables
+    os.environ.clear()
     # load dotenv file with pydantic-settings
     config = DifyConfig(_env_file=example_env_file)
 


### PR DESCRIPTION
# Summary

if we have dify env file `.env` the unit tests will failed too, because the .env timeout is 600 and the tests env is 60
like 

```

example_env_file = '/private/var/folders/c3/51t_3cqj7bx98dq1ptyy0v700000gn/T/pytest-of-hyi/pytest-28/test_dify_config0/.env'

    def test_dify_config(example_env_file):
        # load dotenv file with pydantic-settings
        config = DifyConfig(_env_file=example_env_file)
    
        # constant values
        assert config.COMMIT_SHA == ""
    
        # default values
        assert config.EDITION == "SELF_HOSTED"
        assert config.API_COMPRESSION_ENABLED is False
        assert config.SENTRY_TRACES_SAMPLE_RATE == 1.0
    
        # annotated field with default value
>       assert config.HTTP_REQUEST_MAX_READ_TIMEOUT == 60
E       AssertionError: assert 600 == 60
E        +  where 600 = DifyConfig(ENTERPRISE_ENABLED=False, CAN_REPLACE_LOGO=False, SENTRY_DSN='', SENTRY_TRACES_SAMPLE_RATE=1.0, SENTRY_PROF..., CONSOLE_CORS_ALLOW_ORIGINS=['http://127.0.0.1:3000', '*'], WEB_API_CORS_ALLOW_ORIGINS=['http://127.0.0.1:3000', '*']).HTTP_REQUEST_MAX_READ_TIMEOUT

/Users/hyi/prs/dify/api/tests/unit_tests/configs/test_dify_config.py:53: AssertionError
```

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

