### PR TITLE
fix(docker-compose.yaml): Fix the issue where Docker Compose doesn't …

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -122,6 +122,7 @@ services:
       SANDBOX_PORT: ${SANDBOX_PORT:-8194}
     volumes:
       - ./volumes/sandbox/dependencies:/dependencies
+      - ./volumes/sandbox/conf:/conf
     healthcheck:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:8194/health' ]
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -534,6 +534,7 @@ services:
       SANDBOX_PORT: ${SANDBOX_PORT:-8194}
     volumes:
       - ./volumes/sandbox/dependencies:/dependencies
+      - ./volumes/sandbox/conf:/conf
     healthcheck:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:8194/health' ]
     networks:


### PR DESCRIPTION
…automatically load the sandbox configuration file from the volume during startup.

# Summary

This fix addresses the issue where Docker Compose does not automatically load the sandbox configuration file from the volume during startup. By updating the docker-compose.yaml, the sandbox configuration is now correctly loaded, ensuring the sandbox environment initializes properly. No additional dependencies are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes https://github.com/langgenius/dify/issues/13636

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

