### PR TITLE
fix: with file conversation second chat raise error

### DIFF
--- a/web/app/components/base/chat/chat/utils.ts
+++ b/web/app/components/base/chat/chat/utils.ts
@@ -17,15 +17,35 @@ export const processOpeningStatement = (openingStatement: string, inputs: Record
   })
 }
 
+export const processInputFileFromServer = (fileItem: Record<string, any>) => {
+  return {
+    type: fileItem.type,
+    transfer_method: fileItem.transfer_method,
+    url: fileItem.remote_url,
+    upload_file_id: fileItem.related_id,
+  }
+}
+
 export const getProcessedInputs = (inputs: Record<string, any>, inputsForm: InputForm[]) => {
   const processedInputs = { ...inputs }
 
   inputsForm.forEach((item) => {
-    if (item.type === InputVarType.multiFiles && inputs[item.variable])
-      processedInputs[item.variable] = getProcessedFiles(inputs[item.variable])
+    const inputValue = inputs[item.variable]
+    if (!inputValue)
+      return
 
-    if (item.type === InputVarType.singleFile && inputs[item.variable])
-      processedInputs[item.variable] = getProcessedFiles([inputs[item.variable]])[0]
+    if (item.type === InputVarType.singleFile) {
+      if ('transfer_method' in inputValue)
+        processedInputs[item.variable] = processInputFileFromServer(inputValue)
+      else
+        processedInputs[item.variable] = getProcessedFiles([inputValue])[0]
+    }
+    else if (item.type === InputVarType.multiFiles) {
+      if ('transfer_method' in inputValue[0])
+        processedInputs[item.variable] = inputValue.map(processInputFileFromServer)
+      else
+        processedInputs[item.variable] = getProcessedFiles(inputValue)
+    }
   })
 
   return processedInputs


### PR DESCRIPTION
# Summary

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fix https://github.com/langgenius/dify/issues/14909


debug panel:
![CleanShot 2025-03-06 at 15 05 25@2x](https://github.com/user-attachments/assets/60abe92e-5eaa-4bc5-80a3-816fc6006307)

In the second chat, it will use `inputs` from `/api/conversations` backend api, and the file object not match with the `FileEntity` of frontend

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

