### PR TITLE
 fix Weight rerank mode info missed when create dataset

### DIFF
--- a/api/services/entities/knowledge_entities/knowledge_entities.py
+++ b/api/services/entities/knowledge_entities/knowledge_entities.py
@@ -84,6 +84,22 @@ class RerankingModel(BaseModel):
     reranking_model_name: Optional[str] = None
 
 
+class WeightVectorSetting(BaseModel):
+    vector_weight: float
+    embedding_provider_name: str
+    embedding_model_name: str
+
+
+class WeightKeywordSetting(BaseModel):
+    keyword_weight: float
+
+
+class WeightModel(BaseModel):
+    weight_type: str
+    vector_setting: Optional[WeightVectorSetting] = None
+    keyword_setting: Optional[WeightKeywordSetting] = None
+
+
 class RetrievalModel(BaseModel):
     search_method: Literal["hybrid_search", "semantic_search", "full_text_search"]
     reranking_enable: bool
@@ -92,6 +108,7 @@ class RetrievalModel(BaseModel):
     top_k: int
     score_threshold_enabled: bool
     score_threshold: Optional[float] = None
+    weights: Optional[WeightModel] = None
 
 
 class MetaDataConfig(BaseModel):


### PR DESCRIPTION
# Summary

 fix Weight rerank mode info missed when create dataset

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fix #16173 
fix #16142


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

