### PR TITLE
add azure openai api version 2024-12-01-preview

### DIFF
--- a/api/core/model_runtime/model_providers/azure_openai/azure_openai.yaml
+++ b/api/core/model_runtime/model_providers/azure_openai/azure_openai.yaml
@@ -54,6 +54,9 @@ model_credential_schema:
       required: true
       options:
         - label:
+            en_US: 2024-12-01-preview
+          value: 2024-12-01-preview
+        - label:
             en_US: 2024-10-01-preview
           value: 2024-10-01-preview
         - label:


### PR DESCRIPTION
# Summary

I have added 2024-12-01-preview, which is the minimum API version required to use o1 in Azure Open AI.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

