### PR TITLE
fix: loop and interation node not showing tracing entry in chatflow

### DIFF
--- a/web/app/components/workflow/panel/debug-and-preview/hooks.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/hooks.ts
@@ -413,9 +413,6 @@ export const useChat = (
           }
         },
         onNodeStarted: ({ data }) => {
-          if (data.iteration_id || data.loop_id)
-            return
-
           responseItem.workflowProcess!.tracing!.push({
             ...data,
             status: NodeRunningStatus.Running,
@@ -428,9 +425,6 @@ export const useChat = (
           })
         },
         onNodeRetry: ({ data }) => {
-          if (data.iteration_id || data.loop_id)
-            return
-
           responseItem.workflowProcess!.tracing!.push(data)
 
           updateCurrentQAOnTree({
@@ -441,9 +435,6 @@ export const useChat = (
           })
         },
         onNodeFinished: ({ data }) => {
-          if (data.iteration_id || data.loop_id)
-            return
-
           const currentTracingIndex = responseItem.workflowProcess!.tracing!.findIndex(item => item.id === data.id)
           if (currentTracingIndex > -1) {
             responseItem.workflowProcess!.tracing[currentTracingIndex] = {


### PR DESCRIPTION
# Summary

Fix the tracing entry of loop and iteration node not show in a chatflow

fix #16968 
fix #16252


# Screenshots

| Before | After |
|--------|-------|
| ![Image](https://github.com/user-attachments/assets/9a7cf9ec-c139-45e0-9a06-229b13e8a7a3)  |  ![WX20250406-203413@2x](https://github.com/user-attachments/assets/67bc09ba-d405-43e5-87b2-9a00ba58ec08)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

