### PR TITLE
fix: fix the formatter is not applied on log file

### DIFF
--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -27,12 +27,11 @@ def init_app(app: DifyApp):
     # Always add StreamHandler to log to console
     sh = logging.StreamHandler(sys.stdout)
     sh.addFilter(RequestIdFilter())
-    log_formatter = logging.Formatter(fmt=dify_config.LOG_FORMAT)
-    sh.setFormatter(log_formatter)
     log_handlers.append(sh)
 
     logging.basicConfig(
         level=dify_config.LOG_LEVEL,
+        format=dify_config.LOG_FORMAT,
         datefmt=dify_config.LOG_DATEFORMAT,
         handlers=log_handlers,
         force=True,


### PR DESCRIPTION
# Summary

Fixes https://github.com/langgenius/dify/issues/12744.

In https://github.com/langgenius/dify/pull/11599, the patch removed the formatter from `basicConfig` and added it only to the `stdout`, however, the log file requires formatter as well. This patch adds the formatter back.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

In log files:

Before:
```
INFO:root:Loaded ext_storage (364.46 ms)
INFO:root:Loaded ext_celery (1.46 ms)
INFO:root:Loaded ext_login (0.01 ms)
INFO:root:Skipped ext_mail
INFO:root:Loaded ext_hosting_provider (0.0 ms)
INFO:root:Loaded ext_sentry (0.0 ms)
INFO:root:Loaded ext_proxy_fix (0.0 ms)
INFO:root:Loaded ext_blueprints (373.1 ms)
INFO:root:Loaded ext_commands (1.6 ms)
INFO:root:Finished create_app (11808.69 ms)
INFO:werkzeug:[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5001
 * Running on http://x.x.x.x:5001
INFO:werkzeug:[33mPress CTRL+C to quit[0m
```

After:
```
2025-01-14 23:45:21,637.637 INFO [MainThread] [app_factory.py:90] - Loaded ext_celery (2.81 ms)
2025-01-14 23:45:21,637.637 INFO [MainThread] [app_factory.py:90] - Loaded ext_login (0.02 ms)
2025-01-14 23:45:21,637.637 INFO [MainThread] [app_factory.py:83] - Skipped ext_mail
2025-01-14 23:45:21,637.637 INFO [MainThread] [app_factory.py:90] - Loaded ext_hosting_provider (0.01 ms)
2025-01-14 23:45:21,637.637 INFO [MainThread] [app_factory.py:90] - Loaded ext_sentry (0.0 ms)
2025-01-14 23:45:21,637.637 INFO [MainThread] [app_factory.py:90] - Loaded ext_proxy_fix (0.0 ms)
2025-01-14 23:45:22,001.001 INFO [MainThread] [app_factory.py:90] - Loaded ext_blueprints (364.07 ms)
2025-01-14 23:45:22,003.003 INFO [MainThread] [app_factory.py:90] - Loaded ext_commands (1.27 ms)
2025-01-14 23:45:22,003.003 INFO [MainThread] [app_factory.py:28] - Finished create_app (6042.56 ms)
2025-01-14 23:45:22,008.008 INFO [MainThread] [_internal.py:97] - [31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5001
 * Running on http://x.x.x.x:5001
2025-01-14 23:45:22,008.008 INFO [MainThread] [_internal.py:97] - [33mPress CTRL+C to quit[0m
```

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

