### PR TITLE
Install apt dependencies using bookworm source, consistent with base image. Remove unnecessary, error-prone pins

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -52,10 +52,10 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl nodejs libgmp-dev libmpfr-dev libmpc-dev \
     # if you located in China, you can use aliyun mirror to speed up
     # && echo "deb http://mirrors.aliyun.com/debian testing main" > /etc/apt/sources.list \
-    && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
+    && echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list \
     && apt-get update \
     # For Security
-    && apt-get install -y --no-install-recommends expat=2.6.4-1 libldap2=2.6.9+dfsg-1 perl=5.40.0-8 libsqlite3-0=3.46.1-1 zlib1g=1:1.3.dfsg+really1.3.1-1+b1 \
+    && apt-get install -y --no-install-recommends expat libldap-2.5-0 perl libsqlite3-0 zlib1g \
     # install a chinese font to support the use of tools like matplotlib
     && apt-get install -y fonts-noto-cjk \
     # install libmagic to support the use of python-magic guess MIMETYPE


### PR DESCRIPTION
# Summary

This fixes libldap and libmagic dependency issue which is breaking `main` branch CICD build and causing run-time errors for users.

## Explanation

Current `api/Dockerfile` pinned a small subset (e.g. `libldap`) of dependencies to very specific versions but not the rest of packages. This causes version conflict troubles when other 3rd-party packages get updated.

Using `bookworm` as base Docker image but using `testing` debian package source makes the situation worse. 

As a result, the api docker image build encounters error and breaks CI. 
 
# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

