### PR TITLE
Fix #12592: Execution is interrupted when the subsequent flow of the else branch is in a new parallel stream.

### DIFF
--- a/api/core/workflow/graph_engine/graph_engine.py
+++ b/api/core/workflow/graph_engine/graph_engine.py
@@ -430,7 +430,13 @@ class GraphEngine:
                     next_node_id = final_node_id
 
             if in_parallel_id and self.graph.node_parallel_mapping.get(next_node_id, "") != in_parallel_id:
-                break
+                source_edges = self.graph.reverse_edge_mapping.get(next_node_id, [])
+                source_node_ids = {edge.source_node_id for edge in source_edges}
+                if len(source_node_ids) == 1:
+                    # if -> node1, node2, else -> node2. the current path follows the else branch.
+                    in_parallel_id = self.graph.node_parallel_mapping.get(next_node_id, "")
+                else:
+                    break
 
     def _run_parallel_branches(
         self,


### PR DESCRIPTION
# Summary

Fixes #12592 


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/ddfe6bac-db49-491f-9123-351810f532f2)    | ![image](https://github.com/user-attachments/assets/6ebb2c1d-2723-4715-90ff-778518b206d2)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

