### PR TITLE
chore(api): Disable preview rules of Ruff while running pre-commit hook

### DIFF
--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -1,3 +1,4 @@
+#!/bin/sh
 # get the list of modified files
 files=$(git diff --cached --name-only)
 
@@ -32,7 +33,7 @@ if $api_modified; then
     ruff check --fix ./api
 
     # run Ruff linter checks
-    ruff check --preview ./api || status=$?
+    ruff check  ./api || status=$?
 
     status=${status:-0}
 


### PR DESCRIPTION
# Summary

Preview mode of ruff is unstable, and some rules in preview mode cause false positive in pre-commit script.

Preview mode has already been set to `false` in `.ruff.toml`. Remove the `--preview` flag in pre-commit script to ensure consistent linting rules.

Closes #15987. 

# Screenshots

N/A

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

