### PR TITLE
fix: translate 'back' to '戻る' in Japanese plugin localization

### DIFF
--- a/web/i18n/ja-JP/plugin.ts
+++ b/web/i18n/ja-JP/plugin.ts
@@ -134,7 +134,7 @@ const translation = {
     install: 'インストール',
     dropPluginToInstall: 'プラグインパッケージをここにドロップしてインストールします',
     installPlugin: 'プラグインをインストールする',
-    back: 'バック',
+    back: '戻る',
     uploadingPackage: '{{packageName}}をアップロード中...',
   },
   installFromGitHub: {


### PR DESCRIPTION
# Summary

Improved the Japanese translation of the "Back" button label.

Previously, the label was translated as:
- `back: 'バック'`

This was an unnatural loanword usage in the UI. In Japanese user interfaces, "戻る" is the standard and more intuitive expression for a back navigation action.

Updated it to:
- `back: '戻る'`

# Screenshots

| Before     | After   |
|------------|---------|
| バック      | 戻る      |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods