### PR TITLE
feat: support 'encouraged_response_prefix' parameter of LLM

### DIFF
--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -198,6 +198,7 @@ class LargeLanguageModel(AIModel):
             if (
                 (encouraged_response_prefix := model_parameters.get("encouraged_response_prefix", "")) != ""
                 and self._is_encouraged_response_prefix_enabled(prompt_messages, encouraged_response_prefix)
+                and isinstance(result.message.content, str)
                 and not result.message.content.startswith(encouraged_response_prefix)
             ):
                 result.message.content = encouraged_response_prefix + result.message.content


### PR DESCRIPTION
# Summary

https://github.com/langgenius/dify-plugin-sdks/pull/52.

When the 'encouraged_response_prefix' parameter of LLM is enabled, the response should add the prefix if the model service lack of it.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

