### PR TITLE
feat: support opening new tab in markdown button

### DIFF
--- a/web/app/components/base/markdown-blocks/button.tsx
+++ b/web/app/components/base/markdown-blocks/button.tsx
@@ -9,12 +9,22 @@ const MarkdownButton = ({ node }: any) => {
   const link = node.properties.dataLink
   const size = node.properties.dataSize
 
+  function is_valid_url(url: string): boolean {
+    try {
+      const parsed_url = new URL(url)
+      return ['http:', 'https:'].includes(parsed_url.protocol)
+    }
+    catch {
+      return false
+    }
+  }
+
   return <Button
     variant={variant}
     size={size}
     className={cn('!h-8 !px-3 select-none')}
     onClick={() => {
-      if (link && (!link.startsWith('http') || !link.startsWith('https'))) {
+      if (is_valid_url(link)) {
         window.open(link, '_blank')
         return
       }

--- a/web/app/components/base/markdown-blocks/button.tsx
+++ b/web/app/components/base/markdown-blocks/button.tsx
@@ -6,13 +6,20 @@ const MarkdownButton = ({ node }: any) => {
   const { onSend } = useChatContext()
   const variant = node.properties.dataVariant
   const message = node.properties.dataMessage
+  const link = node.properties.dataLink
   const size = node.properties.dataSize
 
   return <Button
     variant={variant}
     size={size}
     className={cn('!h-8 !px-3 select-none')}
-    onClick={() => onSend?.(message)}
+    onClick={() => {
+      if (link && (!link.startsWith('http') || !link.startsWith('https'))) {
+        window.open(link, '_blank')
+        return
+      }
+      onSend?.(message)
+    }}
   >
     <span className='text-[13px]'>{node.children[0]?.value || ''}</span>
   </Button>


### PR DESCRIPTION
# Summary

- support open new tab with URL in markdown button
- follow-up with #9876

We need to define one new attribute `data-link`.
- data-link: controls the URL for new page

Note:
- NO breaking chages in frontend usage. Previously, markdown display supported opending URLs in `<a href="..."></a>`

- Example:

```
<button data-link="http://https://dify.ai/" data-variant="primary" data>Dify</button>
```

# Screenshots

| Before | After |
|--------|-------|
| ...    | <img width="861" alt="image" src="https://github.com/user-attachments/assets/99755a51-dcdf-4211-a301-b64420dda8de" />   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

