### PR TITLE
fix: fix retrieve input restriction.

### DIFF
--- a/api/controllers/console/datasets/hit_testing_base.py
+++ b/api/controllers/console/datasets/hit_testing_base.py
@@ -43,6 +43,11 @@ class DatasetsHitTestingBase:
         HitTestingService.hit_testing_args_check(args)
 
     @staticmethod
+    def retrieval_args_check(args):
+        HitTestingService.retrieval_args_check(args)
+
+
+    @staticmethod
     def parse_args():
         parser = reqparse.RequestParser()
 

--- a/api/controllers/console/datasets/hit_testing_base.py
+++ b/api/controllers/console/datasets/hit_testing_base.py
@@ -46,7 +46,6 @@ class DatasetsHitTestingBase:
     def retrieval_args_check(args):
         HitTestingService.retrieval_args_check(args)
 
-
     @staticmethod
     def parse_args():
         parser = reqparse.RequestParser()

--- a/api/controllers/service_api/dataset/hit_testing.py
+++ b/api/controllers/service_api/dataset/hit_testing.py
@@ -9,7 +9,7 @@ class HitTestingApi(DatasetApiResource, DatasetsHitTestingBase):
 
         dataset = self.get_and_validate_dataset(dataset_id_str)
         args = self.parse_args()
-        self.hit_testing_args_check(args)
+        self.retrieval_args_check(args)
 
         return self.perform_hit_testing(dataset, args)
 

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -141,6 +141,14 @@ class HitTestingService:
         if not query or len(query) > 250:
             raise ValueError("Query is required and cannot exceed 250 characters")
 
+    @classmethod
+    def retrieval_args_check(cls, args):
+        query = args["query"]
+
+        if not query :
+            raise ValueError("Query is required")
+
+
     @staticmethod
     def escape_query_for_search(query: str) -> str:
         return query.replace('"', '\\"')

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -21,13 +21,13 @@ default_retrieval_model = {
 class HitTestingService:
     @classmethod
     def retrieve(
-            cls,
-            dataset: Dataset,
-            query: str,
-            account: Account,
-            retrieval_model: Any,  # FIXME drop this any
-            external_retrieval_model: dict,
-            limit: int = 10,
+        cls,
+        dataset: Dataset,
+        query: str,
+        account: Account,
+        retrieval_model: Any,  # FIXME drop this any
+        external_retrieval_model: dict,
+        limit: int = 10,
     ) -> dict:
         if dataset.available_document_count == 0 or dataset.available_segment_count == 0:
             return {
@@ -147,6 +147,7 @@ class HitTestingService:
 
         if not query:
             raise ValueError("Query is required")
+
 
     @staticmethod
     def escape_query_for_search(query: str) -> str:

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -21,13 +21,13 @@ default_retrieval_model = {
 class HitTestingService:
     @classmethod
     def retrieve(
-        cls,
-        dataset: Dataset,
-        query: str,
-        account: Account,
-        retrieval_model: Any,  # FIXME drop this any
-        external_retrieval_model: dict,
-        limit: int = 10,
+            cls,
+            dataset: Dataset,
+            query: str,
+            account: Account,
+            retrieval_model: Any,  # FIXME drop this any
+            external_retrieval_model: dict,
+            limit: int = 10,
     ) -> dict:
         if dataset.available_document_count == 0 or dataset.available_segment_count == 0:
             return {
@@ -147,7 +147,6 @@ class HitTestingService:
 
         if not query:
             raise ValueError("Query is required")
-
 
     @staticmethod
     def escape_query_for_search(query: str) -> str:

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -73,11 +73,11 @@ class HitTestingService:
 
     @classmethod
     def external_retrieve(
-        cls,
-        dataset: Dataset,
-        query: str,
-        account: Account,
-        external_retrieval_model: dict,
+            cls,
+            dataset: Dataset,
+            query: str,
+            account: Account,
+            external_retrieval_model: dict,
     ) -> dict:
         if dataset.provider != "external":
             return {

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -145,7 +145,7 @@ class HitTestingService:
     def retrieval_args_check(cls, args):
         query = args["query"]
 
-        if not query :
+        if not query:
             raise ValueError("Query is required")
 
 

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -73,11 +73,11 @@ class HitTestingService:
 
     @classmethod
     def external_retrieve(
-            cls,
-            dataset: Dataset,
-            query: str,
-            account: Account,
-            external_retrieval_model: dict,
+        cls,
+        dataset: Dataset,
+        query: str,
+        account: Account,
+        external_retrieval_model: dict,
     ) -> dict:
         if dataset.provider != "external":
             return {


### PR DESCRIPTION
When calling the interface, only check for the existence of the query without considering character limitations.

Closes https://github.com/langgenius/dify/issues/16724

# Summary

Resolves #<16724>


# Screenshots

| Before | After |



# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

