### PR TITLE
fix: fix issue with `chat-input-area` clearing during Responding state.

### DIFF
--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -39,6 +39,7 @@ type ChatInputAreaProps = {
   inputs?: Record<string, any>
   inputsForm?: InputForm[]
   theme?: Theme | null
+  isResponding?: boolean
 }
 const ChatInputArea = ({
   showFeatureBar,
@@ -51,6 +52,7 @@ const ChatInputArea = ({
   inputs = {},
   inputsForm = [],
   theme,
+  isResponding,
 }: ChatInputAreaProps) => {
   const { t } = useTranslation()
   const { notify } = useToastContext()
@@ -77,6 +79,11 @@ const ChatInputArea = ({
   const historyRef = useRef([''])
   const [currentIndex, setCurrentIndex] = useState(-1)
   const handleSend = () => {
+    if (isResponding) {
+      notify({ type: 'info', message: t('appDebug.errorMessage.waitForResponse') })
+      return
+    }
+
     if (onSend) {
       const { files, setFiles } = filesStore.getState()
       if (files.find(item => item.transferMethod === TransferMethod.local_file && !item.uploadedId)) {
@@ -116,7 +123,7 @@ const ChatInputArea = ({
         setQuery(historyRef.current[currentIndex + 1])
       }
       else if (currentIndex === historyRef.current.length - 1) {
-      // If it is the last element, clear the input box
+        // If it is the last element, clear the input box
         setCurrentIndex(historyRef.current.length)
         setQuery('')
       }

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -292,6 +292,7 @@ const Chat: FC<ChatProps> = ({
                   inputs={inputs}
                   inputsForm={inputsForm}
                   theme={themeBuilder?.theme}
+                  isResponding={isResponding}
                 />
               )
             }


### PR DESCRIPTION
# Summary

Resolves #11849 

***This PR is a resubmission as requested, as part of the now-closed #11850 .***

## Fixed

- Fix the issue where the `chat-input-area` was cleared in response state
  - Fixed the issue where the input box content was cleared after sending a message in response state. Now, it will check if the state is in response mode, and if so, it will display a prompt and retain the input box content.

# Modification Details

> This section was automatically generated by `GitHub Copilot actions`.

This pull request includes changes to the `ChatInputArea` component to handle the scenario when a response is already being processed. The most important changes include adding a new `isResponding` property to the component's props and implementing a check to notify the user if a response is in progress.

Enhancements to `ChatInputArea` component:

* [`web/app/components/base/chat/chat/chat-input-area/index.tsx`](diffhunk://#diff-0f2fea1c6856ffaf8e9ad3be67d02e176e4ed92c585847813210b58a642c2767R42): Added `isResponding` property to `ChatInputAreaProps` and included it in the component's destructured props. [[1]](diffhunk://#diff-0f2fea1c6856ffaf8e9ad3be67d02e176e4ed92c585847813210b58a642c2767R42) [[2]](diffhunk://#diff-0f2fea1c6856ffaf8e9ad3be67d02e176e4ed92c585847813210b58a642c2767R55)
* [`web/app/components/base/chat/chat/chat-input-area/index.tsx`](diffhunk://#diff-0f2fea1c6856ffaf8e9ad3be67d02e176e4ed92c585847813210b58a642c2767R82-R86): Implemented a check in the `handleSend` function to notify the user if a response is already being processed, preventing multiple simultaneous responses.

Integration with `Chat` component:

* [`web/app/components/base/chat/chat/index.tsx`](diffhunk://#diff-1997e9de3191a3a5147e5a628bb6b4bec22e6af48b4e3907a56d4a7fbcac73c4R295): Passed the `isResponding` prop to the `ChatInputArea` component to ensure the new functionality is integrated.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
