### PR TITLE
Fix some prompt typos

### DIFF
--- a/api/core/llm_generator/prompts.py
+++ b/api/core/llm_generator/prompts.py
@@ -1,7 +1,7 @@
 # Written by YORKI MINAKO🤡, Edited by Xiaoyi
 CONVERSATION_TITLE_PROMPT = """You need to decompose the user's input into "subject" and "intention" in order to accurately figure out what the user's input language actually is. 
-Notice: the language type user use could be diverse, which can be English, Chinese, Italian, Español, Arabic, Japanese, French, and etc.
-MAKE SURE your output is the SAME language as the user's input!
+Notice: the language type user uses could be diverse, which can be English, Chinese, Italian, Español, Arabic, Japanese, French, and etc.
+ENSURE your output is in the SAME language as the user's input!
 Your output is restricted only to: (Input language) Intention + Subject(short as possible)
 Your output MUST be a valid JSON.
 
@@ -19,7 +19,7 @@ User Input: hi, yesterday i had some burgers.
 example 2:
 User Input: hello
 {
-  "Language Type": "The user's input is written in pure English",
+  "Language Type": "The user's input is pure English",
   "Your Reasoning": "The language of my output must be pure English.",
   "Your Output": "Greeting myself☺️"
 }
@@ -46,7 +46,7 @@ example 5:
 User Input: why小红的年龄is老than小明？
 {
   "Language Type": "The user's input is English-Chinese mixed",
-  "Your Reasoning": "The English parts are subjective particles, the main intention is written in Chinese, besides, Chinese occupies a greater \"actual meaning\" than English, so the language of my output must be using Chinese.",
+  "Your Reasoning": "The English parts are filler words, the main intention is written in Chinese, besides, Chinese occupies a greater \"actual meaning\" than English, so the language of my output must be using Chinese.",
   "Your Output": "询问小红和小明的年龄"
 }
 
@@ -114,6 +114,13 @@ JAVASCRIPT_CODE_GENERATOR_PROMPT_TEMPLATE = (
     "4. The returned object should contain at least one key-value pair.\n\n"
     "5. The returned object should always be in the format: {result: ...}\n\n"
     "Example:\n"
+    "/**\n"
+    " * Multiplies two numbers together.\n"
+    " *\n"
+    " * @param {number} arg1 - The first number to multiply.\n"
+    " * @param {number} arg2 - The second number to multiply.\n"
+    " * @returns {{ result: number }} The result of the multiplication.\n"
+    " */\n"
     "function main(arg1, arg2) {\n"
     "    return {\n"
     "        result: arg1 * arg2\n"
@@ -130,7 +137,7 @@ JAVASCRIPT_CODE_GENERATOR_PROMPT_TEMPLATE = (
 
 SUGGESTED_QUESTIONS_AFTER_ANSWER_INSTRUCTION_PROMPT = (
     "Please help me predict the three most likely questions that human would ask, "
-    "and keeping each question under 20 characters.\n"
+    "and keep each question under 20 characters.\n"
     "MAKE SURE your output is the SAME language as the Assistant's latest response. "
     "The output must be an array in JSON format following the specified schema:\n"
     '["question1","question2","question3"]\n'
@@ -157,9 +164,9 @@ Here is a task description for which I would like you to create a high-quality p
 </task_description>
 Based on task description, please create a well-structured prompt template that another AI could use to consistently complete the task. The prompt template should include:
 - Do not include <input> or <output> section and variables in the prompt, assume user will add them at their own will. 
-- Clear instructions for the AI that will be using this prompt, demarcated with <instructions> tags. The instructions should provide step-by-step directions on how to complete the task using the input variables. Also Specifies in the instructions that the output should not contain any xml tag. 
+- Clear instructions for the AI that will be using this prompt, demarcated with <instruction> tags. The instructions should provide step-by-step directions on how to complete the task using the input variables. Also Specifies in the instructions that the output should not contain any xml tag. 
 - Relevant examples if needed to clarify the task further, demarcated with <example> tags. Do not include variables in the prompt. Give three pairs of input and output examples.   
-- Include other relevant sections demarcated with appropriate XML tags like <examples>, <instructions>.
+- Include other relevant sections demarcated with appropriate XML tags like <examples>, <instruction>.
 - Use the same language as task description. 
 - Output in ``` xml ``` and start with <instruction>
 Please generate the full prompt template with at least 300 words and output only the prompt template.
@@ -172,7 +179,7 @@ Here is a task description for which I would like you to create a high-quality p
 </task_description>
 Based on task description, please create a well-structured prompt template that another AI could use to consistently complete the task. The prompt template should include:
 - Descriptive variable names surrounded by {{ }} (two curly brackets) to indicate where the actual values will be substituted in. Choose variable names that clearly indicate the type of value expected. Variable names have to be composed of number, english alphabets and underline and nothing else. 
-- Clear instructions for the AI that will be using this prompt, demarcated with <instructions> tags. The instructions should provide step-by-step directions on how to complete the task using the input variables. Also Specifies in the instructions that the output should not contain any xml tag. 
+- Clear instructions for the AI that will be using this prompt, demarcated with <instruction> tags. The instructions should provide step-by-step directions on how to complete the task using the input variables. Also Specifies in the instructions that the output should not contain any xml tag. 
 - Relevant examples if needed to clarify the task further, demarcated with <example> tags. Do not use curly brackets any other than in <instruction> section. 
 - Any other relevant sections demarcated with appropriate XML tags like <input>, <output>, etc.
 - Use the same language as task description. 
@@ -291,32 +298,30 @@ Your task is to convert simple user descriptions into properly formatted JSON Sc
 {
     "type": "object",
     "properties": {
-        "properties": {
-            "songs": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "id": {
-                            "type": "string"
-                        },
-                        "duration": {
-                            "type": "string"
-                        },
-                        "aritst": {
-                            "type": "string"
-                        }
+        "songs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
                     },
-                    "required": [
-                        "name",
-                        "id",
-                        "duration",
-                        "aritst"
-                    ]
-                }
+                    "id": {
+                        "type": "string"
+                    },
+                    "duration": {
+                        "type": "string"
+                    },
+                    "aritst": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "id",
+                    "duration",
+                    "aritst"
+                ]
             }
         }
     },


### PR DESCRIPTION
# Summary

Fixed duplicated and nested `properties` field in the samples along with some other typos. Also added JSDoc sample in the JavaScript code generator prompt for consistency with its instruction.

# Screenshots

none

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

