### PR TITLE
Fix newline characters in tables during document parsing

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -210,11 +210,12 @@ def _extract_text_from_doc(file_content: bytes) -> str:
         # Process sorted content
         for _, item_type, item in content_items:
             if item_type == "paragraph":
-                if isinstance(item,Paragraph):
-                    text.append(item.text)
+                if isinstance(item, Table):
+                    continue
+                text.append(item.text)
             elif item_type == "table":
                 # Process tables
-                if not isinstance(item,Table):
+                if not isinstance(item, Table):
                     continue
                 try:
                     # Check if any cell in the table has text

--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -10,6 +10,7 @@ import docx
 import pandas as pd
 import pypdfium2  # type: ignore
 import yaml  # type: ignore
+import operator
 
 from configs import dify_config
 from core.file import File, FileTransferMethod, file_manager
@@ -202,7 +203,7 @@ def _extract_text_from_doc(file_content: bytes) -> str:
             content_items.append((i, 'table', table))
         
         # Sort content items based on their original position
-        content_items.sort(key=lambda x: x[0])
+        content_items.sort(key=operator.itemgetter(0))
         
         # Process sorted content
         for _, item_type, item in content_items:
@@ -219,8 +220,9 @@ def _extract_text_from_doc(file_content: bytes) -> str:
                             break
                     
                     if has_content:
-                        markdown_table = "| " + " | ".join(cell.text.replace('\n', '<br>') for cell in item.rows[0].cells) + " |\n"
-                        markdown_table += "| " + " | ".join(["---"] * len(item.rows[0].cells)) + " |\n"
+                        cell_texts = [cell.text.replace('\n', '<br>') for cell in item.rows[0].cells]
+                        markdown_table = f"| {' | '.join(cell_texts)} |\n"
+                        markdown_table += f"| {' | '.join(['---'] * len(item.rows[0].cells))} |\n"
                         
                         for row in item.rows[1:]:
                             # Replace newlines with <br> in each cell

--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -210,9 +210,12 @@ def _extract_text_from_doc(file_content: bytes) -> str:
         # Process sorted content
         for _, item_type, item in content_items:
             if item_type == "paragraph":
-                text.append(item.text)
+                if isinstance(item,Paragraph):
+                    text.append(item.text)
             elif item_type == "table":
                 # Process tables
+                if not isinstance(item,Table):
+                    continue
                 try:
                     # Check if any cell in the table has text
                     has_content = False

--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -11,6 +11,8 @@ import docx
 import pandas as pd
 import pypdfium2  # type: ignore
 import yaml  # type: ignore
+from docx.table import Table
+from docx.text.paragraph import Paragraph
 
 from configs import dify_config
 from core.file import File, FileTransferMethod, file_manager
@@ -192,7 +194,7 @@ def _extract_text_from_doc(file_content: bytes) -> str:
         text = []
 
         # Keep track of paragraph and table positions
-        content_items = []
+        content_items: list[tuple[int, str, Table | Paragraph]] = []
 
         # Process paragraphs and tables
         for i, paragraph in enumerate(doc.paragraphs):

--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import logging
+import operator
 import os
 import tempfile
 from typing import cast
@@ -10,7 +11,6 @@ import docx
 import pandas as pd
 import pypdfium2  # type: ignore
 import yaml  # type: ignore
-import operator
 
 from configs import dify_config
 from core.file import File, FileTransferMethod, file_manager
@@ -193,23 +193,23 @@ def _extract_text_from_doc(file_content: bytes) -> str:
 
         # Keep track of paragraph and table positions
         content_items = []
-        
+
         # Process paragraphs and tables
         for i, paragraph in enumerate(doc.paragraphs):
             if paragraph.text.strip():
-                content_items.append((i, 'paragraph', paragraph))
-        
+                content_items.append((i, "paragraph", paragraph))
+
         for i, table in enumerate(doc.tables):
-            content_items.append((i, 'table', table))
-        
+            content_items.append((i, "table", table))
+
         # Sort content items based on their original position
         content_items.sort(key=operator.itemgetter(0))
-        
+
         # Process sorted content
         for _, item_type, item in content_items:
-            if item_type == 'paragraph':
+            if item_type == "paragraph":
                 text.append(item.text)
-            elif item_type == 'table':
+            elif item_type == "table":
                 # Process tables
                 try:
                     # Check if any cell in the table has text
