### PR TITLE
chore: fix typo in zh-Hant localization

### DIFF
--- a/web/i18n/zh-Hant/workflow.ts
+++ b/web/i18n/zh-Hant/workflow.ts
@@ -507,7 +507,7 @@ const translation = {
       optionName: {
         image: '圖像',
         url: '網址',
-        doc: '醫生',
+        doc: '文檔',
         localUpload: '本地上傳',
         video: '視頻',
         audio: '音訊',


### PR DESCRIPTION
# Summary
Fixes #12333 
This commit manually corrects an i18n auto-translation error in the workflow.ts file within the zh-Hant locale. The word '醫生' was incorrectly translated and has been manually changed to '文檔'. This fix ensures consistent and accurate language in the i18n files.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| '醫生' | '文檔' |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

