### PR TITLE
fix: error in migrate_annotation_vector_database when exec vdb-migrate

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import click
 from flask import current_app
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from configs import dify_config
@@ -27,8 +29,6 @@ from models.provider import Provider, ProviderModel
 from services.account_service import RegisterService, TenantService
 from services.plugin.data_migration import PluginDataMigration
 from services.plugin.plugin_migration import PluginMigration
-from sqlalchemy.orm import Session
-from sqlalchemy import select
 
 
 @click.command("reset-password", help="Reset the account password.")

--- a/api/commands.py
+++ b/api/commands.py
@@ -161,7 +161,7 @@ def migrate_annotation_vector_database():
         try:
             # get apps info
             apps = (
-                App.query.filter(App.status == "normal")
+                db.session.query(App).filter(App.status == "normal")
                 .order_by(App.created_at.desc())
                 .paginate(page=page, per_page=50)
             )

--- a/api/commands.py
+++ b/api/commands.py
@@ -161,7 +161,8 @@ def migrate_annotation_vector_database():
         try:
             # get apps info
             apps = (
-                db.session.query(App).filter(App.status == "normal")
+                db.session.query(App)
+                .filter(App.status == "normal")
                 .order_by(App.created_at.desc())
                 .paginate(page=page, per_page=50)
             )

--- a/api/commands.py
+++ b/api/commands.py
@@ -161,8 +161,7 @@ def migrate_annotation_vector_database():
         try:
             # get apps info
             apps = (
-                db.session.query(App)
-                .filter(App.status == "normal")
+                App.query.filter(App.status == "normal")
                 .order_by(App.created_at.desc())
                 .paginate(page=page, per_page=50)
             )

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -73,8 +73,7 @@ class IconType(Enum):
     IMAGE = "image"
     EMOJI = "emoji"
 
-
-class App(db.Model):  # type: ignore[name-defined]
+class App(Base):
     __tablename__ = "apps"
     __table_args__ = (db.PrimaryKeyConstraint("id", name="app_pkey"), db.Index("app_tenant_id_idx", "tenant_id"))
 

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -73,6 +73,7 @@ class IconType(Enum):
     IMAGE = "image"
     EMOJI = "emoji"
 
+
 class App(Base):
     __tablename__ = "apps"
     __table_args__ = (db.PrimaryKeyConstraint("id", name="app_pkey"), db.Index("app_tenant_id_idx", "tenant_id"))

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -74,7 +74,7 @@ class IconType(Enum):
     EMOJI = "emoji"
 
 
-class App(Base):
+class App(db.Model):  # type: ignore[name-defined]
     __tablename__ = "apps"
     __table_args__ = (db.PrimaryKeyConstraint("id", name="app_pkey"), db.Index("app_tenant_id_idx", "tenant_id"))
 


### PR DESCRIPTION
# Summary

Error in migrate_annotation_vector_database() function when executing vdb-migrate:

```
  File "/app/api/commands.py", line 148, in vdb_migrate
    migrate_annotation_vector_database()
  File "/app/api/commands.py", line 164, in migrate_annotation_vector_database
    App.query.filter(App.status == "normal")
    ^^^^^^^^^
AttributeError: type object 'App' has no attribute 'query'
```

Fixed a bug by changing the query method.

Fixes #15936

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


