### PR TITLE
fix: update notice for users for clear-orphaned-file-records and remove-orphaned-files-on-storage commands

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -869,6 +869,15 @@ def clear_orphaned_file_records():
     click.echo(
         click.style("This cannot be undone. Please make sure to back up your database before proceeding.", fg="yellow")
     )
+    click.echo(
+        click.style(
+            (
+                "It is also recommended to run this during the maintenance window, "
+                "as this may cause high load on your instance."
+            ),
+            fg="yellow",
+        )
+    )
     click.confirm("Do you want to proceed?", abort=True)
 
     # start the cleanup process
@@ -1008,7 +1017,16 @@ def remove_orphaned_files_on_storage():
         )
     )
     click.echo(
-        click.style("This cannot be undone. Please make sure to back up your database before proceeding.", fg="yellow")
+        click.style("This cannot be undone. Please make sure to back up your storage before proceeding.", fg="yellow")
+    )
+    click.echo(
+        click.style(
+            (
+                "It is also recommended to run this during the maintenance window, "
+                "as this may cause high load on your instance."
+            ),
+            fg="yellow",
+        )
     )
     click.confirm("Do you want to proceed?", abort=True)
 


### PR DESCRIPTION
# Summary

This is follow-up for #18835 to improve notice for users.

- The backup to be obtained before proceeding `remove-orphaned-files-on-storage` command should be from `storage`, not the `database`. I have corrected the wording.
- Since it may cause high load, I have made it display that running within the maintenance window is recommended.

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/86d90c1d-15b1-46fe-b631-762544512af3)  | ![image](https://github.com/user-attachments/assets/f657b219-ce07-457f-bcbe-a5757c4bb9bf)   |

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/3975449a-8358-4bbf-a731-0d3a4bd25efd)  | ![image](https://github.com/user-attachments/assets/70ead073-b1c2-4ded-a3e4-960a45d8b88e)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

