### PR TITLE
chore: remove unused poetry.toml

### DIFF
--- a/api/poetry.toml
+++ b/api/poetry.toml
@@ -1,4 +1,0 @@
-[virtualenvs]
-in-project = true
-create = true
-prefer-active-python = true


### PR DESCRIPTION
# Summary

- remove api/poetry.toml as poetry has been replaced with uv in #16317 


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

