### PR TITLE
Introducing: Plugin Mechanism

### DIFF
--- a/api/configs/packaging/__init__.py
+++ b/api/configs/packaging/__init__.py
@@ -9,7 +9,7 @@ class PackagingInfo(BaseSettings):
 
     CURRENT_VERSION: str = Field(
         description="Dify version",
-        default="0.15.0",
+        default="1.0.0-beta1",
     )
 
     COMMIT_SHA: str = Field(

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -50,7 +50,7 @@ class WordExtractor(BaseExtractor):
 
             self.web_path = self.file_path
             # TODO: use a better way to handle the file
-            self.temp_file = tempfile.NamedTemporaryFile()
+            self.temp_file = tempfile.NamedTemporaryFile()  # noqa SIM115
             self.temp_file.write(r.content)
             self.file_path = self.temp_file.name
         elif not os.path.isfile(self.file_path):
@@ -234,7 +234,7 @@ class WordExtractor(BaseExtractor):
                                     continue
                                 for i in url_pattern.findall(x.text):
                                     hyperlinks_url = str(i)
-                    except Exception as e:
+                    except Exception:
                         logger.exception("Failed to parse HYPERLINK xml")
 
         def parse_paragraph(paragraph):

--- a/docker-legacy/docker-compose.yaml
+++ b/docker-legacy/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # API service
   api:
-    image: langgenius/dify-api:0.15.0
+    image: langgenius/dify-api:1.0.0-beta1
     restart: always
     environment:
       # Startup mode, 'api' starts the API server.
@@ -227,7 +227,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:0.15.0
+    image: langgenius/dify-api:1.0.0-beta1
     restart: always
     environment:
       CONSOLE_WEB_URL: ''
@@ -397,7 +397,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:0.15.0
+    image: langgenius/dify-web:1.0.0-beta1
     restart: always
     environment:
       # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -2,7 +2,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:13f0c01f933d80b559f4f3bd56cb3ef8dafa7b9a
+    image: langgenius/dify-api:1.0.0-beta1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -34,7 +34,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:13f0c01f933d80b559f4f3bd56cb3ef8dafa7b9a
+    image: langgenius/dify-api:1.0.0-beta1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -62,7 +62,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:13f0c01f933d80b559f4f3bd56cb3ef8dafa7b9a
+    image: langgenius/dify-web:1.0.0-beta1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -388,6 +388,7 @@ x-shared-env: &shared-api-worker-env
   CSP_WHITELIST: ${CSP_WHITELIST:-}
   CREATE_TIDB_SERVICE_JOB_ENABLED: ${CREATE_TIDB_SERVICE_JOB_ENABLED:-false}
   MAX_SUBMIT_COUNT: ${MAX_SUBMIT_COUNT:-100}
+  TOP_K_MAX_VALUE: ${TOP_K_MAX_VALUE:-10}
   DB_PLUGIN_DATABASE: ${DB_PLUGIN_DATABASE:-dify-plugin}
   EXPOSE_PLUGIN_DAEMON_PORT: ${EXPOSE_PLUGIN_DAEMON_PORT:-5002}
   PLUGIN_DAEMON_PORT: ${PLUGIN_DAEMON_PORT:-5002}
@@ -404,12 +405,11 @@ x-shared-env: &shared-api-worker-env
   ENDPOINT_URL_TEMPLATE: ${ENDPOINT_URL_TEMPLATE:-http://localhost/e/{hook_id}}
   MARKETPLACE_ENABLED: ${MARKETPLACE_ENABLED:-true}
   MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace-plugin.dify.dev}
-  TOP_K_MAX_VALUE: ${TOP_K_MAX_VALUE:-10}
 
 services:
   # API service
   api:
-    image: langgenius/dify-api:dev-plugin-deploy
+    image: langgenius/dify-api:1.0.0-beta1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -423,8 +423,8 @@ services:
       PLUGIN_API_URL: ${PLUGIN_DAEMON_URL:-http://plugin_daemon:5002}
       PLUGIN_MAX_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       INNER_API_KEY_FOR_PLUGIN: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
-      MARKETPLACE_ENABLED: ${MARKETPLACE_ENABLED:-false}
-      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace-plugin.dify.dev}
+      MARKETPLACE_ENABLED: ${MARKETPLACE_ENABLED:-true}
+      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace.dify.ai}
       PLUGIN_REMOTE_INSTALL_PORT: ${EXPOSE_PLUGIN_DEBUGGING_PORT:-5003}
       PLUGIN_REMOTE_INSTALL_HOST: ${EXPOSE_PLUGIN_DEBUGGING_HOST:-localhost}
       ENDPOINT_URL_TEMPLATE: ${ENDPOINT_URL_TEMPLATE:-http://localhost/e/{hook_id}}
@@ -441,7 +441,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:dev-plugin-deploy
+    image: langgenius/dify-api:1.0.0-beta1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -456,7 +456,7 @@ services:
       PLUGIN_MAX_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       INNER_API_KEY_FOR_PLUGIN: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
       MARKETPLACE_ENABLED: ${MARKETPLACE_ENABLED:-false}
-      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace-plugin.dify.dev}
+      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace.dify.ai}
     depends_on:
       - db
       - redis
