### PR TITLE
chore: add `'no-empty-function': 'error'` to `eslint.config.mjs`

### DIFF
--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -25,6 +25,7 @@ import { useSelectedDatasetsMode } from '@/app/components/workflow/nodes/knowled
 import Switch from '@/app/components/base/switch'
 import Toast from '@/app/components/base/toast'
 import Divider from '@/app/components/base/divider'
+import { noop } from 'lodash-es'
 
 type Props = {
   datasetConfigs: DatasetConfigs
@@ -41,8 +42,8 @@ const ConfigContent: FC<Props> = ({
   onChange,
   isInWorkflow,
   singleRetrievalModelConfig: singleRetrievalConfig = {} as ModelConfig,
-  onSingleRetrievalModelChange = () => { },
-  onSingleRetrievalModelParamsChange = () => { },
+  onSingleRetrievalModelChange = noop,
+  onSingleRetrievalModelParamsChange = noop,
   selectedDatasets = [],
 }) => {
   const { t } = useTranslation()

--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -197,9 +197,6 @@ const Configuration: FC = () => {
   const isOpenAI = modelConfig.provider === 'langgenius/openai/openai'
 
   const [collectionList, setCollectionList] = useState<Collection[]>([])
-  useEffect(() => {
-
-  }, [])
   const [datasetConfigs, doSetDatasetConfigs] = useState<DatasetConfigs>({
     retrieval_model: RETRIEVE_TYPE.multiWay,
     reranking_model: {

--- a/web/app/components/base/audio-btn/audio.player.manager.ts
+++ b/web/app/components/base/audio-btn/audio.player.manager.ts
@@ -12,9 +12,6 @@ export class AudioPlayerManager {
   private audioPlayers: AudioPlayer | null = null
   private msgId: string | undefined
 
-  private constructor() {
-  }
-
   public static getInstance(): AudioPlayerManager {
     if (!AudioPlayerManager.instance) {
       AudioPlayerManager.instance = new AudioPlayerManager()
@@ -24,7 +21,7 @@ export class AudioPlayerManager {
     return AudioPlayerManager.instance
   }
 
-  public getAudioPlayer(url: string, isPublic: boolean, id: string | undefined, msgContent: string | null | undefined, voice: string | undefined, callback: ((event: string) => {}) | null): AudioPlayer {
+  public getAudioPlayer(url: string, isPublic: boolean, id: string | undefined, msgContent: string | null | undefined, voice: string | undefined, callback: ((event: string) => void) | null): AudioPlayer {
     if (this.msgId && this.msgId === id && this.audioPlayers) {
       this.audioPlayers.setCallback(callback)
       return this.audioPlayers

--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -21,9 +21,9 @@ export default class AudioPlayer {
   isLoadData = false
   url: string
   isPublic: boolean
-  callback: ((event: string) => {}) | null
+  callback: ((event: string) => void) | null
 
-  constructor(streamUrl: string, isPublic: boolean, msgId: string | undefined, msgContent: string | null | undefined, voice: string | undefined, callback: ((event: string) => {}) | null) {
+  constructor(streamUrl: string, isPublic: boolean, msgId: string | undefined, msgContent: string | null | undefined, voice: string | undefined, callback: ((event: string) => void) | null) {
     this.audioContext = new AudioContext()
     this.msgId = msgId
     this.msgContent = msgContent
@@ -68,7 +68,7 @@ export default class AudioPlayer {
     })
   }
 
-  public setCallback(callback: ((event: string) => {}) | null) {
+  public setCallback(callback: ((event: string) => void) | null) {
     this.callback = callback
     if (callback) {
       this.audio.addEventListener('ended', () => {
@@ -209,10 +209,6 @@ export default class AudioPlayer {
     this.callback && this.callback('paused')
     this.audio.pause()
     this.audioContext.suspend()
-  }
-
-  private cancer() {
-
   }
 
   private receiveAudioData(unit8Array: Uint8Array) {

--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -34,6 +34,7 @@ import {
   getProcessedFiles,
   getProcessedFilesFromResponse,
 } from '@/app/components/base/file-uploader/utils'
+import { noop } from 'lodash-es'
 
 type GetAbortController = (abortController: AbortController) => void
 type SendCallback = {
@@ -308,7 +309,7 @@ export const useChat = (
       else
         ttsUrl = `/apps/${params.appId}/text-to-audio`
     }
-    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', (_: any): any => { })
+    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', noop)
     ssePost(
       url,
       {

--- a/web/app/components/base/pagination/pagination.tsx
+++ b/web/app/components/base/pagination/pagination.tsx
@@ -7,10 +7,11 @@ import type {
   IPaginationProps,
   PageButtonProps,
 } from './type'
+import { noop } from 'lodash-es'
 
 const defaultState: IPagination = {
   currentPage: 0,
-  setCurrentPage: () => {},
+  setCurrentPage: noop,
   truncableText: '...',
   truncableClassName: '',
   pages: [],

--- a/web/app/components/datasets/create/step-two/index.tsx
+++ b/web/app/components/datasets/create/step-two/index.tsx
@@ -62,6 +62,7 @@ import Tooltip from '@/app/components/base/tooltip'
 import CustomDialog from '@/app/components/base/dialog'
 import { PortalToFollowElem, PortalToFollowElemContent, PortalToFollowElemTrigger } from '@/app/components/base/portal-to-follow-elem'
 import { AlertTriangle } from '@/app/components/base/icons/src/vender/solid/alertsAndFeedback'
+import { noop } from 'lodash-es'
 
 const TextLabel: FC<PropsWithChildren> = (props) => {
   return <label className='system-sm-semibold text-text-secondary'>{props.children}</label>
@@ -1010,7 +1011,7 @@ const StepTwo = ({
             </div>
           )}
       </div>
-      <FloatRightContainer isMobile={isMobile} isOpen={true} onClose={() => { }} footer={null}>
+      <FloatRightContainer isMobile={isMobile} isOpen={true} onClose={noop} footer={null}>
         <PreviewContainer
           header={<PreviewHeader
             title={t('datasetCreation.stepTwo.preview')}

--- a/web/app/components/datasets/documents/list.tsx
+++ b/web/app/components/datasets/documents/list.tsx
@@ -46,6 +46,7 @@ import { useDocumentArchive, useDocumentDelete, useDocumentDisable, useDocumentE
 import { extensionToFileType } from '@/app/components/datasets/hit-testing/utils/extension-to-file-type'
 import useBatchEditDocumentMetadata from '../metadata/hooks/use-batch-edit-document-metadata'
 import EditMetadataBatchModal from '@/app/components/datasets/metadata/edit-metadata-batch/modal'
+import { noop } from 'lodash-es'
 
 export const useIndexStatus = () => {
   const { t } = useTranslation()
@@ -265,7 +266,7 @@ export const OperationAction: FC<{
 
   return <div className='flex items-center' onClick={e => e.stopPropagation()}>
     {isListScene && !embeddingAvailable && (
-      <Switch defaultValue={false} onChange={() => { }} disabled={true} size='md' />
+      <Switch defaultValue={false} onChange={noop} disabled={true} size='md' />
     )}
     {isListScene && embeddingAvailable && (
       <>
@@ -276,7 +277,7 @@ export const OperationAction: FC<{
             needsDelay
           >
             <div>
-              <Switch defaultValue={false} onChange={() => { }} disabled={true} size='md' />
+              <Switch defaultValue={false} onChange={noop} disabled={true} size='md' />
             </div>
           </Tooltip>
           : <Switch defaultValue={enabled} onChange={v => handleSwitch(v ? 'enable' : 'disable')} size='md' />

--- a/web/app/components/explore/create-app-modal/index.tsx
+++ b/web/app/components/explore/create-app-modal/index.tsx
@@ -13,6 +13,7 @@ import AppIcon from '@/app/components/base/app-icon'
 import { useProviderContext } from '@/context/provider-context'
 import AppsFull from '@/app/components/billing/apps-full-in-dialog'
 import type { AppIconType } from '@/types/app'
+import { noop } from 'lodash-es'
 
 export type CreateAppModalProps = {
   show: boolean
@@ -85,7 +86,7 @@ const CreateAppModal = ({
     <>
       <Modal
         isShow={show}
-        onClose={() => {}}
+        onClose={noop}
         className='relative !max-w-[480px] px-8'
       >
         <div className='absolute right-4 top-4 cursor-pointer p-2' onClick={onHide}>

--- a/web/app/components/header/account-setting/data-source-page/panel/config-item.tsx
+++ b/web/app/components/header/account-setting/data-source-page/panel/config-item.tsx
@@ -10,6 +10,7 @@ import Operate from '../data-source-notion/operate'
 import { DataSourceType } from './types'
 import s from './style.module.css'
 import cn from '@/utils/classnames'
+import { noop } from 'lodash-es'
 
 export type ConfigItemType = {
   id: string
@@ -41,7 +42,7 @@ const ConfigItem: FC<Props> = ({
   const { t } = useTranslation()
   const isNotion = type === DataSourceType.notion
   const isWebsite = type === DataSourceType.website
-  const onChangeAuthorizedPage = notionActions?.onChangeAuthorizedPage || function () { }
+  const onChangeAuthorizedPage = notionActions?.onChangeAuthorizedPage || noop
 
   return (
     <div className={cn(s['workspace-item'], 'mb-1 flex items-center rounded-lg bg-components-panel-on-panel-item-bg py-1 pr-1')} key={payload.id}>

--- a/web/app/components/workflow/block-selector/market-place-plugin/list.tsx
+++ b/web/app/components/workflow/block-selector/market-place-plugin/list.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link'
 import { marketplaceUrlPrefix } from '@/config'
 import { RiArrowRightUpLine, RiSearchLine } from '@remixicon/react'
 // import { RiArrowRightUpLine } from '@remixicon/react'
+import { noop } from 'lodash-es'
 
 type Props = {
   wrapElemRef: React.RefObject<HTMLElement>
@@ -107,7 +108,7 @@ const List = (
           <Item
             key={index}
             payload={item}
-            onAction={() => { }}
+            onAction={noop}
           />
         ))}
         <div className='mb-3 mt-2 flex items-center justify-center space-x-2'>

--- a/web/app/components/workflow/hooks/use-workflow-run.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run.ts
@@ -18,6 +18,7 @@ import { stopWorkflowRun } from '@/service/workflow'
 import { useFeaturesStore } from '@/app/components/base/features/hooks'
 import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import type { VersionHistory } from '@/types/workflow'
+import { noop } from 'lodash-es'
 
 export const useWorkflowRun = () => {
   const store = useStoreApi()
@@ -168,7 +169,7 @@ export const useWorkflowRun = () => {
       else
         ttsUrl = `/apps/${params.appId}/text-to-audio`
     }
-    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', (_: any): any => { })
+    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', noop)
 
     ssePost(
       url,

--- a/web/app/components/workflow/nodes/_base/hooks/use-one-step-run.ts
+++ b/web/app/components/workflow/nodes/_base/hooks/use-one-step-run.ts
@@ -30,7 +30,7 @@ import IterationDefault from '@/app/components/workflow/nodes/iteration/default'
 import DocumentExtractorDefault from '@/app/components/workflow/nodes/document-extractor/default'
 import LoopDefault from '@/app/components/workflow/nodes/loop/default'
 import { ssePost } from '@/service/base'
-
+import { noop } from 'lodash-es'
 import { getInputVars as doGetInputVars } from '@/app/components/base/prompt-editor/constants'
 import type { NodeTracing } from '@/types/workflow'
 const { checkValid: checkLLMValid } = LLMDefault
@@ -233,8 +233,7 @@ const useOneStepRun = <T>({
           getIterationSingleNodeRunUrl(isChatMode, appId!, id),
           { body: { inputs: submitData } },
           {
-            onWorkflowStarted: () => {
-            },
+            onWorkflowStarted: noop,
             onWorkflowFinished: (params) => {
               handleNodeDataUpdate({
                 id,
@@ -331,8 +330,7 @@ const useOneStepRun = <T>({
           getLoopSingleNodeRunUrl(isChatMode, appId!, id),
           { body: { inputs: submitData } },
           {
-            onWorkflowStarted: () => {
-            },
+            onWorkflowStarted: noop,
             onWorkflowFinished: (params) => {
               handleNodeDataUpdate({
                 id,

--- a/web/app/components/workflow/run/utils/format-log/agent/data.ts
+++ b/web/app/components/workflow/run/utils/format-log/agent/data.ts
@@ -177,6 +177,3 @@ export const multiStepsCircle = (() => {
     }],
   }
 })()
-
-export const CircleNestCircle = (() => {
-})()

--- a/web/context/i18n.ts
+++ b/web/context/i18n.ts
@@ -4,6 +4,7 @@ import {
 } from 'use-context-selector'
 import type { Locale } from '@/i18n'
 import { getLanguage } from '@/i18n/language'
+import { noop } from 'lodash-es'
 
 type II18NContext = {
   locale: Locale
@@ -14,7 +15,7 @@ type II18NContext = {
 const I18NContext = createContext<II18NContext>({
   locale: 'en-US',
   i18n: {},
-  setLocaleOnClient: (_lang: Locale, _reloadPage?: boolean) => { },
+  setLocaleOnClient: noop,
 })
 
 export const useI18N = () => useContext(I18NContext)

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -117,6 +117,9 @@ export default combine(
       // antfu migrate to eslint-plugin-unused-imports
       'unused-imports/no-unused-vars': 'warn',
       'unused-imports/no-unused-imports': 'warn',
+
+      // We use `import { noop } from 'lodash-es'` across `web` project
+      'no-empty-function': 'error',
     },
 
     languageOptions: {


### PR DESCRIPTION
# Summary

- refactor & perf: change empty function to `noop` from `lodash-es` across `web` project
- chore: add `'no-empty-function': 'error'` to `eslint.config.mjs`

# Related PR and Comment

- https://github.com/langgenius/dify/pull/17444#issuecomment-2781830040
- https://github.com/langgenius/dify/pull/17439

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

# P.S.

Some files contained typescript errors before this PR, perhaps I can fix these in future PRs.
<img width="1600" alt="Some files contained typescript errors before this PR" src="https://github.com/user-attachments/assets/8f6f7910-06f6-4799-8ad6-fdfbaf0dc8ff" />

