### PR TITLE
fix(follow_ups): handle empty LLM responses in context

### DIFF
--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -44,6 +44,7 @@ class TokenBufferMemory:
                 Message.created_at,
                 Message.workflow_run_id,
                 Message.parent_message_id,
+                Message.answer_tokens,
             )
             .filter(
                 Message.conversation_id == self.conversation.id,
@@ -63,7 +64,7 @@ class TokenBufferMemory:
         thread_messages = extract_thread_messages(messages)
 
         # for newly created message, its answer is temporarily empty, we don't need to add it to memory
-        if thread_messages and not thread_messages[0].answer:
+        if thread_messages and not thread_messages[0].answer and thread_messages[0].answer_tokens == 0:
             thread_messages.pop(0)
 
         messages = list(reversed(thread_messages))


### PR DESCRIPTION
# Summary

When the LLM's answer is empty, it cannot use the latest question as context for follow-ups. This is because the condition in #9297 excludes cases where the LLM is empty, so I added an answer_tokens condition for judgment. When the LLM has not yet answered, the Message's answer field is '', and answer_tokens is 0. When the LLM has answered, but the answer is empty, the Message's answer field is '', and answer_tokens is 1.

Fixes #17841


# Screenshots

| Before | After |
|--------|-------|
| <img width="421" alt="image" src="https://github.com/user-attachments/assets/100ae978-104f-4da1-b59d-04f365009dfb" />   | <img width="412" alt="image" src="https://github.com/user-attachments/assets/c25f2294-fb96-4300-9d07-3a9e8f47d8ad" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

