### PR TITLE
fix: enhance file extension condition check for if-else node

### DIFF
--- a/api/core/workflow/utils/condition/processor.py
+++ b/api/core/workflow/utils/condition/processor.py
@@ -377,6 +377,8 @@ def _process_sub_conditions(
         values = [file_manager.get_attr(file=file, attr=key) for file in files]
         expected_value = condition.value
         if key == FileAttribute.EXTENSION:
+            if not isinstance(expected_value, str):
+                raise TypeError("Expected value must be a string when key is FileAttribute.EXTENSION")
             if expected_value and not expected_value.startswith("."):
                 expected_value = "." + expected_value
 

--- a/api/core/workflow/utils/condition/processor.py
+++ b/api/core/workflow/utils/condition/processor.py
@@ -375,11 +375,23 @@ def _process_sub_conditions(
     for condition in sub_conditions:
         key = FileAttribute(condition.key)
         values = [file_manager.get_attr(file=file, attr=key) for file in files]
+        expected_value = condition.value
+        if key == FileAttribute.EXTENSION:
+            if expected_value and not expected_value.startswith("."):
+                expected_value = "." + expected_value
+
+            normalized_values = []
+            for value in values:
+                if value and isinstance(value, str):
+                    if not value.startswith("."):
+                        value = "." + value
+                normalized_values.append(value)
+            values = normalized_values
         sub_group_results = [
             _evaluate_condition(
                 value=value,
                 operator=condition.comparison_operator,
-                expected=condition.value,
+                expected=expected_value,
             )
             for value in values
         ]


### PR DESCRIPTION
# Summary
Fixes #17057

The issue arises when the processor handles the file extension condition, as the actual file extensions include the `dot` prefix, whereas the user's expected condition value might not. I believe the handling of file extensions needs to be strengthened.



# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

