### PR TITLE
feat: Disable the "Forgot your password?" button when the mail server setup is incomplete

### DIFF
--- a/api/services/feature_service.py
+++ b/api/services/feature_service.py
@@ -63,6 +63,7 @@ class SystemFeatureModel(BaseModel):
     enable_social_oauth_login: bool = False
     is_allow_register: bool = False
     is_allow_create_workspace: bool = False
+    is_email_setup: bool = False
     license: LicenseModel = LicenseModel()
 
 
@@ -88,6 +89,9 @@ class FeatureService:
             system_features.enable_web_sso_switch_component = True
 
             cls._fulfill_params_from_enterprise(system_features)
+
+        if dify_config.MAIL_TYPE:
+            system_features.is_email_setup = True;
 
         return system_features
 

--- a/api/services/feature_service.py
+++ b/api/services/feature_service.py
@@ -91,7 +91,7 @@ class FeatureService:
             cls._fulfill_params_from_enterprise(system_features)
 
         if dify_config.MAIL_TYPE:
-            system_features.is_email_setup = True;
+            system_features.is_email_setup = True
 
         return system_features
 

--- a/api/services/feature_service.py
+++ b/api/services/feature_service.py
@@ -90,9 +90,6 @@ class FeatureService:
 
             cls._fulfill_params_from_enterprise(system_features)
 
-        if dify_config.MAIL_TYPE:
-            system_features.is_email_setup = True
-
         return system_features
 
     @classmethod
@@ -102,6 +99,7 @@ class FeatureService:
         system_features.enable_social_oauth_login = dify_config.ENABLE_SOCIAL_OAUTH_LOGIN
         system_features.is_allow_register = dify_config.ALLOW_REGISTER
         system_features.is_allow_create_workspace = dify_config.ALLOW_CREATE_WORKSPACE
+        system_features.is_email_setup = dify_config.MAIL_TYPE is not None and dify_config.MAIL_TYPE != ""
 
     @classmethod
     def _fulfill_params_from_env(cls, features: FeatureModel):

--- a/web/app/signin/components/mail-and-password-auth.tsx
+++ b/web/app/signin/components/mail-and-password-auth.tsx
@@ -12,12 +12,13 @@ import I18NContext from '@/context/i18n'
 
 type MailAndPasswordAuthProps = {
   isInvite: boolean
+  isEmailSetUp: boolean
   allowRegistration: boolean
 }
 
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/
 
