### PR TITLE
fix(langfuse): qusetion classify node can't see cost in langfuse

### DIFF
--- a/api/core/workflow/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/api/core/workflow/nodes/parameter_extractor/parameter_extractor_node.py
@@ -186,6 +186,8 @@ class ParameterExtractorNode(LLMNode):
             "usage": None,
             "function": {} if not prompt_message_tools else jsonable_encoder(prompt_message_tools[0]),
             "tool_call": None,
+            "model_provider": model_config.provider,
+            "model_name": model_config.model,
         }
 
         try:

--- a/api/core/workflow/nodes/question_classifier/question_classifier_node.py
+++ b/api/core/workflow/nodes/question_classifier/question_classifier_node.py
@@ -130,6 +130,8 @@ class QuestionClassifierNode(LLMNode):
                 ),
                 "usage": jsonable_encoder(usage),
                 "finish_reason": finish_reason,
+                "model_provider": model_config.provider,
+                "model_name": model_config.model,
             }
             outputs = {"class_name": category_name, "class_id": category_id}
 


### PR DESCRIPTION
# Summary

Fixed an issue where the question-classify and parameter extractor nodes couldn't display LLM expenditure amounts on Langfuse.

Fixes #17815 


# Screenshots

| Before | After |
|--------|-------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/67c15429-b990-489a-8a61-02427602c2b3" /> | <img width="289" alt="image" src="https://github.com/user-attachments/assets/c61b6e14-6a3f-42a5-a5d0-e801d37ce0ea" />|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

