### PR TITLE
fix: Encode Chinese characters with Unicode before querying to match the Unicode encoded Chinese characters in the db

### DIFF
--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -27,7 +27,7 @@ class WorkflowAppService:
             query = query.join(WorkflowRun, WorkflowRun.id == WorkflowAppLog.workflow_run_id)
 
         if keyword:
-            keyword_like_val = f"%{args['keyword'][:30]}%"
+            keyword_like_val = f"%{keyword[:30].encode('unicode_escape').decode('utf-8').replace(r"\u", r"\\u")}%"
             keyword_conditions = [
                 WorkflowRun.inputs.ilike(keyword_like_val),
                 WorkflowRun.outputs.ilike(keyword_like_val),

--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -27,7 +27,7 @@ class WorkflowAppService:
             query = query.join(WorkflowRun, WorkflowRun.id == WorkflowAppLog.workflow_run_id)
 
         if keyword:
-            keyword_like_val = f"%{keyword[:30].encode('unicode_escape').decode('utf-8').replace(r"\u", r"\\u")}%"
+            keyword_like_val = f"%{keyword[:30].encode('unicode_escape').decode('utf-8')}%".replace(r'\u', r'\\u')
             keyword_conditions = [
                 WorkflowRun.inputs.ilike(keyword_like_val),
                 WorkflowRun.outputs.ilike(keyword_like_val),

--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -27,7 +27,7 @@ class WorkflowAppService:
             query = query.join(WorkflowRun, WorkflowRun.id == WorkflowAppLog.workflow_run_id)
 
         if keyword:
-            keyword_like_val = f"%{keyword[:30].encode('unicode_escape').decode('utf-8')}%".replace(r'\u', r'\\u')
+            keyword_like_val = f"%{keyword[:30].encode('unicode_escape').decode('utf-8')}%".replace(r"\u", r"\\u")
             keyword_conditions = [
                 WorkflowRun.inputs.ilike(keyword_like_val),
                 WorkflowRun.outputs.ilike(keyword_like_val),


### PR DESCRIPTION
# Summary

The Chinese characters in the inputs and outputs of the workflow table are stored in Unicode encoding, which prevents the search box from querying workflow run log in Chinese.I encoded the Chinese characters with Unicode before searching the  table, so that a match can be hit normally.I have tested that this change will not affect language queries that are not encoded in Unicode.

<img width="465" alt="image" src="https://github.com/user-attachments/assets/a08c22c4-9e7c-4a7f-ab4d-a6e9ded426eb" />

Resolve https://github.com/langgenius/dify/issues/12039 I noticed that someone had mentioned this error before, but it was closed.

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/f68318bc-f5e0-4135-9335-7363f802b88e)![image](https://github.com/user-attachments/assets/adbe9f07-c4c6-4a37-8012-518444e5b931) | ![image](https://github.com/user-attachments/assets/b855183b-52a1-4b4f-a1b2-048bdefa31c9) ![image](https://github.com/user-attachments/assets/bd3c1edb-3e9c-4cfa-971c-595b9a4e76f4)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

