### PR TITLE
use REDIS_PORT to replace 6379 in celery config

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -26,9 +26,6 @@ ACCESS_TOKEN_EXPIRE_MINUTES=60
 # Refresh token expiration time in days
 REFRESH_TOKEN_EXPIRE_DAYS=30
 
-# celery configuration
-CELERY_BROKER_URL=redis://:difyai123456@localhost:6379/1
-
 # redis configuration
 REDIS_HOST=localhost
 REDIS_PORT=6379
@@ -49,6 +46,9 @@ REDIS_SENTINEL_SOCKET_TIMEOUT=0.1
 REDIS_USE_CLUSTERS=false
 REDIS_CLUSTERS=
 REDIS_CLUSTERS_PASSWORD=
+
+# celery configuration
+CELERY_BROKER_URL=redis://:difyai123456@localhost:${REDIS_PORT}/1
 
 # PostgreSQL database configuration
 DB_USERNAME=postgres


### PR DESCRIPTION
# Summary
When use custome redis port , celery config need to change together.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

