### PR TITLE
Retain previous page's search params

### DIFF
--- a/web/app/(commonLayout)/apps/Apps.tsx
+++ b/web/app/(commonLayout)/apps/Apps.tsx
@@ -59,8 +59,8 @@ const Apps = () => {
   const [activeTab, setActiveTab] = useTabSearchParams({
     defaultTab: 'all',
   })
-  const { query: { tagIDs = [], keywords = '' }, setQuery } = useAppsQueryState()
-  const [isCreatedByMe, setIsCreatedByMe] = useState(false)
+  const { query: { tagIDs = [], keywords = '', isCreatedByMe: queryIsCreatedByMe = false }, setQuery } = useAppsQueryState()
+  const [isCreatedByMe, setIsCreatedByMe] = useState(queryIsCreatedByMe)
   const [tagFilterValue, setTagFilterValue] = useState<string[]>(tagIDs)
   const [searchKeywords, setSearchKeywords] = useState(keywords)
   const setKeywords = useCallback((keywords: string) => {
@@ -126,6 +126,12 @@ const Apps = () => {
     handleTagsUpdate()
   }
 
+  const handleCreatedByMeChange = useCallback(() => {
+    const newValue = !isCreatedByMe
+    setIsCreatedByMe(newValue)
+    setQuery(prev => ({ ...prev, isCreatedByMe: newValue }))
+  }, [isCreatedByMe, setQuery])
+
   return (
     <>
       <div className='sticky top-0 flex justify-between items-center pt-4 px-12 pb-2 leading-[56px] bg-background-body z-10 flex-wrap gap-y-2'>
@@ -139,7 +145,7 @@ const Apps = () => {
             className='mr-2'
             label={t('app.showMyCreatedAppsOnly')}
             isChecked={isCreatedByMe}
-            onChange={() => setIsCreatedByMe(!isCreatedByMe)}
+            onChange={handleCreatedByMeChange}
           />
           <TagFilter type='app' value={tagFilterValue} onChange={handleTagsChange} />
           <Input

--- a/web/app/(commonLayout)/apps/hooks/useAppsQueryState.ts
+++ b/web/app/(commonLayout)/apps/hooks/useAppsQueryState.ts
@@ -4,18 +4,20 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 type AppsQuery = {
   tagIDs?: string[]
   keywords?: string
+  isCreatedByMe?: boolean
 }
 
 // Parse the query parameters from the URL search string.
 function parseParams(params: ReadonlyURLSearchParams): AppsQuery {
   const tagIDs = params.get('tagIDs')?.split(';')
   const keywords = params.get('keywords') || undefined
-  return { tagIDs, keywords }
+  const isCreatedByMe = params.get('isCreatedByMe') === 'true'
+  return { tagIDs, keywords, isCreatedByMe }
 }
 
 // Update the URL search string with the given query parameters.
 function updateSearchParams(query: AppsQuery, current: URLSearchParams) {
-  const { tagIDs, keywords } = query || {}
+  const { tagIDs, keywords, isCreatedByMe } = query || {}
 
   if (tagIDs && tagIDs.length > 0)
     current.set('tagIDs', tagIDs.join(';'))
@@ -26,6 +28,11 @@ function updateSearchParams(query: AppsQuery, current: URLSearchParams) {
     current.set('keywords', keywords)
   else
     current.delete('keywords')
+
+  if (isCreatedByMe)
+    current.set('isCreatedByMe', 'true')
+  else
+    current.delete('isCreatedByMe')
 }
 
 function useAppsQueryState() {

--- a/web/app/components/header/nav/index.tsx
+++ b/web/app/components/header/nav/index.tsx
@@ -37,11 +37,11 @@ const Nav = ({
   const isActivated = Array.isArray(activeSegment) ? activeSegment.includes(segment!) : segment === activeSegment
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const [capturedQueryParams, setCapturedQueryParams] = useState('')
+  const [linkLastSearchParams, setLinkLastSearchParams] = useState('')
 
   useEffect(() => {
     if (pathname === link)
-      setCapturedQueryParams(searchParams.toString())
+      setLinkLastSearchParams(searchParams.toString())
   }, [pathname, searchParams])
 
   return (
@@ -50,7 +50,7 @@ const Nav = ({
       ${isActivated && 'bg-components-main-nav-nav-button-bg-active shadow-md font-semibold'}
       ${!curNav && !isActivated && 'hover:bg-components-main-nav-nav-button-bg-hover'}
     `}>
-      <Link href={link + (capturedQueryParams && `?${capturedQueryParams}`)}>
+      <Link href={link + (linkLastSearchParams && `?${linkLastSearchParams}`)}>
         <div
           onClick={() => setAppDetail()}
           className={classNames(`

--- a/web/app/components/header/nav/index.tsx
+++ b/web/app/components/header/nav/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { usePathname, useSearchParams, useSelectedLayoutSegment } from 'next/navigation'
 import type { INavSelectorProps } from './nav-selector'
 import NavSelector from './nav-selector'
 import classNames from '@/utils/classnames'
@@ -35,6 +35,14 @@ const Nav = ({
   const [hovered, setHovered] = useState(false)
   const segment = useSelectedLayoutSegment()
   const isActivated = Array.isArray(activeSegment) ? activeSegment.includes(segment!) : segment === activeSegment
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [capturedQueryParams, setCapturedQueryParams] = useState('')
+
+  useEffect(() => {
+    if (pathname === link)
+      setCapturedQueryParams(searchParams.toString())
+  }, [pathname, searchParams])
 
   return (
     <div className={`
@@ -42,7 +50,7 @@ const Nav = ({
       ${isActivated && 'bg-components-main-nav-nav-button-bg-active shadow-md font-semibold'}
       ${!curNav && !isActivated && 'hover:bg-components-main-nav-nav-button-bg-hover'}
     `}>
-      <Link href={link}>
+      <Link href={link + (capturedQueryParams && `?${capturedQueryParams}`)}>
         <div
           onClick={() => setAppDetail()}
           className={classNames(`


### PR DESCRIPTION
# Summary

When I'm on the `/apps` page and use the available options (tags, keywords search, etc.) to filter the listed apps, I find it annoying that after selecting an app and pressing the back button my filters disappear.

Closes #14190.

This change:
- updates the navigation component to retain the search parameters of the parent page link
- includes the "Created by Me" value as a search parameter as well

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