-export default function MailAndPasswordAuth({ isInvite, allowRegistration }: MailAndPasswordAuthProps) {
+export default function MailAndPasswordAuth({ isInvite, isEmailSetUp, allowRegistration }: MailAndPasswordAuthProps) {
   const { t } = useTranslation()
   const { locale } = useContext(I18NContext)
   const router = useRouter()
@@ -124,7 +125,12 @@ export default function MailAndPasswordAuth({ isInvite, allowRegistration }: Mai
     <div className='mb-3'>
       <label htmlFor="password" className="my-2 flex items-center justify-between">
         <span className='system-md-semibold text-text-secondary'>{t('login.password')}</span>
-        <Link href={`/reset-password?${searchParams.toString()}`} className='system-xs-regular text-components-button-secondary-accent-text'>
+        <Link
+          href={`/reset-password?${searchParams.toString()}`}
+          className={`system-xs-regular ${isEmailSetUp ? 'text-components-button-secondary-accent-text' : 'text-components-button-secondary-accent-text-disabled pointer-events-none'}`}
+          tabIndex={isEmailSetUp ? 0 : -1}
+          aria-disabled={!isEmailSetUp}
+        >
           {t('login.forget')}
         </Link>
       </label>

--- a/web/app/signin/components/mail-and-password-auth.tsx
+++ b/web/app/signin/components/mail-and-password-auth.tsx
@@ -12,13 +12,13 @@ import I18NContext from '@/context/i18n'
 
 type MailAndPasswordAuthProps = {
   isInvite: boolean
-  isEmailSetUp: boolean
+  isEmailSetup: boolean
   allowRegistration: boolean
 }
 
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/
 
-export default function MailAndPasswordAuth({ isInvite, isEmailSetUp, allowRegistration }: MailAndPasswordAuthProps) {
+export default function MailAndPasswordAuth({ isInvite, isEmailSetup, allowRegistration }: MailAndPasswordAuthProps) {
   const { t } = useTranslation()
   const { locale } = useContext(I18NContext)
   const router = useRouter()
@@ -127,9 +127,9 @@ export default function MailAndPasswordAuth({ isInvite, isEmailSetUp, allowRegis
         <span className='system-md-semibold text-text-secondary'>{t('login.password')}</span>
         <Link
           href={`/reset-password?${searchParams.toString()}`}
-          className={`system-xs-regular ${isEmailSetUp ? 'text-components-button-secondary-accent-text' : 'text-components-button-secondary-accent-text-disabled pointer-events-none'}`}
-          tabIndex={isEmailSetUp ? 0 : -1}
-          aria-disabled={!isEmailSetUp}
+          className={`system-xs-regular ${isEmailSetup ? 'text-components-button-secondary-accent-text' : 'text-components-button-secondary-accent-text-disabled pointer-events-none'}`}
+          tabIndex={isEmailSetup ? 0 : -1}
+          aria-disabled={!isEmailSetup}
         >
           {t('login.forget')}
         </Link>

--- a/web/app/signin/normalForm.tsx
+++ b/web/app/signin/normalForm.tsx
@@ -163,7 +163,7 @@ const NormalForm = () => {
                 </div>}
               </>}
               {systemFeatures.enable_email_password_login && authType === 'password' && <>
-                <MailAndPasswordAuth isInvite={isInviteLink} allowRegistration={systemFeatures.is_allow_register} />
+                <MailAndPasswordAuth isInvite={isInviteLink} isEmailSetUp={systemFeatures.is_email_setup} allowRegistration={systemFeatures.is_allow_register} />
                 {systemFeatures.enable_email_code_login && <div className='cursor-pointer py-1 text-center' onClick={() => { updateAuthType('code') }}>
                   <span className='system-xs-medium text-components-button-secondary-accent-text'>{t('login.useVerificationCode')}</span>
                 </div>}

--- a/web/app/signin/normalForm.tsx
+++ b/web/app/signin/normalForm.tsx
@@ -163,7 +163,7 @@ const NormalForm = () => {
                 </div>}
               </>}
               {systemFeatures.enable_email_password_login && authType === 'password' && <>
-                <MailAndPasswordAuth isInvite={isInviteLink} isEmailSetUp={systemFeatures.is_email_setup} allowRegistration={systemFeatures.is_allow_register} />
+                <MailAndPasswordAuth isInvite={isInviteLink} isEmailSetup={systemFeatures.is_email_setup} allowRegistration={systemFeatures.is_allow_register} />
                 {systemFeatures.enable_email_code_login && <div className='cursor-pointer py-1 text-center' onClick={() => { updateAuthType('code') }}>
                   <span className='system-xs-medium text-components-button-secondary-accent-text'>{t('login.useVerificationCode')}</span>
                 </div>}

--- a/web/types/feature.ts
+++ b/web/types/feature.ts
@@ -29,6 +29,7 @@ export type SystemFeatures = {
   enable_social_oauth_login: boolean
   is_allow_create_workspace: boolean
   is_allow_register: boolean
+  is_email_setup: boolean
   license: License
 }
 
@@ -43,6 +44,7 @@ export const defaultSystemFeatures: SystemFeatures = {
   enable_social_oauth_login: false,
   is_allow_create_workspace: false,
   is_allow_register: false,
+  is_email_setup: false,
   license: {
     status: LicenseStatus.NONE,
     expired_at: '',


### PR DESCRIPTION
# Summary

Made the “Forgot your password?” link unclickable when email setup is not complete

close: https://github.com/langgenius/dify/issues/11650

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

## When mail setup is not yet complete
<img width="919" alt="スクリーンショット 2024-12-14 16 25 22" src="https://github.com/user-attachments/assets/8e2efd4b-cf26-48d2-a96a-92255dbb5a7c" />

## When mail setup is complete
<img width="920" alt="スクリーンショット 2024-12-14 16 24 07" src="https://github.com/user-attachments/assets/6ff70491-efec-4519-b558-b1cc23e4aef0" />



> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

