### PR TITLE
feat: support the display of custom web-component components returned by process nodes.

### DIFF
--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -289,7 +289,7 @@ export function Markdown(props: { content: string; className?: string; customDis
                 if (node.type === 'element' && node.properties?.ref)
                   delete node.properties.ref
 
-                if (node.type === 'element' && !/^[a-z][a-z0-9]*$/i.test(node.tagName)) {
+                if (node.type === 'element' && !/^[a-z][a-z0-9]*$/i.test(node.tagName) && !(node.tagName.startsWith('wc-') && node.properties?.dataIsWebComponent === '1')) {
                   node.type = 'text'
                   node.value = `<${node.tagName}`
                 }


### PR DESCRIPTION
# Summary

support the display of custom web-component components returned by process nodes.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
|  |  <img width="1355" alt="image" src="https://github.com/user-attachments/assets/3bdb9747-3ecf-4445-8368-362acdeae436" /> |
| <img width="568" alt="image" src="https://github.com/user-attachments/assets/5d955cbc-bb28-4432-ba82-293a2cd78a83" /> | <img width="717" alt="image" src="https://github.com/user-attachments/assets/75ae2530-e83a-4619-8846-47f3f4b39a3b" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

