### PR TITLE
Remove the useless excluded item in mypy.ini

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -3,8 +3,7 @@ warn_return_any = True
 warn_unused_configs = True
 check_untyped_defs = True
 exclude = (?x)(
-    core/tools/provider/builtin/
-    | core/model_runtime/model_providers/
+    core/model_runtime/model_providers/
     | tests/
     | migrations/
   )


### PR DESCRIPTION
# Summary

The folder `api/core/tools/provider/builtin/` was removed at commit 403e2d58, and was refactored as `api/core/tools/builtin_tool/providers `. So delete the excluded item in mypy.ini.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

