### PR TITLE
fix: Access the text-generation app's API doc error

### DIFF
--- a/web/app/components/develop/template/template.zh.mdx
+++ b/web/app/components/develop/template/template.zh.mdx
@@ -776,6 +776,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
   </Col>
   <Col sticky>
     嵌入模型的提供商和模型名称可以通过以下接口获取：v1/workspaces/current/models/model-types/text-embedding， 具体见：通过 API 维护知识库。 使用的Authorization是Dataset的API Token。
+    该接口是异步执行，所以会返回一个job_id，通过查询job状态接口可以获取到最终的执行结果。
     <CodeGroup
       title="Request"
       tag="POST"
@@ -801,7 +802,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       "job_status": "waiting"
     }
     ```
-    该接口是异步执行，所以会返回一个job_id，通过查询job状态接口可以获取到最终的执行结果。
+    
     </CodeGroup>
   </Col>
 </Row>


### PR DESCRIPTION
# Summary

Fix https://github.com/langgenius/dify/issues/18232
Fix https://github.com/langgenius/dify/issues/18263


# Screenshots

| Before | After |
|--------|-------|
| ...    | ![image](https://github.com/user-attachments/assets/e6c000b1-ed91-40d3-b2f9-8eb940306bfa)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

