### PR TITLE
fix agent_execution_metadata

### DIFF
--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -270,7 +270,8 @@ class ToolNode(BaseNode[ToolNodeData]):
                 if self.node_type == NodeType.AGENT:
                     msg_metadata = message.message.json_object.pop("execution_metadata", {})
                     agent_execution_metadata = {
-                        key: value for key, value in msg_metadata.items() if key in NodeRunMetadataKey
+                        key: value for key, value in msg_metadata.items() if
+                        key in NodeRunMetadataKey.__members__.values()
                     }
                 json.append(message.message.json_object)
             elif message.type == ToolInvokeMessage.MessageType.LINK:

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -270,8 +270,9 @@ class ToolNode(BaseNode[ToolNodeData]):
                 if self.node_type == NodeType.AGENT:
                     msg_metadata = message.message.json_object.pop("execution_metadata", {})
                     agent_execution_metadata = {
-                        key: value for key, value in msg_metadata.items() if
-                        key in NodeRunMetadataKey.__members__.values()
+                        key: value
+                        for key, value in msg_metadata.items()
+                        if key in NodeRunMetadataKey.__members__.values()
                     }
                 json.append(message.message.json_object)
             elif message.type == ToolInvokeMessage.MessageType.LINK:


### PR DESCRIPTION
# Summary
Fixes https://github.com/langgenius/dify/issues/15463

fix tool_node msg_metadata TypeError

error msg:
`
 File "/Users/xxxxxx/project/opensource/dify/api/core/workflow/nodes/tool/tool_node.py", line 273, in <dictcomp>
    key: value for key, value in msg_metadata.items() if key in NodeRunMetadataKey
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py", line 742, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'str' and 'EnumType'
`

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/fc84ad57-77fe-43bc-acbd-8c67b79b5fd1)| ![image](https://github.com/user-attachments/assets/86bebc88-6ed4-4495-b189-119b528c0c7f)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

