### PR TITLE
feat: add consistent keyboard shortcut support and visual indicators across all app creation dialogs

### DIFF
--- a/web/app/components/app/create-app-dialog/index.tsx
+++ b/web/app/components/app/create-app-dialog/index.tsx
@@ -1,4 +1,6 @@
 'use client'
+import { useCallback } from 'react'
+import { useKeyPress } from 'ahooks'
 import AppList from './app-list'
 import FullScreenModal from '@/app/components/base/fullscreen-modal'
 
@@ -10,6 +12,13 @@ type CreateAppDialogProps = {
 }
 
 const CreateAppTemplateDialog = ({ show, onSuccess, onClose, onCreateFromBlank }: CreateAppDialogProps) => {
+  const handleEscKeyPress = useCallback(() => {
+    if (show)
+      onClose()
+  }, [show, onClose])
+
+  useKeyPress('esc', handleEscKeyPress)
+
   return (
     <FullScreenModal
       open={show}

--- a/web/app/components/app/create-from-dsl-modal/index.tsx
+++ b/web/app/components/app/create-from-dsl-modal/index.tsx
@@ -5,7 +5,8 @@ import { useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useContext } from 'use-context-selector'
 import { useTranslation } from 'react-i18next'
-import { RiCloseLine } from '@remixicon/react'
+import { RiCloseLine, RiCommandLine, RiCornerDownLeftLine } from '@remixicon/react'
+import { useDebounceFn, useKeyPress } from 'ahooks'
 import Uploader from './uploader'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
@@ -142,6 +143,18 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
     isCreatingRef.current = false
   }
 
+  const { run: handleCreateApp } = useDebounceFn(onCreate, { wait: 300 })
+
+  useKeyPress(['meta.enter', 'ctrl.enter'], () => {
+    if (show && !isAppsFull && ((currentTab === CreateFromDSLModalTab.FROM_FILE && currentFile) || (currentTab === CreateFromDSLModalTab.FROM_URL && dslUrlValue)))
+      handleCreateApp()
+  })
+
+  useKeyPress('esc', () => {
+    if (show && !showErrorModal)
+      onClose()
+  })
+
   const onDSLConfirm: MouseEventHandler = async () => {
     try {
       if (!importId)
@@ -265,7 +278,18 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
         )}
         <div className='flex justify-end px-6 py-5'>
           <Button className='mr-2' onClick={onClose}>{t('app.newApp.Cancel')}</Button>
-          <Button disabled={buttonDisabled} variant="primary" onClick={onCreate}>{t('app.newApp.Create')}</Button>
+          <Button
+            disabled={buttonDisabled}
+            variant="primary"
+            onClick={handleCreateApp}
+            className="gap-1"
+          >
+            <span>{t('app.newApp.Create')}</span>
+            <div className='flex gap-0.5'>
+              <RiCommandLine size={14} className='system-kbd rounded-sm bg-components-kbd-bg-white p-0.5' />
+              <RiCornerDownLeftLine size={14} className='system-kbd rounded-sm bg-components-kbd-bg-white p-0.5' />
+            </div>
+          </Button>
         </div>
       </Modal>
       <Modal

--- a/web/app/components/explore/create-app-modal/index.tsx
+++ b/web/app/components/explore/create-app-modal/index.tsx
@@ -1,7 +1,8 @@
 'use client'
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { RiCloseLine } from '@remixicon/react'
+import { RiCloseLine, RiCommandLine, RiCornerDownLeftLine } from '@remixicon/react'
+import { useDebounceFn, useKeyPress } from 'ahooks'
 import AppIconPicker from '../../base/app-icon-picker'
 import Modal from '@/app/components/base/modal'
 import Button from '@/app/components/base/button'
@@ -65,7 +66,7 @@ const CreateAppModal = ({
   const { plan, enableBilling } = useProviderContext()
   const isAppsFull = (enableBilling && plan.usage.buildApps >= plan.total.buildApps)
 
-  const submit = () => {
+  const submit = useCallback(() => {
     if (!name.trim()) {
       Toast.notify({ type: 'error', message: t('explore.appCustomize.nameRequired') })
       return
@@ -79,7 +80,19 @@ const CreateAppModal = ({
       use_icon_as_answer_icon: useIconAsAnswerIcon,
     })
     onHide()
-  }
+  }, [name, appIcon, description, useIconAsAnswerIcon, onConfirm, onHide, t])
+
+  const { run: handleSubmit } = useDebounceFn(submit, { wait: 300 })
+
+  useKeyPress(['meta.enter', 'ctrl.enter'], () => {
+    if (show && !(!isEditModal && isAppsFull) && name.trim())
+      handleSubmit()
+  })
+
+  useKeyPress('esc', () => {
+    if (show)
+      onHide()
+  })
 
   return (
     <>
@@ -145,7 +158,18 @@ const CreateAppModal = ({
           {!isEditModal && isAppsFull && <AppsFull className='mt-4' loc='app-explore-create' />}
         </div>
         <div className='flex flex-row-reverse'>
-          <Button disabled={!isEditModal && isAppsFull} className='ml-2 w-24' variant='primary' onClick={submit}>{!isEditModal ? t('common.operation.create') : t('common.operation.save')}</Button>
+          <Button
+            disabled={(!isEditModal && isAppsFull) || !name.trim()}
+            className='ml-2 w-24 gap-1'
+            variant='primary'
+            onClick={handleSubmit}
+          >
+            <span>{!isEditModal ? t('common.operation.create') : t('common.operation.save')}</span>
+            <div className='flex gap-0.5'>
+              <RiCommandLine size={14} className='system-kbd rounded-sm bg-components-kbd-bg-white p-0.5' />
+              <RiCornerDownLeftLine size={14} className='system-kbd rounded-sm bg-components-kbd-bg-white p-0.5' />
+            </div>
+          </Button>
           <Button className='w-24' onClick={onHide}>{t('common.operation.cancel')}</Button>
         </div>
       </Modal>


### PR DESCRIPTION
# Summary
Resolves #17137
1. Support Cmd+Enter/Ctrl+Enter for confirming/creating actions
2. Display visual indicators for keyboard shortcuts next to action buttons
3. Support Escape key to close/cancel dialogs
4. Apply proper debouncing to prevent multiple submissions

# Screenshots

| Before | After |
|--------|-------|
| ![Image](https://github.com/user-attachments/assets/b250617b-cb73-4d46-8cba-380f1d475d76) | ![image](https://github.com/user-attachments/assets/02e9d0e4-795a-4e48-a4b1-87ee214a42b0) |
|![Image](https://github.com/user-attachments/assets/2d8f8eec-492d-49c3-b2c8-c7ab6165b4db) |![image](https://github.com/user-attachments/assets/fc76573c-8ed6-4dd5-9afb-b79ab165b86e)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

