### PR TITLE
fix: wrong zh_Hans translation: Ohio

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/bedrock.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/bedrock.yaml
@@ -54,7 +54,7 @@ provider_credential_schema:
         - value: us-east-2
           label:
             en_US: US East (Ohio)
-            zh_Hans: 美国东部 (弗吉尼亚北部)
+            zh_Hans: 美国东部 (俄亥俄)
         - value: us-west-2
           label:
             en_US: US West (Oregon)


### PR DESCRIPTION
# Summary

Fixed wrong zh_Hans translation: Ohio
Close https://github.com/langgenius/dify/issues/12883

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

