### PR TITLE
fix: plugin parameter type TOOLS_SELECTOR parameter not validation required

### DIFF
--- a/api/core/plugin/entities/parameters.py
+++ b/api/core/plugin/entities/parameters.py
@@ -131,7 +131,7 @@ def cast_parameter_value(typ: enum.StrEnum, value: Any, /):
                     raise ValueError("The selector must be a dictionary.")
                 return value
             case PluginParameterType.TOOLS_SELECTOR:
-                if not isinstance(value, list):
+                if value and not isinstance(value, list):
                     raise ValueError("The tools selector must be a list.")
                 return value
             case _:
@@ -147,7 +147,7 @@ def init_frontend_parameter(rule: PluginParameter, type: enum.StrEnum, value: An
     init frontend parameter by rule
     """
     parameter_value = value
-    if not parameter_value and parameter_value != 0 and type != PluginParameterType.TOOLS_SELECTOR:
+    if not parameter_value and parameter_value != 0:
         # get default value
         parameter_value = rule.default
         if not parameter_value and rule.required:


### PR DESCRIPTION
# Summary

plugin parameter type TOOLS_SELECTOR parameter validation required and required is false the value allow is null.

Close #18058

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