@@ -469,19 +469,17 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:dev-plugin-deploy
+    image: langgenius/dify-web:1.0.0-beta1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
       APP_API_URL: ${APP_API_URL:-}
-      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-}
-      MARKETPLACE_URL: ${MARKETPLACE_URL:-}
       SENTRY_DSN: ${WEB_SENTRY_DSN:-}
       NEXT_TELEMETRY_DISABLED: ${NEXT_TELEMETRY_DISABLED:-0}
       TEXT_GENERATION_TIMEOUT_MS: ${TEXT_GENERATION_TIMEOUT_MS:-60000}
       CSP_WHITELIST: ${CSP_WHITELIST:-}
-      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace-plugin.dify.dev}
-      MARKETPLACE_URL: ${MARKETPLACE_URL:-https://marketplace-plugin.dify.dev}
+      MARKETPLACE_API_URL: ${MARKETPLACE_API_URL:-https://marketplace.dify.ai}
+      MARKETPLACE_URL: ${MARKETPLACE_URL:-https://marketplace.dify.ai}
       TOP_K_MAX_VALUE: ${TOP_K_MAX_VALUE:-}
 
   # The postgres database.
@@ -547,7 +545,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:47c8bed17c22f67bd035d0979e696cb00ca45b16-local
+    image: langgenius/dify-plugin-daemon:0.0.1-local
     restart: always
     environment:
       # Use the shared environment variables.
@@ -557,7 +555,6 @@ services:
       SERVER_KEY: ${PLUGIN_DAEMON_KEY:-lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi}
       MAX_PLUGIN_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       PPROF_ENABLED: ${PLUGIN_PPROF_ENABLED:-false}
-      DEBUGGING_PORT: ${PLUGIN_DEBUGGING_PORT:-5003}
       DIFY_INNER_API_URL: ${PLUGIN_DIFY_INNER_API_URL:-http://api:5001}
       DIFY_INNER_API_KEY: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
       PLUGIN_REMOTE_INSTALLING_HOST: ${PLUGIN_DEBUGGING_HOST:-0.0.0.0}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "0.15.0",
+  "version": "1.0.0-beta1",
   "private": true,
   "engines": {
     "node": ">=18.17.0"


### PR DESCRIPTION
## Introduce Plugin Mechanism
We'm glad to share that we're launching Plugins beta.
Plugins are modular components that extend AI applications with plug-and-play simplicity. Now you can assemble external services and custom functionalities with your Dify apps effortlessly.
### What have we done?
- We've developed a plugin system, a standard for Dify that lets users create plugins with the suffix .difypkg. By installing different plugin packages, you can add various capabilities to Dify.
- Through this system, we've decoupled tools and models that can be expanded from Dify, enabling you to install them in a truly plug-and-play manner.
- We've introduced a new Agent node in Workflow, where the agent's behavior can now be defined by plugins. This means Dify is no longer limited to built-in strategies like CoT; you can define your own agent strategies.
- We've also introduced a new type of plugin called Endpoint, which is a custom service hosted within Dify. You can customize this service's code through plugins to handle external Webhook events.
- We've launched the Dify Marketplace, a centralized platform where plugins can be freely shared, allowing users to publish and download different plugins.
## Importants
- !! This is a beta version of Dify v1.0.0. Please do not upgrade your production environment directly to this version.
- !! In this plugin version, some tools are too closely integrated with Dify and haven't been fully migrated to v1.0.0. This might cause certain tools to become unavailable during migration. Tools developed through custom development on Dify also cannot be migrated. You can manually migrate your existing implementations to plugins by referring to the plugin development documentation.
## Docker Deployment
v1.0.0 supports one-click Docker compose deployment. You can start the Dify service using the following commands:
```bash
git checkout 1.0.0-beta1
cd ./docker
./generate_docker_compose
docker compose -f docker-compose.yaml up -d
```

## Plugin Migration
- !! Note, if you are upgrading from an older version to v1.0.0, you need to execute some basic migration steps.
The first step in upgrading to v1.0.0 is to install the tools and models used in your current environment into the new plugin environment, ensuring plugin installation is completed before database migration. During installation, run the following command:
```bash
poetry run flask extract-plugins --workers=20
```
This command extracts all models and tools used in the current environment. The workers parameter determines the number of parallel processes during extraction; adjust it according to your needs.
The final result will be saved in the plugins.jsonl file, which contains the plugin information for all workspaces in the current Dify instance.
Ensure your network is functioning properly and can access https://marketplace.dify.ai, then run the following command:
```bash
poetry run flask install-plugins
```
This command will download and install all necessary plugins into the latest environment.
## Database Migration
After completing the basic plugin installation process, follow the standard Dify upgrade procedure to update the database schema to the latest version.
```bash
poetry run flask db upgrade
```
Dify v1.0 includes compatibility for old data. You should be able to operate normally, but for better future compatibility, run the following data migration command once you're sure you won't revert to an older version:
```bash
poetry run flask migrate-data-for-plugin
```
This command will prefix existing model and tool vendors in the database with langgenius, such as converting openai to langgenius/openai/openai. This operation may affect the functioning of the older Dify version, so back up your database before running this command to prevent unwanted issues.