### PR TITLE
fix: Validates session factory type in repository

### DIFF
--- a/api/repositories/workflow_node_execution/sqlalchemy_repository.py
+++ b/api/repositories/workflow_node_execution/sqlalchemy_repository.py
@@ -37,8 +37,10 @@ class SQLAlchemyWorkflowNodeExecutionRepository:
         # If an engine is provided, create a sessionmaker from it
         if isinstance(session_factory, Engine):
             self._session_factory = sessionmaker(bind=session_factory, expire_on_commit=False)
-        else:
+        elif isinstance(session_factory, sessionmaker):
             self._session_factory = session_factory
+        else:
+            raise ValueError("session_factory must be a sessionmaker or Engine")
 
         self._tenant_id = tenant_id
         self._app_id = app_id

--- a/api/repositories/workflow_node_execution/sqlalchemy_repository.py
+++ b/api/repositories/workflow_node_execution/sqlalchemy_repository.py
@@ -40,7 +40,9 @@ class SQLAlchemyWorkflowNodeExecutionRepository:
         elif isinstance(session_factory, sessionmaker):
             self._session_factory = session_factory
         else:
-            raise ValueError(f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine")
+            raise ValueError(
+                f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
+            )
 
         self._tenant_id = tenant_id
         self._app_id = app_id

--- a/api/repositories/workflow_node_execution/sqlalchemy_repository.py
+++ b/api/repositories/workflow_node_execution/sqlalchemy_repository.py
@@ -40,7 +40,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository:
         elif isinstance(session_factory, sessionmaker):
             self._session_factory = session_factory
         else:
-            raise ValueError("session_factory must be a sessionmaker or Engine")
+            raise ValueError(f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine")
 
         self._tenant_id = tenant_id
         self._app_id = app_id

--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -133,7 +133,7 @@ class WorkflowRunService:
             params={
                 "tenant_id": app_model.tenant_id,
                 "app_id": app_model.id,
-                "session_factory": db.session.get_bind,
+                "session_factory": db.session.get_bind(),
             }
         )
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -289,7 +289,7 @@ class WorkflowService:
             params={
                 "tenant_id": app_model.tenant_id,
                 "app_id": app_model.id,
-                "session_factory": db.session.get_bind,
+                "session_factory": db.session.get_bind(),
             }
         )
         repository.save(workflow_node_execution)

--- a/api/tasks/remove_app_and_related_data_task.py
+++ b/api/tasks/remove_app_and_related_data_task.py
@@ -193,7 +193,7 @@ def _delete_app_workflow_node_executions(tenant_id: str, app_id: str):
         params={
             "tenant_id": tenant_id,
             "app_id": app_id,
-            "session_factory": db.session.get_bind,
+            "session_factory": db.session.get_bind(),
         }
     )
 


### PR DESCRIPTION


Signed-off-by: -LAN- <laipz8200@outlook.com>

# Summary

follow-up #18382

Adds a type check for the session factory to ensure it is either
a sessionmaker or Engine, raising a ValueError otherwise. This
prevents potential runtime errors from incorrect session factory
types. Also, updates parameter usage in service calls to invoke
session binding methods.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

