### PR TITLE
feat: add ci job to test template for docker compose

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -82,6 +82,33 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: yarn run lint
 
+  docker-compose-template:
+    name: Docker Compose Template
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            docker/generate_docker_compose
+            docker/.env.example
+            docker/docker-compose-template.yaml
+            docker/docker-compose.yaml
+
+      - name: Generate Docker Compose
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          cd docker
+          ./generate_docker_compose
+
+      - name: Check for changes
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: git diff --exit-code
 
   superlinter:
     name: SuperLinter


### PR DESCRIPTION
# Summary

This PR introduce new CI test in `Style check` to test compose file and its template are in sync.
This test fails if _**the docker-compose.yaml and docker-compose-template.yaml are not in sync**_,

- Triggered if the changes are in:
  - docker/generate_docker_compose
  - docker/.env.example
  - docker/docker-compose-template.yaml
  - docker/docker-compose.yaml
- Invokes `generate_docker_compose`
- If any changes are detected by `git diff`, the test will be failed. If not, the test will be passed

Closes #12505 

# Demos

- ✅ No changes on above four files: not triggered:
  - https://github.com/kurokobo/dify/actions/runs/12672961281/job/35318192941
- 🚨 Changes are made, and the files are not in sync:
  - only templae file is updated, so there is diff on docker-compose.yaml (added lines)
  - https://github.com/kurokobo/dify/actions/runs/12673119362/job/35318742314
- 🚨 Changes are made, and the files are not in sync:
  - only compose file is updated, so there is diff on docker-compose.yaml (removed lines)
  - https://github.com/kurokobo/dify/actions/runs/12673161796/job/35318908533
- ✅ Changes are made, and the files are in sync
  - https://github.com/kurokobo/dify/actions/runs/12673225163/job/35319129415

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

