### PR TITLE
fix: make tidb service optional with proper profile in docker compose yaml

### DIFF
--- a/.github/workflows/expose_service_ports.sh
+++ b/.github/workflows/expose_service_ports.sh
@@ -9,5 +9,6 @@ yq eval '.services["pgvecto-rs"].ports += ["5431:5432"]' -i docker/docker-compos
 yq eval '.services["elasticsearch"].ports += ["9200:9200"]' -i docker/docker-compose.yaml
 yq eval '.services.couchbase-server.ports += ["8091-8096:8091-8096"]' -i docker/docker-compose.yaml
 yq eval '.services.couchbase-server.ports += ["11210:11210"]' -i docker/docker-compose.yaml
+yq eval '.services.tidb.ports += ["4000:4000"]' -i docker/docker-compose.yaml
 
-echo "Ports exposed for sandbox, weaviate, qdrant, chroma, milvus, pgvector, pgvecto-rs, elasticsearch, couchbase"
+echo "Ports exposed for sandbox, weaviate, tidb, qdrant, chroma, milvus, pgvector, pgvecto-rs, elasticsearch, couchbase"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -500,8 +500,6 @@ services:
     image: pingcap/tidb:v8.4.0
     profiles:
       - tidb
-    ports:
-      - "4000:4000"
     command:
       - --store=unistore
     restart: always

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -498,6 +498,8 @@ services:
   # For production use, please refer to https://github.com/pingcap/tidb-docker-compose
   tidb:
     image: pingcap/tidb:v8.4.0
+    profiles:
+      - tidb
     ports:
       - "4000:4000"
     command:


### PR DESCRIPTION
# Summary

- adding profile in docker compose for tidb container , making it optional without starting it by default


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

