### PR TITLE
fix: frontend for <think> tags conflicting with original <details> tags

### DIFF
--- a/web/app/components/base/markdown-blocks/think-block.tsx
+++ b/web/app/components/base/markdown-blocks/think-block.tsx
@@ -68,6 +68,9 @@ export const ThinkBlock = ({ children, ...props }: any) => {
   const displayContent = removeEndThink(children)
   const { t } = useTranslation()
 
+  if (!(props['data-think'] ?? false))
+    return (<details {...props}>{children}</details>)
+
   return (
     <details {...(!isComplete && { open: true })} className="group">
       <summary className="text-gray-500 font-bold list-none pl-2 flex items-center cursor-pointer select-none whitespace-nowrap">

--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -72,9 +72,8 @@ const preprocessThinkTag = (content: string) => {
     return content
 
   return flow([
-    (str: string) => str.replaceAll('<think>\n', '<details>\n'),
-    (str: string) => str.replaceAll('\n</think>', '\n[ENDTHINKFLAG]</details>'),
-    (str: string) => str.replaceAll('\n</details>', '\n[ENDTHINKFLAG]</details>'),
+    (str: string) => str.replace('<think>\n', '<details data-think=true>\n'),
+    (str: string) => str.replace('\n</think>', '\n[ENDTHINKFLAG]</details>'),
   ])(content)
 }
 

--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -68,9 +68,6 @@ const preprocessLaTeX = (content: string) => {
 }
 
 const preprocessThinkTag = (content: string) => {
-  if (!(content.trim().startsWith('<think>\n') || content.trim().startsWith('<details style=')))
-    return content
-
   return flow([
     (str: string) => str.replace('<think>\n', '<details data-think=true>\n'),
     (str: string) => str.replace('\n</think>', '\n[ENDTHINKFLAG]</details>'),


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fix #14037 

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

