### PR TITLE
fix: using the number type to filter metadata manually not working pr…

### DIFF
--- a/api/core/variables/segment_group.py
+++ b/api/core/variables/segment_group.py
@@ -20,7 +20,7 @@ class SegmentGroup(Segment):
 
     def to_object(self):
         return [segment.to_object() for segment in self.value]
-    
+
     def get_single_value(self):
         """
         Get the single value from the segment group.

--- a/api/core/variables/segment_group.py
+++ b/api/core/variables/segment_group.py
@@ -20,3 +20,13 @@ class SegmentGroup(Segment):
 
     def to_object(self):
         return [segment.to_object() for segment in self.value]
+    
+    def get_single_value(self):
+        """
+        Get the single value from the segment group.
+        If the group contains only one segment, return its value.
+        If the group contains multiple segments, return the text representation of the group.
+        """
+        if len(self.value) == 1:
+            return self.value[0].value
+        return self.text

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -358,9 +358,8 @@ class KnowledgeRetrievalNode(LLMNode):
                         expected_value = condition.value
                         if expected_value is not None or condition.comparison_operator in ("empty", "not empty"):
                             if isinstance(expected_value, str):
-                                expected_value = self.graph_runtime_state.variable_pool.convert_template(
-                                    expected_value
-                                ).text
+                                tmp_result = self.graph_runtime_state.variable_pool.convert_template(expected_value)
+                                expected_value = tmp_result.get_single_value()
 
                             filters = self._process_metadata_filter_func(
                                 condition.comparison_operator, metadata_name, expected_value, filters


### PR DESCRIPTION
# Summary

Fixes #16649

The issue occurred because of how variable substitution was implemented in the metadata filtering logic. When the system replaces template variables using convert_template(), it returns a SegmentGroup object whose value property is a list of Segment objects. The original code was incorrectly accessing this returned value:
```python
expected_value = self.graph_runtime_state.variable_pool.convert_template(expected_value).text
```

To improve code maintainability and provide a cleaner API for accessing values from SegmentGroup objects, I implemented a get_single_value() helper method on the SegmentGroup class that intelligently returns:
The actual value from the first segment if there's only one segment
The text representation if there are multiple segments
This solution is more robust and semantically clearer than directly accessing internal structure.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

