### PR TITLE
fix: reranking_enable setting failed #13668

### DIFF
--- a/web/app/components/workflow/nodes/knowledge-retrieval/utils.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/utils.ts
@@ -152,8 +152,9 @@ export const getMultipleRetrievalConfig = (
 
   if (allEconomic || mixtureHighQualityAndEconomic || inconsistentEmbeddingModel || allExternal || mixtureInternalAndExternal) {
     result.reranking_mode = RerankingModeEnum.RerankingModel
-    if (result.reranking_enable && (!result.reranking_model?.provider || !result.reranking_model?.model)) {
+    if (!result.reranking_model?.provider || !result.reranking_model?.model) {
       if (rerankModelIsValid) {
+        result.reranking_enable = true
         result.reranking_model = {
           provider: validRerankModel?.provider || '',
           model: validRerankModel?.model || '',

--- a/web/app/components/workflow/nodes/knowledge-retrieval/utils.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/utils.ts
@@ -152,9 +152,8 @@ export const getMultipleRetrievalConfig = (
 
   if (allEconomic || mixtureHighQualityAndEconomic || inconsistentEmbeddingModel || allExternal || mixtureInternalAndExternal) {
     result.reranking_mode = RerankingModeEnum.RerankingModel
-    if (!result.reranking_model?.provider || !result.reranking_model?.model) {
+    if (result.reranking_enable && (!result.reranking_model?.provider || !result.reranking_model?.model)) {
       if (rerankModelIsValid) {
-        result.reranking_enable = true
         result.reranking_model = {
           provider: validRerankModel?.provider || '',
           model: validRerankModel?.model || '',
@@ -166,9 +165,6 @@ export const getMultipleRetrievalConfig = (
           model: '',
         }
       }
-    }
-    else {
-      result.reranking_enable = true
     }
   }
 


### PR DESCRIPTION
# Summary

Fixes #13668

We encountered the same issue as #13668. After reviewing the code, we found that https://github.com/langgenius/dify/blob/33a565a719036a99c95745944ebdff1432abddc9/web/app/components/workflow/nodes/knowledge-retrieval/utils.ts#L171 ignores the user-configured value and always sets it to true by default.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

