### PR TITLE
fix: correct icons for gpt-4 series from non-openai providers

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-icon/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-icon/index.tsx
@@ -23,9 +23,9 @@ const ModelIcon: FC<ModelIconProps> = ({
   isDeprecated = false,
 }) => {
   const language = useLanguage()
-  if (provider?.provider.includes('openai') && modelName?.includes('gpt-4o'))
+  if (provider?.provider && ['openai', 'langgenius/openai/openai'].includes(provider.provider) && modelName?.includes('gpt-4o'))
     return <div className='flex items-center justify-center'><OpenaiBlue className={cn('h-5 w-5', className)} /></div>
-  if (provider?.provider.includes('openai') && modelName?.startsWith('gpt-4'))
+  if (provider?.provider && ['openai', 'langgenius/openai/openai'].includes(provider.provider) && modelName?.startsWith('gpt-4'))
     return <div className='flex items-center justify-center'><OpenaiViolet className={cn('h-5 w-5', className)} /></div>
 
   if (provider?.icon_small) {


### PR DESCRIPTION
# Summary

This PR corrects the conditions for providers to display the correct icons for each model.

Closes #18385

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/d97d3254-3cc3-4a89-bf51-4c40d749c7af)   | ![image](https://github.com/user-attachments/assets/067df4d2-c3a8-4b35-8bb8-21c22f0f1d2d) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

