### PR TITLE
fix: Enhance file type detection in HTTP Request node

### DIFF
--- a/api/core/workflow/nodes/http_request/node.py
+++ b/api/core/workflow/nodes/http_request/node.py
@@ -1,7 +1,7 @@
 import logging
+import mimetypes
 from collections.abc import Mapping, Sequence
 from typing import Any
-import mimetypes
 
 from configs import dify_config
 from core.file import File, FileTransferMethod
@@ -165,9 +165,9 @@ class HttpRequestNode(BaseNode[HttpRequestNodeData]):
         content = response.content
 
         if is_file:
-            # Get mime type from both URL and content type header
-            url_mime_type = mimetypes.guess_type(url)[0] or ""
-            mime_type = content_type or url_mime_type or "application/octet-stream"
+            # Guess file extension from URL or Content-Type header
+            filename = url.split("?")[0].split("/")[-1] or ""
+            mime_type = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
             tool_file = ToolFileManager.create_file_by_raw(
                 user_id=self.user_id,


### PR DESCRIPTION
# Summary

Enhances file type detection in the HTTP Request node by improving MIME type detection logic. The changes include:

1. Added fallback mechanism for content type detection:
   - First tries Content-Type from response headers
   - Then attempts to guess type from URL using mimetypes
   - Finally defaults to "application/octet-stream" if no type can be determined

2. Improved file handling in HTTP responses by properly checking both Content-Type headers and URL patterns

This change ensures more reliable file type detection when handling HTTP responses, particularly for file downloads where the Content-Type header might be missing or incorrect.

close #11459

# Screenshots
<img width="757" alt="image" src="https://github.com/user-attachments/assets/60e5ab53-9e57-4093-9e5c-8e44060a4b20" />

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

