### PR TITLE
fix: change provider should change the content

### DIFF
--- a/web/app/components/datasets/create/website/no-data.tsx
+++ b/web/app/components/datasets/create/website/no-data.tsx
@@ -17,6 +17,7 @@ type Props = {
 
 const NoData: FC<Props> = ({
   onConfig,
+  provider,
 }) => {
   const { t } = useTranslation()
 
@@ -38,7 +39,7 @@ const NoData: FC<Props> = ({
     } : null,
   }
 
-  const currentProvider = Object.values(providerConfig).find(provider => provider !== null) || providerConfig[DataSourceProvider.jinaReader]
+  const currentProvider = providerConfig[provider] || providerConfig[DataSourceProvider.jinaReader]
 
   if (!currentProvider) return null
 


### PR DESCRIPTION
# Summary

Fix https://github.com/langgenius/dify/issues/19073

This pull request updates the `NoData` component in `web/app/components/datasets/create/website/no-data.tsx` to improve how the `currentProvider` is determined by introducing a `provider` prop.

### Changes to `NoData` component:

* Added a new `provider` prop to the `Props` type and destructured it in the `NoData` component.
* Updated the logic for determining `currentProvider` to prioritize the `provider` prop over searching through `providerConfig`.

# Screenshots

| Before | After |
|--------|-------|
| ...    | <img width="663" alt="image" src="https://github.com/user-attachments/assets/62c545f8-22b0-4239-8583-5974224104e1" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

