### PR TITLE
Add llama3.3 70b because llama-3.2-90b-text-preview has been decommissioned and is no longer supported

### DIFF
--- a/api/core/model_runtime/model_providers/groq/llm/llama-3.3-70b-specdec.yaml
+++ b/api/core/model_runtime/model_providers/groq/llm/llama-3.3-70b-specdec.yaml
@@ -1,0 +1,25 @@
+model: llama-3.3-70b-specdec
+label:
+  zh_Hans: Llama 3.3 (text only) (Preview)
+  en_US: Llama 3.3 (text only) (Preview)
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 131072
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 512
+    min: 1
+    max: 8192
+pricing:
+  input: '0.59'
+  output: '0.99'
+  unit: '0.000001'
+  currency: USD

--- a/api/core/model_runtime/model_providers/groq/llm/llama-3.3-70b-versatile.yaml
+++ b/api/core/model_runtime/model_providers/groq/llm/llama-3.3-70b-versatile.yaml
@@ -1,0 +1,25 @@
+model: llama-3.3-70b-versatile
+label:
+  zh_Hans: Llama 3.3 (text only) (Production)
+  en_US: Llama 3.3 (text only) (Production)
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 131072
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 512
+    min: 1
+    max: 8192
+pricing:
+  input: '0.59'
+  output: '0.79'
+  unit: '0.000001'
+  currency: USD


### PR DESCRIPTION

# Summary

Added Groq Models llama-3.3

> [!Tip]
> Close issue syntax: `Resolves #11455`


# Screenshots

| Before | After |
|--------|-------|
| ...    | <img width="311" alt="image" src="https://github.com/user-attachments/assets/51dccb56-9b62-4831-92ff-eeddd9d075ff">  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

