### PR TITLE
fix: Sass @import warning

### DIFF
--- a/web/app/styles/markdown.scss
+++ b/web/app/styles/markdown.scss
@@ -1,7 +1,7 @@
-@import '../../themes/light';
-@import '../../themes/dark';
-@import '../../themes/markdown-light';
-@import '../../themes/markdown-dark';
+@use '../../themes/light';
+@use '../../themes/dark';
+@use '../../themes/markdown-light';
+@use '../../themes/markdown-dark';
 
 .markdown-body {
   -ms-text-size-adjust: 100%;


### PR DESCRIPTION
# Summary
Sass deprecating Sass [@import rules](https://sass-lang.com/documentation/breaking-changes/import/) and global built-in functions now that the module system (@use and @forward rules) has been available for several years.


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

