### PR TITLE
feat: use Gemini response metadata for token counting

### DIFF
--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -317,7 +317,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     )
                 else:
                     # calculate num tokens
-                    if hasattr(response, 'usage_metadata') and response.usage_metadata:
+                    if hasattr(response, "usage_metadata") and response.usage_metadata:
                         prompt_tokens = response.usage_metadata.prompt_token_count
                         completion_tokens = response.usage_metadata.candidates_token_count
                     else:

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -317,7 +317,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     )
                 else:
                     # calculate num tokens
-                    if response.usage_metadata:
+                    if hasattr(response, 'usage_metadata') and response.usage_metadata:
                         prompt_tokens = response.usage_metadata.prompt_token_count
                         completion_tokens = response.usage_metadata.candidates_token_count
                     else:

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -317,8 +317,12 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     )
                 else:
                     # calculate num tokens
-                    prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
-                    completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
+                    if response.usage_metadata:
+                        prompt_tokens = response.usage_metadata.prompt_token_count
+                        completion_tokens = response.usage_metadata.candidates_token_count
+                    else:
+                        prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
+                        completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
 
                     # transform usage
                     usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)


### PR DESCRIPTION
# Summary

Previously, I fixed it in another PR(#11226), but the streaming function wasn't corrected, so this is an additional fix.

Improved token counting for Gemini models by utilizing response metadata. Previously, the system used GPT-2 tokenizer which resulted in inaccurate token counts for both prompt and completion. Now, the system first attempts to get token counts from Gemini's response metadata, falling back to manual calculation only when metadata is unavailable. This change ensures accurate token counting and improves efficiency by leveraging native Gemini functionality.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

