### PR TITLE
fix: fix ssrf_proxy docker-compose start up fail.

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -684,8 +684,9 @@ services:
     volumes:
       - ./ssrf_proxy/squid.conf.template:/etc/squid/squid.conf.template
       - ./ssrf_proxy/docker-entrypoint.sh:/docker-entrypoint-mount.sh
-      - ./ssrf_proxy/logs:/var/log/squid
-      - ./ssrf_proxy/cache:/var/spool/squid
+      # sudo chown -R 13:13 ./volumes/ssrf_proxy/logs ./volumes/ssrf_proxy/cache
+      - ./volumes/ssrf_proxy/logs:/var/log/squid
+      - ./volumes/ssrf_proxy/cache:/var/spool/squid
     entrypoint: [ 'sh', '-c', "cp /docker-entrypoint-mount.sh /docker-entrypoint.sh && sed -i 's/\r$$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh && /docker-entrypoint.sh" ]
     environment:
       # pls clearly modify the squid env vars to fit your network environment.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -684,7 +684,6 @@ services:
     volumes:
       - ./ssrf_proxy/squid.conf.template:/etc/squid/squid.conf.template
       - ./ssrf_proxy/docker-entrypoint.sh:/docker-entrypoint-mount.sh
-      # sudo chown -R 13:13 ./volumes/ssrf_proxy/logs ./volumes/ssrf_proxy/cache
       - ./volumes/ssrf_proxy/logs:/var/log/squid
       - ./volumes/ssrf_proxy/cache:/var/spool/squid
     entrypoint: [ 'sh', '-c', "cp /docker-entrypoint-mount.sh /docker-entrypoint.sh && sed -i 's/\r$$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh && /docker-entrypoint.sh" ]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -684,8 +684,6 @@ services:
     volumes:
       - ./ssrf_proxy/squid.conf.template:/etc/squid/squid.conf.template
       - ./ssrf_proxy/docker-entrypoint.sh:/docker-entrypoint-mount.sh
-      - ./volumes/ssrf_proxy/logs:/var/log/squid
-      - ./volumes/ssrf_proxy/cache:/var/spool/squid
     entrypoint: [ 'sh', '-c', "cp /docker-entrypoint-mount.sh /docker-entrypoint.sh && sed -i 's/\r$$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh && /docker-entrypoint.sh" ]
     environment:
       # pls clearly modify the squid env vars to fit your network environment.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -421,10 +421,10 @@ x-shared-env: &shared-api-worker-env
   SSRF_COREDUMP_DIR: ${SSRF_COREDUMP_DIR:-/var/spool/squid}
   SSRF_REVERSE_PROXY_PORT: ${SSRF_REVERSE_PROXY_PORT:-8194}
   SSRF_SANDBOX_HOST: ${SSRF_SANDBOX_HOST:-sandbox}
-  SSRF_DEFAULT_TIME_OUT: ${SSRF_DEFAULT_TIME_OUT:-5}
-  SSRF_DEFAULT_CONNECT_TIME_OUT: ${SSRF_DEFAULT_CONNECT_TIME_OUT:-5}
-  SSRF_DEFAULT_READ_TIME_OUT: ${SSRF_DEFAULT_READ_TIME_OUT:-5}
-  SSRF_DEFAULT_WRITE_TIME_OUT: ${SSRF_DEFAULT_WRITE_TIME_OUT:-5}
+  SSRF_DEFAULT_TIME_OUT: ${SSRF_DEFAULT_TIME_OUT:-120}
+  SSRF_DEFAULT_CONNECT_TIME_OUT: ${SSRF_DEFAULT_CONNECT_TIME_OUT:-120}
+  SSRF_DEFAULT_READ_TIME_OUT: ${SSRF_DEFAULT_READ_TIME_OUT:-120}
+  SSRF_DEFAULT_WRITE_TIME_OUT: ${SSRF_DEFAULT_WRITE_TIME_OUT:-120}
   EXPOSE_NGINX_PORT: ${EXPOSE_NGINX_PORT:-80}
   EXPOSE_NGINX_SSL_PORT: ${EXPOSE_NGINX_SSL_PORT:-443}
   POSITION_TOOL_PINS: ${POSITION_TOOL_PINS:-}
