### PR TITLE
Fixed the model-modal titles not being clearly distinguished between "Add" and "Setup"

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -270,8 +270,8 @@ const ModelModal: FC<ModelModalProps> = ({
   }
 
   const renderTitlePrefix = () => {
-    const prefix = configurateMethod === ConfigurationMethodEnum.customizableModel ? t('common.operation.add') : t('common.operation.setup')
-
+    const prefix = isEditMode ? t('common.operation.setup') : t('common.operation.add')
+    
     return `${prefix} ${provider.label[language] || provider.label.en_US}`
   }
 

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -271,7 +271,6 @@ const ModelModal: FC<ModelModalProps> = ({
 
   const renderTitlePrefix = () => {
     const prefix = isEditMode ? t('common.operation.setup') : t('common.operation.add')
-    
     return `${prefix} ${provider.label[language] || provider.label.en_US}`
   }
 


### PR DESCRIPTION
### fixed the model-modal titles not being clearly distinguished between "Add" and "Setup"

**link for the issue**👉Fix https://github.com/langgenius/dify/issues/17632

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

Before
![image](https://github.com/user-attachments/assets/89e4cb5c-0a01-4f6a-a708-4ef9b7997919)

After
![image](https://github.com/user-attachments/assets/df29354a-a1b6-4a5f-b3eb-a4195f229195)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

