### PR TITLE
fix(slider): the slider's style is not as expected

### DIFF
--- a/web/app/components/base/slider/index.tsx
+++ b/web/app/components/base/slider/index.tsx
@@ -33,7 +33,8 @@ const Slider: React.FC<ISliderProps> = ({
     step={step || 1}
     className={cn('slider relative', className)}
     thumbClassName={cn('absolute top-[-9px] h-5 w-2 rounded-[3px] border-[0.5px] border-components-slider-knob-border bg-components-slider-knob shadow-sm  focus:outline-none', !disabled && 'cursor-pointer', thumbClassName)}
-    trackClassName={cn('slider-track h-0.5 rounded-full', trackClassName)}
+    // eslint-disable-next-line tailwindcss/classnames-order
+    trackClassName={cn('h-0.5 rounded-full slider-track', trackClassName)}
     onChange={onChange}
   />
 }


### PR DESCRIPTION
# Summary

The slider's style is not as expected

Fix https://github.com/langgenius/dify/issues/17050

# Screenshots

| Before | After |
|--------|-------|
|  <img width="417" alt="image" src="https://github.com/user-attachments/assets/fd512510-d9a1-4f09-8374-b7c777a5c01b" />   | <img width="417" alt="image" src="https://github.com/user-attachments/assets/c71ef205-cf93-4a5f-9aac-079da464a76a" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

