### PR TITLE
Feat：Support dynamic dataset for knowledge retrieval node

### DIFF
--- a/api/core/workflow/nodes/knowledge_retrieval/entities.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/entities.py
@@ -84,3 +84,5 @@ class KnowledgeRetrievalNodeData(BaseNodeData):
     retrieval_mode: Literal["single", "multiple"]
     multiple_retrieval_config: Optional[MultipleRetrievalConfig] = None
     single_retrieval_config: Optional[SingleRetrievalConfig] = None
+    dynamic_dataset_enable: bool = False
+    dataset_ids_variable_selector: list[str]

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -14,7 +14,7 @@ from core.model_runtime.model_providers.__base.large_language_model import Large
 from core.rag.datasource.retrieval_service import RetrievalService
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
-from core.variables import StringSegment, ArrayStringSegment
+from core.variables import ArrayStringSegment, StringSegment
 from core.workflow.entities.node_entities import NodeRunResult
 from core.workflow.nodes.base import BaseNode
 from core.workflow.nodes.enums import NodeType
@@ -70,7 +70,7 @@ class KnowledgeRetrievalNode(BaseNode[KnowledgeRetrievalNodeData]):
                     inputs={},
                     error="Dataset Ids variable is not string array type.",
                 )
-            dataset_ids = variable.value
+            dataset_ids = dataset_ids_var.value
             variables = {"dataset_ids": dataset_ids}
             if not dataset_ids:
                 return NodeRunResult(
@@ -106,7 +106,8 @@ class KnowledgeRetrievalNode(BaseNode[KnowledgeRetrievalNodeData]):
         dataset_ids = node_data.dataset_ids
         if self.node_data.dynamic_dataset_enable:
             dataset_ids_var = self.graph_runtime_state.variable_pool.get(self.node_data.dataset_ids_variable_selector)
-            dataset_ids = dataset_ids_var.value
+            if isinstance(dataset_ids_var, ArrayStringSegment):
+                dataset_ids = dataset_ids_var.value
 
         # Subquery: Count the number of available documents for each dataset
         subquery = (

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -71,7 +71,7 @@ class KnowledgeRetrievalNode(BaseNode[KnowledgeRetrievalNodeData]):
                     error="Dataset Ids variable is not string array type.",
                 )
             dataset_ids = dataset_ids_var.value
-            variables = {"dataset_ids": dataset_ids}
+            variables["dataset_ids"] = dataset_ids
             if not dataset_ids:
                 return NodeRunResult(
                     status=WorkflowNodeExecutionStatus.FAILED, inputs=variables, error="Dataset Ids is required."
@@ -107,7 +107,7 @@ class KnowledgeRetrievalNode(BaseNode[KnowledgeRetrievalNodeData]):
         if self.node_data.dynamic_dataset_enable:
             dataset_ids_var = self.graph_runtime_state.variable_pool.get(self.node_data.dataset_ids_variable_selector)
             if isinstance(dataset_ids_var, ArrayStringSegment):
-                dataset_ids = dataset_ids_var.value
+                dataset_ids = list(dataset_ids_var.value)
 
         # Subquery: Count the number of available documents for each dataset
         subquery = (

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -56,7 +56,7 @@ class KnowledgeRetrievalNode(BaseNode[KnowledgeRetrievalNodeData]):
                 error="Query variable is not string type.",
             )
         query = variable.value
-        variables: Mapping[str, Any] = {"query": query}
+        variables: dict[str, Any] = {"query": query}
         if not query:
             return NodeRunResult(
                 status=WorkflowNodeExecutionStatus.FAILED, inputs=variables, error="Query is required."

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -56,7 +56,7 @@ class KnowledgeRetrievalNode(BaseNode[KnowledgeRetrievalNodeData]):
                 error="Query variable is not string type.",
             )
         query = variable.value
-        variables = {"query": query}
+        variables: Mapping[str, Any] = {"query": query}
         if not query:
             return NodeRunResult(
                 status=WorkflowNodeExecutionStatus.FAILED, inputs=variables, error="Query is required."

--- a/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
@@ -12,6 +12,7 @@ import DatasetList from './components/dataset-list'
 import type { KnowledgeRetrievalNodeType } from './types'
 import Field from '@/app/components/workflow/nodes/_base/components/field'
 import Split from '@/app/components/workflow/nodes/_base/components/split'
+import Switch from '@/app/components/base/switch'
 import OutputVars, { VarItem } from '@/app/components/workflow/nodes/_base/components/output-vars'
 import { InputVarType, type NodePanelProps } from '@/app/components/workflow/types'
 import BeforeRunForm from '@/app/components/workflow/nodes/_base/components/before-run-form'
@@ -46,6 +47,9 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
     runResult,
     rerankModelOpen,
     setRerankModelOpen,
+    setDynamicDatasetEnable,
+    filterDatasetIdsVar,
+    handleDatasetIdsVarChange,
   } = useConfig(id, data)
 
   const handleOpenFromPropsChange = useCallback((openFromProps: boolean) => {
@@ -84,13 +88,25 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
                 singleRetrievalModelConfig={inputs.single_retrieval_config?.model}
                 onSingleRetrievalModelChange={handleModelChanged as any}
                 onSingleRetrievalModelParamsChange={handleCompletionParamsChange}
-                readonly={readOnly || !selectedDatasets.length}
+                readonly={readOnly || (!inputs.dynamic_dataset_enable && !selectedDatasets.length)}
                 openFromProps={rerankModelOpen}
                 onOpenFromPropsChange={handleOpenFromPropsChange}
                 selectedDatasets={selectedDatasets}
               />
               {!readOnly && (<div className='w-px h-3 bg-gray-200'></div>)}
               {!readOnly && (
+                <Switch
+                  size='md'
+                  className='mr-2'
+                  defaultValue={inputs.dynamic_dataset_enable}
+                  onChange={async (val) => {
+                    setDynamicDatasetEnable(val)
+                  }}
+                />
+              )}
+              {!readOnly && (<span className="mr-1 text-text-secondary system-sm-medium">动态</span>)}
+              {!readOnly && !inputs.dynamic_dataset_enable && (<div className='w-px h-3 bg-gray-200'></div>)}
+              {!readOnly && !inputs.dynamic_dataset_enable && (
                 <AddKnowledge
                   selectedIds={inputs.dataset_ids}
                   onChange={handleOnDatasetsChange}
@@ -99,11 +115,25 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
             </div>
           }
         >
-          <DatasetList
-            list={selectedDatasets}
-            onChange={handleOnDatasetsChange}
-            readonly={readOnly}
-          />
+          <div>
+            {!inputs.dynamic_dataset_enable && (
+              <DatasetList
+                list={selectedDatasets}
+                onChange={handleOnDatasetsChange}
+                readonly={readOnly}
+              />
+            )}
+            {inputs.dynamic_dataset_enable && (
+              <VarReferencePicker
+                nodeId={id}
+                readonly={readOnly}
+                isShowNodeName
+                value={inputs.dataset_ids_variable_selector}
+                onChange={handleDatasetIdsVarChange}
+                filterVar={filterDatasetIdsVar}
+              />
+            )}
+          </div>
         </Field>
       </div>
 

--- a/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
@@ -117,7 +117,7 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
                   }}
                 />
               )}
-              {!readOnly && (<span className="mr-1 text-text-secondary system-sm-medium">动态</span>)}
+              {!readOnly && (<span className="mr-1 text-text-secondary system-sm-medium">{t(`${i18nPrefix}.dynamic`)}</span>)}
               {!readOnly && !inputs.dynamic_dataset_enable && (<div className='w-px h-3 bg-gray-200'></div>)}
               {!readOnly && !inputs.dynamic_dataset_enable && (
                 <AddKnowledge

--- a/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
@@ -50,11 +50,24 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
     setDynamicDatasetEnable,
     filterDatasetIdsVar,
     handleDatasetIdsVarChange,
+    dataset_ids,
+    setDatasetIds,
   } = useConfig(id, data)
 
   const handleOpenFromPropsChange = useCallback((openFromProps: boolean) => {
     setRerankModelOpen(openFromProps)
   }, [setRerankModelOpen])
+
+  const dataset_ids_from = {
+    inputs: [{
+      label: t(`${i18nPrefix}.knowledge`)!,
+      variable: 'dataset_ids',
+      type: InputVarType.json,
+      required: true,
+    }],
+    values: { dataset_ids },
+    onChange: (keyValue: any) => setDatasetIds((keyValue as any).dataset_ids),
+  }
 
   return (
     <div className='pt-2'>
@@ -192,6 +205,7 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
                 values: { query },
                 onChange: keyValue => setQuery((keyValue as any).query),
               },
+              ...(inputs.dynamic_dataset_enable ? [dataset_ids_from] : []),
             ]}
             runningStatus={runningStatus}
             onRun={handleRun}

