### PR TITLE
feat: add llm blocking invoke

### DIFF
--- a/api/core/plugin/backwards_invocation/model.py
+++ b/api/core/plugin/backwards_invocation/model.py
@@ -46,7 +46,7 @@ class PluginModelBackwardsInvocation(BaseBackwardsInvocation):
             model_parameters=payload.completion_params,
             tools=payload.tools,
             stop=payload.stop,
-            stream=payload.stream or True,
+            stream=True if payload.stream is None else payload.stream,
             user=user_id,
         )
 


### PR DESCRIPTION
# Summary

Added support for calling blocking model methods from within plugins to enable non-streaming Function Call invocations. The related PRs are as follows:
https://github.com/langgenius/dify-plugin-sdks/pull/40

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

