### PR TITLE
feat: Skip Redis operations if RateLimit is disabled

### DIFF
--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -74,8 +74,8 @@ class RateLimit:
         active_requests_count = redis_client.hlen(self.active_requests_key)
         if active_requests_count >= self.max_active_requests:
             raise AppInvokeQuotaExceededError(
-                "Too many requests. Please try again later. The current maximum "
-                "concurrent requests allowed is {}.".format(self.max_active_requests)
+                f"Too many requests. Please try again later. The current maximum concurrent requests allowed "
+                f"for {self.client_id} is {self.max_active_requests}."
             )
         redis_client.hset(self.active_requests_key, request_id, str(time.time()))
         return request_id


### PR DESCRIPTION
# Summary

This patch skip the useless Redis operations if RateLimit is disabled to reduce the meaningless latency.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

