### PR TITLE
fix(i18n): correct typo in zh-Hant translation

### DIFF
--- a/web/i18n/zh-Hant/common.ts
+++ b/web/i18n/zh-Hant/common.ts
@@ -607,7 +607,7 @@ const translation = {
     pasteFileLink: '粘貼文件連結',
     pasteFileLinkInputPlaceholder: '輸入網址...',
     uploadFromComputerReadError: '檔案讀取失敗，請重試。',
-    uploadFromComputerUploadError: '檔上傳失敗，請重新上傳。',
+    uploadFromComputerUploadError: '檔案上傳失敗，請重新上傳。',
     pasteFileLinkInvalid: '無效的文件連結',
     uploadFromComputer: '本地上傳',
     fileExtensionNotSupport: '不支援檔擴展名',


### PR DESCRIPTION
Corrected the translation for "uploadFromComputerUploadError":
- "檔上傳失敗，請重新上傳。" → "檔案上傳失敗，請重新上傳。"

Fix https://github.com/langgenius/dify/issues/12883

# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Corrected a typo in the Traditional Chinese (zh-Hant) i18n translation for the key uploadFromComputerUploadError.

Original: "檔上傳失敗，請重新上傳。"
Corrected: "檔案上傳失敗，請重新上傳。"
檔 --> 檔案



# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

