### PR TITLE
fix: Integration langfuse, front-end error( #15695)

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
@@ -197,7 +197,7 @@ const Panel: FC = () => {
                 {t(`${I18N_PREFIX}.${enabled ? 'enabled' : 'disabled'}`)}
               </div>
             </div>
-            <InUseProviderIcon className='ml-1 h-4' />
+            {InUseProviderIcon && <InUseProviderIcon className='ml-1 h-4' />}
             <Divider type='vertical' className='h-3.5' />
             <div className='flex items-center' onClick={e => e.stopPropagation()}>
               <ConfigButton


### PR DESCRIPTION
# Summary

InUseProviderIcon may be null, but React cannot render null as a component.

> [!Tip]
>Resolves #15695


# Screenshots
<img width="1914" alt="1741847915247" src="https://github.com/user-attachments/assets/50c3126c-9ae3-4fb1-848c-f64b0046af50" />
![image](https://github.com/user-attachments/assets/4a5244f6-02b6-4fdd-82cd-8d0cd9084820)

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

