### PR TITLE
fix: iteration open parallel not show iteration detail

### DIFF
--- a/web/app/components/workflow/run/utils/format-log/iteration/index.ts
+++ b/web/app/components/workflow/run/utils/format-log/iteration/index.ts
@@ -3,10 +3,10 @@ import type { NodeTracing } from '@/types/workflow'
 import formatParallelNode from '../parallel'
 function addChildrenToIterationNode(iterationNode: NodeTracing, childrenNodes: NodeTracing[]): NodeTracing {
   const details: NodeTracing[][] = []
-  childrenNodes.forEach((item) => {
+  childrenNodes.forEach((item, index) => {
     if (!item.execution_metadata) return
-    const { parallel_mode_run_id, iteration_index = 0 } = item.execution_metadata
-    const runIndex: number = (parallel_mode_run_id || iteration_index) as number
+    const { iteration_index = 0 } = item.execution_metadata
+    const runIndex: number = iteration_index || index
     if (!details[runIndex])
       details[runIndex] = []
 


### PR DESCRIPTION
# Summary
Fix: iteration open parallel not show iteration detail.


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

