### PR TITLE
feat(model): support Gemini 2.0 Flash Lite Preview model (02-05) in Google's model provider

### DIFF
--- a/api/core/model_runtime/model_providers/google/llm/_position.yaml
+++ b/api/core/model_runtime/model_providers/google/llm/_position.yaml
@@ -1,5 +1,6 @@
 - gemini-2.0-flash-001
 - gemini-2.0-flash-exp
+- gemini-2.0-flash-lite-preview-02-05
 - gemini-2.0-pro-exp-02-05
 - gemini-2.0-flash-thinking-exp-1219
 - gemini-2.0-flash-thinking-exp-01-21

--- a/api/core/model_runtime/model_providers/google/llm/gemini-2.0-flash-lite-preview-02-05.yaml
+++ b/api/core/model_runtime/model_providers/google/llm/gemini-2.0-flash-lite-preview-02-05.yaml
@@ -1,0 +1,41 @@
+model: gemini-2.0-flash-lite-preview-02-05
+label:
+  en_US: Gemini 2.0 Flash Lite Preview 0205
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD


### PR DESCRIPTION
# Summary

Add Gemini 2.0 Flash Lite Preview model (02-05) to Google's model provider.

* Original issue: #13246
* Related PRs for Gemini 2.0 models:
  * For Vertex.ai provider: #13266
  * For Google model provider (without lite preview model): #13247

# Screenshots

| Before | After |
|--------|-------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/baa00d3f-0701-499b-9235-a6cc6e28ea52" />  | <img width="300" alt="image" src="https://github.com/user-attachments/assets/4321fa3b-e2a7-4c58-9879-d5782cbdc4a7" />|

Model Selection Screenshot:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/53c67296-d8cb-489c-8594-d03d20b812a5" />

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods