### PR TITLE
perf: optimizing db WorkflowAppLog index

### DIFF
--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -757,7 +757,8 @@ class WorkflowAppLog(Base):
     __tablename__ = "workflow_app_logs"
     __table_args__ = (
         db.PrimaryKeyConstraint("id", name="workflow_app_log_pkey"),
-        db.Index("workflow_app_log_app_idx", "tenant_id", "app_id"),
+        db.Index("workflow_app_log_app_idx", "tenant_id", "app_id", "created_at"),
+        db.Index("workflow_app_log_workflow_run_idx", "workflow_run_id"),
     )
 
     id: Mapped[str] = mapped_column(StringUUID, server_default=db.text("uuid_generate_v4()"))


### PR DESCRIPTION
# Summary

Currently, the primary slow queries in our database are originating from the `get_paginate_workflow_app_logs` method of the `WorkflowAppService`. I've noticed that there might be room for optimization in the index of the WorkflowAppLog table.

Consequently, I have added the most frequently used fields, `created_at` and `workflow_run_id`, to the index.

Close #14752

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

