### PR TITLE
Add DeepSeek R1 support on Alibaba's Bailian platform

### DIFF
--- a/api/core/model_runtime/model_providers/_position.yaml
+++ b/api/core/model_runtime/model_providers/_position.yaml
@@ -23,6 +23,7 @@
 - spark
 - minimax
 - tongyi
+- deepseek-r1
 - wenxin
 - moonshot
 - tencent

--- a/api/core/model_runtime/model_providers/tongyi/tongyi.yaml
+++ b/api/core/model_runtime/model_providers/tongyi/tongyi.yaml
@@ -19,9 +19,11 @@ supported_model_types:
   - tts
   - text-embedding
   - rerank
+  - deepseek-r1
 configurate_methods:
   - predefined-model
   - customizable-model
+  - deepseek-r1
 provider_credential_schema:
   credential_form_schemas:
     - variable: dashscope_api_key


### PR DESCRIPTION
Related to #13437

Add support for DeepSeek R1 on Alibaba's Bailian platform.

* **Update `api/core/model_runtime/model_providers/tongyi/tongyi.yaml`**
  - Add `deepseek-r1` to `supported_model_types`
  - Add `deepseek-r1` to `configurate_methods`

* **Update `api/core/model_runtime/model_providers/_position.yaml`**
  - Add `deepseek-r1` to the list of supported providers

