### PR TITLE
fix: add install a package to improve the accuracy of guessing mime type and file extension (main)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -58,6 +58,8 @@ RUN \
         expat libldap-2.5-0 perl libsqlite3-0 zlib1g \
         # install a chinese font to support the use of tools like matplotlib
         fonts-noto-cjk \
+        # install a package to improve the accuracy of guessing mime type and file extension
+        media-types \
         # install libmagic to support the use of python-magic guess MIMETYPE
         libmagic1 \
     && apt-get autoremove -y \


### PR DESCRIPTION
# Summary

**This is for `main` branch.**

This PR installs `media-types` package to improve the accuracy of guessing mime type and file extension.
When creating a file in the tool plugin, we can specify the mime type for the file, but due to the lack of `media-types` package, even if we provide the correct mime type, the file extension may become `.bin` in some cases.

Closes #13717

The same PR for `plugins/beta` branch: https://github.com/langgenius/dify/pull/13101

# Screenshots

**Before**
Without `media-types`, `mimetypes` module in Python cannot guess the extension for the specific mime types:
![image](https://github.com/user-attachments/assets/ff965c4b-f029-4165-95a2-de06d6bc0e7c)

**After**
By installing `media-types` package, the extension for the specific mime types can be guessed:
![image](https://github.com/user-attachments/assets/93add220-c5c6-457b-a13d-87ab9615ddb4)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

