### PR TITLE
feat: poolize the ops trace instance

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -222,6 +222,7 @@ class OpsTraceManager:
         decrypt_trace_config_key = str(decrypt_trace_config)
         tracing_instance = cls.ops_trace_instances_cache.get(decrypt_trace_config_key)
         if tracing_instance is None:
+            # create new tracing_instance and update the cache if it absent
             tracing_instance = trace_instance(config_class(**decrypt_trace_config))
             cls.ops_trace_instances_cache[decrypt_trace_config_key] = tracing_instance
             logging.info(f"new tracing_instance for app_id: {app_id}")

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -63,10 +63,10 @@ provider_config_map: dict[str, dict[str, Any]] = {
     },
 }
 
-ops_trace_instances_cache = LRUCache(maxsize=128)
-
 
 class OpsTraceManager:
+    ops_trace_instances_cache: LRUCache = LRUCache(maxsize=128)
+
     @classmethod
     def encrypt_tracing_config(
         cls, tenant_id: str, tracing_provider: str, tracing_config: dict, current_trace_config=None
@@ -220,10 +220,10 @@ class OpsTraceManager:
             provider_config_map[tracing_provider]["config_class"],
         )
         decrypt_trace_config_key = str(decrypt_trace_config)
-        tracing_instance = ops_trace_instances_cache.get(decrypt_trace_config_key)
+        tracing_instance = cls.ops_trace_instances_cache.get(decrypt_trace_config_key)
         if tracing_instance is None:
             tracing_instance = trace_instance(config_class(**decrypt_trace_config))
-            ops_trace_instances_cache[decrypt_trace_config_key] = tracing_instance
+            cls.ops_trace_instances_cache[decrypt_trace_config_key] = tracing_instance
             logging.info(f"new tracing_instance for app_id: {app_id}")
         return tracing_instance
 

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Any, Optional, Union
 from uuid import UUID, uuid4
 
+from cachetools import LRUCache
 from flask import current_app
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -61,6 +62,8 @@ provider_config_map: dict[str, dict[str, Any]] = {
         "trace_instance": OpikDataTrace,
     },
 }
+
+ops_trace_instances_cache = LRUCache(maxsize=128)
 
 
 class OpsTraceManager:
@@ -198,28 +201,31 @@ class OpsTraceManager:
             return None
 
         app_ops_trace_config = json.loads(app.tracing) if app.tracing else None
-
         if app_ops_trace_config is None:
+            return None
+        if not app_ops_trace_config.get("enabled"):
             return None
 
         tracing_provider = app_ops_trace_config.get("tracing_provider")
-
         if tracing_provider is None or tracing_provider not in provider_config_map:
             return None
 
         # decrypt_token
         decrypt_trace_config = cls.get_decrypted_tracing_config(app_id, tracing_provider)
-        if app_ops_trace_config.get("enabled"):
-            trace_instance, config_class = (
-                provider_config_map[tracing_provider]["trace_instance"],
-                provider_config_map[tracing_provider]["config_class"],
-            )
-            if not decrypt_trace_config:
-                return None
-            tracing_instance = trace_instance(config_class(**decrypt_trace_config))
-            return tracing_instance
+        if not decrypt_trace_config:
+            return None
 
-        return None
+        trace_instance, config_class = (
+            provider_config_map[tracing_provider]["trace_instance"],
+            provider_config_map[tracing_provider]["config_class"],
+        )
+        decrypt_trace_config_key = str(decrypt_trace_config)
+        tracing_instance = ops_trace_instances_cache.get(decrypt_trace_config_key)
+        if tracing_instance is None:
+            tracing_instance = trace_instance(config_class(**decrypt_trace_config))
+            ops_trace_instances_cache[decrypt_trace_config_key] = tracing_instance
+            logging.info(f"new tracing_instance for app_id: {app_id}")
+        return tracing_instance
 
     @classmethod
     def get_app_config_through_message_id(cls, message_id: str):


### PR DESCRIPTION
# Summary

When enable a Dify application trace with Langfuse, I found there will be many sockets in CLOSE_WAIT state. This patch poolizes the Langfuse client instances, so the instances can be reused and also reduce the latency caused by creating the instances repeatly.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

