### PR TITLE
fix(docker): plugin daemon lacks database dependency

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -154,7 +154,7 @@ services:
     volumes:
       - ./volumes/plugin_daemon:/app/storage
     depends_on:
-     - db
+      - db
 
   # ssrf_proxy server
   # for more information, please refer to

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -153,7 +153,8 @@ services:
       - "${EXPOSE_PLUGIN_DEBUGGING_PORT:-5003}:${PLUGIN_DEBUGGING_PORT:-5003}"
     volumes:
       - ./volumes/plugin_daemon:/app/storage
-
+    depends_on:
+     - db
 
   # ssrf_proxy server
   # for more information, please refer to

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -569,7 +569,7 @@ services:
     volumes:
       - ./volumes/plugin_daemon:/app/storage
     depends_on:
-     - db
+      - db
 
   # ssrf_proxy server
   # for more information, please refer to

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -568,7 +568,8 @@ services:
       - "${EXPOSE_PLUGIN_DEBUGGING_PORT:-5003}:${PLUGIN_DEBUGGING_PORT:-5003}"
     volumes:
       - ./volumes/plugin_daemon:/app/storage
-
+    depends_on:
+     - db
 
   # ssrf_proxy server
   # for more information, please refer to


### PR DESCRIPTION
# Summary

Plugin daemon container starts before db is up and running because of the missing dependency.
This PR just adds this dependency to fix this specific problem.

Fixes #14620

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

