### PR TITLE
fix: regex expressions distorted in code block

### DIFF
--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -66,12 +66,22 @@ const preprocessLaTeX = (content: string) => {
   if (typeof content !== 'string')
     return content
 
-  return flow([
+  const codeBlockRegex = /```[\s\S]*?```/g
+  const codeBlocks = content.match(codeBlockRegex) || []
+  let processedContent = content.replace(codeBlockRegex, 'CODE_BLOCK_PLACEHOLDER')
+
+  processedContent = flow([
     (str: string) => str.replace(/\\\[(.*?)\\\]/g, (_, equation) => `$$${equation}$$`),
     (str: string) => str.replace(/\\\[(.*?)\\\]/gs, (_, equation) => `$$${equation}$$`),
     (str: string) => str.replace(/\\\((.*?)\\\)/g, (_, equation) => `$$${equation}$$`),
     (str: string) => str.replace(/(^|[^\\])\$(.+?)\$/g, (_, prefix, equation) => `${prefix}$${equation}$`),
-  ])(content)
+  ])(processedContent)
+
+  codeBlocks.forEach((block) => {
+    processedContent = processedContent.replace('CODE_BLOCK_PLACEHOLDER', block)
+  })
+
+  return processedContent
 }
 
 const preprocessThinkTag = (content: string) => {


### PR DESCRIPTION
# Summary

Fixes #16557
In markdown components, regex patterns with special characters (like \\( and \\)) are incorrectly processed by the LaTeX preprocessor, which transforms them into math expressions.

I've modified the preprocessLaTeX function to skip code blocks when applying LaTeX transformations. This ensures regex patterns and other special character sequences inside code blocks remain intact.

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/d730f8ff-edc7-4332-9ea2-1505dd99ad25) | ![image](https://github.com/user-attachments/assets/963ced00-9c43-4354-b745-03d9f04859d7)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

