### PR TITLE
fix: variable panel scrollable

### DIFF
--- a/web/app/components/app/log/var-panel.tsx
+++ b/web/app/components/app/log/var-panel.tsx
@@ -39,7 +39,7 @@ const VarPanel: FC<Props> = ({
         }
       </div>
       {!isCollapse && (
-        <div className='p-3 flex flex-col gap-2'>
+        <div className='p-3 flex flex-col gap-2 max-h-[500px] overflow-y-auto'>
           {varList.map(({ label, value }, index) => (
             <div key={index} className='flex py-2 system-xs-medium'>
               <div className='shrink-0 w-[128px] flex text-text-accent'>


### PR DESCRIPTION
# Summary

I found that if there are too long variables in the variable panel of the app log, it will not be able to be viewed.
This is a simple fix that allows var panel to scroll.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![nofix](https://github.com/user-attachments/assets/40f88100-fe78-4a6e-b8d2-c167e0804fb3) | ![fixed](https://github.com/user-attachments/assets/b98fa009-e135-43ad-bdef-a73cd41d529d) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
