### PR TITLE
fix: split dir for opendal tests

### DIFF
--- a/api/tests/unit_tests/oss/__mock/base.py
+++ b/api/tests/unit_tests/oss/__mock/base.py
@@ -13,6 +13,10 @@ def get_example_bucket() -> str:
     return "dify"
 
 
+def get_opendal_bucket() -> str:
+    return "./dify"
+
+
 def get_example_filename() -> str:
     return "test.txt"
 


### PR DESCRIPTION
# Summary

change opendal test dir and make sure we can delete them

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

