### PR TITLE
Resolve Serialization Warnings for Image or File Uploads in Models

### DIFF
--- a/api/core/model_runtime/entities/message_entities.py
+++ b/api/core/model_runtime/entities/message_entities.py
@@ -125,7 +125,7 @@ class PromptMessage(ABC, BaseModel):
     """
 
     role: PromptMessageRole
-    content: Optional[str | Sequence[PromptMessageContent]] = None
+    content: Optional[str | List[PromptMessageContent]] = None
     name: Optional[str] = None
 
     def is_empty(self) -> bool:


### PR DESCRIPTION
# Summary

When uploading files or documents directly to a large model, serialization warnings may occur due to type mismatches. This happens because, in Pydantic v2, the model_dump method expects strict type matching for fields.Currently, the type is explicitly defined as List, so using List reduces potential type mismatch issues and improves code readability.

Usage Location：
![image](https://github.com/user-attachments/assets/905277f4-e1d1-4ebf-828b-25e07ebcd4df)


Warning Screenshot：
![warning](https://github.com/user-attachments/assets/d2c8177a-3426-42c3-a254-7457d3f50199)



