### PR TITLE
fix: cannot close notification manually

### DIFF
--- a/web/app/components/base/toast/index.tsx
+++ b/web/app/components/base/toast/index.tsx
@@ -123,7 +123,17 @@ Toast.notify = ({
     const holder = document.createElement('div')
     const root = createRoot(holder)
 
-    root.render(<Toast type={type} size={size} message={message} duration={duration} className={className} />)
+    root.render(
+      <ToastContext.Provider value={{
+        notify: () => {},
+        close: () => {
+          if (holder)
+            holder.remove()
+        },
+      }}>
+        <Toast type={type} size={size} message={message} duration={duration} className={className} />
+      </ToastContext.Provider>,
+    )
     document.body.appendChild(holder)
     setTimeout(() => {
       if (holder)

--- a/web/app/components/base/toast/index.tsx
+++ b/web/app/components/base/toast/index.tsx
@@ -127,8 +127,10 @@ Toast.notify = ({
       <ToastContext.Provider value={{
         notify: () => {},
         close: () => {
-          if (holder)
+          if (holder) {
+            root.unmount()
             holder.remove()
+          }
         },
       }}>
         <Toast type={type} size={size} message={message} duration={duration} className={className} />
@@ -136,8 +138,10 @@ Toast.notify = ({
     )
     document.body.appendChild(holder)
     setTimeout(() => {
-      if (holder)
+      if (holder) {
+        root.unmount()
         holder.remove()
+      }
     }, duration || defaultDuring)
   }
 }


### PR DESCRIPTION
# Summary

Fixed the issue where the notification could not be closed manually. Additionally, to prevent potential memory leaks, ensured that the Toast component is properly unmounted on close.

# Screenshots

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/efc77e5b-eb78-4fbd-8232-c1bd0da682cb">    |  <video src="https://github.com/user-attachments/assets/ee1d6191-b60c-4fa2-9e66-55ef92c4f0c7">   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

