### PR TITLE
feat(llm): Add prompt caching for Anthropic Claude models

### DIFF
--- a/api/core/model_runtime/model_providers/anthropic/llm/claude-3-5-sonnet-20240620.yaml
+++ b/api/core/model_runtime/model_providers/anthropic/llm/claude-3-5-sonnet-20240620.yaml
@@ -33,6 +33,15 @@ parameter_rules:
     max: 8192
   - name: response_format
     use_template: response_format
+  - name: prompt_caching
+    label:
+      en_US: Prompt Caching
+      zh_Hans: 提示词缓存
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 缓存使用<prompt-cache></prompt-cache> 包裹的提示词（最多 4 组，每组 1024+ 个 token）
+      en_US: Cache prompts in <prompt-cache> tags (max 4, 1024+ tokens)
 pricing:
   input: '3.00'
   output: '15.00'

--- a/api/core/model_runtime/model_providers/anthropic/llm/claude-3-5-sonnet-20241022.yaml
+++ b/api/core/model_runtime/model_providers/anthropic/llm/claude-3-5-sonnet-20241022.yaml
@@ -33,6 +33,15 @@ parameter_rules:
     max: 8192
   - name: response_format
     use_template: response_format
+  - name: prompt_caching
+    label:
+      en_US: Prompt Caching
+      zh_Hans: 提示词缓存
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 缓存使用<prompt-cache></prompt-cache> 包裹的提示词（最多 4 组，每组 1024+ 个 token）
+      en_US: Cache prompts in <prompt-cache> tags (max 4, 1024+ tokens)
 pricing:
   input: '3.00'
   output: '15.00'

--- a/api/core/model_runtime/model_providers/anthropic/llm/claude-3-haiku-20240307.yaml
+++ b/api/core/model_runtime/model_providers/anthropic/llm/claude-3-haiku-20240307.yaml
@@ -32,6 +32,15 @@ parameter_rules:
     max: 4096
   - name: response_format
     use_template: response_format
+  - name: prompt_caching
+    label:
+      en_US: Prompt Caching
+      zh_Hans: 提示词缓存
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 缓存使用<prompt-cache></prompt-cache> 包裹的提示词（最多 4 组，每组 1024+ 个 token）
+      en_US: Cache prompts in <prompt-cache> tags (max 4, 1024+ tokens)
 pricing:
   input: '0.25'
   output: '1.25'

--- a/api/core/model_runtime/model_providers/anthropic/llm/claude-3-opus-20240229.yaml
+++ b/api/core/model_runtime/model_providers/anthropic/llm/claude-3-opus-20240229.yaml
@@ -32,6 +32,15 @@ parameter_rules:
     max: 4096
   - name: response_format
     use_template: response_format
+  - name: prompt_caching
+    label:
+      en_US: Prompt Caching
+      zh_Hans: 提示词缓存
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 缓存使用<prompt-cache></prompt-cache> 包裹的提示词（最多 4 组，每组 1024+ 个 token）
+      en_US: Cache prompts in <prompt-cache> tags (max 4, 1024+ tokens)
 pricing:
   input: '15.00'
   output: '75.00'

--- a/api/core/model_runtime/model_providers/anthropic/llm/claude-3-sonnet-20240229.yaml
+++ b/api/core/model_runtime/model_providers/anthropic/llm/claude-3-sonnet-20240229.yaml
@@ -32,6 +32,15 @@ parameter_rules:
     max: 4096
   - name: response_format
     use_template: response_format
+  - name: prompt_caching
+    label:
+      en_US: Prompt Caching
+      zh_Hans: 提示词缓存
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 缓存使用<prompt-cache></prompt-cache> 包裹的提示词（最多 4 组，每组 1024+ 个 token）
+      en_US: Cache prompts in <prompt-cache> tags (max 4, 1024+ tokens)
 pricing:
   input: '3.00'
   output: '15.00'


### PR DESCRIPTION
Add prompt caching parameters for all Claude-3 series models, supporting tagged text caching to improve response speed. Each model can cache up to 4 text blocks.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Resolves #7382 

# Screenshots

### Before
<img width="384" alt="iShot_2024-12-30_09 11 53" src="https://github.com/user-attachments/assets/ef3c4b51-7491-4b95-9fb1-20fcb4b6ad4b" />
 
### After
<img width="386" alt="iShot_2024-12-30_09 10 41" src="https://github.com/user-attachments/assets/f8ec94bf-46c4-4559-b58f-210c4e0bad2c" />
<img width="377" alt="iShot_2024-12-30_09 14 14" src="https://github.com/user-attachments/assets/a2efd4de-3fe8-4873-99e1-e20ce9109c2f" />

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

