### PR TITLE
fix: hardcoded provider id not correct

### DIFF
--- a/api/core/plugin/entities/plugin.py
+++ b/api/core/plugin/entities/plugin.py
@@ -151,6 +151,11 @@ class GenericProviderID:
         return str(self)
 
     def __str__(self) -> str:
+        from core.tools.tool_manager import ToolManager
+
+        if self.organization == "langgenius" and ToolManager.is_hardcoded_provider(self.provider_name):
+            return self.provider_name
+
         return f"{self.organization}/{self.plugin_name}/{self.provider_name}"
 
     def __init__(self, value: str, is_hardcoded: bool = False) -> None:

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -62,6 +62,12 @@ class ToolManager:
     _builtin_tools_labels: dict[str, Union[I18nObject, None]] = {}
 
     @classmethod
+    def is_hardcoded_provider(cls, provider_name: str) -> bool:
+        if provider_name in cls._hardcoded_providers:
+            return True
+        return False
+
+    @classmethod
     def get_hardcoded_provider(cls, provider: str) -> BuiltinToolProviderController:
         """
         get the hardcoded provider

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -63,9 +63,7 @@ class ToolManager:
 
     @classmethod
     def is_hardcoded_provider(cls, provider_name: str) -> bool:
-        if provider_name in cls._hardcoded_providers:
-            return True
-        return False
+        return provider_name in cls._hardcoded_providers
 
     @classmethod
     def get_hardcoded_provider(cls, provider: str) -> BuiltinToolProviderController:


### PR DESCRIPTION
# Summary

The hardcoded tool used identity.name as its provider before Dify 1.0.0.

After Dify 1.0.0, it was forcibly changed to langgenius/<identity.name>/<identity.name>.

If a hardcoded tool is configured with credentials_for_provider, the current code will cause many issues. For example, when configuring credentials, the provider field inserted into tool_builtin_providers is langgenius/<identity.name>/<identity.name>. However, when querying the page again, it still looks for provider=<identity.name>, making it appear as if the tool has never been configured with credentials.

To ensure compatibility, I think the to_string method of the GenericProviderID class should check whether the tool is hardcoded. If it is, it should continue using <identity.name>. Otherwise, it should follow the Dify plugin marketplace format and use langgenius/<identity.name>/<identity.name>.

硬编码的tool，在dify1.0.0之前，使用的是identity.name作为它的provider。
在dify1.0.0之后，强行把它改成了langgenius/<identity.name>/<identity.name>
如果硬编码的tool配置了credentials_for_provider，现行代码中会导致很多问题，例如配置credentials的时候，插入tool_builtin_providers的provider字段的是langgenius/<identity.name>/<identity.name>，但是页面再次查询的时候还是查的provider=<identity.name>，导致认为该工具一直没配置密钥。

为了兼容这个问题，我觉得应该在GenericProviderID类的to_string方法，判断下如果是hardcoded的tool，仍然取<identity.name>，其它的按照dify插件市场的格式，走langgenius/<identity.name>/<identity.name>

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

