### PR TITLE
fix:message api doc

### DIFF
--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -10,7 +10,7 @@ from controllers.service_api.app.error import NotChatAppError
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.app.entities.app_invoke_entities import InvokeFrom
 from fields.conversation_fields import message_file_fields
-from fields.message_fields import feedback_fields, retriever_resource_fields
+from fields.message_fields import agent_thought_fields, feedback_fields, retriever_resource_fields
 from fields.raws import FilesContainedField
 from libs.helper import TimestampField, uuid_value
 from models.model import App, AppMode, EndUser
@@ -19,20 +19,6 @@ from services.message_service import MessageService
 
 
 class MessageListApi(Resource):
-    agent_thought_fields = {
-        "id": fields.String,
-        "chain_id": fields.String,
-        "message_id": fields.String,
-        "position": fields.Integer,
-        "thought": fields.String,
-        "tool": fields.String,
-        "tool_labels": fields.Raw,
-        "tool_input": fields.String,
-        "created_at": TimestampField,
-        "observation": fields.String,
-        "message_files": fields.List(fields.Nested(message_file_fields)),
-    }
-
     message_fields = {
         "id": fields.String,
         "conversation_id": fields.String,

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -641,7 +641,7 @@ Chat applications support session persistence, allowing previous chat history to
                         "tool_input": "{\"dalle2\": {\"prompt\": \"cat\"}}",
                         "created_at": 1705988186,
                         "observation": "image has been created and sent to user already, you should tell user to check it now.",
-                        "message_files": [
+                        "files": [
                             "976990d2-5294-47e6-8f14-7356ba9d2d76"
                         ]
                     },
@@ -655,7 +655,7 @@ Chat applications support session persistence, allowing previous chat history to
                         "tool_input": "",
                         "created_at": 1705988199,
                         "observation": "",
-                        "message_files": []
+                        "files": []
                     }
                 ]
             }

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -641,7 +641,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
                         "tool_input": "{\"dalle2\": {\"prompt\": \"cat\"}}",
                         "created_at": 1705988186,
                         "observation": "画像はすでに作成され、ユーザーに送信されました。今すぐユーザーに確認するように伝えてください。",
-                        "message_files": [
+                        "files": [
                             "976990d2-5294-47e6-8f14-7356ba9d2d76"
                         ]
                     },
@@ -655,7 +655,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
                         "tool_input": "",
                         "created_at": 1705988199,
                         "observation": "",
-                        "message_files": []
+                        "files": []
                     }
                 ]
             }

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -657,7 +657,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
                     "tool_input": "{\"dalle2\": {\"prompt\": \"cat\"}}",
                     "created_at": 1705988186,
                     "observation": "image has been created and sent to user already, you should tell user to check it now.",
-                    "message_files": [
+                    "files": [
                         "976990d2-5294-47e6-8f14-7356ba9d2d76"
                     ]
                 },
@@ -671,7 +671,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
                     "tool_input": "",
                     "created_at": 1705988199,
                     "observation": "",
-                    "message_files": []
+                    "files": []
                 }
             ]
         }


### PR DESCRIPTION
# Summary
 when use Get Conversation History Messages api (v1/messages of Agent Assistant) it return
 ```
 ...
 "agent thoughts":[
   {
     ...
    "message_files":[
      {
         "id":null
       }
    ]
     ...
    }
 ]
 ...
 ```
but  the api doc  show 
```
 "message_files": [
   "976990d2-5294-47e6-8f14-7356ba9d2d76"
  ]
```
and /api/messages show 
```
"files": [
   "976990d2-5294-47e6-8f14-7356ba9d2d76"
  ]
```
I think it's necessary to maintain unity

> [!Tip]
> Close issue syntax:  fix #15070



# Screenshots

| Before | After |
|--------|-------|
| ![79bd8b4913807fffc3df6341654c62c](https://github.com/user-attachments/assets/be8bd19f-9b47-41c8-bc1a-ae96bda308af) | ![140fd1bd749c28b5a2f6d1f57a72779](https://github.com/user-attachments/assets/bc113eb2-9d88-48e6-9a14-308ac9f6ddb5) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

