### PR TITLE
fix: when cot_agent call tool like searxng lost some response content

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -246,7 +246,7 @@ class ToolEngine:
                     + "you do not need to create it, just tell the user to check it now."
                 )
             elif response.type == ToolInvokeMessage.MessageType.JSON:
-                result = json.dumps(
+                result += json.dumps(
                     cast(ToolInvokeMessage.JsonMessage, response.message).json_object, ensure_ascii=False
                 )
             else:


### PR DESCRIPTION
# Summary
fix: #17091 

when cot_agent call tool like searxng which return list tool_responses, but current code will  lost some response only return last record


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

