### PR TITLE
fix: correct fetch_from for customizable models

### DIFF
--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -978,7 +978,7 @@ class ProviderConfiguration(BaseModel):
                     label=custom_model_schema.label,
                     model_type=custom_model_schema.model_type,
                     features=custom_model_schema.features,
-                    fetch_from=custom_model_schema.fetch_from,
+                    fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
                     model_properties=custom_model_schema.model_properties,
                     deprecated=custom_model_schema.deprecated,
                     provider=SimpleModelProviderEntity(self.provider),


### PR DESCRIPTION
# Summary

This PR is for `fix/chore-fix` branch, as a follow-up for #12372.

This PR fixes the issue that customizable models are treated as predefined models by API which causes the missing `Config` button for customizable models on Web UI.

Additional context: https://discord.com/channels/1082486657678311454/1324964911356317736, https://github.com/langgenius/dify/pull/12372#issuecomment-2572328093

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

