### PR TITLE
Fix HTTP Request node to give priority to file extension of content-disposition

### DIFF
--- a/api/core/workflow/nodes/http_request/entities.py
+++ b/api/core/workflow/nodes/http_request/entities.py
@@ -109,14 +109,12 @@ class Response:
         3. MIME type analysis
         """
         content_type = self.content_type.split(";")[0].strip().lower()
-        content_disposition = self.response.headers.get("content-disposition", "")
+        parsed_content_disposition = self.parsed_content_disposition
 
         # Check if it's explicitly marked as an attachment
-        if content_disposition:
-            msg = Message()
-            msg["content-disposition"] = content_disposition
-            disp_type = msg.get_content_disposition()  # Returns 'attachment', 'inline', or None
-            filename = msg.get_filename()  # Returns filename if present, None otherwise
+        if parsed_content_disposition:
+            disp_type = parsed_content_disposition.get_content_disposition()  # Returns 'attachment', 'inline', or None
+            filename = parsed_content_disposition.get_filename()  # Returns filename if present, None otherwise
             if disp_type == "attachment" or filename is not None:
                 return True
 
@@ -178,3 +176,12 @@ class Response:
             return f"{(self.size / 1024):.2f} KB"
         else:
             return f"{(self.size / 1024 / 1024):.2f} MB"
+
+    @property
+    def parsed_content_disposition(self) -> Optional[Message]:
+        content_disposition = self.headers.get("content-disposition", "")
+        if content_disposition:
+            msg = Message()
+            msg["content-disposition"] = content_disposition
+            return msg
+        return None

--- a/api/core/workflow/nodes/http_request/node.py
+++ b/api/core/workflow/nodes/http_request/node.py
@@ -173,6 +173,13 @@ class HttpRequestNode(BaseNode[HttpRequestNodeData]):
         is_file = response.is_file
         content_type = response.content_type
         content = response.content
+        parsed_content_disposition = response.parsed_content_disposition
+
+        if parsed_content_disposition:
+            content_disposition_filename = parsed_content_disposition.get_filename()
+            if content_disposition_filename:
+                # If filename is available from content-disposition, use it to guess the content type
+                content_type = mimetypes.guess_type(content_disposition_filename)[0]
 
         if is_file:
             # Guess file extension from URL or Content-Type header

--- a/api/core/workflow/nodes/http_request/node.py
+++ b/api/core/workflow/nodes/http_request/node.py
@@ -169,7 +169,7 @@ class HttpRequestNode(BaseNode[HttpRequestNodeData]):
         """
         Extract files from response by checking both Content-Type header and URL
         """
-        files = []
+        files: list[File] = []
         is_file = response.is_file
         content_type = response.content_type
         content = response.content


### PR DESCRIPTION
# Summary
In the HTTP Request Node, I have modified the configuration to prioritize the value of the Content-Disposition header of response. This change ensures that even if a downloaded file is identified as a binary (bin) file, it will be treated as a Docx document, aligning with our expectation.
Fixes #12608 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

