### PR TITLE
fix: iteration node in parallel mode token count error

### DIFF
--- a/api/core/workflow/nodes/iteration/iteration_node.py
+++ b/api/core/workflow/nodes/iteration/iteration_node.py
@@ -182,7 +182,6 @@ class IterationNode(BaseNode[IterationNodeData]):
                     future.add_done_callback(thread_pool.task_done_callback)
                     futures.append(future)
                 succeeded_count = 0
-                empty_count = 0
                 while True:
                     try:
                         event = q.get(timeout=1)
@@ -202,6 +201,8 @@ class IterationNode(BaseNode[IterationNodeData]):
                         if isinstance(event, IterationRunFailedEvent):
                             q.put(None)
                             yield event
+                        if isinstance(event, int):
+                            graph_engine.graph_runtime_state.total_tokens += event
                     except Empty:
                         continue
 
@@ -593,3 +594,4 @@ class IterationNode(BaseNode[IterationNodeData]):
                 parallel_mode_run_id=parallel_mode_run_id,
             ):
                 q.put(event)
+            q.put(graph_engine_copy.graph_runtime_state.total_tokens)

--- a/api/core/workflow/nodes/iteration/iteration_node.py
+++ b/api/core/workflow/nodes/iteration/iteration_node.py
@@ -201,8 +201,6 @@ class IterationNode(BaseNode[IterationNodeData]):
                         if isinstance(event, IterationRunFailedEvent):
                             q.put(None)
                             yield event
-                        if isinstance(event, int):
-                            graph_engine.graph_runtime_state.total_tokens += event
                     except Empty:
                         continue
 
@@ -594,4 +592,4 @@ class IterationNode(BaseNode[IterationNodeData]):
                 parallel_mode_run_id=parallel_mode_run_id,
             ):
                 q.put(event)
-            q.put(graph_engine_copy.graph_runtime_state.total_tokens)
+            graph_engine.graph_runtime_state.total_tokens += graph_engine_copy.graph_runtime_state.total_tokens


### PR DESCRIPTION
# Summary

when use the iteration node in parallel mode, the llm token usage is 0 before, now the iteration token is the right number.

> [!Tip]
Fixes #10655 

# Screenshots

| Before | After |
|--------|-------|
|  <img width="1776" alt="image" src="https://github.com/user-attachments/assets/ed788329-5972-4d5b-b3d6-478b8537ad41">| ![img_v3_02hf_e1af8d7d-f4eb-4fde-bdb9-e7dcf7a12bcg](https://github.com/user-attachments/assets/123c7f75-d76a-4c14-a829-246ae5180c37) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

