### PR TITLE
fix: update workflow doc

### DIFF
--- a/web/app/components/develop/template/template_workflow.en.mdx
+++ b/web/app/components/develop/template/template_workflow.en.mdx
@@ -43,18 +43,9 @@ Workflow applications offers non-session support and is ideal for translation, a
       - `inputs` (object) Required
         Allows the entry of various variable values defined by the App.
         The `inputs` parameter contains multiple key/value pairs, with each key corresponding to a specific variable and each value being the specific value for that variable.
-        The workflow application requires at least one key/value pair to be inputted.
-        If the variable is of File type, specify an object that has the keys described in `files` below.
-      - `response_mode` (string) Required
-        The mode of response return, supporting:
-        - `streaming` Streaming mode (recommended), implements a typewriter-like output through SSE ([Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)).
-        - `blocking` Blocking mode, returns result after execution is complete. (Requests may be interrupted if the process is long)
-        <i>Due to Cloudflare restrictions, the request will be interrupted without a return after 100 seconds.</i>
-      - `user` (string) Required
-        User identifier, used to define the identity of the end-user for retrieval and statistics.
-        Should be uniquely defined by the developer within the application.
-      - `files` (array[object]) Optional
-        File list, suitable for inputting files combined with text understanding and answering questions, available only when the model supports file parsing and understanding capability.
+        The workflow application requires at least one key/value pair to be inputted. The variable can be of File Array type.
+        File Array type variable is suitable for inputting files combined with text understanding and answering questions, available only when the model supports file parsing and understanding capability.
+        If the variable is of File Array type, the corresponding value should be a list whose elements contain following attributions: 
           - `type` (string) Supported type: 
             - `document` ('TXT', 'MD', 'MARKDOWN', 'PDF', 'HTML', 'XLSX', 'XLS', 'DOCX', 'CSV', 'EML', 'MSG', 'PPTX', 'PPT', 'XML', 'EPUB')
             - `image` ('JPG', 'JPEG', 'PNG', 'GIF', 'WEBP', 'SVG')
@@ -64,6 +55,15 @@ Workflow applications offers non-session support and is ideal for translation, a
           - `transfer_method` (string) Transfer method, `remote_url` for image URL / `local_file` for file upload
           - `url` (string) Image URL (when the transfer method is `remote_url`)
           - `upload_file_id` (string) Uploaded file ID, which must be obtained by uploading through the File Upload API in advance (when the transfer method is `local_file`)
+
+      - `response_mode` (string) Required
+        The mode of response return, supporting:
+        - `streaming` Streaming mode (recommended), implements a typewriter-like output through SSE ([Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)).
+        - `blocking` Blocking mode, returns result after execution is complete. (Requests may be interrupted if the process is long)
+        <i>Due to Cloudflare restrictions, the request will be interrupted without a return after 100 seconds.</i>
+      - `user` (string) Required
+        User identifier, used to define the identity of the end-user for retrieval and statistics.
+        Should be uniquely defined by the developer within the application.
 
     ### Response
     When `response_mode` is `blocking`, return a CompletionResponse object.
