### PR TITLE
[Fix] Sagemaker LLM Provider can't adjust context size, it'a always 2…

### DIFF
--- a/api/core/model_runtime/model_providers/sagemaker/llm/llm.py
+++ b/api/core/model_runtime/model_providers/sagemaker/llm/llm.py
@@ -430,7 +430,7 @@ class SageMakerLargeLanguageModel(LargeLanguageModel):
                 type=ParameterType.INT,
                 use_template="max_tokens",
                 min=1,
-                max=credentials.get("context_length", 2048),
+                max=int(credentials.get("context_length", 2048)),
                 default=512,
                 label=I18nObject(zh_Hans="最大生成长度", en_US="Max Tokens"),
             ),
@@ -448,7 +448,7 @@ class SageMakerLargeLanguageModel(LargeLanguageModel):
         if support_vision:
             features.append(ModelFeature.VISION)
 
-        context_length = credentials.get("context_length", 2048)
+        context_length = int(credentials.get("context_length", 2048))
 
         entity = AIModelEntity(
             model=model,

--- a/api/core/model_runtime/model_providers/sagemaker/sagemaker.yaml
+++ b/api/core/model_runtime/model_providers/sagemaker/sagemaker.yaml
@@ -59,6 +59,19 @@ model_credential_schema:
       placeholder:
         zh_Hans: 请输出你的Sagemaker推理端点
         en_US: Enter your Sagemaker Inference endpoint
+    - variable: context_length
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 模型上下文长度
+        en_US: Model context size
+      type: text-input
+      default: '4096'
+      required: true
+      placeholder:
+        zh_Hans: 在此输入您的模型上下文长度
+        en_US: Enter your Model context size
     - variable: audio_s3_cache_bucket
       show_on:
         - variable: __model_type


### PR DESCRIPTION
Fix https://github.com/langgenius/dify/issues/13461

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

