### PR TITLE
modify OCI_ENDPOINT example value Fixes #15336

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -344,7 +344,7 @@ TENCENT_COS_SCHEME=your-scheme
 
 # Oracle Storage Configuration
 #
-OCI_ENDPOINT=https://objectstorage.us-ashburn-1.oraclecloud.com
+OCI_ENDPOINT=https://{object-storage-namespace}.compat.objectstorage.{region}.oraclecloud.com
 OCI_BUCKET_NAME=your-bucket-name
 OCI_ACCESS_KEY=your-access-key
 OCI_SECRET_KEY=your-secret-key

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -344,7 +344,7 @@ TENCENT_COS_SCHEME=your-scheme
 
 # Oracle Storage Configuration
 #
-OCI_ENDPOINT=https://{object-storage-namespace}.compat.objectstorage.{region}.oraclecloud.com
+OCI_ENDPOINT=https://your-object-storage-namespace.compat.objectstorage.us-ashburn-1.oraclecloud.com
 OCI_BUCKET_NAME=your-bucket-name
 OCI_ACCESS_KEY=your-access-key
 OCI_SECRET_KEY=your-secret-key

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -105,7 +105,7 @@ x-shared-env: &shared-api-worker-env
   TENCENT_COS_SECRET_ID: ${TENCENT_COS_SECRET_ID:-your-secret-id}
   TENCENT_COS_REGION: ${TENCENT_COS_REGION:-your-region}
   TENCENT_COS_SCHEME: ${TENCENT_COS_SCHEME:-your-scheme}
-  OCI_ENDPOINT: ${OCI_ENDPOINT:-https://objectstorage.us-ashburn-1.oraclecloud.com}
+  OCI_ENDPOINT: ${OCI_ENDPOINT:-https://your-object-storage-namespace.compat.objectstorage.us-ashburn-1.oraclecloud.com}
   OCI_BUCKET_NAME: ${OCI_BUCKET_NAME:-your-bucket-name}
   OCI_ACCESS_KEY: ${OCI_ACCESS_KEY:-your-access-key}
   OCI_SECRET_KEY: ${OCI_SECRET_KEY:-your-secret-key}


### PR DESCRIPTION
# Summary

The example of oci_endpoint value format is wrong

in docker/.env.example:
OCI_ENDPOINT=https://objectstorage.us-ashburn-1.oraclecloud.com/

in docker/docker-compose.yaml:
OCI_ENDPOINT: ${OCI_ENDPOINT:-https://objectstorage.us-ashburn-1.oraclecloud.com}/

Right format is: https://{object-storage-namespace}.compat.objectstorage.{region}.oraclecloud.com

refer to: https://docs.public.oneportal.content.oci.oraclecloud.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm

Fix #15336

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

