### PR TITLE
Fix the issue of repeated escaping of quotes in hit test

### DIFF
--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from typing import Optional
 
@@ -171,7 +172,7 @@ class RetrievalService:
                 vector = Vector(dataset=dataset)
 
                 documents = vector.search_by_vector(
-                    cls.escape_query_for_search(query),
+                    query,
                     search_type="similarity_score_threshold",
                     top_k=top_k,
                     score_threshold=score_threshold,
@@ -250,7 +251,7 @@ class RetrievalService:
 
     @staticmethod
     def escape_query_for_search(query: str) -> str:
-        return query.replace('"', '\\"')
+        return json.dumps(query).strip('"')
 
     @staticmethod
     def format_retrieval_documents(documents: list[Document]) -> list[RetrievalSegments]:

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -47,7 +47,7 @@ class HitTestingService:
         all_documents = RetrievalService.retrieve(
             retrieval_method=retrieval_model.get("search_method", "semantic_search"),
             dataset_id=dataset.id,
-            query=cls.escape_query_for_search(query),
+            query=query,
             top_k=retrieval_model.get("top_k", 2),
             score_threshold=retrieval_model.get("score_threshold", 0.0)
             if retrieval_model["score_threshold_enabled"]


### PR DESCRIPTION
# Summary

Fix the issue of repeated escaping of quotes in hit test。
On the knowledge retrieval page, if your input is JSON, GraphQL will report an error due to repeated escaping of quotes in the code.

Fixes #13506


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/042e029e-7487-4b6e-affc-2df204263391)    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

