### PR TITLE
fix: provider credentials load error

### DIFF
--- a/api/core/tools/builtin_tool/provider.py
+++ b/api/core/tools/builtin_tool/provider.py
@@ -35,7 +35,7 @@ class BuiltinToolProviderController(ToolProviderController):
                 provider_yaml["credentials_for_provider"][credential_name]["name"] = credential_name
 
         credentials_schema = []
-        for credential in provider_yaml.get("credentials_for_provider", {}):
+        for credential in provider_yaml.get("credentials_for_provider", {}).values():
             credentials_schema.append(credential)
 
         super().__init__(

--- a/api/core/tools/builtin_tool/providers/webscraper/webscraper.yaml
+++ b/api/core/tools/builtin_tool/providers/webscraper/webscraper.yaml
@@ -12,4 +12,4 @@ identity:
   icon: icon.svg
   tags:
     - productivity
-credentials_for_provider: []
+credentials_for_provider: {}


### PR DESCRIPTION
# Summary

fix provider credentials load error:
 provider credentials is a dict, not an array.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

