### PR TITLE
chore: fix typo in Japanese localization

### DIFF
--- a/web/i18n/ja-JP/app.ts
+++ b/web/i18n/ja-JP/app.ts
@@ -128,7 +128,7 @@ const translation = {
     inUse: '使用中',
     configProvider: {
       title: '配置 ',
-      placeholder: 'あなた様の{{key}}を入力しでください',
+      placeholder: 'あなた様の{{key}}を入力してください',
       project: 'プロジェクト',
       publicKey: '公開キー',
       secretKey: '秘密キー',

--- a/web/i18n/ja-JP/tools.ts
+++ b/web/i18n/ja-JP/tools.ts
@@ -27,7 +27,7 @@ const translation = {
     type: 'タイプ',
     category: 'カテゴリー',
     add: '追加',
-    added: '追加されだ',
+    added: '追加された',
     manageInTools: 'ツールリストに移動して管理する',
     emptyTitle: '利用可能なワークフローツールはありません',
     emptyTip: '追加するには、「ワークフロー -> ツールとして公開 」に移動する',


### PR DESCRIPTION
# Summary

Fixed a typo in the Japanese localization (i18n)

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

