### PR TITLE
chore: use POSIX shell syntax in pre-commit script

### DIFF
--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -9,13 +9,17 @@ web_modified=false
 
 for file in $files
 do
-    if [[ $file == "api/"* && $file == *.py ]]; then
-        # set api_modified flag to true
-        api_modified=true
-    elif [[ $file == "web/"* ]]; then
-        # set web_modified flag to true
-        web_modified=true
-    fi
+    # Use POSIX compliant pattern matching
+    case "$file" in
+        api/*.py)
+            # set api_modified flag to true
+            api_modified=true
+            ;;
+        web/*)
+            # set web_modified flag to true
+            web_modified=true
+            ;;
+    esac
 done
 
 # run linters based on the modified modules
@@ -24,7 +28,7 @@ if $api_modified; then
     echo "Running Ruff linter on api module"
 
     # python style checks rely on `ruff` in path
-    if ! command -v ruff &> /dev/null; then
+    if ! command -v ruff > /dev/null 2>&1; then
         echo "Installing linting tools (Ruff, dotenv-linter ...) ..."
         poetry install -C api --only lint
     fi


### PR DESCRIPTION
# Summary

`[[ ]]` is not supported by POSIX shell, and husky always use `sh` to run git hook scripts.

Use POSIX shell syntax in the pre-commit script to avoid compatibility and linting problems.

Closes #16021.

# Screenshots

N/A

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

