### PR TITLE
fix: resolve sub parallels from current parallel start node

### DIFF
--- a/api/core/workflow/graph_engine/entities/graph.py
+++ b/api/core/workflow/graph_engine/entities/graph.py
@@ -349,6 +349,10 @@ class Graph(BaseModel):
                         edge_mapping=edge_mapping,
                         reverse_edge_mapping=reverse_edge_mapping,
                         parallel_branch_node_ids=condition_parallel_branch_node_ids,
+                        parent_parallel=parallel,
+                        start_node_id=start_node_id,
+                        node_parallel_mapping=node_parallel_mapping,
+                        parallel_mapping=parallel_mapping,
                     )
 
                     # collect all branches node ids
@@ -559,6 +563,10 @@ class Graph(BaseModel):
         edge_mapping: dict[str, list[GraphEdge]],
         reverse_edge_mapping: dict[str, list[GraphEdge]],
         parallel_branch_node_ids: list[str],
+        parent_parallel: GraphParallel,
+        start_node_id: str,
+        node_parallel_mapping: dict[str, str],
+        parallel_mapping: dict[str, GraphParallel],
     ) -> dict[str, list[str]]:
         """
         Fetch all node ids in parallels
@@ -628,6 +636,15 @@ class Graph(BaseModel):
         for node_id, branch_node_ids in merge_branch_node_ids.items():
             if len(branch_node_ids) <= 1:
                 continue
+
+            p = GraphParallel(
+                start_from_node_id=start_node_id,
+                end_node_id=node_id,
+                parent_parallel_id=parent_parallel.id,
+                parent_parallel_start_node_id=parent_parallel.start_from_node_id,
+            )
+            if p.start_from_node_id not in node_parallel_mapping or p.end_to_node_id not in node_parallel_mapping:
+                parallel_mapping[p.id] = p
 
             for branch_node_id in branch_node_ids:
                 if branch_node_id in branches_merge_node_ids:

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_graph.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_graph.py
@@ -789,3 +789,279 @@ def test_parallels_graph6():
 
     for node_id in ["code1", "code2"]:
         assert graph.node_parallel_mapping[node_id] == child_parallel.id
+
+
+def test_parallel_graph7():
+    graph_config = {
+        "edges": [
+            {
+                "id": "1734339163183-source-1734436159127-target",
+                "source": "1734339163183",
+                "sourceHandle": "source",
+                "target": "1734436159127",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734339163183-source-1734436167750-target",
+                "source": "1734339163183",
+                "sourceHandle": "source",
+                "target": "1734436167750",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734339163183-source-1734436179342-target",
+                "source": "1734339163183",
+                "sourceHandle": "source",
+                "target": "1734436179342",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734436167750-source-1734436187534-target",
+                "source": "1734436167750",
+                "sourceHandle": "source",
+                "target": "1734436187534",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734436179342-source-1734436187534-target",
+                "source": "1734436179342",
+                "sourceHandle": "source",
+                "target": "1734436187534",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734436187534-source-1734436200878-target",
+                "source": "1734436187534",
+                "sourceHandle": "source",
+                "target": "1734436200878",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734436159127-true-1734436217190-target",
+                "source": "1734436159127",
+                "sourceHandle": "true",
+                "target": "1734436217190",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734436217190-source-1734436200878-target",
+                "source": "1734436217190",
+                "sourceHandle": "source",
+                "target": "1734436200878",
+                "targetHandle": "target"
+            },
+            {
+                "id": "1734436200878-source-1734436245606-target",
+                "source": "1734436200878",
+                "sourceHandle": "source",
+                "target": "1734436245606",
+                "targetHandle": "target"
+            }
+        ],
+        "nodes": [
+            {
+                "data": {
+                    "title": "start",
+                    "type": "start",
+                    "variables": [
+                        {
+                            "label": "arg",
+                            "max_length": 48,
+                            "options": [
+
+                            ],
+                            "required": True,
+                            "type": "text-input",
+                            "variable": "arg"
+                        }
+                    ]
+                },
+                "id": "1734339163183"
+            },
+            {
+                "data": {
+                    "cases": [
+                        {
+                            "case_id": "true",
+                            "conditions": [
+                                {
+                                    "comparison_operator": "contains",
+                                    "id": "09823c40-b824-4931-bb9a-7d733e1cade6",
+                                    "value": "aaa",
+                                    "varType": "string",
+                                    "variable_selector": [
+                                        "1734339163183",
+                                        "arg"
+                                    ]
+                                }
+                            ],
+                            "id": "true",
+                            "logical_operator": "and"
+                        }
+                    ],
+                    "title": "if-else",
+                    "type": "if-else"
+                },
+                "id": '1734436159127'
+            },
+            {
+                "data": {
+                    "code": "\ndef main(arg1: str, arg2: str) -> dict:\n    return {\n        \"result\": arg1 + arg2,\n    }\n",
+                    "code_language": "python3",
+                    "desc": "",
+                    "outputs": {
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "code1",
+                    "type": "code",
+                    "variables": [
+                        {
+                            "value_selector": [
+                                "1734339163183",
+                                "arg"
+                            ],
+                            "variable": "arg1"
+                        },
+                        {
+                            "value_selector": [
+                                "1734339163183",
+                                "arg"
+                            ],
+                            "variable": "arg2"
+                        }
+                    ]
+                },
+                "id": '1734436167750'
+            },
+            {
+                "data": {
+                    "code": "\ndef main(arg1: str, arg2: str) -> dict:\n    return {\n        \"result\": arg1 + arg2,\n    }\n",
+                    "code_language": "python3",
+                    "outputs": {
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "code2",
+                    "type": "code",
+                    "variables": [
+                        {
+                            "value_selector": [
+                                "1734339163183",
+                                "arg"
+                            ],
+                            "variable": "arg1"
+                        },
+                        {
+                            "value_selector": [
+                                "1734339163183",
+                                "arg"
+                            ],
+                            "variable": "arg2"
+                        }
+                    ]
+                },
+                "id": '1734436179342'
+            },
+            {
+                "data": {
+                    "code": "\ndef main(arg1: str, arg2: str) -> dict:\n    return {\n        \"result\": arg1 + arg2,\n    }\n",
+                    "code_language": "python3",
+                    "outputs": {
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "code3",
+                    "type": "code",
+                    "variables": [
+                        {
+                            "value_selector": [
+                                "1734436167750",
+                                "result"
+                            ],
+                            "variable": "arg1"
+                        },
+                        {
+                            "value_selector": [
+                                "1734436179342",
+                                "result"
+                            ],
+                            "variable": "arg2"
+                        }
+                    ]
+                },
+                "id": '1734436187534'
+            },
+            {
+                "data": {
+                    "desc": "",
+                    "output_type": "string",
+                    "title": "vg",
+                    "type": "variable-aggregator",
+                    "variables": [
+                        [
+                            "1734436187534",
+                            "result"
+                        ],
+                        [
+                            "1734436217190",
+                            "result"
+                        ]
+                    ]
+                },
+                "id": '1734436200878'
+            },
+            {
+                "data": {
+                    "code": "\ndef main(arg1: str, arg2: str) -> dict:\n    return {\n        \"result\": arg1 + arg2,\n    }\n",
+                    "code_language": "python3",
+                    "outputs": {
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "code4",
+                    "type": "code",
+                    "variables": [
+                        {
+                            "value_selector": [
+                                "1734339163183",
+                                "arg"
+                            ],
+                            "variable": "arg1"
+                        },
+                        {
+                            "value_selector": [
+                                "1734339163183",
+                                "arg"
+                            ],
+                            "variable": "arg2"
+                        }
+                    ]
+                },
+                "id": '1734436217190'
+            },
+            {
+                "data": {
+                    "desc": "",
+                    "outputs": [
+                        {
+                            "value_selector": [
+                                "1734436200878",
+                                "output"
+                            ],
+                            "variable": "output"
+                        }
+                    ],
+                    "title": "end",
+                    "type": "end"
+                },
+                "id": '1734436245606'
+            }
+        ]
+    }
+    graph = Graph.init(graph_config)
+    assert len(graph.parallel_mapping) == 3


### PR DESCRIPTION
### fix #11756

- reason analysis 

Let's say there's one node N in graph, current code seems to assume that there's only one parallel start from node N. However in fact, there can be multiple sub parallels start from N, because some of the branches start from N may merge before they all merge, just like figure below.
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/8a800d6d-d888-45b2-844b-8c6a4c87fec6" />

- fix method
Add sub parallels in method Graph._fetch_all_node_ids_in_parallels, this method already resolved all intersect points of the branches