### PR TITLE
fix: get property of string type variable caused page crash

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -546,7 +546,9 @@ export const getVarType = ({
   else {
     (valueSelector as ValueSelector).slice(1).forEach((key, i) => {
       const isLast = i === valueSelector.length - 2
-      curr = curr?.find((v: any) => v.variable === key)
+      if (Array.isArray(curr))
+        curr = curr?.find((v: any) => v.variable === key)
+
       if (isLast) {
         type = curr?.type
       }


### PR DESCRIPTION
# Summary

Fix: get property of string type variable caused page crash. 


# Screenshots
![image](https://github.com/user-attachments/assets/37d24fb3-89bf-4306-904a-7a9e8c89a9f4)
![image](https://github.com/user-attachments/assets/35969a0a-0e43-47ed-ace9-db08ded8a82c)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

