### PR TITLE
Optimize the compatibility of Chinese strings in journey charts

### DIFF
--- a/web/app/components/base/mermaid/index.tsx
+++ b/web/app/components/base/mermaid/index.tsx
@@ -46,27 +46,25 @@ const Flowchart = (
   const [imagePreviewUrl, setImagePreviewUrl] = useState('')
 
   function processMermaidCode(code: string) {
-    if (!code.trim().startsWith('journey')) {
+    if (!code.trim().startsWith('journey'))
       return code
-    }
-    
+
     const lines = code.split('\n')
-    const processedLines = lines.map(line => {
+    const processedLines = lines.map((line) => {
       if (line.trim().startsWith('section')) {
-        if (line.includes('：')) {
+        if (line.includes('：'))
           return line
-        }
-        
+
         const sectionPart = line.match(/^(\s*section\s+)([^:]*)(:.*)$/)
-        if (sectionPart) {
+        if (sectionPart)
           return `${sectionPart[1]}${sectionPart[2]}：${sectionPart[3].substring(1)}`
-        }
+
         return line
       }
-      
+
       return line
     })
-    
+
     return processedLines.join('\n')
   }
 

--- a/web/app/components/base/mermaid/index.tsx
+++ b/web/app/components/base/mermaid/index.tsx
@@ -47,38 +47,36 @@ const Flowchart = (
 
   function processMermaidCode(code: string) {
     if (!code.trim().startsWith('journey')) {
-      return code;
+      return code
     }
     
-    const lines = code.split('\n');
+    const lines = code.split('\n')
     const processedLines = lines.map(line => {
       if (line.trim().startsWith('section')) {
         if (line.includes('：')) {
-          return line;
+          return line
         }
         
-        const sectionPart = line.match(/^(\s*section\s+)([^:]*)(:.*)$/);
+        const sectionPart = line.match(/^(\s*section\s+)([^:]*)(:.*)$/)
         if (sectionPart) {
-          return `${sectionPart[1]}${sectionPart[2]}：${sectionPart[3].substring(1)}`;
-        } else {
-          return line;
+          return `${sectionPart[1]}${sectionPart[2]}：${sectionPart[3].substring(1)}`
         }
+        return line
       }
       
-      return line;
-    });
+      return line
+    })
     
-    return processedLines.join('\n');
+    return processedLines.join('\n')
   }
 
   const renderFlowchart = useCallback(async (PrimitiveCode: string) => {
-    PrimitiveCode = processMermaidCode(PrimitiveCode)
     setSvgCode(null)
     setIsLoading(true)
 
     try {
       if (typeof window !== 'undefined' && mermaidAPI) {
-        const svgGraph = await mermaidAPI.render('flowchart', PrimitiveCode)
+        const svgGraph = await mermaidAPI.render('flowchart', processMermaidCode(PrimitiveCode))
         const base64Svg: any = await svgToBase64(cleanUpSvgCode(svgGraph.svg))
         setSvgCode(base64Svg)
         setIsLoading(false)

--- a/web/app/components/base/mermaid/index.tsx
+++ b/web/app/components/base/mermaid/index.tsx
@@ -45,7 +45,34 @@ const Flowchart = (
   const [errMsg, setErrMsg] = useState('')
   const [imagePreviewUrl, setImagePreviewUrl] = useState('')
 
+  function processMermaidCode(code: string) {
+    if (!code.trim().startsWith('journey')) {
+      return code;
+    }
+    
+    const lines = code.split('\n');
+    const processedLines = lines.map(line => {
+      if (line.trim().startsWith('section')) {
+        if (line.includes('：')) {
+          return line;
+        }
+        
+        const sectionPart = line.match(/^(\s*section\s+)([^:]*)(:.*)$/);
+        if (sectionPart) {
+          return `${sectionPart[1]}${sectionPart[2]}：${sectionPart[3].substring(1)}`;
+        } else {
+          return line;
+        }
+      }
+      
+      return line;
+    });
+    
+    return processedLines.join('\n');
+  }
+
   const renderFlowchart = useCallback(async (PrimitiveCode: string) => {
+    PrimitiveCode = processMermaidCode(PrimitiveCode)
     setSvgCode(null)
     setIsLoading(true)
 


### PR DESCRIPTION
# Summary

Fix Mermaid journey diagram rendering issue with Chinese colons in section labels. The problem occurs because Mermaid treats colons (:) as syntax separators, but in Chinese text, colons (：) should be part of the text content.
This PR adds preprocessing for journey diagrams that automatically converts English colons to Chinese colons in section labels while preserving required English colons in task definitions. This ensures proper rendering of journey diagrams with Chinese text without compromising the syntax integrity.
Fixes #17885



# Screenshots


Before ：
![image](https://github.com/user-attachments/assets/b155aaef-1dc2-4063-a6df-3dbc22ebb3ee)

After ：
![image](https://github.com/user-attachments/assets/d760b431-2506-421f-9777-a2390db1dd66)



# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

