### PR TITLE
feat: added all DeepSeek r1 models on aws bedrock to bedrock model provider

### DIFF
--- a/api/core/model_runtime/model_providers/bedrock/llm/_position.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/_position.yaml
@@ -12,6 +12,13 @@
 - cohere.command-text-v14
 - cohere.command-r-plus-v1.0
 - cohere.command-r-v1.0
+- deepseek-llm-r1-distill-llama-8b
+- deepseek-llm-r1-distill-llama-70b
+- deepseek-llm-r1-distill-qwen-1.5b
+- deepseek-llm-r1-distill-qwen-7b
+- deepseek-llm-r1-distill-qwen-14b
+- deepseek-llm-r1-distill-qwen-32b
+- deepseek-llm-r1
 - meta.llama3-1-8b-instruct-v1:0
 - meta.llama3-1-70b-instruct-v1:0
 - meta.llama3-1-405b-instruct-v1:0

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-llama-70b.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-llama-70b.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1-distill-llama-70b
+label:
+  en_US: deepseek-llm-r1-distill-llama-70b
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-llama-8b.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-llama-8b.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1-distill-llama-8b
+label:
+  en_US: deepseek-llm-r1-distill-llama-8b
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-1.5b.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-1.5b.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1-distill-qwen-1.5b
+label:
+  en_US: deepseek-llm-r1-distill-qwen-1.5b
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-14b.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-14b.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1-distill-qwen-14b
+label:
+  en_US: deepseek-llm-r1-distill-qwen-14b
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-32b.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-32b.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1-distill-qwen-32b
+label:
+  en_US: deepseek-llm-r1-distill-qwen-32b
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-7b.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1-distill-qwen-7b.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1-distill-qwen-7b
+label:
+  en_US: deepseek-llm-r1-distill-qwen-7b
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB

--- a/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1.yaml
+++ b/api/core/model_runtime/model_providers/bedrock/llm/deepseek-llm-r1.yaml
@@ -1,0 +1,20 @@
+model: deepseek-llm-r1
+label:
+  en_US: deepseek-llm-r1
+model_type: llm
+features:
+  - agent-thought
+model_properties:
+  mode: chat
+  context_size: 64000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 8192
+    default: 4096
+pricing:
+  input: "4"
+  output: "16"
+  unit: "0.000001"
+  currency: RMB


### PR DESCRIPTION
# Summary

I have added all DeepSeek r1 models on aws bedrock by adding the required yaml files to bedrock model provider in `api\core\model_runtime\model_providers\bedrock`. Partially fixes #13248 . One thing I am not sure about is pricing since bedrock pricing is different(since it uses instance pricing) from the direct api pricing which I have used in my yaml files.

The models themselves can be found on this [page](https://us-east-2.console.aws.amazon.com/bedrock/home?region=us-east-2#/model-catalog)(Note: use US-East or US-West region to find the deepseek models)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

