### PR TITLE
fix: typo when assign doc_metadata when non-empty

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1245,7 +1245,7 @@ class DocumentService:
             document.name = document_data.name
         # update doc_type and doc_metadata if provided
         if document_data.metadata is not None:
-            document.doc_metadata = document_data.metadata.doc_type
+            document.doc_metadata = document_data.metadata.doc_metadata
             document.doc_type = document_data.metadata.doc_type
         # update document to be waiting
         document.indexing_status = "waiting"


### PR DESCRIPTION
# Summary

See and Fixes #15054

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| not change write db value due to typo assign    | ok, as expect   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

