### PR TITLE
Fixed: Run failed: Failed to invoke tool: File.__init__() got an unexpected keyword argument

### DIFF
--- a/api/core/file/models.py
+++ b/api/core/file/models.py
@@ -48,7 +48,7 @@ class File(BaseModel):
     size: int = -1
 
     # Those properties are private, should not be exposed to the outside.
-    _storage_key: str
+    _storage_key: Optional[str] = None
 
     def __init__(
         self,

--- a/api/core/file/models.py
+++ b/api/core/file/models.py
@@ -81,7 +81,7 @@ class File(BaseModel):
             dify_model_identity=dify_model_identity,
             url=url,
         )
-        self._storage_key = str(storage_key) if storage_key is not None else None
+        self._storage_key = str(storage_key)
 
     def to_dict(self) -> Mapping[str, str | int | None]:
         data = self.model_dump(mode="json")

--- a/api/core/file/models.py
+++ b/api/core/file/models.py
@@ -48,7 +48,7 @@ class File(BaseModel):
     size: int = -1
 
     # Those properties are private, should not be exposed to the outside.
-    _storage_key: Optional[str] = None
+    _storage_key: str
 
     def __init__(
         self,
@@ -81,7 +81,7 @@ class File(BaseModel):
             dify_model_identity=dify_model_identity,
             url=url,
         )
-        self._storage_key = storage_key
+        self._storage_key = storage_key if storage_key is not None else None
 
     def to_dict(self) -> Mapping[str, str | int | None]:
         data = self.model_dump(mode="json")

--- a/api/core/file/models.py
+++ b/api/core/file/models.py
@@ -81,7 +81,7 @@ class File(BaseModel):
             dify_model_identity=dify_model_identity,
             url=url,
         )
-        self._storage_key = storage_key if storage_key is not None else None
+        self._storage_key = str(storage_key) if storage_key is not None else None
 
     def to_dict(self) -> Mapping[str, str | int | None]:
         data = self.model_dump(mode="json")

--- a/api/core/file/models.py
+++ b/api/core/file/models.py
@@ -63,7 +63,9 @@ class File(BaseModel):
         extension: Optional[str] = None,
         mime_type: Optional[str] = None,
         size: int = -1,
-        storage_key: str,
+        storage_key: Optional[str] = None,
+        dify_model_identity: Optional[str] = FILE_MODEL_IDENTITY,
+        url: Optional[str] = None,
     ):
         super().__init__(
             id=id,
@@ -76,6 +78,8 @@ class File(BaseModel):
             extension=extension,
             mime_type=mime_type,
             size=size,
+            dify_model_identity=dify_model_identity,
+            url=url,
         )
         self._storage_key = storage_key
 


### PR DESCRIPTION
# Summary

core.file.models.File

The url and dify_model_identity fields are missing from the file.__init__ () method in this File, and storage_key is not Optional, resulting in errors when using file.model_validate (item).

TypeError: File.__init__() got an unexpected keyword argument ‘dify_model_identity'

ValueError: Run failed: Failed to invoke tool: File.__init__() got an unexpected keyword argument ‘url’

Run failed: Failed to invoke tool: File.__init__() missing 1 required keyword-only argument: 'storage_key'


<img width="693" alt="image" src="https://github.com/user-attachments/assets/e7c1268d-cf28-48f2-82b6-8fa16d45e8f3" />

<img width="996" alt="image" src="https://github.com/user-attachments/assets/e84fff4a-8228-48fe-880e-d45da36f107c" />

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/eadd5853-0e95-484f-aeeb-ea0989ee0572" />


> [!Tip]
> Close issue syntax: 


# Screenshots

| Before | After |
|--------|-------|
| TypeError: File.__init__() got an unexpected keyword argument ‘dify_model_identity'
ValueError: Run failed: Failed to invoke tool: File.__init__() got an unexpected keyword argument ‘url’
Run failed: Failed to invoke tool: File.__init__() missing 1 required keyword-only argument: 'storage_key'    | No error  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

