### PR TITLE
"fix: Changed the translated text from '障害者' (#18427)"

### DIFF
--- a/web/i18n/ja-JP/plugin.ts
+++ b/web/i18n/ja-JP/plugin.ts
@@ -70,7 +70,7 @@ const translation = {
     endpointDeleteTip: 'エンドポイントを削除',
     modelNum: '{{num}} モデルが含まれています',
     serviceOk: 'サービスは正常です',
-    disabled: '障害者',
+    disabled: 'サービスは無効化されています',
     endpoints: 'エンドポイント',
     endpointsTip: 'このプラグインはエンドポイントを介して特定の機能を提供し、現在のワークスペースのために複数のエンドポイントセットを構成できます。',
     configureModel: 'モデルを設定する',


### PR DESCRIPTION
# Summary

Fixes an inappropriate Japanese translation for the `disabled` label in the plugin settings.

Previously, the translation was:
- `disabled: '障害者'` (meaning "person with a disability")

This was misleading and inappropriate, as the context is referring to a disabled *service / plugin*, not a person. The new translation is:
- `disabled: 'サービスは無効化されています'` ("The service is disabled")


# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods