### PR TITLE
fix: move hardcoded text to language settings (#16990)

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -52,6 +52,7 @@ from core.rag.retrieval.template_prompts import (
     METADATA_FILTER_USER_PROMPT_2,
     METADATA_FILTER_USER_PROMPT_3,
 )
+from core.tools.entities.common_entities import I18nObject
 from core.tools.utils.dataset_retriever.dataset_retriever_base_tool import DatasetRetrieverBaseTool
 from extensions.ext_database import db
 from libs.json_in_md_parser import parse_and_check_json_markdown
@@ -293,7 +294,10 @@ class DatasetRetrieval:
         for dataset in available_datasets:
             description = dataset.description
             if not description:
-                description = "useful for when you want to answer queries about the " + dataset.name
+                description = I18nObject(
+                    en_US="useful for when you want to answer queries about the " + dataset.name,
+                    zh_Hans="用于回答关于 " + dataset.name + " 的查询",
+                )
 
             description = description.replace("\n", "").replace("\r", "")
             message_tool = PromptMessageTool(

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -6,6 +6,7 @@ from core.rag.datasource.retrieval_service import RetrievalService
 from core.rag.entities.context_entities import DocumentContext
 from core.rag.models.document import Document as RetrievalDocument
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
+from core.tools.entities.common_entities import I18nObject
 from core.tools.utils.dataset_retriever.dataset_retriever_base_tool import DatasetRetrieverBaseTool
 from extensions.ext_database import db
 from models.dataset import Dataset
@@ -38,7 +39,10 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
     def from_dataset(cls, dataset: Dataset, **kwargs):
         description = dataset.description
         if not description:
-            description = "useful for when you want to answer queries about the " + dataset.name
+            description = I18nObject(
+                en_US="useful for when you want to answer queries about the " + dataset.name,
+                zh_Hans="用于回答关于 " + dataset.name + " 的查询",
+            )
 
         description = description.replace("\n", "").replace("\r", "")
         return cls(

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -21,6 +21,7 @@ from core.plugin.entities.plugin import ModelProviderID
 from core.rag.index_processor.constant.built_in_field import BuiltInField
 from core.rag.index_processor.constant.index_type import IndexType
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
+from core.tools.entities.common_entities import I18nObject
 from events.dataset_event import dataset_was_deleted
 from events.document_event import document_was_deleted
 from extensions.ext_database import db
@@ -1373,7 +1374,10 @@ class DocumentService:
         cut_length = 18
         cut_name = documents[0].name[:cut_length]
         dataset.name = cut_name + "..."
-        dataset.description = "useful for when you want to answer queries about the " + documents[0].name
+        dataset.description = I18nObject(
+            en_US="useful for when you want to answer queries about the " + documents[0].name,
+            zh_Hans="用于回答关于 " + documents[0].name + " 的查询",
+        )
         db.session.commit()
 
         return dataset, documents, batch

--- a/web/app/(commonLayout)/datasets/Container.tsx
+++ b/web/app/(commonLayout)/datasets/Container.tsx
@@ -38,6 +38,8 @@ const Container = () => {
   const { showExternalApiPanel, setShowExternalApiPanel } = useExternalApiPanel()
   const [includeAll, { toggle: toggleIncludeAll }] = useBoolean(false)
 
+  document.title = `${t('dataset.knowledge')} - Dify`
+
   const options = useMemo(() => {
     return [
       { value: 'dataset', text: t('dataset.datasets') },

--- a/web/app/(commonLayout)/datasets/page.tsx
+++ b/web/app/(commonLayout)/datasets/page.tsx
@@ -4,8 +4,4 @@ const AppList = async () => {
   return <Container />
 }
 
-export const metadata = {
-  title: 'Datasets - Dify',
-}
-
 export default AppList

--- a/web/app/(commonLayout)/plugins/page.tsx
+++ b/web/app/(commonLayout)/plugins/page.tsx
@@ -13,8 +13,4 @@ const PluginList = async () => {
   )
 }
 
-export const metadata = {
-  title: 'Plugins - Dify',
-}
-
 export default PluginList

--- a/web/app/components/base/app-icon-picker/ImageInput.tsx
+++ b/web/app/components/base/app-icon-picker/ImageInput.tsx
@@ -4,6 +4,7 @@ import type { ChangeEvent, FC } from 'react'
 import { createRef, useEffect, useState } from 'react'
 import Cropper, { type Area, type CropperProps } from 'react-easy-crop'
 import classNames from 'classnames'
+import { useTranslation } from 'react-i18next'
 
 import { ImagePlus } from '../icons/src/vender/line/images'
 import { useDraggableUploader } from './hooks'
@@ -26,6 +27,7 @@ const ImageInput: FC<UploaderProps> = ({
   cropShape,
   onImageInput,
 }) => {
+  const { t } = useTranslation()
   const [inputImage, setInputImage] = useState<{ file: File; url: string }>()
   const [isAnimatedImage, setIsAnimatedImage] = useState<boolean>(false)
   useEffect(() => {
@@ -103,8 +105,8 @@ const ImageInput: FC<UploaderProps> = ({
             ? <>
               <ImagePlus className="pointer-events-none mb-3 h-[30px] w-[30px]" />
               <div className="mb-[2px] text-sm font-medium">
-                <span className="pointer-events-none">Drop your image here, or&nbsp;</span>
-                <button className="text-components-button-primary-bg" onClick={() => inputRef.current?.click()}>browse</button>
+                <span className="pointer-events-none">{t('common.imageInput.dropImageHere')}&nbsp;</span>
+                <button className="text-components-button-primary-bg" onClick={() => inputRef.current?.click()}>{t('common.imageInput.browse')}</button>
                 <input
                   ref={inputRef} type="file" className="hidden"
                   onClick={e => ((e.target as HTMLInputElement).value = '')}
@@ -112,7 +114,7 @@ const ImageInput: FC<UploaderProps> = ({
                   onChange={handleLocalFileInput}
                 />
               </div>
-              <div className="pointer-events-none text-xs">Supports PNG, JPG, JPEG, WEBP and GIF</div>
+              <div className="pointer-events-none">{t('common.imageInput.supportedFormats')}</div>
             </>
             : handleShowImage()
         }

--- a/web/app/components/plugins/plugin-page/index.tsx
+++ b/web/app/components/plugins/plugin-page/index.tsx
@@ -56,6 +56,8 @@ const PluginPage = ({
   const searchParams = useSearchParams()
   const { replace } = useRouter()
 
+  document.title = `${t('plugin.metadata.title')} - Dify`
+
   // just support install one package now
   const packageId = useMemo(() => {
     const idStrings = searchParams.get(PACKAGE_IDS_KEY)

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -649,6 +649,11 @@ const translation = {
   pagination: {
     perPage: 'Items per page',
   },
+  imageInput: {
+    dropImageHere: 'Drop your image here, or',
+    browse: 'browse',
+    supportedFormats: 'Supports PNG, JPG, JPEG, WEBP and GIF',
+  },
 }
 
 export default translation

--- a/web/i18n/en-US/plugin.ts
+++ b/web/i18n/en-US/plugin.ts
@@ -1,4 +1,7 @@
 const translation = {
+  metadata: {
+    title: 'Plugins',
+  },
   category: {
     all: 'All',
     models: 'Models',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -649,6 +649,11 @@ const translation = {
   pagination: {
     perPage: '每页显示',
   },
+  imageInput: {
+    dropImageHere: '将图片拖放到此处，或',
+    browse: '浏览',
+    supportedFormats: '支持PNG、JPG、JPEG、WEBP和GIF格式',
+  },
 }
 
 export default translation

--- a/web/i18n/zh-Hans/plugin.ts
+++ b/web/i18n/zh-Hans/plugin.ts
@@ -1,4 +1,7 @@
 const translation = {
+  metadata: {
+    title: '插件',
+  },
   category: {
     all: '全部',
     models: '模型',


### PR DESCRIPTION
- Move hardcoded text from components and API to language configuration files
- Improve internationalization support for plugins, image inputs and dataset messages

# Summary

This PR addresses issue #16990 by moving hardcoded text from components and API code to language configuration files. The changes focus on three main areas:

1. Replaced hardcoded text in API code (such as default conversation names and dataset descriptions) with I18nObject instances that support multilingual content.
2. Moved hardcoded UI text from frontend components (like ImageInput prompts) to i18n configuration files.
3. Improved internationalization support for plugins, image inputs, and dataset-related messages.

These changes enhance the system's internationalization capabilities, making textual content more maintainable and extensible across different languages.

Fixes #16990 

# Screenshots

| Before | After |
|--------|-------|
| Hardcoded dataset description text "useful for when you want to answer queries about..." | Using I18nObject with multilingual dataset descriptions |
| Hardcoded image upload component prompt text ![image](https://github.com/user-attachments/assets/921300d9-c2ba-4bee-b91c-928bee4bf7f9) | Using i18n configured multilingual prompt text ![image](https://github.com/user-attachments/assets/e8fca54d-a256-41f5-8975-3af4f3cfee26) |
| Static page title "Plugins - Dify" ![image](https://github.com/user-attachments/assets/d49a74e0-48d4-4ba9-be12-1d3b70cecd13) | Dynamic i18n title using `${t('plugin.metadata.title')} - Dify` ![image](https://github.com/user-attachments/assets/4f98dbf2-725c-4001-a299-4e846a2cf4a8) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

