### PR TITLE
fix(settings): add notClearable prop to language selection

### DIFF
--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -289,6 +289,7 @@ const SettingsModal: FC<ISettingsModalProps> = ({
               items={languages.filter(item => item.supported)}
               defaultValue={language}
               onSelect={item => setLanguage(item.value as Language)}
+              notClearable
             />
           </div>
           {/* theme color */}


### PR DESCRIPTION
# Summary

Make `language` setting in app's setting not clearable.  

fixes https://github.com/langgenius/dify/issues/13405

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![スクリーンショット 2025-02-08 18 31 37](https://github.com/user-attachments/assets/6b44639e-37ba-4cbc-a76f-1fb8f656a8ed) | ![スクリーンショット 2025-02-08 18 36 20](https://github.com/user-attachments/assets/d04998ca-5d6f-4004-a08c-19612e58ba0e)|



# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

