### PR TITLE
fix: improve translation of community code of conduct sentence

### DIFF
--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -6,7 +6,7 @@
 
 本指南和 Dify 一样在不断完善中。如果有任何滞后于项目实际情况的地方，恳请谅解，我们也欢迎任何改进建议。
 
-关于许可证，请花一分钟阅读我们简短的[许可和贡献者协议](./LICENSE)。社区同时也遵循[行为准则](https://github.com/langgenius/.github/blob/main/CODE_OF_CONDUCT.md)。
+关于许可证，请花一分钟阅读我们简短的[许可和贡献者协议](./LICENSE)。同时也请遵循社区[行为准则](https://github.com/langgenius/.github/blob/main/CODE_OF_CONDUCT.md)。
 
 ## 开始之前
 


### PR DESCRIPTION
# Summary

fix(docs): improve translation of code of conduct section in Chinese
## What This PR Does

This PR improves the Chinese translation of the sentence referring to the community's adherence to the code of conduct.

### Before:
社区同时也遵守行为准则。

### After:
同时也请遵守社区行为准则。

## Why This Change

The updated version is more idiomatic and natural in Chinese. It also better conveys the polite and suggestive tone intended in the original English ("please adhere to...").

This change helps Chinese users understand the expected behavior more clearly and aligns with common usage in Chinese technical documentation.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

