### PR TITLE
fix: iteration node log time error

### DIFF
--- a/api/core/app/task_pipeline/workflow_cycle_manage.py
+++ b/api/core/app/task_pipeline/workflow_cycle_manage.py
@@ -266,6 +266,7 @@ class WorkflowCycleManage:
             workflow_node_execution.error = error
             workflow_node_execution.finished_at = now
             workflow_node_execution.elapsed_time = (now - workflow_node_execution.created_at).total_seconds()
+            session.add(workflow_node_execution)
 
         if trace_manager:
             trace_manager.add_trace_task(

--- a/api/core/app/task_pipeline/workflow_cycle_manage.py
+++ b/api/core/app/task_pipeline/workflow_cycle_manage.py
@@ -266,7 +266,6 @@ class WorkflowCycleManage:
             workflow_node_execution.error = error
             workflow_node_execution.finished_at = now
             workflow_node_execution.elapsed_time = (now - workflow_node_execution.created_at).total_seconds()
-            session.add(workflow_node_execution)
 
         if trace_manager:
             trace_manager.add_trace_task(
@@ -843,4 +842,4 @@ class WorkflowCycleManage:
         if node_execution_id not in self._workflow_node_executions:
             raise ValueError(f"Workflow node execution not found: {node_execution_id}")
         cached_workflow_node_execution = self._workflow_node_executions[node_execution_id]
-        return cached_workflow_node_execution
+        return session.merge(cached_workflow_node_execution)


### PR DESCRIPTION
# Summary

When parallel and iteration nodes are running, if the node is not completed and other nodes cause it to terminate due to an error, the log of the node will remain in the running state. This issue has now been fixed.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|    <img width="389" alt="image" src="https://github.com/user-attachments/assets/2d6829d4-fc6b-4022-b05c-91ff8f56e2ba" /> | <img width="399" alt="image" src="https://github.com/user-attachments/assets/4990875c-09ff-4aee-9443-7d2fb984e996" />|
| <img width="397" alt="image" src="https://github.com/user-attachments/assets/00773092-df0d-41f7-8b68-00c600912e5e" /> | <img width="387" alt="image" src="https://github.com/user-attachments/assets/cd8e9693-b868-494d-8d41-b9c62245166b" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

