### PR TITLE
fix: fix the app max_active_requests been overwritten bug

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -130,7 +130,6 @@ class AppApi(Resource):
         parser.add_argument("icon_type", type=str, location="json")
         parser.add_argument("icon", type=str, location="json")
         parser.add_argument("icon_background", type=str, location="json")
-        parser.add_argument("max_active_requests", type=int, location="json")
         parser.add_argument("use_icon_as_answer_icon", type=bool, location="json")
         args = parser.parse_args()
 

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -9,7 +9,6 @@ from flask_sqlalchemy.pagination import Pagination
 from configs import dify_config
 from constants.model_template import default_app_templates
 from core.agent.entities import AgentToolEntity
-from core.app.features.rate_limiting import RateLimit
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelPropertyKey, ModelType
@@ -222,7 +221,6 @@ class AppService:
         """
         app.name = args.get("name")
         app.description = args.get("description", "")
-        app.max_active_requests = args.get("max_active_requests")
         app.icon_type = args.get("icon_type", "emoji")
         app.icon = args.get("icon")
         app.icon_background = args.get("icon_background")
@@ -231,9 +229,6 @@ class AppService:
         app.updated_at = datetime.now(UTC).replace(tzinfo=None)
         db.session.commit()
 
-        if app.max_active_requests is not None:
-            rate_limit = RateLimit(app.id, app.max_active_requests)
-            rate_limit.flush_cache(use_local_value=True)
         return app
 
     def update_app_name(self, app: App, name: str) -> App:


### PR DESCRIPTION
# Summary

In https://github.com/langgenius/dify/pull/5844, the rate limiter is added to the app, but only partial feature has been merged, the max_active_requests can not be updated via the frontend.

Now when edit the app's basic information, e.g. app name, description or icon, the `max_active_requests` is set as None, which means it is been reset. This cause a bug if the `max_active_requests` has been updated (via SQL operate on the `max_active_requests` field of the `apps` table).

This patch leave the `max_active_requests` field unchange when update the app.

close https://github.com/langgenius/dify/pull/16485

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

