### PR TITLE
fix: add compatibility config for third-party S3-compatible providers

### DIFF
--- a/api/extensions/storage/aws_s3_storage.py
+++ b/api/extensions/storage/aws_s3_storage.py
@@ -32,7 +32,9 @@ class AwsS3Storage(BaseStorage):
                 aws_access_key_id=dify_config.S3_ACCESS_KEY,
                 endpoint_url=dify_config.S3_ENDPOINT,
                 region_name=dify_config.S3_REGION,
-                config=Config(s3={"addressing_style": dify_config.S3_ADDRESS_STYLE}),
+                config=Config(s3={"addressing_style": dify_config.S3_ADDRESS_STYLE},
+                              request_checksum_calculation="when_required",
+                              response_checksum_validation="when_required"),
             )
         # create bucket
         try:

--- a/api/extensions/storage/aws_s3_storage.py
+++ b/api/extensions/storage/aws_s3_storage.py
@@ -32,9 +32,11 @@ class AwsS3Storage(BaseStorage):
                 aws_access_key_id=dify_config.S3_ACCESS_KEY,
                 endpoint_url=dify_config.S3_ENDPOINT,
                 region_name=dify_config.S3_REGION,
-                config=Config(s3={"addressing_style": dify_config.S3_ADDRESS_STYLE},
-                              request_checksum_calculation="when_required",
-                              response_checksum_validation="when_required"),
+                config=Config(
+                    s3={"addressing_style": dify_config.S3_ADDRESS_STYLE},
+                    request_checksum_calculation="when_required",
+                    response_checksum_validation="when_required",
+                ),
             )
         # create bucket
         try:


### PR DESCRIPTION
# Summary

dify 0.15.3 upgraded boto3 version

<img width="501" alt="image" src="https://github.com/user-attachments/assets/ac3f6acf-52d6-4654-8d85-88220060d29d" />


Starting in boto3-1.36.0, the request_checksum_calculation config is set to when_supported in all AWS SDKs and AWS CLI (see https://github.com/boto/boto3/issues/4392 for more details). This means SDKs will now compute checksums by default for service operations that model support for them.

This update has introduced an incompatibility issue with certain third-party S3-compatible providers including Huawei Cloud OBS and ByteDance TOS, which currently do not support this new configuration. When executing the PutObject operation, the system returns an error: "The provided content-sha256 does not match what was computed."

Setting the following when create boto3 client fixes the problem, this skips the calculation and validation of checksums when not required:
`request_checksum_calculation="when_required"`
`response_checksum_validation="when_required"`

Rolling back to `boto3==1.35.x` can also solve this problem, but I'm not sure if there are any features that depend on the new version sdk.

See the [Data Integrity Protections for Amazon S3](https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html) guide for more details.

Resolves https://github.com/langgenius/dify/issues/13348


# Screenshots

| Before | After |
|--------|-------|
| <img width="1584" alt="bug" src="https://github.com/user-attachments/assets/da49cccd-3418-4128-a23c-c39ac41dbdee" /> | <img width="1572" alt="fix" src="https://github.com/user-attachments/assets/b768afe6-0162-49ce-b0fd-a9fdaf8ea651" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

