### PR TITLE
Fix/dsl kb encrypt

### DIFF
--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -761,7 +761,7 @@ class AppDslService:
         return base64.b64encode(ct_bytes).decode()
 
     @classmethod
-    def decrypt_dataset_id(cls, encrypted_data: str, tenant_id: str) -> str:
+    def decrypt_dataset_id(cls, encrypted_data: str, tenant_id: str) -> str | None:
         """AES decryption"""
         try:
             key = cls._generate_aes_key(tenant_id)

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import logging
 import uuid
 from collections.abc import Mapping
@@ -5,11 +7,10 @@ from enum import StrEnum
 from typing import Optional
 from urllib.parse import urlparse
 from uuid import uuid4
-import hashlib
+
+import yaml  # type: ignore
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad, unpad
-import base64
-import yaml  # type: ignore
 from packaging import version
 from pydantic import BaseModel, Field
 from sqlalchemy import select

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -487,8 +487,9 @@ class AppDslService:
                 if node.get("data", {}).get("type", "") == NodeType.KNOWLEDGE_RETRIEVAL.value:
                     dataset_ids = node["data"].get("dataset_ids", [])
                     node["data"]["dataset_ids"] = [
-                        self.decrypt_dataset_id(encrypted_data=dataset_id, tenant_id=app.tenant_id)
+                        decrypted_id
                         for dataset_id in dataset_ids
+                        if (decrypted_id := self.decrypt_dataset_id(encrypted_data=dataset_id, tenant_id=app.tenant_id))
                     ]
             workflow_service.sync_draft_workflow(
                 app_model=app,
@@ -769,4 +770,4 @@ class AppDslService:
             pt = unpad(cipher.decrypt(base64.b64decode(encrypted_data)), AES.block_size)
             return pt.decode()
         except Exception:
-            return ""
+            return None


### PR DESCRIPTION
# Summary

In the DSL, the ID of the knowledge base is encrypted based on the tenant ID, and it can only be decrypted with the same tenant ID.
Fixes #16702 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

