### PR TITLE
fix(1.0): unexpected error raise

### DIFF
--- a/api/core/plugin/manager/tool.py
+++ b/api/core/plugin/manager/tool.py
@@ -48,8 +48,10 @@ class PluginToolManager(BasePluginManager):
         tool_provider_id = GenericProviderID(provider)
 
         def transformer(json_response: dict[str, Any]) -> dict:
-            for tool in json_response.get("data", {}).get("declaration", {}).get("tools", []):
-                tool["identity"]["provider"] = tool_provider_id.provider_name
+            data = json_response.get("data")
+            if data:
+                for tool in data.get("declaration", {}).get("tools", []):
+                    tool["identity"]["provider"] = tool_provider_id.provider_name
 
             return json_response
 

--- a/api/core/tools/plugin_tool/provider.py
+++ b/api/core/tools/plugin_tool/provider.py
@@ -48,7 +48,9 @@ class PluginToolProviderController(BuiltinToolProviderController):
         """
         return tool with given name
         """
-        tool_entity = next(tool_entity for tool_entity in self.entity.tools if tool_entity.identity.name == tool_name)
+        tool_entity = next(
+            (tool_entity for tool_entity in self.entity.tools if tool_entity.identity.name == tool_name), None
+        )
 
         if not tool_entity:
             raise ValueError(f"Tool with name {tool_name} not found")


### PR DESCRIPTION
# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

### First
![71d198310db93b12262e05e12f28f2f](https://github.com/user-attachments/assets/fdd0ccf3-343f-46e0-93ad-10739960b075)
This will raise `None type has no attribute 'get'`

### Second
![f80c50462ffcbe735f9acc38d656dee](https://github.com/user-attachments/assets/0c63caad-6aa7-4f66-b400-531d439202bc)
the expected `Tool with name not found` error will not raised


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

