### PR TITLE
fix: thought time display error

### DIFF
--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -34,6 +34,7 @@ import {
   getProcessedFiles,
   getProcessedFilesFromResponse,
 } from '@/app/components/base/file-uploader/utils'
+import { stopThinking } from '@/app/components/base/markdown-blocks/think-block'
 
 type GetAbortController = (abortController: AbortController) => void
 type SendCallback = {
@@ -161,6 +162,7 @@ export const useChat = (
       conversationMessagesAbortControllerRef.current.abort()
     if (suggestedQuestionsAbortControllerRef.current)
       suggestedQuestionsAbortControllerRef.current.abort()
+    stopThinking()
   }, [stopChat, handleResponding])
 
   const handleRestart = useCallback(() => {

--- a/web/app/components/base/markdown-blocks/think-block.tsx
+++ b/web/app/components/base/markdown-blocks/think-block.tsx
@@ -14,26 +14,6 @@ const hasEndThink = (children: any): boolean => {
   return false
 }
 
-const removeEndThink = (children: any): any => {
-  if (typeof children === 'string')
-    return children.replace('[ENDTHINKFLAG]', '')
-
-  if (Array.isArray(children))
-    return children.map(child => removeEndThink(child))
-
-  if (children?.props?.children) {
-    return React.cloneElement(
-      children,
-      {
-        ...children.props,
-        children: removeEndThink(children.props.children),
-      },
-    )
-  }
-
-  return children
-}
-
 const useThinkTimer = (children: any) => {
   const [startTime] = useState(Date.now())
   const [elapsedTime, setElapsedTime] = useState(0)
@@ -43,8 +23,8 @@ const useThinkTimer = (children: any) => {
   useEffect(() => {
     timerRef.current = setInterval(() => {
       if (!isComplete)
-        setElapsedTime(Math.floor((Date.now() - startTime) / 100) / 10)
-    }, 100)
+        setElapsedTime(Math.floor((Date.now() - startTime) / 1000))
+    }, 1000)
 
     return () => {
       if (timerRef.current)
@@ -63,9 +43,17 @@ const useThinkTimer = (children: any) => {
   return { elapsedTime, isComplete }
 }
 
+export const stopThinking = () => {
+  const alldetails = document.getElementsByTagName('details')
+  const lastDetailsElement = alldetails[alldetails.length - 1]
+  if (lastDetailsElement) {
+    const html = lastDetailsElement.innerHTML
+    lastDetailsElement.innerHTML = `${html}<span style="display:none">[ENDTHINKFLAG]</span>`
+  }
+}
+
 export const ThinkBlock = ({ children, ...props }: any) => {
   const { elapsedTime, isComplete } = useThinkTimer(children)
-  const displayContent = removeEndThink(children)
   const { t } = useTranslation()
 
   return (
@@ -85,11 +73,13 @@ export const ThinkBlock = ({ children, ...props }: any) => {
               d="M9 5l7 7-7 7"
             />
           </svg>
-          {isComplete ? `${t('common.chat.thought')}(${elapsedTime.toFixed(1)}s)` : `${t('common.chat.thinking')}(${elapsedTime.toFixed(1)}s)`}
+          {isComplete
+            ? `${t('common.chat.thought')}${elapsedTime > 0 ? `(${elapsedTime >= 60 ? `${Math.floor(elapsedTime / 60)}m` : `${elapsedTime}s`})` : ''}`
+            : `${t('common.chat.thinking')}(${elapsedTime >= 60 ? `${Math.floor(elapsedTime / 60)}m` : `${elapsedTime}s`})`}
         </div>
       </summary>
       <div className="text-gray-500 p-3 ml-2 bg-gray-50 border-l border-gray-300">
-        {displayContent}
+        {children}
       </div>
     </details>
   )

--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -74,7 +74,7 @@ const preprocessThinkTag = (content: string) => {
 
   return flow([
     (str: string) => str.replace('<think>\n', '<details>\n'),
-    (str: string) => str.replace('\n</think>', '\n[ENDTHINKFLAG]</details>'),
+    (str: string) => str.replace('\n</think>', '<span style="display:none">[ENDTHINKFLAG]</span></details>'),
   ])(content)
 }
 


### PR DESCRIPTION
# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fix https://github.com/langgenius/dify/issues/13521
also fix the issue where clicking the "Stop Responding" button does not prevent the thinking time from continuing to increase.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

