### PR TITLE
refactor(tool-engine): Optimize tool engine response handling

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -247,8 +247,7 @@ class ToolEngine:
                 )
             elif response.type == ToolInvokeMessage.MessageType.JSON:
                 result = json.dumps(
-                    cast(ToolInvokeMessage.JsonMessage, response.message).json_object,
-                    ensure_ascii=False
+                    cast(ToolInvokeMessage.JsonMessage, response.message).json_object, ensure_ascii=False
                 )
             else:
                 result += str(response.message)

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -246,10 +246,9 @@ class ToolEngine:
                     + "you do not need to create it, just tell the user to check it now."
                 )
             elif response.type == ToolInvokeMessage.MessageType.JSON:
-                text = json.dumps(cast(ToolInvokeMessage.JsonMessage, response.message).json_object, ensure_ascii=False)
-                result += f"tool response: {text}."
+                result = json.dumps(cast(ToolInvokeMessage.JsonMessage, response.message).json_object, ensure_ascii=False)
             else:
-                result += f"tool response: {response.message!r}."
+                result += str(response.message)
 
         return result
 

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -246,7 +246,10 @@ class ToolEngine:
                     + "you do not need to create it, just tell the user to check it now."
                 )
             elif response.type == ToolInvokeMessage.MessageType.JSON:
-                result = json.dumps(cast(ToolInvokeMessage.JsonMessage, response.message).json_object, ensure_ascii=False)
+                result = json.dumps(
+                    cast(ToolInvokeMessage.JsonMessage, response.message).json_object,
+                    ensure_ascii=False
+                )
             else:
                 result += str(response.message)
 


### PR DESCRIPTION
- Removed the unnecessary "tool response:" prefix from JSON and default responses to prevent confusion for LLMs and reduce token waste.
resolve #13566 

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #13566 ` , see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

