### PR TITLE
fix(web): add missing 'clsx' dependency for pagination component

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -61,6 +61,7 @@
     "ahooks": "^3.8.4",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "copy-to-clipboard": "^3.3.3",
     "crypto-js": "^4.2.0",
     "dayjs": "^1.11.13",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       copy-to-clipboard:
         specifier: ^3.3.3
         version: 3.3.3


### PR DESCRIPTION
# Summary

This PR fixes a missing direct dependency in the Dify web module.

The `clsx` library is used directly in components such as `pagination.tsx` to conditionally join class names, but it was not explicitly declared in `web/package.json`.

Although `clsx` may exist as a transitive dependency through other packages, this can lead to build errors such as:

Module not found: Can't resolve 'clsx'


This PR adds `clsx` as an explicit dependency and updates the corresponding `pnpm-lock.yaml` file to ensure consistent builds and better maintainability.


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

