### PR TITLE
fix(workflow): correct edge type mapping typo

### DIFF
--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -82,6 +82,7 @@ import {
   initialNodes,
 } from './utils'
 import {
+  CUSTOM_EDGE,
   CUSTOM_NODE,
   DSL_EXPORT_CHECK,
   ITERATION_CHILDREN_Z_INDEX,
@@ -103,7 +104,7 @@ const nodeTypes = {
   [CUSTOM_ITERATION_START_NODE]: CustomIterationStartNode,
 }
 const edgeTypes = {
-  [CUSTOM_NODE]: CustomEdge,
+  [CUSTOM_EDGE]: CustomEdge,
 }
 
 type WorkflowProps = {


### PR DESCRIPTION
# Summary

This PR updates the mapping of custom edge types in the workflow component. The change involves replacing the key from `CUSTOM_NODE` to `CUSTOM_EDGE` in the edgeTypes object within `app/components/workflow/index.tsx`.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

