### PR TITLE
fix: dataset search-input compostion can't work in chrome

### DIFF
--- a/web/app/components/base/search-input/index.tsx
+++ b/web/app/components/base/search-input/index.tsx
@@ -23,6 +23,7 @@ const SearchInput: FC<SearchInputProps> = ({
   const { t } = useTranslation()
   const [focus, setFocus] = useState<boolean>(false)
   const isComposing = useRef<boolean>(false)
+  const [internalValue, setInternalValue] = useState<string>(value)
 
   return (
     <div className={cn(
@@ -45,16 +46,18 @@ const SearchInput: FC<SearchInputProps> = ({
           white && '!bg-white hover:!bg-white group-hover:!bg-white placeholder:!text-gray-400',
         )}
         placeholder={placeholder || t('common.operation.search')!}
-        value={value}
+        value={internalValue}
         onChange={(e) => {
+          setInternalValue(e.target.value)
           if (!isComposing.current)
             onChange(e.target.value)
         }}
-        onCompositionStart={() => {
+        onCompositionStart={(e) => {
           isComposing.current = true
         }}
-        onCompositionEnd={() => {
+        onCompositionEnd={(e) => {
           isComposing.current = false
+          onChange(e.data)
         }}
         onFocus={() => setFocus(true)}
         onBlur={() => setFocus(false)}
@@ -63,7 +66,10 @@ const SearchInput: FC<SearchInputProps> = ({
       {value && (
         <div
           className='shrink-0 flex items-center justify-center w-4 h-4 cursor-pointer group/clear'
-          onClick={() => onChange('')}
+          onClick={() => {
+            onChange('')
+            setInternalValue('')
+          }}
         >
           <XCircle className='w-3.5 h-3.5 text-gray-400 group-hover/clear:text-gray-600' />
         </div>

--- a/web/app/components/base/search-input/index.tsx
+++ b/web/app/components/base/search-input/index.tsx
@@ -52,7 +52,7 @@ const SearchInput: FC<SearchInputProps> = ({
           if (!isComposing.current)
             onChange(e.target.value)
         }}
-        onCompositionStart={(e) => {
+        onCompositionStart={() => {
           isComposing.current = true
         }}
         onCompositionEnd={(e) => {


### PR DESCRIPTION
# Summary

The search box on the dataset page has two bugs when using Chinese input in chrome browser.

1. "isComposing" prevents characters from being rendered and makes the input method not work properly.(first gif below)
2. The onChange event of the input component triggers before the onCompositionEnd event in chrome, causing the search api not to be triggered after the IME confirms the input.(second gif below)

I added an internal value to make sure the input box renders the character being typed in IME properly to fix the first bug, and called the onchange event trigger at the end of onCompositionEnd to fix bug 2

# Screenshots

I've added console log logging to keep track of variables when debugging locally
<img width="920" alt="console_log" src="https://github.com/user-attachments/assets/a3dbc42c-7c8b-411b-8557-c57938c4929a" />


| Before | After(fix bug1) | After(fix bug1+bug2)
|--------|-------|-------|
| ![nofix](https://github.com/user-attachments/assets/41771303-0567-4b1f-b671-fadc5550dece) | ![fixed1](https://github.com/user-attachments/assets/8903ad73-091e-423c-b03f-08984dea4b7d)| ![fixed2](https://github.com/user-attachments/assets/2381b7b7-459b-4552-b7a1-501acf789dda)|
#
# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

