### PR TITLE
feat: add think display for volcengine and generic openapi 

### DIFF
--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -543,7 +543,6 @@ class OAIAPICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                         delta_content = "\n\n" + delta_content
                         is_reasoning_started = False
 
-
                     assistant_message_tool_calls = None
 
                     if "tool_calls" in delta and credentials.get("function_calling_type", "no_call") == "tool_call":

--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -473,6 +473,8 @@ class OAIAPICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
 
         finish_reason = None  # The default value of finish_reason is None
         message_id, usage = None, None
+        is_reasoning_started = False
+        is_reasoning_started_tag = False
         for chunk in response.iter_lines(decode_unicode=True, delimiter=delimiter):
             chunk = chunk.strip()
             if chunk:
@@ -513,6 +515,34 @@ class OAIAPICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 if "delta" in choice:
                     delta = choice["delta"]
                     delta_content = delta.get("content")
+
+                    if not is_reasoning_started_tag and "<think>" in delta_content:
+                        is_reasoning_started_tag = True
+                        delta_content = "> 💭 " + delta_content.replace("<think>", "")
+                    elif is_reasoning_started_tag and "</think>" in delta_content:
+                        delta_content = delta_content.replace("</think>", "") + "\n\n"
+                        is_reasoning_started_tag = False
+                    elif is_reasoning_started_tag:
+                        if "\n\n" in delta_content:
+                            delta_content = delta_content.replace("\n\n", "\n> ")
+                        elif "\n" in delta_content:
+                            delta_content = delta_content.replace("\n", "\n> ")
+
+                    reasoning_content = delta.get("reasoning_content")
+                    if reasoning_content:
+                        if not is_reasoning_started:
+                            delta_content = "> 💭 " + reasoning_content
+                            is_reasoning_started = True
+                        elif "\n\n" in delta_content:
+                            delta_content = reasoning_content.replace("\n\n", "\n> ")
+                        elif "\n" in delta_content:
+                            delta_content = reasoning_content.replace("\n", "\n> ")
+                    elif is_reasoning_started:
+                        # If we were in reasoning mode but now getting regular content,
+                        # add \n\n to close the reasoning block
+                        delta_content = "\n\n" + delta_content
+                        is_reasoning_started = False
+
 
                     assistant_message_tool_calls = None
 

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -266,7 +266,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
 
                         content = delta_content
                     elif is_reasoning_started:
-                        content = "\n\n" + content
+                        content = "\n\n" + chunk.choices[0].delta.content
                         is_reasoning_started = False
                     else:
                         content = chunk.choices[0].delta.content
@@ -277,7 +277,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                     delta=LLMResultChunkDelta(
                         index=0,
                         message=AssistantPromptMessage(
-                            content=chunk.choices[0].delta.content if chunk.choices else "", tool_calls=[]
+                            content=content, tool_calls=[]
                         ),
                         usage=self._calc_response_usage(
                             model=model,

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -251,7 +251,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
             for chunk in chunks:
                 content = ""
                 if chunk.choices:
-                    if hasattr(chunk.choices[0].delta, 'reasoning_content'):
+                    if hasattr(chunk.choices[0].delta, "reasoning_content"):
                         delta_content = ""
                         if not is_reasoning_started:
                             is_reasoning_started = True
@@ -276,9 +276,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                     prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=0,
-                        message=AssistantPromptMessage(
-                            content=content, tool_calls=[]
-                        ),
+                        message=AssistantPromptMessage(content=content, tool_calls=[]),
                         usage=self._calc_response_usage(
                             model=model,
                             credentials=credentials,


### PR DESCRIPTION
# Summary

Similar to #12949 and #13152, but for volcengine and generic openapi.

Theoritically, this could remove duplicated code in those two PRs, but sadly I don't have accounts and keys to test them... So I only add new code.

Close https://github.com/langgenius/dify/issues/13255

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ![图片](https://github.com/user-attachments/assets/47bed915-1da9-4c36-8a14-bbc07f310c74)  |
| ... | ![图片](https://github.com/user-attachments/assets/31633639-aba8-4833-9b3a-7192d5184a43)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

