### PR TITLE
Fix/10584 wrong message when no custom tool available in custom tool list

### DIFF
--- a/web/app/components/tools/add-tool-modal/empty.tsx
+++ b/web/app/components/tools/add-tool-modal/empty.tsx
@@ -8,14 +8,12 @@ const Empty = () => {
   return (
     <div className='flex flex-col items-center'>
       <div className="shrink-0 w-[163px] h-[149px] bg-cover bg-no-repeat bg-[url('~@/app/components/tools/add-tool-modal/empty.png')]"></div>
-      {searchParams.get('category') === 'workflow' && <>
-        <div className='mb-1 text-[13px] font-medium text-text-primary leading-[18px]'>{t('tools.addToolModal.emptyTitle')}</div>
-        <div className='text-[13px] text-text-tertiary leading-[18px]'>{t('tools.addToolModal.emptyTip')}</div>
-      </>}
-      {searchParams.get('category') !== 'workflow' && <>
-        <div className='mb-1 text-[13px] font-medium text-text-primary leading-[18px]'>{t('tools.addToolModal.emptyTitleCustom')}</div>
-        <div className='text-[13px] text-text-tertiary leading-[18px]'>{t('tools.addToolModal.emptyTipCustom')}</div>
-      </>}
+      <div className='mb-1 text-[13px] font-medium text-text-primary leading-[18px]'>
+        {t(`tools.addToolModal.${searchParams.get('category') === 'workflow' ? 'emptyTitle' : 'emptyTitleCustom'}`)}
+      </div>
+      <div className='text-[13px] text-text-tertiary leading-[18px]'>
+        {t(`tools.addToolModal.${searchParams.get('category') === 'workflow' ? 'emptyTip' : 'emptyTipCustom'}`)}
+      </div>
     </div>
   )
 }

--- a/web/app/components/tools/add-tool-modal/empty.tsx
+++ b/web/app/components/tools/add-tool-modal/empty.tsx
@@ -1,13 +1,21 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
-
 const Empty = () => {
   const { t } = useTranslation()
+  const searchParams = useSearchParams()
 
   return (
     <div className='flex flex-col items-center'>
       <div className="shrink-0 w-[163px] h-[149px] bg-cover bg-no-repeat bg-[url('~@/app/components/tools/add-tool-modal/empty.png')]"></div>
-      <div className='mb-1 text-[13px] font-medium text-text-primary leading-[18px]'>{t('tools.addToolModal.emptyTitle')}</div>
-      <div className='text-[13px] text-text-tertiary leading-[18px]'>{t('tools.addToolModal.emptyTip')}</div>
+      {searchParams.get('category') === 'workflow' && <>
+        <div className='mb-1 text-[13px] font-medium text-text-primary leading-[18px]'>{t('tools.addToolModal.emptyTitle')}</div>
+        <div className='text-[13px] text-text-tertiary leading-[18px]'>{t('tools.addToolModal.emptyTip')}</div>
+      </>}
+      {searchParams.get('category') !== 'workflow' && <>
+        <div className='mb-1 text-[13px] font-medium text-text-primary leading-[18px]'>{t('tools.addToolModal.emptyTitleCustom')}</div>
+        <div className='text-[13px] text-text-tertiary leading-[18px]'>{t('tools.addToolModal.emptyTipCustom')}</div>
+      </>}
     </div>
   )
 }

--- a/web/i18n/en-US/tools.ts
+++ b/web/i18n/en-US/tools.ts
@@ -31,6 +31,8 @@ const translation = {
     manageInTools: 'Manage in Tools',
     emptyTitle: 'No workflow tool available',
     emptyTip: 'Go to "Workflow -> Publish as Tool"',
+    emptyTitleCustom: 'No custom tool available',
+    emptyTipCustom: 'Create a custom tool',
   },
   createTool: {
     title: 'Create Custom Tool',

--- a/web/i18n/zh-Hans/tools.ts
+++ b/web/i18n/zh-Hans/tools.ts
@@ -31,6 +31,8 @@ const translation = {
     manageInTools: '去工具列表管理',
     emptyTitle: '没有可用的工作流工具',
     emptyTip: '去 “工作流 -> 发布为工具” 添加',
+    emptyTitleCustom: '没有可用的自定义工具',
+    emptyTipCustom: '创建自定义工具',
   },
   createTool: {
     title: '创建自定义工具',


### PR DESCRIPTION
# Summary

Fix #10584

# Screenshots

| Before | After |
|--------|-------|
| <img width="1105" alt="image" src="https://github.com/user-attachments/assets/aa0261d0-4e11-4561-b440-782ca00edfa6" /> | <img width="282" alt="image" src="https://github.com/user-attachments/assets/3f9ed5d1-fbf2-45d1-901b-899020ab9ecc" />  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

