### PR TITLE
chore: fix Japanese translation for updating tool

### DIFF
--- a/web/i18n/ja-JP/tools.ts
+++ b/web/i18n/ja-JP/tools.ts
@@ -106,7 +106,7 @@ const translation = {
     customDisclaimer: 'カスタム免責事項',
     customDisclaimerPlaceholder: 'カスタム免責事項を入力してください',
     confirmTitle: '保存しますか？',
-    confirmTip: '新しバージョン保存すると、このツールを使用されているアプリは影響を受けます',
+    confirmTip: 'このツールを使用しているアプリは影響を受けます',
     deleteToolConfirmTitle: 'このツールを削除しますか？',
     deleteToolConfirmContent: 'ツールの削除は取り消しできません。ユーザーはもうあなた様のツールにアクセスできません。',
   },


### PR DESCRIPTION
# Summary

Updated the Japanese translation of tip when updating a workflow as a tool. There was an error in the previous translation. 
This PR, it is synchronized with the English text.

Resolve #12883 

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

