### PR TITLE
feat: add moonshot-v1-auto and vision model

### DIFF
--- a/api/core/model_runtime/model_providers/moonshot/llm/_position.yaml
+++ b/api/core/model_runtime/model_providers/moonshot/llm/_position.yaml
@@ -1,3 +1,7 @@
+- moonshot-v1-auto
 - moonshot-v1-8k
 - moonshot-v1-32k
 - moonshot-v1-128k
+- moonshot-v1-8k-vision-preview
+- moonshot-v1-32k-vision-preview
+- moonshot-v1-128k-vision-preview

--- a/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-128k-vision-preview.yaml
+++ b/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-128k-vision-preview.yaml
@@ -1,0 +1,41 @@
+model: moonshot-v1-128k-vision-preview
+label:
+  zh_Hans: moonshot-v1-128k-vision-preview
+  en_US: moonshot-v1-128k-vision-preview
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 128000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 1024
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '0.06'
+  output: '0.06'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-32k-vision-preview.yaml
+++ b/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-32k-vision-preview.yaml
@@ -1,0 +1,41 @@
+model: moonshot-v1-32k-vision-preview
+label:
+  zh_Hans: moonshot-v1-32k-vision-preview
+  en_US: moonshot-v1-32k-vision-preview
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 32000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 1024
+    min: 1
+    max: 32000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '0.024'
+  output: '0.024'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-8k-vision-preview.yaml
+++ b/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-8k-vision-preview.yaml
@@ -1,0 +1,41 @@
+model: moonshot-v1-8k-vision-preview
+label:
+  zh_Hans: moonshot-v1-8k-vision-preview
+  en_US: moonshot-v1-8k-vision-preview
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 8192
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 512
+    min: 1
+    max: 8192
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '0.012'
+  output: '0.012'
+  unit: '0.001'
+  currency: RMB

--- a/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-auto.yaml
+++ b/api/core/model_runtime/model_providers/moonshot/llm/moonshot-v1-auto.yaml
@@ -1,0 +1,40 @@
+model: moonshot-v1-auto
+label:
+  zh_Hans: moonshot-v1-auto
+  en_US: moonshot-v1-auto
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 128000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 1024
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '0.012'
+  output: '0.012'
+  unit: '0.001'
+  currency: RMB


### PR DESCRIPTION
# Summary

add new model, support vision : 

- moonshot-v1-auto
- moonshot-v1-8k-vision-preview
- moonshot-v1-32k-vision-preview
- moonshot-v1-128k-vision-preview


1. auto model: https://platform.moonshot.cn/docs/guide/choose-an-appropriate-kimi-model
2. vision model: https://platform.moonshot.cn/docs/guide/use-kimi-vision-model

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/308cc5ff-6fd4-48f4-bc3f-9cf186150ae1)  | ![image](https://github.com/user-attachments/assets/2a4a5496-eb5d-4f73-8f96-3036d479fb81)  |

moonshot-v1-auto model
![image](https://github.com/user-attachments/assets/d1ee1d37-75a1-4040-b7cf-4443e708a305)

moonshot-v1-8k-vision-preview
![image](https://github.com/user-attachments/assets/dc614d8d-a867-4a50-b5ac-3d092f298bd0)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

