### PR TITLE
feat: add model credential schema for Google provider

### DIFF
--- a/api/core/model_runtime/model_providers/google/google.yaml
+++ b/api/core/model_runtime/model_providers/google/google.yaml
@@ -19,6 +19,19 @@ supported_model_types:
   - llm
 configurate_methods:
   - predefined-model
+model_credential_schema:
+  model:
+    label:
+      en_US: Model Name
+  credential_form_schemas:
+    - variable: google_api_key
+      label:
+        en_US: API Key
+      type: secret-input
+      required: true
+      placeholder:
+        zh_Hans: 在此输入您的 API Key
+        en_US: Enter your API Key
 provider_credential_schema:
   credential_form_schemas:
     - variable: google_api_key


### PR DESCRIPTION
# Summary

Fixes #12850

I added the `model_credential_schema` setting because without it the encrypted key cannot be decrypted.

https://github.com/langgenius/dify/blob/bc3a570dda37cbb8539d9a5c1494e3a4317fc090/api/core/provider_manager.py#L891-L900

I don't understand the correct role of `model_credential_schema` . If this could cause other issues, please fix the PR.


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

