### PR TITLE
feat(api): include icon in app information response

### DIFF
--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -49,7 +49,14 @@ class AppInfoApi(Resource):
     def get(self, app_model: App):
         """Get app information"""
         tags = [tag.name for tag in app_model.tags]
-        return {"name": app_model.name, "description": app_model.description, "tags": tags}
+        return {
+            "name": app_model.name,
+            "description": app_model.description,
+            "tags": tags,
+            "icon_type": app_model.icon_type,
+            "icon": app_model.icon,
+            "icon_background": app_model.icon_background
+        }
 
 
 api.add_resource(AppParameterApi, "/parameters")

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -55,7 +55,7 @@ class AppInfoApi(Resource):
             "tags": tags,
             "icon_type": app_model.icon_type,
             "icon": app_model.icon,
-            "icon_background": app_model.icon_background
+            "icon_background": app_model.icon_background,
         }
 
 


### PR DESCRIPTION
# Summary

Add a icon to {api}/v1/info.


# Screenshots

### Before
```
{
    "name": "sample chat app",
    "description": "sample chat app description",
    "tags": [
        "tag_1",
        "tag_2"
    ]

}
```

### After
```
{
    "name": "chat app 1",
    "description": "chat app 1 description",
    "tags": [
        "tag_1",
        "tag_2"
    ],
    "icon_type": "emoji",
    "icon": "😀",
    "icon_background": "#FF0000"
}
```

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

