### PR TITLE
fix: better opendal tests

### DIFF
--- a/api/extensions/storage/opendal_storage.py
+++ b/api/extensions/storage/opendal_storage.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import opendal
+
 from configs.middleware.storage.opendal_storage_config import OpenDALScheme
 from extensions.storage.base_storage import BaseStorage
 

--- a/api/extensions/storage/opendal_storage.py
+++ b/api/extensions/storage/opendal_storage.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import opendal
-
 from configs.middleware.storage.opendal_storage_config import OpenDALScheme
 from extensions.storage.base_storage import BaseStorage
 
@@ -58,8 +57,14 @@ class OpenDALStorage(BaseStorage):
         with Path(target_filepath).open("wb") as f:
             f.write(self.op.read(path=filename))
 
-    def exists(self, filename: str):
-        return self.op.stat(path=filename).mode.is_file()
+    def exists(self, filename: str) -> bool:
+        # FIXME this is a workaround for opendal python-binding do not have a exists method and no better
+        # error handler here when opendal python-binding has a exists method, we should use it
+        # more https://github.com/apache/opendal/blob/main/bindings/python/src/operator.rs
+        try:
+            return self.op.stat(path=filename).mode.is_file()
+        except Exception as e:
+            return False
 
     def delete(self, filename: str):
         if self.exists(filename):

--- a/api/tests/unit_tests/oss/opendal/test_opendal.py
+++ b/api/tests/unit_tests/oss/opendal/test_opendal.py
@@ -1,15 +1,20 @@
+import os
+from collections.abc import Generator
+from pathlib import Path
+
 import pytest
 
 from configs.middleware.storage.opendal_storage_config import OpenDALScheme
 from extensions.storage.opendal_storage import OpenDALStorage
 from tests.unit_tests.oss.__mock.base import (
-    BaseStorageTest,
+    get_example_data,
+    get_example_filename,
+    get_example_filepath,
     get_example_folder,
 )
-from tests.unit_tests.oss.__mock.local import setup_local_fs_mock
 
 
-class TestOpenDAL(BaseStorageTest):
+class TestOpenDAL:
     @pytest.fixture(autouse=True)
     def setup_method(self, *args, **kwargs):
         """Executed before each test method."""
@@ -17,3 +22,68 @@ class TestOpenDAL(BaseStorageTest):
             scheme=OpenDALScheme.FS,
             root=get_example_folder(),
         )
+
+    def teardown_method(self, method):
+        """Clean up after each test method."""
+        try:
+            if self.storage.exists(get_example_filename()):
+                self.storage.delete(get_example_filename())
+
+            filepath = Path(get_example_filepath())
+            if filepath.exists():
+                filepath.unlink()
+        except:
+            pass
+
+    def test_save_and_exists(self):
+        """Test saving data and checking existence."""
+        filename = get_example_filename()
+        data = get_example_data()
+
+        assert not self.storage.exists(filename)
+        self.storage.save(filename, data)
+        assert self.storage.exists(filename)
+
+    def test_load_once(self):
+        """Test loading data once."""
+        filename = get_example_filename()
+        data = get_example_data()
+
+        self.storage.save(filename, data)
+        loaded_data = self.storage.load_once(filename)
+        assert loaded_data == data
+
+    def test_load_stream(self):
+        """Test loading data as a stream."""
+        filename = get_example_filename()
+        data = get_example_data()
+
+        self.storage.save(filename, data)
+        generator = self.storage.load_stream(filename)
+        assert isinstance(generator, Generator)
+        assert next(generator) == data
+
+    def test_download(self):
+        """Test downloading data to a file."""
+        filename = get_example_filename()
+        filepath = get_example_filepath()
+        data = get_example_data()
+
+        self.storage.save(filename, data)
+        self.storage.download(filename, filepath)
+
+        downloaded_path = Path(filepath)
+        assert downloaded_path.exists()
+        downloaded_data = downloaded_path.read_bytes()
+        assert downloaded_data == data
+
+    def test_delete(self):
+        """Test deleting a file."""
+        filename = get_example_filename()
+        data = get_example_data()
+
+        self.storage.save(filename, data)
+        assert self.storage.exists(filename)
+
+        self.storage.delete(filename)
+        assert not self.storage.exists(filename)


### PR DESCRIPTION
This patch use better opendal tests that use its own tests and delete the dir created during the tests after unit test done. also fix OpenDALStorage exists api for opendal python binding do not support the exists for now, and add FIXME to info us.

more info can check this commit, opendal tests now, may add a empty dir and may push by accident...:

https://github.com/langgenius/dify/pull/11561/commits/1fe3c0ca6880da7903b53b6c318356eee0d06238

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

