### PR TITLE
Fix: Add a INFO-level log when fallback to gpt2tokenizer

### DIFF
--- a/api/core/model_runtime/model_providers/__base/tokenizers/gpt2_tokenzier.py
+++ b/api/core/model_runtime/model_providers/__base/tokenizers/gpt2_tokenzier.py
@@ -1,5 +1,8 @@
+import logging
 from threading import Lock
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 _tokenizer: Any = None
 _lock = Lock()
@@ -43,5 +46,6 @@ class GPT2Tokenizer:
                     base_path = abspath(__file__)
                     gpt2_tokenizer_path = join(dirname(base_path), "gpt2")
                     _tokenizer = TransformerGPT2Tokenizer.from_pretrained(gpt2_tokenizer_path)
+                    logger.info("Fallback to Transformers' GPT-2 tokenizer from tiktoken")
 
             return _tokenizer


### PR DESCRIPTION
# Summary
To improve user noticefication when fallback to gpt2tokenizer, I added INFO logs to the following script.
[dify/api/core/model_runtime/model_providers/__base/tokenizers/gpt2_tokenzier.py](https://github.com/langgenius/dify/blob/0a49d3dd5274e1f37d9d05ccbc7284c64d9d20a4/api/core/model_runtime/model_providers/__base/tokenizers/gpt2_tokenzier.py#L38)
Fixes #12486 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

