### PR TITLE
fix: more robust toolcall argument json.load

### DIFF
--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -340,7 +340,27 @@ class FunctionCallAgentRunner(BaseAgentRunner):
         for prompt_message in llm_result_chunk.delta.message.tool_calls:
             args = {}
             if prompt_message.function.arguments != "":
-                args = json.loads(prompt_message.function.arguments)
+                try_load_str = prompt_message.function.arguments
+                while True:
+                    if len(try_load_str) == 0:
+                        break
+                    try:
+                        args = json.loads(try_load_str)
+                        break
+                    except Exception as e:
+                        logging.error("error try_load_str: " + try_load_str)
+                        first_left_brace_index = try_load_str.find("{")
+                        if len(try_load_str) >= first_left_brace_index + 1:
+                            try_load_str = try_load_str[try_load_str.find("{") + 1 :]
+                            # find next left brace
+                            next_left_brace_index = try_load_str.find("{")
+                            if next_left_brace_index == -1:
+                                logging.error("error try_load_str not found next left brace: " + try_load_str)
+                                break
+                            try_load_str = try_load_str[next_left_brace_index:]
+                        else:
+                            logging.error("error try_load_str not found next left brace: " + try_load_str)
+                            break
 
             tool_calls.append(
                 (


### PR DESCRIPTION
# Summary

Sometimes dify tool`s arguments parse error and failed. After debug the code and make llm request manually I find that the llm api return tool`s arguments in wrong format like this: 
```
{\"min_age\":{\"min_age\": 35}
```
so we should make arguments parse in more robust way, just find the correct left brace and parse it.
> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

