### PR TITLE
fix: update the en-US i18n for logAndAnn

### DIFF
--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -494,7 +494,7 @@ const translation = {
     overview: 'Monitoring',
     promptEng: 'Orchestrate',
     apiAccess: 'API Access',
-    logAndAnn: 'Logs & Ann.',
+    logAndAnn: 'Logs & Annotations',
     logs: 'Logs',
   },
   environment: {


### PR DESCRIPTION
# Summary

Update the en-US i18n for logAndAnn from `Logs & Ann.` to `Logs & Annotations`.

The phrase 'Logs & Ann.' is a bit confusing; it cannot be identified properly by translation apps or even AI.

Close #12883

# Screenshots

| Before | After |
|--------|-------|
| <img width="448" alt="image" src="https://github.com/user-attachments/assets/5428adbf-4d93-4b25-81c1-a47be5fb1251" /> |<img width="448" alt="image" src="https://github.com/user-attachments/assets/c98f75a0-fb82-4b58-b255-b51cc6556ee2" />|

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

