### PR TITLE
feat: support select-type variables in Metadata Filtering (#17440

### DIFF
--- a/web/app/components/app/configuration/dataset-config/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/index.tsx
@@ -270,7 +270,7 @@ const DatasetConfig: FC = () => {
           handleMetadataModelChange={handleMetadataModelChange}
           handleMetadataCompletionParamsChange={handleMetadataCompletionParamsChange}
           isCommonVariable
-          availableCommonStringVars={promptVariablesToSelect.filter(item => item.type === MetadataFilteringVariableType.string)}
+          availableCommonStringVars={promptVariablesToSelect.filter(item => item.type === MetadataFilteringVariableType.string || item.type === MetadataFilteringVariableType.select)}
           availableCommonNumberVars={promptVariablesToSelect.filter(item => item.type === MetadataFilteringVariableType.number)}
         />
       </div>

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-item.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-item.tsx
@@ -77,7 +77,9 @@ const ConditionItem = ({
 
   const valueAndValueMethod = useMemo(() => {
     if (
-      (currentMetadata?.type === MetadataFilteringVariableType.string || currentMetadata?.type === MetadataFilteringVariableType.number)
+      (currentMetadata?.type === MetadataFilteringVariableType.string
+       || currentMetadata?.type === MetadataFilteringVariableType.number
+       || currentMetadata?.type === MetadataFilteringVariableType.select)
       && typeof condition.value === 'string'
     ) {
       const regex = isCommonVariable ? COMMON_VARIABLE_REGEX : VARIABLE_REGEX
@@ -140,7 +142,9 @@ const ConditionItem = ({
         </div>
         <div className='border-t border-t-divider-subtle'>
           {
-            !comparisonOperatorNotRequireValue(condition.comparison_operator) && currentMetadata?.type === MetadataFilteringVariableType.string && (
+            !comparisonOperatorNotRequireValue(condition.comparison_operator)
+            && (currentMetadata?.type === MetadataFilteringVariableType.string
+             || currentMetadata?.type === MetadataFilteringVariableType.select) && (
               <ConditionString
                 valueMethod={localValueMethod}
                 onValueMethodChange={handleValueMethodChange}

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/utils.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/utils.ts
@@ -22,6 +22,7 @@ export const isComparisonOperatorNeedTranslate = (operator?: ComparisonOperator)
 export const getOperators = (type?: MetadataFilteringVariableType) => {
   switch (type) {
     case MetadataFilteringVariableType.string:
+    case MetadataFilteringVariableType.select:
       return [
         ComparisonOperator.is,
         ComparisonOperator.isNot,

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-icon.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-icon.tsx
@@ -18,7 +18,7 @@ const MetadataIcon = ({
   return (
     <>
       {
-        type === MetadataFilteringVariableType.string && (
+        (type === MetadataFilteringVariableType.string || type === MetadataFilteringVariableType.select) && (
           <RiTextSnippet className={cn('h-3.5 w-3.5', className)} />
         )
       }

--- a/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
@@ -80,6 +80,7 @@ export enum MetadataFilteringVariableType {
   string = 'string',
   number = 'number',
   time = 'time',
+  select = 'select',
 }
 
 export type MetadataFilteringCondition = {


### PR DESCRIPTION
# Summary

## Description

This PR adds support for select-type variables in the Metadata Filtering feature for knowledge retrieval. 
Previously, only string and number variables were supported, but select variables (dropdown options) 
were being filtered out despite being functionally equivalent to strings at runtime.

## Changes Made

- Added 'select' to MetadataFilteringVariableType enum
- Updated dataset-config component to include select variables in the string variable filter
- Modified utils.ts to apply string-type operators to select variables
- Updated condition-item.tsx to handle and render select variables as strings
- Added select variable support to the metadata icon component

## Testing Done

Tested the changes by:
- Creating an app with select-type variables
- Confirming select variables now appear in the metadata filtering dropdown
- Verifying that filtering with select variables works as expected in knowledge retrieval

fixes #17440


# Screenshots

## Before:

![430183974-216afe0f-c5fa-4608-870d-1add2184eaa1](https://github.com/user-attachments/assets/e35e97a2-baf9-42d0-889a-4c3a6e06be8b)

## After:

![image](https://github.com/user-attachments/assets/ce41b36d-80b8-4e76-9af8-2ce17122ce6c)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

