### PR TITLE
docs: replace outdated Enterprise inquiry link with a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://cloud.dify.ai">Dify Cloud</a> ·
   <a href="https://docs.dify.ai/getting-started/install-self-hosted">Self-hosting</a> ·
   <a href="https://docs.dify.ai">Documentation</a> ·
-  <a href="https://udify.app/chat/22L1zSxg6yW1cWQg">Enterprise inquiry</a>
+  <a href="https://dify.ai/pricing">Dify edition overview</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
# Summary

replaced the outdated **enterprise inquiry** link with a more suitable destination.  
enterprise users can now find the contact entry point on the new overview page.

# Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/20c7ed0f-7e08-48f3-a7f0-cb8fdca78e6e) | ![after](https://github.com/user-attachments/assets/d1b3c9c2-f28a-4d40-b2d7-8eeb163c6d94) |