### PR TITLE
When decrypt_trace_config is empty, it should be skipped directly

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -214,6 +214,8 @@ class OpsTraceManager:
                 provider_config_map[tracing_provider]["trace_instance"],
                 provider_config_map[tracing_provider]["config_class"],
             )
+            if not decrypt_trace_config:
+                return None
             tracing_instance = trace_instance(config_class(**decrypt_trace_config))
             return tracing_instance
 


### PR DESCRIPTION
When decrypt_trace_config is empty, return None directly to avoid errors

Resolves #13088 
# Summary

In the chat bot application link tracking, I directly removed the configuration of opik and saved it (note that the link tracking status is still enabled at this time). After restarting dify with docker compose down && docker compose up -d, I found that all chat bots with opik removed could not be used, and the UI reported an error:
![截圖 2025-03-14 下午3 57 45](https://github.com/user-attachments/assets/720897f7-dcfa-425f-bd0b-d46ad51ae449)

Then the docker-api-1 container reported an error:
```
2025-03-14 08:45:17.221 ERROR [Dummy-338] [completion.py:138] - internal server error.
Traceback (most recent call last):
  File "/app/api/controllers/service_api/app/completion.py", line 115, in post
    response = AppGenerateService.generate(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/services/app_generate_service.py", line 75, in generate
    AdvancedChatAppGenerator().generate(
  File "/app/api/core/app/apps/advanced_chat/app_generator.py", line 128, in generate
    trace_manager = TraceQueueManager(
                    ^^^^^^^^^^^^^^^^^^
  File "/app/api/core/ops/ops_trace_manager.py", line 752, in __init__
    self.trace_instance = OpsTraceManager.get_ops_trace_instance(app_id)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/core/ops/ops_trace_manager.py", line 217, in get_ops_trace_instance
    tracing_instance = trace_instance(config_class(**decrypt_trace_config))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: core.ops.entities.config_entity.OpikConfig() argument after ** must be a mapping, not NoneType
2025-03-14 08:45:17.229 ERROR [Dummy-338] [app.py:875] - Exception on /v1/chat-messages [POST]
Traceback (most recent call last):
  File "/app/api/controllers/service_api/app/completion.py", line 115, in post
    response = AppGenerateService.generate(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/services/app_generate_service.py", line 75, in generate
    AdvancedChatAppGenerator().generate(
  File "/app/api/core/app/apps/advanced_chat/app_generator.py", line 128, in generate
    trace_manager = TraceQueueManager(
                    ^^^^^^^^^^^^^^^^^^
  File "/app/api/core/ops/ops_trace_manager.py", line 752, in __init__
    self.trace_instance = OpsTraceManager.get_ops_trace_instance(app_id)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/core/ops/ops_trace_manager.py", line 217, in get_ops_trace_instance
    tracing_instance = trace_instance(config_class(**decrypt_trace_config))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: core.ops.entities.config_entity.OpikConfig() argument after ** must be a mapping, not NoneType

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/api/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/.venv/lib/python3.12/site-packages/flask_restful/__init__.py", line 489, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/.venv/lib/python3.12/site-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/.venv/lib/python3.12/site-packages/flask_restful/__init__.py", line 604, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/controllers/service_api/wraps.py", line 83, in decorated_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api/controllers/service_api/app/completion.py", line 139, in post
    raise InternalServerError()
werkzeug.exceptions.InternalServerError: 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server isoverloaded or there is an error in the application.
```

This PR is to solve this kind of problem. I think it is necessary to determine whether the configuration file exists before returning "tracing_instance". . . .

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
Before:
![截圖 2025-03-14 下午3 57 45](https://github.com/user-attachments/assets/dd2f7804-a02b-4c71-b935-ed9ab5f7d8be)

After:
The chat bot is back to normal
![image](https://github.com/user-attachments/assets/31fb027f-3f21-4990-b081-547ea36d9f79)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

