### PR TITLE
Fix ruff linting error caused by `api/models/dataset.py`

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -583,7 +583,7 @@ class DocumentSegment(db.Model):  # type: ignore[name-defined]
                 return []
         else:
             return []
-    
+
     @property
     def sign_content(self):
         return self.get_sign_content()


### PR DESCRIPTION
# Summary
Fix ruff linting error 

This resolves one of the blocking conditions in https://github.com/langgenius/dify/pull/13214

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

