### PR TITLE
feat: Auto-switch to authorized workspace when accessing URL

### DIFF
--- a/api/controllers/console/app/wraps.py
+++ b/api/controllers/console/app/wraps.py
@@ -36,7 +36,7 @@ def get_app_model(view: Optional[Callable] = None, *, mode: Union[AppMode, list[
                         App.id == app_id,
                         App.status == "normal",
                         TenantAccountJoin.account_id == current_user.id,
-                        Tenant.id != current_user.current_tenant_id
+                        Tenant.id != current_user.current_tenant_id,
                     )
                     .first()
                 )


### PR DESCRIPTION
# Summary

user story:
Our product managers usually share prototype URLs to each other. They usually don’t understand the program or dify product logic, so we need to guide them to switch workspaces. I made a small optimization to automatically switch workspaces if there is permission.


# Screenshots

| Before | After |
|--------|-------|
| ![20241226191940](https://github.com/user-attachments/assets/dde556dc-c136-43e3-b8f0-99c3c7746f1d)    | no longer when accessible   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

