### PR TITLE
refactor: switch to dynamic versioning in package configuration

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.3.1"
+dynamic = ["version"]
 requires-python = ">=3.11,<3.13"
 
 dependencies = [
@@ -89,8 +89,12 @@ dependencies = [
 # Before adding new dependency, consider place it in
 # alphabet order (a-z) and suitable group.
 
+[tool.setuptools]
+packages = []
+
 [tool.uv]
 default-groups = ["storage", "tools", "vdb"]
+package = false
 
 [dependency-groups]
 

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1155,7 +1155,6 @@ wheels = [
 
 [[package]]
 name = "dify-api"
-version = "1.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION


Signed-off-by: -LAN- <laipz8200@outlook.com>

# Summary

close #19018

- Replace static version "1.3.1" with dynamic versioning in pyproject.toml
- Configure setuptools to not include any packages by default
- Set package=false in uv configuration to prevent package building
- Update uv.lock to reflect version changes

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

