### PR TITLE
Fix 11979

### DIFF
--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -867,7 +867,8 @@ class LLMNode(BaseNode[LLMNodeData]):
                     variable_pool=variable_pool,
                 )
                 prompt_message = _combine_message_content_with_role(
-                    contents=[TextPromptMessageContent(data=result_text)], role=message.role)
+                    contents=[TextPromptMessageContent(data=result_text)], role=message.role
+                )
                 prompt_messages.append(prompt_message)
             else:
                 # Get segment group from basic message

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -860,14 +860,15 @@ class LLMNode(BaseNode[LLMNodeData]):
     ) -> Sequence[PromptMessage]:
         prompt_messages: list[PromptMessage] = []
         for message in messages:
-            contents: list[PromptMessageContent] = []
             if message.edition_type == "jinja2":
                 result_text = _render_jinja2_message(
                     template=message.jinja2_text or "",
                     jinjia2_variables=jinja2_variables,
                     variable_pool=variable_pool,
                 )
-                contents.append(TextPromptMessageContent(data=result_text))
+                prompt_message = _combine_message_content_with_role(
+                    contents=[TextPromptMessageContent(data=result_text)], role=message.role)
+                prompt_messages.append(prompt_message)
             else:
                 # Get segment group from basic message
                 if context:


### PR DESCRIPTION
Fix this issue
[…s during execution if there are variables in the prompt text.
](https://github.com/langgenius/dify/issues/11979)
Fix #11979
# Summary

Fix the bug in the workflow's llm node, if the system prompts that there are variables in the text, the execution will report an error.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

