### PR TITLE
chore: enhance dev script robustness by determining the script directory

### DIFF
--- a/dev/mypy-check
+++ b/dev/mypy-check
@@ -2,6 +2,9 @@
 
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/.."
+
 # run mypy checks
 uv run --directory api --dev \
   python -m mypy --install-types --non-interactive .

--- a/dev/pytest/pytest_all_tests.sh
+++ b/dev/pytest/pytest_all_tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 # ModelRuntime
 dev/pytest/pytest_model_runtime.sh
 

--- a/dev/pytest/pytest_artifacts.sh
+++ b/dev/pytest/pytest_artifacts.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 pytest api/tests/artifact_tests/

--- a/dev/pytest/pytest_model_runtime.sh
+++ b/dev/pytest/pytest_model_runtime.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 pytest api/tests/integration_tests/model_runtime/anthropic \
   api/tests/integration_tests/model_runtime/azure_openai \
   api/tests/integration_tests/model_runtime/openai api/tests/integration_tests/model_runtime/chatglm \

--- a/dev/pytest/pytest_tools.sh
+++ b/dev/pytest/pytest_tools.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 pytest api/tests/integration_tests/tools

--- a/dev/pytest/pytest_unit_tests.sh
+++ b/dev/pytest/pytest_unit_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 # libs
 pytest api/tests/unit_tests

--- a/dev/pytest/pytest_vdb.sh
+++ b/dev/pytest/pytest_vdb.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 pytest api/tests/integration_tests/vdb/chroma \
   api/tests/integration_tests/vdb/milvus \
   api/tests/integration_tests/vdb/pgvecto_rs \

--- a/dev/pytest/pytest_workflow.sh
+++ b/dev/pytest/pytest_workflow.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/../.."
+
 pytest api/tests/integration_tests/workflow

--- a/dev/reformat
+++ b/dev/reformat
@@ -2,6 +2,9 @@
 
 set -x
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/.."
+
 # run ruff linter
 uv run --directory api --dev ruff check --fix ./
 

--- a/dev/sync-uv
+++ b/dev/sync-uv
@@ -6,5 +6,8 @@ if ! command -v uv &> /dev/null; then
     pip install uv
 fi
 
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/.."
+
 # check uv.lock in sync with pyproject.toml
 uv lock --project api


### PR DESCRIPTION
# Summary

Modified the scripts in the `dev` directory to determine script their own location  and adjust the working directory to the repository root.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.
Fixes https://github.com/langgenius/dify/issues/19185

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

