### PR TITLE
fix: bump the minimal node requirement to fix eslint fail

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -7,7 +7,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 ### Run by source code
 
 Before starting the web frontend service, please make sure the following environment is ready.
-- [Node.js](https://nodejs.org) >= v18.x
+- [Node.js](https://nodejs.org) >= v22.11.x
 - [pnpm](https://pnpm.io) v10.x
 
 First, install the dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.0",
   "private": true,
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=v22.11.0"
   },
   "scripts": {
     "dev": "cross-env NODE_OPTIONS='--inspect' next dev",


### PR DESCRIPTION
# Summary

Fixes https://github.com/langgenius/dify/issues/17414

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|  ![CleanShot 2025-04-12 at 21 54 18@2x](https://github.com/user-attachments/assets/1675fdc7-60f9-4321-a9bd-38faf313190f) | ![CleanShot 2025-04-12 at 21 54 58@2x](https://github.com/user-attachments/assets/2e2198c6-972e-4ff8-95e8-fdb9216eb6fe)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

