### PR TITLE
fix error with literal_eval

### DIFF
--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -1,5 +1,5 @@
-from ast import literal_eval
 import json
+from ast import literal_eval
 from collections.abc import Generator, Mapping, Sequence
 from typing import Any, cast
 

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -1,3 +1,4 @@
+from ast import literal_eval
 import json
 from collections.abc import Generator, Mapping, Sequence
 from typing import Any, cast
@@ -151,7 +152,10 @@ class AgentNode(ToolNode):
             if (parameter_value.startswith("{") and parameter_value.endswith("}")) or (
                 parameter_value.startswith("[") and parameter_value.endswith("]")
             ):
-                value = json.loads(parameter_value.replace("'", '"'))  # transform string to python object
+                try:
+                    value = literal_eval(parameter_value)
+                except:
+                    value = json.loads(parameter_value.replace("'", '"'))  # transform string to python object
             if parameter.type == "array[tools]":
                 value = cast(list[dict[str, Any]], value)
                 value = [tool for tool in value if tool.get("enabled", False)]

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -143,14 +143,16 @@ class AgentNode(ToolNode):
                     raise ValueError(f"Variable {agent_input.value} does not exist")
                 parameter_value = variable.value
             elif agent_input.type in {"mixed", "constant"}:
-                # Convert dictionary to string to retrieve the variable's value
+                # variable_pool.convert_template expects a string template,
+                # but if passing a dict, convert to JSON string first before rendering
                 try:
                     parameter_value = json.dumps(agent_input.value, ensure_ascii=False)
                 except TypeError:
                     parameter_value = str(agent_input.value)
                 segment_group = variable_pool.convert_template(parameter_value)
                 parameter_value = segment_group.log if for_log else segment_group.text
-                # Convert string to dictionary to handle array[tools] and model-selector type
+                # variable_pool.convert_template returns a string,
+                # so we need to convert it back to a dictionary
                 try:
                     parameter_value = json.loads(parameter_value)
                 except json.JSONDecodeError:

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -143,12 +143,14 @@ class AgentNode(ToolNode):
                     raise ValueError(f"Variable {agent_input.value} does not exist")
                 parameter_value = variable.value
             elif agent_input.type in {"mixed", "constant"}:
+                # Convert dictionary to string to retrieve the variable's value
                 try:
                     parameter_value = json.dumps(agent_input.value, ensure_ascii=False)
                 except TypeError:
                     parameter_value = str(agent_input.value)
                 segment_group = variable_pool.convert_template(parameter_value)
                 parameter_value = segment_group.log if for_log else segment_group.text
+                # Convert string to dictionary to handle array[tools] and model-selector type
                 try:
                     parameter_value = json.loads(parameter_value)
                 except json.JSONDecodeError:

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -1,5 +1,4 @@
 import json
-from ast import literal_eval
 from collections.abc import Generator, Mapping, Sequence
 from typing import Any, cast
 
@@ -144,18 +143,19 @@ class AgentNode(ToolNode):
                     raise ValueError(f"Variable {agent_input.value} does not exist")
                 parameter_value = variable.value
             elif agent_input.type in {"mixed", "constant"}:
-                segment_group = variable_pool.convert_template(str(agent_input.value))
+                try:
+                    parameter_value = json.dumps(agent_input.value, ensure_ascii=False)
+                except TypeError:
+                    parameter_value = str(agent_input.value)
+                segment_group = variable_pool.convert_template(parameter_value)
                 parameter_value = segment_group.log if for_log else segment_group.text
+                try:
+                    parameter_value = json.loads(parameter_value)
+                except json.JSONDecodeError:
+                    parameter_value = parameter_value
             else:
                 raise ValueError(f"Unknown agent input type '{agent_input.type}'")
-            value = parameter_value.strip()
-            if (parameter_value.startswith("{") and parameter_value.endswith("}")) or (
-                parameter_value.startswith("[") and parameter_value.endswith("]")
-            ):
-                try:
-                    value = literal_eval(parameter_value)
-                except:
-                    value = json.loads(parameter_value.replace("'", '"'))  # transform string to python object
+            value = parameter_value
             if parameter.type == "array[tools]":
                 value = cast(list[dict[str, Any]], value)
                 value = [tool for tool in value if tool.get("enabled", False)]

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -1,4 +1,4 @@
-from ast import literal_eval
+import json
 from collections.abc import Generator, Mapping, Sequence
 from typing import Any, cast
 
@@ -151,7 +151,7 @@ class AgentNode(ToolNode):
             if (parameter_value.startswith("{") and parameter_value.endswith("}")) or (
                 parameter_value.startswith("[") and parameter_value.endswith("]")
             ):
-                value = literal_eval(parameter_value)  # transform string to python object
+                value = json.loads(parameter_value.replace("'", '"'))  # transform string to python object
             if parameter.type == "array[tools]":
                 value = cast(list[dict[str, Any]], value)
                 value = [tool for tool in value if tool.get("enabled", False)]


### PR DESCRIPTION
# Summary

Fix an error issue with an Agent node.  Content starting with "{" can be parsed correctly.

## Before
![Xnip2025-03-20_11-02-12](https://github.com/user-attachments/assets/aa82ca0d-d3a6-47f0-9c30-22fc47c56a1d)

## After
![Xnip2025-03-20_12-51-27](https://github.com/user-attachments/assets/0b1678a6-1360-418b-8a2e-6ea5e7004efd)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

