### PR TITLE
chore: use the wrap thinking api for volcengine

### DIFF
--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -410,16 +410,8 @@ if you are not sure about the structure.
         :return: tuple of (processed_content, is_reasoning)
         """
 
-        content = ""
-        reasoning_content = None
-        if isinstance(delta, dict):
-            content = delta.get("content") or ""
-            reasoning_content = delta.get("reasoning_content")
-        else:
-            if hasattr(delta, "content"):
-                content = delta.content
-            if hasattr(delta, "reasoning_content"):
-                reasoning_content = delta.reasoning_content
+        content = delta.get("content") or ""
+        reasoning_content = delta.get("reasoning_content")
 
         if reasoning_content:
             if not is_reasoning:

--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -410,8 +410,16 @@ if you are not sure about the structure.
         :return: tuple of (processed_content, is_reasoning)
         """
 
-        content = delta.get("content") or ""
-        reasoning_content = delta.get("reasoning_content")
+        content = ""
+        reasoning_content = None
+        if isinstance(delta, dict):
+            content = delta.get("content") or ""
+            reasoning_content = delta.get("reasoning_content")
+        else:
+            if hasattr(delta, "content"):
+                content = delta.content
+            if hasattr(delta, "reasoning_content"):
+                reasoning_content = delta.reasoning_content
 
         if reasoning_content:
             if not is_reasoning:
@@ -419,7 +427,9 @@ if you are not sure about the structure.
                 is_reasoning = True
             else:
                 content = reasoning_content
-        elif is_reasoning:
+        elif is_reasoning and content:
+            # do not end reasoning when content is empty
+            # there may be more reasoning_content later that follows previous reasoning closely
             content = "\n</think>" + content
             is_reasoning = False
         return content, is_reasoning

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from collections.abc import Generator
 from typing import Optional
 

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -253,22 +253,9 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                 content = ""
                 if chunk.choices:
                     delta = chunk.choices[0].delta
-                    if is_reasoning_started and not hasattr(delta, "reasoning_content") and not delta.content:
-                        content = ""
-                    elif hasattr(delta, "reasoning_content"):
-                        if not is_reasoning_started:
-                            is_reasoning_started = True
-                            content = "> 💭 " + delta.reasoning_content
-                        else:
-                            content = delta.reasoning_content
-
-                        if "\n" in content:
-                            content = re.sub(r"\n(?!(>|\n))", "\n> ", content)
-                    elif is_reasoning_started:
-                        content = "\n\n" + delta.content
-                        is_reasoning_started = False
-                    else:
-                        content = delta.content
+                    content, is_reasoning_started = self._wrap_thinking_by_reasoning_content(
+                        delta, is_reasoning_started
+                    )
 
                 yield LLMResultChunk(
                     model=model,

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -230,6 +230,15 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
             return _handle_chat_response()
         return _handle_stream_chat_response()
 
+    def wrap_thinking(self, delta: dict, is_reasoning: bool) -> tuple[str, bool]:
+        content = ""
+        reasoning_content = None
+        if hasattr(delta, "content"):
+            content = delta.content
+        if hasattr(delta, "reasoning_content"):
+            reasoning_content = delta.reasoning_content
+        return self._wrap_thinking_by_reasoning_content({"content": content, "reasoning_content": reasoning_content}, is_reasoning)
+
     def _generate_v3(
         self,
         model: str,
@@ -252,7 +261,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                 content = ""
                 if chunk.choices:
                     delta = chunk.choices[0].delta
-                    content, is_reasoning_started = self._wrap_thinking_by_reasoning_content(
+                    content, is_reasoning_started = self.wrap_thinking(
                         delta, is_reasoning_started
                     )
 

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -237,7 +237,9 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
             content = delta.content
         if hasattr(delta, "reasoning_content"):
             reasoning_content = delta.reasoning_content
-        return self._wrap_thinking_by_reasoning_content({"content": content, "reasoning_content": reasoning_content}, is_reasoning)
+        return self._wrap_thinking_by_reasoning_content(
+            {"content": content, "reasoning_content": reasoning_content}, is_reasoning
+        )
 
     def _generate_v3(
         self,
@@ -261,9 +263,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                 content = ""
                 if chunk.choices:
                     delta = chunk.choices[0].delta
-                    content, is_reasoning_started = self.wrap_thinking(
-                        delta, is_reasoning_started
-                    )
+                    content, is_reasoning_started = self.wrap_thinking(delta, is_reasoning_started)
 
                 yield LLMResultChunk(
                     model=model,


### PR DESCRIPTION
# Summary

As title, and also a bug fix.

#13299 had reverted one behavior I made in #13260, specifically, the problem 2, which is kinda common in some API(siliconflow and one generic provider I am using).

The whole reasoning content were cut into three pieces of `<think></think>` with disconnected sentences, because there was one single response with both empty reasoning_content and content, which ended the reasoning just in the middle unexpectedly.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ![图片](https://github.com/user-attachments/assets/f9002738-dcda-4f5f-925d-1710155ae99f)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

