### PR TITLE
feat(plugin/endpoint): add supports for provider to register `array[tool]` type field

### DIFF
--- a/api/core/entities/provider_entities.py
+++ b/api/core/entities/provider_entities.py
@@ -146,6 +146,7 @@ class BasicProviderConfig(BaseModel):
         BOOLEAN = CommonParameterType.BOOLEAN.value
         APP_SELECTOR = CommonParameterType.APP_SELECTOR.value
         MODEL_SELECTOR = CommonParameterType.MODEL_SELECTOR.value
+        TOOLS_SELECTOR = CommonParameterType.TOOLS_SELECTOR.value
 
         @classmethod
         def value_of(cls, value: str) -> "ProviderConfig.Type":


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

For endpoint plugins like `hjlarry/mcp-server` need to export tools on Dify as a MCP server, so it requires the ability to register a setting field lets user to select which tool to be exported.

- close #17350 

# Screenshots

| Before | After |
|--------|-------|
| Cannot register array[tool] field | ![image](https://github.com/user-attachments/assets/f871a44a-e3c0-4041-84eb-13116e0c9368) ![image](https://github.com/user-attachments/assets/c26f83c4-08f5-4301-b8f8-66096cca22d9)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

