### PR TITLE
Change Image Size to 100%

### DIFF
--- a/web/app/styles/markdown.scss
+++ b/web/app/styles/markdown.scss
@@ -157,6 +157,7 @@
   max-width: 100%;
   box-sizing: content-box;
   background-color: var(--color-canvas-default);
+  height: 100%;
 }
 
 .markdown-body code,


### PR DESCRIPTION
The image size is too small due to:
```
.style_item__mwjpN {
    height: 200px; 
    margin-right: 8px;
    margin-bottom: 8px;
    -o-object-fit: cover;
    object-fit: cover;
    -o-object-position: center;
    object-position: center;
    border-radius: 8px;
    cursor: pointer;
}
```
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/4f64f811-60b3-4a98-b1ff-92f224d38499" />

This PR overrides the fixed height of 200px by adding `height: 100%`:
```
.markdown-body img {
  border-style: none;
  max-width: 100%;
  box-sizing: content-box;
  background-color: var(--color-canvas-default);
  height: 100%;
}
```
Now, the image is in its full size.

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/37a7c0cb-c27b-4fbe-b13a-d4d2b26e6727" />

