### PR TITLE
fix: use correct SlideSpeak API endpoint to verify API Key and fix typo

### DIFF
--- a/api/core/tools/provider/builtin/slidespeak/slidespeak.py
+++ b/api/core/tools/provider/builtin/slidespeak/slidespeak.py
@@ -20,9 +20,9 @@ class SlideSpeakProvider(BuiltinToolProviderController):
 
         headers = {"Content-Type": "application/json", "X-API-Key": api_key}
 
-        test_task_id = "xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        url = f"{base_url or 'https://api.slidespeak.co/api/v1'}/task_status/{test_task_id}"
+
+        url = f"{base_url or 'https://api.slidespeak.co/api/v1'}/me"
 
         response = requests.get(url, headers=headers)
         if response.status_code != 200:
-            raise ToolProviderCredentialValidationError("Invalid SlidePeak API key")
+            raise ToolProviderCredentialValidationError("Invalid SlideSpeak API key")


### PR DESCRIPTION
# Summary

Ensures the application correctly calls the designated API key verification endpoint, fixing improper authentication requests and improving API compliance. 

Fix typo in Slide**S**peak

Fixes #13754 

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

