### PR TITLE
fix: [PromptEditorHeightResizeWrap] Bug  #12410 

### DIFF
--- a/web/app/components/app/configuration/config-prompt/prompt-editor-height-resize-wrap.tsx
+++ b/web/app/components/app/configuration/config-prompt/prompt-editor-height-resize-wrap.tsx
@@ -26,13 +26,15 @@ const PromptEditorHeightResizeWrap: FC<Props> = ({
   const [clientY, setClientY] = useState(0)
   const [isResizing, setIsResizing] = useState(false)
   const [prevUserSelectStyle, setPrevUserSelectStyle] = useState(getComputedStyle(document.body).userSelect)
+  const [oldHeight, setOldHeight] = useState(height)
 
   const handleStartResize = useCallback((e: React.MouseEvent<HTMLElement>) => {
     setClientY(e.clientY)
     setIsResizing(true)
+    setOldHeight(height)
     setPrevUserSelectStyle(getComputedStyle(document.body).userSelect)
     document.body.style.userSelect = 'none'
-  }, [])
+  }, [height])
 
   const handleStopResize = useCallback(() => {
     setIsResizing(false)
@@ -44,8 +46,7 @@ const PromptEditorHeightResizeWrap: FC<Props> = ({
       return
 
     const offset = e.clientY - clientY
-    let newHeight = height + offset
-    setClientY(e.clientY)
+    let newHeight = oldHeight + offset
     if (newHeight < minHeight)
       newHeight = minHeight
     onHeightChange(newHeight)


### PR DESCRIPTION
# Summary

fix: `PromptEditorHeightResizeWrap`  Bug where the mouse and drag bar may be misaligned

Close: #12410 

# Screenshots

| Before | After |
|--------|-------|
|![before](https://github.com/user-attachments/assets/7010301c-1e56-487c-83eb-6ee147545cd2)  | ![after](https://github.com/user-attachments/assets/99f88006-0846-498d-9163-a5e189d11bc9) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

