### PR TITLE
fix: make prompt consistent with few-show examples

### DIFF
--- a/api/core/workflow/nodes/question_classifier/template_prompts.py
+++ b/api/core/workflow/nodes/question_classifier/template_prompts.py
@@ -1,21 +1,21 @@
 QUESTION_CLASSIFIER_SYSTEM_PROMPT = """
-    ### Job Description',
-    You are a text classification engine that analyzes text data and assigns categories based on user input or automatically determined categories.
-    ### Task
-    Your task is to assign one categories ONLY to the input text and only one category may be assigned returned in the output. Additionally, you need to extract the key words from the text that are related to the classification.
-    ### Format
-    The input text is in the variable input_text. Categories are specified as a category list with two filed category_id and category_name in the variable categories. Classification instructions may be included to improve the classification accuracy.
-    ### Constraint
-    DO NOT include anything other than the JSON array in your response.
-    ### Memory
-    Here are the chat histories between human and assistant, inside <histories></histories> XML tags.
-    <histories>
-    {histories}
-    </histories>
+### Job Description',
+You are a text classification engine that analyzes text data and assigns categories based on user input or automatically determined categories.
+### Task
+Your task is to assign one categories ONLY to the input text and only one category may be assigned returned in the output. Additionally, you need to extract the key words from the text that are related to the classification.
+### Format
+The input text is in the variable input_text. Categories are specified as a category list with two filed category_id and category_name in the variable categories. Classification instructions may be included to improve the classification accuracy.
+### Constraint
+DO NOT include anything other than the JSON array in your response.
+### Memory
+Here are the chat histories between human and assistant, inside <histories></histories> XML tags.
+<histories>
+{histories}
+</histories>
 """  # noqa: E501
 
 QUESTION_CLASSIFIER_USER_PROMPT_1 = """
-    { "input_text": ["I recently had a great experience with your company. The service was prompt and the staff was very friendly."],
+    {"input_text": ["I recently had a great experience with your company. The service was prompt and the staff was very friendly."],
     "categories": [{"category_id":"f5660049-284f-41a7-b301-fd24176a711c","category_name":"Customer Service"},{"category_id":"8d007d06-f2c9-4be5-8ff6-cd4381c13c60","category_name":"Satisfaction"},{"category_id":"5fbbbb18-9843-466d-9b8e-b9bfbb9482c8","category_name":"Sales"},{"category_id":"23623c75-7184-4a2e-8226-466c2e4631e4","category_name":"Product"}],
     "classification_instructions": ["classify the text based on the feedback provided by customer"]}
 """  # noqa: E501
@@ -43,9 +43,9 @@ QUESTION_CLASSIFIER_ASSISTANT_PROMPT_2 = """
 """
 
 QUESTION_CLASSIFIER_USER_PROMPT_3 = """
-    '{{"input_text": ["{input_text}"],',
-    '"categories": {categories}, ',
-    '"classification_instructions": ["{classification_instructions}"]}}'
+    {{"input_text": ["{input_text}"],
+    "categories": {categories},
+    "classification_instructions": ["{classification_instructions}"]}}
 """
 
 QUESTION_CLASSIFIER_COMPLETION_PROMPT = """

--- a/api/core/workflow/nodes/question_classifier/template_prompts.py
+++ b/api/core/workflow/nodes/question_classifier/template_prompts.py
@@ -1,4 +1,4 @@
-QUESTION_CLASSIFIER_SYSTEM_PROMPT = """\
+QUESTION_CLASSIFIER_SYSTEM_PROMPT = """
 ### Job Description',
 You are a text classification engine that analyzes text data and assigns categories based on user input or automatically determined categories.
 ### Task

--- a/api/core/workflow/nodes/question_classifier/template_prompts.py
+++ b/api/core/workflow/nodes/question_classifier/template_prompts.py
@@ -1,4 +1,4 @@
-QUESTION_CLASSIFIER_SYSTEM_PROMPT = """
+QUESTION_CLASSIFIER_SYSTEM_PROMPT = """\
 ### Job Description',
 You are a text classification engine that analyzes text data and assigns categories based on user input or automatically determined categories.
 ### Task


### PR DESCRIPTION
# Summary

- `QUESTION_CLASSIFIER_USER_PROMPT_3` has different style with few-shot examples.
- fix markdown
- fix json

# Screenshots

| Before | After |
|--------|-------|
| `    ### Task` | `### Task` |
| `{ "input_text"`   | `{"input_text"`  |
| `'{{"input_text":`   | `{{"input_text":`  |


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

