### PR TITLE
Flask solves the problem of Chinese garbled characters. If the response returns Chinese characters (such as \uxxx, etc.), it is necessary to set secure_ascii=False

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -35,6 +35,11 @@ else:
     from app_factory import create_app
 
     app = create_app()
+
+    # fix:Flask solves the problem of Chinese garbled characters. If the response returns Chinese characters (such as \ uxxx, etc.), it is necessary to set secure_ascii=False
+    app.json.ensure_ascii = False
+    app.config['JSON_AS_ASCII'] = False
+
     celery = app.extensions["celery"]
 
 if __name__ == "__main__":


### PR DESCRIPTION
…sponse returns Chinese characters (such as \uxxx, etc.), it is necessary to set secure_ascii=False

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

