### PR TITLE
fix(ui): improve chart text spacing and prevent unnecessary truncation

### DIFF
--- a/web/app/components/app-sidebar/basic.tsx
+++ b/web/app/components/app-sidebar/basic.tsx
@@ -54,7 +54,7 @@ const ICON_MAP = {
   notion: <AppIcon innerIcon={NotionSvg} className='!border-[0.5px] !border-indigo-100 !bg-white' />,
 }
 
-export default function AppBasic({ icon, icon_background, name, isExternal, type, hoverTip, textStyle, mode = 'expand', iconType = 'app' }: IAppBasicProps) {
+export default function AppBasic({ icon, icon_background, name, isExternal, type, hoverTip, textStyle, isExtraInLine, mode = 'expand', iconType = 'app' }: IAppBasicProps) {
   const { t } = useTranslation()
 
   return (
@@ -70,9 +70,9 @@ export default function AppBasic({ icon, icon_background, name, isExternal, type
         </div>
 
       }
-      {mode === 'expand' && <div className="group">
+      {mode === 'expand' && <div className="group w-full">
         <div className={`system-md-semibold flex flex-row items-center text-text-secondary group-hover:text-text-primary ${textStyle?.main ?? ''}`}>
-          <div className="max-w-[180px] truncate">
+          <div className="min-w-0 overflow-hidden text-ellipsis break-normal">
             {name}
           </div>
           {hoverTip
@@ -88,7 +88,11 @@ export default function AppBasic({ icon, icon_background, name, isExternal, type
             />
           }
         </div>
-        <div className='system-2xs-medium-uppercase text-text-tertiary'>{isExternal ? t('dataset.externalTag') : ''}</div>
+        {isExtraInLine ? (
+          <div className="system-2xs-medium-uppercase flex text-text-tertiary">{type}</div>
+        ) : (
+          <div className='system-2xs-medium-uppercase text-text-tertiary'>{isExternal ? t('dataset.externalTag') : type}</div>
+        )}
       </div>}
     </div>
   )

--- a/web/app/components/app/overview/appChart.tsx
+++ b/web/app/components/app/overview/appChart.tsx
@@ -237,7 +237,7 @@ const Chart: React.FC<IChartProps> = ({
       <div className='mb-4 flex-1'>
         <Basic
           isExtraInLine={CHART_TYPE_CONFIG[chartType].showTokens}
-          name={chartType !== 'costs' ? (sumData.toLocaleString() + unit) : `${sumData < 1000 ? sumData : (`${formatNumber(Math.round(sumData / 1000))}k`)}`}
+          name={chartType !== 'costs' ? (`${sumData.toLocaleString()} ${unit}`) : `${sumData < 1000 ? sumData : (`${formatNumber(Math.round(sumData / 1000))}k`)}`}
           type={!CHART_TYPE_CONFIG[chartType].showTokens
             ? ''
             : <span>{t('appOverview.analysis.tokenUsage.consumed')} Tokens<span className='text-sm'>
@@ -350,6 +350,7 @@ export const TokenPerSecond: FC<IBizChartProps> = ({ id, period }) => {
     isAvg
     unit={t('appOverview.analysis.tokenPS') as string}
     {...(noDataFlag && { yMax: 100 })}
+    className="min-w-0"
   />
 }
 


### PR DESCRIPTION
# Summary

Resolves #16624
## Problem
In the application overview charts, there was no space between the numeric values and their units (e.g. "19.461Tokens/sec"). Additionally, text was being unnecessarily truncated even when there was sufficient space available for display due to a fixed width constraint.

## Solution
1. Added a space between numeric values and their units to improve readability
2. Optimized the `AppBasic` component's text container styles to adapt to available space:
   - Changed from `max-w-[180px] truncate` to `min-w-0 overflow-hidden text-ellipsis break-normal`
   - Added `w-full` to container to utilize available space properly
3. Improved line breaking behavior to allow text to wrap naturally when needed instead of being cut off
4. Added `min-w-0` class to Chart components to ensure proper container size response

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/f5b62f85-c5a7-4114-8c94-0c57e1800eb9)  | ![image](https://github.com/user-attachments/assets/215463b5-0baf-4a46-a905-72fce65b26b3)  |
| ![image](https://github.com/user-attachments/assets/a5e9d673-f3ce-44e8-a8a4-5cdc19ad1da9) | ![image](https://github.com/user-attachments/assets/8a39e9b1-d828-498b-8009-323143e6590b) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

