### PR TITLE
chore: add comment to the PLUGIN_DIFY_INNER_API_KEY key

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -959,7 +959,7 @@ PLUGIN_DEBUGGING_PORT=5003
 EXPOSE_PLUGIN_DEBUGGING_HOST=localhost
 EXPOSE_PLUGIN_DEBUGGING_PORT=5003
 
-# If you change this key, you need to change the DIFY_INNER_API_KEY key in the plugin_daemon service, or the agent node will not work.
+# If this key is changed, DIFY_INNER_API_KEY in plugin_daemon service must also be updated or agent node will fail.
 PLUGIN_DIFY_INNER_API_KEY=QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1
 PLUGIN_DIFY_INNER_API_URL=http://api:5001
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -959,6 +959,7 @@ PLUGIN_DEBUGGING_PORT=5003
 EXPOSE_PLUGIN_DEBUGGING_HOST=localhost
 EXPOSE_PLUGIN_DEBUGGING_PORT=5003
 
+# If you change this key, you need to change the DIFY_INNER_API_KEY key in the plugin_daemon service, or the agent node will not work.
 PLUGIN_DIFY_INNER_API_KEY=QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1
 PLUGIN_DIFY_INNER_API_URL=http://api:5001
 


### PR DESCRIPTION
# Summary

If PLUGIN_DIFY_INNER_API_KEY in docker/.env is changed, the DIFY_INNER_API_KEY in the plugin_daemon service must be synchronized accordingly, otherwise the Agent node will fail.

Resolves #15118
Resolves #14850

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

