### PR TITLE
fix: set indexing technique from dataset during update-by-text

### DIFF
--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -143,6 +143,9 @@ class DocumentUpdateByTextApi(DatasetApiResource):
         if not dataset:
             raise ValueError("Dataset is not exist.")
 
+        # indexing_technique is already set in dataset since this is an update
+        args["indexing_technique"] = dataset.indexing_technique
+
         # Validate metadata if provided
         if args.get("doc_type") or args.get("doc_metadata"):
             if not args.get("doc_type") or not args.get("doc_metadata"):


### PR DESCRIPTION
# Summary

This PR fixes an `invalid_param` error in the `update-by-text` API endpoint. 
The error occurs when `indexing_technique` is not provided to the `KnowledgeConfig` validation, resulting in a Pydantic validation error.

Example of the current error:
```curl
curl --location --request POST 'http://127.0.0.1:5001/v1/datasets/UUID_HERE/documents/UUID_HERE/update-by-text' \
--header 'Authorization: Bearer API_KEY_HERE' \
--header 'Content-Type: application/json' \
--data-raw '{"name": "name2","text": "text"}'
```

Response:
```json
{
    "code": "invalid_param",
    "message": "1 validation error for KnowledgeConfig\nindexing_technique\n  Field required [type=missing, input_value={'name': 'name2', 'text':...4da8-9a39-a78f4108669a'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.9/v/missing",
    "status": 400
}
```

The `indexing_technique` parameter is only meant to be set during document creation or initial upload, as shown in the [current dataset_service implementation](https://github.com/langgenius/dify/blob/main/api/services/dataset_service.py#L789). For update operations, this field should not be required since it's already set and immutable.

This PR fixes the issue by defaulting to the dataset's existing `indexing_technique` value in the update API endpoint.

resolves #12465

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

