### PR TITLE
fix: prevent AppIconPicker click event from propagating (#15575)

### DIFF
--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -439,23 +439,25 @@ const SettingsModal: FC<ISettingsModalProps> = ({
           <Button className='mr-2' onClick={onHide}>{t('common.operation.cancel')}</Button>
           <Button variant='primary' onClick={onClickSave} loading={saveLoading}>{t('common.operation.save')}</Button>
         </div>
-      </Modal >
-      {showAppIconPicker && (
-        <AppIconPicker
-          onSelect={(payload) => {
-            setAppIcon(payload)
-            setShowAppIconPicker(false)
-          }}
-          onClose={() => {
-            setAppIcon(icon_type === 'image'
-              ? { type: 'image', url: icon_url!, fileId: icon }
-              : { type: 'emoji', icon, background: icon_background! })
-            setShowAppIconPicker(false)
-          }}
-        />
-      )}
-    </>
 
+        {showAppIconPicker && (
+          <div onClick={e => e.stopPropagation()}>
+            <AppIconPicker
+              onSelect={(payload) => {
+                setAppIcon(payload)
+                setShowAppIconPicker(false)
+              }}
+              onClose={() => {
+                setAppIcon(icon_type === 'image'
+                  ? { type: 'image', url: icon_url!, fileId: icon }
+                  : { type: 'emoji', icon, background: icon_background! })
+                setShowAppIconPicker(false)
+              }}
+            />
+          </div>
+        )}
+      </Modal>
+    </>
   )
 }
 export default React.memo(SettingsModal)


### PR DESCRIPTION
# Summary

Fixed an issue where clicking on the AppIconPicker inside SettingsModal would cause the SettingsModal to close unexpectedly. This was happening due to event bubbling between nested modals.

> [!Tip]
> Fixes #15575

# Screenshots

## Before

https://github.com/user-attachments/assets/e1994213-41e3-4e82-b04b-fd840ac440ca

## After
 
https://github.com/user-attachments/assets/ae82b202-e998-4f34-a237-2a569b8e2e14


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

