### PR TITLE
Fixed: The use of default parameters in API interfaces

### DIFF
--- a/api/core/tools/custom_tool/tool.py
+++ b/api/core/tools/custom_tool/tool.py
@@ -105,10 +105,10 @@ class ApiTool(Tool):
         needed_parameters = [parameter for parameter in (self.api_bundle.parameters or []) if parameter.required]
         for parameter in needed_parameters:
             if parameter.required and parameter.name not in parameters:
-                raise ToolParameterValidationError(f"Missing required parameter {parameter.name}")
-
-            if parameter.default is not None and parameter.name not in parameters:
-                parameters[parameter.name] = parameter.default
+                if parameter.default is not None:
+                    parameters[parameter.name] = parameter.default
+                else:
+                    raise ToolParameterValidationError(f"Missing required parameter {parameter.name}")
 
         return headers
 


### PR DESCRIPTION
# Summary

When the API interface parameter has a default value, use the default value; if not, and no value is passed, return an error.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fixed #14242 

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
