### PR TITLE
fix: fix cannot select stream-tool-call in agent modal

### DIFF
--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -77,6 +77,7 @@ import {
   correctToolProvider,
 } from '@/utils'
 import PluginDependency from '@/app/components/workflow/plugin-dependency'
+import { supportFunctionCall } from '@/utils/tool-call'
 
 type PublishConfig = {
   modelConfig: ModelConfig
@@ -347,12 +348,7 @@ const Configuration: FC = () => {
     },
   )
 
-  const isFunctionCall = (() => {
-    const features = currModel?.features
-    if (!features)
-      return false
-    return features.includes(ModelFeatureEnum.toolCall) || features.includes(ModelFeatureEnum.multiToolCall)
-  })()
+  const isFunctionCall = supportFunctionCall(currModel?.features)
 
   // Fill old app data missing model mode.
   useEffect(() => {

--- a/web/app/components/header/account-setting/model-provider-page/declarations.ts
+++ b/web/app/components/header/account-setting/model-provider-page/declarations.ts
@@ -55,6 +55,7 @@ export enum ModelFeatureEnum {
   toolCall = 'tool-call',
   multiToolCall = 'multi-tool-call',
   agentThought = 'agent-thought',
+  streamToolCall = 'stream-tool-call',
   vision = 'vision',
   video = 'video',
   document = 'document',

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
@@ -15,6 +15,7 @@ import { useLanguage } from '../hooks'
 import PopupItem from './popup-item'
 import { XCircle } from '@/app/components/base/icons/src/vender/solid/general'
 import { useModalContext } from '@/context/modal-context'
+import { supportFunctionCall } from '@/utils/tool-call'
 
 type PopupProps = {
   defaultModel?: DefaultModel
@@ -50,7 +51,7 @@ const Popup: FC<PopupProps> = ({
             return true
           return scopeFeatures.every((feature) => {
             if (feature === ModelFeatureEnum.toolCall)
-              return modelItem.features?.some(featureItem => featureItem === ModelFeatureEnum.toolCall || featureItem === ModelFeatureEnum.multiToolCall)
+              return supportFunctionCall(modelItem.features)
             return modelItem.features?.some(featureItem => featureItem === feature)
           })
         })

--- a/web/app/components/workflow/nodes/parameter-extractor/use-config.ts
+++ b/web/app/components/workflow/nodes/parameter-extractor/use-config.ts
@@ -12,13 +12,11 @@ import useOneStepRun from '../_base/hooks/use-one-step-run'
 import useConfigVision from '../../hooks/use-config-vision'
 import type { Param, ParameterExtractorNodeType, ReasoningModeType } from './types'
 import { useModelListAndDefaultModelAndCurrentProviderAndModel, useTextGenerationCurrentProviderAndModelAndModelList } from '@/app/components/header/account-setting/model-provider-page/hooks'
-import {
-  ModelFeatureEnum,
-  ModelTypeEnum,
-} from '@/app/components/header/account-setting/model-provider-page/declarations'
+import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import useNodeCrud from '@/app/components/workflow/nodes/_base/hooks/use-node-crud'
 import { checkHasQueryBlock } from '@/app/components/base/prompt-editor/constants'
 import useAvailableVarList from '@/app/components/workflow/nodes/_base/hooks/use-available-var-list'
+import { supportFunctionCall } from '@/utils/tool-call'
 
 const useConfig = (id: string, payload: ParameterExtractorNodeType) => {
   const { nodesReadOnly: readOnly } = useNodesReadOnly()
@@ -159,7 +157,7 @@ const useConfig = (id: string, payload: ParameterExtractorNodeType) => {
     },
   )
 
-  const isSupportFunctionCall = currModel?.features?.includes(ModelFeatureEnum.toolCall) || currModel?.features?.includes(ModelFeatureEnum.multiToolCall)
+  const isSupportFunctionCall = supportFunctionCall(currModel?.features)
 
   const filterInputVar = useCallback((varPayload: Var) => {
     return [VarType.number, VarType.string].includes(varPayload.type)

--- a/web/utils/tool-call.ts
+++ b/web/utils/tool-call.ts
@@ -1,0 +1,6 @@
+import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
+
+export const supportFunctionCall = (features: ModelFeatureEnum[] = []): boolean => {
+  if (!features || !features.length) return false
+  return features.some(feature => [ModelFeatureEnum.toolCall, ModelFeatureEnum.multiToolCall, ModelFeatureEnum.streamToolCall].includes(feature))
+}


### PR DESCRIPTION
# Summary

fix lost  tool-call enum: stream-tool-call, so we can select stream-tool-call in agent 

Close https://github.com/langgenius/dify/issues/16613
Fixes #17012

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/f57aebc3-064b-425b-a979-1e95aec0cf48) | ![image](https://github.com/user-attachments/assets/080eb8a0-6d22-4a96-8e5d-b3b6265b09b8) |

# Checklist
![image](https://github.com/user-attachments/assets/b830af21-04ed-4adb-93c9-e3c25e789670)
this backend enum for tool-call

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

