### PR TITLE
[Documentation] Update README under docker folder for middleware components.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,8 @@ Welcome to the new `docker` directory for deploying Dify using Docker Compose. T
     - Navigate to the `docker` directory.
     - Ensure the `middleware.env` file is created by running `cp middleware.env.example middleware.env` (refer to the `middleware.env.example` file).
 2. **Running Middleware Services**:
-    - Execute `docker-compose -f docker-compose.middleware.yaml up --env-file middleware.env -d` to start the middleware services.
+    - Navigate to the `docker` directory.
+    - Execute `docker compose -f docker-compose.middleware.yaml --profile weaviate -p dify up -d` to start the middleware services. (Change the profile to other vector database if you are not using weaviate)
 
 ### Migration for Existing Users
 


### PR DESCRIPTION
# Summary

This pull request includes an update to the `docker/README.md` file to improve the deployment instructions for Dify using Docker Compose. The most important change is the modification of the command to start the middleware services, adding a profile for Weaviate and providing flexibility for other vector databases.

Deployment instructions update:

* [`docker/README.md`](diffhunk://#diff-da8fcbe728a9172b578e5d754f8e2df214c658c4321f610e63dd68bea828ab49L39-R40): Modified the command to start middleware services to include the `--profile weaviate` option and provided guidance on changing the profile for other vector databases.



# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/fd4d3cc1-309e-4902-a699-c6f92d405d2d) | ![image](https://github.com/user-attachments/assets/68bf0623-f52a-4e8a-896b-b44b4bc97ac6)   |

# Checklist


- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

