### PR TITLE
hotfix: Fixed tags not updating in real time in the label management of apps #15113

### DIFF
--- a/web/app/components/base/tag-management/selector.tsx
+++ b/web/app/components/base/tag-management/selector.tsx
@@ -16,7 +16,7 @@ import Checkbox from '@/app/components/base/checkbox'
 import { bindTag, createTag, fetchTagList, unBindTag } from '@/service/tag'
 import { ToastContext } from '@/app/components/base/toast'
 
-interface TagSelectorProps {
+type TagSelectorProps = {
   targetID: string
   isPopover?: boolean
   position?: 'bl' | 'br'
@@ -215,6 +215,7 @@ const TagSelector: FC<TagSelectorProps> = ({
 }) => {
   const { t } = useTranslation()
 
+  const tagList = useTagStore(s => s.tagList)
   const setTagList = useTagStore(s => s.setTagList)
 
   const getTagList = async () => {
@@ -224,9 +225,9 @@ const TagSelector: FC<TagSelectorProps> = ({
 
   const triggerContent = useMemo(() => {
     if (selectedTags?.length)
-      return selectedTags.map(tag => tag.name).join(', ')
+      return selectedTags.filter(selectedTag => tagList.find(tag => tag.id === selectedTag.id)).map(tag => tag.name).join(', ')
     return ''
-  }, [selectedTags])
+  }, [selectedTags, tagList])
 
   const Trigger = () => {
     return (


### PR DESCRIPTION
# Summary

In the **label management** of **apps**, modifying labels or deleting reference labels will **not update** the description on the card in real time, and it takes effect only after **refreshing the page**

Fix https://github.com/langgenius/dify/issues/15113


# Screenshots

| Before | After |
|--------|-------|
|![bug](https://github.com/user-attachments/assets/3a51f72b-f42b-49fe-8a8e-d0b4305733c9) |![fixed](https://github.com/user-attachments/assets/2b4adaaf-16e0-4fb0-baf4-1a152b3b99a3) |


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

