### PR TITLE
fix: fix variable-aggregator cannot pass node check in group mode

### DIFF
--- a/web/app/components/workflow/nodes/variable-assigner/default.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/default.ts
@@ -35,15 +35,18 @@ const nodeDefault: NodeDefault<VariableAssignerNodeType> = {
     if (group_enabled) {
       if (!groups || groups.length === 0) {
         errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
-      } else if (!errorMessages)
+      }
+      else if (!errorMessages) {
         groups.forEach((group) => {
           validateVariables(group.variables || [], `${i18nPrefix}.errorMsg.fields.variableValue`)
-        });
-    } else {
+        })
+      }
+    }
+    else {
       if (!variables || variables.length === 0)
-        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) });
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
       else if (!errorMessages)
-        validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`);
+        validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`)
     }
 
     return {

--- a/web/app/components/workflow/nodes/variable-assigner/default.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/default.ts
@@ -22,14 +22,35 @@ const nodeDefault: NodeDefault<VariableAssignerNodeType> = {
   },
   checkValid(payload: VariableAssignerNodeType, t: any) {
     let errorMessages = ''
-    const { variables } = payload
-    if (!variables || variables.length === 0)
-      errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
-    if (!errorMessages) {
-      variables.forEach((variable) => {
-        if (!variable || variable.length === 0)
-          errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.errorMsg.fields.variableValue`) })
-      })
+    const { variables, advanced_settings } = payload
+    const { group_enabled = false, groups = [] } = advanced_settings || {}
+    // enable group
+    if (group_enabled) {
+      // no groups
+      if (!groups || groups.length === 0)
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
+
+      if (!errorMessages) {
+        groups.forEach((group) => {
+          const { variables = [] } = group
+          variables.forEach((variable) => {
+            if (!variable || variable.length === 0)
+              errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.errorMsg.fields.variableValue`) })
+          })
+        })
+      }
+    }
+    else {
+      // no groups and no variables
+      if (!variables || variables.length === 0)
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
+
+      if (!errorMessages) {
+        variables.forEach((variable) => {
+          if (!variable || variable.length === 0)
+            errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.errorMsg.fields.variableValue`) })
+        })
+      }
     }
 
     return {

--- a/web/app/components/workflow/nodes/variable-assigner/default.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/default.ts
@@ -35,17 +35,15 @@ const nodeDefault: NodeDefault<VariableAssignerNodeType> = {
     if (group_enabled) {
       if (!groups || groups.length === 0) {
         errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
-      } else if (!errorMessages) {
+      } else if (!errorMessages)
         groups.forEach((group) => {
           validateVariables(group.variables || [], `${i18nPrefix}.errorMsg.fields.variableValue`)
-        })
-      }
+        });
     } else {
-      if (!variables || variables.length === 0) {
-        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
-      } else if (!errorMessages) {
-        validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`)
-      }
+      if (!variables || variables.length === 0)
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) });
+      else if (!errorMessages)
+        validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`);
     }
 
     return {

--- a/web/app/components/workflow/nodes/variable-assigner/default.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/default.ts
@@ -27,24 +27,24 @@ const nodeDefault: NodeDefault<VariableAssignerNodeType> = {
     // enable group
     const validateVariables = (variables: any[], field: string) => {
       variables.forEach((variable) => {
-      if (!variable || variable.length === 0)
-        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(field) })
+        if (!variable || variable.length === 0)
+          errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(field) })
       })
     }
 
     if (group_enabled) {
       if (!groups || groups.length === 0) {
-      errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
       } else if (!errorMessages) {
-      groups.forEach((group) => {
-        validateVariables(group.variables || [], `${i18nPrefix}.errorMsg.fields.variableValue`)
-      })
+        groups.forEach((group) => {
+          validateVariables(group.variables || [], `${i18nPrefix}.errorMsg.fields.variableValue`)
+        })
       }
     } else {
       if (!variables || variables.length === 0) {
-      errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
       } else if (!errorMessages) {
-      validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`)
+        validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`)
       }
     }
 

--- a/web/app/components/workflow/nodes/variable-assigner/default.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/default.ts
@@ -25,31 +25,26 @@ const nodeDefault: NodeDefault<VariableAssignerNodeType> = {
     const { variables, advanced_settings } = payload
     const { group_enabled = false, groups = [] } = advanced_settings || {}
     // enable group
-    if (group_enabled) {
-      // no groups
-      if (!groups || groups.length === 0)
-        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
-
-      if (!errorMessages) {
-        groups.forEach((group) => {
-          const { variables = [] } = group
-          variables.forEach((variable) => {
-            if (!variable || variable.length === 0)
-              errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.errorMsg.fields.variableValue`) })
-          })
-        })
-      }
+    const validateVariables = (variables: any[], field: string) => {
+      variables.forEach((variable) => {
+      if (!variable || variable.length === 0)
+        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(field) })
+      })
     }
-    else {
-      // no groups and no variables
-      if (!variables || variables.length === 0)
-        errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
 
-      if (!errorMessages) {
-        variables.forEach((variable) => {
-          if (!variable || variable.length === 0)
-            errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.errorMsg.fields.variableValue`) })
-        })
+    if (group_enabled) {
+      if (!groups || groups.length === 0) {
+      errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
+      } else if (!errorMessages) {
+      groups.forEach((group) => {
+        validateVariables(group.variables || [], `${i18nPrefix}.errorMsg.fields.variableValue`)
+      })
+      }
+    } else {
+      if (!variables || variables.length === 0) {
+      errorMessages = t(`${i18nPrefix}.errorMsg.fieldRequired`, { field: t(`${i18nPrefix}.nodes.variableAssigner.title`) })
+      } else if (!errorMessages) {
+      validateVariables(variables, `${i18nPrefix}.errorMsg.fields.variableValue`)
       }
     }
 


### PR DESCRIPTION
# Summary

fix variable-aggregator cannot pass node check in group mode

![image](https://github.com/user-attachments/assets/39467f07-b3ed-435b-a3bc-65e5fdfd4cc6)



> [!Tip]
> Close issue syntax:  fix  this issue : https://github.com/langgenius/dify/issues/16416  


# Screenshots

| Before | After |
|--------|-------|
| 
![image](https://github.com/user-attachments/assets/14cf9f74-f417-47b2-bbd9-508e79355ff5)
   | 
![image](https://github.com/user-attachments/assets/7c38f141-46aa-4d66-a0e9-a0369448e220)
 |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

