### PR TITLE
Resolves #18536 Retreive conversation variables

### DIFF
--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -109,12 +109,13 @@ class ConversationVariablesApi(Resource):
         conversation_id = str(c_id)
 
         parser = reqparse.RequestParser()
+        parser.add_argument("last_id", type=uuid_value, location="args")
         parser.add_argument("limit", type=int_range(1, 100), required=False, default=20, location="args")
         args = parser.parse_args()
 
         try:
             return ConversationService.get_conversational_variable(
-                app_model, conversation_id, end_user, args["limit"]
+                app_model, conversation_id, end_user, args["limit"], args["last_id"]
             )
         except services.errors.conversation.ConversationNotExistsError:
             raise NotFound("Conversation Not Exists.")

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -100,7 +100,6 @@ class ConversationVariablesApi(Resource):
     @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.QUERY))
     @marshal_with(conversation_variable_infinite_scroll_pagination_fields)
     def get(self, app_model: App, end_user: EndUser, c_id):
-
         # conversational variable only for chat app
         app_mode = AppMode.value_of(app_model.mode)
         if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT}:

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -1,6 +1,5 @@
 from flask_restful import Resource, marshal_with, reqparse  # type: ignore
 from flask_restful.inputs import int_range  # type: ignore
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 

--- a/api/fields/conversation_variable_fields.py
+++ b/api/fields/conversation_variable_fields.py
@@ -19,3 +19,9 @@ paginated_conversation_variable_fields = {
     "has_more": fields.Boolean,
     "data": fields.List(fields.Nested(conversation_variable_fields), attribute="data"),
 }
+
+conversation_variable_infinite_scroll_pagination_fields = {
+    "limit": fields.Integer,
+    "has_more": fields.Boolean,
+    "data": fields.List(fields.Nested(conversation_variable_fields)),
+}

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -195,7 +195,7 @@ class ConversationService:
                 last_variable = session.scalar(stmt.where(ConversationVariable.id == last_id))
                 if not last_variable:
                     raise ConversationVariableNotExistsError()
-                
+
                 # Filter for variables created after the last_id
                 stmt = stmt.where(ConversationVariable.created_at > last_variable.created_at)
 

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -14,8 +14,8 @@ from models.account import Account
 from models.model import App, Conversation, EndUser, Message
 from services.errors.conversation import (
     ConversationNotExistsError,
-    LastConversationNotExistsError,
     ConversationVariableNotExistsError,
+    LastConversationNotExistsError,
 )
 from services.errors.message import MessageNotExistsError
 

--- a/api/services/errors/conversation.py
+++ b/api/services/errors/conversation.py
@@ -11,3 +11,7 @@ class ConversationNotExistsError(BaseServiceError):
 
 class ConversationCompletedError(Exception):
     pass
+
+
+class ConversationVariableNotExistsError(BaseServiceError):
+    pass

--- a/web/app/components/develop/template/template_advanced_chat.en.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.en.mdx
@@ -869,13 +869,17 @@ Chat applications support session persistence, allowing previous chat history to
       <Property name='user' type='string' key='user'>
         The user identifier, defined by the developer, must ensure uniqueness within the application
       </Property>
+      <Property name='last_id' type='string' key='last_id'>
+          (Optional) The ID of the last record on the current page, default is null.
+      </Property>
+      <Property name='limit' type='int' key='limit'>
+          (Optional) How many records to return in one request, default is the most recent 20 entries. Maximum 100, minimum 1.
+      </Property>
     </Properties>
 
     ### Response
 
-    - `page` (int) Current page number
     - `limit` (int) Number of items per page
-    - `total` (int) Total number of items
     - `has_more` (bool) Whether there is a next page
     - `data` (array[object]) List of variables
       - `id` (string) Variable ID
@@ -911,9 +915,7 @@ Chat applications support session persistence, allowing previous chat history to
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-      "page": 1,
       "limit": 100,
