### PR TITLE
fix: reset inputs when reset conversation

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -183,7 +183,10 @@ export const useEmbeddedChatbot = () => {
 
   useEffect(() => {
     // init inputs from url params
-    setInitInputs(getProcessedInputsFromUrlParams())
+    (async () => {
+      const inputs = await getProcessedInputsFromUrlParams()
+      setInitInputs(inputs)
+    })()
   }, [])
   useEffect(() => {
     const conversationInputs: Record<string, any> = {}
@@ -288,11 +291,11 @@ export const useEmbeddedChatbot = () => {
     if (conversationId)
       setClearChatList(false)
   }, [handleConversationIdInfoChange, setClearChatList])
-  const handleNewConversation = useCallback(() => {
+  const handleNewConversation = useCallback(async () => {
     currentChatInstanceRef.current.handleStop()
     setShowNewConversationItemInList(true)
     handleChangeConversation('')
-    handleNewConversationInputsChange({})
+    handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())
     setClearChatList(true)
   }, [handleChangeConversation, setShowNewConversationItemInList, handleNewConversationInputsChange, setClearChatList])
 

--- a/web/app/components/base/chat/utils.ts
+++ b/web/app/components/base/chat/utils.ts
@@ -10,12 +10,14 @@ async function decodeBase64AndDecompress(base64String: string) {
   return new TextDecoder().decode(decompressedArrayBuffer)
 }
 
-function getProcessedInputsFromUrlParams(): Record<string, any> {
+async function getProcessedInputsFromUrlParams(): Promise<Record<string, any>> {
   const urlParams = new URLSearchParams(window.location.search)
   const inputs: Record<string, any> = {}
-  urlParams.forEach(async (value, key) => {
-    inputs[key] = await decodeBase64AndDecompress(decodeURIComponent(value))
-  })
+  await Promise.all(
+    urlParams.entries().map(async ([key, value]) => {
+      inputs[key] = await decodeBase64AndDecompress(decodeURIComponent(value))
+    }),
+  )
   return inputs
 }
 


### PR DESCRIPTION
# Summary

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.
-->

This PR tries to deal with the problem of resetting a dialog and then losing the url that has inputs set but not set to the page. Close https://github.com/langgenius/dify/issues/13903 .


# Screenshots

With this chatflow:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9712cb55-acac-432c-829a-1a3b342a695d" />


| Before | After |
|--------|-------|
| Please check linked issue or the below video. <video src="https://github.com/user-attachments/assets/4d42808c-9a03-4b44-878a-d8f5ae7da243" />  | Please check the below video. <video src="https://github.com/user-attachments/assets/c59a8a0f-4527-4fcd-a0c0-d93ca45682fb" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

