### PR TITLE
fix: code block syntax cannot be displayed correctly in react mode

### DIFF
--- a/api/tests/unit_tests/core/agent/output_parser/test_cot_output_parser.py
+++ b/api/tests/unit_tests/core/agent/output_parser/test_cot_output_parser.py
@@ -1,0 +1,76 @@
+import json
+
+from core.agent.entities import AgentScratchpadUnit
+from core.agent.output_parser.cot_output_parser import CotAgentOutputParser
+from collections.abc import Generator
+from core.model_runtime.entities.llm_entities import LLMResultChunk, LLMResultChunkDelta, AssistantPromptMessage
+import pytest
+
+
+def mock_llm_response(text) -> Generator[LLMResultChunk, None, None]:
+    for i in range(len(text)):
+        yield LLMResultChunk(
+            model="model",
+            prompt_messages=[],
+            delta=LLMResultChunkDelta(
+                index=0,
+                message=AssistantPromptMessage(
+                    content=text[i], tool_calls=[]
+                )
+            )
+        )
+
+
+def test_cot_output_parser():
+    test_cases = [
+        {
+            "input": "Through: abc\nAction: ```{\"action\": \"Final Answer\", \"action_input\": \"```echarts\n {}\n```\"}```",
+            "action": {
+                "action": "Final Answer",
+                "action_input": "```echarts\n {}\n```"
+            },
+            "output": 'Through: abc\n {"action": "Final Answer", "action_input": "```echarts\\n {}\\n```"}'
+        },
+        # list
+        {
+            "input": "Through: abc\nAction: ```[{\"action\": \"Final Answer\", \"action_input\": \"```echarts\n {}\n```\"}]```",
+            "action": {
+                "action": "Final Answer",
+                "action_input": "```echarts\n {}\n```"
+            },
+            "output": 'Through: abc\n {"action": "Final Answer", "action_input": "```echarts\\n {}\\n```"}'
+        },
+        # no code block
+        {
+            "input": "Through: abc\nAction: {\"action\": \"Final Answer\", \"action_input\": \"```echarts\n {}\n```\"}",
+            "action": {
+                "action": "Final Answer",
+                "action_input": "```echarts\n {}\n```"
+            },
+            "output": 'Through: abc\n {"action": "Final Answer", "action_input": "```echarts\\n {}\\n```"}'
+        },
+        # no code block and json
+        {
+            "input": "Through: abc\nAction: efg",
+            "action": {
+            },
+            "output": 'Through: abc\n efg'
+        }
+    ]
+
+    parser = CotAgentOutputParser()
+    usage_dict = {}
+    for test_case in test_cases:
+        # mock llm_response as a generator by text
+        llm_response: Generator[LLMResultChunk, None, None] = mock_llm_response(test_case["input"])
+        results = parser.handle_react_stream_output(llm_response, usage_dict)
+        output = ""
+        for result in results:
+            if isinstance(result, str):
+                output += result
+            elif isinstance(result, AgentScratchpadUnit.Action):
+                if test_case["action"]:
+                    assert result.to_dict() == test_case["action"]
+                output += json.dumps(result.to_dict())
+        if test_case["output"]:
+            assert output == test_case["output"]


### PR DESCRIPTION
fix [16873](https://github.com/langgenius/dify/issues/16873)
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

