### PR TITLE
feat: add support for X-Forwarded-Port in ProxyFix middleware

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -315,8 +315,8 @@ class HttpConfig(BaseSettings):
     )
 
     RESPECT_XFORWARD_HEADERS_ENABLED: bool = Field(
-        description="Enable or disable the X-Forwarded-For Proxy Fix middleware from Werkzeug"
-        " to respect X-* headers to redirect clients",
+        description="Enable handling of X-Forwarded-For, X-Forwarded-Proto, and X-Forwarded-Port headers"
+        " when the app is behind a single trusted reverse proxy.",
         default=False,
     )
 

--- a/api/extensions/ext_proxy_fix.py
+++ b/api/extensions/ext_proxy_fix.py
@@ -6,4 +6,4 @@ def init_app(app: DifyApp):
     if dify_config.RESPECT_XFORWARD_HEADERS_ENABLED:
         from werkzeug.middleware.proxy_fix import ProxyFix
 
-        app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
+        app.wsgi_app = ProxyFix(app.wsgi_app, x_port=1)  # type: ignore

--- a/docker/nginx/proxy.conf.template
+++ b/docker/nginx/proxy.conf.template
@@ -3,6 +3,7 @@
 proxy_set_header Host $host;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Port $server_port;
 proxy_http_version 1.1;
 proxy_set_header Connection "";
 proxy_buffering off;


### PR DESCRIPTION
# Summary

Updated ProxyFix middleware to include x_port=1 for handling the X-Forwarded-Port header. Improved the description of RESPECT_XFORWARD_HEADERS_ENABLED for clarity.

I couldn't find RESPECT_XFORWARD_HEADERS_ENABLED in the [Dify Document](https://github.com/langgenius/dify-docs). Please advise if documentation should be added.

Fixes #13070 

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist


- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

