### PR TITLE
Feat: add comparison table to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,18 +108,72 @@ Please refer to our [FAQ](https://docs.dify.ai/getting-started/install-self-host
 **7. Backend-as-a-Service**: 
   All of Dify's offerings come with corresponding APIs, so you could effortlessly integrate Dify into your own business logic.
 
-##Features
-
-| Feature                               | Dify.AI            | LangChain        | Flowise         | OpenAI Assistants API |
-|---------------------------------------|--------------------|------------------|-----------------|-----------------------|
-| Programming Approach                  | API + App-oriented | Python Code      | App-oriented    | API-oriented          |
-| Supported LLMs                        | Rich Variety       | Rich Variety     | Rich Variety    | OpenAI-only           |
-| RAG Engine                            | ✅                 | ✅               | ✅              | ✅                    |
-| Agent                                 | ✅                 | ✅               | ❌              | ✅                    |
-| Workflow                              | ✅                 | ❌               | ✅              | ❌                    |
-| Observability                         | ✅                 | ✅               | ❌              | ❌                    |
-| Enterprise Feature (SSO/Access control)| ✅                 | ❌               | ❌              | ❌                    |
-| Local Deployment                      | ✅                 | ✅               | ✅              | ❌                    |
+## Feature Comparison
+<table style="width: 100%;">
+  <tr>
+    <th align="center">Feature</th>
+    <th align="center">Dify.AI</th>
+    <th align="center">LangChain</th>
+    <th align="center">Flowise</th>
+    <th align="center">OpenAI Assistants API</th>
+  </tr>
+  <tr>
+    <td align="center">Programming Approach</td>
+    <td align="center">API + App-oriented</td>
+    <td align="center">Python Code</td>
+    <td align="center">App-oriented</td>
+    <td align="center">API-oriented</td>
+  </tr>
+  <tr>
+    <td align="center">Supported LLMs</td>
+    <td align="center">Rich Variety</td>
+    <td align="center">Rich Variety</td>
+    <td align="center">Rich Variety</td>
+    <td align="center">OpenAI-only</td>
+  </tr>
+  <tr>
+    <td align="center">RAG Engine</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr>
+    <td align="center">Agent</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr>
+    <td align="center">Workflow</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+  </tr>
+  <tr>
+    <td align="center">Observability</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+  </tr>
+  <tr>
+    <td align="center">Enterprise Feature (SSO/Access control)</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+  </tr>
+  <tr>
+    <td align="center">Local Deployment</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+  </tr>
+</table>
 
 You can copy and paste this into your Markdown file.
 ## Using Dify

--- a/README.md
+++ b/README.md
@@ -108,7 +108,20 @@ Please refer to our [FAQ](https://docs.dify.ai/getting-started/install-self-host
 **7. Backend-as-a-Service**: 
   All of Dify's offerings come with corresponding APIs, so you could effortlessly integrate Dify into your own business logic.
 
+##Features
 
+| Feature                               | Dify.AI            | LangChain        | Flowise         | OpenAI Assistants API |
+|---------------------------------------|--------------------|------------------|-----------------|-----------------------|
+| Programming Approach                  | API + App-oriented | Python Code      | App-oriented    | API-oriented          |
+| Supported LLMs                        | Rich Variety       | Rich Variety     | Rich Variety    | OpenAI-only           |
+| RAG Engine                            | ✅                 | ✅               | ✅              | ✅                    |
+| Agent                                 | ✅                 | ✅               | ❌              | ✅                    |
+| Workflow                              | ✅                 | ❌               | ✅              | ❌                    |
+| Observability                         | ✅                 | ✅               | ❌              | ❌                    |
+| Enterprise Feature (SSO/Access control)| ✅                 | ❌               | ❌              | ❌                    |
+| Local Deployment                      | ✅                 | ✅               | ✅              | ❌                    |
+
+You can copy and paste this into your Markdown file.
 ## Using Dify
 
 - **Cloud </br>**

--- a/README_KL.md
+++ b/README_KL.md
@@ -87,9 +87,7 @@ Dify is an open-source LLM app development platform. Its intuitive interface com
 
 ## Feature Comparison
 <table style="width: 100%;">
-  <tr
-
->
+  <tr>
     <th align="center">Feature</th>
     <th align="center">Dify.AI</th>
     <th align="center">LangChain</th>

--- a/README_SI.md
+++ b/README_SI.md
@@ -106,8 +106,6 @@ Prosimo, glejte naša pogosta vprašanja [FAQ](https://docs.dify.ai/getting-star
 **7. Backend-as-a-Service**: 
   AVse ponudbe Difyja so opremljene z ustreznimi API-ji, tako da lahko Dify brez težav integrirate v svojo poslovno logiko.
 
-  Below is the translated table in Slovenian:
-
 ## Primerjava Funkcij
 
 <table style="width: 100%;">

--- a/README_SI.md
+++ b/README_SI.md
@@ -106,6 +106,75 @@ Prosimo, glejte naša pogosta vprašanja [FAQ](https://docs.dify.ai/getting-star
 **7. Backend-as-a-Service**: 
   AVse ponudbe Difyja so opremljene z ustreznimi API-ji, tako da lahko Dify brez težav integrirate v svojo poslovno logiko.
 
+  Below is the translated table in Slovenian:
+
+## Primerjava Funkcij
+
+<table style="width: 100%;">
+  <tr>
+    <th align="center">Funkcija</th>
+    <th align="center">Dify.AI</th>
+    <th align="center">LangChain</th>
+    <th align="center">Flowise</th>
+    <th align="center">OpenAI Assistants API</th>
+  </tr>
+  <tr>
+    <td align="center">Programski pristop</td>
+    <td align="center">API + usmerjeno v aplikacije</td>
+    <td align="center">Python koda</td>
+    <td align="center">Usmerjeno v aplikacije</td>
+    <td align="center">Usmerjeno v API</td>
+  </tr>
+  <tr>
+    <td align="center">Podprti LLM-ji</td>
+    <td align="center">Bogata izbira</td>
+    <td align="center">Bogata izbira</td>
+    <td align="center">Bogata izbira</td>
+    <td align="center">Samo OpenAI</td>
+  </tr>
+  <tr>
+    <td align="center">RAG pogon</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr>
+    <td align="center">Agent</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr>
+    <td align="center">Potek dela</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+  </tr>
+  <tr>
+    <td align="center">Spremljanje</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+  </tr>
+  <tr>
+    <td align="center">Funkcija za podjetja (SSO/nadzor dostopa)</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+  </tr>
+  <tr>
+    <td align="center">Lokalna namestitev</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">❌</td>
+  </tr>
+</table>
 
 ## Uporaba Dify
 


### PR DESCRIPTION
# Summary

I noticed that the main README.md lacked the feature comparison table while other README had it, so I added it to README.md, fixed it in README_KL.md and added it to the README_SI.md(translating using OpenAI O3-mini).

Fixes #13436


# Screenshots

| Before | After |
|--------|-------|
| ![Screenshot 2025-02-09 075653](https://github.com/user-attachments/assets/5e793218-4e7f-40cf-9453-1782a498f49d) | ![Screenshot 2025-02-09 075605](https://github.com/user-attachments/assets/f4d68f2c-318c-4012-83fe-d815b407f4ae) |
| ![Screenshot 2025-02-09 080514](https://github.com/user-attachments/assets/7f5bf274-ef74-4f7d-8055-72ac6e2b4375) | ![Screenshot 2025-02-09 080550](https://github.com/user-attachments/assets/dec95100-b3c3-4057-8db4-962cc6b0ce08) |

This version removes extra spaces and newlines so that the images show up correctly within the table.
# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

