### PR TITLE
Fix: only retrieval plugin-compatible providers when provider_name starts with `langgenius` 

### DIFF
--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -187,18 +187,30 @@ class ProviderConfiguration(BaseModel):
         :return:
         """
         # get provider
-        provider_record = (
-            db.session.query(Provider)
-            .filter(
-                Provider.tenant_id == self.tenant_id,
-                Provider.provider_type == ProviderType.CUSTOM.value,
-                or_(
-                    Provider.provider_name == ModelProviderID(self.provider.provider).plugin_name,
-                    Provider.provider_name == self.provider.provider,
-                ),
+        model_provider_id = ModelProviderID(self.provider.provider)
+        if model_provider_id.is_langgenius():
+            provider_record = (
+                db.session.query(Provider)
+                .filter(
+                    Provider.tenant_id == self.tenant_id,
+                    Provider.provider_type == ProviderType.CUSTOM.value,
+                    or_(
+                        Provider.provider_name == model_provider_id.provider_name,
+                        Provider.provider_name == self.provider.provider,
+                    ),
+                )
+                .first()
             )
-            .first()
-        )
+        else:
+            provider_record = (
+                db.session.query(Provider)
+                .filter(
+                    Provider.tenant_id == self.tenant_id,
+                    Provider.provider_type == ProviderType.CUSTOM.value,
+                    Provider.provider_name == self.provider.provider,
+                )
+                .first()
+            )
 
         # Get provider credential secret variables
         provider_credential_secret_variables = self.extract_secret_variables(

--- a/api/core/plugin/entities/plugin.py
+++ b/api/core/plugin/entities/plugin.py
@@ -164,6 +164,9 @@ class GenericProviderID:
         self.organization, self.plugin_name, self.provider_name = value.split("/")
         self.is_hardcoded = is_hardcoded
 
+    def is_langgenius(self) -> bool:
+        return self.organization == "langgenius"
+
     @property
     def plugin_id(self) -> str:
         return f"{self.organization}/{self.plugin_name}"


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

