### PR TITLE
chore: skip installing packages for building Python dependency wheels in api dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,9 +23,6 @@ FROM base AS packages
 # if you located in China, you can use aliyun mirror to speed up
 # RUN sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list.d/debian.sources
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc g++ libc-dev libffi-dev libgmp-dev libmpfr-dev libmpc-dev
-
 # Install Python dependencies
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --sync --no-cache --no-root


### PR DESCRIPTION
# Summary

- The packages install on OS images with in `packages` stage are no longer required, as prebuilt Python dependencies are all satisfied.
- successfully build API image without skipped packages
  - on amd64: https://github.com/langgenius/dify/actions/runs/12433693846/job/34715821051?pr=10732#step:4:1565
  - on arm64: https://github.com/langgenius/dify/actions/runs/12433693846/job/34715821381?pr=10732#step:4:458

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

