### PR TITLE
refactor: add API endpoint to list latest plugin versions and query it in asynchronous way

### DIFF
--- a/api/controllers/console/workspace/plugin.py
+++ b/api/controllers/console/workspace/plugin.py
@@ -49,6 +49,23 @@ class PluginListApi(Resource):
         return jsonable_encoder({"plugins": plugins})
 
 
+class PluginListLatestVersionsApi(Resource):
+    @setup_required
+    @login_required
+    @account_initialization_required
+    def post(self):
+        req = reqparse.RequestParser()
+        req.add_argument("plugin_ids", type=list, required=True, location="json")
+        args = req.parse_args()
+
+        try:
+            versions = PluginService.list_latest_versions(args["plugin_ids"])
+        except PluginDaemonClientSideError as e:
+            raise ValueError(e)
+
+        return jsonable_encoder({"versions": versions})
+
+
 class PluginListInstallationsFromIdsApi(Resource):
     @setup_required
     @login_required
@@ -453,6 +470,7 @@ class PluginFetchPermissionApi(Resource):
 
 api.add_resource(PluginDebuggingKeyApi, "/workspaces/current/plugin/debugging-key")
 api.add_resource(PluginListApi, "/workspaces/current/plugin/list")
+api.add_resource(PluginListLatestVersionsApi, "/workspaces/current/plugin/list/latest-versions")
 api.add_resource(PluginListInstallationsFromIdsApi, "/workspaces/current/plugin/list/installations/ids")
 api.add_resource(PluginIconApi, "/workspaces/current/plugin/icon")
 api.add_resource(PluginUploadFromPkgApi, "/workspaces/current/plugin/upload/pkg")

--- a/api/core/plugin/entities/plugin.py
+++ b/api/core/plugin/entities/plugin.py
@@ -120,8 +120,6 @@ class PluginEntity(PluginInstallation):
     name: str
     installation_id: str
     version: str
-    latest_version: Optional[str] = None
-    latest_unique_identifier: Optional[str] = None
 
     @model_validator(mode="after")
     def set_plugin_id(self):

--- a/api/services/plugin/plugin_service.py
+++ b/api/services/plugin/plugin_service.py
@@ -95,28 +95,19 @@ class PluginService:
         return manager.get_debugging_key(tenant_id)
 
     @staticmethod
+    def list_latest_versions(plugin_ids: Sequence[str]) -> Mapping[str, Optional[LatestPluginCache]]:
+        """
+        List the latest versions of the plugins
+        """
+        return PluginService.fetch_latest_plugin_version(plugin_ids)
+
+    @staticmethod
     def list(tenant_id: str) -> list[PluginEntity]:
         """
         list all plugins of the tenant
         """
         manager = PluginInstallationManager()
         plugins = manager.list_plugins(tenant_id)
-        plugin_ids = [plugin.plugin_id for plugin in plugins if plugin.source == PluginInstallationSource.Marketplace]
-        try:
-            manifests = PluginService.fetch_latest_plugin_version(plugin_ids)
-        except Exception:
-            manifests = {}
-            logger.exception("failed to fetch plugin manifests")
-
-        for plugin in plugins:
-            if plugin.source == PluginInstallationSource.Marketplace:
-                if plugin.plugin_id in manifests:
-                    latest_plugin_cache = manifests[plugin.plugin_id]
-                    if latest_plugin_cache:
-                        # set latest_version
-                        plugin.latest_version = latest_plugin_cache.version
-                        plugin.latest_unique_identifier = latest_plugin_cache.unique_identifier
-
         return plugins
 
     @staticmethod

--- a/web/app/components/plugins/types.ts
+++ b/web/app/components/plugins/types.ts
@@ -318,6 +318,15 @@ export type InstalledPluginListResponse = {
   plugins: PluginDetail[]
 }
 
+export type InstalledLatestVersionResponse = {
+  versions: {
+    [plugin_id: string]: {
+      unique_identifier: string
+      version: string
+    } | null
+  }
+}
+
 export type UninstallPluginResponse = {
   success: boolean
 }

--- a/web/service/use-plugins.ts
+++ b/web/service/use-plugins.ts
@@ -9,6 +9,7 @@ import type {
   Dependency,
   GitHubItemAndMarketPlaceDependency,
   InstallPackageResponse,
+  InstalledLatestVersionResponse,
   InstalledPluginListResponse,
   PackageDependency,
   Permissions,
@@ -69,6 +70,19 @@ export const useInstalledPluginList = (disable?: boolean) => {
     queryFn: () => get<InstalledPluginListResponse>('/workspaces/current/plugin/list'),
     enabled: !disable,
     initialData: !disable ? undefined : { plugins: [] },
+  })
+}
+
+export const useInstalledLatestVersion = (pluginIds: string[]) => {
+  return useQuery<InstalledLatestVersionResponse>({
+    queryKey: [NAME_SPACE, 'installedLatestVersion', pluginIds],
+    queryFn: () => post<InstalledLatestVersionResponse>('/workspaces/current/plugin/list/latest-versions', {
+      body: {
+        plugin_ids: pluginIds,
+      },
+    }),
+    enabled: !!pluginIds.length,
+    initialData: pluginIds.length ? undefined : { versions: {} },
   })
 }
 


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

