### PR TITLE
Update the provider_id validation to fix the error message displayed …

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -257,7 +257,7 @@ class App(Base):
                 provider_id = tool.get("provider_id", "")
 
                 if provider_type == ToolProviderType.API.value:
-                    if provider_id not in existing_api_providers:
+                    if uuid.UUID(provider_id) not in existing_api_providers:
                         deleted_tools.append(
                             {
                                 "type": ToolProviderType.API.value,


### PR DESCRIPTION
# Summary

Update the `provider_id` validation to fix the error message displayed in the Agent's tool.

After upgrading from 0.15.3 to 1.0.0, I noticed that the Agent's tool displayed a "Tool removed" warning message. However, the tool still exists and functions normally. The issue occurred because the tool's `provider_id` was not converted to a UUID before comparison, leading to an incorrect evaluation.

Fix https://github.com/langgenius/dify/issues/14932
Fix https://github.com/langgenius/dify/issues/14660

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before (0.15.3) | After (1.0.0) |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/1cc6f94d-3eb4-4291-a343-d895f132db44)    | ![image](https://github.com/user-attachments/assets/efc1b215-50d9-421e-b141-340650272590)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

