### PR TITLE
fix(fail-branch): prevent streaming output in exception branches

### DIFF
--- a/api/tests/unit_tests/core/workflow/nodes/test_continue_on_error.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_continue_on_error.py
@@ -1,14 +1,20 @@
+from unittest.mock import patch
+
 from core.app.entities.app_invoke_entities import InvokeFrom
+from core.workflow.entities.node_entities import NodeRunMetadataKey, NodeRunResult
 from core.workflow.enums import SystemVariableKey
 from core.workflow.graph_engine.entities.event import (
     GraphRunPartialSucceededEvent,
     NodeRunExceptionEvent,
+    NodeRunFailedEvent,
     NodeRunStreamChunkEvent,
 )
 from core.workflow.graph_engine.entities.graph import Graph
 from core.workflow.graph_engine.graph_engine import GraphEngine
+from core.workflow.nodes.event.event import RunCompletedEvent, RunStreamChunkEvent
+from core.workflow.nodes.llm.node import LLMNode
 from models.enums import UserFrom
-from models.workflow import WorkflowType
+from models.workflow import WorkflowNodeExecutionStatus, WorkflowType
 
 
 class ContinueOnErrorTestHelper:
@@ -489,11 +495,16 @@ def test_variable_pool_error_type_variable():
 def test_no_node_in_fail_branch_continue_on_error():
     """Test HTTP node with fail-branch error strategy"""
     graph_config = {
-        "edges": FAIL_BRANCH_EDGES[:-1],
+        "edges": FAIL_BRANCH_EDGES
+        + [{"id": "fail-source-answer-target", "source": "node", "target": "answer", "sourceHandle": "source"}],
         "nodes": [
             {"data": {"title": "Start", "type": "start", "variables": []}, "id": "start"},
             {
-                "data": {"title": "success", "type": "answer", "answer": "HTTP request successful"},
+                "data": {"title": "success", "type": "answer", "answer": "LLM request successful"},
+                "id": "success",
+            },
+            {
+                "data": {"title": "success", "type": "answer", "answer": "{{#node.query#}}"},
                 "id": "success",
             },
             ContinueOnErrorTestHelper.get_http_node(),
@@ -506,3 +517,47 @@ def test_no_node_in_fail_branch_continue_on_error():
     assert any(isinstance(e, NodeRunExceptionEvent) for e in events)
     assert any(isinstance(e, GraphRunPartialSucceededEvent) and e.outputs == {} for e in events)
     assert sum(1 for e in events if isinstance(e, NodeRunStreamChunkEvent)) == 0
+
+
+def test_stream_output_with_fail_branch_continue_on_error():
+    """Test stream output with fail-branch error strategy"""
+    graph_config = {
+        "edges": FAIL_BRANCH_EDGES,
+        "nodes": [
+            {"data": {"title": "Start", "type": "start", "variables": []}, "id": "start"},
+            {
+                "data": {"title": "success", "type": "answer", "answer": "LLM request successful"},
+                "id": "success",
+            },
+            {
+                "data": {"title": "error", "type": "answer", "answer": "{{#node.text#}}"},
+                "id": "error",
+            },
+            ContinueOnErrorTestHelper.get_llm_node(),
+        ],
+    }
+    graph_engine = ContinueOnErrorTestHelper.create_test_graph_engine(graph_config)
+
+    def llm_generator(self):
+        contents = ["hi", "bye", "good morning"]
+
+        yield RunStreamChunkEvent(chunk_content=contents[0], from_variable_selector=[self.node_id, "text"])
+
+        yield RunCompletedEvent(
+            run_result=NodeRunResult(
+                status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                inputs={},
+                process_data={},
+                outputs={},
+                metadata={
+                    NodeRunMetadataKey.TOTAL_TOKENS: 1,
+                    NodeRunMetadataKey.TOTAL_PRICE: 1,
+                    NodeRunMetadataKey.CURRENCY: "USD",
+                },
+            )
+        )
+
+    with patch.object(LLMNode, "_run", new=llm_generator):
+        events = list(graph_engine.run())
+        assert sum(isinstance(e, NodeRunStreamChunkEvent) for e in events) == 1
+        assert all(not isinstance(e, NodeRunFailedEvent | NodeRunExceptionEvent) for e in events)

--- a/api/tests/unit_tests/core/workflow/nodes/test_continue_on_error.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_continue_on_error.py
@@ -495,18 +495,10 @@ def test_variable_pool_error_type_variable():
 def test_no_node_in_fail_branch_continue_on_error():
     """Test HTTP node with fail-branch error strategy"""
     graph_config = {
-        "edges": FAIL_BRANCH_EDGES
-        + [{"id": "fail-source-answer-target", "source": "node", "target": "answer", "sourceHandle": "source"}],
+        "edges": FAIL_BRANCH_EDGES[:-1],
         "nodes": [
             {"data": {"title": "Start", "type": "start", "variables": []}, "id": "start"},
-            {
-                "data": {"title": "success", "type": "answer", "answer": "LLM request successful"},
-                "id": "success",
-            },
-            {
-                "data": {"title": "success", "type": "answer", "answer": "{{#node.query#}}"},
-                "id": "success",
-            },
+            {"data": {"title": "success", "type": "answer", "answer": "HTTP request successful"}, "id": "success"},
             ContinueOnErrorTestHelper.get_http_node(),
         ],
     }


### PR DESCRIPTION
# Summary

Prevent streaming output in exception branches.

# Screenshots

| Before | After |
|--------|-------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/e4449818-1d0d-4d2b-9cd5-f1bfc03ac0fb" />| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/530fcb27-fd41-4f8d-8952-9281ad056372" />   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

