### PR TITLE
feat: add script to convert docker-compose to podman-compose. for `:z` subfix auto adding.

### DIFF
--- a/docker/to_podman.sh
+++ b/docker/to_podman.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# To convert volume mappings in docker-compose.yaml to Podman's format with permission flags
+# Usage: bash to_podman.sh
+
+# Copy docker-compose.yaml to podman-compose.yaml
+cp -f docker-compose.yaml podman-compose.yaml
+
+# Add subfix to the volume mappings in podman-compose.yaml
+# The :z flag for Podman is used to share the volume with all containers
+sed -i '
+# Search for volumes: and lines that do not start with a space
+/volumes:/,/^[^ ]/ {
+    # Skip lines that do not start with a space
+    /volumes:\|:z[[:space:]]*\($\|#\)/ b
+    
+    # Skip lines that do not have a colon
+    /[[:space:]]*-[[:space:]]*\([\.\/][^:]*:[^:#]*\)[[:space:]]*\(#.*\)*$/ {
+        # Do not process lines that already have :z
+        s/\([[:space:]]*-[[:space:]]*[^:]*:[^[:space:]]*\).*$/\1/
+        # Append :z to the end of the line
+        s/\([[:space:]]*-[[:space:]]*[^:]*:[^[:space:]]*\)\([[:space:]]*\(#.*\)\?$\)/\1:z\2/
+    }
+}' podman-compose.yaml
+
+echo "Volume mappings have been updated for Podman in podman-compose.yaml"
+echo "Run 'podman-compose -f podman-compose.yaml up -d' to start the containers"


### PR DESCRIPTION
# Summary

feat: add script to convert docker-compose to podman-compose. for `:z` subfix auto adding.

a bash script to convert `docker-compose.yaml` to `podman-compose.yaml`

auto add `:z` subfix to volumes items. to make it working with podman.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

