### PR TITLE
fix: iteration output array type causes always outputting string array

### DIFF
--- a/web/app/components/workflow/nodes/iteration/use-config.ts
+++ b/web/app/components/workflow/nodes/iteration/use-config.ts
@@ -52,6 +52,12 @@ const useConfig = (id: string, payload: IterationNodeType) => {
         [VarType.number]: VarType.arrayNumber,
         [VarType.object]: VarType.arrayObject,
         [VarType.file]: VarType.arrayFile,
+        // list operator node can output array
+        [VarType.array]: VarType.array,
+        [VarType.arrayFile]: VarType.arrayFile,
+        [VarType.arrayString]: VarType.arrayString,
+        [VarType.arrayNumber]: VarType.arrayNumber,
+        [VarType.arrayObject]: VarType.arrayObject,
       } as Record<VarType, VarType>)[outputItemType] || VarType.arrayString
     })
     setInputs(newInputs)


### PR DESCRIPTION
# Summary
Fix: iteration output array type causes always outputting string array.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

