### PR TITLE
fix: incorrect transferMethod assignment for remote file

### DIFF
--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -211,7 +211,7 @@ export const useFile = (fileConfig: FileUpload) => {
       type: '',
       size: 0,
       progress: 0,
-      transferMethod: TransferMethod.local_file,
+      transferMethod: TransferMethod.remote_url,
       supportFileType: '',
       url,
       isRemote: true,


### PR DESCRIPTION
# Summary

Fixes #13285 

https://github.com/langgenius/dify/blob/16865d43a8195053a5f1fe45d414e5332a568c1d/api/factories/file_factory.py#L260 

The `file_transfer_method` is always set to `local_file`, causing a validation error when `config.image_config.transfer_methods` is set to `[remote_url]`.


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

