### PR TITLE
feat: when inputForms is empty, ConfigPanel set hide

### DIFF
--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -207,6 +207,12 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     handleNewConversationInputsChange(conversationInputs)
   }, [handleNewConversationInputsChange, inputsForms])
 
+  // when inputForms is empty, ConfigPanel set hide
+  useEffect(() => {
+    if (!inputsForms || inputsForms.length === 0) 
+      setShowConfigPanelBeforeChat(false)
+  }, [inputsForms, setShowConfigPanelBeforeChat])
+
   const { data: newConversation } = useSWR(newConversationId ? [isInstalledApp, appId, newConversationId] : null, () => generationConversationName(isInstalledApp, appId, newConversationId), { revalidateOnFocus: false })
   const [originConversationList, setOriginConversationList] = useState<ConversationItem[]>([])
   useEffect(() => {

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -317,6 +317,12 @@ export const useEmbeddedChatbot = () => {
     notify({ type: 'success', message: t('common.api.success') })
   }, [isInstalledApp, appId, t, notify])
 
+  // when inputForms is empty, ConfigPanel set hide
+  useEffect(() => {
+    if (!inputsForms || inputsForms.length === 0) 
+      setShowConfigPanelBeforeChat(false)
+  }, [inputsForms, setShowConfigPanelBeforeChat])
+
   return {
     appInfoError,
     appInfoLoading,


### PR DESCRIPTION
# Summary

When inputForms is empty, ConfigPanel set hide. Handle this issue #1365 .

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

