### PR TITLE
chore: bump pnpm to v10 in web dockerfile

### DIFF
--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-npm add -g pnpm@9.12.2
+npm add -g pnpm@10.8.0
 cd web && pnpm install
 pipx install poetry
 

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -31,7 +31,9 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: web/**
+
       - name: Install pnpm
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 10

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="takatost@gmail.com"
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 
 RUN apk add --no-cache tzdata
-RUN npm install -g pnpm@9.12.2
+RUN npm install -g pnpm@10.8.0
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/web/README.md
+++ b/web/README.md
@@ -6,7 +6,9 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ### Run by source code
 
-To start the web frontend service, you will need [Node.js v18.x (LTS)](https://nodejs.org/en) and [pnpm version 9.12.2](https://pnpm.io).
+Before starting the web frontend service, please make sure the following environment is ready.
+- [Node.js v18.x (LTS)](https://nodejs.org)
+- [pnpm v10.x](https://pnpm.io)
 
 First, install the dependencies:
 

--- a/web/README.md
+++ b/web/README.md
@@ -7,8 +7,8 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 ### Run by source code
 
 Before starting the web frontend service, please make sure the following environment is ready.
-- [Node.js v18.x (LTS)](https://nodejs.org)
-- [pnpm v10.x](https://pnpm.io)
+- [Node.js](https://nodejs.org) >= v18.x
+- [pnpm](https://pnpm.io) v10.x
 
 First, install the dependencies:
 


### PR DESCRIPTION
# Summary

- to close #17610
- pnpm 10 is released in Jan 2025, with better performance in re-installation and compatible with current lockfile
   - v10.0 https://github.com/pnpm/pnpm/releases/tag/v10.0.0
   - v10.8 https://github.com/pnpm/pnpm/releases/tag/v10.8.0
- pnpm 10 has been already used in web tests
- Bump pnpm to v10 in web/dockerfile

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

