### PR TITLE
fix: allow fallback to remote_url when url is not provided

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -158,7 +158,7 @@ def _build_from_remote_url(
     tenant_id: str,
     transfer_method: FileTransferMethod,
 ) -> File:
-    url = mapping.get("url")
+    url = mapping.get("url") or mapping.get("remote_url")
     if not url:
         raise ValueError("Invalid file url")
 


### PR DESCRIPTION
# Summary

When handling files from a URL, the parameter should be `remote_url`, so this function should also get it from `remote_url`. However, the actual implementation references the `url` parameter.
I was unable to confirm whether the `url` parameter was actually used, so the original parameter implementation has been left intact.
If the `url` parameter is not used, you can delete this part.

Fixes #12454
Also Fixes #12209

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

