### PR TITLE
fix: missing action value to `tools.includeToolNum` lang for custom t…

### DIFF
--- a/web/app/components/tools/provider/detail.tsx
+++ b/web/app/components/tools/provider/detail.tsx
@@ -337,7 +337,7 @@ const ProviderDetail = ({
           {/* Custom type */}
           {!isDetailLoading && (collection.type === CollectionType.custom) && (
             <div className='text-text-secondary system-sm-semibold-uppercase'>
-              <span className=''>{t('tools.includeToolNum', { num: toolList.length }).toLocaleUpperCase()}</span>
+              <span className=''>{t('tools.includeToolNum', { num: toolList.length, action: toolList.length > 1 ? 'actions' : 'action' }).toLocaleUpperCase()}</span>
             </div>
           )}
           {/* Workflow type */}


### PR DESCRIPTION
fix: missing action value to `tools.includeToolNum` lang for custom tool detail info panel.

fix #12883 

![image](https://github.com/user-attachments/assets/29aa1bc3-8762-493b-9b43-2a25a7f8c31c)

