### PR TITLE
feat: add support for specifying content-type with OSS across storage…

### DIFF
--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -75,7 +75,7 @@ class ToolFileManager:
             # Add extension flexibly
             present_filename = filename if has_extension else f"{filename}{extension}"
         filepath = f"tools/{tenant_id}/{unique_filename}"
-        storage.save(filepath, file_binary)
+        storage.save(filepath, file_binary, mimetype)
 
         tool_file = ToolFile(
             user_id=user_id,
@@ -113,7 +113,7 @@ class ToolFileManager:
         unique_name = uuid4().hex
         filename = f"{unique_name}{extension}"
         filepath = f"tools/{tenant_id}/{filename}"
-        storage.save(filepath, blob)
+        storage.save(filepath, blob, mimetype)
 
         tool_file = ToolFile(
             user_id=user_id,

--- a/api/extensions/ext_storage.py
+++ b/api/extensions/ext_storage.py
@@ -72,9 +72,9 @@ class Storage:
             case _:
                 raise ValueError(f"unsupported storage type {storage_type}")
 
-    def save(self, filename, data):
+    def save(self, filename, data, content_type=None):
         try:
-            self.storage_runner.save(filename, data)
+            self.storage_runner.save(filename, data, content_type)
         except Exception as e:
             logger.exception(f"Failed to save file {filename}")
             raise e

--- a/api/extensions/storage/aliyun_oss_storage.py
+++ b/api/extensions/storage/aliyun_oss_storage.py
@@ -28,8 +28,9 @@ class AliyunOssStorage(BaseStorage):
             region=region,
         )
 
-    def save(self, filename, data):
-        self.client.put_object(self.__wrapper_folder_filename(filename), data)
+    def save(self, filename, data, content_type=None):
+        headers = {"Content-Type": content_type} if content_type else None
+        self.client.put_object(self.__wrapper_folder_filename(filename), data, headers=headers)
 
     def load_once(self, filename: str) -> bytes:
         obj = self.client.get_object(self.__wrapper_folder_filename(filename))

--- a/api/extensions/storage/aws_s3_storage.py
+++ b/api/extensions/storage/aws_s3_storage.py
@@ -48,8 +48,9 @@ class AwsS3Storage(BaseStorage):
                 # other error, raise exception
                 raise
 
-    def save(self, filename, data):
-        self.client.put_object(Bucket=self.bucket_name, Key=filename, Body=data)
+    def save(self, filename, data, content_type=None):
+        content_type = content_type or "application/octet-stream"
+        self.client.put_object(Bucket=self.bucket_name, Key=filename, Body=data, ContentType=content_type)
 
     def load_once(self, filename: str) -> bytes:
         try:

--- a/api/extensions/storage/azure_blob_storage.py
+++ b/api/extensions/storage/azure_blob_storage.py
@@ -26,10 +26,11 @@ class AzureBlobStorage(BaseStorage):
         else:
             self.credential = None
 
-    def save(self, filename, data):
+    def save(self, filename, data, content_type=None):
+        metadata = {"Content-Type": content_type} if content_type else None
         client = self._sync_client()
         blob_container = client.get_container_client(container=self.bucket_name)
-        blob_container.upload_blob(filename, data)
+        blob_container.upload_blob(filename, data, metadata=metadata)
 
     def load_once(self, filename: str) -> bytes:
         client = self._sync_client()

--- a/api/extensions/storage/baidu_obs_storage.py
+++ b/api/extensions/storage/baidu_obs_storage.py
@@ -26,12 +26,17 @@ class BaiduObsStorage(BaseStorage):
 
         self.client = BosClient(config=client_config)
 
-    def save(self, filename, data):
+    def save(self, filename, data, content_type=None):
         md5 = hashlib.md5()
         md5.update(data)
         content_md5 = base64.standard_b64encode(md5.digest())
         self.client.put_object(
-            bucket_name=self.bucket_name, key=filename, data=data, content_length=len(data), content_md5=content_md5
+            bucket_name=self.bucket_name,
+            key=filename,
+            data=data,
+            content_length=len(data),
+            content_md5=content_md5,
+            content_type=content_type,
         )
 
     def load_once(self, filename: str) -> bytes:

--- a/api/extensions/storage/base_storage.py
+++ b/api/extensions/storage/base_storage.py
@@ -8,7 +8,7 @@ class BaseStorage(ABC):
     """Interface for file storage."""
 
     @abstractmethod
-    def save(self, filename, data):
+    def save(self, filename, data, content_type=None):
         raise NotImplementedError
 
     @abstractmethod

--- a/api/extensions/storage/google_cloud_storage.py
+++ b/api/extensions/storage/google_cloud_storage.py
@@ -26,11 +26,11 @@ class GoogleCloudStorage(BaseStorage):
         else:
             self.client = google_cloud_storage.Client()
 
-    def save(self, filename, data):
+    def save(self, filename, data, content_type=None):
         bucket = self.client.get_bucket(self.bucket_name)
         blob = bucket.blob(filename)
         with io.BytesIO(data) as stream:
-            blob.upload_from_file(stream)
+            blob.upload_from_file(stream, content_type=content_type)
 
     def load_once(self, filename: str) -> bytes:
         bucket = self.client.get_bucket(self.bucket_name)

--- a/api/extensions/storage/huawei_obs_storage.py
+++ b/api/extensions/storage/huawei_obs_storage.py
@@ -19,8 +19,9 @@ class HuaweiObsStorage(BaseStorage):
             server=dify_config.HUAWEI_OBS_SERVER,
         )
 
