### PR TITLE
fix(workflow_cycle_manage): failed nodes were not updated in workflow_node_executions

### DIFF
--- a/api/core/app/task_pipeline/workflow_cycle_manage.py
+++ b/api/core/app/task_pipeline/workflow_cycle_manage.py
@@ -380,7 +380,7 @@ class WorkflowCycleManage:
         workflow_node_execution.finished_at = finished_at
         workflow_node_execution.elapsed_time = elapsed_time
         workflow_node_execution.execution_metadata = execution_metadata
-        
+
         self._workflow_node_execution_repository.update(workflow_node_execution)
 
         return workflow_node_execution

--- a/api/core/app/task_pipeline/workflow_cycle_manage.py
+++ b/api/core/app/task_pipeline/workflow_cycle_manage.py
@@ -380,6 +380,8 @@ class WorkflowCycleManage:
         workflow_node_execution.finished_at = finished_at
         workflow_node_execution.elapsed_time = elapsed_time
         workflow_node_execution.execution_metadata = execution_metadata
+        
+        self._workflow_node_execution_repository.update(workflow_node_execution)
 
         return workflow_node_execution
 


### PR DESCRIPTION
fix(workflow_cycle_manage): failed nodes were not updated in workflow_node_executions

# Summary

There was no table update in _handle_workflow_node_execution_failed, so when a node failed, its execution record wasn't updated correctly.

fixes #18993
> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/51b84ed6-a025-4c11-800a-036e81f14acd)| ![image](https://github.com/user-attachments/assets/2908d6df-3dbf-40a2-9022-f779a89bb500) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

