### PR TITLE
fix(answer): The chat interface outputs twice

### DIFF
--- a/web/app/components/base/chat/chat/answer/index.tsx
+++ b/web/app/components/base/chat/chat/answer/index.tsx
@@ -164,7 +164,7 @@ const Answer: FC<AnswerProps> = ({
               )
             }
             {
-              (hasAgentThoughts || content) && (
+              (hasAgentThoughts) && (
                 <AgentContent
                   item={item}
                   responding={responding}


### PR DESCRIPTION
# Summary

The chat interface outputs twice.

Fixes #16794 #16950

# Screenshots

| Before | After |
|--------|-------|
|  <img width="1512" alt="image" src="https://github.com/user-attachments/assets/782c57c3-b07c-4616-b21f-5d0a9fa3e574" />|  <img width="1512" alt="image" src="https://github.com/user-attachments/assets/db48c00a-f46e-4ecf-ab82-714d7d03ef42" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

