### PR TITLE
fix: Support custom mode for parent-child document structure

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1060,7 +1060,7 @@ class DocumentService:
         dataset: Dataset,
         process_rule_id: str,
         data_source_type: str,
-        document_form: str,  
+        document_form: str,
         document_language: str,
         data_source_info: dict,
         created_from: str,

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1060,7 +1060,7 @@ class DocumentService:
         dataset: Dataset,
         process_rule_id: str,
         data_source_type: str,
-        document_form: str,  # 这里接收 doc_form
+        document_form: str,  
         document_language: str,
         data_source_info: dict,
         created_from: str,

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1060,7 +1060,7 @@ class DocumentService:
         dataset: Dataset,
         process_rule_id: str,
         data_source_type: str,
-        document_form: str,
+        document_form: str,  # 这里接收 doc_form
         document_language: str,
         data_source_info: dict,
         created_from: str,

--- a/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
+++ b/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
@@ -39,7 +39,7 @@ type IChildSegmentCardProps = {
   isLoading?: boolean
   focused?: boolean
   mode: string
-
+}
 const ChildSegmentList: FC<IChildSegmentCardProps> = ({
   childChunks,
   parentChunkId,

--- a/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
+++ b/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
@@ -1,11 +1,11 @@
 /**
  * ChildSegmentList Component
- * 
+ *
  * This component handles the display of child segments in both hierarchical and custom modes.
  * It supports two processing modes as per API documentation:
  * - 'custom': The mode specified in API documentation for parent-child structure
  * - 'hierarchical': The original mode for backward compatibility
- * 
+ *
  * The component adapts its display based on the parent mode (paragraph or full-doc)
  * and the processing mode (custom or hierarchical).
  */
@@ -38,8 +38,7 @@ type IChildSegmentCardProps = {
   onClearFilter?: () => void
   isLoading?: boolean
   focused?: boolean
-  mode: string  // Added to support both 'custom' and 'hierarchical' modes as per API documentation
-}
+  mode: string
 
 const ChildSegmentList: FC<IChildSegmentCardProps> = ({
   childChunks,
@@ -54,7 +53,7 @@ const ChildSegmentList: FC<IChildSegmentCardProps> = ({
   onClearFilter,
   isLoading,
   focused = false,
-  mode,  // Receive mode from parent to determine display logic
+  mode,
 }) => {
   const { t } = useTranslation()
   const parentMode = useDocumentContext(s => s.parentMode)

--- a/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
+++ b/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
@@ -1,3 +1,15 @@
+/**
+ * ChildSegmentList Component
+ * 
+ * This component handles the display of child segments in both hierarchical and custom modes.
+ * It supports two processing modes as per API documentation:
+ * - 'custom': The mode specified in API documentation for parent-child structure
+ * - 'hierarchical': The original mode for backward compatibility
+ * 
+ * The component adapts its display based on the parent mode (paragraph or full-doc)
+ * and the processing mode (custom or hierarchical).
+ */
+
 import { type FC, useMemo, useState } from 'react'
 import { RiArrowDownSLine, RiArrowRightSLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
@@ -26,6 +38,7 @@ type IChildSegmentCardProps = {
   onClearFilter?: () => void
   isLoading?: boolean
   focused?: boolean
+  mode: string  // Added to support both 'custom' and 'hierarchical' modes as per API documentation
 }
 
 const ChildSegmentList: FC<IChildSegmentCardProps> = ({
@@ -41,6 +54,7 @@ const ChildSegmentList: FC<IChildSegmentCardProps> = ({
   onClearFilter,
   isLoading,
   focused = false,
+  mode,  // Receive mode from parent to determine display logic
 }) => {
   const { t } = useTranslation()
   const parentMode = useDocumentContext(s => s.parentMode)
@@ -52,13 +66,33 @@ const ChildSegmentList: FC<IChildSegmentCardProps> = ({
     setCollapsed(!collapsed)
   }
 
-  const isParagraphMode = useMemo(() => {
-    return parentMode === 'paragraph'
-  }, [parentMode])
+  /**
+   * Determines if the current mode supports parent-child structure
+   * Supports both 'custom' (API documentation) and 'hierarchical' (legacy) modes
+   */
+  const isParentChildMode = useMemo(() => {
+    return mode === 'hierarchical' || mode === 'custom'
+  }, [mode])
 
+  /**
+   * Checks if the current mode is paragraph mode
+   * Must satisfy both:
+   * 1. Parent mode is 'paragraph'
+   * 2. Processing mode is either 'custom' or 'hierarchical'
+   */
+  const isParagraphMode = useMemo(() => {
+    return parentMode === 'paragraph' && (mode === 'hierarchical' || mode === 'custom')
+  }, [mode, parentMode])
+
+  /**
+   * Checks if the current mode is full document mode
+   * Must satisfy both:
+   * 1. Parent mode is 'full-doc'
+   * 2. Processing mode is either 'custom' or 'hierarchical'
+   */
   const isFullDocMode = useMemo(() => {
-    return parentMode === 'full-doc'
-  }, [parentMode])
+    return parentMode === 'full-doc' && (mode === 'hierarchical' || mode === 'custom')
+  }, [mode, parentMode])
 
   const contentOpacity = useMemo(() => {
     return (enabled || focused) ? '' : 'opacity-50 group-hover/card:opacity-100'

--- a/web/app/components/datasets/documents/detail/completed/index.tsx
+++ b/web/app/components/datasets/documents/detail/completed/index.tsx
@@ -89,7 +89,7 @@ type ICompletedProps = {
 }
 /**
  * Completed Component
- * 
+ *
  * This component handles the display of completed documents and their segments.
  * It supports both 'custom' (API spec) and 'hierarchical' (legacy) modes for parent-child structure.
  */
@@ -381,7 +381,7 @@ const Completed: FC<ICompletedProps> = ({
 
   useEffect(() => {
     resetList()
-  }, [pathname])
+  }, [pathname, resetList])
 
   useEffect(() => {
     if (importStatus === ProcessStatus.COMPLETED)

--- a/web/app/components/datasets/documents/detail/completed/index.tsx
+++ b/web/app/components/datasets/documents/detail/completed/index.tsx
@@ -88,8 +88,10 @@ type ICompletedProps = {
   archived?: boolean
 }
 /**
- * Embedding done, show list of all segments
- * Support search and filter
+ * Completed Component
+ * 
+ * This component handles the display of completed documents and their segments.
+ * It supports both 'custom' (API spec) and 'hierarchical' (legacy) modes for parent-child structure.
  */
 const Completed: FC<ICompletedProps> = ({
   embeddingAvailable,
@@ -624,6 +626,7 @@ const Completed: FC<ICompletedProps> = ({
                 segmentIndex: currSegment?.segInfo?.id === segments[0]?.id,
                 segmentContent: currSegment?.segInfo?.id === segments[0]?.id,
               }}
+              mode={mode}
             />
             <ChildSegmentList
               parentChunkId={segments[0]?.id}
@@ -637,6 +640,7 @@ const Completed: FC<ICompletedProps> = ({
               inputValue={inputValue}
               onClearFilter={onClearFilter}
               isLoading={isLoadingSegmentList || isLoadingChildSegmentList}
+              mode={mode}
             />
           </div>
           : <SegmentList
@@ -654,6 +658,7 @@ const Completed: FC<ICompletedProps> = ({
             handleAddNewChildChunk={handleAddNewChildChunk}
             onClickSlice={onClickSlice}
             onClearFilter={onClearFilter}
+            mode={mode}
           />
       }
       {/* Pagination */}

--- a/web/app/components/datasets/documents/detail/completed/segment-card/index.tsx
+++ b/web/app/components/datasets/documents/detail/completed/segment-card/index.tsx
@@ -36,6 +36,7 @@ type ISegmentCardProps = {
     segmentIndex: boolean
     segmentContent: boolean
   }
+  mode: string
 }
 
 const SegmentCard: FC<ISegmentCardProps> = ({
@@ -52,6 +53,7 @@ const SegmentCard: FC<ISegmentCardProps> = ({
   archived,
   embeddingAvailable,
   focused,
+  mode,
 }) => {
   const { t } = useTranslation()
   const {
@@ -69,7 +71,6 @@ const SegmentCard: FC<ISegmentCardProps> = ({
     updated_at,
   } = detail as Required<ISegmentCardProps>['detail']
   const [showModal, setShowModal] = useState(false)
-  const mode = useDocumentContext(s => s.mode)
   const parentMode = useDocumentContext(s => s.parentMode)
 
   const isGeneralMode = useMemo(() => {

--- a/web/app/components/datasets/documents/detail/completed/segment-list.tsx
+++ b/web/app/components/datasets/documents/detail/completed/segment-list.tsx
@@ -1,4 +1,4 @@
-import React, { type ForwardedRef, useMemo } from 'react'
+import React, { type ForwardedRef, useMemo, type FC } from 'react'
 import { useDocumentContext } from '../index'
 import SegmentCard from './segment-card'
 import Empty from './common/empty'
@@ -9,7 +9,7 @@ import type { ChildChunkDetail, SegmentDetailModel } from '@/models/datasets'
 import Checkbox from '@/app/components/base/checkbox'
 import Divider from '@/app/components/base/divider'
 
-type ISegmentListProps = {
+type SegmentListProps = {
   isLoading: boolean
   items: SegmentDetailModel[]
   selectedSegmentIds: string[]
@@ -23,9 +23,10 @@ type ISegmentListProps = {
   archived?: boolean
   embeddingAvailable: boolean
   onClearFilter: () => void
+  mode: string
 }
 
-const SegmentList = React.forwardRef(({
+const SegmentList: FC<SegmentListProps> = ({
   isLoading,
   items,
   selectedSegmentIds,
@@ -39,10 +40,8 @@ const SegmentList = React.forwardRef(({
   archived,
   embeddingAvailable,
   onClearFilter,
-}: ISegmentListProps,
-ref: ForwardedRef<HTMLDivElement>,
-) => {
-  const mode = useDocumentContext(s => s.mode)
+  mode,
+}, ref: ForwardedRef<HTMLDivElement>) => {
   const parentMode = useDocumentContext(s => s.parentMode)
   const currSegment = useSegmentListContext(s => s.currSegment)
   const currChildChunk = useSegmentListContext(s => s.currChildChunk)
@@ -98,6 +97,7 @@ ref: ForwardedRef<HTMLDivElement>,
                     segmentIndex: segmentIndexFocused,
                     segmentContent: segmentContentFocused,
                   }}
+                  mode={mode}
                 />
                 {!isLast && <div className='w-full px-3'>
                   <Divider type='horizontal' className='bg-divider-subtle my-1' />
@@ -109,7 +109,7 @@ ref: ForwardedRef<HTMLDivElement>,
       }
     </div>
   )
-})
+}
 
 SegmentList.displayName = 'SegmentList'
 

--- a/web/app/components/datasets/documents/detail/completed/segment-list.tsx
+++ b/web/app/components/datasets/documents/detail/completed/segment-list.tsx
@@ -1,4 +1,4 @@
-import React, { type ForwardedRef, useMemo, type FC } from 'react'
+import React, { type FC, type ForwardedRef, useMemo } from 'react'
 import { useDocumentContext } from '../index'
 import SegmentCard from './segment-card'
 import Empty from './common/empty'


### PR DESCRIPTION
# Summary

This PR modifies the frontend components to support both 'custom' and 'hierarchical' modes for parent-child document structure. The change aligns the frontend implementation with the API documentation where the process rule mode is specified as 'custom'.

Key changes:
- Modified mode handling in SegmentCard, SegmentList, and ChildSegmentList components
- Updated mode logic to support both 'custom' and 'hierarchical' modes
- Passed mode prop through component hierarchy instead of relying on context
- Maintained backward compatibility with existing 'hierarchical' mode

This change ensures proper rendering of parent-child document structure when documents are created through the API with 'custom' mode.

# Screenshots

| Before | After |
![image](https://github.com/user-attachments/assets/b1cb5154-0e17-4c8b-9b15-8bc1b037a76b)
![image](https://github.com/user-attachments/assets/83f3eb04-ae85-46cf-9c68-24aab7310fc7)

|--------|-------|
| Parent-child structure not showing with API-created documents | Proper hierarchical display regardless of creation method |

# Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods