### PR TITLE
chore : fix translation Typo in ko-KR localization

### DIFF
--- a/web/i18n/ko-KR/dataset-documents.ts
+++ b/web/i18n/ko-KR/dataset-documents.ts
@@ -220,7 +220,7 @@ const translation = {
         paragraphs: '문단',
         hitCount: '검색 횟수',
         embeddingTime: '임베딩 시간',
-        embeddedSpend: '임베딩 시간',
+        embeddedSpend: '임베딩 소모',
       },
     },
     languageMap: {


### PR DESCRIPTION
# Summary
This PR resolves a translation issue in the Korean (ko-KR) localization file dataset-documents.ts for embedding metrics. Both "Embedding Time" and "Embedding Spend" were previously translated as "임베딩 시간," causing user confusion. The term "Embedding Spend" has been corrected to "임베딩 소모" to differentiate between the two metrics.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

