### PR TITLE
feat: implement blob chunk handling in plugin manager

### DIFF
--- a/api/core/plugin/manager/base.py
+++ b/api/core/plugin/manager/base.py
@@ -82,7 +82,7 @@ class BasePluginManager:
         Make a stream request to the plugin daemon inner API
         """
         response = self._request(method, path, headers, data, params, files, stream=True)
-        for line in response.iter_lines():
+        for line in response.iter_lines(chunk_size=1024 * 8):
             line = line.decode("utf-8").strip()
             if line.startswith("data:"):
                 line = line[5:].strip()

--- a/api/core/plugin/manager/tool.py
+++ b/api/core/plugin/manager/tool.py
@@ -110,7 +110,62 @@ class PluginToolManager(BasePluginManager):
                 "Content-Type": "application/json",
             },
         )
-        return response
+
+        class FileChunk:
+            """
+            Only used for internal processing.
+            """
+
+            bytes_written: int
+            total_length: int
+            data: bytearray
+
+            def __init__(self, total_length: int):
+                self.bytes_written = 0
+                self.total_length = total_length
+                self.data = bytearray(total_length)
+
+        files: dict[str, FileChunk] = {}
+        for resp in response:
+            if resp.type == ToolInvokeMessage.MessageType.BLOB_CHUNK:
+                assert isinstance(resp.message, ToolInvokeMessage.BlobChunkMessage)
+                # Get blob chunk information
+                chunk_id = resp.message.id
+                total_length = resp.message.total_length
+                blob_data = resp.message.blob
+                is_end = resp.message.end
+
+                # Initialize buffer for this file if it doesn't exist
+                if chunk_id not in files:
+                    files[chunk_id] = FileChunk(total_length)
+
+                # If this is the final chunk, yield a complete blob message
+                if is_end:
+                    yield ToolInvokeMessage(
+                        type=ToolInvokeMessage.MessageType.BLOB,
+                        message=ToolInvokeMessage.BlobMessage(blob=files[chunk_id].data),
+                        meta=resp.meta,
+                    )
+                else:
+                    # Check if file is too large (30MB limit)
+                    if files[chunk_id].bytes_written + len(blob_data) > 30 * 1024 * 1024:
+                        # Delete the file if it's too large
+                        del files[chunk_id]
+                        # Skip yielding this message
+                        raise ValueError("File is too large which reached the limit of 30MB")
+
+                    # Check if single chunk is too large (8KB limit)
+                    if len(blob_data) > 8192:
+                        # Skip yielding this message
+                        raise ValueError("File chunk is too large which reached the limit of 8KB")
+
+                    # Append the blob data to the buffer
+                    files[chunk_id].data[
+                        files[chunk_id].bytes_written : files[chunk_id].bytes_written + len(blob_data)
+                    ] = blob_data
+                    files[chunk_id].bytes_written += len(blob_data)
+            else:
+                yield resp
 
     def validate_provider_credentials(
         self, tenant_id: str, user_id: str, provider: str, credentials: dict[str, Any]

--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -120,6 +120,13 @@ class ToolInvokeMessage(BaseModel):
     class BlobMessage(BaseModel):
         blob: bytes
 
+    class BlobChunkMessage(BaseModel):
+        id: str = Field(..., description="The id of the blob")
+        sequence: int = Field(..., description="The sequence of the chunk")
+        total_length: int = Field(..., description="The total length of the blob")
+        blob: bytes = Field(..., description="The blob data of the chunk")
+        end: bool = Field(..., description="Whether the chunk is the last chunk")
+
     class FileMessage(BaseModel):
         pass
 
@@ -180,12 +187,15 @@ class ToolInvokeMessage(BaseModel):
         VARIABLE = "variable"
         FILE = "file"
         LOG = "log"
+        BLOB_CHUNK = "blob_chunk"
 
     type: MessageType = MessageType.TEXT
     """
         plain text, image url or link url
     """
-    message: JsonMessage | TextMessage | BlobMessage | LogMessage | FileMessage | None | VariableMessage
+    message: (
+        JsonMessage | TextMessage | BlobChunkMessage | BlobMessage | LogMessage | FileMessage | None | VariableMessage
+    )
     meta: dict[str, Any] | None = None
 
     @field_validator("message", mode="before")


### PR DESCRIPTION
- Added support for processing blob chunks in the PluginToolManager.
- Introduced a new BlobChunkMessage model to handle chunked data.
- Implemented size validation for both total blob size and individual chunk size.
- Updated the BasePluginManager to handle streaming responses with a specified chunk size.

Related RPs:
- https://github.com/langgenius/dify-plugin-daemon/pull/208

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|  <img width="426" alt="image" src="https://github.com/user-attachments/assets/dce39390-08a7-4309-8092-51d56d5e8ace" /> | <img width="422" alt="image" src="https://github.com/user-attachments/assets/4a5a5a21-61a0-4d6c-9974-b5fc2a7685c4" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

