### PR TITLE
feat: add parameters for JinaReaderTool

### DIFF
--- a/api/core/tools/provider/builtin/jina/tools/jina_reader.py
+++ b/api/core/tools/provider/builtin/jina/tools/jina_reader.py
@@ -43,6 +43,13 @@ class JinaReaderTool(BuiltinTool):
         if wait_for_selector is not None and wait_for_selector != "":
             headers["X-Wait-For-Selector"] = wait_for_selector
 
+        remove_selector = tool_parameters.get("remove_selector")
+        if remove_selector is not None and remove_selector != "":
+            headers["X-Remove-Selector"] = remove_selector
+
+        if tool_parameters.get("retain_images", False):
+            headers["X-Retain-Images"] = "true"
+
         if tool_parameters.get("image_caption", False):
             headers["X-With-Generated-Alt"] = "true"
 
@@ -58,6 +65,12 @@ class JinaReaderTool(BuiltinTool):
 
         if tool_parameters.get("no_cache", False):
             headers["X-No-Cache"] = "true"
+
+        if tool_parameters.get("with_iframe", False):
+            headers["X-With-Iframe"] = "true"
+
+        if tool_parameters.get("with_shadow_dom", False):
+            headers["X-With-Shadow-Dom"] = "true"
 
         max_retries = tool_parameters.get("max_retries", 3)
         response = ssrf_proxy.get(

--- a/api/core/tools/provider/builtin/jina/tools/jina_reader.yaml
+++ b/api/core/tools/provider/builtin/jina/tools/jina_reader.yaml
@@ -67,6 +67,33 @@ parameters:
       pt_BR: css selector para aguardar elementos específicos
     llm_description: css selector of the target element to wait for
     form: form
+  - name: remove_selector
+    type: string
+    required: false
+    label:
+      en_US: Excluded Selector
+      zh_Hans: 排除选择器
+      pt_BR: Seletor Excluído
+    human_description:
+      en_US: css selector for remove for specific elements
+      zh_Hans: css 选择器用于排除特定元素
+      pt_BR: seletor CSS para remover elementos específicos
+    llm_description: css selector of the target element to remove for
+    form: form
+  - name: retain_images
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Remove All Images
+      zh_Hans: 删除所有图片
+      pt_BR: Remover todas as imagens
+    human_description:
+      en_US: Removes all images from the response.
+      zh_Hans: 从响应中删除所有图片。
+      pt_BR: Remove todas as imagens da resposta.
+    llm_description: Remove all images
+    form: form
   - name: image_caption
     type: boolean
     required: false
@@ -135,6 +162,34 @@ parameters:
       zh_Hans: 是否绕过缓存
       pt_BR: Ignorar o cache
     llm_description: bypass the cache
+    form: form
+  - name: with_iframe
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Enable iframe extraction
+      zh_Hans: 启用 iframe 提取
+      pt_BR: Habilitar extração de iframe
+    human_description:
+      en_US: Extract and process content of all embedded iframes in the DOM tree.
+      zh_Hans: 提取并处理 DOM 树中所有嵌入 iframe 的内容。
+      pt_BR: Extrair e processar o conteúdo de todos os iframes incorporados na árvore DOM.
+    llm_description: Extract content from embedded iframes
+    form: form
+  - name: with_shadow_dom
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Enable Shadow DOM extraction
+      zh_Hans: 启用 Shadow DOM 提取
+      pt_BR: Habilitar extração de Shadow DOM
+    human_description:
+      en_US: Traverse all Shadow DOM roots in the document and extract content.
+      zh_Hans: 遍历文档中所有 Shadow DOM 根并提取内容。
+      pt_BR: Percorra todas as raízes do Shadow DOM no documento e extraia o conteúdo.
+    llm_description: Extract content from Shadow DOM roots
     form: form
   - name: summary
     type: boolean


### PR DESCRIPTION
# Summary

Based on the [jina.ai](https://jina.ai/reader/) documentation, the following new parameters have been added to JinaReaderTool to enhance its functionality and flexibility:

- `X-Remove-Selector`: Excluded Selector。
- `X-Retain-Images`: Remove All Images
- `X-With-Iframe`: Enable iframe extraction
- `X-With-Shadow-Dom`: Enable Shadow DOM extraction

![image](https://github.com/user-attachments/assets/8bce758d-253e-4b94-b1d8-81b59e519ce4)

# Screenshots

| Before | After |
|--------|-------|
| ![屏幕截图 2024-12-12 jina-before](https://github.com/user-attachments/assets/28af8dfc-4a3d-4235-bdeb-4ec1c50f0e1e) | ![屏幕截图 2024-12-12 jina-after](https://github.com/user-attachments/assets/91e0758d-4afd-4798-a6ec-5acdfc371dff)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

