### PR TITLE
fix: only the owner can edit the member information

### DIFF
--- a/web/app/components/header/account-setting/members-page/index.tsx
+++ b/web/app/components/header/account-setting/members-page/index.tsx
@@ -132,7 +132,7 @@ const MembersPage = () => {
                   <div className='system-sm-regular flex w-[104px] shrink-0 items-center py-2 text-text-secondary'>{dayjs(Number((account.last_active_at || account.created_at)) * 1000).locale(locale === 'zh-Hans' ? 'zh-cn' : 'en').fromNow()}</div>
                   <div className='flex w-[96px] shrink-0 items-center'>
                     {
-                      ((isCurrentWorkspaceOwner && account.role !== 'owner') || (isCurrentWorkspaceManager && !['owner', 'admin'].includes(account.role)))
+                      isCurrentWorkspaceOwner && account.role !== 'owner'
                         ? <Operation member={account} operatorRole={currentWorkspace.role} onOperate={mutate} />
                         : <div className='system-sm-regular px-3 text-text-secondary'>{RoleMap[account.role] || RoleMap.normal}</div>
                     }


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #17394 
![image](https://github.com/user-attachments/assets/8bf057f2-7743-4676-a35e-40da021d46d2)
Back-end source code, only the OWNER has the permission for remove and update.
The Admin backend does not allow update and remove, so there should be no editable operations on the frontend.

# Screenshots

| Before | After |
|--------|-------|
| ![dd3cf8a14e1ff33cde97d97ed1c6e2d](https://github.com/user-attachments/assets/32a02c67-dec4-4988-851f-d1e850abb157)    | ![2caac84320c7623ed71325ba7b4dccf](https://github.com/user-attachments/assets/4f7cbc43-557c-4bd0-a320-3b0a91ecf34b)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

