### PR TITLE
fix: properly escape `collectionName` in query string parameters

### DIFF
--- a/web/service/_tools_util.spec.ts
+++ b/web/service/_tools_util.spec.ts
@@ -1,0 +1,16 @@
+import { buildProviderQuery } from './_tools_util'
+
+describe('makeProviderQuery', () => {
+  test('collectionName without special chars', () => {
+    expect(buildProviderQuery('ABC')).toBe('provider=ABC')
+  })
+  test('should escape &', () => {
+    expect(buildProviderQuery('ABC&DEF')).toBe('provider=ABC%26DEF')
+  })
+  test('should escape /', () => {
+    expect(buildProviderQuery('ABC/DEF')).toBe('provider=ABC%2FDEF')
+  })
+  test('should escape ?', () => {
+    expect(buildProviderQuery('ABC?DEF')).toBe('provider=ABC%3FDEF')
+  })
+})

--- a/web/service/_tools_util.ts
+++ b/web/service/_tools_util.ts
@@ -1,0 +1,5 @@
+export const buildProviderQuery = (collectionName: string): string => {
+  const query = new URLSearchParams()
+  query.set('provider', collectionName)
+  return query.toString()
+}

--- a/web/service/tools.ts
+++ b/web/service/tools.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/app/components/tools/types'
 import type { ToolWithProvider } from '@/app/components/workflow/types'
 import type { Label } from '@/app/components/tools/labels/constant'
+import { buildProviderQuery } from './_tools_util'
 
 export const fetchCollectionList = () => {
   return get<Collection[]>('/workspaces/current/tool-providers')
@@ -24,11 +25,13 @@ export const fetchBuiltInToolList = (collectionName: string) => {
 }
 
 export const fetchCustomToolList = (collectionName: string) => {
-  return get<Tool[]>(`/workspaces/current/tool-provider/api/tools?provider=${collectionName}`)
+  const query = buildProviderQuery(collectionName)
+  return get<Tool[]>(`/workspaces/current/tool-provider/api/tools?${query}`)
 }
 
 export const fetchModelToolList = (collectionName: string) => {
-  return get<Tool[]>(`/workspaces/current/tool-provider/model/tools?provider=${collectionName}`)
+  const query = buildProviderQuery(collectionName)
+  return get<Tool[]>(`/workspaces/current/tool-provider/model/tools?${query}`)
 }
 
 export const fetchWorkflowToolList = (appID: string) => {
@@ -65,7 +68,8 @@ export const parseParamsSchema = (schema: string) => {
 }
 
 export const fetchCustomCollection = (collectionName: string) => {
-  return get<CustomCollectionBackend>(`/workspaces/current/tool-provider/api/get?provider=${collectionName}`)
+  const query = buildProviderQuery(collectionName)
+  return get<CustomCollectionBackend>(`/workspaces/current/tool-provider/api/get?${query}`)
 }
 
 export const createCustomCollection = (collection: CustomCollectionBackend) => {


### PR DESCRIPTION
# Summary

The `collectionName` for a tool can be user-generated (e.g., for
custom tools and user-published workflows). It may contain special
characters such as `&`, which have specific meanings in HTTP
query strings. Directly concatenating `collectionName` into the
query string without proper escaping can lead to parsing ambiguities.

This PR addresses the issue by using `URLSearchParams` to ensure
all query string parameters are correctly escaped.

Closes #14119.

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/1a506c83-1ccd-408b-b195-a57554aec749)   | 
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/bee13cff-b361-4347-8bad-fd2fe360ba29" />  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