@@ -190,15 +190,18 @@ Workflow applications offers non-session support and is ideal for translation, a
     ```
 
     </CodeGroup>
-    <CodeGroup title="File variable example">
+    <CodeGroup title="Example: file array as an input variable">
       ```json {{ title: 'File variable example' }}
       {
         "inputs": {
-          "{variable_name}": {
+          "{variable_name}": 
+          [
+            {
             "transfer_method": "local_file",
             "upload_file_id": "{upload_file_id}",
             "type": "{document_type}"
-          }
+            }
+          ]
         }
       }
       ```
@@ -279,11 +282,11 @@ Workflow applications offers non-session support and is ideal for translation, a
 
           data = {
               "inputs": {
-                  "orig_mail": {
+                  "orig_mail": [{
                       "transfer_method": "local_file",
                       "upload_file_id": file_id,
                       "type": "document"
-                  }
+                  }]
               },
               "response_mode": response_mode,
               "user": user

--- a/web/app/components/develop/template/template_workflow.ja.mdx
+++ b/web/app/components/develop/template/template_workflow.ja.mdx
@@ -43,18 +43,10 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       - `inputs` (object) 必須
         アプリで定義されたさまざまな変数値の入力を許可します。
         `inputs`パラメータには複数のキー/値ペアが含まれ、各キーは特定の変数に対応し、各値はその変数の特定の値です。
-        ワークフローアプリケーションは少なくとも1つのキー/値ペアの入力を必要とします。
-        変数がファイルタイプの場合、以下の`files`で説明されているキーを持つオブジェクトを指定してください。
-      - `response_mode` (string) 必須
-        応答の返却モードを指定します。サポートされているモード：
-        - `streaming` ストリーミングモード（推奨）、SSE（[Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)）を通じてタイプライターのような出力を実装します。
-        - `blocking` ブロッキングモード、実行完了後に結果を返します。（プロセスが長い場合、リクエストが中断される可能性があります）
-        <i>Cloudflareの制限により、100秒後に応答がない場合、リクエストは中断されます。</i>
-      - `user` (string) 必須
-        ユーザー識別子、エンドユーザーのアイデンティティを定義するために使用されます。
-        アプリケーション内で開発者によって一意に定義される必要があります。
-      - `files` (array[object]) オプション
+        ワークフローアプリケーションは少なくとも1つのキー/値ペアの入力を必要とします。値はファイルリストである場合もあります。
         ファイルリストは、テキスト理解と質問への回答を組み合わせたファイルの入力に適しています。モデルがファイルの解析と理解機能をサポートしている場合にのみ使用できます。
+
+        変数がファイルリストの場合、リストの各要素は以下の属性を持つ必要があります。
           - `type` (string) サポートされているタイプ: 
             - `document` ('TXT', 'MD', 'MARKDOWN', 'PDF', 'HTML', 'XLSX', 'XLS', 'DOCX', 'CSV', 'EML', 'MSG', 'PPTX', 'PPT', 'XML', 'EPUB')
             - `image` ('JPG', 'JPEG', 'PNG', 'GIF', 'WEBP', 'SVG')
@@ -64,6 +56,17 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
           - `transfer_method` (string) 転送方法、画像URLの場合は`remote_url` / ファイルアップロードの場合は`local_file`
           - `url` (string) 画像URL（転送方法が`remote_url`の場合）
           - `upload_file_id` (string) アップロードされたファイルID、事前にファイルアップロードAPIを通じて取得する必要があります（転送方法が`local_file`の場合）
+
+      - `response_mode` (string) 必須
+        応答の返却モードを指定します。サポートされているモード：
+        - `streaming` ストリーミングモード（推奨）、SSE（[Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)）を通じてタイプライターのような出力を実装します。
+        - `blocking` ブロッキングモード、実行完了後に結果を返します。（プロセスが長い場合、リクエストが中断される可能性があります）
+        <i>Cloudflareの制限により、100秒後に応答がない場合、リクエストは中断されます。</i>
+      - `user` (string) 必須
+        ユーザー識別子、エンドユーザーのアイデンティティを定義するために使用されます。
+        アプリケーション内で開発者によって一意に定義される必要があります。
+      - `files` (array[object]) オプション
+        
 
     ### 応答
     `response_mode`が`blocking`の場合、CompletionResponseオブジェクトを返します。
@@ -194,11 +197,14 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       ```json {{ title: 'ファイル変数の例' }}
       {
         "inputs": {
-          "{variable_name}": {
+          "{variable_name}": 
+          [
+            {
             "transfer_method": "local_file",
             "upload_file_id": "{upload_file_id}",
             "type": "{document_type}"
-          }
+            }
+          ]
         }
       }
       ```
@@ -279,11 +285,11 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
 
           data = {
               "inputs": {
-                  "orig_mail": {
+                  "orig_mail": [{
                       "transfer_method": "local_file",
                       "upload_file_id": file_id,
                       "type": "document"
-                  }
+                  }]
               },
               "response_mode": response_mode,
               "user": user

--- a/web/app/components/develop/template/template_workflow.zh.mdx
+++ b/web/app/components/develop/template/template_workflow.zh.mdx
@@ -41,18 +41,8 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
     ### Request Body
       - `inputs` (object) Required
         允许传入 App 定义的各变量值。
-        inputs 参数包含了多组键值对（Key/Value pairs），每组的键对应一个特定变量，每组的值则是该变量的具体值。
-        如果变量是文件类型，请指定一个包含以下 `files` 中所述键的对象。
-      - `response_mode` (string) Required
-        返回响应模式，支持：
-        - `streaming` 流式模式（推荐）。基于 SSE（**[Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)**）实现类似打字机输出方式的流式返回。
-        - `blocking` 阻塞模式，等待执行完毕后返回结果。（请求若流程较长可能会被中断）。
-        <i>由于 Cloudflare 限制，请求会在 100 秒超时无返回后中断。</i>
-      - `user` (string) Required
-        用户标识，用于定义终端用户的身份，方便检索、统计。
-        由开发者定义规则，需保证用户标识在应用内唯一。
-      - `files` (array[object]) Optional
-          文件列表，适用于传入文件结合文本理解并回答问题，仅当模型支持该类型文件解析能力时可用。
+        inputs 参数包含了多组键值对（Key/Value pairs），每组的键对应一个特定变量，每组的值则是该变量的具体值。变量可以是文件列表类型。
+        文件列表类型变量适用于传入文件结合文本理解并回答问题，仅当模型支持该类型文件解析能力时可用。如果该变量是文件列表类型，该变量对应的值应是列表格式，其中每个元素应包含以下内容：
           - `type` (string) 支持类型：
             - `document` 具体类型包含：'TXT', 'MD', 'MARKDOWN', 'PDF', 'HTML', 'XLSX', 'XLS', 'DOCX', 'CSV', 'EML', 'MSG', 'PPTX', 'PPT', 'XML', 'EPUB'
             - `image` 具体类型包含：'JPG', 'JPEG', 'PNG', 'GIF', 'WEBP', 'SVG'
@@ -62,6 +52,15 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
           - `transfer_method` (string) 传递方式，`remote_url` 图片地址 / `local_file` 上传文件
           - `url` (string) 图片地址（仅当传递方式为 `remote_url` 时）
           - `upload_file_id` (string) (string) 上传文件 ID（仅当传递方式为 `local_file` 时）
+      - `response_mode` (string) Required
+        返回响应模式，支持：
+        - `streaming` 流式模式（推荐）。基于 SSE（**[Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)**）实现类似打字机输出方式的流式返回。
+        - `blocking` 阻塞模式，等待执行完毕后返回结果。（请求若流程较长可能会被中断）。
+        <i>由于 Cloudflare 限制，请求会在 100 秒超时无返回后中断。</i>
+      - `user` (string) Required
+        用户标识，用于定义终端用户的身份，方便检索、统计。
+        由开发者定义规则，需保证用户标识在应用内唯一。
+
 
     ### Response
     当 `response_mode` 为 `blocking` 时，返回 CompletionResponse object。
@@ -184,15 +183,18 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
     }'
     ```
     </CodeGroup>
