### PR TITLE
chore(lint): correct allowed-unused-imports settings for cleanup unused imports in tests

### DIFF
--- a/api/.ruff.toml
+++ b/api/.ruff.toml
@@ -85,11 +85,11 @@ ignore = [
 ]
 "tests/*" = [
     "F811", # redefined-while-unused
-    "F401", # unused-import
 ]
 
 [lint.pyflakes]
-extend-generics = [
+allowed-unused-imports = [
     "_pytest.monkeypatch",
     "tests.integration_tests",
+    "tests.unit_tests",
 ]

--- a/api/migrations/README
+++ b/api/migrations/README
@@ -1,2 +1,1 @@
 Single-database configuration for Flask.
-

--- a/api/tests/integration_tests/model_runtime/__mock/google.py
+++ b/api/tests/integration_tests/model_runtime/__mock/google.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import google.generativeai.types.generation_types as generation_config_types  # type: ignore

--- a/api/tests/integration_tests/vdb/baidu/test_baidu.py
+++ b/api/tests/integration_tests/vdb/baidu/test_baidu.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 from core.rag.datasource.vdb.baidu.baidu_vector import BaiduConfig, BaiduVector
 from tests.integration_tests.vdb.__mock.baiduvectordb import setup_baiduvectordb_mock
 from tests.integration_tests.vdb.test_vector_store import AbstractVectorTest, get_example_text, setup_mock_redis

--- a/api/tests/integration_tests/vdb/tidb_vector/test_tidb_vector.py
+++ b/api/tests/integration_tests/vdb/tidb_vector/test_tidb_vector.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from core.rag.datasource.vdb.tidb_vector.tidb_vector import TiDBVector, TiDBVectorConfig

--- a/api/tests/unit_tests/core/prompt/test_advanced_prompt_transform.py
+++ b/api/tests/unit_tests/core/prompt/test_advanced_prompt_transform.py
@@ -4,7 +4,7 @@ import pytest
 
 from configs import dify_config
 from core.app.app_config.entities import ModelConfigEntity
-from core.file import File, FileTransferMethod, FileType, FileUploadConfig, ImageConfig
+from core.file import File, FileTransferMethod, FileType
 from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_runtime.entities.message_entities import (
     AssistantPromptMessage,

--- a/api/tests/unit_tests/core/workflow/nodes/answer/test_answer_stream_processor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/answer/test_answer_stream_processor.py
@@ -1,6 +1,6 @@
 import uuid
 from collections.abc import Generator
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 from core.workflow.entities.variable_pool import VariablePool
 from core.workflow.enums import SystemVariableKey

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -21,8 +21,7 @@ from core.model_runtime.entities.message_entities import (
 from core.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelFeature, ModelType
 from core.model_runtime.model_providers.model_provider_factory import ModelProviderFactory
 from core.prompt.entities.advanced_prompt_entities import MemoryConfig
-from core.variables import ArrayAnySegment, ArrayFileSegment, NoneSegment, StringSegment
-from core.workflow.entities.variable_entities import VariableSelector
+from core.variables import ArrayAnySegment, ArrayFileSegment, NoneSegment
 from core.workflow.entities.variable_pool import VariablePool
 from core.workflow.graph_engine import Graph, GraphInitParams, GraphRuntimeState
 from core.workflow.nodes.answer import AnswerStreamGenerateRoute

--- a/api/tests/unit_tests/core/workflow/nodes/test_retry.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_retry.py
@@ -1,7 +1,6 @@
 from core.workflow.graph_engine.entities.event import (
     GraphRunFailedEvent,
     GraphRunPartialSucceededEvent,
-    GraphRunSucceededEvent,
     NodeRunRetryEvent,
 )
 from tests.unit_tests.core.workflow.nodes.test_continue_on_error import ContinueOnErrorTestHelper

--- a/api/tests/unit_tests/core/workflow/nodes/variable_assigner/v2/test_helpers.py
+++ b/api/tests/unit_tests/core/workflow/nodes/variable_assigner/v2/test_helpers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from core.variables import SegmentType
 from core.workflow.nodes.variable_assigner.v2.enums import Operation
 from core.workflow.nodes.variable_assigner.v2.helpers import is_input_value_valid

--- a/api/tests/unit_tests/oss/aliyun_oss/aliyun_oss/test_aliyun_oss.py
+++ b/api/tests/unit_tests/oss/aliyun_oss/aliyun_oss/test_aliyun_oss.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from oss2 import Auth  # type: ignore

--- a/api/tests/unit_tests/utils/test_text_processing.py
+++ b/api/tests/unit_tests/utils/test_text_processing.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 import pytest
 
 from core.tools.utils.text_processing_utils import remove_leading_symbols


### PR DESCRIPTION
# Summary

- correct [extend-generics](https://docs.astral.sh/ruff/settings/#lint_pyflakes_extend-generics) settings to [allowed-unused-imports](https://docs.astral.sh/ruff/settings/#lint_pyflakes_allowed-unused-imports) for removing unused imports in tests


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

