### PR TITLE
fix: datasets documents update-by-file api missing assign field 'indexing_technique' internally

### DIFF
--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -336,6 +336,10 @@ class DocumentUpdateByFileApi(DatasetApiResource):
 
         if not dataset:
             raise ValueError("Dataset is not exist.")
+
+        # indexing_technique is already set in dataset since this is an update
+        args["indexing_technique"] = dataset.indexing_technique
+
         if "file" in request.files:
             # save file info
             file = request.files["file"]


### PR DESCRIPTION
# Summary
when post `/datasets/{dataset_id}/documents/{document_id}/update-by-file` with only `name` and `file` filed,  i got error: 

```json
{
  "code": "invalid_param",
  "message": "1 validation error for KnowledgeConfig\nindexing_technique\n  Field required [type=missing, input_value={'doc_form': 'text_model'...45c5-b58f-642ae837a9b9'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.9/v/missing",
  "status": 400
}
```

this pr fix this problem just like https://github.com/langgenius/dify/blob/7790214620c653a6f6c19c402969a0474a3e5778/api/controllers/service_api/dataset/document.py#L146-L147 do


to fix https://github.com/langgenius/dify/issues/14266


# Screenshots
see [Summary](#Summary)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

