### PR TITLE
fix: correct unsupported German date format on document list page

### DIFF
--- a/web/i18n/de-DE/dataset-hit-testing.ts
+++ b/web/i18n/de-DE/dataset-hit-testing.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Abruf-Test',
   desc: 'Testen Sie die Treffereffektivität des Wissens anhand des gegebenen Abfragetextes.',
-  dateTimeFormat: 'MM/TT/JJJJ hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
   recents: 'Kürzlich',
   table: {
     header: {


### PR DESCRIPTION
# Summary

Fixes #17920.

This PR replaces the unsupported date format `MM/TT/JJJJ` with the correct one `MM/DD/YYYY`.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/fb3ad659-0794-4ce2-b47d-2ba5a9efceff) | ![after](https://github.com/user-attachments/assets/5d07e8c0-a07e-46c3-89f5-bfc5f1d5e1a0) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

