### PR TITLE
fix:Nginx template not replace env correctly

### DIFF
--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+HTTPS_CONFIG=''
+
 if [ "${NGINX_HTTPS_ENABLED}" = "true" ]; then
     # Check if the certificate and key files for the specified domain exist
     if [ -n "${CERTBOT_DOMAIN}" ] && \
@@ -20,6 +22,7 @@ if [ "${NGINX_HTTPS_ENABLED}" = "true" ]; then
     # Substitute the HTTPS_CONFIG in the default.conf.template with content from https.conf.template
     envsubst '${HTTPS_CONFIG}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 fi
+export HTTPS_CONFIG
 
 if [ "${NGINX_ENABLE_CERTBOT_CHALLENGE}" = "true" ]; then
     ACME_CHALLENGE_LOCATION='location /.well-known/acme-challenge/ { root /var/www/html; }'
@@ -33,7 +36,7 @@ env_vars=$(printenv | cut -d= -f1 | sed 's/^/$/g' | paste -sd, -)
 envsubst "$env_vars" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 envsubst "$env_vars" < /etc/nginx/proxy.conf.template > /etc/nginx/proxy.conf
 
-envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst "$env_vars" < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 # Start Nginx using the default entrypoint
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
# Summary
Fixed an issue that nginx template not replace env correctly when using nginx internal variables.

Fixes #15650

# Screenshots
## Brefore
![图片](https://github.com/user-attachments/assets/e675ecf6-d128-4e7c-81e3-4e2a35915540)

## After
![图片](https://github.com/user-attachments/assets/ff2f971e-d91f-4210-b4ae-27d7edd46c6c)


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] Shell script change, no code changed

