### PR TITLE
fix: buildin tool provider credentials_for_provider

### DIFF
--- a/api/core/tools/builtin_tool/provider.py
+++ b/api/core/tools/builtin_tool/provider.py
@@ -35,8 +35,9 @@ class BuiltinToolProviderController(ToolProviderController):
                 provider_yaml["credentials_for_provider"][credential_name]["name"] = credential_name
 
         credentials_schema = []
-        for credential in provider_yaml.get("credentials_for_provider", {}).values():
-            credentials_schema.append(credential)
+        for credential in provider_yaml.get("credentials_for_provider", {}):
+            credential_dict = provider_yaml.get('credentials_for_provider', {}).get(credential, {})
+            credentials_schema.append(credential_dict)
 
         super().__init__(
             entity=ToolProviderEntity(

--- a/api/core/tools/builtin_tool/provider.py
+++ b/api/core/tools/builtin_tool/provider.py
@@ -36,7 +36,7 @@ class BuiltinToolProviderController(ToolProviderController):
 
         credentials_schema = []
         for credential in provider_yaml.get("credentials_for_provider", {}):
-            credential_dict = provider_yaml.get('credentials_for_provider', {}).get(credential, {})
+            credential_dict = provider_yaml.get("credentials_for_provider", {}).get(credential, {})
             credentials_schema.append(credential_dict)
 
         super().__init__(


### PR DESCRIPTION
# Summary

If tool is added in buildin and credentials_for_provider is added in tool, an error will be reported when the service starts because incorrect data was used in the code. It has now been fixed.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| <img width="994" alt="image" src="https://github.com/user-attachments/assets/ec8c6dba-076b-4797-9a5e-f21eb951a141" /> | work  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

