### PR TITLE
fix: add safe dictionary access for bedrock credentials

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
+++ b/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
@@ -1,11 +1,15 @@
 import boto3
 from botocore.config import Config
-
+from core.model_runtime.errors.invoke import InvokeBadRequestError
 
 def get_bedrock_client(service_name, credentials=None):
-    client_config = Config(region_name=credentials["aws_region"])
-    aws_access_key_id = credentials["aws_access_key_id"]
-    aws_secret_access_key = credentials["aws_secret_access_key"]
+    region_name = credentials.get("aws_region")
+    if not region_name:
+        raise InvokeBadRequestError("aws_region is required")
+    client_config = Config(region_name=region_name)
+    aws_access_key_id = credentials.get("aws_access_key_id")
+    aws_secret_access_key = credentials.get("aws_secret_access_key")
+    
     if aws_access_key_id and aws_secret_access_key:
         # use aksk to call bedrock
         client = boto3.client(

--- a/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
+++ b/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
@@ -1,10 +1,12 @@
+from collections.abc import Mapping
+
 import boto3
 from botocore.config import Config
 
 from core.model_runtime.errors.invoke import InvokeBadRequestError
 
 
-def get_bedrock_client(service_name, credentials=None):
+def get_bedrock_client(service_name: str, credentials: Mapping[str, str]):
     region_name = credentials.get("aws_region")
     if not region_name:
         raise InvokeBadRequestError("aws_region is required")

--- a/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
+++ b/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
@@ -11,7 +11,7 @@ def get_bedrock_client(service_name, credentials=None):
     client_config = Config(region_name=region_name)
     aws_access_key_id = credentials.get("aws_access_key_id")
     aws_secret_access_key = credentials.get("aws_secret_access_key")
-    
+
     if aws_access_key_id and aws_secret_access_key:
         # use aksk to call bedrock
         client = boto3.client(

--- a/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
+++ b/api/core/model_runtime/model_providers/bedrock/get_bedrock_client.py
@@ -1,6 +1,8 @@
 import boto3
 from botocore.config import Config
+
 from core.model_runtime.errors.invoke import InvokeBadRequestError
+
 
 def get_bedrock_client(service_name, credentials=None):
     region_name = credentials.get("aws_region")

--- a/api/core/model_runtime/model_providers/bedrock/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/bedrock/rerank/rerank.py
@@ -62,7 +62,10 @@ class BedrockRerankModel(RerankModel):
                 }
             )
         modelId = model
-        region = credentials["aws_region"]
+        region = credentials.get("aws_region")
+        # region is a required field
+        if not region:
+            raise InvokeBadRequestError("aws_region is required in credentials")
         model_package_arn = f"arn:aws:bedrock:{region}::foundation-model/{modelId}"
         rerankingConfiguration = {
             "type": "BEDROCK_RERANKING_MODEL",


### PR DESCRIPTION
# Summary
This PR enhances error handling as discussed in Issue #11819 by implementing safe dictionary access for AWS credentials. Previously, the code relied on direct dictionary access, which risked KeyError exceptions if aws_region was missing in the provided credentials.

Changes made:
- Replace direct dictionary access with `.get()` method for aws_region
- Add validation check to ensure aws_region is provided
- Raise InvokeBadRequestError with a clear error message if the required credential is missing

This change makes the code more robust and provides better error handling for missing AWS region configuration.

# Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change
- [x] I've updated the documentation accordingly
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
