### PR TITLE
optimize account status  field hard coded

### DIFF
--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -10,9 +10,9 @@ from configs import dify_config
 from controllers.console.workspace.error import AccountNotInitializedError
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
+from models.account import AccountStatus
 from models.dataset import RateLimitLog
 from models.model import DifySetup
-from models.account import AccountStatus
 from services.feature_service import FeatureService, LicenseStatus
 from services.operation_service import OperationService
 

--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -12,6 +12,7 @@ from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.dataset import RateLimitLog
 from models.model import DifySetup
+from models.account import AccountStatus
 from services.feature_service import FeatureService, LicenseStatus
 from services.operation_service import OperationService
 
@@ -24,7 +25,7 @@ def account_initialization_required(view):
         # check account initialization
         account = current_user
 
-        if account.status == "uninitialized":
+        if account.status == AccountStatus.UNINITIALIZED:
             raise AccountNotInitializedError()
 
         return view(*args, **kwargs)


### PR DESCRIPTION
Just optimize the hard-coded operation of the` account.status` field：
```
def account_initialization_required(view):
    @wraps(view)
    def decorated(*args, **kwargs):
        # check account initialization
        account = current_user

        if account.status == "uninitialized": #  here changed to AccountStatus.UNINITIALIZED
            raise AccountNotInitializedError()

        return view(*args, **kwargs)

    return decorated

```