### PR TITLE
Use DefaultAzureCredential for managed identity in azure blob extention

### DIFF
--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -65,7 +65,7 @@ class AzureBlobStorage(BaseStorage):
     def _sync_client(self):
         if self.account_key == "managedidentity":
             return BlobServiceClient(account_url=self.account_url, credential=self.credential)
-        
+
         cache_key = "azure_blob_sas_token_{}_{}".format(self.account_name, self.account_key)
         cache_result = redis_client.get(cache_key)
         if cache_result is not None:

--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -19,7 +19,7 @@ class AzureBlobStorage(BaseStorage):
         self.account_name = dify_config.AZURE_BLOB_ACCOUNT_NAME
         self.account_key = dify_config.AZURE_BLOB_ACCOUNT_KEY
 
-        if not self.account_key:
+        if self.account_key == "managedidentity":
             self.credential = DefaultAzureCredential()
         else:
             self.credential = None
@@ -63,7 +63,7 @@ class AzureBlobStorage(BaseStorage):
         blob_container.delete_blob(filename)
 
     def _sync_client(self):
-        if not self.account_key and self.credential:
+        if self.account_key == "managedidentity":
             return BlobServiceClient(account_url=self.account_url, credential=self.credential)
         
         cache_key = "azure_blob_sas_token_{}_{}".format(self.account_name, self.account_key)

--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 
+from azure.identity import DefaultAzureCredential
 from azure.storage.blob import AccountSasPermissions, BlobServiceClient, ResourceTypes, generate_account_sas
 
 from configs import dify_config
@@ -17,6 +18,11 @@ class AzureBlobStorage(BaseStorage):
         self.account_url = dify_config.AZURE_BLOB_ACCOUNT_URL
         self.account_name = dify_config.AZURE_BLOB_ACCOUNT_NAME
         self.account_key = dify_config.AZURE_BLOB_ACCOUNT_KEY
+
+        if not self.account_key:
+            self.credential = DefaultAzureCredential()
+        else:
+            self.credential = None
 
     def save(self, filename, data):
         client = self._sync_client()
@@ -57,6 +63,9 @@ class AzureBlobStorage(BaseStorage):
         blob_container.delete_blob(filename)
 
     def _sync_client(self):
+        if not self.account_key and self.credential:
+            return BlobServiceClient(account_url=self.account_url, credential=self.credential)
+        
         cache_key = "azure_blob_sas_token_{}_{}".format(self.account_name, self.account_key)
         cache_result = redis_client.get(cache_key)
         if cache_result is not None:


### PR DESCRIPTION
# Summary

I prefer not to save the key as an environment variable when using Dify on Azure. I would like to modify it so that when `AZURE_BLOB_ACCOUNT_KEY` is set to `managedidentity`, it uses DefaultAzureCredential to use the Managed Identity assigned to the resource.

Resolves #11558 


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

