### PR TITLE
fix: missing headers in some cases

### DIFF
--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -180,6 +180,12 @@ async function base<T>(url: string, options: FetchOptionType = {}, otherOptions:
     },
     ...(bodyStringify ? { json: body } : { body: body as BodyInit }),
     searchParams: params,
+    fetch: function (resource: RequestInfo | URL, options?: RequestInit) {
+      if (resource instanceof Request && options) {
+        options.headers = resource.headers
+      }
+      return globalThis.fetch(resource, options)
+    },
   })
 
   if (needAllResponseContent)

--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -182,7 +182,11 @@ async function base<T>(url: string, options: FetchOptionType = {}, otherOptions:
     searchParams: params,
     fetch: function (resource: RequestInfo | URL, options?: RequestInit) {
       if (resource instanceof Request && options) {
-        options.headers = resource.headers
+        const mergedHeaders = new Headers(options.headers || {});
+        resource.headers.forEach((value, key) => {
+          mergedHeaders.append(key, value);
+        });
+        options.headers = mergedHeaders;
       }
       return globalThis.fetch(resource, options)
     },

--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -132,12 +132,13 @@ async function base<T>(url: string, options: FetchOptionType = {}, otherOptions:
     getAbortController,
   } = otherOptions
 
-  const base
-    = isMarketplaceAPI
-      ? MARKETPLACE_API_PREFIX
-      : isPublicAPI
-        ? PUBLIC_API_PREFIX
-        : API_PREFIX
+  let base: string
+  if (isMarketplaceAPI)
+    base = MARKETPLACE_API_PREFIX
+   else if (isPublicAPI)
+    base = PUBLIC_API_PREFIX
+   else
+    base = API_PREFIX
 
   if (getAbortController) {
     const abortController = new AbortController()
@@ -145,7 +146,7 @@ async function base<T>(url: string, options: FetchOptionType = {}, otherOptions:
     options.signal = abortController.signal
   }
 
-  const fetchPathname = `${base}${url.startsWith('/') ? url : `/${url}`}`
+  const fetchPathname = base + (url.startsWith('/') ? url : `/${url}`)
 
   if (deleteContentType)
     (headers as any).delete('Content-Type')
@@ -180,13 +181,13 @@ async function base<T>(url: string, options: FetchOptionType = {}, otherOptions:
     },
     ...(bodyStringify ? { json: body } : { body: body as BodyInit }),
     searchParams: params,
-    fetch: function (resource: RequestInfo | URL, options?: RequestInit) {
+    fetch(resource: RequestInfo | URL, options?: RequestInit) {
       if (resource instanceof Request && options) {
-        const mergedHeaders = new Headers(options.headers || {});
+        const mergedHeaders = new Headers(options.headers || {})
         resource.headers.forEach((value, key) => {
-          mergedHeaders.append(key, value);
-        });
-        options.headers = mergedHeaders;
+          mergedHeaders.append(key, value)
+        })
+        options.headers = mergedHeaders
       }
       return globalThis.fetch(resource, options)
     },


### PR DESCRIPTION
# Summary

some version of iOS webview will miss some headers while seding XHR requests, refactor `fetch` function to ensure adding headers

Fixes #17835


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| missing `Authorization`, `X-App-Code`    | with the header   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

