### PR TITLE
fix: add location directive for /explore

### DIFF
--- a/docker/nginx/conf.d/default.conf.template
+++ b/docker/nginx/conf.d/default.conf.template
@@ -24,6 +24,11 @@ server {
       include proxy.conf;
     }
 
+    location /explore {
+      proxy_pass http://web:3000;
+      include proxy.conf;
+    }
+
     location /e {
       proxy_pass http://plugin_daemon:5002;
       include proxy.conf;


### PR DESCRIPTION
# Summary

**This is for `plugins/beta` branch**

Add a `location` directive for `/explore` to prevent requests for `/explore` from being matched with `/e` and routed to the plugin daemon.

Closes #12570

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/eaaae85d-1765-46cf-8e00-fdd1587efaa1)   | ![image](https://github.com/user-attachments/assets/e6fe0281-9236-4835-93b7-db7bf61620e6)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

