### PR TITLE
fix: document extractor parsing order for docx files

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -4,17 +4,17 @@ import json
 import logging
 import os
 import tempfile
-from collections.abc import Mapping, Sequence
-from typing import Any, cast, Union, Iterator
+from collections.abc import Iterator, Mapping, Sequence
+from typing import Any, Union, cast
 
+import docx
 import pandas as pd
 import pypdfium2  # type: ignore
 import yaml  # type: ignore
-import docx
 from docx.document import Document as _Document
-from docx.table import Table, _Cell  
-from docx.text.paragraph import Paragraph
 from docx.oxml.ns import qn
+from docx.table import Table, _Cell
+from docx.text.paragraph import Paragraph
 
 from configs import dify_config
 from core.file import File, FileTransferMethod, file_manager
@@ -27,7 +27,8 @@ from core.workflow.nodes.enums import NodeType
 from models.workflow import WorkflowNodeExecutionStatus
 
 from .entities import DocumentExtractorNodeData
-from .exc import DocumentExtractorError, FileDownloadError, TextExtractionError, UnsupportedFileTypeError
+from .exc import (DocumentExtractorError, FileDownloadError,
+                  TextExtractionError, UnsupportedFileTypeError)
 
 logger = logging.getLogger(__name__)
 
@@ -278,8 +279,7 @@ def _extract_text_from_docx(file_content: bytes) -> str:
         return "\n".join(text)
 
     except Exception as e:
-        logger.exception(f"Failed to extract text from DOCX: {e}")
-        return ""
+        raise TextExtractionError(f"Failed to extract text from DOCX: {str(e)}") from e
 
 
 def _download_file_content(file: File) -> bytes:
@@ -453,6 +453,7 @@ def _iter_block_items(parent: Union[_Document, _Cell]) -> Iterator[Union[Paragra
             yield Paragraph(child, parent)
         elif child.tag == qn("w:tbl"):
             yield Table(child, parent)
+
 
 def _has_valid_iterchildren(element) -> bool:
     """


### PR DESCRIPTION
# Summary
Fixes #13094
1. In the current version, the document extractor node does not preserve the original order when parsing DOCX files containing table data.
2. This commit addresses the issue by ensuring that the extracted content maintains the same sequence as in the source document.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

