### PR TITLE
fix: skip file format check of mime types for generated files by tools

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -253,8 +253,6 @@ def _build_from_tool_file(
     extension = "." + tool_file.file_key.split(".")[-1] if "." in tool_file.file_key else ".bin"
 
     file_type = _standardize_file_type(extension=extension, mime_type=tool_file.mimetype)
-    if file_type.value != mapping.get("type", "custom"):
-        raise ValueError("Detected file type does not match the specified type. Please verify the file.")
 
     return File(
         id=mapping.get("id"),


### PR DESCRIPTION
# Summary

- to fix #17453
- bypass and skip format type check for generated files from tools, which is introduced in #16203

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| <img width="969" alt="Image" src="https://github.com/user-attachments/assets/4591e369-d728-403c-b0a4-6167edcdb659" />   | <img width="915" alt="image" src="https://github.com/user-attachments/assets/65fa7ed4-f348-408f-95ba-bbce04f2aacc" />   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

