### PR TITLE
fix: image icon can not display

### DIFF
--- a/web/app/components/base/app-icon/index.tsx
+++ b/web/app/components/base/app-icon/index.tsx
@@ -3,7 +3,6 @@
 import type { FC } from 'react'
 import { init } from 'emoji-mart'
 import data from '@emoji-mart/data'
-import Image from 'next/image'
 import { cva } from 'class-variance-authority'
 import type { AppIconType } from '@/types/app'
 import classNames from '@/utils/classnames'
@@ -62,7 +61,8 @@ const AppIcon: FC<AppIconProps> = ({
     onClick={onClick}
   >
     {isValidImageIcon
-      ? <Image src={imageUrl} className="w-full h-full" alt="app icon" />
+      // eslint-disable-next-line @next/next/no-img-element
+      ? <img src={imageUrl} className="w-full h-full" alt="app icon" />
       : (innerIcon || ((icon && icon !== '') ? <em-emoji id={icon} /> : <em-emoji id='🤖' />))
     }
   </span>

--- a/web/i18n/en-US/app.ts
+++ b/web/i18n/en-US/app.ts
@@ -125,7 +125,7 @@ const translation = {
   switchStart: 'Start switch',
   openInExplore: 'Open in Explore',
   typeSelector: {
-    all: 'ALL Types',
+    all: 'All Types ',
     chatbot: 'Chatbot',
     agent: 'Agent',
     workflow: 'Workflow',

--- a/web/i18n/tr-TR/app.ts
+++ b/web/i18n/tr-TR/app.ts
@@ -112,7 +112,7 @@ const translation = {
   removeOriginal: 'Orijinal uygulamayı sil',
   switchStart: 'Geçişi Başlat',
   typeSelector: {
-    all: 'ALL Types',
+    all: 'All Types',
     chatbot: 'Chatbot',
     agent: 'Agent',
     workflow: 'Workflow',


### PR DESCRIPTION
# Summary

https://nextjs.org/docs/messages/next-image-unconfigured-host
Revert to `<img />`

# Screenshots

| Before | After |
|--------|-------|
| <img width="368" alt="image" src="https://github.com/user-attachments/assets/dab0e8ad-d27b-4514-a36f-90265976f45e" />  | <img width="364" alt="image" src="https://github.com/user-attachments/assets/4576282d-57c9-439c-8a15-e05efc2b40cf" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

