### PR TITLE
support config filename in meta for create_blob_message

### DIFF
--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -63,11 +63,18 @@ class ToolFileManager:
         conversation_id: Optional[str],
         file_binary: bytes,
         mimetype: str,
+        filename: Optional[str] = None,
     ) -> ToolFile:
         extension = guess_extension(mimetype) or ".bin"
         unique_name = uuid4().hex
-        filename = f"{unique_name}{extension}"
-        filepath = f"tools/{tenant_id}/{filename}"
+        unique_filename = f"{unique_name}{extension}"
+        # default just as before
+        present_filename = unique_filename
+        if filename is not None:
+            has_extension = len(filename.split(".")) > 1
+            # Add extension flexibly
+            present_filename = has_extension if filename else f"{filename}{extension}"
+        filepath = f"tools/{tenant_id}/{unique_filename}"
         storage.save(filepath, file_binary)
 
         tool_file = ToolFile(
@@ -76,7 +83,7 @@ class ToolFileManager:
             conversation_id=conversation_id,
             file_key=filepath,
             mimetype=mimetype,
-            name=filename,
+            name=present_filename,
             size=len(file_binary),
         )
 

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -73,7 +73,7 @@ class ToolFileManager:
         if filename is not None:
             has_extension = len(filename.split(".")) > 1
             # Add extension flexibly
-            present_filename = filename if has_extension  else f"{filename}{extension}"
+            present_filename = filename if has_extension else f"{filename}{extension}"
         filepath = f"tools/{tenant_id}/{unique_filename}"
         storage.save(filepath, file_binary)
 

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -73,7 +73,7 @@ class ToolFileManager:
         if filename is not None:
             has_extension = len(filename.split(".")) > 1
             # Add extension flexibly
-            present_filename = has_extension if filename else f"{filename}{extension}"
+            present_filename = filename if has_extension  else f"{filename}{extension}"
         filepath = f"tools/{tenant_id}/{unique_filename}"
         storage.save(filepath, file_binary)
 

--- a/api/core/tools/utils/message_transformer.py
+++ b/api/core/tools/utils/message_transformer.py
@@ -59,6 +59,8 @@ class ToolFileMessageTransformer:
                 meta = message.meta or {}
 
                 mimetype = meta.get("mime_type", "application/octet-stream")
+                # get filename from meta
+                filename = meta.get("file_name", None)
                 # if message is str, encode it to bytes
 
                 if not isinstance(message.message, ToolInvokeMessage.BlobMessage):
@@ -72,6 +74,7 @@ class ToolFileMessageTransformer:
                     conversation_id=conversation_id,
                     file_binary=message.message.blob,
                     mimetype=mimetype,
+                    filename=filename,
                 )
 
                 url = cls.get_tool_file_url(tool_file_id=file.id, extension=guess_extension(file.mimetype))


### PR DESCRIPTION
# Summary
Fixes #15322
- If the meta has a "file_name" key:
  - If an extension is set, the system does nothing.
  - If no extension is set, it automatically adds an extension.
- If the meta lacks a "file_name" key, the system uses the original naming method.

# Screenshots
when the meta has a "file_name" key
![a dify plugin tool use create_blob_message and add file_name key in meta](https://github.com/user-attachments/assets/def3200d-cf99-410f-b8fd-28da2364de12)

## before
![unexpected filename in response message](https://github.com/user-attachments/assets/6d15ce10-644f-4057-af72-7bad983963a7)

## after
![expected filename in response message](https://github.com/user-attachments/assets/632eff73-5df5-4249-a169-ef18c4fe83f9)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [zh_CN tool.md](https://github.com/langgenius/dify-docs/zh_CN/plugins/schema-definition/tool.md),[jp tool.md](https://github.com/langgenius/dify-docs/jp/plugins/schema-definition/tool.md),[en tool.md](https://github.com/langgenius/dify-docs/en/plugins/schema-definition/tool.md)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

