### PR TITLE
fix: github tool NoneType has no len()

### DIFF
--- a/api/core/tools/provider/builtin/github/tools/github_repositories.py
+++ b/api/core/tools/provider/builtin/github/tools/github_repositories.py
@@ -50,9 +50,12 @@ class GithubRepositoriesTool(BuiltinTool):
                         updated_at_object = datetime.strptime(item["updated_at"], "%Y-%m-%dT%H:%M:%SZ")
                         content["owner"] = item["owner"]["login"]
                         content["name"] = item["name"]
-                        content["description"] = (
-                            item["description"][:100] + "..." if len(item["description"]) > 100 else item["description"]
-                        )
+                        if item["description"] is not None:
+                            content["description"] = (
+                               item["description"][:100] + "..." if len(item["description"]) > 100 else item["description"]
+                            )
+                        else:
+                            content["description"] = ""
                         content["url"] = item["html_url"]
                         content["star"] = item["watchers"]
                         content["forks"] = item["forks"]


### PR DESCRIPTION
# Summary

Fixed the NoneType has no len() error that occurs when using GitHub tool to search repository lists where repository descriptions are None/empty.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

