### PR TITLE
feat: add keyboard shortcuts support for dialog confirmation

### DIFF
--- a/web/app/components/base/confirm/index.tsx
+++ b/web/app/components/base/confirm/index.tsx
@@ -46,13 +46,17 @@ function Confirm({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape')
         onCancel()
+      if (event.key === 'Enter' && isShow) {
+        event.preventDefault()
+        onConfirm()
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [onCancel])
+  }, [onCancel, onConfirm, isShow])
 
   const handleClickOutside = (event: MouseEvent) => {
     if (maskClosable && dialogRef.current && !dialogRef.current.contains(event.target as Node))


### PR DESCRIPTION
# Summary

This PR adds keyboard shortcuts support to the confirm dialog component:
- Enter key to confirm dialog action

Close #15711

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

