### PR TITLE
Fix comfyui tool https

### DIFF
--- a/api/core/tools/provider/builtin/comfyui/comfyui.py
+++ b/api/core/tools/provider/builtin/comfyui/comfyui.py
@@ -11,7 +11,10 @@ class ComfyUIProvider(BuiltinToolProviderController):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         ws = websocket.WebSocket()
         base_url = URL(credentials.get("base_url"))
-        ws_address = f"ws://{base_url.authority}/ws?clientId=test123"
+        ws_protocol = "ws"
+        if base_url.scheme == "https":
+            ws_protocol = "wss"
+        ws_address = f"{ws_protocol}://{base_url.authority}/ws?clientId=test123"
 
         try:
             ws.connect(ws_address)

--- a/api/core/tools/provider/builtin/comfyui/tools/comfyui_client.py
+++ b/api/core/tools/provider/builtin/comfyui/tools/comfyui_client.py
@@ -40,7 +40,10 @@ class ComfyUiClient:
     def open_websocket_connection(self) -> tuple[WebSocket, str]:
         client_id = str(uuid.uuid4())
         ws = WebSocket()
-        ws_address = f"ws://{self.base_url.authority}/ws?clientId={client_id}"
+        ws_protocol = "ws"
+        if self.base_url.scheme == "https":
+            ws_protocol = "wss"
+        ws_address = f"{ws_protocol}://{self.base_url.authority}/ws?clientId={client_id}"
         ws.connect(ws_address)
         return ws, client_id
 


### PR DESCRIPTION
@crazywoola Sorry, I missed one. When comfyui generates pictures, you also need to use websocket connection~

# Summary
Fixes #11822 
Because not all comfyui are deployed with dify, this part of the code currently has a check for "if comfyui is an https website, it cannot be successfully connected", so the judgment of the http protocol is added. If the comfyui website protocol is http, the websocket connection string is ws://, if the comfyui website protocol is https, then the websocket connection string is wss://.

> [!Tip]
>Fixes #11822 


# Screenshots
Before:
This is an error before it is fixed. Regardless of the comfyui website protocol, ws:// will be used for websocket connectivity testing.
![image](https://github.com/user-attachments/assets/96d7a865-66d0-4dd1-9398-01c814c7655d)

After：
This is after the repair, select the websocket connection string according to the comfyui website protocol
![image](https://github.com/user-attachments/assets/6b686b3d-958a-463c-b83f-f15446eaeab6)

# Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

