### PR TITLE
fix: removed LLM output from the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Please refer to our [FAQ](https://docs.dify.ai/getting-started/install-self-host
   </tr>
 </table>
 
-You can copy and paste this into your Markdown file.
 ## Using Dify
 
 - **Cloud </br>**


### PR DESCRIPTION
# Summary

I accidently pasted in some LLM output in the main README when making changes in PR #13435 so I created this PR to remove that output.

Fixes #13505

# Screenshots

| Before | After |
|---|---|
| ![Screenshot 2025-02-10 150958](https://github.com/user-attachments/assets/67b9d9bf-c586-47f6-9397-a1e83568db8c) | ![Screenshot 2025-02-10 151200](https://github.com/user-attachments/assets/63f34c7f-98ea-4174-8828-e2696bbe5eec) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

