### PR TITLE
fix: fix ui layout when in mobile mode

### DIFF
--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -188,7 +188,7 @@ const ChatWrapper = () => {
       return null
     if (welcomeMessage.suggestedQuestions && welcomeMessage.suggestedQuestions?.length > 0) {
       return (
-        <div className='flex h-[50vh] items-center justify-center px-4 py-12'>
+        <div className='flex min-h-[50vh] items-center justify-center px-4 py-12'>
           <div className='flex max-w-[720px] grow gap-4'>
             <AppIcon
               size='xl'
@@ -197,9 +197,11 @@ const ChatWrapper = () => {
               background={appData?.site.icon_background}
               imageUrl={appData?.site.icon_url}
             />
-            <div className='body-lg-regular grow rounded-2xl bg-chat-bubble-bg px-4 py-3 text-text-primary'>
-              <Markdown content={welcomeMessage.content} />
-              <SuggestedQuestions item={welcomeMessage} />
+            <div className='w-0 grow'>
+              <div className='body-lg-regular grow rounded-2xl bg-chat-bubble-bg px-4 py-3 text-text-primary'>
+                <Markdown content={welcomeMessage.content} />
+                <SuggestedQuestions item={welcomeMessage} />
+              </div>
             </div>
           </div>
         </div>

--- a/web/app/components/base/chat/chat/answer/suggested-questions.tsx
+++ b/web/app/components/base/chat/chat/answer/suggested-questions.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 import type { ChatItem } from '../../types'
 import { useChatContext } from '../context'
 import Button from '@/app/components/base/button'
+import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 
 type SuggestedQuestionsProps = {
   item: ChatItem
@@ -11,6 +12,10 @@ const SuggestedQuestions: FC<SuggestedQuestionsProps> = ({
   item,
 }) => {
   const { onSend } = useChatContext()
+  const media = useBreakpoints()
+  const isMobile = media === MediaType.mobile
+  const klassName = `mr-1 mt-1 ${isMobile ? 'block overflow-hidden text-ellipsis' : ''} max-w-full shrink-0 last:mr-0`
+
   const {
     isOpeningStatement,
     suggestedQuestions,
@@ -25,7 +30,7 @@ const SuggestedQuestions: FC<SuggestedQuestionsProps> = ({
         <Button
           key={index}
           variant='secondary-accent'
-          className='mr-1 mt-1 max-w-full shrink-0 last:mr-0'
+          className={klassName}
           onClick={() => onSend?.(question)}
         >
           {question}


### PR DESCRIPTION
# Summary

fix ui layout in mobile mode
1. fix the layout for opening remarks; 
2. show ellipsis on mobile devices when the text is too long, only in mobile mode. 
3. add class ``` min-h-[50vh]``` for chat-wrapper


> [!Tip]
Fixes #16790


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/8023df6c-eb03-4d5f-858a-fab39a10345c) 
![image](https://github.com/user-attachments/assets/3e441572-c762-4f10-a24e-d86d4fcda5fc)
 | ![image](https://github.com/user-attachments/assets/b025850f-77c5-4fda-ac2e-6d0cf6168c00) ![image](https://github.com/user-attachments/assets/06f40c27-75c6-4652-bd01-9bc4bf92ffcc) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

