### PR TITLE
fix: add the missing abab6.5t-chat model of Minimax

### DIFF
--- a/api/core/model_runtime/model_providers/minimax/llm/llm.py
+++ b/api/core/model_runtime/model_providers/minimax/llm/llm.py
@@ -35,6 +35,7 @@ from core.model_runtime.model_providers.minimax.llm.types import MinimaxMessage
 class MinimaxLargeLanguageModel(LargeLanguageModel):
     model_apis = {
         "abab7-chat-preview": MinimaxChatCompletionPro,
+        "abab6.5t-chat": MinimaxChatCompletionPro,
         "abab6.5s-chat": MinimaxChatCompletionPro,
         "abab6.5-chat": MinimaxChatCompletionPro,
         "abab6-chat": MinimaxChatCompletionPro,


### PR DESCRIPTION
# Summary

There is a LLM model named `abab6.5t-chat` in `api/core/model_runtime/model_providers/minimax/llm`, but it's missing in `api/core/model_runtime/model_providers/minimax/llm/llm.py`, so if select `abab6.5t-chat` model and run the application, a `KeyError` will be threw.


# Screenshots

-

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

