### PR TITLE
fix: token calculation method of Moonshot and Stepfun

### DIFF
--- a/api/core/model_runtime/model_providers/moonshot/llm/llm.py
+++ b/api/core/model_runtime/model_providers/moonshot/llm/llm.py
@@ -200,8 +200,8 @@ class MoonshotLargeLanguageModel(OAIAPICompatLargeLanguageModel):
             index: int, message: AssistantPromptMessage, finish_reason: str
         ) -> LLMResultChunk:
             # calculate num tokens
-            prompt_tokens = self._num_tokens_from_string(model, prompt_messages[0].content)
-            completion_tokens = self._num_tokens_from_string(model, full_assistant_content)
+            prompt_tokens = self._num_tokens_from_string(text=prompt_messages[0].content)
+            completion_tokens = self._num_tokens_from_string(text=full_assistant_content)
 
             # transform usage
             usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)

--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -638,8 +638,8 @@ class OAIAPICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
             completion_tokens = usage["completion_tokens"]
         else:
             # calculate num tokens
-            prompt_tokens = self._num_tokens_from_string(model, prompt_messages[0].content)
-            completion_tokens = self._num_tokens_from_string(model, assistant_message.content)
+            prompt_tokens = self._num_tokens_from_string(text=prompt_messages[0].content)
+            completion_tokens = self._num_tokens_from_string(text=assistant_message.content)
 
         # transform usage
         usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)

--- a/api/core/model_runtime/model_providers/stepfun/llm/llm.py
+++ b/api/core/model_runtime/model_providers/stepfun/llm/llm.py
@@ -201,8 +201,8 @@ class StepfunLargeLanguageModel(OAIAPICompatLargeLanguageModel):
             index: int, message: AssistantPromptMessage, finish_reason: str
         ) -> LLMResultChunk:
             # calculate num tokens
-            prompt_tokens = self._num_tokens_from_string(model, prompt_messages[0].content)
-            completion_tokens = self._num_tokens_from_string(model, full_assistant_content)
+            prompt_tokens = self._num_tokens_from_string(text=prompt_messages[0].content)
+            completion_tokens = self._num_tokens_from_string(text=full_assistant_content)
 
             # transform usage
             usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)


### PR DESCRIPTION
# Summary

Caused by this PR #13518. It only fix the case where tools is not a list when inputting token calculation.

But the root cause lies in the parameter change of _num_tokens_from_string. #13299 
The above fix will cause tokens calculation to use model as calculation, resulting in miscalculation.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

