### PR TITLE
fix: Fix HTTP request node non 443 port SSL site inaccessible

### DIFF
--- a/docker/ssrf_proxy/squid.conf.template
+++ b/docker/ssrf_proxy/squid.conf.template
@@ -7,6 +7,7 @@ acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
 acl localnet src fc00::/7       	# RFC 4193 local private network range
 acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
 acl SSL_ports port 443
+acl SSL_ports port 1025-65535
 acl Safe_ports port 80		# http
 acl Safe_ports port 21		# ftp
 acl Safe_ports port 443		# https


### PR DESCRIPTION
# Summary

Fix the issue where HTTP request nodes cannot access SSL sites on ports other than 443.

Closes #12792

# Screenshots

| Before | After |
|--------|-------|
|  ![image](https://github.com/user-attachments/assets/01da75e8-9a60-495d-884c-fa5699f74360) | ![image](https://github.com/user-attachments/assets/52dab794-1660-4506-8979-9147eb100253) |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

