### PR TITLE
fix: retrieve metadata filter with weaviate will returns None

### DIFF
--- a/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
+++ b/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
@@ -189,7 +189,10 @@ class WeaviateVector(BaseVector):
         vector = {"vector": query_vector}
         document_ids_filter = kwargs.get("document_ids_filter")
         if document_ids_filter:
-            where_filter = {"operator": "ContainsAny", "path": ["document_id"], "valueTextArray": document_ids_filter}
+            operands = []
+            for document_id_filter in document_ids_filter:
+                operands.append({"path": ["document_id"], "operator": "Equal", "valueText": document_id_filter})
+            where_filter = {"operator": "Or", "operands": operands}
             query_obj = query_obj.with_where(where_filter)
         result = (
             query_obj.with_near_vector(vector)
@@ -237,7 +240,10 @@ class WeaviateVector(BaseVector):
         query_obj = self._client.query.get(collection_name, properties)
         document_ids_filter = kwargs.get("document_ids_filter")
         if document_ids_filter:
-            where_filter = {"operator": "ContainsAny", "path": ["document_id"], "valueTextArray": document_ids_filter}
+            operands = []
+            for document_id_filter in document_ids_filter:
+                operands.append({"path": ["document_id"], "operator": "Equal", "valueText": document_id_filter})
+            where_filter = {"operator": "Or", "operands": operands}
             query_obj = query_obj.with_where(where_filter)
         query_obj = query_obj.with_additional(["vector"])
         properties = ["text"]


### PR DESCRIPTION
# Summary

Because `ContainsAny` work with Weaviate’s 1.21 version , change to the another filter

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

fix https://github.com/langgenius/dify/issues/16176

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

