### PR TITLE
fix: improve selection of variable in workflow

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -109,6 +109,7 @@ const Item: FC<ItemProps> = ({
             'relative w-full flex items-center h-6 pl-3  rounded-md cursor-pointer')
           }
           onClick={handleChosen}
+          onMouseDown={e => e.preventDefault()}
         >
           <div className='flex items-center w-0 grow'>
             {!isEnv && !isChatVar && <Variable02 className={cn('shrink-0 w-3.5 h-3.5 text-text-accent', isException && 'text-text-warning')} />}


### PR DESCRIPTION
# Summary

Fixes #14494 
In the menu for selecting variables to be used in a workflow, mousedown event would cause the focus to be removed (blur event), so quick mouseup is needed to successfully select variables. This pull request fixes this behavior and makes it easier to select variables with touchpad and slow mouseup.

# Screenshots

Operation movies:

| Before | After |
|--------|-------|
| https://drive.google.com/file/d/1gwQkgm-TKsj6D6190ouvKfD_qHxKrK68/view?usp=sharing    | https://drive.google.com/file/d/10-tKAMLIAJ8ch9MqYb0f_Pmszvccmm4T/view?usp=sharing   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

