### PR TITLE
fix: install installed plugin problem

### DIFF
--- a/web/app/components/plugins/install-plugin/hooks/use-check-installed.tsx
+++ b/web/app/components/plugins/install-plugin/hooks/use-check-installed.tsx
@@ -15,7 +15,6 @@ const useCheckInstalled = (props: Props) => {
 
     const res: Record<string, VersionInfo> = {}
     data?.plugins.forEach((plugin) => {
-      console.log(plugin)
       res[plugin.plugin_id] = {
         installedId: plugin.id,
         installedVersion: plugin.declaration.version,

--- a/web/app/components/plugins/install-plugin/hooks/use-check-installed.tsx
+++ b/web/app/components/plugins/install-plugin/hooks/use-check-installed.tsx
@@ -15,7 +15,9 @@ const useCheckInstalled = (props: Props) => {
 
     const res: Record<string, VersionInfo> = {}
     data?.plugins.forEach((plugin) => {
+      console.log(plugin)
       res[plugin.plugin_id] = {
+        installedId: plugin.id,
         installedVersion: plugin.declaration.version,
         uniqueIdentifier: plugin.plugin_unique_identifier,
       }

--- a/web/app/components/plugins/install-plugin/install-from-local-package/steps/install.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/steps/install.tsx
@@ -8,8 +8,9 @@ import Button from '@/app/components/base/button'
 import { Trans, useTranslation } from 'react-i18next'
 import { RiLoader2Line } from '@remixicon/react'
 import checkTaskStatus from '../../base/check-task-status'
-import { useInstallPackageFromLocal, usePluginTaskList, useUpdatePackageFromMarketPlace } from '@/service/use-plugins'
+import { useInstallPackageFromLocal, usePluginTaskList } from '@/service/use-plugins'
 import useCheckInstalled from '@/app/components/plugins/install-plugin/hooks/use-check-installed'
+import { uninstallPlugin } from '@/service/plugins'
 import Version from '../../base/version'
 
 const i18nPrefix = 'plugin.installModal'
@@ -50,7 +51,6 @@ const Installed: FC<Props> = ({
 
   const [isInstalling, setIsInstalling] = React.useState(false)
   const { mutateAsync: installPackageFromLocal } = useInstallPackageFromLocal()
-  const { mutateAsync: updatePackageFromMarketPlace } = useUpdatePackageFromMarketPlace()
 
   const {
     check,
@@ -69,27 +69,18 @@ const Installed: FC<Props> = ({
     onStartToInstall?.()
 
     try {
-      let taskId
-      let isInstalled
       if (hasInstalled) {
-        const {
-          all_installed,
-          task_id,
-        } = await updatePackageFromMarketPlace({
-          original_plugin_unique_identifier: installedInfoPayload.uniqueIdentifier,
-          new_plugin_unique_identifier: uniqueIdentifier,
-        })
-        taskId = task_id
-        isInstalled = all_installed
+        const res = await uninstallPlugin(installedInfoPayload.installedId)
+        if (!res.success)
+          return
       }
-      else {
-        const {
-          all_installed,
-          task_id,
-        } = await installPackageFromLocal(uniqueIdentifier)
-        taskId = task_id
-        isInstalled = all_installed
-      }
+
+      const {
+        all_installed,
+        task_id,
+      } = await installPackageFromLocal(uniqueIdentifier)
+      const taskId = task_id
+      const isInstalled = all_installed
 
       if (isInstalled) {
         onInstalled()

--- a/web/app/components/plugins/install-plugin/install-from-local-package/steps/install.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/steps/install.tsx
@@ -69,11 +69,8 @@ const Installed: FC<Props> = ({
     onStartToInstall?.()
 
     try {
-      if (hasInstalled) {
-        const res = await uninstallPlugin(installedInfoPayload.installedId)
-        if (!res.success)
-          return
-      }
+      if (hasInstalled)
+        await uninstallPlugin(installedInfoPayload.installedId)
 
       const {
         all_installed,

--- a/web/app/components/plugins/types.ts
+++ b/web/app/components/plugins/types.ts
@@ -373,6 +373,7 @@ export type VersionListResponse = {
 }
 
 export type VersionInfo = {
+  installedId: string, // use to uninstall
   installedVersion: string,
   uniqueIdentifier: string
 }

--- a/web/service/use-plugins.ts
+++ b/web/service/use-plugins.ts
@@ -30,6 +30,7 @@ import {
 } from '@tanstack/react-query'
 import { useInvalidateAllBuiltInTools } from './use-tools'
 import usePermission from '@/app/components/plugins/plugin-page/use-permission'
+import { uninstallPlugin } from '@/service/plugins'
 
 const NAME_SPACE = 'plugins'
 
@@ -237,10 +238,20 @@ export const useInstallOrUpdate = ({
             }
           }
           if (isInstalled) {
-            await updatePackageFromMarketPlace({
-              original_plugin_unique_identifier: installedPayload?.uniqueIdentifier,
-              new_plugin_unique_identifier: uniqueIdentifier,
-            })
+            if (item.type === 'package') {
+              await uninstallPlugin(installedPayload.installedId)
+              await post<InstallPackageResponse>('/workspaces/current/plugin/install/pkg', {
+                body: {
+                  plugin_unique_identifiers: [uniqueIdentifier],
+                },
+              })
+            }
+            else {
+              await updatePackageFromMarketPlace({
+                original_plugin_unique_identifier: installedPayload?.uniqueIdentifier,
+                new_plugin_unique_identifier: uniqueIdentifier,
+              })
+            }
           }
           return ({ success: true })
         }


### PR DESCRIPTION
# Summary

If install a plugin through local package and the plugin has been installed, it will upgrade the plugin by the marketplace version. The right logic should  uninstall the plugin then install the local package.


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

