### PR TITLE
fix: start api and worker after the database has become healthy

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -17,8 +17,10 @@ services:
       PLUGIN_MAX_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       INNER_API_KEY_FOR_PLUGIN: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
@@ -42,8 +44,10 @@ services:
       PLUGIN_MAX_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       INNER_API_KEY_FOR_PLUGIN: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -485,8 +485,10 @@ services:
       PLUGIN_MAX_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       INNER_API_KEY_FOR_PLUGIN: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
@@ -510,8 +512,10 @@ services:
       PLUGIN_MAX_PACKAGE_SIZE: ${PLUGIN_MAX_PACKAGE_SIZE:-52428800}
       INNER_API_KEY_FOR_PLUGIN: ${PLUGIN_DIFY_INNER_API_KEY:-QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1}
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage


### PR DESCRIPTION
# Summary

This PR modifies the startup order so that the `api` and `worker` are initiated only after the database is healthy. This applies the changes made in [#17928](https://github.com/langgenius/dify/pull/17928) to the `plugin_daemon` to both the `api` and `worker`.

While I was trying to set up Dify in some environments, I encountered an issue where the initial startup fails, especially in environments that do not have abundant computing resources or fast disks. This is due to the following behavior:

- The power-on for `api` and `worker` occurs immediately after the power-on of the `db`.
- In some environments, the initialization of the database does not complete right away.
- The `api` and `worker` fail to connect to the DB during the first migration process due to connection errors.
- Consequently, the `api` and `worker` start their services regardless.

After that, when accessing `/install` in this state, nothing is displayed because the DB has not been initialized, and error messages appear in the container logs.

By ensuring that the power-on for `api` and `worker` occurs after the DB is healthy, this issue can be avoided.

- Benefits:
  - Increases the success rate of the initial setup of Dify in more environments.
- Side Effects:
  - In all environments, the power-on for `api` and `worker` will be a few seconds delayed compared to before, resulting in a few seconds longer startup time.

Feel free to decide whether or not to merge this.

If you want to simulate an environment with issues, please use the following override file to set the database startup time to be delayed 10 seconds.

```yaml
services:
  db:
    entrypoint:
      - /bin/sh
      - -c
      - |
        sleep 10 &&
        exec docker-entrypoint.sh postgres -c 'max_connections=${POSTGRES_MAX_CONNECTIONS:-100}'
               -c 'shared_buffers=${POSTGRES_SHARED_BUFFERS:-128MB}'
               -c 'work_mem=${POSTGRES_WORK_MEM:-4MB}'
               -c 'maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-64MB}'
               -c 'effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-4096MB}'
    command: ""
```

Related issues:
- https://github.com/langgenius/dify/issues/15901
- https://github.com/langgenius/dify/issues/13540

# Screenshots

- Before
  - `/install` displays nothing, the error `relation "dify_setups" does not exist` is logged
- After
  - `/install` works as expected

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

