### PR TITLE
doc: Added explanation of chunk_overlap to knowledge API

### DIFF
--- a/web/app/(commonLayout)/datasets/template/template.en.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.en.mdx
@@ -78,6 +78,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) Child chunk rules
               - <code>separator</code> Segmentation identifier. Currently, only one delimiter is allowed. The default is <code>***</code>
               - <code>max_tokens</code> The maximum length (tokens) must be validated to be shorter than the length of the parent chunk
+              - <code>chunk_overlap</code> Define the overlap between adjacent chunks (optional)
       </Property>
     </Properties>
   </Col>
@@ -191,6 +192,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) Child chunk rules
               - <code>separator</code> Segmentation identifier. Currently, only one delimiter is allowed. The default is <code>***</code>
               - <code>max_tokens</code> The maximum length (tokens) must be validated to be shorter than the length of the parent chunk
+              - <code>chunk_overlap</code> Define the overlap between adjacent chunks (optional)
       </Property>
       <Property name='file' type='multipart/form-data' key='file'>
         Files that need to be uploaded.
@@ -477,6 +479,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) Child chunk rules
               - <code>separator</code> Segmentation identifier. Currently, only one delimiter is allowed. The default is <code>***</code>
               - <code>max_tokens</code> The maximum length (tokens) must be validated to be shorter than the length of the parent chunk
+              - <code>chunk_overlap</code> Define the overlap between adjacent chunks (optional)
       </Property>
     </Properties>
   </Col>
@@ -578,6 +581,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) Child chunk rules
               - <code>separator</code> Segmentation identifier. Currently, only one delimiter is allowed. The default is <code>***</code>
               - <code>max_tokens</code> The maximum length (tokens) must be validated to be shorter than the length of the parent chunk
+              - <code>chunk_overlap</code> Define the overlap between adjacent chunks (optional)
       </Property>
     </Properties>
   </Col>

--- a/web/app/(commonLayout)/datasets/template/template.zh.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.zh.mdx
@@ -78,6 +78,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) 子分段规则
               - <code>separator</code> 分段标识符，目前仅允许设置一个分隔符。默认为 <code>***</code>
               - <code>max_tokens</code> 最大长度 (token) 需要校验小于父级的长度
+              - <code>chunk_overlap</code> 分段重叠指的是在对数据进行分段时，段与段之间存在一定的重叠部分（选填）
       </Property>
     </Properties>
   </Col>
@@ -191,6 +192,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) 子分段规则
               - <code>separator</code> 分段标识符，目前仅允许设置一个分隔符。默认为 <code>***</code>
               - <code>max_tokens</code> 最大长度 (token) 需要校验小于父级的长度
+              - <code>chunk_overlap</code> 分段重叠指的是在对数据进行分段时，段与段之间存在一定的重叠部分（选填）
       </Property>
       <Property name='file' type='multipart/form-data' key='file'>
         需要上传的文件。
@@ -477,6 +479,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) 子分段规则
               - <code>separator</code> 分段标识符，目前仅允许设置一个分隔符。默认为 <code>***</code>
               - <code>max_tokens</code> 最大长度 (token) 需要校验小于父级的长度
+              - <code>chunk_overlap</code> 分段重叠指的是在对数据进行分段时，段与段之间存在一定的重叠部分（选填）
       </Property>
     </Properties>
   </Col>
@@ -578,6 +581,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
             - <code>subchunk_segmentation</code> (object) 子分段规则
               - <code>separator</code> 分段标识符，目前仅允许设置一个分隔符。默认为 <code>***</code>
               - <code>max_tokens</code> 最大长度 (token) 需要校验小于父级的长度
+              - <code>chunk_overlap</code> 分段重叠指的是在对数据进行分段时，段与段之间存在一定的重叠部分（选填）
       </Property>
     </Properties>
   </Col>


### PR DESCRIPTION
# Summary

The following four Knowledge APIs allow you to specify "chunk_overlap" as a parameter when creating a document.
However, this is not described in the API specifications, so it needs to be added.

* Create a Document from Text
* Create a Document from a File
* Update a Document with Text
* Update a Document with a File

Fixes https://github.com/langgenius/dify/issues/12180

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

