### PR TITLE
hotfix: Fixed a problem with create datasets page style

### DIFF
--- a/web/app/components/datasets/create/file-uploader/index.tsx
+++ b/web/app/components/datasets/create/file-uploader/index.tsx
@@ -243,7 +243,7 @@ const FileUploader = ({
   }, [handleDrop])
 
   return (
-    <div className="mb-5 w-[640px]">
+    <div className="mb-5 max-w-[640px]">
       {!hideUpload && (
         <input
           ref={fileUploader}

--- a/web/app/components/datasets/create/step-one/index.tsx
+++ b/web/app/components/datasets/create/step-one/index.tsx
@@ -129,7 +129,7 @@ const StepOne = ({
     <div className='flex w-full h-full'>
       <div className='w-1/2 h-full overflow-y-auto relative'>
         <div className='flex justify-end'>
-          <div className={classNames(s.form)}>
+          <div className={classNames(s.form, 'overflow-hidden')}>
             {
               shouldShowDataSourceTypeList && (
                 <div className={classNames(s.stepHeader, 'z-10 text-text-secondary bg-components-panel-bg-blur')}>{t('datasetCreation.steps.one')}</div>


### PR DESCRIPTION
# Summary

In a small or flat screen, the style of the new knowledge base page is blocked

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![bug](https://github.com/user-attachments/assets/5895c9b3-b7e7-41a6-8e07-fb12e9e4ccd2) | ![fixed](https://github.com/user-attachments/assets/7d23bb34-cae4-4b90-bfc1-6404419a1ae8) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

