### PR TITLE
remove mermail render cache

### DIFF
--- a/web/app/components/base/mermaid/index.tsx
+++ b/web/app/components/base/mermaid/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import mermaid from 'mermaid'
 import { usePrevious } from 'ahooks'
-import CryptoJS from 'crypto-js'
 import { useTranslation } from 'react-i18next'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import LoadingAnim from '@/app/components/base/chat/chat/loading-anim'
@@ -38,7 +37,6 @@ const Flowchart = React.forwardRef((props: {
   const [svgCode, setSvgCode] = useState(null)
   const [look, setLook] = useState<'classic' | 'handDrawn'>('classic')
 
-  const chartId = useRef(`flowchart_${CryptoJS.MD5(props.PrimitiveCode).toString()}`)
   const prevPrimitiveCode = usePrevious(props.PrimitiveCode)
   const [isLoading, setIsLoading] = useState(true)
   const timeRef = useRef<NodeJS.Timeout>()
@@ -51,12 +49,10 @@ const Flowchart = React.forwardRef((props: {
 
     try {
       if (typeof window !== 'undefined' && mermaidAPI) {
-        const svgGraph = await mermaidAPI.render(chartId.current, PrimitiveCode)
+        const svgGraph = await mermaidAPI.render('flowchart', PrimitiveCode)
         const base64Svg: any = await svgToBase64(svgGraph.svg)
         setSvgCode(base64Svg)
         setIsLoading(false)
-        if (chartId.current && base64Svg)
-          localStorage.setItem(chartId.current, base64Svg)
       }
     }
     catch (error) {
@@ -79,19 +75,11 @@ const Flowchart = React.forwardRef((props: {
         },
       })
 
-      localStorage.removeItem(chartId.current)
       renderFlowchart(props.PrimitiveCode)
     }
   }, [look])
 
   useEffect(() => {
-    const cachedSvg: any = localStorage.getItem(chartId.current)
-
-    if (cachedSvg) {
-      setSvgCode(cachedSvg)
-      setIsLoading(false)
-      return
-    }
     if (timeRef.current)
       clearTimeout(timeRef.current)
 


### PR DESCRIPTION
# Summary

In version 0.13.1, there will be a render bug when render a flowchart in a stream mode response.
This is because `chartId` in  web/app/components/base/mermaid/index.tsx nerver changed when props.PrimitiveCode is different, which made it easy to render the same cache svg by the same chartId. 
When  `props.PrimitiveCode` changed, it will create to many cache in localstorage in the middle of stream  without a cleaning stratege. 
So I made this pr to remove the cache.


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

