### PR TITLE
fix: SparkLite API Auth error (#12781)

### DIFF
--- a/api/core/model_runtime/model_providers/spark/llm/_client.py
+++ b/api/core/model_runtime/model_providers/spark/llm/_client.py
@@ -21,7 +21,7 @@ class SparkLLMClient:
             domain = api_domain
 
         model_api_configs = {
-            "spark-lite": {"version": "v1.1", "chat_domain": "general"},
+            "spark-lite": {"version": "v1.1", "chat_domain": "lite"},
             "spark-pro": {"version": "v3.1", "chat_domain": "generalv3"},
             "spark-pro-128k": {"version": "pro-128k", "chat_domain": "pro-128k"},
             "spark-max": {"version": "v3.5", "chat_domain": "generalv3.5"},


### PR DESCRIPTION
# Summary

Fixes #12781 

According to the official documentation, the chat_domain of spark-lite should be "lite".
https://www.xfyun.cn/doc/spark/Web.html#_1-%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E
![image](https://github.com/user-attachments/assets/ad0893cf-6c51-4762-9abb-fc5789a0bbab)


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

