### PR TITLE
fix: update Japanese translation for 'switchVersion' in plugin.ts to …

### DIFF
--- a/web/i18n/ja-JP/plugin.ts
+++ b/web/i18n/ja-JP/plugin.ts
@@ -81,7 +81,7 @@ const translation = {
     endpointDeleteContent: '{{name}}を削除しますか？',
     actionNum: '{{num}} {{action}} が含まれています',
     endpointsDocLink: 'ドキュメントを表示する',
-    switchVersion: 'スイッチ版',
+    switchVersion: 'バージョンの切り替え',
   },
   debugInfo: {
     title: 'デバッグ',


### PR DESCRIPTION
# Summary

Improved the Japanese translation of the `switchVersion` label for better clarity and user understanding.

## Before

- `switchVersion: 'スイッチ版'`

This translation was ambiguous in Japanese. The term “スイッチ版” is not commonly used and could be misinterpreted (e.g., as referring to a Nintendo Switch version or a different product edition). It didn’t clearly communicate the intended action.

## After

- `switchVersion: 'バージョンの切り替え'`

This revised translation clearly describes the intended user action — switching between different versions — and aligns with common Japanese UI terminology.

# Screenshots

| Before       | After               |
|--------------|---------------------|
| スイッチ版     | バージョンの切り替え |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods