### PR TITLE
fix: "today" statistics are not displayed  in chart view

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chartView.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chartView.tsx
@@ -53,7 +53,7 @@ export default function ChartView({ appId }: IChartViewProps) {
           className='mt-0 !w-40'
           onSelect={(item) => {
             const id = item.value
-            const value = TIME_PERIOD_MAPPING[id]?.value || '-1'
+            const value = TIME_PERIOD_MAPPING[id]?.value ?? '-1'
             const name = item.name || t('appLog.filter.period.allTime')
             onSelect({ value, name })
           }}


### PR DESCRIPTION
# Summary

Fixes #13105

https://github.com/langgenius/dify/blob/abe5aca3e217a5575dd733cbd9d94e3107e68ea4/web/app/(commonLayout)/app/(appDetailLayout)/%5BappId%5D/overview/chartView.tsx#L56

**Previous:**
```
const value = TIME_PERIOD_MAPPING[id]?.value || '-1'
```
If `TIME_PERIOD_MAPPING[id]?.value` is 0, value will be "-1", this is unexpected.
Use nullish coalescing operator for default value in chart view

**Current:**
```
const value = TIME_PERIOD_MAPPING[id]?.value ?? '-1'
```



# Screenshots

N/A

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

