### PR TITLE
fix: Missing EXPOSE_DB_PORT

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -186,6 +186,8 @@ DB_PASSWORD=difyai123456
 DB_HOST=db
 DB_PORT=5432
 DB_DATABASE=dify
+
+EXPOSE_DB_PORT=5432
 # The size of the database connection pool.
 # The default is 30 connections, which can be appropriately increased.
 SQLALCHEMY_POOL_SIZE=30

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -186,8 +186,8 @@ DB_PASSWORD=difyai123456
 DB_HOST=db
 DB_PORT=5432
 DB_DATABASE=dify
-
 EXPOSE_DB_PORT=5432
+
 # The size of the database connection pool.
 # The default is 30 connections, which can be appropriately increased.
 SQLALCHEMY_POOL_SIZE=30

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -312,6 +312,7 @@ x-shared-env: &shared-api-worker-env
   PGUSER: ${PGUSER:-${DB_USERNAME}}
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-${DB_PASSWORD}}
   POSTGRES_DB: ${POSTGRES_DB:-${DB_DATABASE}}
+  EXPOSE_DB_PORT: ${EXPOSE_DB_PORT:-${DB_PORT}}
   PGDATA: ${PGDATA:-/var/lib/postgresql/data/pgdata}
   SANDBOX_API_KEY: ${SANDBOX_API_KEY:-dify-sandbox}
   SANDBOX_GIN_MODE: ${SANDBOX_GIN_MODE:-release}


### PR DESCRIPTION
# Summary

Fix: #13407 

Add EXPOSE_DB_PORT to .env.example and docker-compose.yml to prevent conflicts with existing local ports.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

