### PR TITLE
feat: add docker-compose.override.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ docker/nginx/conf.d/default.conf
 docker/nginx/ssl/*
 !docker/nginx/ssl/.gitkeep
 docker/middleware.env
+docker/docker-compose.override.yaml
 
 sdks/python-client/build
 sdks/python-client/dist


### PR DESCRIPTION
# Summary

Closes #15287

This PR adds `docker-compose.override.yaml` to `.gitignore`.

# Screenshots

| Before | After |
|--------|-------|
| Tracked by Git<br>![image](https://github.com/user-attachments/assets/ae874fb8-d114-4c13-b052-c2797ace6750) | Untracked<br>![image](https://github.com/user-attachments/assets/f024a455-9f1d-4062-bbf9-0146429c2a46) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

