### PR TITLE
feat(logAndAnn): add control option for question editing feature

### DIFF
--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -429,6 +429,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
                   text_to_speech: {
                     enabled: true,
                   },
+                  questionEditEnable: false,
                   supportAnnotation: true,
                   annotation_reply: {
                     enabled: true,
@@ -484,6 +485,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
                     text_to_speech: {
                       enabled: true,
                     },
+                    questionEditEnable: false,
                     supportAnnotation: true,
                     annotation_reply: {
                       enabled: true,

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -265,6 +265,7 @@ const Chat: FC<ChatProps> = ({
                     item={item}
                     questionIcon={questionIcon}
                     theme={themeBuilder?.theme}
+                    enableEdit={config?.questionEditEnable}
                     switchSibling={switchSibling}
                   />
                 )

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -28,6 +28,7 @@ type QuestionProps = {
   item: ChatItem
   questionIcon?: ReactNode
   theme: Theme | null | undefined
+  enableEdit?: boolean
   switchSibling?: (siblingMessageId: string) => void
 }
 
@@ -35,6 +36,7 @@ const Question: FC<QuestionProps> = ({
   item,
   questionIcon,
   theme,
+  enableEdit = true,
   switchSibling,
 }) => {
   const { t } = useTranslation()
@@ -87,9 +89,9 @@ const Question: FC<QuestionProps> = ({
             }}>
               <RiClipboardLine className='h-4 w-4' />
             </ActionButton>
-            <ActionButton onClick={handleEdit}>
+            {enableEdit && <ActionButton onClick={handleEdit}>
               <RiEditLine className='h-4 w-4' />
-            </ActionButton>
+            </ActionButton>}
           </div>
         </div>
         <div

--- a/web/app/components/base/chat/types.ts
+++ b/web/app/components/base/chat/types.ts
@@ -46,6 +46,7 @@ export type EnableType = {
 export type ChatConfig = Omit<ModelConfig, 'model'> & {
   supportAnnotation?: boolean
   appId?: string
+  questionEditEnable?: boolean
   supportFeedback?: boolean
   supportCitationHitInfo?: boolean
 }


### PR DESCRIPTION
# Summary

Resolves #19110 

- In the `Question` component, determine whether to display the edit button based on the `enableEdit` property
- Add `questionEditEnable` property to the `DetailPanel` component, and defaulting to disable question editing
- Add `questionEditEnable` property to the `ChatConfig` type as an optional configuration option

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/d96a7df1-5f93-4afb-a4b2-e8e866943406)| ![image](https://github.com/user-attachments/assets/82f306c3-f8f4-4d91-8317-cf67a24a9879)  |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

