### PR TITLE
fix: error in obtaining end_to_node_id during conditional parallel execution

### DIFF
--- a/api/core/workflow/graph_engine/entities/graph.py
+++ b/api/core/workflow/graph_engine/entities/graph.py
@@ -590,8 +590,6 @@ class Graph(BaseModel):
                             start_node_id=node_id,
                             routes_node_ids=routes_node_ids,
                         )
-                        # Exclude conditional branch nodes
-                        and all(edge.run_condition is None for edge in reverse_edge_mapping.get(node_id, []))
                     ):
                         if node_id not in merge_branch_node_ids:
                             merge_branch_node_ids[node_id] = []


### PR DESCRIPTION
# Summary

When this condition is added, it causes the parallel end nodes to be incorrectly obtained during conditional branch parallel processing, leading to parallel execution errors.

 It's my fault. :(

Fixes #13628 


# Screenshots

| Before | After |
|--------|-------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/cf980ed7-67a9-4103-98a8-028c5fa922d4" />   | <img width="1512" alt="image" src="https://github.com/user-attachments/assets/833f8855-bdc9-4f95-9fb0-43a58e4e432a" />|
| | |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

