### PR TITLE
 add flask request hook && log request and response content

### DIFF
--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -30,11 +30,12 @@ def create_flask_app_with_configs() -> DifyApp:
         # log request data info
         request_id = get_request_id()
         if request.headers.get("content-type", "").lower() == "application/json":
-            logging.info(f"[before request]|request_id: {request_id},"
-                         f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}")
+            logging.info(
+                f"[before request]|request_id: {request_id},"
+                f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}"
+            )
         else:
-            logging.info(f"[before request]|request_id: {request_id},"
-                         f" method: {request.method}, url: {request.url}")
+            logging.info(f"[before request]|request_id: {request_id}, method: {request.method}, url: {request.url}")
 
     # add extra `request_id` field for every response data
     @dify_app.after_request
@@ -44,8 +45,7 @@ def create_flask_app_with_configs() -> DifyApp:
             request_id = get_request_id()
             obj["request_id"] = request_id
             resp.set_data(json.dumps(obj))
-            logging.info(f"[finish request]|request_id: {request_id},"
-                         f" response: {obj}")
+            logging.info(f"[finish request]|request_id: {request_id}, response: {obj}")
         return resp
 
     return dify_app

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -2,12 +2,12 @@ import logging
 import time
 import json
 
+from flask import request
+
 from configs import dify_config
 from contexts.wrapper import RecyclableContextVar
 from dify_app import DifyApp
 from extensions.ext_logging import get_request_id
-
-from flask import request
 
 
 # ----------------------------

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -1,9 +1,13 @@
 import logging
 import time
+import json
 
 from configs import dify_config
 from contexts.wrapper import RecyclableContextVar
 from dify_app import DifyApp
+from extensions.ext_logging import get_request_id
+
+from flask import request
 
 
 # ----------------------------
@@ -22,6 +26,27 @@ def create_flask_app_with_configs() -> DifyApp:
     def before_request():
         # add an unique identifier to each request
         RecyclableContextVar.increment_thread_recycles()
+
+        # log request data info
+        request_id = get_request_id()
+        if request.headers.get("content-type", "").lower() == "application/json":
+            logging.info(f"[before request]|request_id: {request_id},"
+                         f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}")
+        else:
+            logging.info(f"[before request]|request_id: {request_id},"
+                         f" method: {request.method}, url: {request.url}")
+
+    # add extra `request_id` field for every response data
+    @dify_app.after_request
+    def add_extra_info(resp):
+        obj = resp.get_json()
+        if isinstance(obj, dict):
+            request_id = get_request_id()
+            obj["request_id"] = request_id
+            resp.set_data(json.dumps(obj))
+            logging.info(f"[finish request]|request_id: {request_id},"
+                         f" response: {obj}")
+        return resp
 
     return dify_app
 

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -1,6 +1,6 @@
+import json
 import logging
 import time
-import json
 
 from flask import request
 

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -29,7 +29,7 @@ def create_flask_app_with_configs() -> DifyApp:
 
         # log request data info
         request_id = get_request_id()
-        if request.headers.get("content-type", "").lower() == "application/json":
+        if "application/json" in request.headers.get("content-type", "").lower():
             logging.info(
                 f"[before request]|request_id: {request_id},"
                 f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}"

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -31,8 +31,10 @@ def create_flask_app_with_configs() -> DifyApp:
         request_id = get_request_id()
 
         try:
-            if request.method.lower() == "post" and "application/json" in request.headers.get("content-type",
-                                                                                              "").lower():
+            if (
+                request.method.lower() == "post"
+                and "application/json" in request.headers.get("content-type", "").lower()
+            ):
                 logging.info(
                     f"[before request]|request_id: {request_id},"
                     f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}"

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -29,19 +29,25 @@ def create_flask_app_with_configs() -> DifyApp:
 
         # log request data info
         request_id = get_request_id()
-        if "application/json" in request.headers.get("content-type", "").lower():
-            logging.info(
-                f"[before request]|request_id: {request_id},"
-                f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}"
-            )
-        else:
-            logging.info(f"[before request]|request_id: {request_id}, method: {request.method}, url: {request.url}")
+
+        try:
+            if request.method.lower() == "post" and "application/json" in request.headers.get("content-type",
+                                                                                              "").lower():
+                logging.info(
+                    f"[before request]|request_id: {request_id},"
+                    f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}"
+                )
+
+            else:
+                logging.info(f"[before request]|request_id: {request_id}, method: {request.method}, url: {request.url}")
+        except Exception as e:
+            logging.info(f"before_request handler err {e}")
 
     # add extra `request_id` field for every response data
     @dify_app.after_request
     def add_extra_info(resp):
         obj = resp.get_json()
-        if isinstance(obj, dict):
+        if obj is not None and isinstance(obj, dict):
             request_id = get_request_id()
             obj["request_id"] = request_id
             resp.set_data(json.dumps(obj))

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 
@@ -7,7 +6,6 @@ from flask import request
 from configs import dify_config
 from contexts.wrapper import RecyclableContextVar
 from dify_app import DifyApp
-from extensions.ext_logging import get_request_id
 
 
 # ----------------------------
