### PR TITLE
fix: keywords field not persist in segements api

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1663,7 +1663,7 @@ class SegmentService:
                     content=content,
                     word_count=len(content),
                     tokens=tokens,
-                    keywords=segment_item.get('keywords', []),
+                    keywords=segment_item.get("keywords", []),
                     status="completed",
                     indexing_at=datetime.datetime.now(datetime.UTC).replace(tzinfo=None),
                     completed_at=datetime.datetime.now(datetime.UTC).replace(tzinfo=None),

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1663,6 +1663,7 @@ class SegmentService:
                     content=content,
                     word_count=len(content),
                     tokens=tokens,
+                    keywords=segment_item.get('keywords', []),
                     status="completed",
                     indexing_at=datetime.datetime.now(datetime.UTC).replace(tzinfo=None),
                     completed_at=datetime.datetime.now(datetime.UTC).replace(tzinfo=None),


### PR DESCRIPTION
# Summary

Call the interface
> v1/datasets/<dataset_id>/documents/<document_id>/segments

with the params `keywords`, but this field is not persisted.
![image](https://github.com/user-attachments/assets/72e35ee4-aea1-443b-8c1e-ffd9dcd0aa99)


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

