### PR TITLE
fix: create_feedback args are wrong

### DIFF
--- a/api/controllers/console/explore/message.py
+++ b/api/controllers/console/explore/message.py
@@ -70,7 +70,7 @@ class MessageFeedbackApi(InstalledAppResource):
         args = parser.parse_args()
 
         try:
-            MessageService.create_feedback(app_model, message_id, current_user, args["rating"])
+            MessageService.create_feedback(app_model, message_id, current_user, args["rating"], args["content"])
         except services.errors.message.MessageNotExistsError:
             raise NotFound("Message Not Exists.")
 

--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -108,7 +108,7 @@ class MessageFeedbackApi(WebApiResource):
         args = parser.parse_args()
 
         try:
-            MessageService.create_feedback(app_model, message_id, end_user, args["rating"])
+            MessageService.create_feedback(app_model, message_id, end_user, args["rating"], args["content"])
         except services.errors.message.MessageNotExistsError:
             raise NotFound("Message Not Exists.")
 


### PR DESCRIPTION
# Summary

found by typing fix, missing args for create_feedback

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

