### PR TITLE
fix: image preview triggers binary download

### DIFF
--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -75,7 +75,7 @@ class FilePreviewApi(Resource):
         if args["as_attachment"]:
             encoded_filename = quote(upload_file.name)
             response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
-        response.headers["Content-Type"] = "application/octet-stream"
+            response.headers["Content-Type"] = "application/octet-stream"
 
         return response
 


### PR DESCRIPTION
# Summary

Fix indentation.
Image preview would trigger unwanted image downloads due to indentation problems.
Image URLs passed to large models couldn't properly retrieve images due to incorrect indentation.

Fix #19072


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