-      "total": 2,
       "has_more": false,
       "data": [
         {

--- a/web/app/components/develop/template/template_advanced_chat.en.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.en.mdx
@@ -846,6 +846,104 @@ Chat applications support session persistence, allowing previous chat history to
 ---
 
 <Heading
+  url='/conversations/:conversation_id/variables'
+  method='GET'
+  title='Get Conversation Variables'
+  name='#conversation-variables'
+/>
+<Row>
+  <Col>
+    Retrieve variables from a specific conversation. This endpoint is useful for extracting structured data that was captured during the conversation.
+
+    ### Path Parameters
+
+    <Properties>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        The ID of the conversation to retrieve variables from.
+      </Property>
+    </Properties>
+
+    ### Query Parameters
+
+    <Properties>
+      <Property name='user' type='string' key='user'>
+        The user identifier, defined by the developer, must ensure uniqueness within the application
+      </Property>
+    </Properties>
+
+    ### Response
+
+    - `page` (int) Current page number
+    - `limit` (int) Number of items per page
+    - `total` (int) Total number of items
+    - `has_more` (bool) Whether there is a next page
+    - `data` (array[object]) List of variables
+      - `id` (string) Variable ID
+      - `name` (string) Variable name
+      - `value_type` (string) Variable type (string, number, object, etc.)
+      - `value` (string) Variable value
+      - `description` (string) Variable description
+      - `created_at` (int) Creation timestamp
+      - `updated_at` (int) Last update timestamp
+
+    ### Errors
+    - 404, `conversation_not_exists`, Conversation not found
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/conversations/:conversation_id/variables" targetCode={`curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \\\n--header 'Authorization: Bearer {api_key}'`}>
+
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Request with variable name filter">
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123&variable_name=customer_name' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "page": 1,
+      "limit": 100,
+      "total": 2,
+      "has_more": false,
+      "data": [
+        {
+          "id": "variable-uuid-1",
+          "name": "customer_name",
+          "value_type": "string",
+          "value": "John Doe",
+          "description": "Customer name extracted from the conversation",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        },
+        {
+          "id": "variable-uuid-2",
+          "name": "order_details",
+          "value_type": "json",
+          "value": "{\"product\":\"Widget\",\"quantity\":5,\"price\":19.99}",
+          "description": "Order details from the customer",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        }
+      ]
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
   url='/audio-to-text'
   method='POST'
   title='Speech to Text'

--- a/web/app/components/develop/template/template_advanced_chat.ja.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.ja.mdx
@@ -845,6 +845,104 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
 ---
 
 <Heading
+  url='/conversations/:conversation_id/variables'
+  method='GET'
+  title='会話変数の取得'
+  name='#conversation-variables'
+/>
+<Row>
+  <Col>
+    特定の会話から変数を取得します。このエンドポイントは、会話中に取得された構造化データを抽出するのに役立ちます。
+
+    ### パスパラメータ
+
+    <Properties>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        変数を取得する会話のID。
+      </Property>
+    </Properties>
+
+    ### クエリパラメータ
+
+    <Properties>
+      <Property name='user' type='string' key='user'>
+        ユーザー識別子。開発者によって定義されたルールに従い、アプリケーション内で一意である必要があります。
+      </Property>
+    </Properties>
+
+    ### レスポンス
+
+    - `page` (int) 現在のページ番号
+    - `limit` (int) ページごとのアイテム数
+    - `total` (int) アイテムの総数
+    - `has_more` (bool) さらにアイテムがあるかどうか
+    - `data` (array[object]) 変数のリスト
+      - `id` (string) 変数ID
+      - `name` (string) 変数名
+      - `value_type` (string) 変数タイプ（文字列、数値、真偽値など）
+      - `value` (string) 変数値
+      - `description` (string) 変数の説明
+      - `created_at` (int) 作成タイムスタンプ
+      - `updated_at` (int) 最終更新タイムスタンプ
+
+    ### エラー
+    - 404, `conversation_not_exists`, 会話が見つかりません
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/conversations/:conversation_id/variables" targetCode={`curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \\\n--header 'Authorization: Bearer {api_key}'`}>
+
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Request with variable name filter">
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123&variable_name=customer_name' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "page": 1,
+      "limit": 100,
+      "total": 2,
+      "has_more": false,
+      "data": [
+        {
+          "id": "variable-uuid-1",
+          "name": "customer_name",
+          "value_type": "string",
+          "value": "John Doe",
+          "description": "会話から抽出された顧客名",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        },
+        {
+          "id": "variable-uuid-2",
+          "name": "order_details",
+          "value_type": "json",
+          "value": "{\"product\":\"Widget\",\"quantity\":5,\"price\":19.99}",
+          "description": "顧客の注文詳細",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        }
+      ]
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
   url='/audio-to-text'
   method='POST'
   title='音声からテキストへ'

--- a/web/app/components/develop/template/template_advanced_chat.ja.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.ja.mdx
@@ -868,13 +868,17 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       <Property name='user' type='string' key='user'>
         ユーザー識別子。開発者によって定義されたルールに従い、アプリケーション内で一意である必要があります。
       </Property>
+      <Property name='last_id' type='string' key='last_id'>
+          (Optional)現在のページの最後の記録のID、デフォルトはnullです。
+      </Property>
+      <Property name='limit' type='int' key='limit'>
+          (Optional)1回のリクエストで返す記録の数、デフォルトは最新の20件です。最大100、最小1。
+      </Property>
     </Properties>
 
     ### レスポンス
 
-    - `page` (int) 現在のページ番号
     - `limit` (int) ページごとのアイテム数
-    - `total` (int) アイテムの総数
     - `has_more` (bool) さらにアイテムがあるかどうか
     - `data` (array[object]) 変数のリスト
       - `id` (string) 変数ID
@@ -910,9 +914,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-      "page": 1,
       "limit": 100,
-      "total": 2,
       "has_more": false,
       "data": [
         {

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -905,13 +905,17 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       <Property name='user' type='string' key='user'>
         用户标识符，由开发人员定义的规则，在应用程序内必须唯一。
       </Property>
+      <Property name='last_id' type='string' key='last_id'>
+        （选填）当前页最后面一条记录的 ID，默认 null
+      </Property>
+      <Property name='limit' type='int' key='limit'>
+        （选填）一次请求返回多少条记录，默认 20 条，最大 100 条，最小 1 条。
+      </Property>
     </Properties>
 
     ### 响应
 
-    - `page` (int) 当前页码
     - `limit` (int) 每页项目数
-    - `total` (int) 项目总数
     - `has_more` (bool) 是否有更多项目
     - `data` (array[object]) 变量列表
       - `id` (string) 变量ID
@@ -947,9 +951,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-      "page": 1,
       "limit": 100,
-      "total": 2,
       "has_more": false,
       "data": [
         {

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -882,6 +882,104 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
 ---
 
 <Heading
+  url='/conversations/:conversation_id/variables'
+  method='GET'
+  title='获取对话变量'
+  name='#conversation-variables'
+/>
+<Row>
+  <Col>
+    从特定对话中检索变量。此端点对于提取对话过程中捕获的结构化数据非常有用。
+
+    ### 路径参数
+
+    <Properties>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        要从中检索变量的对话ID。
+      </Property>
+    </Properties>
+
+    ### 查询参数
+
+    <Properties>
+      <Property name='user' type='string' key='user'>
+        用户标识符，由开发人员定义的规则，在应用程序内必须唯一。
+      </Property>
+    </Properties>
+
+    ### 响应
+
+    - `page` (int) 当前页码
+    - `limit` (int) 每页项目数
+    - `total` (int) 项目总数
+    - `has_more` (bool) 是否有更多项目
+    - `data` (array[object]) 变量列表
+      - `id` (string) 变量ID
+      - `name` (string) 变量名称
+      - `value_type` (string) 变量类型（字符串、数字、布尔等）
+      - `value` (string) 变量值
+      - `description` (string) 变量描述
+      - `created_at` (int) 创建时间戳
+      - `updated_at` (int) 最后更新时间戳
+
+    ### 错误
+    - 404, `conversation_not_exists`, 对话不存在
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/conversations/:conversation_id/variables" targetCode={`curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \\\n--header 'Authorization: Bearer {api_key}'`}>
+
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Request with variable name filter">
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123&variable_name=customer_name' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "page": 1,
+      "limit": 100,
+      "total": 2,
+      "has_more": false,
+      "data": [
+        {
+          "id": "variable-uuid-1",
+          "name": "customer_name",
+          "value_type": "string",
+          "value": "John Doe",
+          "description": "客户名称（从对话中提取）",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        },
+        {
+          "id": "variable-uuid-2",
+          "name": "order_details",
+          "value_type": "json",
+          "value": "{\"product\":\"Widget\",\"quantity\":5,\"price\":19.99}",
+          "description": "客户的订单详情",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        }
+      ]
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
   url='/audio-to-text'
   method='POST'
   title='语音转文字'

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -879,6 +879,104 @@ Chat applications support session persistence, allowing previous chat history to
 ---
 
 <Heading
+  url='/conversations/:conversation_id/variables'
+  method='GET'
+  title='Get Conversation Variables'
+  name='#conversation-variables'
+/>
+<Row>
+  <Col>
+    Retrieve variables from a specific conversation. This endpoint is useful for extracting structured data that was captured during the conversation.
+
+    ### Path Parameters
+
+    <Properties>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        The ID of the conversation to retrieve variables from.
+      </Property>
+    </Properties>
+
+    ### Query Parameters
+
+    <Properties>
+      <Property name='user' type='string' key='user'>
+        The user identifier, defined by the developer, must ensure uniqueness within the application
+      </Property>
+    </Properties>
+
+    ### Response
+
+    - `page` (int) Current page number
+    - `limit` (int) Number of items per page
+    - `total` (int) Total number of items
+    - `has_more` (bool) Whether there is a next page
+    - `data` (array[object]) List of variables
+      - `id` (string) Variable ID
+      - `name` (string) Variable name
+      - `value_type` (string) Variable type (string, number, object, etc.)
+      - `value` (string) Variable value
+      - `description` (string) Variable description
+      - `created_at` (int) Creation timestamp
+      - `updated_at` (int) Last update timestamp
+
+    ### Errors
+    - 404, `conversation_not_exists`, Conversation not found
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/conversations/:conversation_id/variables" targetCode={`curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \\\n--header 'Authorization: Bearer {api_key}'`}>
+
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Request with variable name filter">
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123&variable_name=customer_name' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "page": 1,
+      "limit": 100,
+      "total": 2,
+      "has_more": false,
+      "data": [
+        {
+          "id": "variable-uuid-1",
+          "name": "customer_name",
+          "value_type": "string",
+          "value": "John Doe",
+          "description": "Customer name extracted from the conversation",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        },
+        {
+          "id": "variable-uuid-2",
+          "name": "order_details",
+          "value_type": "json",
+          "value": "{\"product\":\"Widget\",\"quantity\":5,\"price\":19.99}",
+          "description": "Order details from the customer",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        }
+      ]
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
   url='/audio-to-text'
   method='POST'
   title='Speech to Text'

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -902,13 +902,17 @@ Chat applications support session persistence, allowing previous chat history to
       <Property name='user' type='string' key='user'>
         The user identifier, defined by the developer, must ensure uniqueness within the application
       </Property>
+      <Property name='last_id' type='string' key='last_id'>
+          (Optional) The ID of the last record on the current page, default is null.
+      </Property>
+      <Property name='limit' type='int' key='limit'>
+          (Optional) How many records to return in one request, default is the most recent 20 entries. Maximum 100, minimum 1.
+      </Property>
     </Properties>
 
     ### Response
 
-    - `page` (int) Current page number
     - `limit` (int) Number of items per page
-    - `total` (int) Total number of items
     - `has_more` (bool) Whether there is a next page
     - `data` (array[object]) List of variables
       - `id` (string) Variable ID
@@ -944,9 +948,7 @@ Chat applications support session persistence, allowing previous chat history to
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-      "page": 1,
       "limit": 100,
-      "total": 2,
       "has_more": false,
       "data": [
         {

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -900,13 +900,17 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       <Property name='user' type='string' key='user'>
         ユーザー識別子。開発者によって定義されたルールに従い、アプリケーション内で一意である必要があります。
       </Property>
+      <Property name='last_id' type='string' key='last_id'>
+          (Optional)現在のページの最後のレコードのID、デフォルトはnullです。
+      </Property>
+      <Property name='limit' type='int' key='limit'>
+          (Optional)1回のリクエストで返すレコードの数、デフォルトは最新の20件です。最大100、最小1。
+      </Property>
     </Properties>
 
     ### レスポンス
 
-    - `page` (int) 現在のページ番号
     - `limit` (int) ページごとのアイテム数
-    - `total` (int) アイテムの総数
     - `has_more` (bool) さらにアイテムがあるかどうか
     - `data` (array[object]) 変数のリスト
       - `id` (string) 変数ID
@@ -942,9 +946,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-      "page": 1,
       "limit": 100,
-      "total": 2,
       "has_more": false,
       "data": [
         {

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -877,6 +877,104 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
 ---
 
 <Heading
+  url='/conversations/:conversation_id/variables'
+  method='GET'
+  title='会話変数の取得'
+  name='#conversation-variables'
+/>
+<Row>
+  <Col>
+    特定の会話から変数を取得します。このエンドポイントは、会話中に取得された構造化データを抽出するのに役立ちます。
+
+    ### パスパラメータ
+
+    <Properties>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        変数を取得する会話のID。
+      </Property>
+    </Properties>
+
+    ### クエリパラメータ
+
+    <Properties>
+      <Property name='user' type='string' key='user'>
+        ユーザー識別子。開発者によって定義されたルールに従い、アプリケーション内で一意である必要があります。
+      </Property>
+    </Properties>
+
+    ### レスポンス
+
+    - `page` (int) 現在のページ番号
+    - `limit` (int) ページごとのアイテム数
+    - `total` (int) アイテムの総数
+    - `has_more` (bool) さらにアイテムがあるかどうか
+    - `data` (array[object]) 変数のリスト
+      - `id` (string) 変数ID
+      - `name` (string) 変数名
+      - `value_type` (string) 変数タイプ（文字列、数値、真偽値など）
+      - `value` (string) 変数値
+      - `description` (string) 変数の説明
+      - `created_at` (int) 作成タイムスタンプ
+      - `updated_at` (int) 最終更新タイムスタンプ
+
+    ### エラー
+    - 404, `conversation_not_exists`, 会話が見つかりません
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/conversations/:conversation_id/variables" targetCode={`curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \\\n--header 'Authorization: Bearer {api_key}'`}>
+
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Request with variable name filter">
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123&variable_name=customer_name' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "page": 1,
+      "limit": 100,
+      "total": 2,
+      "has_more": false,
+      "data": [
+        {
+          "id": "variable-uuid-1",
+          "name": "customer_name",
+          "value_type": "string",
+          "value": "John Doe",
+          "description": "会話から抽出された顧客名",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        },
+        {
+          "id": "variable-uuid-2",
+          "name": "order_details",
+          "value_type": "json",
+          "value": "{\"product\":\"Widget\",\"quantity\":5,\"price\":19.99}",
+          "description": "顧客の注文詳細",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        }
+      ]
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
   url='/audio-to-text'
   method='POST'
   title='音声からテキストへ'

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -917,13 +917,17 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       <Property name='user' type='string' key='user'>
         用户标识符，由开发人员定义的规则，在应用程序内必须唯一。
       </Property>
+      <Property name='last_id' type='string' key='last_id'>
+        （选填）当前页最后面一条记录的 ID，默认 null
+      </Property>
+      <Property name='limit' type='int' key='limit'>
+        （选填）一次请求返回多少条记录，默认 20 条，最大 100 条，最小 1 条。
+      </Property>
     </Properties>
 
     ### 响应
 
-    - `page` (int) 当前页码
     - `limit` (int) 每页项目数
-    - `total` (int) 项目总数
     - `has_more` (bool) 是否有更多项目
     - `data` (array[object]) 变量列表
       - `id` (string) 变量ID
@@ -959,9 +963,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     <CodeGroup title="Response">
     ```json {{ title: 'Response' }}
     {
-      "page": 1,
       "limit": 100,
-      "total": 2,
       "has_more": false,
       "data": [
         {

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -894,6 +894,104 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
 ---
 
 <Heading
+  url='/conversations/:conversation_id/variables'
+  method='GET'
+  title='获取对话变量'
+  name='#conversation-variables'
+/>
+<Row>
+  <Col>
+    从特定对话中检索变量。此端点对于提取对话过程中捕获的结构化数据非常有用。
+
+    ### 路径参数
+
+    <Properties>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        要从中检索变量的对话ID。
+      </Property>
+    </Properties>
+
+    ### 查询参数
+
+    <Properties>
+      <Property name='user' type='string' key='user'>
+        用户标识符，由开发人员定义的规则，在应用程序内必须唯一。
+      </Property>
+    </Properties>
+
+    ### 响应
+
+    - `page` (int) 当前页码
+    - `limit` (int) 每页项目数
+    - `total` (int) 项目总数
+    - `has_more` (bool) 是否有更多项目
+    - `data` (array[object]) 变量列表
+      - `id` (string) 变量ID
+      - `name` (string) 变量名称
+      - `value_type` (string) 变量类型（字符串、数字、布尔等）
+      - `value` (string) 变量值
+      - `description` (string) 变量描述
+      - `created_at` (int) 创建时间戳
+      - `updated_at` (int) 最后更新时间戳
+
+    ### 错误
+    - 404, `conversation_not_exists`, 对话不存在
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/conversations/:conversation_id/variables" targetCode={`curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \\\n--header 'Authorization: Bearer {api_key}'`}>
+
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Request with variable name filter">
+    ```bash {{ title: 'cURL' }}
+    curl -X GET '${props.appDetail.api_base_url}/conversations/{conversation_id}/variables?user=abc-123&variable_name=customer_name' \
+    --header 'Authorization: Bearer {api_key}'
+    ```
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "page": 1,
+      "limit": 100,
+      "total": 2,
+      "has_more": false,
+      "data": [
+        {
+          "id": "variable-uuid-1",
+          "name": "customer_name",
+          "value_type": "string",
+          "value": "John Doe",
+          "description": "客户名称（从对话中提取）",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        },
+        {
+          "id": "variable-uuid-2",
+          "name": "order_details",
+          "value_type": "json",
+          "value": "{\"product\":\"Widget\",\"quantity\":5,\"price\":19.99}",
+          "description": "客户的订单详情",
+          "created_at": 1650000000000,
+          "updated_at": 1650000000000
+        }
+      ]
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
   url='/audio-to-text'
   method='POST'
   title='语音转文字'


### PR DESCRIPTION
# Summary

Add a new api to retreive all the conversational variables from the conversation of chat/chatflow
Close https://github.com/langgenius/dify/issues/18536

# Screenshots
![image](https://github.com/user-attachments/assets/473f11c3-acac-4046-814a-878078bbfd82)
![image](https://github.com/user-attachments/assets/7c28df2d-936b-4f11-8153-3ec35f99ad81)

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

