### PR TITLE
feat: add parameter for SearchAPI

### DIFF
--- a/api/core/tools/provider/builtin/searchapi/tools/google_news.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/google_news.py
@@ -94,8 +94,14 @@ class GoogleNewsTool(BuiltinTool):
 
         api_key = self.runtime.credentials["searchapi_api_key"]
         result = SearchAPI(api_key).run(
-            query, result_type=result_type, num=num, google_domain=google_domain, gl=gl, hl=hl, location=location,
-            time_period=time_period
+            query,
+            result_type=result_type,
+            num=num,
+            google_domain=google_domain,
+            gl=gl,
+            hl=hl,
+            location=location,
+            time_period=time_period,
         )
 
         if result_type == "text":

--- a/api/core/tools/provider/builtin/searchapi/tools/google_news.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/google_news.py
@@ -90,7 +90,7 @@ class GoogleNewsTool(BuiltinTool):
         gl = tool_parameters.get("gl", "us")
         hl = tool_parameters.get("hl", "en")
         location = tool_parameters.get("location")
-        time_period = tool_parameters.get("time_period","last_month")
+        time_period = tool_parameters.get("time_period", "last_month")
 
         api_key = self.runtime.credentials["searchapi_api_key"]
         result = SearchAPI(api_key).run(

--- a/api/core/tools/provider/builtin/searchapi/tools/google_news.py
+++ b/api/core/tools/provider/builtin/searchapi/tools/google_news.py
@@ -35,11 +35,15 @@ class SearchAPI:
 
     def get_params(self, query: str, **kwargs: Any) -> dict[str, str]:
         """Get parameters for SearchAPI."""
-        return {
+        params = {
             "engine": "google_news",
             "q": query,
-            **{key: value for key, value in kwargs.items() if value not in {None, ""}},
         }
+        # Add all non-empty parameters
+        for key, value in kwargs.items():
+            if value not in {None, ""}:
+                params[key] = value
+        return params
 
     @staticmethod
     def _process_response(res: dict, type: str) -> str:
@@ -86,10 +90,12 @@ class GoogleNewsTool(BuiltinTool):
         gl = tool_parameters.get("gl", "us")
         hl = tool_parameters.get("hl", "en")
         location = tool_parameters.get("location")
+        time_period = tool_parameters.get("time_period","last_month")
 
         api_key = self.runtime.credentials["searchapi_api_key"]
         result = SearchAPI(api_key).run(
-            query, result_type=result_type, num=num, google_domain=google_domain, gl=gl, hl=hl, location=location
+            query, result_type=result_type, num=num, google_domain=google_domain, gl=gl, hl=hl, location=location,
+            time_period=time_period
         )
 
         if result_type == "text":

--- a/api/core/tools/provider/builtin/searchapi/tools/google_news.yaml
+++ b/api/core/tools/provider/builtin/searchapi/tools/google_news.yaml
@@ -1920,3 +1920,36 @@ parameters:
       pt_BR: Specifies the number of results to display per page. Default is 10. Max number - 100, min - 1.
     llm_description: Specifies the num of results to display per page.
     form: llm
+  - name: time_period
+    type: select
+    required: false
+    options:
+      - value: last_hour
+        label:
+          en_US: Last Hour
+          zh_Hans: 最近一小时
+      - value: last_day
+        label:
+          en_US: Last 24 Hours
+          zh_Hans: 最近24小时
+      - value: last_week
+        label:
+          en_US: Last Week
+          zh_Hans: 最近一周
+      - value: last_month
+        label:
+          en_US: Last Month
+          zh_Hans: 最近一个月
+      - value: last_year
+        label:
+          en_US: Last Year
+          zh_Hans: 最近一年
+    default: last_month
+    label:
+      en_US: Time Period
+      zh_Hans: 时间段
+    human_description:
+      en_US: Filter results by time period
+      zh_Hans: 按时间段筛选结果
+    llm_description: Filter results by time period (last_hour, last_day, last_week, last_month, last_year)
+    form: form


### PR DESCRIPTION
# Summary

Added time_period parameter for SearchAPI. It is needed while searching current news.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

<img width="711" alt="Screenshot 2024-12-21 at 3 02 37 AM" src="https://github.com/user-attachments/assets/b51a42c9-c810-410b-aeb7-c987ad90fe81" />


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

