### PR TITLE
fix(web): fix knowledge tab document table style

### DIFF
--- a/web/app/components/datasets/documents/list.tsx
+++ b/web/app/components/datasets/documents/list.tsx
@@ -501,7 +501,7 @@ const DocumentList: FC<IDocumentListProps> = ({
 
   return (
     <div className='relative w-full h-full overflow-x-auto'>
-      <table className={`min-w-[700px] max-w-full w-full border-collapse border-0 text-sm mt-3 ${s.documentTable}`}>
+      <table className={`min-w-[700px] max-w-full w-full border-collapse border-0 text-sm mt-3 mb-12 ${s.documentTable}`}>
         <thead className="h-8 leading-8 border-b border-divider-subtle text-text-tertiary font-medium text-xs uppercase">
           <tr>
             <td className='w-12'>


### PR DESCRIPTION
# Summary

On the table page of the knowledge base, when the screen is small or a scrollbar appears, the navigation bar at the bottom overlaps with the table content.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|  ![before](https://github.com/user-attachments/assets/3a121470-0e9b-452d-b1a7-7dbb0bac41d1)  | ![after](https://github.com/user-attachments/assets/83ee854a-e901-4370-a1bd-d0a021c9b551)|

# Checklist

> [!IMPORTANT]  

> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

