### PR TITLE
fix: change `Switch.props.ref` to optional prop to align with `OriginalSwitch`

### DIFF
--- a/web/app/components/base/switch/index.tsx
+++ b/web/app/components/base/switch/index.tsx
@@ -20,7 +20,7 @@ const Switch = (
     disabled = false,
     className,
   }: SwitchProps & {
-    ref: React.RefObject<HTMLButtonElement>;
+    ref?: React.RefObject<HTMLButtonElement>;
   },
 ) => {
   const [enabled, setEnabled] = useState(defaultValue)


### PR DESCRIPTION
# Summary

Why?
=> Fix TypeScript error on files using `Switch` component

How?
=> fix: change `Switch.props.ref` to optional prop to align with `OriginalSwitch`

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|![螢幕擷取畫面 2025-04-04 105910](https://github.com/user-attachments/assets/34115243-96fc-41c8-883a-57210096b005)|![螢幕擷取畫面 2025-04-04 110251](https://github.com/user-attachments/assets/85aef674-fd82-4ba3-8ec4-169f166cd58b)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods