### PR TITLE
Fix function's name mismatch

### DIFF
--- a/api/schedule/mail_clean_document_notify_task.py
+++ b/api/schedule/mail_clean_document_notify_task.py
@@ -15,11 +15,11 @@ from services.feature_service import FeatureService
 
 
 @app.celery.task(queue="dataset")
-def send_document_clean_notify_task():
+def mail_clean_document_notify_task():
     """
     Async Send document clean notify mail
 
-    Usage: send_document_clean_notify_task.delay()
+    Usage: mail_clean_document_notify_task.delay()
     """
     if not mail.is_inited():
         return


### PR DESCRIPTION
function name `send_document_clean_notify_task` is wrong and should be `mail_clean_document_notify_task`, please refer to `api/extensions/ext_celery.py`.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

