### PR TITLE
fix: --name option for the create-tenant command does not take effect

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -562,8 +562,13 @@ def create_tenant(email: str, language: Optional[str] = None, name: Optional[str
     new_password = secrets.token_urlsafe(16)
 
     # register account
-    account = RegisterService.register(email=email, name=account_name, password=new_password, language=language)
-
+    account = RegisterService.register(
+        email=email,
+        name=account_name,
+        password=new_password,
+        language=language,
+        create_workspace_required=False,
+    )
     TenantService.create_owner_tenant_if_not_exist(account, name)
 
     click.echo(

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -793,6 +793,7 @@ class RegisterService:
         language: Optional[str] = None,
         status: Optional[AccountStatus] = None,
         is_setup: Optional[bool] = False,
+        create_workspace_required: Optional[bool] = True,
     ) -> Account:
         db.session.begin_nested()
         """Register account"""
@@ -810,7 +811,7 @@ class RegisterService:
             if open_id is not None or provider is not None:
                 AccountService.link_account_integrate(provider, open_id, account)
 
-            if FeatureService.get_system_features().is_allow_create_workspace:
+            if FeatureService.get_system_features().is_allow_create_workspace and create_workspace_required:
                 tenant = TenantService.create_tenant(f"{account.name}'s Workspace")
                 TenantService.create_tenant_member(tenant, account, role="owner")
                 account.current_tenant = tenant


### PR DESCRIPTION
# Summary

Fixes #11991

The issue is:

When run `create_tenant` command, it first registers an account, and then call `create_owner_tenant_if_not_exist` method. （`api/commands.py:565`）

However, a default tenant will be created during the register account process.
```py
    # api/services/account_service.py:815
    def register(
        ...
    ) -> Account:
        create account...

            if FeatureService.get_system_features().is_allow_create_workspace:
                tenant = TenantService.create_tenant(f"{account.name}'s Workspace")
```

Therefore, a tenant will always exist when `create_owner_tenant_if_not_exist` is called,  and won't create a tenant with --name option.

```py
    # api/services/account_service.py:517
    # available_ta will always be true
    def create_owner_tenant_if_not_exist(
        account: Account, name: Optional[str] = None, is_setup: Optional[bool] = False
    ):
        """Check if user have a workspace or not"""
        available_ta = (
            TenantAccountJoin.query.filter_by(account_id=account.id).order_by(TenantAccountJoin.id.asc()).first()
        )

        if available_ta:
            return
```

# Screenshots

Run command:
```sh
cd api
poetry run python -m flask create-tenant --email 'admin@local.com' --name "Custom Tenant" --language 'zh-Hans'
```

| Before | After |
|--------|-------|
|<img width="718" alt="image" src="https://github.com/user-attachments/assets/2e1ca509-f63b-4fcf-bb37-a61a17536170" />|<img width="715" alt="image" src="https://github.com/user-attachments/assets/10e4c3db-e990-4c7d-939c-aa7b031ff201" />|

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

