### PR TITLE
fix: return absolute path as the icon url if CONSOLE_API_URL is empty

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -765,17 +765,22 @@ class ToolManager:
 
     @classmethod
     def generate_builtin_tool_icon_url(cls, provider_id: str) -> str:
-        return (
-            dify_config.CONSOLE_API_URL
-            + "/console/api/workspaces/current/tool-provider/builtin/"
-            + provider_id
-            + "/icon"
+        return str(
+            URL(dify_config.CONSOLE_API_URL or "/")
+            / "console"
+            / "api"
+            / "workspaces"
+            / "current"
+            / "tool-provider"
+            / "builtin"
+            / provider_id
+            / "icon"
         )
 
     @classmethod
     def generate_plugin_tool_icon_url(cls, tenant_id: str, filename: str) -> str:
         return str(
-            URL(dify_config.CONSOLE_API_URL)
+            URL(dify_config.CONSOLE_API_URL or "/")
             / "console"
             / "api"
             / "workspaces"

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class ToolTransformService:
     @classmethod
     def get_plugin_icon_url(cls, tenant_id: str, filename: str) -> str:
-        url_prefix = URL(dify_config.CONSOLE_API_URL) / "console" / "api" / "workspaces" / "current" / "plugin" / "icon"
+        url_prefix = URL(dify_config.CONSOLE_API_URL or "/") / "console" / "api" / "workspaces" / "current" / "plugin" / "icon"
         return str(url_prefix % {"tenant_id": tenant_id, "filename": filename})
 
     @classmethod
@@ -37,7 +37,7 @@ class ToolTransformService:
         """
         get tool provider icon url
         """
-        url_prefix = URL(dify_config.CONSOLE_API_URL) / "console" / "api" / "workspaces" / "current" / "tool-provider"
+        url_prefix = URL(dify_config.CONSOLE_API_URL or "/") / "console" / "api" / "workspaces" / "current" / "tool-provider"
 
         if provider_type == ToolProviderType.BUILT_IN.value:
             return str(url_prefix / "builtin" / provider_name / "icon")

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 class ToolTransformService:
     @classmethod
     def get_plugin_icon_url(cls, tenant_id: str, filename: str) -> str:
-        url_prefix = URL(dify_config.CONSOLE_API_URL or "/") / "console" / "api" / "workspaces" / "current" / "plugin" / "icon"
+        url_prefix = (
+            URL(dify_config.CONSOLE_API_URL or "/") / "console" / "api" / "workspaces" / "current" / "plugin" / "icon"
+        )
         return str(url_prefix % {"tenant_id": tenant_id, "filename": filename})
 
     @classmethod
@@ -37,7 +39,9 @@ class ToolTransformService:
         """
         get tool provider icon url
         """
-        url_prefix = URL(dify_config.CONSOLE_API_URL or "/") / "console" / "api" / "workspaces" / "current" / "tool-provider"
+        url_prefix = (
+            URL(dify_config.CONSOLE_API_URL or "/") / "console" / "api" / "workspaces" / "current" / "tool-provider"
+        )
 
         if provider_type == ToolProviderType.BUILT_IN.value:
             return str(url_prefix / "builtin" / provider_name / "icon")

--- a/api/tests/unit_tests/libs/test_yarl.py
+++ b/api/tests/unit_tests/libs/test_yarl.py
@@ -18,6 +18,12 @@ def test_yarl_urls():
     assert str(URL("https://dify.ai/api") / "v1") == expected_3
     assert str(URL("https://dify.ai/api/") / "v1") == expected_3
 
+    expected_4 = "api"
+    assert str(URL("") / "api") == expected_4
+
+    expected_5 = "/api"
+    assert str(URL("/") / "api") == expected_5
+
     with pytest.raises(ValueError) as e1:
         str(URL("https://dify.ai") / "/api")
     assert str(e1.value) == "Appending path '/api' starting from slash is forbidden"

--- a/docker/nginx/conf.d/default.conf.template
+++ b/docker/nginx/conf.d/default.conf.template
@@ -4,19 +4,6 @@ server {
     listen ${NGINX_PORT};
     server_name ${NGINX_SERVER_NAME};
 
-    # Rule 1: Handle application entry points (preserve /app/{id})
-    location ~ ^/app/[a-f0-9-]+$ {
-      proxy_pass http://api:5001;
-      include proxy.conf;
-    }
-
-    # Rule 2: Handle static resource requests (remove /app/{id} prefix)
-    location ~ ^/app/[a-f0-9-]+/(console/api/.*)$ {
-      rewrite ^/app/[a-f0-9-]+/(.*)$ /$1 break;
-      proxy_pass http://api:5001;
-      include proxy.conf;
-    }
-
     location /console/api {
       proxy_pass http://api:5001;
       include proxy.conf;


### PR DESCRIPTION
# Summary

This is follow-up for #15241 by @crazywoola and @zhangxl01.

- Reverts #15241 
- Change API to solve the issue
- Add test cases for `yarl.URL`

The PR #15241 solves the issue by Nginx, but I think the issue should be solved by the API side.

The issue is fundamentally caused by the API returning a relative path (without leading `/`) as the icon URL when the `CONSOLE_API_URL` is empty.

![Image](https://github.com/user-attachments/assets/3029278c-e6db-4e9d-a80c-0e8892ec38a8)

If the specified URL does not start with `/`, the browser treats it as a relative path from the current URL. This causes 404 for all icons (See the screen shot below).

Simply ensuring that the API returns a path starting with `/` as the icon URL will resolve the issue, as the browser will interpret it as an absolute path from the root of the current domain.

Related #15189, #14668, #14835, #14570, #13982, #14835, #14578

# Screenshots

| Before | After |
|--------|-------|
| ![Image](https://github.com/user-attachments/assets/fce381cf-0ddb-46c8-a101-2563baa7f2e2) | ![Image](https://github.com/user-attachments/assets/959c31a1-e026-4756-8d44-a56ed860dbaa) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