@@ -218,22 +218,22 @@ def _extract_text_from_doc(file_content: bytes) -> str:
                         if any(cell.text.strip() for cell in row.cells):
                             has_content = True
                             break
-                    
+
                     if has_content:
-                        cell_texts = [cell.text.replace('\n', '<br>') for cell in item.rows[0].cells]
+                        cell_texts = [cell.text.replace("\n", "<br>") for cell in item.rows[0].cells]
                         markdown_table = f"| {' | '.join(cell_texts)} |\n"
                         markdown_table += f"| {' | '.join(['---'] * len(item.rows[0].cells))} |\n"
-                        
+
                         for row in item.rows[1:]:
                             # Replace newlines with <br> in each cell
-                            row_cells = [cell.text.replace('\n', '<br>') for cell in row.cells]
+                            row_cells = [cell.text.replace("\n", "<br>") for cell in row.cells]
                             markdown_table += "| " + " | ".join(row_cells) + " |\n"
-                        
+
                         text.append(markdown_table)
                 except Exception as e:
                     logger.warning(f"Failed to extract table from DOC/DOCX: {e}")
                     continue
-        
+
         return "\n".join(text)
 
     except Exception as e:

--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -189,35 +189,51 @@ def _extract_text_from_doc(file_content: bytes) -> str:
         doc_file = io.BytesIO(file_content)
         doc = docx.Document(doc_file)
         text = []
-        # Process paragraphs
-        for paragraph in doc.paragraphs:
-            if paragraph.text.strip():
-                text.append(paragraph.text)
 
-        # Process tables
-        for table in doc.tables:
-            # Table header
-            try:
-                # table maybe cause errors so ignore it.
-                if len(table.rows) > 0 and table.rows[0].cells is not None:
+        # Keep track of paragraph and table positions
+        content_items = []
+        
+        # Process paragraphs and tables
+        for i, paragraph in enumerate(doc.paragraphs):
+            if paragraph.text.strip():
+                content_items.append((i, 'paragraph', paragraph))
+        
+        for i, table in enumerate(doc.tables):
+            content_items.append((i, 'table', table))
+        
+        # Sort content items based on their original position
+        content_items.sort(key=lambda x: x[0])
+        
+        # Process sorted content
+        for _, item_type, item in content_items:
+            if item_type == 'paragraph':
+                text.append(item.text)
+            elif item_type == 'table':
+                # Process tables
+                try:
                     # Check if any cell in the table has text
                     has_content = False
-                    for row in table.rows:
+                    for row in item.rows:
                         if any(cell.text.strip() for cell in row.cells):
                             has_content = True
                             break
-
+                    
                     if has_content:
-                        markdown_table = "| " + " | ".join(cell.text for cell in table.rows[0].cells) + " |\n"
-                        markdown_table += "| " + " | ".join(["---"] * len(table.rows[0].cells)) + " |\n"
-                        for row in table.rows[1:]:
-                            markdown_table += "| " + " | ".join(cell.text for cell in row.cells) + " |\n"
+                        markdown_table = "| " + " | ".join(cell.text.replace('\n', '<br>') for cell in item.rows[0].cells) + " |\n"
+                        markdown_table += "| " + " | ".join(["---"] * len(item.rows[0].cells)) + " |\n"
+                        
+                        for row in item.rows[1:]:
+                            # Replace newlines with <br> in each cell
+                            row_cells = [cell.text.replace('\n', '<br>') for cell in row.cells]
+                            markdown_table += "| " + " | ".join(row_cells) + " |\n"
+                        
                         text.append(markdown_table)
-            except Exception as e:
-                logger.warning(f"Failed to extract table from DOC/DOCX: {e}")
-                continue
-
+                except Exception as e:
+                    logger.warning(f"Failed to extract table from DOC/DOCX: {e}")
+                    continue
+        
         return "\n".join(text)
+
     except Exception as e:
         raise TextExtractionError(f"Failed to extract text from DOC/DOCX: {str(e)}") from e
 


### PR DESCRIPTION
# Summary

This commit addresses an issue where newline characters within table cells were causing incorrect formatting and table misalignment during document parsing. 

The fix ensures that newline characters within table cells are properly handled, allowing the table to maintain its intended structure and position in the parsed text. This improves the accuracy and readability of the parsed documents.


Fixes #12436 


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots
![image](https://github.com/user-attachments/assets/70eeb5c8-ea18-4e43-b9ab-810f2320206c)



# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

