### PR TITLE
fix: remove setPublishedAt on handleRestoreFromPublishedWorkflow

### DIFF
--- a/web/app/components/workflow/hooks/use-workflow-run.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run.ts
@@ -342,7 +342,6 @@ export const useWorkflowRun = () => {
     }
 
     featuresStore?.setState({ features: mappedFeatures })
-    workflowStore.getState().setPublishedAt(publishedWorkflow.created_at)
     workflowStore.getState().setEnvironmentVariables(publishedWorkflow.environment_variables || [])
   }, [featuresStore, handleUpdateWorkflowCanvas, workflowStore])
 


### PR DESCRIPTION
# Summary
Fixes #17267

1. the `handleRestoreFromPublishedWorkflow` function has been modified to completely remove the logic for setting `publishedAt`, ensuring that the published time is not changed when browsing the version history. 
2. the `publishedAt` value is only updated when an actual publish operation is performed, ensuring that the latest published time displayed is always correct.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

