### PR TITLE
fix: Multiple Paths Between IF/ELSE Branches Invalidate Conditions 

### DIFF
--- a/api/core/workflow/nodes/answer/answer_stream_generate_router.py
+++ b/api/core/workflow/nodes/answer/answer_stream_generate_router.py
@@ -147,6 +147,8 @@ class AnswerStreamGeneratorRouter:
         reverse_edges = reverse_edge_mapping.get(current_node_id, [])
         for edge in reverse_edges:
             source_node_id = edge.source_node_id
+            if source_node_id not in node_id_config_mapping:
+                continue
             source_node_type = node_id_config_mapping[source_node_id].get("data", {}).get("type")
             if source_node_type in {
                 NodeType.ANSWER,

--- a/api/core/workflow/nodes/end/end_stream_generate_router.py
+++ b/api/core/workflow/nodes/end/end_stream_generate_router.py
@@ -135,6 +135,8 @@ class EndStreamGeneratorRouter:
         reverse_edges = reverse_edge_mapping.get(current_node_id, [])
         for edge in reverse_edges:
             source_node_id = edge.source_node_id
+            if source_node_id not in node_id_config_mapping:
+                continue
             source_node_type = node_id_config_mapping[source_node_id].get("data", {}).get("type")
             if source_node_type in {
                 NodeType.IF_ELSE.value,


### PR DESCRIPTION
# Summary

fix: Multiple Paths Between IF/ELSE Branches Invalidate Conditions by `contiune` the id do not in the map.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fix https://github.com/langgenius/dify/issues/11542

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