@@ -684,6 +684,8 @@ services:
     volumes:
       - ./ssrf_proxy/squid.conf.template:/etc/squid/squid.conf.template
       - ./ssrf_proxy/docker-entrypoint.sh:/docker-entrypoint-mount.sh
+      - ./ssrf_proxy/logs:/var/log/squid
+      - ./ssrf_proxy/cache:/var/spool/squid
     entrypoint: [ 'sh', '-c', "cp /docker-entrypoint-mount.sh /docker-entrypoint.sh && sed -i 's/\r$$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh && /docker-entrypoint.sh" ]
     environment:
       # pls clearly modify the squid env vars to fit your network environment.

--- a/docker/ssrf_proxy/docker-entrypoint.sh
+++ b/docker/ssrf_proxy/docker-entrypoint.sh
@@ -20,6 +20,9 @@ echo "[ENTRYPOINT] re-create snakeoil self-signed certificate removed in the bui
 if [ ! -f /etc/ssl/private/ssl-cert-snakeoil.key ]; then
     /usr/sbin/make-ssl-cert generate-default-snakeoil --force-overwrite > /dev/null 2>&1
 fi
+# ssrf_proxy is not running as root, so we need to set the permissions
+chown -R 13:13 /var/log/squid /var/spool/squid /var/cache/squid
+
 
 tail -F /var/log/squid/access.log 2>/dev/null &
 tail -F /var/log/squid/error.log 2>/dev/null &


### PR DESCRIPTION
1. set SSRF_DEFAULT_TIME_OUT to 60s, it will  fix plugin download fail.
2. add ssrf_proxy docker volume, fix ssrf_proxy start err.


maybe fix https://github.com/langgenius/dify/issues/19302

# Summary

docker-compse delpyment, docker-ssrf_proxy-1 will exit.
that log like it: 

```log
2025/05/03 02:49:46| Configuring Parent sandbox
fopen: Permission denied
2025/05/03 02:49:46 pinger| Initialising ICMP pinger ...
2025/05/03 02:49:46 pinger| Open  icmp_sock: (1) Operation not permitted
2025/05/03 02:49:46 pinger| ERROR: Unable to start ICMP pinger.
2025/05/03 02:49:46 pinger| Open  icmp_sock: (1) Operation not permitted
2025/05/03 02:49:46 pinger| ERROR: Unable to start ICMPv6 pinger.
2025/05/03 02:49:46 pinger| FATAL: Unable to open any ICMP sockets.
2025/05/03 02:49:47| storeLateRelease: released 0 objects
2025/05/03 02:49:47| ERROR: logfileHandleWrite: daemon:/var/log/squid/access.log: error writing ((32) Broken pipe)
2025/05/03 02:49:47| Closing HTTP(S) port [::]:3128
    listening port: 3128
2025/05/03 02:49:47| Closing HTTP(S) port [::]:8194
    listening port: 8194
2025/05/03 02:49:47| storeDirWriteCleanLogs: Starting...
2025/05/03 02:49:47|   Finished.  Wrote 0 entries.
2025/05/03 02:49:47|   Took 0.00 seconds (  0.00 entries/sec).
2025/05/03 02:49:47| FATAL: I don't handle this error well!
2025/05/03 02:49:47| Squid Cache (Version 6.6): Terminated abnormally.
CPU Usage: 0.018 seconds = 0.010 user + 0.008 sys
Maximum Resident Size: 93696 KB
Page faults with physical i/o: 0
2025/05/03 02:49:47| Removing PID file (/run/squid.pid)
2025/05/03 02:49:47| Closing Pinger socket on FD 14
```

the config fix logs and cache volumes.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

