### PR TITLE
chore: Modify watercrawl translation in en-US and zh-Hans

### DIFF
--- a/web/i18n/en-US/dataset-creation.ts
+++ b/web/i18n/en-US/dataset-creation.ts
@@ -69,8 +69,6 @@ const translation = {
       chooseProvider: 'Select a provider',
       fireCrawlNotConfigured: 'Firecrawl is not configured',
       fireCrawlNotConfiguredDescription: 'Configure Firecrawl with API key to use it.',
-      watercrawlNotConfigured: 'Watercrawl is not configured',
-      watercrawlNotConfiguredDescription: 'Configure Watercrawl with API key to use it.',
       jinaReaderNotConfigured: 'Jina Reader is not configured',
       jinaReaderNotConfiguredDescription: 'Set up Jina Reader by entering your free API key for access.',
       waterCrawlNotConfigured: 'Watercrawl is not configured',

--- a/web/i18n/zh-Hans/dataset-creation.ts
+++ b/web/i18n/zh-Hans/dataset-creation.ts
@@ -15,6 +15,11 @@ const translation = {
     apiKeyPlaceholder: '从 firecrawl.dev 获取 API Key',
     getApiKeyLinkText: '从 firecrawl.dev 获取您的 API Key',
   },
+  watercrawl: {
+    configWatercrawl: '配置 Watercrawl',
+    apiKeyPlaceholder: '从 watercrawl.dev 获取 API Key',
+    getApiKeyLinkText: '从 watercrawl.dev 获取您的 API Key',
+  },
   jinaReader: {
     configJinaReader: '配置 Jina Reader',
     apiKeyPlaceholder: '从 jina.ai 获取 API Key',


### PR DESCRIPTION
# Summary

**en-US duplicate**: watercrawlNotConfigured and waterCrawlNotConfigured, watercrawlNotConfiguredDescription and waterCrawlNotConfiguredDescription, only waterCrawlNotConfigured and waterCrawlNotConfiguredDescription are actually effective.
**watercraw translation is missing in zh-Hans**: configWatercrawl, apiKeyPlaceholder, getApiKeyLinkText translation are missing.

> [!Tip]
> Issue: Resolves #17826 


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

