### PR TITLE
fix: api error of get all workspaces

### DIFF
--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -97,11 +97,11 @@ class WorkspaceListApi(Resource):
             has_more = True
 
         return {
-                   "data": marshal(tenants.items, workspace_fields),
-                   "has_more": has_more,
-                   "limit": args["limit"],
-                   "page": args["page"],
-                   "total": tenants.total,
+            "data": marshal(tenants.items, workspace_fields),
+            "has_more": has_more,
+            "limit": args["limit"],
+            "page": args["page"],
+            "total": tenants.total,
         }, 200
 
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -88,28 +88,20 @@ class WorkspaceListApi(Resource):
         parser.add_argument("limit", type=inputs.int_range(1, 100), required=False, default=20, location="args")
         args = parser.parse_args()
 
-        tenants = Tenant.query.order_by(Tenant.created_at.desc()).paginate(page=args["page"], per_page=args["limit"])
-
+        tenants = Tenant.query.order_by(Tenant.created_at.desc()).paginate(
+            page=args["page"], per_page=args["limit"], error_out=False
+        )
         has_more = False
-        if len(tenants.items) == args["limit"]:
-            current_page_first_tenant = tenants[-1]
-            rest_count = (
-                db.session.query(Tenant)
-                .filter(
-                    Tenant.created_at < current_page_first_tenant.created_at, Tenant.id != current_page_first_tenant.id
-                )
-                .count()
-            )
 
-            if rest_count > 0:
-                has_more = True
-        total = db.session.query(Tenant).count()
+        if tenants.has_next:
+            has_more = True
+
         return {
-            "data": marshal(tenants.items, workspace_fields),
-            "has_more": has_more,
-            "limit": args["limit"],
-            "page": args["page"],
-            "total": total,
+                   "data": marshal(tenants.items, workspace_fields),
+                   "has_more": has_more,
+                   "limit": args["limit"],
+                   "page": args["page"],
+                   "total": tenants.total,
         }, 200
 
 


### PR DESCRIPTION
# Summary

Fixes #15784 
Close https://github.com/langgenius/dify/pull/15872
fix the TypeError of the api  `/console/api/all-workspaces` &&  optimized the paging judgment and counting logic

Fixed this bug and optimized code implementation, improving code robustness

# Screenshots

| Before | After |
|--------|-------|
| <img width="976" alt="0315-before" src="https://github.com/user-attachments/assets/82d755c4-cb63-4586-8451-d3a5e14813aa" />| <img width="965" alt="0315-after" src="https://github.com/user-attachments/assets/192e577e-cccf-4a86-87a1-fb7776cb7caa" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

