### PR TITLE
fix: run out of memory due to indexing/embedding documents

### DIFF
--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -156,7 +156,12 @@ class Vector:
         if texts:
             for i in range(0, len(texts), max_batch_documents):
                 batch_documents = texts[i : i + max_batch_documents]
-                self.add_texts(batch_documents, duplicate_check=True, **kwargs)
+                batch_contents = [document.page_content for document in batch_documents]
+                batch_embeddings = self._embeddings.embed_documents(batch_contents)
+                if i < max_batch_documents:
+                    self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
+                else:
+                    self._vector_processor.add_texts(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
 
     def add_texts(self, documents: list[Document], **kwargs):
         if kwargs.get("duplicate_check", False):

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -150,7 +150,7 @@ class Vector:
                 return OceanBaseVectorFactory
             case _:
                 raise ValueError(f"Vector store {vector_type} is not supported.")
-    
+
     max_batch_documents = 1000
 
     def create(self, texts: Optional[list] = None, **kwargs):

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -152,6 +152,7 @@ class Vector:
                 raise ValueError(f"Vector store {vector_type} is not supported.")
     
     max_batch_documents = 1000
+
     def create(self, texts: Optional[list] = None, **kwargs):
         if texts:
             for i in range(0, len(texts), self.max_batch_documents):

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -151,12 +151,11 @@ class Vector:
             case _:
                 raise ValueError(f"Vector store {vector_type} is not supported.")
 
-    max_batch_documents = 1000
-
     def create(self, texts: Optional[list] = None, **kwargs):
+        max_batch_documents = 1000
         if texts:
-            for i in range(0, len(texts), self.max_batch_documents):
-                batch_documents = texts[i : i + self.max_batch_documents]
+            for i in range(0, len(texts), max_batch_documents):
+                batch_documents = texts[i : i + max_batch_documents]
                 batch_contents = [document.page_content for document in batch_documents]
                 batch_embeddings = self._embeddings.embed_documents(batch_contents)
                 self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -161,7 +161,7 @@ class Vector:
                 if i < max_batch_documents:
                     self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
                 else:
-                    self._vector_processor.add_texts(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
+                    self._vector_processor.add_texts(documents=batch_documents, embeddings=batch_embeddings, **kwargs)
 
     def add_texts(self, documents: list[Document], **kwargs):
         if kwargs.get("duplicate_check", False):

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -154,8 +154,8 @@ class Vector:
     max_batch_documents = 1000
     def create(self, texts: Optional[list] = None, **kwargs):
         if texts:
-            for i in range(0, len(texts), self.max_documents):
-                batch_documents = texts[i:i + self.max_documents]
+            for i in range(0, len(texts), self.max_batch_documents):
+                batch_documents = texts[i:i + self.max_batch_documents]
                 batch_embeddings = self._embeddings.embed_documents([document.page_content for document in batch_documents])
                 self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
 

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -150,11 +150,14 @@ class Vector:
                 return OceanBaseVectorFactory
             case _:
                 raise ValueError(f"Vector store {vector_type} is not supported.")
-
+    
+    max_batch_documents = 1000
     def create(self, texts: Optional[list] = None, **kwargs):
         if texts:
-            embeddings = self._embeddings.embed_documents([document.page_content for document in texts])
-            self._vector_processor.create(texts=texts, embeddings=embeddings, **kwargs)
+            for i in range(0, len(texts), self.max_documents):
+                batch_documents = texts[i:i + self.max_documents]
+                batch_embeddings = self._embeddings.embed_documents([document.page_content for document in batch_documents])
+                self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
 
     def add_texts(self, documents: list[Document], **kwargs):
         if kwargs.get("duplicate_check", False):

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -156,7 +156,8 @@ class Vector:
         if texts:
             for i in range(0, len(texts), self.max_batch_documents):
                 batch_documents = texts[i:i + self.max_batch_documents]
-                batch_embeddings = self._embeddings.embed_documents([document.page_content for document in batch_documents])
+                batch_contents = [document.page_content for document in batch_documents]
+                batch_embeddings = self._embeddings.embed_documents(batch_contents)
                 self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
 
     def add_texts(self, documents: list[Document], **kwargs):

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -156,7 +156,7 @@ class Vector:
     def create(self, texts: Optional[list] = None, **kwargs):
         if texts:
             for i in range(0, len(texts), self.max_batch_documents):
-                batch_documents = texts[i:i + self.max_batch_documents]
+                batch_documents = texts[i : i + self.max_batch_documents]
                 batch_contents = [document.page_content for document in batch_documents]
                 batch_embeddings = self._embeddings.embed_documents(batch_contents)
                 self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -156,9 +156,7 @@ class Vector:
         if texts:
             for i in range(0, len(texts), max_batch_documents):
                 batch_documents = texts[i : i + max_batch_documents]
-                batch_contents = [document.page_content for document in batch_documents]
-                batch_embeddings = self._embeddings.embed_documents(batch_contents)
-                self._vector_processor.create(texts=batch_documents, embeddings=batch_embeddings, **kwargs)
+                self.add_texts(batch_documents, duplicate_check=True, **kwargs)
 
     def add_texts(self, documents: list[Document], **kwargs):
         if kwargs.get("duplicate_check", False):


### PR DESCRIPTION
# Summary

Fixes #12893 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| document pending indexing. ![image](https://github.com/user-attachments/assets/0be4b68e-d183-41c8-9c28-3e39316f340a)    | document avaliable. ![image](https://github.com/user-attachments/assets/644108a4-1a7b-4df5-b4be-eb3b3cdcd6b2)
  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

