### PR TITLE
fix: #12143  support streaming mode content start with "data:"

### DIFF
--- a/api/core/model_runtime/model_providers/moonshot/llm/llm.py
+++ b/api/core/model_runtime/model_providers/moonshot/llm/llm.py
@@ -252,7 +252,7 @@ class MoonshotLargeLanguageModel(OAIAPICompatLargeLanguageModel):
                 # ignore sse comments
                 if chunk.startswith(":"):
                     continue
-                decoded_chunk = chunk.strip().removeprefix("data: ")
+                decoded_chunk = chunk.strip().removeprefix("data:").lstrip()
                 chunk_json = None
                 try:
                     chunk_json = json.loads(decoded_chunk)

--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -462,7 +462,7 @@ class OAIAPICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 # ignore sse comments
                 if chunk.startswith(":"):
                     continue
-                decoded_chunk = chunk.strip().removeprefix("data: ")
+                decoded_chunk = chunk.strip().removeprefix("data:").lstrip()
                 if decoded_chunk == "[DONE]":  # Some provider returns "data: [DONE]"
                     continue
 

--- a/api/core/model_runtime/model_providers/stepfun/llm/llm.py
+++ b/api/core/model_runtime/model_providers/stepfun/llm/llm.py
@@ -250,7 +250,7 @@ class StepfunLargeLanguageModel(OAIAPICompatLargeLanguageModel):
                 # ignore sse comments
                 if chunk.startswith(":"):
                     continue
-                decoded_chunk = chunk.strip().removeprefix("data: ")
+                decoded_chunk = chunk.strip().removeprefix("data:").lstrip()
                 chunk_json = None
                 try:
                     chunk_json = json.loads(decoded_chunk)


### PR DESCRIPTION
# Summary
When deploying LLM with ms-swift, the streaming data returned does not consistently start with "data: ". Specifically, the data does not include a leading space after "data:". This inconsistency stems from the pull request #11272 return failed，the version of Dify before 0.13.0 is ok. To address this, my code has been updated to support both formats: "data:" and "data: "

streaming content e.g.
```
"data:{"model": "my-llm", "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hello! How ", "tool_calls": null}, "finish_reason": null, "logprobs": null}], "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}, "id": "chatcmpl-d802c95d766a41a5bf9491aafdba2b36", "object": "chat.completion.chunk", "created": 1735303124}"
```

Fixes #12143 

# Screenshots

 Before 
![image](https://github.com/user-attachments/assets/2ff9cf83-a34d-4413-b5e0-bf0a23d3cf92)

After 
![image](https://github.com/user-attachments/assets/82a107d0-2bbb-4fb9-85a3-649ba99d529b)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

