### PR TITLE
Fix (api): Fix the processing logic of the retriever_resources field. 

### DIFF
--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -31,7 +31,10 @@ class MessageListApi(Resource):
         "feedback": fields.Nested(feedback_fields, attribute="user_feedback", allow_null=True),
         "retriever_resources": fields.List(
             fields.Nested(retriever_resource_fields),
-            attribute=lambda x: json.loads(x.message_metadata).get('retriever_resources',[]) if x.message_metadata else []
+            attribute=lambda x: (
+                json.loads(x.message_metadata).get('retriever_resources', [])
+                if x.message_metadata else []
+            ) if self._is_valid_json(x.message_metadata) else []
         ),
         "created_at": TimestampField,
         "agent_thoughts": fields.List(fields.Nested(agent_thought_fields)),

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 from flask_restful import Resource, fields, marshal_with, reqparse  # type: ignore
 from flask_restful.inputs import int_range  # type: ignore
@@ -28,7 +29,10 @@ class MessageListApi(Resource):
         "answer": fields.String(attribute="re_sign_file_url_answer"),
         "message_files": fields.List(fields.Nested(message_file_fields)),
         "feedback": fields.Nested(feedback_fields, attribute="user_feedback", allow_null=True),
-        "retriever_resources": fields.List(fields.Nested(retriever_resource_fields)),
+        "retriever_resources": fields.List(
+            fields.Nested(retriever_resource_fields),
+            attribute=lambda x: json.loads(x.message_metadata).get('retriever_resources',[]) if x.message_metadata else []
+        ),
         "created_at": TimestampField,
         "agent_thoughts": fields.List(fields.Nested(agent_thought_fields)),
         "status": fields.String,


### PR DESCRIPTION
# Summary

When querying historical message data using the messages interface, it is found that the return field retrieverResources is [] anyway. So I want to submit a PR to fix this problem.
fixes #14650

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/e4fec2b4-8c7b-4e68-b948-8c7d6cccba25) | ![image](https://github.com/user-attachments/assets/0c40afdb-d73f-4fa3-b528-efced05c4f72) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

