### PR TITLE
fix: WorkflowRunDetailApi created_at、finished_at types changed to timestamps

### DIFF
--- a/api/controllers/service_api/app/workflow.py
+++ b/api/controllers/service_api/app/workflow.py
@@ -27,6 +27,7 @@ from core.model_runtime.errors.invoke import InvokeError
 from extensions.ext_database import db
 from fields.workflow_app_log_fields import workflow_app_log_pagination_fields
 from libs import helper
+from libs.helper import TimestampField
 from models.model import App, AppMode, EndUser
 from models.workflow import WorkflowRun, WorkflowRunStatus
 from services.app_generate_service import AppGenerateService
@@ -44,8 +45,8 @@ workflow_run_fields = {
     "error": fields.String,
     "total_steps": fields.Integer,
     "total_tokens": fields.Integer,
-    "created_at": fields.DateTime,
-    "finished_at": fields.DateTime,
+    "created_at": TimestampField,
+    "finished_at": TimestampField,
     "elapsed_time": fields.Float,
 }
 

--- a/web/app/components/develop/template/template_workflow.en.mdx
+++ b/web/app/components/develop/template/template_workflow.en.mdx
@@ -370,8 +370,8 @@ Workflow applications offers non-session support and is ideal for translation, a
         "error": null,
         "total_steps": 3,
         "total_tokens": 0,
-        "created_at": "Thu, 18 Jul 2024 03:17:40 -0000",
-        "finished_at": "Thu, 18 Jul 2024 03:18:10 -0000",
+        "created_at": 1705407629,
+        "finished_at": 1727807631,
         "elapsed_time": 30.098514399956912
     }
     ```

--- a/web/app/components/develop/template/template_workflow.ja.mdx
+++ b/web/app/components/develop/template/template_workflow.ja.mdx
@@ -373,8 +373,8 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
         "error": null,
         "total_steps": 3,
         "total_tokens": 0,
-        "created_at": "Thu, 18 Jul 2024 03:17:40 -0000",
-        "finished_at": "Thu, 18 Jul 2024 03:18:10 -0000",
+        "created_at": 1705407629,
+        "finished_at": 1727807631,
         "elapsed_time": 30.098514399956912
     }
     ```

--- a/web/app/components/develop/template/template_workflow.zh.mdx
+++ b/web/app/components/develop/template/template_workflow.zh.mdx
@@ -363,8 +363,8 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
         "error": null,
         "total_steps": 3,
         "total_tokens": 0,
-        "created_at": "Thu, 18 Jul 2024 03:17:40 -0000",
-        "finished_at": "Thu, 18 Jul 2024 03:18:10 -0000",
+        "created_at": 1705407629,
+        "finished_at": 1727807631,
         "elapsed_time": 30.098514399956912
     }
     ```


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes #15632

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/0f8e2937-07c0-4f50-9cf5-ee0cfe6e907a)    | ![image](https://github.com/user-attachments/assets/bc9c8d9f-0867-43c8-bcba-350d17f2cb56)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

