### PR TITLE
Fix: Removed model params except max_token for deepseek r1 in volcengine

### DIFF
--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -333,54 +333,71 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
         """
         model_config = get_model_config(credentials)
 
-        rules = [
-            ParameterRule(
-                name="temperature",
-                type=ParameterType.FLOAT,
-                use_template="temperature",
-                label=I18nObject(zh_Hans="温度", en_US="Temperature"),
-            ),
-            ParameterRule(
-                name="top_p",
-                type=ParameterType.FLOAT,
-                use_template="top_p",
-                label=I18nObject(zh_Hans="Top P", en_US="Top P"),
-            ),
-            ParameterRule(
-                name="top_k", type=ParameterType.INT, min=1, default=1, label=I18nObject(zh_Hans="Top K", en_US="Top K")
-            ),
-            ParameterRule(
-                name="presence_penalty",
-                type=ParameterType.FLOAT,
-                use_template="presence_penalty",
-                label=I18nObject(
-                    en_US="Presence Penalty",
-                    zh_Hans="存在惩罚",
+        if model.startswith("DeepSeek-R1"):
+            rules = [
+                ParameterRule(
+                    name="max_tokens",
+                    type=ParameterType.INT,
+                    use_template="max_tokens",
+                    min=1,
+                    max=model_config.properties.max_tokens,
+                    default=512,
+                    label=I18nObject(zh_Hans="最大生成长度", en_US="Max Tokens"),
                 ),
-                min=-2.0,
-                max=2.0,
-            ),
-            ParameterRule(
-                name="frequency_penalty",
-                type=ParameterType.FLOAT,
-                use_template="frequency_penalty",
-                label=I18nObject(
-                    en_US="Frequency Penalty",
-                    zh_Hans="频率惩罚",
+            ]
+        else:
+            rules = [
+                ParameterRule(
+                    name="temperature",
+                    type=ParameterType.FLOAT,
+                    use_template="temperature",
+                    label=I18nObject(zh_Hans="温度", en_US="Temperature"),
                 ),
-                min=-2.0,
-                max=2.0,
-            ),
-            ParameterRule(
-                name="max_tokens",
-                type=ParameterType.INT,
-                use_template="max_tokens",
-                min=1,
-                max=model_config.properties.max_tokens,
-                default=512,
-                label=I18nObject(zh_Hans="最大生成长度", en_US="Max Tokens"),
-            ),
-        ]
+                ParameterRule(
+                    name="top_p",
+                    type=ParameterType.FLOAT,
+                    use_template="top_p",
+                    label=I18nObject(zh_Hans="Top P", en_US="Top P"),
+                ),
+                ParameterRule(
+                    name="top_k",
+                    type=ParameterType.INT,
+                    min=1,
+                    default=1,
+                    label=I18nObject(zh_Hans="Top K", en_US="Top K")
+                ),
+                ParameterRule(
+                    name="presence_penalty",
+                    type=ParameterType.FLOAT,
+                    use_template="presence_penalty",
+                    label=I18nObject(
+                        en_US="Presence Penalty",
+                        zh_Hans="存在惩罚",
+                    ),
+                    min=-2.0,
+                    max=2.0,
+                ),
+                ParameterRule(
+                    name="frequency_penalty",
+                    type=ParameterType.FLOAT,
+                    use_template="frequency_penalty",
+                    label=I18nObject(
+                        en_US="Frequency Penalty",
+                        zh_Hans="频率惩罚",
+                    ),
+                    min=-2.0,
+                    max=2.0,
+                ),
+                ParameterRule(
+                    name="max_tokens",
+                    type=ParameterType.INT,
+                    use_template="max_tokens",
+                    min=1,
+                    max=model_config.properties.max_tokens,
+                    default=512,
+                    label=I18nObject(zh_Hans="最大生成长度", en_US="Max Tokens"),
+                ),
+            ]
 
         model_properties = {}
         model_properties[ModelPropertyKey.CONTEXT_SIZE] = model_config.properties.context_size

--- a/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
+++ b/api/core/model_runtime/model_providers/volcengine_maas/llm/llm.py
@@ -364,7 +364,7 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                     type=ParameterType.INT,
                     min=1,
                     default=1,
-                    label=I18nObject(zh_Hans="Top K", en_US="Top K")
+                    label=I18nObject(zh_Hans="Top K", en_US="Top K"),
                 ),
                 ParameterRule(
                     name="presence_penalty",


### PR DESCRIPTION
# Summary

According to the [reasoning_model](https://api-docs.deepseek.com/zh-cn/guides/reasoning_model), all model parameters except for max_token have been removed for DeepSeek R1 in Volcengine.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

