### PR TITLE
fix: change http node params from dict to list tuple

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -90,16 +90,25 @@ class Executor:
 
     def _init_params(self):
         """
-        Same as _init_headers(), but response as a list tuple.
-        Because params allow same key, like 'aa=1&aa=2'
+        Almost same as _init_headers(), difference:
+        1. response a list tuple to support same key, like 'aa=1&aa=2'
+        2. param value may have '\n', we need to splitlines then extract the variable value.
         """
-        params = self.variable_pool.convert_template(self.node_data.params).text
-        self.params = [
-            (key.strip(), value[0].strip() if value else "")
-            for line in params.splitlines()
-            if line.strip()
-            for key, *value in [line.split(":", 1)]
-        ]
+        result = []
+        for line in self.node_data.params.splitlines():
+            if not (line := line.strip()):
+                continue
+
+            key, *value = line.split(":", 1)
+            if not (key := key.strip()):
+                continue
+
+            value = value[0].strip() if value else ""
+            result.append(
+                (self.variable_pool.convert_template(key).text, self.variable_pool.convert_template(value).text)
+            )
+
+        self.params = result
 
     def _init_headers(self):
         """

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -195,7 +195,7 @@ def test_extract_selectors_from_template_with_newline():
         variable_pool=variable_pool,
     )
 
-    assert executor.params == [('test', 'line1\nline2')]
+    assert executor.params == [("test", "line1\nline2")]
 
 
 def test_executor_with_form_data():
@@ -268,7 +268,6 @@ def test_executor_with_form_data():
 
 
 def test_init_headers():
-
     def create_executor(headers: str) -> Executor:
         node_data = HttpRequestNodeData(
             title="test",
@@ -276,7 +275,7 @@ def test_init_headers():
             url="http://example.com",
             headers=headers,
             params="",
-            authorization=HttpRequestNodeAuthorization(type="no-auth")
+            authorization=HttpRequestNodeAuthorization(type="no-auth"),
         )
         timeout = HttpRequestNodeTimeout(connect=10, read=30, write=30)
         return Executor(node_data=node_data, timeout=timeout, variable_pool=VariablePool())
@@ -299,7 +298,6 @@ def test_init_headers():
 
 
 def test_init_params():
-
     def create_executor(params: str) -> Executor:
         node_data = HttpRequestNodeData(
             title="test",
@@ -307,7 +305,7 @@ def test_init_params():
             url="http://example.com",
             headers="",
             params=params,
-            authorization=HttpRequestNodeAuthorization(type="no-auth")
+            authorization=HttpRequestNodeAuthorization(type="no-auth"),
         )
         timeout = HttpRequestNodeTimeout(connect=10, read=30, write=30)
         return Executor(node_data=node_data, timeout=timeout, variable_pool=VariablePool())
@@ -315,39 +313,24 @@ def test_init_params():
     # Test basic key-value pairs
     executor = create_executor("key1:value1\nkey2:value2")
     executor._init_params()
-    assert executor.params == [
-        ("key1", "value1"),
-        ("key2", "value2")
-    ]
+    assert executor.params == [("key1", "value1"), ("key2", "value2")]
 
     # Test empty values
     executor = create_executor("key1:\nkey2:")
     executor._init_params()
-    assert executor.params == [
-        ("key1", ""),
-        ("key2", "")
-    ]
+    assert executor.params == [("key1", ""), ("key2", "")]
 
     # Test duplicate keys (which is allowed for params)
     executor = create_executor("key1:value1\nkey1:value2")
     executor._init_params()
-    assert executor.params == [
-        ("key1", "value1"),
-        ("key1", "value2")
-    ]
+    assert executor.params == [("key1", "value1"), ("key1", "value2")]
 
     # Test whitespace handling
     executor = create_executor(" key1 : value1 \n key2 : value2 ")
     executor._init_params()
-    assert executor.params == [
-        ("key1", "value1"),
-        ("key2", "value2")
-    ]
+    assert executor.params == [("key1", "value1"), ("key2", "value2")]
 
     # Test empty lines and extra whitespace
     executor = create_executor("key1:value1\n\nkey2:value2\n\n")
     executor._init_params()
-    assert executor.params == [
-        ("key1", "value1"),
-        ("key2", "value2")
-    ]
+    assert executor.params == [("key1", "value1"), ("key2", "value2")]

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -48,7 +48,7 @@ def test_executor_with_json_body_and_number_variable():
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/data"
     assert executor.headers == {"Content-Type": "application/json"}
-    assert executor.params == {}
+    assert executor.params == []
     assert executor.json == {"number": 42}
     assert executor.data is None
     assert executor.files is None
@@ -101,7 +101,7 @@ def test_executor_with_json_body_and_object_variable():
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/data"
     assert executor.headers == {"Content-Type": "application/json"}
-    assert executor.params == {}
+    assert executor.params == []
     assert executor.json == {"name": "John Doe", "age": 30, "email": "john@example.com"}
     assert executor.data is None
     assert executor.files is None
@@ -156,7 +156,7 @@ def test_executor_with_json_body_and_nested_object_variable():
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/data"
     assert executor.headers == {"Content-Type": "application/json"}
-    assert executor.params == {}
+    assert executor.params == []
     assert executor.json == {"object": {"name": "John Doe", "age": 30, "email": "john@example.com"}}
     assert executor.data is None
     assert executor.files is None
@@ -195,7 +195,7 @@ def test_extract_selectors_from_template_with_newline():
         variable_pool=variable_pool,
     )
 
-    assert executor.params == {"test": "line1\nline2"}
+    assert executor.params == [('test', 'line1\nline2')]
 
 
 def test_executor_with_form_data():
@@ -244,7 +244,7 @@ def test_executor_with_form_data():
     assert executor.url == "https://api.example.com/upload"
     assert "Content-Type" in executor.headers
     assert "multipart/form-data" in executor.headers["Content-Type"]
-    assert executor.params == {}
+    assert executor.params == []
     assert executor.json is None
     assert executor.files is None
     assert executor.content is None

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -265,3 +265,89 @@ def test_executor_with_form_data():
     assert "Hello, World!" in raw_request
     assert "number_field" in raw_request
     assert "42" in raw_request
+
+
+def test_init_headers():
+
+    def create_executor(headers: str) -> Executor:
+        node_data = HttpRequestNodeData(
+            title="test",
+            method="get",
+            url="http://example.com",
+            headers=headers,
+            params="",
+            authorization=HttpRequestNodeAuthorization(type="no-auth")
+        )
+        timeout = HttpRequestNodeTimeout(connect=10, read=30, write=30)
+        return Executor(node_data=node_data, timeout=timeout, variable_pool=VariablePool())
+
+    executor = create_executor("aa\n cc:")
+    executor._init_headers()
+    assert executor.headers == {"aa": "", "cc": ""}
+
+    executor = create_executor("aa:bb\n cc:dd")
+    executor._init_headers()
+    assert executor.headers == {"aa": "bb", "cc": "dd"}
+
+    executor = create_executor("aa:bb\n cc:dd\n")
+    executor._init_headers()
+    assert executor.headers == {"aa": "bb", "cc": "dd"}
+
+    executor = create_executor("aa:bb\n\n cc : dd\n\n")
+    executor._init_headers()
+    assert executor.headers == {"aa": "bb", "cc": "dd"}
+
+
+def test_init_params():
+
+    def create_executor(params: str) -> Executor:
+        node_data = HttpRequestNodeData(
+            title="test",
+            method="get",
+            url="http://example.com",
+            headers="",
+            params=params,
+            authorization=HttpRequestNodeAuthorization(type="no-auth")
+        )
+        timeout = HttpRequestNodeTimeout(connect=10, read=30, write=30)
+        return Executor(node_data=node_data, timeout=timeout, variable_pool=VariablePool())
+
+    # Test basic key-value pairs
+    executor = create_executor("key1:value1\nkey2:value2")
+    executor._init_params()
+    assert executor.params == [
+        ("key1", "value1"),
+        ("key2", "value2")
+    ]
+
+    # Test empty values
+    executor = create_executor("key1:\nkey2:")
+    executor._init_params()
+    assert executor.params == [
+        ("key1", ""),
+        ("key2", "")
+    ]
+
+    # Test duplicate keys (which is allowed for params)
+    executor = create_executor("key1:value1\nkey1:value2")
+    executor._init_params()
+    assert executor.params == [
+        ("key1", "value1"),
+        ("key1", "value2")
+    ]
+
+    # Test whitespace handling
+    executor = create_executor(" key1 : value1 \n key2 : value2 ")
+    executor._init_params()
+    assert executor.params == [
+        ("key1", "value1"),
+        ("key2", "value2")
+    ]
+
+    # Test empty lines and extra whitespace
+    executor = create_executor("key1:value1\n\nkey2:value2\n\n")
+    executor._init_params()
+    assert executor.params == [
+        ("key1", "value1"),
+        ("key2", "value2")
+    ]

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_node.py
@@ -14,16 +14,8 @@ from core.workflow.nodes.http_request import (
     HttpRequestNodeBody,
     HttpRequestNodeData,
 )
-from core.workflow.nodes.http_request.executor import _plain_text_to_dict
 from models.enums import UserFrom
 from models.workflow import WorkflowNodeExecutionStatus, WorkflowType
-
-
-def test_plain_text_to_dict():
-    assert _plain_text_to_dict("aa\n cc:") == {"aa": "", "cc": ""}
-    assert _plain_text_to_dict("aa:bb\n cc:dd") == {"aa": "bb", "cc": "dd"}
-    assert _plain_text_to_dict("aa:bb\n cc:dd\n") == {"aa": "bb", "cc": "dd"}
-    assert _plain_text_to_dict("aa:bb\n\n cc : dd\n\n") == {"aa": "bb", "cc": "dd"}
 
 
 def test_http_request_node_binary_file(monkeypatch):


### PR DESCRIPTION
# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fix https://github.com/langgenius/dify/issues/11660
also fix the key of param can't extract vaiable pool's value

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

