### PR TITLE
Fixes #12414: Add cheaper model and long context model for Qwen2.5-72B-Instruct from siliconflow

### DIFF
--- a/api/core/model_runtime/model_providers/siliconflow/llm/_position.yaml
+++ b/api/core/model_runtime/model_providers/siliconflow/llm/_position.yaml
@@ -7,6 +7,8 @@
 - Qwen/Qwen2.5-Coder-7B-Instruct
 - Qwen/Qwen2-VL-72B-Instruct
 - Qwen/Qwen2-1.5B-Instruct
+- Qwen/Qwen2.5-72B-Instruct-128K
+- Vendor-A/Qwen/Qwen2.5-72B-Instruct
 - Pro/Qwen/Qwen2-VL-7B-Instruct
 - OpenGVLab/InternVL2-26B
 - Pro/OpenGVLab/InternVL2-8B

--- a/api/core/model_runtime/model_providers/siliconflow/llm/qwen2.5-72b-instruct-128k.yaml
+++ b/api/core/model_runtime/model_providers/siliconflow/llm/qwen2.5-72b-instruct-128k.yaml
@@ -1,12 +1,12 @@
-model: Qwen/Qwen2.5-72B-Instruct
+model: Qwen/Qwen2.5-72B-Instruct-128K
 label:
-  en_US: Qwen/Qwen2.5-72B-Instruct
+  en_US: Qwen/Qwen2.5-72B-Instruct-128K
 model_type: llm
 features:
   - agent-thought
 model_properties:
   mode: chat
-  context_size: 32768
+  context_size: 131072
 parameter_rules:
   - name: temperature
     use_template: temperature

--- a/api/core/model_runtime/model_providers/siliconflow/llm/qwen2.5-72b-instruct-vendorA.yaml
+++ b/api/core/model_runtime/model_providers/siliconflow/llm/qwen2.5-72b-instruct-vendorA.yaml
@@ -1,6 +1,6 @@
-model: Qwen/Qwen2.5-72B-Instruct
+model: Vendor-A/Qwen/Qwen2.5-72B-Instruct
 label:
-  en_US: Qwen/Qwen2.5-72B-Instruct
+  en_US: Vendor-A/Qwen/Qwen2.5-72B-Instruct
 model_type: llm
 features:
   - agent-thought
@@ -45,7 +45,7 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: '4.13'
-  output: '4.13'
+  input: '1.00'
+  output: '1.00'
   unit: '0.000001'
   currency: RMB


### PR DESCRIPTION
# Summary

Fixes #12414

Add cheaper model and long context model for Qwen2.5-72B-Instruct from siliconflow 


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

