### PR TITLE
fix: 17712-get-messages-api-encountered-internal-server-error

### DIFF
--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -20,14 +20,6 @@ from services.message_service import MessageService
 
 
 class MessageListApi(Resource):
-    def get_retriever_resources(self):
-        try:
-            if self.message_metadata:
-                return json.loads(self.message_metadata).get("retriever_resources", [])
-            return []
-        except (json.JSONDecodeError, TypeError):
-            return []
-
     message_fields = {
         "id": fields.String,
         "conversation_id": fields.String,
@@ -37,7 +29,11 @@ class MessageListApi(Resource):
         "answer": fields.String(attribute="re_sign_file_url_answer"),
         "message_files": fields.List(fields.Nested(message_file_fields)),
         "feedback": fields.Nested(feedback_fields, attribute="user_feedback", allow_null=True),
-        "retriever_resources": get_retriever_resources,
+        "retriever_resources": fields.Raw(
+            attribute=lambda obj: json.loads(obj.message_metadata).get("retriever_resources", [])
+            if obj.message_metadata
+            else []
+        ),
         "created_at": TimestampField,
         "agent_thoughts": fields.List(fields.Nested(agent_thought_fields)),
         "status": fields.String,


### PR DESCRIPTION
# Summary

```
"retriever_resources": fields.Raw(
            attribute=lambda obj: json.loads(obj.message_metadata).get("retriever_resources", [])
            if obj.message_metadata
            else []
 ),
```

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

