### PR TITLE
fix: remove port expose on db

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -91,8 +91,6 @@ services:
       interval: 1s
       timeout: 3s
       retries: 30
-    ports:
-      - '${EXPOSE_DB_PORT:-5432}:5432'
 
   # The redis cache.
   redis:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -506,8 +506,6 @@ services:
       interval: 1s
       timeout: 3s
       retries: 30
-    ports:
-      - '${EXPOSE_DB_PORT:-5432}:5432'
 
   # The redis cache.
   redis:


### PR DESCRIPTION
# Summary

Closes #15285 

In the PR #13836 that introduced the plugin feature, the `ports` was added to the `db` in the `docker-compose.yml`, allowing PostgreSQL to be exposed outside the Docker host by default.

This configuration is unnecessary for typical self-hosting scenarios.

It simply increases the potential for unauthorized access to the database and attacks. Due to the high security risk, the any port should be kept private by default.

# Screenshots

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/217b3936-1895-4513-a0bf-cf0e40786b77)| ![image](https://github.com/user-attachments/assets/9e0d117a-2391-46fa-9845-75996483fc03) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

