### PR TITLE
Fix external knowledge Issues:  (#17685)

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -206,6 +206,7 @@ class DatasetRetrieval:
             source = {
                 "dataset_id": item.metadata.get("dataset_id"),
                 "dataset_name": item.metadata.get("dataset_name"),
+                "document_id": item.metadata.get("document_id") or item.metadata.get("title"),
                 "document_name": item.metadata.get("title"),
                 "data_source_type": "external",
                 "retriever_from": invoke_from.to_source(),

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -86,6 +86,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                         "position": position,
                         "dataset_id": item.metadata.get("dataset_id"),
                         "dataset_name": item.metadata.get("dataset_name"),
+                        "document_id": item.metadata.get("document_id") or item.metadata.get("title"),
                         "document_name": item.metadata.get("title"),
                         "data_source_type": "external",
                         "retriever_from": self.retriever_from,

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -259,6 +259,7 @@ class KnowledgeRetrievalNode(LLMNode):
                     "_source": "knowledge",
                     "dataset_id": item.metadata.get("dataset_id"),
                     "dataset_name": item.metadata.get("dataset_name"),
+                    "document_id": item.metadata.get("document_id") or item.metadata.get("title"),
                     "document_name": item.metadata.get("title"),
                     "data_source_type": "external",
                     "retriever_from": "workflow",


### PR DESCRIPTION
Use metadata.document_id or title for external KB retrieval to fix citation grouping

# Summary

Resolves #17685 

When processing external knowledge base retrieval results, the `document_id` was not assigned, resulting in all retrieved results having a `document_id` of null. However, the front-end page happens to group and display cited files based on the `document_id`, leading to a maximum of only one file citation being displayed during the conversation.

Solution: When processing external knowledge base retrieval results, attempt to obtain `metadata.document_id` from the external knowledge base's returned results. If there is no `document_id`, then take `metadata.title` as the `document_id`.


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/791c7432-ae81-4cf8-8f77-727e6246a55d)| ![image](https://github.com/user-attachments/assets/8699d6fe-04ec-4320-8c03-14dc0847b48c) |
# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

