### PR TITLE
fix: tool constant params change cause page crashed

### DIFF
--- a/web/app/components/workflow/nodes/tool/components/input-var-list.tsx
+++ b/web/app/components/workflow/nodes/tool/components/input-var-list.tsx
@@ -165,7 +165,7 @@ const InputVarList: FC<Props> = ({
                   value={varInput?.type === VarKindType.constant ? (varInput?.value || '') : (varInput?.value || [])}
                   onChange={handleNotMixedTypeChange(variable)}
                   onOpen={handleOpen(index)}
-                  defaultVarKindType={isNumber ? VarKindType.constant : VarKindType.variable}
+                  defaultVarKindType={varInput?.type || (isNumber ? VarKindType.constant : VarKindType.variable)}
                   isSupportConstantValue={isSupportConstantValue}
                   filterVar={isNumber ? filterVar : undefined}
                   availableVars={isSelect ? availableVars : undefined}

--- a/web/app/components/workflow/nodes/tool/components/input-var-list.tsx
+++ b/web/app/components/workflow/nodes/tool/components/input-var-list.tsx
@@ -66,7 +66,7 @@ const InputVarList: FC<Props> = ({
         }
         else {
           draft[variable] = {
-            type: varKindType || VarKindType.variable,
+            type: varKindType,
             value: varValue,
           }
         }

--- a/web/app/components/workflow/nodes/tool/components/input-var-list.tsx
+++ b/web/app/components/workflow/nodes/tool/components/input-var-list.tsx
@@ -61,20 +61,12 @@ const InputVarList: FC<Props> = ({
       const newValue = produce(value, (draft: ToolVarInputs) => {
         const target = draft[variable]
         if (target) {
-          if (!isSupportConstantValue || varKindType === VarKindType.variable) {
-            if (isSupportConstantValue)
-              target.type = VarKindType.variable
-
-            target.value = varValue as ValueSelector
-          }
-          else {
-            target.type = VarKindType.constant
-            target.value = varValue as string
-          }
+          target.type = varKindType
+          target.value = varValue
         }
         else {
           draft[variable] = {
-            type: VarKindType.variable,
+            type: varKindType || VarKindType.variable,
             value: varValue,
           }
         }

--- a/web/app/components/workflow/nodes/tool/use-config.ts
+++ b/web/app/components/workflow/nodes/tool/use-config.ts
@@ -132,7 +132,7 @@ const useConfig = (id: string, payload: ToolNodeType) => {
         draft.tool_parameters = {}
     })
     setInputs(inputsWithDefaultValue)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currTool])
 
   // setting when call
@@ -214,8 +214,13 @@ const useConfig = (id: string, payload: ToolNodeType) => {
     .map(k => inputs.tool_parameters[k])
 
   const varInputs = getInputVars(hadVarParams.map((p) => {
-    if (p.type === VarType.variable)
+    if (p.type === VarType.variable) {
+      // handle the old wrong value not crash the page
+      if (!(p.value as any).join)
+        return `{{#${p.value}#}}`
+
       return `{{#${(p.value as ValueSelector).join('.')}#}}`
+    }
 
     return p.value as string
   }))


### PR DESCRIPTION
# Summary
Fix: 
1. Tool constant params change cause page crashed. 
2. Tool constant params set to variable would be overwrited by number.

fixes: https://github.com/langgenius/dify/issues/11656


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

