### PR TITLE
test: run vdb tests on TiDB Vector with docker in CI tests

### DIFF
--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Expose Service Ports
         run: sh .github/workflows/expose_service_ports.sh
 
-      - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
+      - name: Set up Vector Stores (TiDB, Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
         uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           compose-file: |
@@ -67,6 +67,7 @@ jobs:
             pgvector
             chroma
             elasticsearch
+            tidb
 
       - name: Test Vector Stores
         run: poetry run -C api bash dev/pytest/pytest_vdb.sh

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Expose Service Ports
         run: sh .github/workflows/expose_service_ports.sh
 
-      - name: Set up Vector Stores (TiDB, Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
+      - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
         uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           compose-file: |
@@ -67,7 +67,6 @@ jobs:
             pgvector
             chroma
             elasticsearch
-            tidb
 
       - name: Test Vector Stores
         run: poetry run -C api bash dev/pytest/pytest_vdb.sh

--- a/api/core/rag/datasource/vdb/tidb_vector/tidb_vector.py
+++ b/api/core/rag/datasource/vdb/tidb_vector/tidb_vector.py
@@ -37,8 +37,6 @@ class TiDBVectorConfig(BaseModel):
             raise ValueError("config TIDB_VECTOR_PORT is required")
         if not values["user"]:
             raise ValueError("config TIDB_VECTOR_USER is required")
-        if not values["password"]:
-            raise ValueError("config TIDB_VECTOR_PASSWORD is required")
         if not values["database"]:
             raise ValueError("config TIDB_VECTOR_DATABASE is required")
         if not values["program_name"]:

--- a/api/core/rag/datasource/vdb/tidb_vector/tidb_vector.py
+++ b/api/core/rag/datasource/vdb/tidb_vector/tidb_vector.py
@@ -37,6 +37,8 @@ class TiDBVectorConfig(BaseModel):
             raise ValueError("config TIDB_VECTOR_PORT is required")
         if not values["user"]:
             raise ValueError("config TIDB_VECTOR_USER is required")
+        if not values["password"]:
+            raise ValueError("config TIDB_VECTOR_PASSWORD is required")
         if not values["database"]:
             raise ValueError("config TIDB_VECTOR_DATABASE is required")
         if not values["program_name"]:

--- a/api/tests/integration_tests/vdb/tidb_vector/test_tidb_vector.py
+++ b/api/tests/integration_tests/vdb/tidb_vector/test_tidb_vector.py
@@ -12,11 +12,11 @@ def tidb_vector():
     return TiDBVector(
         collection_name="test_collection",
         config=TiDBVectorConfig(
-            host="xxx.eu-central-1.xxx.aws.tidbcloud.com",
-            port="4000",
-            user="xxx.root",
-            password="xxxxxx",
-            database="dify",
+            host="localhost",
+            port=4000,
+            user="root",
+            password="",
+            database="test",
             program_name="langgenius/dify",
         ),
     )
@@ -27,35 +27,14 @@ class TiDBVectorTest(AbstractVectorTest):
         super().__init__()
         self.vector = vector
 
-    def text_exists(self):
-        exist = self.vector.text_exists(self.example_doc_id)
-        assert exist == False
-
-    def search_by_vector(self):
-        hits_by_vector: list[Document] = self.vector.search_by_vector(query_vector=self.example_embedding)
-        assert len(hits_by_vector) == 0
-
     def search_by_full_text(self):
         hits_by_full_text: list[Document] = self.vector.search_by_full_text(query=get_example_text())
         assert len(hits_by_full_text) == 0
 
     def get_ids_by_metadata_field(self):
-        ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
-        assert len(ids) == 0
+        ids = self.vector.get_ids_by_metadata_field(key="doc_id", value=self.example_doc_id)
+        assert len(ids) == 1
 
 
-def test_tidb_vector(setup_mock_redis, setup_tidbvector_mock, tidb_vector, mock_session):
+def test_tidb_vector(setup_mock_redis, tidb_vector):
     TiDBVectorTest(vector=tidb_vector).run_all_tests()
-
-
-@pytest.fixture
-def mock_session():
-    with patch("core.rag.datasource.vdb.tidb_vector.tidb_vector.Session", new_callable=MagicMock) as mock_session:
-        yield mock_session
-
-
-@pytest.fixture
-def setup_tidbvector_mock(tidb_vector, mock_session):
-    with patch("core.rag.datasource.vdb.tidb_vector.tidb_vector.create_engine"):
-        with patch.object(tidb_vector._engine, "connect"):
-            yield tidb_vector

--- a/api/tests/integration_tests/vdb/tidb_vector/test_tidb_vector.py
+++ b/api/tests/integration_tests/vdb/tidb_vector/test_tidb_vector.py
@@ -12,11 +12,11 @@ def tidb_vector():
     return TiDBVector(
         collection_name="test_collection",
         config=TiDBVectorConfig(
-            host="localhost",
-            port=4000,
-            user="root",
-            password="",
-            database="test",
+            host="xxx.eu-central-1.xxx.aws.tidbcloud.com",
+            port="4000",
+            user="xxx.root",
+            password="xxxxxx",
+            database="dify",
             program_name="langgenius/dify",
         ),
     )
@@ -27,14 +27,35 @@ class TiDBVectorTest(AbstractVectorTest):
         super().__init__()
         self.vector = vector
 
+    def text_exists(self):
+        exist = self.vector.text_exists(self.example_doc_id)
+        assert exist == False
+
+    def search_by_vector(self):
+        hits_by_vector: list[Document] = self.vector.search_by_vector(query_vector=self.example_embedding)
+        assert len(hits_by_vector) == 0
+
     def search_by_full_text(self):
         hits_by_full_text: list[Document] = self.vector.search_by_full_text(query=get_example_text())
         assert len(hits_by_full_text) == 0
 
     def get_ids_by_metadata_field(self):
-        ids = self.vector.get_ids_by_metadata_field(key="doc_id", value=self.example_doc_id)
-        assert len(ids) == 1
+        ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
+        assert len(ids) == 0
 
 
-def test_tidb_vector(setup_mock_redis, tidb_vector):
+def test_tidb_vector(setup_mock_redis, setup_tidbvector_mock, tidb_vector, mock_session):
     TiDBVectorTest(vector=tidb_vector).run_all_tests()
+
+
+@pytest.fixture
+def mock_session():
+    with patch("core.rag.datasource.vdb.tidb_vector.tidb_vector.Session", new_callable=MagicMock) as mock_session:
+        yield mock_session
+
+
+@pytest.fixture
+def setup_tidbvector_mock(tidb_vector, mock_session):
+    with patch("core.rag.datasource.vdb.tidb_vector.tidb_vector.create_engine"):
+        with patch.object(tidb_vector._engine, "connect"):
+            yield tidb_vector

--- a/dev/pytest/pytest_vdb.sh
+++ b/dev/pytest/pytest_vdb.sh
@@ -14,3 +14,4 @@ pytest api/tests/integration_tests/vdb/chroma \
   api/tests/integration_tests/vdb/upstash \
   api/tests/integration_tests/vdb/couchbase \
   api/tests/integration_tests/vdb/oceanbase \
+  api/tests/integration_tests/vdb/tidb_vector \

--- a/dev/pytest/pytest_vdb.sh
+++ b/dev/pytest/pytest_vdb.sh
@@ -14,4 +14,3 @@ pytest api/tests/integration_tests/vdb/chroma \
   api/tests/integration_tests/vdb/upstash \
   api/tests/integration_tests/vdb/couchbase \
   api/tests/integration_tests/vdb/oceanbase \
-  api/tests/integration_tests/vdb/tidb_vector \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -491,16 +491,6 @@ services:
       - '${EXPOSE_NGINX_PORT:-80}:${NGINX_PORT:-80}'
       - '${EXPOSE_NGINX_SSL_PORT:-443}:${NGINX_SSL_PORT:-443}'
 
-  # The TiDB vector store.
-  # For production use, please refer to https://github.com/pingcap/tidb-docker-compose
-  tidb:
-    image: pingcap/tidb:latest
-    ports:
-      - "4000:4000"
-    command:
-      - --store=unistore
-    restart: on-failure
-
   # The Weaviate vector store.
   weaviate:
     image: semitechnologies/weaviate:1.19.0

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -494,12 +494,12 @@ services:
   # The TiDB vector store.
   # For production use, please refer to https://github.com/pingcap/tidb-docker-compose
   tidb:
-    image: pingcap/tidb:latest
+    image: pingcap/tidb:v8.4.0
     ports:
       - "4000:4000"
     command:
       - --store=unistore
-    restart: on-failure
+    restart: always
 
   # The Weaviate vector store.
   weaviate:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -491,6 +491,16 @@ services:
       - '${EXPOSE_NGINX_PORT:-80}:${NGINX_PORT:-80}'
       - '${EXPOSE_NGINX_SSL_PORT:-443}:${NGINX_SSL_PORT:-443}'
 
+  # The TiDB vector store.
+  # For production use, please refer to https://github.com/pingcap/tidb-docker-compose
+  tidb:
+    image: pingcap/tidb:latest
+    ports:
+      - "4000:4000"
+    command:
+      - --store=unistore
+    restart: on-failure
+
   # The Weaviate vector store.
   weaviate:
     image: semitechnologies/weaviate:1.19.0


### PR DESCRIPTION
# Summary
- TiDB v8.4.0 has been released with Vector Search in self-managed version for the first time in Nov 2024, referring to (https://docs.pingcap.com/tidb/v8.4/release-8.4.0#tidb-840-release-notes). 
- This PR set-up TiDB for vdb tests with docker compose and run CI tests on it.


# Screenshots

<img width="981" alt="image" src="https://github.com/user-attachments/assets/d8241539-10d2-4952-9e68-c0045efca404" />


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

