### PR TITLE
fix: typo in clean messages periodical task's logging

### DIFF
--- a/api/schedule/clean_messages.py
+++ b/api/schedule/clean_messages.py
@@ -28,7 +28,6 @@ def clean_messages():
     plan_sandbox_clean_message_day = datetime.datetime.now() - datetime.timedelta(
         days=dify_config.PLAN_SANDBOX_CLEAN_MESSAGE_DAY_SETTING
     )
-    page = 1
     while True:
         try:
             # Main query with join and filter
@@ -79,4 +78,4 @@ def clean_messages():
                 db.session.query(Message).filter(Message.id == message.id).delete()
                 db.session.commit()
     end_at = time.perf_counter()
-    click.echo(click.style("Cleaned unused dataset from db success latency: {}".format(end_at - start_at), fg="green"))
+    click.echo(click.style("Cleaned messages from db success latency: {}".format(end_at - start_at), fg="green"))


### PR DESCRIPTION
# Summary

- fix typo in logging of `Cleaned unused dataset` to `Cleaned messages` in `clean_message` periodical task
- remove the unused variable `page`


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

