### PR TITLE
Fix the issue where `TextGeneration` component does not correctly clear input data.

### DIFF
--- a/web/app/components/share/text-generation/index.tsx
+++ b/web/app/components/share/text-generation/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { FC } from 'react'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   RiErrorWarningFill,
@@ -93,8 +93,12 @@ const TextGeneration: FC<IMainProps> = ({
   // Notice this situation isCallBatchAPI but not in batch tab
   const [isCallBatchAPI, setIsCallBatchAPI] = useState(false)
   const isInBatchTab = currentTab === 'batch'
-  const [inputs, setInputs] = useState<Record<string, any>>({})
+  const [inputs, doSetInputs] = useState<Record<string, any>>({})
   const inputsRef = useRef(inputs)
+  const setInputs = useCallback((newInputs: Record<string, any>) => {
+    doSetInputs(newInputs)
+    inputsRef.current = newInputs
+  }, [])
   const [appId, setAppId] = useState<string>('')
   const [siteInfo, setSiteInfo] = useState<SiteInfo | null>(null)
   const [canReplaceLogo, setCanReplaceLogo] = useState<boolean>(false)


### PR DESCRIPTION
# Summary

Resolves #11849 

***This PR is a resubmission as requested, as part of the now-closed #11850 .***

# Fixed 

- **Fix the issue where `TextGeneration` component does not correctly clear input data**
    - Fixed the issue in the text generation application where the `TextGeneration` component did not properly reset references when clearing the form. This issue caused old form values to be automatically filled in upon re-entering data. Now, the form references are correctly reset after clearing, ensuring that new input data is not affected by previous values.

# Modification Details

> This section was automatically generated by `GitHub Copilot actions`.

This pull request includes changes to the `web/app/components/share/text-generation/index.tsx` file to improve the handling of state updates and references. The most important changes are the addition of the `useCallback` hook and the refactoring of the `inputs` state management.

Improvements to state management:

* Added `useCallback` to memoize the `setInputs` function, ensuring that it does not get recreated on each render. (`web/app/components/share/text-generation/index.tsx`)
* Refactored the `inputs` state management by introducing `doSetInputs` and `inputsRef` to keep the state and its reference in sync. (`web/app/components/share/text-generation/index.tsx`)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
