### PR TITLE
Fix code scanning alert no. 111: Incomplete URL substring sanitization

### DIFF
--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from urllib.parse import urlparse
 from core.helper import ssrf_proxy
 from events.app_event import app_model_config_was_updated, app_was_created
 from extensions.ext_redis import redis_client
@@ -114,7 +115,8 @@ class AppDslService:
             try:
                 max_size = 10 * 1024 * 1024  # 10MB
                 # tricky way to handle url from github to github raw url
-                if yaml_url.startswith("https://github.com") and yaml_url.endswith((".yml", ".yaml")):
+                parsed_url = urlparse(yaml_url)
+                if parsed_url.scheme == "https" and parsed_url.netloc == "github.com" and parsed_url.path.endswith((".yml", ".yaml")):
                     yaml_url = yaml_url.replace("https://github.com", "https://raw.githubusercontent.com")
                     yaml_url = yaml_url.replace("/blob/", "/")
                 response = ssrf_proxy.get(yaml_url.strip(), follow_redirects=True, timeout=(10, 10))

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from enum import StrEnum
 from typing import Optional, cast
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import yaml  # type: ignore
@@ -10,7 +11,6 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from urllib.parse import urlparse
 from core.helper import ssrf_proxy
 from events.app_event import app_model_config_was_updated, app_was_created
 from extensions.ext_redis import redis_client
@@ -116,7 +116,11 @@ class AppDslService:
                 max_size = 10 * 1024 * 1024  # 10MB
                 # tricky way to handle url from github to github raw url
                 parsed_url = urlparse(yaml_url)
-                if parsed_url.scheme == "https" and parsed_url.netloc == "github.com" and parsed_url.path.endswith((".yml", ".yaml")):
+                if (
+                    parsed_url.scheme == "https"
+                    and parsed_url.netloc == "github.com"
+                    and parsed_url.path.endswith((".yml", ".yaml"))
+                ):
                     yaml_url = yaml_url.replace("https://github.com", "https://raw.githubusercontent.com")
                     yaml_url = yaml_url.replace("/blob/", "/")
                 response = ssrf_proxy.get(yaml_url.strip(), follow_redirects=True, timeout=(10, 10))

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -114,7 +114,6 @@ class AppDslService:
                 )
             try:
                 max_size = 10 * 1024 * 1024  # 10MB
-                # tricky way to handle url from github to github raw url
                 parsed_url = urlparse(yaml_url)
                 if (
                     parsed_url.scheme == "https"


### PR DESCRIPTION
Fixes [https://github.com/langgenius/dify/security/code-scanning/111](https://github.com/langgenius/dify/security/code-scanning/111)

To fix the problem, we need to parse the URL and ensure that the host is correctly validated. Instead of using `startswith` and `endswith`, we will use the `urlparse` function from the `urllib.parse` module to extract the hostname and validate it.

1. Parse the URL using `urlparse`.
2. Check if the hostname is "github.com".
3. Ensure the path ends with ".yml" or ".yaml".
4. Replace the URL parts to convert it to the raw GitHub URL if the checks pass.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