--- a/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
@@ -37,4 +37,6 @@ export type KnowledgeRetrievalNodeType = CommonNodeType & {
   multiple_retrieval_config?: MultipleRetrievalConfig
   single_retrieval_config?: SingleRetrievalConfig
   _datasets?: DataSet[]
+  dataset_ids_variable_selector: ValueSelector
+  dynamic_dataset_enable: boolean
 }

--- a/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
@@ -307,6 +307,14 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
     setInputs(newInputs)
   }, [inputs, setInputs, setSelectedDatasets])
 
+  const dataset_ids = runInputData.dataset_ids
+  const setDatasetIds = useCallback((newQuery: string[]) => {
+    setRunInputData({
+      ...runInputData,
+      dataset_ids: newQuery,
+    })
+  }, [runInputData, setRunInputData])
+
   return {
     readOnly,
     inputs,
@@ -331,6 +339,8 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
     setDynamicDatasetEnable,
     filterDatasetIdsVar,
     handleDatasetIdsVarChange,
+    dataset_ids,
+    setDatasetIds,
   }
 }
 

--- a/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
@@ -261,6 +261,10 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
     return varPayload.type === VarType.string
   }, [])
 
+  const filterDatasetIdsVar = useCallback((varPayload: Var) => {
+    return varPayload.type === VarType.arrayString
+  }, [])
+
   // single run
   const {
     isShowSingleRun,
@@ -287,6 +291,22 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
     })
   }, [runInputData, setRunInputData])
 
+  const handleDatasetIdsVarChange = useCallback((newVar: ValueSelector | string) => {
+    const newInputs = produce(inputs, (draft) => {
+      draft.dataset_ids_variable_selector = newVar as ValueSelector
+    })
+    setInputs(newInputs)
+  }, [inputs, setInputs])
+
+  const setDynamicDatasetEnable = useCallback((newVar: boolean) => {
+    setSelectedDatasets([])
+    const newInputs = produce(inputs, (draft) => {
+      draft.dynamic_dataset_enable = newVar
+      draft.dataset_ids_variable_selector = []
+    })
+    setInputs(newInputs)
+  }, [inputs, setInputs, setSelectedDatasets])
+
   return {
     readOnly,
     inputs,
@@ -308,6 +328,9 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
     runResult,
     rerankModelOpen,
     setRerankModelOpen,
+    setDynamicDatasetEnable,
+    filterDatasetIdsVar,
+    handleDatasetIdsVarChange,
   }
 }
 

--- a/web/i18n/de-DE/workflow.ts
+++ b/web/i18n/de-DE/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'Segmentierte URL',
         metadata: 'Weitere Metadaten',
       },
+      dynamic: 'Dynamisch',
     },
     http: {
       inputVars: 'Eingabevariablen',

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -409,6 +409,7 @@ const translation = {
     knowledgeRetrieval: {
       queryVariable: 'Query Variable',
       knowledge: 'Knowledge',
+      dynamic: 'Dynamic',
       outputVars: {
         output: 'Retrieval segmented data',
         content: 'Segmented content',

--- a/web/i18n/es-ES/workflow.ts
+++ b/web/i18n/es-ES/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL segmentada',
         metadata: 'Metadatos adicionales',
       },
+      dynamic: 'Dinámico',
     },
     http: {
       inputVars: 'Variables de entrada',

--- a/web/i18n/fa-IR/workflow.ts
+++ b/web/i18n/fa-IR/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL تقسیم‌بندی شده',
         metadata: 'سایر متاداده‌ها',
       },
+      dynamic: 'پویا',
     },
     http: {
       inputVars: 'متغیرهای ورودی',

--- a/web/i18n/fr-FR/workflow.ts
+++ b/web/i18n/fr-FR/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL segmentée',
         metadata: 'Autres métadonnées',
       },
+      dynamic: 'Dynamique',
     },
     http: {
       inputVars: 'Variables de saisie',

--- a/web/i18n/hi-IN/workflow.ts
+++ b/web/i18n/hi-IN/workflow.ts
@@ -423,6 +423,7 @@ const translation = {
         url: 'विभाजित URL',
         metadata: 'अन्य मेटाडेटा',
       },
+      dynamic: 'गतिशील',
     },
     http: {
       inputVars: 'इनपुट वेरिएबल्स',

--- a/web/i18n/it-IT/workflow.ts
+++ b/web/i18n/it-IT/workflow.ts
@@ -427,6 +427,7 @@ const translation = {
         url: 'URL segmentato',
         metadata: 'Altri metadati',
       },
+      dynamic: 'Dinamico',
     },
     http: {
       inputVars: 'Variabili di Input',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'セグメント化されたURL',
         metadata: 'その他のメタデータ',
       },
+      dynamic: 'ダイナミック',
     },
     http: {
       inputVars: '入力変数',

--- a/web/i18n/ko-KR/workflow.ts
+++ b/web/i18n/ko-KR/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: '세그먼트 URL',
         metadata: '기타 메타데이터',
       },
+      dynamic: '동적인',
     },
     http: {
       inputVars: '입력 변수',

--- a/web/i18n/pl-PL/workflow.ts
+++ b/web/i18n/pl-PL/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL segmentowany',
         metadata: 'Inne metadane',
       },
+      dynamic: 'Dynamiczny',
     },
     http: {
       inputVars: 'Zmienne wejściowe',

--- a/web/i18n/pt-BR/workflow.ts
+++ b/web/i18n/pt-BR/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL segmentado',
         metadata: 'Outros metadados',
       },
+      dynamic: 'Dinâmico',
     },
     http: {
       inputVars: 'Variáveis de entrada',

--- a/web/i18n/ro-RO/workflow.ts
+++ b/web/i18n/ro-RO/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL segmentat',
         metadata: 'Alte metadate',
       },
+      dynamic: 'Dinamic',
     },
     http: {
       inputVars: 'Variabile de intrare',

--- a/web/i18n/ru-RU/workflow.ts
+++ b/web/i18n/ru-RU/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'Сегментированный URL',
         metadata: 'Другие метаданные',
       },
+      dynamic: 'Динамический',
     },
     http: {
       inputVars: 'Входные переменные',

--- a/web/i18n/sl-SI/workflow.ts
+++ b/web/i18n/sl-SI/workflow.ts
@@ -847,6 +847,7 @@ const translation = {
       },
       queryVariable: 'Spremenljivka poizvedbe',
       knowledge: 'Znanje',
+      dynamic: 'Dinamično',
     },
     http: {
       outputVars: {

--- a/web/i18n/th-TH/workflow.ts
+++ b/web/i18n/th-TH/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL ที่แบ่งกลุ่ม',
         metadata: 'ข้อมูลเมตาอื่นๆ',
       },
+      dynamic: 'พลวัต',
     },
     http: {
       inputVars: 'ตัวแปรอินพุต',

--- a/web/i18n/tr-TR/workflow.ts
+++ b/web/i18n/tr-TR/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'Parça URL\'si',
         metadata: 'Diğer meta veriler',
       },
+      dynamic: 'Dinamik',
     },
     http: {
       inputVars: 'Giriş Değişkenleri',

--- a/web/i18n/uk-UA/workflow.ts
+++ b/web/i18n/uk-UA/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'Сегментована URL',
         metadata: 'Інші метадані',
       },
+      dynamic: 'Динамічний',
     },
     http: {
       inputVars: 'Вхідні змінні',

--- a/web/i18n/vi-VN/workflow.ts
+++ b/web/i18n/vi-VN/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: 'URL phân đoạn',
         metadata: 'Siêu dữ liệu khác',
       },
+      dynamic: 'Năng động',
     },
     http: {
       inputVars: 'Biến đầu vào',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -417,6 +417,7 @@ const translation = {
         url: '分段链接',
         metadata: '其他元数据',
       },
+      dynamic: '动态',
     },
     http: {
       inputVars: '输入变量',

--- a/web/i18n/zh-Hant/workflow.ts
+++ b/web/i18n/zh-Hant/workflow.ts
@@ -410,6 +410,7 @@ const translation = {
         url: '分段鏈接',
         metadata: '其他元數據',
       },
+      dynamic: '動態',
     },
     http: {
       inputVars: '輸入變量',


### PR DESCRIPTION
# Summary
Support dynamic dataset for knowledge retrieval node. We can create a dataset and use it without modify the workflow.

Close https://github.com/langgenius/dify/issues/14285

# Screenshots

| Before | After |
|--------|-------|
| ![20250224180502](https://github.com/user-attachments/assets/a7cb7605-329e-4b60-8674-978c961d6900) | ![20250224180438](https://github.com/user-attachments/assets/fecc9ca6-130b-49db-96da-de7ed3511921) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

