### PR TITLE
fix: file upload auth

### DIFF
--- a/api/controllers/console/files.py
+++ b/api/controllers/console/files.py
@@ -1,6 +1,7 @@
 from flask import request
 from flask_login import current_user
 from flask_restful import Resource, marshal_with
+from werkzeug.exceptions import Forbidden
 
 import services
 from configs import dify_config
@@ -57,6 +58,9 @@ class FileApi(Resource):
 
         if not file.filename:
             raise FilenameNotExistsError
+
+        if source == "datasets" and not current_user.is_dataset_editor:
+            raise Forbidden()
 
         if source not in ("datasets", None):
             source = None


### PR DESCRIPTION
# Summary

Normal users do not have the permission to upload dataset files.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

