### PR TITLE
fix: can not connect host.docker.internal host

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -417,7 +417,7 @@ services:
       - ssrf_proxy_network
       - default
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - host.docker.internal:host-gateway
 
   # worker service
   # The Celery worker for processing the queue.
@@ -442,7 +442,7 @@ services:
       - ssrf_proxy_network
       - default
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - host.docker.internal:host-gateway
 
   # Frontend web application.
   web:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -416,6 +416,8 @@ services:
     networks:
       - ssrf_proxy_network
       - default
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   # worker service
   # The Celery worker for processing the queue.
@@ -439,6 +441,8 @@ services:
     networks:
       - ssrf_proxy_network
       - default
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   # Frontend web application.
   web:


### PR DESCRIPTION
# Summary

Fails to connect the ollama service from docker container by "host.docker.internal" host.

Fixes #13498.

# Screenshots

| Before | After |
|--------|-------|
|  ![image](https://github.com/user-attachments/assets/ed22d210-0e73-4772-8183-51532076a422) |  ![image](https://github.com/user-attachments/assets/b74940c4-0f90-47db-97dd-40c53022490d) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

