### PR TITLE
fix: _build_from_remote_url get extension is .bin

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -196,7 +196,7 @@ def _build_from_remote_url(
         raise ValueError("Invalid file url")
 
     mime_type, filename, file_size = _get_remote_file_info(url)
-    extension = mimetypes.guess_extension(mime_type) or "." + filename.split(".")[-1] if "." in filename else ".bin"
+    extension = mimetypes.guess_extension(mime_type) or ("." + filename.split(".")[-1] if "." in filename else ".bin")
 
     file_type = FileType(mapping.get("type", "custom"))
     file_type = _standardize_file_type(file_type, extension=extension, mime_type=mime_type)


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

Fixes #17019

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/15430c5b-4a56-42d4-8891-37d513dff510)    | ![image](https://github.com/user-attachments/assets/073cd86b-43f0-4730-92a3-12e494d17fc8)
   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

