### PR TITLE
fix: Patch OpenTelemetry to handle None tokens

### DIFF
--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -52,6 +52,7 @@ def initialize_extensions(app: DifyApp):
         ext_mail,
         ext_migrate,
         ext_otel,
+        ext_otel_patch,
         ext_proxy_fix,
         ext_redis,
         ext_repositories,
@@ -84,6 +85,7 @@ def initialize_extensions(app: DifyApp):
         ext_proxy_fix,
         ext_blueprints,
         ext_commands,
+        ext_otel_patch,  # Apply patch before initializing OpenTelemetry
         ext_otel,
     ]
     for ext in extensions:

--- a/api/extensions/ext_otel_patch.py
+++ b/api/extensions/ext_otel_patch.py
@@ -1,0 +1,63 @@
+"""
+Patch for OpenTelemetry context detach method to handle None tokens gracefully.
+
+This patch addresses the issue where OpenTelemetry's context.detach() method raises a TypeError
+when called with a None token. The error occurs in the contextvars_context.py file where it tries
+to call reset() on a None token.
+
+Related GitHub issue: https://github.com/langgenius/dify/issues/18496
+
+Error being fixed:
+```
+Traceback (most recent call last):
+  File "opentelemetry/context/__init__.py", line 154, in detach
+    _RUNTIME_CONTEXT.detach(token)
+  File "opentelemetry/context/contextvars_context.py", line 50, in detach
+    self._current_context.reset(token)  # type: ignore
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+TypeError: expected an instance of Token, got None
+```
+
+Instead of modifying the third-party package directly, this patch monkey-patches the
+context.detach method to gracefully handle None tokens.
+"""
+
+import logging
+from functools import wraps
+
+from opentelemetry import context
+
+logger = logging.getLogger(__name__)
+
+# Store the original detach method
+original_detach = context.detach
+
+
+# Create a patched version that handles None tokens
+@wraps(original_detach)
+def patched_detach(token):
+    """
+    A patched version of context.detach that handles None tokens gracefully.
+    """
+    if token is None:
+        logger.debug("Attempted to detach a None token, skipping")
+        return
+
+    return original_detach(token)
+
+
+def is_enabled():
+    """
+    Check if the extension is enabled.
+    Always enable this patch to prevent errors even when OpenTelemetry is disabled.
+    """
+    return True
+
+
+def init_app(app):
+    """
+    Initialize the OpenTelemetry context patch.
+    """
+    # Replace the original detach method with our patched version
+    context.detach = patched_detach
+    logger.info("OpenTelemetry context.detach patched to handle None tokens")


### PR DESCRIPTION

Signed-off-by: -LAN- <laipz8200@outlook.com>

# Summary

Adds a patch to OpenTelemetry's context.detach method to prevent
TypeErrors when detaching None tokens. This change addresses an
issue where the original method fails, causing errors in context
management. The patch ensures graceful handling of such cases
without modifying the third-party package.

Relates to issue #18496

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

