### PR TITLE
fix: cannot delete workflow version if other version is published as a tool

### DIFF
--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -245,6 +245,13 @@ class Workflow(Base):
 
     @property
     def tool_published(self) -> bool:
+        """
+        DEPRECATED: This property is not accurate for determining if a workflow is published as a tool.
+        It only checks if there's a WorkflowToolProvider for the app, not if this specific workflow version
+        is the one being used by the tool.
+
+        For accurate checking, use a direct query with tenant_id, app_id, and version.
+        """
         from models.tools import WorkflowToolProvider
 
         return (

--- a/api/tests/unit_tests/services/workflow/test_workflow_deletion.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_deletion.py
@@ -40,6 +40,10 @@ def workflow_setup():
 
 def test_delete_workflow_success(workflow_setup):
     # Setup mocks
+
+    # Mock the tool provider query to return None (not published as a tool)
+    workflow_setup["session"].query.return_value.filter.return_value.first.return_value = None
+
     workflow_setup["session"].scalar = MagicMock(
         side_effect=[workflow_setup["workflow"], None]
     )  # Return workflow first, then None for app
@@ -97,7 +101,12 @@ def test_delete_workflow_in_use_by_app_error(workflow_setup):
 
 def test_delete_workflow_published_as_tool_error(workflow_setup):
     # Setup mocks
-    workflow_setup["workflow"].tool_published = True
+    from models.tools import WorkflowToolProvider
+
+    # Mock the tool provider query
+    mock_tool_provider = MagicMock(spec=WorkflowToolProvider)
+    workflow_setup["session"].query.return_value.filter.return_value.first.return_value = mock_tool_provider
+
     workflow_setup["session"].scalar = MagicMock(
         side_effect=[workflow_setup["workflow"], None]
     )  # Return workflow first, then None for app


### PR DESCRIPTION


Signed-off-by: -LAN- <laipz8200@outlook.com>

# Summary

follow-up #17900

Deprecates the inaccurate tool_published property for determining if a workflow is published as a tool. Introduces a direct database query to verify if a specific workflow version is used by a tool, preventing deletion when in use.

Updates tests to mock the new query behavior, ensuring proper validation of workflows published as tools.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

