### PR TITLE
feat: add json_schema option to parameter rules for o1 & o3-mini

### DIFF
--- a/api/core/model_runtime/model_providers/openai/llm/o1.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/o1.yaml
@@ -42,6 +42,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '15.00'
   output: '60.00'

--- a/api/core/model_runtime/model_providers/openai/llm/o3-mini-2025-01-31.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/o3-mini-2025-01-31.yaml
@@ -39,6 +39,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '1.10'
   output: '4.40'

--- a/api/core/model_runtime/model_providers/openai/llm/o3-mini.yaml
+++ b/api/core/model_runtime/model_providers/openai/llm/o3-mini.yaml
@@ -39,6 +39,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '1.10'
   output: '4.40'


### PR DESCRIPTION
# Summary

This PR introduces JSON schema support for three model variants: o1, o3-mini, and o3-mini-2025-01-31. OpenAI already supports the JSON schema for the response format of these models ([reference](https://platform.openai.com/docs/guides/structured-outputs?example=chain-of-thought#supported-models)).

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

