### PR TITLE
Non-Streaming Models Do Not Return Results Properly in _handle_invoke_result

### DIFF
--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -246,7 +246,7 @@ class LLMNode(BaseNode[LLMNodeData]):
         return self._handle_invoke_result(invoke_result=invoke_result)
 
     def _handle_invoke_result(self, invoke_result: LLMResult | Generator) -> Generator[NodeEvent, None, None]:
-         if isinstance(invoke_result, LLMResult):
+        if isinstance(invoke_result, LLMResult):
             content = invoke_result.message.content
             if content is None:
                 message_text = ""

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -1,4 +1,4 @@
-import json
+_handle_invoke_resultimport json
 import logging
 from collections.abc import Generator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional, cast
@@ -247,6 +247,11 @@ class LLMNode(BaseNode[LLMNodeData]):
 
     def _handle_invoke_result(self, invoke_result: LLMResult | Generator) -> Generator[NodeEvent, None, None]:
         if isinstance(invoke_result, LLMResult):
+            yield ModelInvokeCompletedEvent(
+                text=invoke_result.message.content,
+                usage=invoke_result.usage,
+                finish_reason=None,
+            )
             return
 
         model = None

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -1,4 +1,4 @@
-_handle_invoke_resultimport json
+import json
 import logging
 from collections.abc import Generator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional, cast

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -246,9 +246,23 @@ class LLMNode(BaseNode[LLMNodeData]):
         return self._handle_invoke_result(invoke_result=invoke_result)
 
     def _handle_invoke_result(self, invoke_result: LLMResult | Generator) -> Generator[NodeEvent, None, None]:
-        if isinstance(invoke_result, LLMResult):
+         if isinstance(invoke_result, LLMResult):
+            content = invoke_result.message.content
+            if content is None:
+                message_text = ""
+            elif isinstance(content, str):
+                message_text = content
+            elif isinstance(content, list):
+                # Assuming the list contains PromptMessageContent objects with a "data" attribute
+                message_text = "".join(
+                    item.data if hasattr(item, "data") and isinstance(item.data, str) else str(item)
+                    for item in content
+                )
+            else:
+                message_text = str(content)
+
             yield ModelInvokeCompletedEvent(
-                text=invoke_result.message.content,
+                text=message_text,
                 usage=invoke_result.usage,
                 finish_reason=None,
             )

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -255,8 +255,7 @@ class LLMNode(BaseNode[LLMNodeData]):
             elif isinstance(content, list):
                 # Assuming the list contains PromptMessageContent objects with a "data" attribute
                 message_text = "".join(
-                    item.data if hasattr(item, "data") and isinstance(item.data, str) else str(item)
-                    for item in content
+                    item.data if hasattr(item, "data") and isinstance(item.data, str) else str(item) for item in content
                 )
             else:
                 message_text = str(content)


### PR DESCRIPTION
Fix: Non-Streaming Models Do Not Return Results Properly in _handle_invoke_result
Summary
This PR fixes an issue where models that do not support streaming (stream=False) fail to return results properly. The _handle_invoke_result function was not yielding any events when it received an LLMResult, leading to an empty generator. As a result, the for event in generator: loop in _run() never executed, causing missing responses for non-streaming models.

Issue:
Non-streaming models (stream=False) return an LLMResult, but _handle_invoke_result does not yield anything.
This causes _run() to receive an empty generator, resulting in no response being sent.
Streaming models (stream=True) work fine, as their results are handled iteratively.
Root Cause:
The _handle_invoke_result method contained this condition:

FIx https://github.com/langgenius/dify/issues/13569


if isinstance(invoke_result, LLMResult):
    return  # ❌ This exits without yielding any event
Since _handle_invoke_result did not yield an event for non-streaming models, the generator was empty.
_run() expects to iterate over generator, but since it was empty, the loop never executed.
Fix Implemented
The fix ensures _handle_invoke_result always yields a ModelInvokeCompletedEvent when stream=False, preventing an empty generator.

Updated _handle_invoke_result Implementation:

def _handle_invoke_result(self, invoke_result: LLMResult | Generator) -> Generator[NodeEvent, None, None]:


    # Handle non-streaming models
    if isinstance(invoke_result, LLMResult):
        yield ModelInvokeCompletedEvent(
            text=invoke_result.message.content,
            usage=invoke_result.usage,
            finish_reason=None,  # Adjust as needed
        )
        return  # Ensures at least one event is yielded

   
Impact of the Fix
✅ Non-streaming models now return responses correctly.
✅ Streaming models (stream=True) remain unaffected.
✅ Prevents missing responses by ensuring _handle_invoke_result always yields an event.

Testing & Validation
 Verified that non-streaming models (stream=False) now return valid responses.
 Ensured that streaming models (stream=True) function as expected.
 Confirmed that _handle_invoke_result always yields at least one event, preventing an empty generator.


