### PR TITLE
fix: add animation to workflow process loader icon

### DIFF
--- a/web/app/components/base/chat/chat/answer/workflow-process.tsx
+++ b/web/app/components/base/chat/chat/answer/workflow-process.tsx
@@ -56,7 +56,7 @@ const WorkflowProcessItem = ({
       >
         {
           running && (
-            <RiLoader2Line className='shrink-0 mr-1 w-3.5 h-3.5 text-text-tertiary' />
+            <RiLoader2Line className='shrink-0 mr-1 w-3.5 h-3.5 animate-spin text-text-tertiary' />
           )
         }
         {


### PR DESCRIPTION
# Summary

Running workflows lacked a loading state indicator. This PR addresses the issue by adding an `animate-spin` class to the loader icon, providing users with clear visual feedback of workflow execution status.

Close https://github.com/langgenius/dify/issues/15505

# Screenshots

## Before
https://github.com/user-attachments/assets/4d631f4d-94d4-483d-9bc1-390ac1063ed8

## After
https://github.com/user-attachments/assets/28b3eaae-2abf-4544-8144-1471d5a3f0b6

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

