### PR TITLE
docs: Add DaoCloud mirror proxy instructions to README_CN.md

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -186,6 +186,8 @@ Dify 是一个开源的 LLM 应用开发平台。其直观的界面结合了 AI 
 
 启动 Dify 服务器的最简单方法是运行我们的 [docker-compose.yml](docker/docker-compose.yaml) 文件。在运行安装命令之前，请确保您的机器上安装了 [Docker](https://docs.docker.com/get-docker/) 和 [Docker Compose](https://docs.docker.com/compose/install/)：
 
+> **镜像加速**：如果您在中国大陆地区，可能会遇到 Docker 镜像拉取速度慢的问题。您可以使用 DaoCloud 提供的[镜像代理加速](https://github.com/DaoCloud/public-image-mirror)：`docker.m.daocloud.io`。比如只需在 docker-compose.yaml 文件中将所有的 `langgenius/` 镜像前缀替换为 `docker.m.daocloud.io/langgenius/`，将 `postgres:15-alpine` 替换为 `docker.m.daocloud.io/postgres:15-alpine` 即可。
+
 ```bash
 cd docker
 cp .env.example .env


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

- Added information about using the DaoCloud mirror proxy (`docker.m.daocloud.io`) in the "Quick Start" section of README_CN.md
- Included a link to the DaoCloud public image mirror repository for reference
- Provided clear instructions on how to modify the docker-compose.yaml file to use the mirror

Close https://github.com/langgenius/dify/issues/14615

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

