### PR TITLE
Add 'document' feature to Sonnet 3.5 through OpenRouter

### DIFF
--- a/api/core/model_runtime/model_providers/openrouter/llm/claude-3-5-sonnet.yaml
+++ b/api/core/model_runtime/model_providers/openrouter/llm/claude-3-5-sonnet.yaml
@@ -7,6 +7,7 @@ features:
   - vision
   - tool-call
   - stream-tool-call
+  - document
 model_properties:
   mode: chat
   context_size: 200000


### PR DESCRIPTION
Adding 'document' feature flag fixes #12443 and allows document uploading if Sonnet 3.5 is used through OpenRouter instead of Anthropic.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

