### PR TITLE
Fix typo: Window -> Windows in .gitattributes comment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Ensure that .sh scripts use LF as line separator, even if they are checked out
-# to Windows(NTFS) file-system, by a user of Docker for Window. 
+# to Windows(NTFS) file-system, by a user of Docker for Windows. 
 # These .sh scripts will be run from the Container after `docker compose up -d`.
 # If they appear to be CRLF style, Dash from the Container will fail to execute
 # them.


### PR DESCRIPTION
# Summary

Fixed a typo in the .gitattributes file comment where "Window" was incorrectly used instead of "Windows" in the Docker for Windows reference.

This is a minor documentation fix that improves the accuracy of the comment explaining the purpose of the LF line endings for .sh scripts.

Fix https://github.com/langgenius/dify/issues/14969

# Screenshots

| Before | After |
|--------|-------|
| `# to Windows(NTFS) file-system, by a user of Docker for Window.` | `# to Windows(NTFS) file-system, by a user of Docker for Windows.` |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods