### PR TITLE
chore: skip document segments fetching with non-existed dataset of DatasetDocument in add_document_to_index_task task

### DIFF
--- a/api/tasks/add_document_to_index_task.py
+++ b/api/tasks/add_document_to_index_task.py
@@ -34,6 +34,10 @@ def add_document_to_index_task(dataset_document_id: str):
     if dataset_document.indexing_status != "completed":
         return
 
+    dataset = dataset_document.dataset
+    if not dataset:
+        raise Exception(f"Document {dataset_document.id} dataset {dataset_document.dataset_id} doesn't exist.")
+
     indexing_cache_key = "document_{}_indexing".format(dataset_document.id)
 
     try:
@@ -76,11 +80,6 @@ def add_document_to_index_task(dataset_document_id: str):
                         child_documents.append(child_document)
                     document.children = child_documents
             documents.append(document)
-
-        dataset = dataset_document.dataset
-
-        if not dataset:
-            raise Exception("Document has no dataset")
 
         index_type = dataset.doc_form
         index_processor = IndexProcessorFactory(index_type).init_index_processor()

--- a/api/tasks/add_document_to_index_task.py
+++ b/api/tasks/add_document_to_index_task.py
@@ -34,13 +34,13 @@ def add_document_to_index_task(dataset_document_id: str):
     if dataset_document.indexing_status != "completed":
         return
 
-    dataset = dataset_document.dataset
-    if not dataset:
-        raise Exception(f"Document {dataset_document.id} dataset {dataset_document.dataset_id} doesn't exist.")
-
     indexing_cache_key = "document_{}_indexing".format(dataset_document.id)
 
     try:
+        dataset = dataset_document.dataset
+        if not dataset:
+            raise Exception(f"Document {dataset_document.id} dataset {dataset_document.dataset_id} doesn't exist.")
+
         segments = (
             db.session.query(DocumentSegment)
             .filter(


### PR DESCRIPTION
# Summary

- to close #14936
- move the existence checks in front of document segments fetcheing for better performance in `add_document_to_index_task` task


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