-    def save(self, filename, data):
-        self.client.putObject(bucketName=self.bucket_name, objectKey=filename, content=data)
+    def save(self, filename, data, content_type=None):
+        headers = {"contentType": content_type} if content_type else None
+        self.client.putObject(bucketName=self.bucket_name, objectKey=filename, content=data, headers=headers)
 
     def load_once(self, filename: str) -> bytes:
         data: bytes = self.client.getObject(bucketName=self.bucket_name, objectKey=filename)["body"].response.read()

--- a/api/extensions/storage/opendal_storage.py
+++ b/api/extensions/storage/opendal_storage.py
@@ -40,8 +40,9 @@ class OpenDALStorage(BaseStorage):
         self.op = self.op.layer(retry_layer)
         logger.debug("added retry layer to opendal operator")
 
-    def save(self, filename: str, data: bytes) -> None:
-        self.op.write(path=filename, bs=data)
+    def save(self, filename: str, data: bytes, content_type=None) -> None:
+        content_type = content_type or "application/octet-stream"
+        self.op.write(path=filename, bs=data, content_type=content_type)
         logger.debug(f"file {filename} saved")
 
     def load_once(self, filename: str) -> bytes:

--- a/api/extensions/storage/oracle_oci_storage.py
+++ b/api/extensions/storage/oracle_oci_storage.py
@@ -22,8 +22,9 @@ class OracleOCIStorage(BaseStorage):
             region_name=dify_config.OCI_REGION,
         )
 
-    def save(self, filename, data):
-        self.client.put_object(Bucket=self.bucket_name, Key=filename, Body=data)
+    def save(self, filename, data, content_type=None):
+        content_type = content_type or "application/octet-stream"
+        self.client.put_object(Bucket=self.bucket_name, Key=filename, Body=data, ContentType=content_type)
 
     def load_once(self, filename: str) -> bytes:
         try:

--- a/api/extensions/storage/supabase_storage.py
+++ b/api/extensions/storage/supabase_storage.py
@@ -28,8 +28,9 @@ class SupabaseStorage(BaseStorage):
         if not self.bucket_exists():
             self.client.storage.create_bucket(id=id, name=bucket_name)
 
-    def save(self, filename, data):
-        self.client.storage.from_(self.bucket_name).upload(filename, data)
+    def save(self, filename, data, content_type=None):
+        file_options = {"content-type": content_type} if content_type else None
+        self.client.storage.from_(self.bucket_name).upload(filename, data, file_options)
 
     def load_once(self, filename: str) -> bytes:
         content: bytes = self.client.storage.from_(self.bucket_name).download(filename)

--- a/api/extensions/storage/tencent_cos_storage.py
+++ b/api/extensions/storage/tencent_cos_storage.py
@@ -21,8 +21,9 @@ class TencentCosStorage(BaseStorage):
         )
         self.client = CosS3Client(config)
 
-    def save(self, filename, data):
-        self.client.put_object(Bucket=self.bucket_name, Body=data, Key=filename)
+    def save(self, filename, data, content_type=None):
+        metadata = {"ContentType": content_type or "application/octet-stream"}
+        self.client.put_object(Bucket=self.bucket_name, Body=data, Key=filename, Metadata=metadata)
 
     def load_once(self, filename: str) -> bytes:
         data: bytes = self.client.get_object(Bucket=self.bucket_name, Key=filename)["Body"].get_raw_stream().read()

--- a/api/extensions/storage/volcengine_tos_storage.py
+++ b/api/extensions/storage/volcengine_tos_storage.py
@@ -19,8 +19,8 @@ class VolcengineTosStorage(BaseStorage):
             region=dify_config.VOLCENGINE_TOS_REGION,
         )
 
-    def save(self, filename, data):
-        self.client.put_object(bucket=self.bucket_name, key=filename, content=data)
+    def save(self, filename, data, content_type=None):
+        self.client.put_object(bucket=self.bucket_name, key=filename, content=data, content_type=content_type)
 
     def load_once(self, filename: str) -> bytes:
         data = self.client.get_object(bucket=self.bucket_name, key=filename).read()

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -70,7 +70,7 @@ class FileService:
         file_key = "upload_files/" + (current_tenant_id or "") + "/" + file_uuid + "." + extension
 
         # save file to storage
-        storage.save(file_key, content)
+        storage.save(file_key, content, mimetype)
 
         # save file to db
         upload_file = UploadFile(
@@ -116,7 +116,7 @@ class FileService:
         file_key = "upload_files/" + current_user.current_tenant_id + "/" + file_uuid + ".txt"
 
         # save file to storage
-        storage.save(file_key, text.encode("utf-8"))
+        storage.save(file_key, text.encode("utf-8"), "text/plain")
 
         # save file to db
         upload_file = UploadFile(

--- a/api/tests/unit_tests/oss/__mock/volcengine_tos.py
+++ b/api/tests/unit_tests/oss/__mock/volcengine_tos.py
@@ -42,7 +42,7 @@ class MockVolcengineTosClass:
             }
         )
 
-    def put_object(self, bucket: str, key: str, content=None) -> PutObjectOutput:
+    def put_object(self, bucket: str, key: str, content=None, content_type=None) -> PutObjectOutput:
         assert bucket == self.bucket_name
         assert key == self.key
         assert content == self.content


### PR DESCRIPTION

# Summary

feat: add support for specifying content-type with OSS across storage providers

This feature will be useful for people who want to view files via the browser `http` or `https` protocol.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

