### PR TITLE
fix: improve markdown code block horizontal scrolling

### DIFF
--- a/web/app/styles/markdown.scss
+++ b/web/app/styles/markdown.scss
@@ -213,7 +213,7 @@
   display: block;
   width: max-content;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: auto;
   border: 1px solid var(--color-divider-regular);
   border-radius: 8px;
 }


### PR DESCRIPTION
The change modifies the markdown styles to enable horizontal scrolling for code blocks when content exceeds the container width, ensuring better readability and user experience.

# Summary

Fixes https://github.com/langgenius/dify/issues/15560

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

