### PR TITLE
Fix: update dataset segment keywords

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -747,6 +747,14 @@ class DatasetKeywordTable(db.Model):  # type: ignore[name-defined]
                 logging.exception(f"Failed to load keyword table from file: {file_key}")
                 return None
 
+    def update_keyword_table_dict(self, new_keyword_table_dict):
+        if self.data_source_type != "database":
+            return
+        updated_keyword_table = json.dumps(new_keyword_table_dict, default=list)
+        self.keyword_table = updated_keyword_table
+        db.session.add(self)
+        db.session.commit()
+
 
 class Embedding(db.Model):  # type: ignore[name-defined]
     __tablename__ = "embeddings"


### PR DESCRIPTION
# Summary

Fix the issue that the inverted index of the knowledge base is not updated synchronously when adding keywords to the segment.

Fixes #12884

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/b91c7ca4-b2b2-479c-8b73-0ebbdf77e82b)|![image](https://github.com/user-attachments/assets/94d17cc7-e7b4-448a-816e-648099b04540)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

