### PR TITLE
fix: sandbox can upload multiple files by upload

### DIFF
--- a/web/app/components/datasets/create/file-uploader/index.tsx
+++ b/web/app/components/datasets/create/file-uploader/index.tsx
@@ -204,10 +204,13 @@ const FileUploader = ({
     if (!e.dataTransfer)
       return
 
-    const files = [...e.dataTransfer.files] as File[]
+    let files = [...e.dataTransfer.files] as File[]
+    if (notSupportBatchUpload)
+      files = files.slice(0, 1)
+
     const validFiles = files.filter(isValid)
     initialUpload(validFiles)
-  }, [initialUpload, isValid])
+  }, [initialUpload, isValid, notSupportBatchUpload])
 
   const selectHandle = () => {
     if (fileUploader.current)


### PR DESCRIPTION
Input can upload multiple files via drag and drop, even if the multiple attribute is set.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

