### PR TITLE
Delete reasoning_content in next conversation

### DIFF
--- a/api/core/prompt/prompt_transform.py
+++ b/api/core/prompt/prompt_transform.py
@@ -6,7 +6,10 @@ from core.model_manager import ModelInstance
 from core.model_runtime.entities.message_entities import PromptMessage
 from core.model_runtime.entities.model_entities import ModelPropertyKey
 from core.prompt.entities.advanced_prompt_entities import MemoryConfig
-
+import re
+def clean_answer(answer):
+    cleaned_answer = re.sub(r'<details.*?</details>', '', answer, flags=re.DOTALL)
+    return cleaned_answer
 
 class PromptTransform:
     def _append_chat_histories(
@@ -18,6 +21,9 @@ class PromptTransform:
     ) -> list[PromptMessage]:
         rest_tokens = self._calculate_rest_token(prompt_messages, model_config)
         histories = self._get_history_messages_list_from_memory(memory, memory_config, rest_tokens)
+        for history in histories:
+            ## delete reasoning_content in history for next conservation
+            history.content=clean_answer(history.content)
         prompt_messages.extend(histories)
 
         return prompt_messages


### PR DESCRIPTION
# Summary
DeepSeek's official recommendation is that the thinking content should not be carried over to the next conversation's prompt.
Fixes  #13692 
## Screenshots

| Before | After |
|-------|--------|
| ![image](https://github.com/user-attachments/assets/1f0e69b9-db50-4a43-bf1b-47562a5a1eca) | ![image](https://github.com/user-attachments/assets/46d27f02-dc96-437f-9db3-055f8f6c9dbf) |



> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
