### PR TITLE
refactor & perf: declare const object outside component `VarReferencePicker`

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
@@ -68,12 +68,14 @@ type Props = {
   zIndex?: number
 }
 
+const DEFAULT_VALUE_SELECTOR: Props['value'] = []
+
 const VarReferencePicker: FC<Props> = ({
   nodeId,
   readonly,
   className,
   isShowNodeName = true,
-  value = [],
+  value = DEFAULT_VALUE_SELECTOR,
   onOpen = noop,
   onChange,
   isSupportConstantValue,


### PR DESCRIPTION
# Summary

Why? To avoid recreating different object reference across re-renders

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods