### PR TITLE
feat: env for agent max iterations

### DIFF
--- a/api/core/agent/cot_agent_runner.py
+++ b/api/core/agent/cot_agent_runner.py
@@ -2,6 +2,7 @@ import json
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping, Sequence
 from typing import Any, Optional
+from configs import dify_config
 
 from core.agent.base_agent_runner import BaseAgentRunner
 from core.agent.entities import AgentScratchpadUnit
@@ -63,7 +64,7 @@ class CotAgentRunner(BaseAgentRunner, ABC):
         self._instruction = self._fill_in_inputs_from_external_data_tools(instruction, inputs)
 
         iteration_step = 1
-        max_iteration_steps = min(app_config.agent.max_iteration if app_config.agent else 5, 5) + 1
+        max_iteration_steps = min(app_config.agent.max_iteration if app_config.agent else dify_config.AGENT_SETTING_MAX_ITERATION, dify_config.AGENT_SETTING_MAX_ITERATION) + 1
 
         # convert tools into ModelRuntime Tool format
         tool_instances, prompt_messages_tools = self._init_prompt_tools()

--- a/api/core/agent/entities.py
+++ b/api/core/agent/entities.py
@@ -1,6 +1,6 @@
+from configs import dify_config
 from enum import StrEnum
 from typing import Any, Optional, Union
-
 from pydantic import BaseModel, Field
 
 from core.tools.entities.tool_entities import ToolInvokeMessage, ToolProviderType
@@ -82,7 +82,7 @@ class AgentEntity(BaseModel):
     strategy: Strategy
     prompt: Optional[AgentPromptEntity] = None
     tools: Optional[list[AgentToolEntity]] = None
-    max_iteration: int = 5
+    max_iteration: int = dify_config.AGENT_SETTING_MAX_ITERATION
 
 
 class AgentInvokeMessage(ToolInvokeMessage):

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Generator
 from copy import deepcopy
 from typing import Any, Optional, Union
+from configs import dify_config
 
 from core.agent.base_agent_runner import BaseAgentRunner
 from core.app.apps.base_app_queue_manager import PublishFrom
@@ -49,7 +50,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
         assert app_config.agent
 
         iteration_step = 1
-        max_iteration_steps = min(app_config.agent.max_iteration, 5) + 1
+        max_iteration_steps = min(app_config.agent.max_iteration, dify_config.AGENT_SETTING_MAX_ITERATION) + 1
 
         # continue to run until there is not any tool call
         function_call_state = True

--- a/api/core/app/app_config/easy_ui_based_app/agent/manager.py
+++ b/api/core/app/app_config/easy_ui_based_app/agent/manager.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from configs import dify_config
 
 from core.agent.entities import AgentEntity, AgentPromptEntity, AgentToolEntity
 from core.agent.prompt.template import REACT_PROMPT_TEMPLATES
@@ -75,7 +76,7 @@ class AgentConfigManager:
                     strategy=strategy,
                     prompt=agent_prompt_entity,
                     tools=agent_tools,
-                    max_iteration=agent_dict.get("max_iteration", 5),
+                    max_iteration=agent_dict.get("max_iteration", dify_config.AGENT_SETTING_MAX_ITERATION),
                 )
 
         return None

--- a/web/app/components/app/configuration/config/agent/agent-setting/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-setting/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 }
 
 const maxIterationsMin = 1
-const maxIterationsMax = 5
+const maxIterationsMax = process.env.AGENT_SETTING_MAX_ITERATION
 
 const AgentSetting: FC<Props> = ({
   isChatModel,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -166,7 +166,7 @@ export const MAX_TOOLS_NUM = 10
 
 export const DEFAULT_AGENT_SETTING = {
   enabled: false,
-  max_iteration: 5,
+  max_iteration: process.env.AGENT_SETTING_MAX_ITERATION || 5,
   strategy: AgentStrategy.functionCall,
   tools: [],
 }


### PR DESCRIPTION
# Summary

Add an env to set max iterations for agents

Issues related:

[#8896](https://github.com/langgenius/dify/discussions/8896)
[#8692](https://github.com/langgenius/dify/issues/8692)
[#2792](https://github.com/langgenius/dify/issues/2792)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

