### PR TITLE
fix: mypy checks violation in AzureBlobStorage

### DIFF
--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -1,7 +1,8 @@
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
+from typing import Optional
 
-from azure.identity import DefaultAzureCredential
+from azure.identity import ChainedTokenCredential, DefaultAzureCredential
 from azure.storage.blob import AccountSasPermissions, BlobServiceClient, ResourceTypes, generate_account_sas
 
 from configs import dify_config
@@ -19,6 +20,7 @@ class AzureBlobStorage(BaseStorage):
         self.account_name = dify_config.AZURE_BLOB_ACCOUNT_NAME
         self.account_key = dify_config.AZURE_BLOB_ACCOUNT_KEY
 
+        self.credential: Optional[ChainedTokenCredential] = None
         if self.account_key == "managedidentity":
             self.credential = DefaultAzureCredential()
         else:

--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -64,7 +64,7 @@ class AzureBlobStorage(BaseStorage):
 
     def _sync_client(self):
         if self.account_key == "managedidentity":
-            return BlobServiceClient(account_url=self.account_url, credential=self.credential) # type: ignore
+            return BlobServiceClient(account_url=self.account_url, credential=self.credential)  # type: ignore
 
         cache_key = "azure_blob_sas_token_{}_{}".format(self.account_name, self.account_key)
         cache_result = redis_client.get(cache_key)

--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -64,7 +64,7 @@ class AzureBlobStorage(BaseStorage):
 
     def _sync_client(self):
         if self.account_key == "managedidentity":
-            return BlobServiceClient(account_url=self.account_url, credential=self.credential)
+            return BlobServiceClient(account_url=self.account_url, credential=self.credential) # type: ignore
 
         cache_key = "azure_blob_sas_token_{}_{}".format(self.account_name, self.account_key)
         cache_result = redis_client.get(cache_key)


### PR DESCRIPTION
# Summary
- to fix #13216 bug introduced in #13216
- to fix the violation in mypy checks:
```
extensions/storage/azure_blob_storage.py:25: error: Incompatible types in assignment (expression has type "None", variable has type "DefaultAzureCredential")  [assignment]
extensions/storage/azure_blob_storage.py:67: error: Argument "account_url" to "BlobServiceClient" has incompatible type "str | None"; expected "str"  [arg-type]
Found 2 errors in 1 file (checked 952 source files)
```

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

