### PR TITLE
fix: resolve issue with the opening statement generated by the `AutomaticRes` component failing to sync between states.

### DIFF
--- a/web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx
+++ b/web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx
@@ -27,6 +27,7 @@ import { ADD_EXTERNAL_DATA_TOOL } from '@/app/components/app/configuration/confi
 import { INSERT_VARIABLE_VALUE_BLOCK_COMMAND } from '@/app/components/base/prompt-editor/plugins/variable-block'
 import { PROMPT_EDITOR_UPDATE_VALUE_BY_EVENT_EMITTER } from '@/app/components/base/prompt-editor/plugins/update-block'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { useFeaturesStore } from '@/app/components/base/features/hooks'
 
 export type ISimplePromptInput = {
   mode: AppType
@@ -54,6 +55,11 @@ const Prompt: FC<ISimplePromptInput> = ({
   const { t } = useTranslation()
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
+  const featuresStore = useFeaturesStore()
+  const {
+    features,
+    setFeatures,
+  } = featuresStore!.getState()
 
   const { eventEmitter } = useEventEmitterContextContext()
   const {
@@ -137,8 +143,18 @@ const Prompt: FC<ISimplePromptInput> = ({
     })
     setModelConfig(newModelConfig)
     setPrevPromptConfig(modelConfig.configs)
-    if (mode !== AppType.completion)
+
+    if (mode !== AppType.completion) {
       setIntroduction(res.opening_statement)
+      const newFeatures = produce(features, (draft) => {
+        draft.opening = {
+          ...draft.opening,
+          enabled: !!res.opening_statement,
+          opening_statement: res.opening_statement,
+        }
+      })
+      setFeatures(newFeatures)
+    }
     showAutomaticFalse()
   }
   const minHeight = initEditorHeight || 228


### PR DESCRIPTION
# Summary

Resolves #11849 

***This PR is a resubmission as requested, as part of the now-closed #11850 .***

# Fixed 

- Fix the issue where the opening statement generated by the AutomaticRes component was not synchronized between states
  - Before the fix, the opening statement generated by the AutomaticRes component would not automatically apply to the current orchestration state and needed to be saved to take effect. Now, the opening statement will automatically sync with the current orchestration state.

# Modification Details

> This section was automatically generated by `GitHub Copilot actions`.

This pull request includes updates to the `simple-prompt-input.tsx` file to integrate feature management within the prompt configuration component. The main changes involve adding the `useFeaturesStore` hook and updating the state management to include new features.

Feature management integration:

* [`web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx`](diffhunk://#diff-a86c61b88c871ad120b6e92ac1ff479df26e24699919bab80ebf77b9bbbd9a2dR30): Added import for `useFeaturesStore` hook.
* [`web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx`](diffhunk://#diff-a86c61b88c871ad120b6e92ac1ff479df26e24699919bab80ebf77b9bbbd9a2dR58-R62): Initialized `featuresStore` and extracted `features` and `setFeatures` from the store.
* [`web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx`](diffhunk://#diff-a86c61b88c871ad120b6e92ac1ff479df26e24699919bab80ebf77b9bbbd9a2dL140-R157): Updated the prompt configuration logic to set new features when the mode is not `AppType.completion`.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
