### PR TITLE
Update iteration_node.py to fix  #14098: Token count increases exponen…

### DIFF
--- a/api/core/workflow/nodes/iteration/iteration_node.py
+++ b/api/core/workflow/nodes/iteration/iteration_node.py
@@ -590,6 +590,7 @@ class IterationNode(BaseNode[IterationNodeData]):
         with flask_app.app_context():
             parallel_mode_run_id = uuid.uuid4().hex
             graph_engine_copy = graph_engine.create_copy()
+            graph_engine_copy.graph_runtime_state.total_tokens = 0
             variable_pool_copy = graph_engine_copy.graph_runtime_state.variable_pool
             variable_pool_copy.add([self.node_id, "index"], index)
             variable_pool_copy.add([self.node_id, "item"], item)


### PR DESCRIPTION

graph_engine_copy.graph_runtime_state.total_tokens should reset to zero to make the token count correct when using parallel nodes.

# Summary

Fixes #14098
