### PR TITLE
fix: replace old-style <br> tags to fix Mermaid rendering issues

### DIFF
--- a/web/app/components/base/mermaid/index.tsx
+++ b/web/app/components/base/mermaid/index.tsx
@@ -3,6 +3,7 @@ import mermaid from 'mermaid'
 import { usePrevious } from 'ahooks'
 import { useTranslation } from 'react-i18next'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { cleanUpSvgCode } from './utils'
 import LoadingAnim from '@/app/components/base/chat/chat/loading-anim'
 import cn from '@/utils/classnames'
 import ImagePreview from '@/app/components/base/image-uploader/image-preview'
@@ -44,7 +45,7 @@ const Flowchart = React.forwardRef((props: {
     try {
       if (typeof window !== 'undefined' && mermaidAPI) {
         const svgGraph = await mermaidAPI.render('flowchart', PrimitiveCode)
-        const base64Svg: any = await svgToBase64(svgGraph.svg)
+        const base64Svg: any = await svgToBase64(cleanUpSvgCode(svgGraph.svg))
         setSvgCode(base64Svg)
         setIsLoading(false)
       }

--- a/web/app/components/base/mermaid/utils.spec.ts
+++ b/web/app/components/base/mermaid/utils.spec.ts
@@ -1,0 +1,8 @@
+import { cleanUpSvgCode } from './utils'
+
+describe('cleanUpSvgCode', () => {
+  it('replaces old-style <br> tags with the new style', () => {
+    const result = cleanUpSvgCode('<br>test<br>')
+    expect(result).toEqual('<br/>test<br/>')
+  })
+})

--- a/web/app/components/base/mermaid/utils.ts
+++ b/web/app/components/base/mermaid/utils.ts
@@ -1,0 +1,3 @@
+export function cleanUpSvgCode(svgCode: string): string {
+  return svgCode.replaceAll('<br>', '<br/>')
+}


### PR DESCRIPTION
# Summary

Fixes #13481 to ensure Mermaid renders correctly when the code contains `<br>` tags. The Mermaid Live Editor also does the same thing to ensure the exported SVG file is valid (see [here](https://github.com/mermaid-js/mermaid-live-editor/blob/9a70c08a6f6592f00c1307a1f66ca9a45b8d0f41/src/lib/components/Actions.svelte#L32)).

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After | Mermaid Code |
|--------|-------|-------|
| ![rendered-flowchart-before](https://github.com/user-attachments/assets/a486fe8d-c1e9-4d0d-8436-640b41c6cb4d) | ![rendered-flowchart-after](https://github.com/user-attachments/assets/2d900e58-fe68-4452-ace2-8ea1f75edb80) | See Code 1 below |
| ![rendered-flowchart-with-newline-before](https://github.com/user-attachments/assets/c6ad989d-cb90-4293-a248-9ed8e4a85c16) | ![rendered-flowchart-with-newline-after](https://github.com/user-attachments/assets/f32a90f2-d4aa-4632-8e63-5e7260694195) | See Code 2 below |

## Code 1

```
graph TD
    A[Start<br>Initialization] --> B{Condition?};
    B -- Yes --> C[Process A<br>Update Value];
    B -- No --> D[Process B<br>Skip Step];
    C --> E[End];
    D --> E;
```

## Code 2

```
flowchart TD
    A[Christmas] -->|Get money| B(Go shopping)
    B --> C{Let me
 think}
    C -->|One| D[Laptop]
    C -->|Two| E[iPhone]
    C -->|Three| F[fa:fa-car Car]
```

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

