### PR TITLE
make login lockout duration configurable

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -435,3 +435,5 @@ CREATE_TIDB_SERVICE_JOB_ENABLED=false
 
 # Maximum number of submitted thread count in a ThreadPool for parallel node execution
 MAX_SUBMIT_COUNT=100
+# Lockout duration in seconds
+LOGIN_LOCKOUT_DURATION=86400

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -485,6 +485,11 @@ class AuthConfig(BaseSettings):
         default=60,
     )
 
+    LOGIN_LOCKOUT_DURATION: PositiveInt = Field(
+        description="Time (in seconds) a user must wait before retrying login after exceeding the rate limit.",
+        default=86400,
+    )
+
 
 class ModerationConfig(BaseSettings):
     """

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -420,7 +420,7 @@ class AccountService:
         if count is None:
             count = 0
         count = int(count) + 1
-        redis_client.setex(key, 60 * 60 * 24, count)
+        redis_client.setex(key, dify_config.LOGIN_LOCKOUT_DURATION, count)
 
     @staticmethod
     def is_login_error_rate_limit(email: str) -> bool:


### PR DESCRIPTION
# Summary

**This is the implementation for #11698**

When login attempts exceeds limit, login lockout happens for security reason, which is reasonable. However, currently lockout duration is too long i.e. 24hours, and it's not configurable. 
I believe this is inconvinient depending on the environments being used and so making it configurable via .env file in api.

Changes are:
 - **api/configs/feature/__init__.py:** adding LOGIN_LOCKOUT_DURATION to AuthConfig class with default=86400(24hours).
 - **.env.example:** adding template parameter in .env.example having value equal to default value
 - **api/services/account_service.py:**  changing timeout seconds of redis_client.setex function used to calculate login error count in add_login_error_rate_limit function


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

