### PR TITLE
docs: correct  type desc

### DIFF
--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -124,7 +124,7 @@ Chat applications support session persistence, allowing previous chat history to
       - `created_at` (int) Creation timestamp, e.g.: 1705395332
     - `event: agent_thought` thought of Agent, contains the thought of LLM, input and output of tool calls (Only supported in Agent mode)
       - `id` (string) Agent thought ID, every iteration has a unique agent thought ID
-      - `task_id` (string) (string) Task ID, used for request tracking and the below Stop Generate API
+      - `task_id` (string)  Task ID, used for request tracking and the below Stop Generate API
       - `message_id` (string) Unique message ID
       - `position` (int) Position of current agent thought, each message may have multiple thoughts in order.
       - `thought` (string) What LLM is thinking about

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -124,7 +124,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       - `created_at` (int) 作成タイムスタンプ、例：1705395332
     - `event: agent_thought` エージェントの思考、LLMの思考、ツール呼び出しの入力と出力を含みます（エージェントモードでのみサポート）
       - `id` (string) エージェント思考ID、各反復には一意のエージェント思考IDがあります
-      - `task_id` (string) (string) タスクID、リクエスト追跡と以下のStop Generate APIに使用
+      - `task_id` (string)  タスクID、リクエスト追跡と以下のStop Generate APIに使用
       - `message_id` (string) 一意のメッセージID
       - `position` (int) 現在のエージェント思考の位置、各メッセージには順番に複数の思考が含まれる場合があります。
       - `thought` (string) LLMが考えていること

--- a/web/app/components/develop/template/template_workflow.zh.mdx
+++ b/web/app/components/develop/template/template_workflow.zh.mdx
@@ -51,7 +51,7 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
             - `custom` 具体类型包含：其他文件类型
           - `transfer_method` (string) 传递方式，`remote_url` 图片地址 / `local_file` 上传文件
           - `url` (string) 图片地址（仅当传递方式为 `remote_url` 时）
-          - `upload_file_id` (string) (string) 上传文件 ID（仅当传递方式为 `local_file` 时）
+          - `upload_file_id` (string)  上传文件 ID（仅当传递方式为 `local_file` 时）
       - `response_mode` (string) Required
         返回响应模式，支持：
         - `streaming` 流式模式（推荐）。基于 SSE（**[Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)**）实现类似打字机输出方式的流式返回。


### PR DESCRIPTION
# Summary

The type definition for `upload_file_id` is duplicated in the documentation for the `https://{BASE_URL}/app/{app_id}/develop` page. Only the relevant documentation (English/Chinese/Japanese) needs to be modified; there are no other impacts.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| <img width="1898" alt="image" src="https://github.com/user-attachments/assets/2c8cac2d-8b61-4064-8d7c-36358352ce12" />    | <img width="1914" alt="image" src="https://github.com/user-attachments/assets/5821c57b-993d-4690-8c36-a195fe4cfcd2" />   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

