### PR TITLE
fix: add text overflow ellipsis and title for iteration and loop log

### DIFF
--- a/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
+++ b/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
@@ -37,18 +37,24 @@ const IterationLogTrigger = ({
     e.nativeEvent.stopImmediatePropagation()
     onShowIterationResultList(nodeInfo.details || [], nodeInfo?.iterDurationMap || nodeInfo.execution_metadata?.iteration_duration_map || {})
   }
+  
+  const iterationText = t('workflow.nodes.iteration.iteration', { count: getCount(nodeInfo.details?.length, nodeInfo.metadata?.iterator_length) }) + 
+    (getErrorCount(nodeInfo.details) > 0 ? 
+      `${t('workflow.nodes.iteration.comma')}${t('workflow.nodes.iteration.error', { count: getErrorCount(nodeInfo.details) })}` : 
+      '')
+  
   return (
     <Button
       className='flex items-center w-full self-stretch gap-2 px-3 py-2 bg-components-button-tertiary-bg-hover hover:bg-components-button-tertiary-bg-hover rounded-lg cursor-pointer border-none'
       onClick={handleOnShowIterationDetail}
     >
       <Iteration className='w-4 h-4 text-components-button-tertiary-text shrink-0' />
-      <div className='flex-1 text-left system-sm-medium text-components-button-tertiary-text'>{t('workflow.nodes.iteration.iteration', { count: getCount(nodeInfo.details?.length, nodeInfo.metadata?.iterator_length) })}{getErrorCount(nodeInfo.details) > 0 && (
-        <>
-          {t('workflow.nodes.iteration.comma')}
-          {t('workflow.nodes.iteration.error', { count: getErrorCount(nodeInfo.details) })}
-        </>
-      )}</div>
+      <div 
+        className='flex-1 text-left system-sm-medium text-components-button-tertiary-text whitespace-nowrap overflow-hidden text-ellipsis'
+        title={iterationText}
+      >
+        {iterationText}
+      </div>
       <RiArrowRightSLine className='w-4 h-4 text-components-button-tertiary-text shrink-0' />
     </Button>
   )

--- a/web/app/components/workflow/run/loop-log/loop-log-trigger.tsx
+++ b/web/app/components/workflow/run/loop-log/loop-log-trigger.tsx
@@ -37,18 +37,24 @@ const LoopLogTrigger = ({
     e.nativeEvent.stopImmediatePropagation()
     onShowLoopResultList(nodeInfo.details || [], nodeInfo?.loopDurationMap || nodeInfo.execution_metadata?.loop_duration_map || {})
   }
+  
+  const loopText = t('workflow.nodes.loop.loop', { count: getCount(nodeInfo.details?.length, nodeInfo.metadata?.loop_length) }) + 
+    (getErrorCount(nodeInfo.details) > 0 ? 
+      `${t('workflow.nodes.loop.comma')}${t('workflow.nodes.loop.error', { count: getErrorCount(nodeInfo.details) })}` : 
+      '')
+  
   return (
     <Button
       className='flex items-center w-full self-stretch gap-2 px-3 py-2 bg-components-button-tertiary-bg-hover hover:bg-components-button-tertiary-bg-hover rounded-lg cursor-pointer border-none'
       onClick={handleOnShowLoopDetail}
     >
       <Loop className='w-4 h-4 text-components-button-tertiary-text shrink-0' />
-      <div className='flex-1 text-left system-sm-medium text-components-button-tertiary-text'>{t('workflow.nodes.loop.loop', { count: getCount(nodeInfo.details?.length, nodeInfo.metadata?.loop_length) })}{getErrorCount(nodeInfo.details) > 0 && (
-        <>
-          {t('workflow.nodes.loop.comma')}
-          {t('workflow.nodes.loop.error', { count: getErrorCount(nodeInfo.details) })}
-        </>
-      )}</div>
+      <div 
+        className='flex-1 text-left system-sm-medium text-components-button-tertiary-text whitespace-nowrap overflow-hidden text-ellipsis'
+        title={loopText}
+      >
+        {loopText}
+      </div>
       <RiArrowRightSLine className='w-4 h-4 text-components-button-tertiary-text shrink-0' />
     </Button>
   )


### PR DESCRIPTION
…triggers

# Summary

Added text overflow handling for the iteration and loop log trigger components in the workflow run page. When the text content is too long, it is now automatically truncated and ellipsis is displayed. At the same time, a title attribute is added so that users can view the full content by hovering the mouse.

This improvement improves the user experience and makes the interface more tidy while ensuring that users can get complete information.

Modifications:
1. Added `whitespace-nowrap`, `overflow-hidden` and `text-ellipsis` styles
2. Added title attribute to display full text
3. Optimized code structure and created variables to store displayed text

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| 
![image](https://github.com/user-attachments/assets/bd3eeedb-90bf-4555-931b-20a359a21d08)
 | 
![image](https://github.com/user-attachments/assets/92c2dbff-4602-43de-83d9-33f8fac759d7)
 |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

