### PR TITLE
Fix docker-compose command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Ensure that .sh scripts use LF as line separator, even if they are checked out
 # to Windows(NTFS) file-system, by a user of Docker for Window. 
-# These .sh scripts will be run from the Container after `docker compose up -d`.
+# These .sh scripts will be run from the Container after `docker-compose up -d`.
 # If they appear to be CRLF style, Dash from the Container will fail to execute
 # them.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The easiest way to start the Dify server is through [docker compose](docker/dock
 cd dify
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 After running, you can access the Dify dashboard in your browser at [http://localhost/install](http://localhost/install) and start the initialization process.

--- a/README_AR.md
+++ b/README_AR.md
@@ -163,7 +163,7 @@
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 بعد التشغيل، يمكنك الوصول إلى لوحة تحكم Dify في متصفحك على [http://localhost/install](http://localhost/install) وبدء عملية التهيئة.

--- a/README_CN.md
+++ b/README_CN.md
@@ -186,7 +186,7 @@ Dify 是一个开源的 LLM 应用开发平台。其直观的界面结合了 AI 
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 运行后，可以在浏览器上访问 [http://localhost/install](http://localhost/install) 进入 Dify 控制台并开始初始化安装操作。

--- a/README_ES.md
+++ b/README_ES.md
@@ -186,7 +186,7 @@ La forma más fácil de iniciar el servidor de Dify es ejecutar nuestro archivo 
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 Después de ejecutarlo, puedes acceder al panel de control de Dify en tu navegador en [http://localhost/install](http://localhost/install) y comenzar el proceso de inicialización.

--- a/README_FR.md
+++ b/README_FR.md
@@ -186,7 +186,7 @@ La manière la plus simple de démarrer le serveur Dify est d'exécuter notre fi
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 Après l'exécution, vous pouvez accéder au tableau de bord Dify dans votre navigateur à [http://localhost/install](http://localhost/install) et commencer le processus d'initialisation.

--- a/README_JA.md
+++ b/README_JA.md
@@ -185,7 +185,7 @@ Difyサーバーを起動する最も簡単な方法は、[docker-compose.yml](d
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 実行後、ブラウザで[http://localhost/install](http://localhost/install)にアクセスし、初期化プロセスを開始できます。

--- a/README_KL.md
+++ b/README_KL.md
@@ -186,7 +186,7 @@ The easiest way to start the Dify server is to run our [docker-compose.yml](dock
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 After running, you can access the Dify dashboard in your browser at [http://localhost/install](http://localhost/install) and start the initialization process.

--- a/README_KR.md
+++ b/README_KR.md
@@ -178,7 +178,7 @@ Dify 서버를 시작하는 가장 쉬운 방법은 [docker-compose.yml](docker/
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 실행 후 브라우저의 [http://localhost/install](http://localhost/install) 에서 Dify 대시보드에 액세스하고 초기화 프로세스를 시작할 수 있습니다.

--- a/README_PT.md
+++ b/README_PT.md
@@ -184,7 +184,7 @@ A maneira mais fácil de iniciar o servidor Dify é executar nosso arquivo [dock
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 Após a execução, você pode acessar o painel do Dify no navegador em [http://localhost/install](http://localhost/install) e iniciar o processo de inicialização.

--- a/README_SI.md
+++ b/README_SI.md
@@ -63,7 +63,7 @@ Najlažji način za zagon strežnika Dify je prek docker compose . Preden zažen
 cd dify
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 Po zagonu lahko dostopate do nadzorne plošče Dify v brskalniku na [http://localhost/install](http://localhost/install) in začnete postopek inicializacije.

--- a/README_TR.md
+++ b/README_TR.md
@@ -184,7 +184,7 @@ Dify sunucusunu başlatmanın en kolay yolu, [docker-compose.yml](docker/docker-
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 Çalıştırdıktan sonra, tarayıcınızda [http://localhost/install](http://localhost/install) adresinden Dify kontrol paneline erişebilir ve başlangıç ayarları sürecini başlatabilirsiniz.

--- a/README_VI.md
+++ b/README_VI.md
@@ -180,7 +180,7 @@ Cách dễ nhất để khởi động máy chủ Dify là chạy tệp [docker-
 ```bash
 cd docker
 cp .env.example .env
-docker compose up -d
+docker-compose up -d
 ```
 
 Sau khi chạy, bạn có thể truy cập bảng điều khiển Dify trong trình duyệt của bạn tại [http://localhost/install](http://localhost/install) và bắt đầu quá trình khởi tạo.

--- a/api/README.md
+++ b/api/README.md
@@ -13,7 +13,7 @@
    cd ../docker
    cp middleware.env.example middleware.env
    # change the profile to other vector database if you are not using weaviate
-   docker compose -f docker-compose.middleware.yaml --profile weaviate -p dify up -d
+   docker-compose -f docker-compose.middleware.yaml --profile weaviate -p dify up -d
    cd ../api
    ```
 

--- a/docker/certbot/README.md
+++ b/docker/certbot/README.md
@@ -72,5 +72,5 @@ docker compose exec nginx nginx -s reload
 To use cert files dir `nginx/ssl` as before, simply launch containers WITHOUT `--profile certbot` option.
 
 ```shell
-docker compose up -d
+docker-compose up -d
 ```


### PR DESCRIPTION
This PR reverts #5681.

Since the [README](https://github.com/langgenius/dify/blob/d1ca492563c176ea120d732263b840ad64bfc1b4/README.md#quick-start) already instructs users to ensure that Docker Compose is installed, it is reasonable to assume that Docker Compose is already installed.
https://github.com/langgenius/dify/blob/d1ca492563c176ea120d732263b840ad64bfc1b4/README.md#L62

Moreover, this is a backend document, and I believe it is essential to ensure the accuracy of the documentation. Especially since this is within a markdown code block, every line must run correctly (if there is an error, you should Google where the problem is or raise an issue).

And if they are indeed noobs, the original modification would actually lead them in the wrong direction.