-    <CodeGroup title="File variable example">
+    <CodeGroup title="Example: file array as an input variable">
       ```json {{ title: 'File variable example' }}
       {
         "inputs": {
-          "{variable_name}": {
+          "{variable_name}": 
+          [
+            {
             "transfer_method": "local_file",
             "upload_file_id": "{upload_file_id}",
             "type": "{document_type}"
-          }
+            }
+          ]
         }
       }
       ```
@@ -273,11 +275,11 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
 
           data = {
               "inputs": {
-                  "orig_mail": {
+                  "orig_mail": [{
                       "transfer_method": "local_file",
                       "upload_file_id": file_id,
                       "type": "document"
-                  }
+                  }]
               },
               "response_mode": response_mode,
               "user": user


### PR DESCRIPTION
# Summary

The original file variable has been replaced with a file array, so the doc needs to be updated.

### Takeaways:
1. The original documentation shows a `files` attribute that does not exist in the current version.
2. Move the format description inside `inputs` to make the documentation more straightforward.
3. Update the data and code examples to use a file array instead of a single file. Otherwise, users will encounter the following error when following the current documentation:
```
400, {"code": "invalid_param", "message": "XXX in input form must be a list of files", "status": 400}
```


# Screenshots

## Before
<img width="388" alt="image" src="https://github.com/user-attachments/assets/b3344e2b-16b1-4be0-a522-39695f17566a" />
<img width="376" alt="image" src="https://github.com/user-attachments/assets/424c9524-a892-4df6-9430-53cb4f057f12" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9288103b-7c3b-4603-9a7b-9e04036e0a5d" />
<img width="384" alt="image" src="https://github.com/user-attachments/assets/fe0df1a7-fd8b-4fd9-aab4-5836c45fc098" />
<img width="322" alt="image" src="https://github.com/user-attachments/assets/c8dcf90b-a9f3-4b1e-b3f6-38f16f84ecbf" />


## After
<img width="395" alt="image" src="https://github.com/user-attachments/assets/06484da4-803b-47f1-beff-b4582c8da279" />
<img width="383" alt="image" src="https://github.com/user-attachments/assets/3ef4195b-c6e9-4522-a2cf-41b80ce8a33a" />
<img width="395" alt="image" src="https://github.com/user-attachments/assets/9f1dbf99-aa23-43a7-a954-1a78b1ecfc29" />
<img width="372" alt="image" src="https://github.com/user-attachments/assets/d712eabb-d5f3-47f3-b1f0-cd901a152090" />
<img width="323" alt="image" src="https://github.com/user-attachments/assets/a25e78bc-76d9-4e82-91d3-da1372440116" />


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

