### PR TITLE
fix: i.find is not a function

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -596,17 +596,16 @@ const getIterationItemType = ({
     arrayType = curr.find((v: any) => v.variable === (valueSelector).join('.'))?.type
   }
   else {
-    (valueSelector).slice(1).forEach((key, i) => {
+    for (let i = 1; i < valueSelector.length - 1; i++) {
+      const key = valueSelector[i]
       const isLast = i === valueSelector.length - 2
-      curr = curr?.find((v: any) => v.variable === key)
-      if (isLast) {
-        arrayType = curr?.type
-      }
-      else {
-        if (curr?.type === VarType.object || curr?.type === VarType.file)
-          curr = curr.children
-      }
-    })
+      curr = Array.isArray(curr) ? curr.find(v => v.variable === key) : []
+
+      if (isLast)
+      arrayType = curr?.type
+      else if (curr?.type === VarType.object || curr?.type === VarType.file)
+      curr = curr.children || []
+    }
   }
 
   switch (arrayType as VarType) {
@@ -631,7 +630,7 @@ const getLoopItemType = ({
 }: {
   valueSelector: ValueSelector
   beforeNodesOutputVars: NodeOutPutVar[]
-  // eslint-disable-next-line sonarjs/no-identical-functions
+
 }): VarType => {
   const outputVarNodeId = valueSelector[0]
   const isSystem = isSystemVar(valueSelector)


### PR DESCRIPTION
# Summary
This pull request refactors utility functions in `utils.ts` to improve code readability and maintainability. The changes include restructuring the `getIterationItemType` function to simplify the loop logic and removing an unnecessary ESLint directive in the `getLoopItemType` function.

### Refactoring for improved readability and maintainability:

* `getIterationItemType` in `utils.ts`: Refactored the loop to use a `for` loop instead of `forEach`, added clearer variable naming, and simplified conditional checks for handling `VarType.object` and `VarType.file`. This improves the readability and structure of the function.

* `getLoopItemType` in `utils.ts`: Removed an unused ESLint directive (`// eslint-disable-next-line sonarjs/no-identical-functions`) to clean up the code.

Close https://github.com/langgenius/dify/issues/18937
Close https://github.com/langgenius/dify/issues/18836


# Screenshots

| Before | After |
|--------|-------|
| ...    | <img width="1109" alt="image" src="https://github.com/user-attachments/assets/9c9cd785-a004-41c7-bc83-118b21abd6c5" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

