### PR TITLE
feat: hide 'Find More in Marketplace in Tools'

### DIFF
--- a/web/app/components/workflow/block-selector/all-tools.tsx
+++ b/web/app/components/workflow/block-selector/all-tools.tsx
@@ -20,6 +20,7 @@ import ActionButton from '../../base/action-button'
 import { RiAddLine } from '@remixicon/react'
 import { PluginType } from '../../plugins/types'
 import { useMarketplacePlugins } from '../../plugins/marketplace/hooks'
+import { useSelector as useAppContextSelector } from '@/context/app-context'
 
 type AllToolsProps = {
   className?: string
@@ -82,7 +83,10 @@ const AllTools = ({
     plugins: notInstalledPlugins = [],
   } = useMarketplacePlugins()
 
+  const { enable_marketplace } = useAppContextSelector(s => s.systemFeatures)
+
   useEffect(() => {
+    if (enable_marketplace) return
     if (searchText || tags.length > 0) {
       fetchPlugins({
         query: searchText,
@@ -91,7 +95,7 @@ const AllTools = ({
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchText, tags])
+  }, [searchText, tags, enable_marketplace])
 
   const pluginRef = useRef(null)
   const wrapElemRef = useRef<HTMLDivElement>(null)
@@ -144,13 +148,13 @@ const AllTools = ({
           selectedTools={selectedTools}
         />
         {/* Plugins from marketplace */}
-        <PluginList
+        {enable_marketplace && <PluginList
           wrapElemRef={wrapElemRef}
           list={notInstalledPlugins as any} ref={pluginRef}
           searchText={searchText}
           toolContentClassName={toolContentClassName}
           tags={tags}
-        />
+        />}
       </div>
     </div>
   )


### PR DESCRIPTION
# Summary

When set MARKETPLACE_ENABLED=false, Find More in Marketplace in Tools should be hidden.

> [!Tip]
>Fixes #16941.


# Screenshots
![image](https://github.com/user-attachments/assets/aa5686bb-c5d4-43bc-a6c5-7bab1f0e17de)


| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

