### PR TITLE
chore: update langfuse description

### DIFF
--- a/web/i18n/en-US/app.ts
+++ b/web/i18n/en-US/app.ts
@@ -155,7 +155,7 @@ const translation = {
     },
     langfuse: {
       title: 'Langfuse',
-      description: 'Traces, evals, prompt management and metrics to debug and improve your LLM application.',
+      description: 'Open-source LLM observability, evaluation, prompt management and metrics to debug and improve your LLM application.',
     },
     opik: {
       title: 'Opik',


### PR DESCRIPTION

This is a straightforward update to the description of the Langfuse observability extension to make it more informative.

Fix #12883 