### PR TITLE
fix: After setting Top K and score threshold in Retrieval Setting and…

### DIFF
--- a/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
@@ -32,6 +32,8 @@ import {
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { fetchMembers } from '@/service/common'
 import type { Member } from '@/models/common'
+import useUpdateFlagStore from '@/app/components/workflow/nodes/knowledge-retrieval/useUpdateFlagStore'
+
 
 type SettingsModalProps = {
   currentDataset: DataSet
@@ -89,6 +91,8 @@ const SettingsModal: FC<SettingsModalProps> = ({
     if (data.score_threshold_enabled !== undefined)
       setScoreThresholdEnabled(data.score_threshold_enabled)
   }
+
+  const toggleFlag = useUpdateFlagStore(s => s.toggleFlag)
 
   const handleSave = async () => {
     if (loading)
@@ -149,6 +153,7 @@ const SettingsModal: FC<SettingsModalProps> = ({
         indexing_technique: indexMethod,
         retrieval_model_dict: retrievalConfig,
       })
+      toggleFlag()
     }
     catch {
       notify({ type: 'error', message: t('common.actionMsg.modifiedUnsuccessfully') })

--- a/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
@@ -34,7 +34,6 @@ import { fetchMembers } from '@/service/common'
 import type { Member } from '@/models/common'
 import useUpdateFlagStore from '@/app/components/workflow/nodes/knowledge-retrieval/useUpdateFlagStore'
 
-
 type SettingsModalProps = {
   currentDataset: DataSet
   onCancel: () => void

--- a/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
@@ -32,6 +32,7 @@ import {
   getMultipleRetrievalConfig,
   getSelectedDatasetsMode,
 } from './utils'
+import useUpdateFlagStore from './useUpdateFlagStore'
 import { RETRIEVE_TYPE } from '@/types/app'
 import { DATASET_DEFAULT } from '@/config'
 import type { DataSet } from '@/models/datasets'
@@ -51,6 +52,9 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
   const startNodeId = startNode?.id
   const { inputs, setInputs: doSetInputs } = useNodeCrud<KnowledgeRetrievalNodeType>(id, payload)
   const updateDatasetsDetail = useDatasetsDetailStore(s => s.updateDatasetsDetail)
+
+  const updateFlag = useUpdateFlagStore(s => s.updateFlag)
+
 
   const inputRef = useRef(inputs)
 
@@ -231,7 +235,7 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
       setSelectedDatasetsLoaded(true)
     })()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [updateFlag])
 
   useEffect(() => {
     const inputs = inputRef.current

--- a/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/use-config.ts
@@ -55,7 +55,6 @@ const useConfig = (id: string, payload: KnowledgeRetrievalNodeType) => {
 
   const updateFlag = useUpdateFlagStore(s => s.updateFlag)
 
-
   const inputRef = useRef(inputs)
 
   const setInputs = useCallback((s: KnowledgeRetrievalNodeType) => {

--- a/web/app/components/workflow/nodes/knowledge-retrieval/useUpdateFlagStore.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/useUpdateFlagStore.ts
@@ -1,0 +1,16 @@
+// stores/useUpdateFlagStore.ts
+import { create } from 'zustand'
+
+type UpdateFlagStore = {
+  updateFlag: boolean
+  toggleFlag: () => void
+  setFlag: (value: boolean) => void
+}
+
+const useUpdateFlagStore = create<UpdateFlagStore>(set => ({
+  updateFlag: false,
+  toggleFlag: () => set(state => ({ updateFlag: !state.updateFlag })),
+  setFlag: value => set({ updateFlag: value }),
+}))
+
+export default useUpdateFlagStore


### PR DESCRIPTION
# Summary

The problem that the data of Top K and score threshold will be refreshed only when re - entering the Knowledge Retrieval panel has been solved.

> [!Tip]
> Close issue syntax: `Fixes #<issue 18467>`, see [documentation](https://github.com/langgenius/dify/issues/18467) for more details.

Fixes #18467

# Screenshots

| Before && After | 
|--------|
| ![iShot2025-04-21 16 02 45](https://github.com/user-attachments/assets/c55ce2e6-2cf2-4427-8f0d-922faa3b9e5a) | 
![iShot2025-04-21 15 56 05](https://github.com/user-attachments/assets/d1f26928-7f1d-4849-9ddd-9f068d47db98)
   |

