### PR TITLE
bugfix: db insert error when notion page_name too long

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -975,6 +975,8 @@ class DocumentService:
                                     "notion_page_icon": page.page_icon.model_dump() if page.page_icon else None,
                                     "type": page.type,
                                 }
+                                # Truncate page name to 255 characters to prevent DB field length errors
+                                truncated_page_name = page.page_name[:255] if page.page_name else "nopagename"
                                 document = DocumentService.build_document(
                                     dataset,
                                     dataset_process_rule.id,  # type: ignore
@@ -985,7 +987,7 @@ class DocumentService:
                                     created_from,
                                     position,
                                     account,
-                                    page.page_name,
+                                    truncated_page_name,
                                     batch,
                                     knowledge_config.metadata,
                                 )


### PR DESCRIPTION
fix the bug: 
SQL error cause by page_name too long when Sync Notion pages 
Resolve https://github.com/langgenius/dify/issues/14314

# Summary

Truncate page name to 255 characters to prevent DB field length errors
Fixes #<14314>



# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