@@ -27,21 +25,17 @@ def create_flask_app_with_configs() -> DifyApp:
         # add an unique identifier to each request
         RecyclableContextVar.increment_thread_recycles()
 
-        # log request data info
-        request_id = get_request_id()
-
         try:
             if (
                 request.method.lower() == "post"
                 and "application/json" in request.headers.get("content-type", "").lower()
             ):
                 logging.info(
-                    f"[before request]|request_id: {request_id},"
-                    f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}"
+                    f"[before request]| method: "
+                    f"{request.method}, url: {request.url}, request_data: {request.get_json()}"
                 )
-
             else:
-                logging.info(f"[before request]|request_id: {request_id}, method: {request.method}, url: {request.url}")
+                logging.info(f"[before request]| method: {request.method}, url: {request.url}")
         except Exception as e:
             logging.info(f"before_request handler err {e}")
 
@@ -50,10 +44,7 @@ def create_flask_app_with_configs() -> DifyApp:
     def add_extra_info(resp):
         obj = resp.get_json()
         if obj is not None and isinstance(obj, dict):
-            request_id = get_request_id()
-            obj["request_id"] = request_id
-            resp.set_data(json.dumps(obj))
-            logging.info(f"[finish request]|request_id: {request_id}, response: {obj}")
+            logging.info(f"[finish request]|response: {obj}")
         return resp
 
     return dify_app


### PR DESCRIPTION
When a user http request fails, it is not possible to obtain more useful log content from the log.
for example, when the http 400 error occurs:
```
2025-04-28 03:38:06,486 INFO [_internal.py:97]  127.0.0.1 - - [28/Apr/2025 03:38:06] "POST /console/api/login HTTP/1.1" 400 -
```
> You can only see the request error and cannot know the actual user parameters to further locate the problem

### 

so I modified the flask hook function content based on the existing one, and printed the input and output content for the application/json request

```
 @dify_app.before_request
    def before_request():
        # add an unique identifier to each request
        RecyclableContextVar.increment_thread_recycles()

        # log request data info
        request_id = get_request_id()
        if request.headers.get("content-type", "").lower() == "application/json":
            logging.info(f"[before request]|request_id: {request_id},"
                         f" method: {request.method}, url: {request.url}, request_data: {request.get_json()}")
        else:
            logging.info(f"[before request]|request_id: {request_id},"
                         f" method: {request.method}, url: {request.url}")

    # add extra `request_id` field for every response data
    @dify_app.after_request
    def add_extra_info(resp):
        obj = resp.get_json()
        if isinstance(obj, dict):
            request_id = get_request_id()
            obj["request_id"] = request_id
            resp.set_data(json.dumps(obj))
            logging.info(f"[finish request]|request_id: {request_id},"
                         f" response: {obj}")
        return resp
```
### 
After modification, you can see the user request parameters and return content：
```
2025-04-28 03:38:58,923 INFO [app_factory.py:38] 265127d1fb [before request]|request_id: 265127d1fb, method: POST, url: http://127.0.0.1:5001/console/api/login, request_data: {'email': 'xxxx@sina.cn', 'password': 'abcs123451'}
2025-04-28 03:38:59,237 INFO [app_factory.py:51] 265127d1fb [finish request]|request_id: 265127d1fb, response: {'code': 'email_or_password_mismatch', 'message': 'The email or password is mismatched.', 'status': 400, 'request_id': '265127d1fb'}
2025-04-28 03:38:59,239 INFO [_internal.py:97]  127.0.0.1 - - [28/Apr/2025 03:38:59] "POST /console/api/login HTTP/1.1" 400 -
```
> http post request log

```
2025-04-28 03:29:16,753 INFO [app_factory.py:38] e7a60bc84a [before request]|request_id: e7a60bc84a, method: POST, url: http://127.0.0.1:5001/console/api/login, request_data: {'email': 'xxxx@sina.cn', 'password': 'abcs123451'}
2025-04-28 03:29:17,161 INFO [app_factory.py:51] e7a60bc84a [finish request]|request_id: e7a60bc84a, response: {'result': 'success', 'data': {'access_token': 'xxxxx', 'refresh_token': 'xxxxxxx'}, 'request_id': 'e7a60bc84a'}
```
>  http post request log


```
2025-04-28 04:33:03,67 INFO [app_factory.py:30] 30a59db87b [before request]|request_id: 30a59db87b, method: GET, url: http://127.0.0.1:5001/console/api/account/profile
2025-04-28 04:33:03,397 INFO [app_factory.py:40] 30a59db87b [finish request]|request_id: 30a59db87b, response: {'id': '36ef6af8-xxxxxxx', 'name': 'gsmini',  'avatar': None, 'avatar_url': None, 'email': 'xxx@sina.cn', 'is_password_set': True, 'interface_language': 'zh-Hans', 'interface_theme': 'light', 'timezone': 'Asia/Shanghai', 'last_login_at': 1745814762, 'last_login_ip': '127.0.0.1', 'is_admin_group': True,  'created_at': 1745395821, 'request_id': '30a59db87b'}
2025-04-28 04:33:03,399 INFO [_internal.py:97]  127.0.0.1 - - [28/Apr/2025 04:33:03] "GET /console/api/account/profile HTTP/1.1" 200 -
```
> http get request log