### PR TITLE
fix: gemini system prompt with variable raise error

### DIFF
--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -200,7 +200,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 system_instruction = content["parts"][0]
             else:
                 history.append(content)
-        
+
         if not history:
             raise InvokeError("The user prompt message is required. You only add a system prompt message.")
 

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -144,7 +144,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         """
 
         try:
-            ping_message = SystemPromptMessage(content="ping")
+            ping_message = UserPromptMessage(content="ping")
             self._generate(model, credentials, [ping_message], {"max_output_tokens": 5})
 
         except Exception as ex:

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -20,8 +20,8 @@ from core.model_runtime.entities.message_entities import (
     PromptMessageContent,
     PromptMessageContentType,
     PromptMessageTool,
-    TextPromptMessageContent,
     SystemPromptMessage,
+    TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
 )

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -190,7 +190,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         genai.configure(api_key=credentials["google_api_key"])
 
         history = []
-        system_instruction = ""
+        system_instruction = None
 
         for msg in prompt_messages:  # makes message roles strictly alternating
             content = self._format_message_to_glm_content(msg)

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -200,6 +200,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 system_instruction = content["parts"][0]
             else:
                 history.append(content)
+        
+        if not history:
+            raise InvokeError("The user prompt message is required. You only add a system prompt message.")
 
         google_model = genai.GenerativeModel(model_name=model, system_instruction=system_instruction)
         response = google_model.generate_content(

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import os
-import sys
 import tempfile
 import time
 from collections.abc import Generator

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -187,7 +187,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         if stop:
             config_kwargs["stop_sequences"] = stop
 
-        genai.configure(api_key=credentials["google_api_key"])  
+        genai.configure(api_key=credentials["google_api_key"])
 
         history = []
         system_instruction = ""

--- a/api/core/model_runtime/model_providers/google/llm/llm.py
+++ b/api/core/model_runtime/model_providers/google/llm/llm.py
@@ -20,6 +20,7 @@ from core.model_runtime.entities.message_entities import (
     PromptMessageContent,
     PromptMessageContentType,
     PromptMessageTool,
+    TextPromptMessageContent,
     SystemPromptMessage,
     ToolPromptMessage,
     UserPromptMessage,
@@ -404,6 +405,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 )
             return glm_content
         elif isinstance(message, SystemPromptMessage):
+            if isinstance(message.content, list):
+                text_contents = filter(lambda c: isinstance(c, TextPromptMessageContent), message.content)
+                message.content = "".join(c.data for c in text_contents)
             return {"role": "user", "parts": [to_part(message.content)]}
         elif isinstance(message, ToolPromptMessage):
             return {


### PR DESCRIPTION
# Summary


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

when add variables into system prompt of LLM node will raise error:
```
[on_llm_invoke_error]
2024-12-21 12:42:11,077.077 ERROR [Thread-574 (_generate_worker)] [logging_callback.py:169] - Could not create `Blob`, expected `Blob`, `dict` or an `Image` type(`PIL.Image.Image` or `IPython.display.Image`).
Got a: <class 'list'>
Value: [TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='你是一个友好的AI助理'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='2024-12-21 12:42:11')]
Traceback (most recent call last):
  File "/home/njue/software/code/dify/api/core/model_runtime/model_providers/__base/large_language_model.py", line 110, in invoke
    result = self._invoke(
             ^^^^^^^^^^^^^
  File "/home/njue/software/code/dify/api/core/model_runtime/model_providers/google/llm/llm.py", line 66, in _invoke
    return self._generate(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/njue/software/code/dify/api/core/model_runtime/model_providers/google/llm/llm.py", line 195, in _generate
    content = self._format_message_to_glm_content(msg)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/njue/software/code/dify/api/core/model_runtime/model_providers/google/llm/llm.py", line 407, in _format_message_to_glm_content
    return {"role": "user", "parts": [to_part(message.content)]}
                                      ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/njue/anaconda3/envs/dify/lib/python3.12/site-packages/google/generativeai/types/content_types.py", line 249, in to_part
    return protos.Part(inline_data=to_blob(part))
                                   ^^^^^^^^^^^^^
  File "/home/njue/anaconda3/envs/dify/lib/python3.12/site-packages/google/generativeai/types/content_types.py", line 195, in to_blob
    raise TypeError(
TypeError: Could not create `Blob`, expected `Blob`, `dict` or an `Image` type(`PIL.Image.Image` or `IPython.display.Image`).
Got a: 
```


also make the system prompt message to google's system_instructions.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

