### PR TITLE
feat: update privacy policy URL and add validation for privacy policy link

### DIFF
--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -162,9 +162,20 @@ const SettingsModal: FC<ISettingsModalProps> = ({
       return check
     }
 
+    const validatePrivacyPolicy = (privacyPolicy: string | null) => {
+      if (privacyPolicy === null || privacyPolicy?.length === 0)
+        return true
+
+      return privacyPolicy.startsWith('http://') || privacyPolicy.startsWith('https://')
+    }
+
     if (inputInfo !== null) {
       if (!validateColorHex(inputInfo.chatColorTheme)) {
         notify({ type: 'error', message: t(`${prefixSettings}.invalidHexMessage`) })
+        return
+      }
+      if (!validatePrivacyPolicy(inputInfo.privacyPolicy)) {
+        notify({ type: 'error', message: t(`${prefixSettings}.invalidPrivacyPolicy`) })
         return
       }
     }
@@ -410,7 +421,7 @@ const SettingsModal: FC<ISettingsModalProps> = ({
                 <p className={cn('body-xs-regular pb-0.5 text-text-tertiary')}>
                   <Trans
                     i18nKey={`${prefixSettings}.more.privacyPolicyTip`}
-                    components={{ privacyPolicyLink: <Link href={'https://docs.dify.ai/user-agreement/privacy-policy'} target='_blank' rel='noopener noreferrer' className='text-text-accent' /> }}
+                    components={{ privacyPolicyLink: <Link href={'https://dify.ai/privacy'} target='_blank' rel='noopener noreferrer' className='text-text-accent' /> }}
                   />
                 </p>
                 <Input

--- a/web/i18n/de-DE/app-overview.ts
+++ b/web/i18n/de-DE/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Legen Sie das Farbschema des Chatbots fest',
         chatColorThemeInverted: 'Invertiert',
         invalidHexMessage: 'Ungültiger Hex-Wert',
+        invalidPrivacyPolicy: 'Ungültiger Link zur Datenschutzrichtlinie. Bitte verwenden Sie einen gültigen Link, der mit http oder https beginnt',
         more: {
           entry: 'Mehr Einstellungen anzeigen',
           copyright: 'Urheberrecht',

--- a/web/i18n/en-US/app-overview.ts
+++ b/web/i18n/en-US/app-overview.ts
@@ -57,6 +57,7 @@ const translation = {
         chatColorThemeDesc: 'Set the color theme of the chatbot',
         chatColorThemeInverted: 'Inverted',
         invalidHexMessage: 'Invalid hex value',
+        invalidPrivacyPolicy: 'Invalid privacy policy link. Please use a valid link that starts with http or https',
         sso: {
           label: 'SSO Enforcement',
           title: 'WebApp SSO',

--- a/web/i18n/es-ES/app-overview.ts
+++ b/web/i18n/es-ES/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Establece el tema de color del chatbot',
         chatColorThemeInverted: 'Invertido',
         invalidHexMessage: 'Valor hexadecimal no válido',
+        invalidPrivacyPolicy: 'Enlace de política de privacidad no válido. Por favor, utiliza un enlace válido que comience con http o https',
         more: {
           entry: 'Mostrar más configuraciones',
           copyright: 'Derechos de autor',

--- a/web/i18n/fa-IR/app-overview.ts
+++ b/web/i18n/fa-IR/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'تم رنگی چت‌بات را تنظیم کنید',
         chatColorThemeInverted: 'معکوس',
         invalidHexMessage: 'مقدار هگز نامعتبر',
+        invalidPrivacyPolicy: 'لینک سیاست حفظ حریم خصوصی نامعتبر است. لطفاً از یک لینک معتبر که با http یا https شروع میشود استفاده کنید',
         more: {
           entry: 'نمایش تنظیمات بیشتر',
           copyright: 'حق نسخه‌برداری',

--- a/web/i18n/fr-FR/app-overview.ts
+++ b/web/i18n/fr-FR/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Définir le thème de couleur du chatbot',
         chatColorThemeInverted: 'Inversé',
         invalidHexMessage: 'Valeur hexadécimale invalide',
+        invalidPrivacyPolicy: 'Lien de politique de confidentialité invalide. Veuillez utiliser un lien valide commençant par http ou https',
         more: {
           entry: 'Afficher plus de paramètres',
           copyright: 'Droits d\'auteur',

--- a/web/i18n/hi-IN/app-overview.ts
+++ b/web/i18n/hi-IN/app-overview.ts
@@ -59,6 +59,7 @@ const translation = {
         chatColorThemeDesc: 'चैटबॉट का रंग थीम निर्धारित करें',
         chatColorThemeInverted: 'उल्टा',
         invalidHexMessage: 'अमान्य हेक्स मान',
+        invalidPrivacyPolicy: 'गोपनीयता नीति लिंक अमान्य है। कृपया http या https से शुरू होने वाला एक वैध लिंक उपयोग करें।',
         more: {
           entry: 'अधिक सेटिंग्स दिखाएं',
           copyright: 'कॉपीराइट',

--- a/web/i18n/it-IT/app-overview.ts
+++ b/web/i18n/it-IT/app-overview.ts
@@ -59,6 +59,7 @@ const translation = {
         chatColorThemeDesc: 'Imposta il tema colore del chatbot',
         chatColorThemeInverted: 'Inverso',
         invalidHexMessage: 'Valore esadecimale non valido',
+        invalidPrivacyPolicy: 'Link alla privacy policy non valido. Si prega di utilizzare un link valido che inizi con http o https',
         more: {
           entry: 'Mostra più impostazioni',
           copyright: 'Copyright',

--- a/web/i18n/ja-JP/app-overview.ts
+++ b/web/i18n/ja-JP/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'チャットボットのカラーテーマを設定します',
         chatColorThemeInverted: '反転',
         invalidHexMessage: '無効な16進数値',
+        invalidPrivacyPolicy: '無効なプライバシーポリシーのリンクです。http または https で始まる有効なリンクを使用してください',
         more: {
           entry: 'その他の設定を表示',
           copyright: '著作権',

--- a/web/i18n/ko-KR/app-overview.ts
+++ b/web/i18n/ko-KR/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: '챗봇의 색상 테마를 설정하세요',
         chatColorThemeInverted: '반전',
         invalidHexMessage: '잘못된 16진수 값',
+        invalidPrivacyPolicy: '유효하지 않은 개인정보처리방침 링크입니다. http 또는 https로 시작하는 유효한 링크를 사용해 주세요',
         more: {
           entry: '추가 설정 보기',
           copyright: '저작권',

--- a/web/i18n/pl-PL/app-overview.ts
+++ b/web/i18n/pl-PL/app-overview.ts
@@ -59,6 +59,7 @@ const translation = {
         chatColorThemeDesc: 'Ustaw motyw kolorystyczny czatu',
         chatColorThemeInverted: 'Odwrócony',
         invalidHexMessage: 'Nieprawidłowa wartość heksadecymalna',
+        invalidPrivacyPolicy: 'Nieprawidłowy link do polityki prywatności. Proszę użyć prawidłowego linku zaczynającego się od http lub https',
         more: {
           entry: 'Pokaż więcej ustawień',
           copyright: 'Prawa autorskie',

--- a/web/i18n/pt-BR/app-overview.ts
+++ b/web/i18n/pt-BR/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Defina o tema de cor do chatbot',
         chatColorThemeInverted: 'Inve',
         invalidHexMessage: 'Valor hex inválido',
+        invalidPrivacyPolicy: 'Link de política de privacidade inválido. Por favor, use um link válido que comece com http ou https',
         more: {
           entry: 'Mostrar mais configurações',
           copyright: 'Direitos autorais',

--- a/web/i18n/ro-RO/app-overview.ts
+++ b/web/i18n/ro-RO/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Setați tema de culoare a chatbotului',
         chatColorThemeInverted: 'Inversat',
         invalidHexMessage: 'Valoare hex nevalidă',
+        invalidPrivacyPolicy: 'Link politică de confidențialitate invalid. Vă rugăm să folosiți un link valid care începe cu http sau https',
         more: {
           entry: 'Afișați mai multe setări',
           copyright: 'Drepturi de autor',

--- a/web/i18n/ru-RU/app-overview.ts
+++ b/web/i18n/ru-RU/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Установите цветовую тему чат-бота',
         chatColorThemeInverted: 'Инвертированные цвета',
         invalidHexMessage: 'Неверное HEX-значение',
+        invalidPrivacyPolicy: 'Недопустимая ссылка на политику конфиденциальности. Пожалуйста, используйте действительную ссылку, начинающуюся с http или https',
         sso: {
           label: 'SSO аутентификация',
           title: 'WebApp SSO',

--- a/web/i18n/sl-SI/app-overview.ts
+++ b/web/i18n/sl-SI/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Nastavite barvno temo klepetalnega bota',
         chatColorThemeInverted: 'Inverzna',
         invalidHexMessage: 'Neveljavna vrednost heksa',
+        invalidPrivacyPolicy: 'Neveljavna povezava do pravilnika o zasebnosti. Uporabite veljavno povezavo, ki se začne z http ali https',
         sso: {
           label: 'SSO avtentikacija',
           title: 'SSO spletne aplikacije',

--- a/web/i18n/th-TH/app-overview.ts
+++ b/web/i18n/th-TH/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'กําหนดธีมสีของแชทบอท',
         chatColorThemeInverted: 'คว่ำ',
         invalidHexMessage: 'ค่าฐานสิบหกไม่ถูกต้อง',
+        invalidPrivacyPolicy: 'ลิงก์นโยบายความเป็นส่วนตัวไม่ถูกต้อง โปรดใช้ลิงก์ที่ถูกต้องขึ้นต้นด้วย http หรือ https',
         sso: {
           label: 'การรับรองความถูกต้องของ SSO',
           title: 'เว็บแอป SSO',

--- a/web/i18n/tr-TR/app-overview.ts
+++ b/web/i18n/tr-TR/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Sohbet botunun renk temasını ayarlayın',
         chatColorThemeInverted: 'Tersine çevrilmiş',
         invalidHexMessage: 'Geçersiz hex değeri',
+        invalidPrivacyPolicy: 'Geçersiz gizlilik politikası bağlantısı. Lütfen http veya https ile başlayan geçerli bir bağlantı kullanın',
         more: {
           entry: 'Daha fazla ayarı göster',
           copyright: 'Telif Hakkı',

--- a/web/i18n/uk-UA/app-overview.ts
+++ b/web/i18n/uk-UA/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Встановіть тему кольору чат-бота',
         chatColorThemeInverted: 'Інвертовано',
         invalidHexMessage: 'Недійсне шістнадцяткове значення',
+        invalidPrivacyPolicy: 'Недійсне посилання на політику конфіденційності. Будь ласка, використовуйте дійсне посилання, яке починається з http або https',
         more: {
           entry: 'Показати додаткові налаштування',
           copyright: 'Авторське право',

--- a/web/i18n/vi-VN/app-overview.ts
+++ b/web/i18n/vi-VN/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: 'Thiết lập giao diện màu của chatbot',
         chatColorThemeInverted: 'Đảo ngược',
         invalidHexMessage: 'Giá trị mã màu không hợp lệ',
+        invalidPrivacyPolicy: 'Liên kết chính sách bảo mật không hợp lệ. Vui lòng sử dụng liên kết hợp lệ bắt đầu bằng http hoặc https',
         more: {
           entry: 'Hiển thị thêm cài đặt',
           copyright: 'Bản quyền',

--- a/web/i18n/zh-Hans/app-overview.ts
+++ b/web/i18n/zh-Hans/app-overview.ts
@@ -57,6 +57,7 @@ const translation = {
         chatColorThemeDesc: '设置聊天机器人的颜色主题',
         chatColorThemeInverted: '反转',
         invalidHexMessage: '无效的十六进制值',
+        invalidPrivacyPolicy: '无效的隐私政策链接，请使用以 http 或 https 开头的有效链接',
         sso: {
           label: '单点登录认证',
           title: 'WebApp SSO 认证',

--- a/web/i18n/zh-Hant/app-overview.ts
+++ b/web/i18n/zh-Hant/app-overview.ts
@@ -55,6 +55,7 @@ const translation = {
         chatColorThemeDesc: '設定聊天機器人的顏色主題',
         chatColorThemeInverted: '反轉',
         invalidHexMessage: '無效的十六進制值',
+        invalidPrivacyPolicy: '無效的隱私政策連結，請使用以 http 或 https 開頭的有效連結',
         more: {
           entry: '展示更多設定',
           copyright: '版權',


### PR DESCRIPTION
… policy link

# Summary

1. Fix Dify's privacy policy URL.

2. Add a new feature to check whether a privacy policy URL is valid.


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots
### Before
After set privacy policy as `test privacy policy`, and open it in webapp.
<img width="2462" alt="image" src="https://github.com/user-attachments/assets/982ba1ae-b0b4-48a7-ac44-8db08343ece6" />


### After
When we submit the information of app site, it will check whether a privacy policy URL is valid.
<img width="1656" alt="image" src="https://github.com/user-attachments/assets/6ec02227-858b-4c96-a29b-9416bb91efb2" />



# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

