### PR TITLE
fix(chatbot): update button class to include text color for better visibility

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/config-panel/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/config-panel/index.tsx
@@ -78,7 +78,7 @@ const ConfigPanel = () => {
                   styleCss={CssTransform(themeBuilder.theme?.backgroundButtonDefaultColorStyle ?? '')}
                   variant='secondary-accent'
                   size='small'
-                  className='shrink-0'
+                  className='shrink-0 text-white'
                   onClick={() => setCollapsed(false)}
                 >
                   <Edit02 className='mr-1 w-3 h-3' />


### PR DESCRIPTION

# Summary
Make `edit` button in embedded chat page visible by setting its txt color to white.

Relates : https://github.com/langgenius/dify/issues/13393

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![スクリーンショット 2025-02-08 19 19 19](https://github.com/user-attachments/assets/934069ee-c00f-4481-b335-07297e15d984)    | ![スクリーンショット 2025-02-08 19 18 16](https://github.com/user-attachments/assets/df29e712-a426-470a-b48f-c4276983a98d)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

