### PR TITLE
Bugfix/style and i18n fixes

### DIFF
--- a/web/app/components/app/configuration/dataset-config/params-config/weighted-score.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/weighted-score.tsx
@@ -29,7 +29,7 @@ const WeightedScore = ({
 
   return (
     <div>
-      <div className='px-3 pt-5 h-[52px] space-x-3 rounded-lg border border-components-panel-border'>
+      <div className='px-3 pt-5 pb-2 space-x-3 rounded-lg border border-components-panel-border'>
         <Slider
           className={cn('grow h-0.5 !bg-util-colors-teal-teal-500 rounded-full')}
           max={1.0}
@@ -39,7 +39,7 @@ const WeightedScore = ({
           onChange={v => onChange({ value: [v, (10 - v * 10) / 10] })}
           trackClassName='weightedScoreSliderTrack'
         />
-        <div className='flex justify-between mt-1'>
+        <div className='flex justify-between mt-3'>
           <div className='shrink-0 flex items-center w-[90px] system-xs-semibold-uppercase text-util-colors-blue-light-blue-light-500'>
             <div className='mr-1 truncate uppercase' title={t('dataset.weightedScore.semantic') || ''}>
               {t('dataset.weightedScore.semantic')}

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -28,8 +28,8 @@ const Question: FC<QuestionProps> = ({
   } = item
 
   return (
-    <div className='flex justify-end mb-2 last:mb-0 pl-10'>
-      <div className='group relative mr-4'>
+    <div className='flex justify-end mb-2 last:mb-0 pl-14'>
+      <div className='group relative mr-4 max-w-full'>
         <div
           className='px-4 py-3 bg-[#D1E9FF]/50 rounded-2xl text-sm text-gray-900'
           style={theme?.chatBubbleColorStyle ? CssTransform(theme.chatBubbleColorStyle) : {}}

--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -111,9 +111,9 @@ const CodeBlock: CodeComponent = memo(({ inline, className, children, ...props }
     }
     else if (language === 'echarts') {
       return (
-        <div style={{ minHeight: '350px', minWidth: '700px' }}>
+        <div style={{ minHeight: '350px', minWidth: '100%', overflowX: 'scroll' }}>
           <ErrorBoundary>
-            <ReactEcharts option={chartData} />
+            <ReactEcharts option={chartData} style={{ minWidth: '700px' }} />
           </ErrorBoundary>
         </div>
       )

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -39,6 +39,7 @@ const translation = {
     rename: 'Rename',
     audioSourceUnavailable: 'AudioSource is unavailable',
     copyImage: 'Copy Image',
+    imageCopied: 'Image copied',
     zoomOut: 'Zoom Out',
     zoomIn: 'Zoom In',
     openInNewTab: 'Open in new tab',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -39,6 +39,7 @@ const translation = {
     rename: '重命名',
     audioSourceUnavailable: '音源不可用',
     copyImage: '复制图片',
+    imageCopied: '图片已复制',
     zoomOut: '缩小',
     zoomIn: '放大',
     openInNewTab: '在新标签页打开',


### PR DESCRIPTION
# Summary

Resolves #11849 

***This PR is a resubmission as requested, as part of the now-closed #11850 .***

# Fixed 

- **Fix the style issue with the `WeightedScore` component**
    - Corrected the issue where the `WeightedScore` component slightly overlapped with other elements.

- **Fix the issue of Echarts charts and Markdown tables being too wide in conversations**
    - Resolved the problem where Echarts charts and Markdown tables appeared too wide in conversations, ensuring they display correctly within the message window.

- **Add missing i18n items**
    - Added the missing i18n item for the copy image button in the image preview component.
# Modification Details

> This section was automatically generated by `GitHub Copilot actions`.

This pull request includes several updates to the user interface and internationalization files. The most important changes involve adjustments to the layout and styling of components, as well as updates to translations.

### User Interface Adjustments:

* [`web/app/components/app/configuration/dataset-config/params-config/weighted-score.tsx`](diffhunk://#diff-4b55e7b0ca14b3e8ecd425c7c08bfaeb647db979e79f4dc48e2fb789f85a87ebL32-R32): Adjusted padding and margin in the `WeightedScore` component to improve layout. [[1]](diffhunk://#diff-4b55e7b0ca14b3e8ecd425c7c08bfaeb647db979e79f4dc48e2fb789f85a87ebL32-R32) [[2]](diffhunk://#diff-4b55e7b0ca14b3e8ecd425c7c08bfaeb647db979e79f4dc48e2fb789f85a87ebL42-R42)
* [`web/app/components/base/chat/chat/question.tsx`](diffhunk://#diff-e2ad056343741bcfec2b026286000ef01fe4fa36aa49ced966385840ad255132L31-R32): Modified padding and width properties in the `Question` component to enhance the chat bubble appearance.
* [`web/app/components/base/markdown.tsx`](diffhunk://#diff-52c498c83b6057a375fec61d92cb64425781c64218c6f24bdb3110203a020ddbL114-R116): Updated the `CodeBlock` component to make the chart container responsive and add a horizontal scroll for better display on smaller screens.

### Internationalization Updates:

* [`web/i18n/en-US/common.ts`](diffhunk://#diff-834afc54ad67c45f7cbcaf316e0fddab37b61a7dd741a2abff1a34e4ffdcb620R42): Added a new translation key for "Image copied".
* [`web/i18n/zh-Hans/common.ts`](diffhunk://#diff-414a473343ae77601ef4f5ae2912b7636a38ed80d05611b9b2c70f54a1d91fccR42): Added a new translation key for "图片已复制" (Image copied).