### PR TITLE
feat: plugin tool selector add tool default description

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
@@ -125,11 +125,12 @@ const ToolSelector: FC<Props> = ({
       type: tool.provider_type,
       tool_name: tool.tool_name,
       tool_label: tool.tool_label,
+      tool_description: tool.tool_description,
       settings: settingValues,
       parameters: paramValues,
       enabled: tool.is_team_authorization,
       extra: {
-        description: '',
+        description: tool.tool_description,
       },
       schemas: tool.paramSchemas,
     }

--- a/web/app/components/workflow/block-selector/tool/action-item.tsx
+++ b/web/app/components/workflow/block-selector/tool/action-item.tsx
@@ -65,6 +65,7 @@ const ToolItem: FC<Props> = ({
             provider_name: provider.name,
             tool_name: payload.name,
             tool_label: payload.label[language],
+            tool_description: payload.description[language],
             title: payload.label[language],
             is_team_authorization: provider.is_team_authorization,
             output_schema: payload.output_schema,

--- a/web/app/components/workflow/block-selector/types.ts
+++ b/web/app/components/workflow/block-selector/types.ts
@@ -24,6 +24,7 @@ export type ToolDefaultValue = {
   provider_name: string
   tool_name: string
   tool_label: string
+  tool_description: string
   title: string
   is_team_authorization: boolean
   params: Record<string, any>
@@ -35,6 +36,7 @@ export type ToolValue = {
   provider_name: string
   tool_name: string
   tool_label: string
+  tool_description: string
   settings?: Record<string, any>
   parameters?: Record<string, any>
   enabled?: boolean


### PR DESCRIPTION
# Summary

agent-strategy and extension plugin tool selector add tool default description.

Resolves #18016


# Screenshots

| Before | After |
|--------|-------|
| ![cd38aa1c549ab93b2e2c1b8d4eb6e87](https://github.com/user-attachments/assets/23af423d-f3be-42cb-9ed2-7b6379f3a57a)   | ![a83d2c287cc0a7393308aef327d5cae](https://github.com/user-attachments/assets/0e849a04-b224-414f-b353-39a866ad085c)   |
| ![0bba080e1f663f1c1ccfef6cf4ad548](https://github.com/user-attachments/assets/a046cabd-a4f4-4234-8638-4cc603ab70ed)   | ![0a575f154b9cda1988fec104626fc26](https://github.com/user-attachments/assets/80498cd7-236f-4e94-ade4-5834d183b7bf)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

