### PR TITLE
fix: retry log running error

### DIFF
--- a/api/core/workflow/graph_engine/graph_engine.py
+++ b/api/core/workflow/graph_engine/graph_engine.py
@@ -648,7 +648,7 @@ class GraphEngine:
                                     retries += 1
                                     route_node_state.node_run_result = run_result
                                     yield NodeRunRetryEvent(
-                                        id=node_instance.id,
+                                        id=str(uuid.uuid4()),
                                         node_id=node_instance.node_id,
                                         node_type=node_instance.node_type,
                                         node_data=node_instance.node_data,
@@ -663,7 +663,7 @@ class GraphEngine:
                                         start_at=retry_start_at,
                                     )
                                     time.sleep(retry_interval)
-                                    continue
+                                    break
                             route_node_state.set_finished(run_result=run_result)
 
                             if run_result.status == WorkflowNodeExecutionStatus.FAILED:


### PR DESCRIPTION
# Summary

Fixed the display error of the retry node. Previously, enabling retry on the node would cause the log to always show a running state. This issue has now been resolved.

Fixes #13386
Should fixes #13492

# Screenshots

| Before | After |
|--------|-------|
| <img width="383" alt="image" src="https://github.com/user-attachments/assets/2b0b2f17-7785-44e7-a10a-164bb0138387" />| <img width="395" alt="image" src="https://github.com/user-attachments/assets/ee4e2d19-3b3f-4bd2-890f-ca091ef43eda" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

