### PR TITLE
ci: skip setting up opengauss for vdb tests

### DIFF
--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -76,7 +76,6 @@ jobs:
             milvus-standalone
             pgvecto-rs
             pgvector
-            opengauss
             chroma
             elasticsearch
 


### PR DESCRIPTION
# Summary

- to close #17013, which blocks CI tests
- opengauss/opengauss:7.0.0-RC1 is not availible on DockerHub: https://hub.docker.com/r/opengauss/opengauss/tags
- opengauss is never used in real vdb tests in Python

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

