### PR TITLE
bug: fixed bedrock rerank bug

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/rerank/rerank.py
+++ b/api/core/model_runtime/model_providers/bedrock/rerank/rerank.py
@@ -70,7 +70,7 @@ class BedrockRerankModel(RerankModel):
         rerankingConfiguration = {
             "type": "BEDROCK_RERANKING_MODEL",
             "bedrockRerankingConfiguration": {
-                "numberOfResults": top_n,
+                "numberOfResults": min(top_n, len(text_sources)),
                 "modelConfiguration": {
                     "modelArn": model_package_arn,
                 },


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> [bedrock] Error: An error occurred (ValidationException) when calling the Rerank operation: Cannot provide numberOfResults value that exceeds the number of sources.

Close https://github.com/langgenius/dify/issues/12640

# Screenshots

| Before | After |
|--------|-------|
| <img width="1277" alt="image" src="https://github.com/user-attachments/assets/9ccfdc87-4b7d-4769-a3ca-6b43f6c38c02" />  | <img width="972" alt="image" src="https://github.com/user-attachments/assets/59cda73f-1529-4103-b3e0-f986daedbb8b" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

