### PR TITLE
enhance: avoid to use transaction Redis commands in rate limiter

### DIFF
--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -45,7 +45,6 @@ class RateLimit:
             self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
             redis_client.expire(self.max_active_requests_key, timedelta(days=1))
 
-            with redis_client.pipeline() as pipe:
                 self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
                 redis_client.expire(self.max_active_requests_key, timedelta(days=1))
 

--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -40,11 +40,11 @@ class RateLimit:
         self.last_recalculate_time = time.time()
         # flush max active requests
         if use_local_value or not redis_client.exists(self.max_active_requests_key):
-            with redis_client.pipeline() as pipe:
-                pipe.set(self.max_active_requests_key, self.max_active_requests)
-                pipe.expire(self.max_active_requests_key, timedelta(days=1))
-                pipe.execute()
+            redis_client.setex(self.max_active_requests_key, timedelta(days=1), self.max_active_requests)
         else:
+            self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
+            redis_client.expire(self.max_active_requests_key, timedelta(days=1))
+
             with redis_client.pipeline() as pipe:
                 self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
                 redis_client.expire(self.max_active_requests_key, timedelta(days=1))

--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -45,9 +45,6 @@ class RateLimit:
             self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
             redis_client.expire(self.max_active_requests_key, timedelta(days=1))
 
-                self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
-                redis_client.expire(self.max_active_requests_key, timedelta(days=1))
-
         # flush max active requests (in-transit request list)
         if not redis_client.exists(self.active_requests_key):
             return


### PR DESCRIPTION
# Summary

The RateLimit of concurrent app requests needs the Redis supports transaction, however, the Redis cluster or some Redis proxies don't support some transaction commands (e.g. `EXEC`).

This change to use non-transaction Redis commands instead.

Fix https://github.com/langgenius/dify/issues/15967

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

