### PR TITLE
fix: Prompt users to avoid the issue of errors caused by inconsistent model names(Ollama).

### DIFF
--- a/api/core/model_runtime/model_providers/ollama/ollama.yaml
+++ b/api/core/model_runtime/model_providers/ollama/ollama.yaml
@@ -23,8 +23,8 @@ model_credential_schema:
       en_US: Model Name
       zh_Hans: 模型名称
     placeholder:
-      en_US: Enter your model name
-      zh_Hans: 输入模型名称
+      en_US: Enter your model name, consistent with that in Ollama
+      zh_Hans: 输入模型名称，需要和Ollama中运行的模型名称一致
   credential_form_schemas:
     - variable: base_url
       label:


### PR DESCRIPTION
Ollama

# Summary

With the current placeholder, users are unsure of what to input for [Model Name]. Actually, you need to input a model name consistent with the one running in Ollama. When a user inputs an inconsistent model name, an error will be raised, which is very confusing. It would be better to change the placeholder for the content in the commit.

eg:
wrong: qwen2.5
right: qwen2.5:7b

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

<img width="1018" alt="bug1" src="https://github.com/user-attachments/assets/85b2e735-1186-42ae-8fdd-c6e6be2c3b22" />
