### PR TITLE
fix: 500 error in Notion integration API

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -135,7 +135,7 @@ class DataSourceNotionListApi(Resource):
                         data_source_info = json.loads(document.data_source_info)
                         exist_page_ids.append(data_source_info["notion_page_id"])
             # get all authorized pages
-            data_source_bindings = session.execute(
+            data_source_bindings = session.scalars(
                 select(DataSourceOauthBinding).filter_by(
                     tenant_id=current_user.current_tenant_id, provider="notion", disabled=False
                 )


### PR DESCRIPTION
# Summary
Fixed 500 error in Notion integration API caused by incorrect SQLAlchemy query result handling. The issue occurred when users tried to access Notion workspace list in the knowledge base section. 

Changes made:
- Replace `session.execute()` with `session.scalars()` in DataSourceNotionListApi
- Fix SQLAlchemy query result handling for notion workspace listing
- Ensure proper model instance access for source_info

No new dependencies required.

Fixes #12933

# Checklist
> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods