### PR TITLE
fix(transport): add missing verify parameter to httpx.HTTPTransport

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -56,8 +56,14 @@ def make_request(method, url, max_retries=SSRF_DEFAULT_MAX_RETRIES, **kwargs):
                     response = client.request(method=method, url=url, **kwargs)
             elif dify_config.SSRF_PROXY_HTTP_URL and dify_config.SSRF_PROXY_HTTPS_URL:
                 proxy_mounts = {
-                    "http://": httpx.HTTPTransport(proxy=dify_config.SSRF_PROXY_HTTP_URL),
-                    "https://": httpx.HTTPTransport(proxy=dify_config.SSRF_PROXY_HTTPS_URL),
+                    "http://": httpx.HTTPTransport(
+                        proxy=dify_config.SSRF_PROXY_HTTP_URL,
+                        verify=HTTP_REQUEST_NODE_SSL_VERIFY
+                    ),
+                    "https://": httpx.HTTPTransport(
+                        proxy=dify_config.SSRF_PROXY_HTTPS_URL,
+                        verify=HTTP_REQUEST_NODE_SSL_VERIFY
+                    ),
                 }
                 with httpx.Client(mounts=proxy_mounts, verify=HTTP_REQUEST_NODE_SSL_VERIFY) as client:
                     response = client.request(method=method, url=url, **kwargs)

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -57,12 +57,10 @@ def make_request(method, url, max_retries=SSRF_DEFAULT_MAX_RETRIES, **kwargs):
             elif dify_config.SSRF_PROXY_HTTP_URL and dify_config.SSRF_PROXY_HTTPS_URL:
                 proxy_mounts = {
                     "http://": httpx.HTTPTransport(
-                        proxy=dify_config.SSRF_PROXY_HTTP_URL,
-                        verify=HTTP_REQUEST_NODE_SSL_VERIFY
+                        proxy=dify_config.SSRF_PROXY_HTTP_URL, verify=HTTP_REQUEST_NODE_SSL_VERIFY
                     ),
                     "https://": httpx.HTTPTransport(
-                        proxy=dify_config.SSRF_PROXY_HTTPS_URL,
-                        verify=HTTP_REQUEST_NODE_SSL_VERIFY
+                        proxy=dify_config.SSRF_PROXY_HTTPS_URL, verify=HTTP_REQUEST_NODE_SSL_VERIFY
                     ),
                 }
                 with httpx.Client(mounts=proxy_mounts, verify=HTTP_REQUEST_NODE_SSL_VERIFY) as client:


### PR DESCRIPTION
fix https://github.com/langgenius/dify/issues/16268
# Summary
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

​**​Affected Scope​**​:  
- External tool integration via Swagger API imports  
- HTTPS client configuration in SSRF proxy module  

​**​Root Cause Analysis​**​:  
1. Global `verify=False` setting wasn't propagated to HTTPTransport initialization  
2. SSL verification was hardcoded to True in transport layer (observed in error logs: `CERTIFICATE_VERIFY_FAILED`)[16](@ref)  

​**​Solution Implementation​**​:  
```python
# Before
httpx.HTTPTransport(proxy=config.PROXY_URL)

# After 
httpx.HTTPTransport(
    proxy=config.PROXY_URL,
    verify=HTTP_REQUEST_NODE_SSL_VERIFY  # Added parameter
)
```


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/7cbe70e5-7f63-486b-87b7-b061da6bc69e)   | ![image](https://github.com/user-attachments/assets/d9fc9a40-971d-4792-ad96-dba57fecd849)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

