### PR TITLE
fix: 'dict_keys' object is not subscriptable error

### DIFF
--- a/api/core/tools/provider/app_tool_provider.py
+++ b/api/core/tools/provider/app_tool_provider.py
@@ -62,7 +62,7 @@ class AppToolProviderEntity(ToolProviderController):
             user_input_form_list = app_model_config.user_input_form_list
             for input_form in user_input_form_list:
                 # get type
-                form_type = input_form.keys()[0]
+                form_type = list(input_form.keys())[0]
                 default = input_form[form_type]["default"]
                 required = input_form[form_type]["required"]
                 label = input_form[form_type]["label"]


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

