### PR TITLE
fix: remove wrong padding-bottom=0

### DIFF
--- a/web/app/components/app/text-generate/item/index.tsx
+++ b/web/app/components/app/text-generate/item/index.tsx
@@ -218,7 +218,7 @@ const GenerationItem: FC<IGenerationItemProps> = ({
               {workflowProcessData && (
                 <>
                   <div className={cn(
-                    'p-3 pb-0',
+                    'p-3',
                     showResultTabs && 'border-b border-divider-subtle',
                   )}>
                     {taskId && (


### PR DESCRIPTION
# Summary
Fixes #17548

Setting the wrong `pb-0`, I think removing it the layout is fine.

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/c71eadfa-5c61-4d7a-a1cf-8149423b4fd5) | ![image](https://github.com/user-attachments/assets/bc3ac7da-35e1-429c-9f9e-6cfb323b7964)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

