### PR TITLE
chore: avoid repeated type ignore noqa by adding flask_restful and flask_login in mypy import exclusions

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -18,7 +18,7 @@ else:
     # so we need to disable gevent in debug mode.
     # If you are using debugpy and set GEVENT_SUPPORT=True, you can debug with gevent.
     if (flask_debug := os.environ.get("FLASK_DEBUG", "0")) and flask_debug.lower() in {"false", "0", "no"}:
-        from gevent import monkey  # type: ignore
+        from gevent import monkey
 
         # gevent
         monkey.patch_all()

--- a/api/commands.py
+++ b/api/commands.py
@@ -668,7 +668,7 @@ def upgrade_db():
             click.echo(click.style("Starting database migration.", fg="green"))
 
             # run db migration
-            import flask_migrate  # type: ignore
+            import flask_migrate
 
             flask_migrate.upgrade()
 

--- a/api/controllers/common/fields.py
+++ b/api/controllers/common/fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 parameters__system_parameters = {
     "image_file_size_limit": fields.Integer,

--- a/api/controllers/console/admin.py
+++ b/api/controllers/console/admin.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound, Unauthorized

--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import flask_restful
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from flask_restful import Resource, fields, marshal_with
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import flask_restful  # type: ignore
+import flask_restful
 from flask_login import current_user  # type: ignore
 from flask_restful import Resource, fields, marshal_with
 from sqlalchemy import select

--- a/api/controllers/console/app/advanced_prompt_template.py
+++ b/api/controllers/console/app/advanced_prompt_template.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.wraps import account_initialization_required, setup_required

--- a/api/controllers/console/app/agent.py
+++ b/api/controllers/console/app/agent.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.app.wraps import get_app_model

--- a/api/controllers/console/app/annotation.py
+++ b/api/controllers/console/app/annotation.py
@@ -1,6 +1,6 @@
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -1,8 +1,8 @@
 import uuid
 from typing import cast
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, inputs, marshal, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, inputs, marshal, marshal_with, reqparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, Forbidden, abort

--- a/api/controllers/console/app/app_import.py
+++ b/api/controllers/console/app/app_import.py
@@ -1,7 +1,7 @@
 from typing import cast
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 

--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import InternalServerError
 
 import services

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -1,7 +1,7 @@
 import logging
 
-import flask_login  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+import flask_login
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -1,9 +1,9 @@
 from datetime import UTC, datetime
 
 import pytz  # pip install pytz
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
-from flask_restful.inputs import int_range  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
+from flask_restful.inputs import int_range
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import Forbidden, NotFound

--- a/api/controllers/console/app/conversation_variables.py
+++ b/api/controllers/console/app/conversation_variables.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, marshal_with, reqparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 

--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -1,7 +1,7 @@
 import os
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.app.error import (

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -1,8 +1,8 @@
 import logging
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, fields, marshal_with, reqparse  # type: ignore
-from flask_restful.inputs import int_range  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal_with, reqparse
+from flask_restful.inputs import int_range
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
 from controllers.console import api

--- a/api/controllers/console/app/model_config.py
+++ b/api/controllers/console/app/model_config.py
@@ -2,8 +2,8 @@ import json
 from typing import cast
 
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource
 
 from controllers.console import api
 from controllers.console.app.wraps import get_app_model

--- a/api/controllers/console/app/ops_trace.py
+++ b/api/controllers/console/app/ops_trace.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import BadRequest
 
 from controllers.console import api

--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden, NotFound
 
 from constants.languages import supported_language

--- a/api/controllers/console/app/statistic.py
+++ b/api/controllers/console/app/statistic.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 
 import pytz
 from flask import jsonify
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.app.wraps import get_app_model

--- a/api/controllers/console/app/workflow.py
+++ b/api/controllers/console/app/workflow.py
@@ -3,7 +3,7 @@ import logging
 from typing import cast
 
 from flask import abort, request
-from flask_restful import Resource, inputs, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, inputs, marshal_with, reqparse
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 

--- a/api/controllers/console/app/workflow_app_log.py
+++ b/api/controllers/console/app/workflow_app_log.py
@@ -1,6 +1,6 @@
 from dateutil.parser import isoparse
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful import Resource, marshal_with, reqparse
+from flask_restful.inputs import int_range
 from sqlalchemy.orm import Session
 
 from controllers.console import api

--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -1,5 +1,5 @@
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful import Resource, marshal_with, reqparse
+from flask_restful.inputs import int_range
 
 from controllers.console import api
 from controllers.console.app.wraps import get_app_model

--- a/api/controllers/console/app/workflow_statistic.py
+++ b/api/controllers/console/app/workflow_statistic.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 
 import pytz
 from flask import jsonify
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.app.wraps import get_app_model

--- a/api/controllers/console/auth/activate.py
+++ b/api/controllers/console/auth/activate.py
@@ -1,7 +1,7 @@
 import datetime
 
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 from constants.languages import supported_language
 from controllers.console import api

--- a/api/controllers/console/auth/data_source_bearer_auth.py
+++ b/api/controllers/console/auth/data_source_bearer_auth.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/auth/data_source_oauth.py
+++ b/api/controllers/console/auth/data_source_oauth.py
@@ -2,8 +2,8 @@ import logging
 
 import requests
 from flask import current_app, redirect, request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource
 from werkzeug.exceptions import Forbidden
 
 from configs import dify_config

--- a/api/controllers/console/auth/forgot_password.py
+++ b/api/controllers/console/auth/forgot_password.py
@@ -2,7 +2,7 @@ import base64
 import secrets
 
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -1,8 +1,8 @@
 from typing import cast
 
-import flask_login  # type: ignore
+import flask_login
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 import services
 from configs import dify_config

--- a/api/controllers/console/auth/oauth.py
+++ b/api/controllers/console/auth/oauth.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import requests
 from flask import current_app, redirect, request
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Unauthorized

--- a/api/controllers/console/billing/billing.py
+++ b/api/controllers/console/billing/billing.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.wraps import account_initialization_required, only_edition_cloud, setup_required

--- a/api/controllers/console/billing/compliance.py
+++ b/api/controllers/console/billing/compliance.py
@@ -1,6 +1,6 @@
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 
 from libs.helper import extract_remote_ip
 from libs.login import login_required

--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -2,8 +2,8 @@ import datetime
 import json
 
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound

--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -1,7 +1,7 @@
-import flask_restful  # type: ignore
+import flask_restful
 from flask import request
-from flask_login import current_user  # type: ignore  # type: ignore
-from flask_restful import Resource, marshal, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services

--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -4,8 +4,8 @@ from datetime import UTC, datetime
 from typing import cast
 
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, fields, marshal, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal, marshal_with, reqparse
 from sqlalchemy import asc, desc
 from werkzeug.exceptions import Forbidden, NotFound
 

--- a/api/controllers/console/datasets/datasets_segments.py
+++ b/api/controllers/console/datasets/datasets_segments.py
@@ -2,8 +2,8 @@ import uuid
 
 import pandas as pd
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal, reqparse
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services

--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -1,6 +1,6 @@
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal, reqparse
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
 import services

--- a/api/controllers/console/datasets/hit_testing.py
+++ b/api/controllers/console/datasets/hit_testing.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 
 from controllers.console import api
 from controllers.console.datasets.hit_testing_base import DatasetsHitTestingBase

--- a/api/controllers/console/datasets/hit_testing_base.py
+++ b/api/controllers/console/datasets/hit_testing_base.py
@@ -1,7 +1,7 @@
 import logging
 
-from flask_login import current_user  # type: ignore
-from flask_restful import marshal, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import marshal, reqparse
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
 import services.dataset_service

--- a/api/controllers/console/datasets/metadata.py
+++ b/api/controllers/console/datasets/metadata.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
 from werkzeug.exceptions import NotFound
 
 from controllers.console import api

--- a/api/controllers/console/datasets/website.py
+++ b/api/controllers/console/datasets/website.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 from controllers.console import api
 from controllers.console.datasets.error import WebsiteCrawlError

--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -66,7 +66,7 @@ class ChatAudioApi(InstalledAppResource):
 
 class ChatTextApi(InstalledAppResource):
     def post(self, installed_app):
-        from flask_restful import reqparse  # type: ignore
+        from flask_restful import reqparse
 
         app_model = installed_app.app
         try:

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -1,8 +1,8 @@
 import logging
 from datetime import UTC, datetime
 
-from flask_login import current_user  # type: ignore
-from flask_restful import reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import reqparse
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services

--- a/api/controllers/console/explore/conversation.py
+++ b/api/controllers/console/explore/conversation.py
@@ -1,6 +1,6 @@
 from flask_login import current_user
 from flask_restful import marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 

--- a/api/controllers/console/explore/conversation.py
+++ b/api/controllers/console/explore/conversation.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -2,8 +2,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, inputs, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, inputs, marshal_with, reqparse
 from sqlalchemy import and_
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 

--- a/api/controllers/console/explore/message.py
+++ b/api/controllers/console/explore/message.py
@@ -1,7 +1,7 @@
 import logging
 
-from flask_login import current_user  # type: ignore
-from flask_restful import marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from werkzeug.exceptions import InternalServerError, NotFound
 

--- a/api/controllers/console/explore/message.py
+++ b/api/controllers/console/explore/message.py
@@ -2,7 +2,7 @@ import logging
 
 from flask_login import current_user
 from flask_restful import marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services

--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -1,4 +1,4 @@
-from flask_restful import marshal_with  # type: ignore
+from flask_restful import marshal_with
 
 from controllers.common import fields
 from controllers.console import api

--- a/api/controllers/console/explore/recommended_app.py
+++ b/api/controllers/console/explore/recommended_app.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, fields, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal_with, reqparse
 
 from constants.languages import languages
 from controllers.console import api

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import fields, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import fields, marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from werkzeug.exceptions import NotFound
 

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -1,6 +1,6 @@
 from flask_login import current_user
 from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from werkzeug.exceptions import NotFound
 
 from controllers.console import api

--- a/api/controllers/console/explore/workflow.py
+++ b/api/controllers/console/explore/workflow.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_restful import reqparse  # type: ignore
+from flask_restful import reqparse
 from werkzeug.exceptions import InternalServerError
 
 from controllers.console.app.error import (

--- a/api/controllers/console/explore/wraps.py
+++ b/api/controllers/console/explore/wraps.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource
 from werkzeug.exceptions import NotFound
 
 from controllers.console.wraps import account_initialization_required

--- a/api/controllers/console/extension.py
+++ b/api/controllers/console/extension.py
@@ -1,4 +1,4 @@
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from flask_restful import Resource, marshal_with, reqparse
 
 from constants import HIDDEN_VALUE

--- a/api/controllers/console/extension.py
+++ b/api/controllers/console/extension.py
@@ -1,5 +1,5 @@
 from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, marshal_with, reqparse
 
 from constants import HIDDEN_VALUE
 from controllers.console import api

--- a/api/controllers/console/feature.py
+++ b/api/controllers/console/feature.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource
 
 from libs.login import login_required
 from services.feature_service import FeatureService

--- a/api/controllers/console/files.py
+++ b/api/controllers/console/files.py
@@ -1,8 +1,8 @@
 from typing import Literal
 
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with
 from werkzeug.exceptions import Forbidden
 
 import services

--- a/api/controllers/console/init_validate.py
+++ b/api/controllers/console/init_validate.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import session
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 

--- a/api/controllers/console/ping.py
+++ b/api/controllers/console/ping.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 
 from controllers.console import api
 

--- a/api/controllers/console/remote_files.py
+++ b/api/controllers/console/remote_files.py
@@ -2,8 +2,8 @@ import urllib.parse
 from typing import cast
 
 import httpx
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
 
 import services
 from controllers.common import helpers

--- a/api/controllers/console/setup.py
+++ b/api/controllers/console/setup.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 from configs import dify_config
 from libs.helper import StrLen, email, extract_remote_ip

--- a/api/controllers/console/tag/tags.py
+++ b/api/controllers/console/tag/tags.py
@@ -1,6 +1,6 @@
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/version.py
+++ b/api/controllers/console/version.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 import requests
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from packaging import version
 
 from configs import dify_config

--- a/api/controllers/console/workspace/__init__.py
+++ b/api/controllers/console/workspace/__init__.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 

--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -2,8 +2,8 @@ import datetime
 
 import pytz
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, fields, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, fields, marshal_with, reqparse
 
 from configs import dify_config
 from constants.languages import supported_language

--- a/api/controllers/console/workspace/agent_providers.py
+++ b/api/controllers/console/workspace/agent_providers.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource
 
 from controllers.console import api
 from controllers.console.wraps import account_initialization_required, setup_required

--- a/api/controllers/console/workspace/endpoint.py
+++ b/api/controllers/console/workspace/endpoint.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/workspace/load_balancing_config.py
+++ b/api/controllers/console/workspace/load_balancing_config.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -1,7 +1,7 @@
 from urllib import parse
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, abort, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, abort, marshal_with, reqparse
 
 import services
 from configs import dify_config

--- a/api/controllers/console/workspace/model_providers.py
+++ b/api/controllers/console/workspace/model_providers.py
@@ -1,8 +1,8 @@
 import io
 
 from flask import send_file
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -1,7 +1,7 @@
 import logging
 
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.console import api

--- a/api/controllers/console/workspace/plugin.py
+++ b/api/controllers/console/workspace/plugin.py
@@ -1,8 +1,8 @@
 import io
 
 from flask import request, send_file
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden
 
 from configs import dify_config

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,8 +1,8 @@
 import io
 
 from flask import send_file
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, reqparse
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -1,8 +1,8 @@
 import logging
 
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource, fields, inputs, marshal, marshal_with, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource, fields, inputs, marshal, marshal_with, reqparse
 from werkzeug.exceptions import Unauthorized
 
 import services

--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -4,7 +4,7 @@ import time
 from functools import wraps
 
 from flask import abort, request
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 
 from configs import dify_config
 from controllers.console.workspace.error import AccountNotInitializedError

--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -1,7 +1,7 @@
 from urllib.parse import quote
 
 from flask import Response, request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import NotFound
 
 import services

--- a/api/controllers/files/tool_files.py
+++ b/api/controllers/files/tool_files.py
@@ -1,5 +1,5 @@
 from flask import Response
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import Forbidden, NotFound
 
 from controllers.files import api

--- a/api/controllers/files/upload.py
+++ b/api/controllers/files/upload.py
@@ -1,7 +1,7 @@
 from mimetypes import guess_extension
 
 from flask import request
-from flask_restful import Resource, marshal_with  # type: ignore
+from flask_restful import Resource, marshal_with
 from werkzeug.exceptions import Forbidden
 
 import services

--- a/api/controllers/inner_api/plugin/plugin.py
+++ b/api/controllers/inner_api/plugin/plugin.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 
 from controllers.console.wraps import setup_required
 from controllers.inner_api import api

--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -3,7 +3,7 @@ from functools import wraps
 from typing import Optional
 
 from flask import request
-from flask_restful import reqparse  # type: ignore
+from flask_restful import reqparse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 

--- a/api/controllers/inner_api/workspace/workspace.py
+++ b/api/controllers/inner_api/workspace/workspace.py
@@ -1,6 +1,6 @@
 import json
 
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 
 from controllers.console.wraps import setup_required
 from controllers.inner_api import api

--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource, marshal, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, marshal, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden
 
 from controllers.service_api import api

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, marshal_with  # type: ignore
+from flask_restful import Resource, marshal_with
 
 from controllers.common import fields
 from controllers.service_api import api

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import request
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import InternalServerError
 
 import services

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_restful import Resource, reqparse  # type: ignore
+from flask_restful import Resource, reqparse
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 

--- a/api/controllers/service_api/app/file.py
+++ b/api/controllers/service_api/app/file.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import Resource, marshal_with  # type: ignore
+from flask_restful import Resource, marshal_with
 
 import services
 from controllers.common.errors import FilenameNotExistsError

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from flask_restful import Resource, fields, marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import services

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from flask_restful import Resource, fields, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, fields, marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 

--- a/api/controllers/service_api/app/workflow.py
+++ b/api/controllers/service_api/app/workflow.py
@@ -2,7 +2,7 @@ import logging
 
 from dateutil.parser import isoparse
 from flask_restful import Resource, fields, marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import InternalServerError
 

--- a/api/controllers/service_api/app/workflow.py
+++ b/api/controllers/service_api/app/workflow.py
@@ -1,7 +1,7 @@
 import logging
 
 from dateutil.parser import isoparse
-from flask_restful import Resource, fields, marshal_with, reqparse  # type: ignore
+from flask_restful import Resource, fields, marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import InternalServerError

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import marshal, reqparse  # type: ignore
+from flask_restful import marshal, reqparse
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services.dataset_service

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -1,7 +1,7 @@
 import json
 
 from flask import request
-from flask_restful import marshal, reqparse  # type: ignore
+from flask_restful import marshal, reqparse
 from sqlalchemy import desc
 from werkzeug.exceptions import NotFound
 

--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore  # type: ignore
-from flask_restful import marshal, reqparse  # type: ignore
+from flask_login import current_user  # type: ignore
+from flask_restful import marshal, reqparse
 from werkzeug.exceptions import NotFound
 
 from controllers.service_api import api

--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -1,6 +1,6 @@
 from flask import request
-from flask_login import current_user  # type: ignore
-from flask_restful import marshal, reqparse  # type: ignore
+from flask_login import current_user
+from flask_restful import marshal, reqparse
 from werkzeug.exceptions import NotFound
 
 from controllers.service_api import api

--- a/api/controllers/service_api/index.py
+++ b/api/controllers/service_api/index.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 
 from configs import dify_config
 from controllers.service_api import api

--- a/api/controllers/service_api/workspace/models.py
+++ b/api/controllers/service_api/workspace/models.py
@@ -1,5 +1,5 @@
-from flask_login import current_user  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_login import current_user
+from flask_restful import Resource
 
 from controllers.service_api import api
 from controllers.service_api.wraps import validate_dataset_token

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from flask import current_app, request
 from flask_login import user_logged_in  # type: ignore
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -1,4 +1,4 @@
-from flask_restful import marshal_with  # type: ignore
+from flask_restful import marshal_with
 
 from controllers.common import fields
 from controllers.web import api

--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -65,7 +65,7 @@ class AudioApi(WebApiResource):
 
 class TextApi(WebApiResource):
     def post(self, app_model: App, end_user):
-        from flask_restful import reqparse  # type: ignore
+        from flask_restful import reqparse
 
         try:
             parser = reqparse.RequestParser()

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_restful import reqparse  # type: ignore
+from flask_restful import reqparse
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services

--- a/api/controllers/web/conversation.py
+++ b/api/controllers/web/conversation.py
@@ -1,5 +1,5 @@
 from flask_restful import marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 

--- a/api/controllers/web/conversation.py
+++ b/api/controllers/web/conversation.py
@@ -1,4 +1,4 @@
-from flask_restful import marshal_with, reqparse  # type: ignore
+from flask_restful import marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound

--- a/api/controllers/web/feature.py
+++ b/api/controllers/web/feature.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 
 from controllers.web import api
 from services.feature_service import FeatureService

--- a/api/controllers/web/files.py
+++ b/api/controllers/web/files.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restful import marshal_with  # type: ignore
+from flask_restful import marshal_with
 
 import services
 from controllers.common.errors import FilenameNotExistsError

--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_restful import fields, marshal_with, reqparse  # type: ignore
+from flask_restful import fields, marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from werkzeug.exceptions import InternalServerError, NotFound
 

--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services

--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -1,7 +1,7 @@
 import uuid
 
 from flask import request
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 from werkzeug.exceptions import NotFound, Unauthorized
 
 from controllers.web import api

--- a/api/controllers/web/remote_files.py
+++ b/api/controllers/web/remote_files.py
@@ -1,7 +1,7 @@
 import urllib.parse
 
 import httpx
-from flask_restful import marshal_with, reqparse  # type: ignore
+from flask_restful import marshal_with, reqparse
 
 import services
 from controllers.common import helpers

--- a/api/controllers/web/saved_message.py
+++ b/api/controllers/web/saved_message.py
@@ -1,4 +1,4 @@
-from flask_restful import fields, marshal_with, reqparse  # type: ignore
+from flask_restful import fields, marshal_with, reqparse
 from flask_restful.inputs import int_range  # type: ignore
 from werkzeug.exceptions import NotFound
 

--- a/api/controllers/web/saved_message.py
+++ b/api/controllers/web/saved_message.py
@@ -1,5 +1,5 @@
 from flask_restful import fields, marshal_with, reqparse
-from flask_restful.inputs import int_range  # type: ignore
+from flask_restful.inputs import int_range
 from werkzeug.exceptions import NotFound
 
 from controllers.web import api

--- a/api/controllers/web/site.py
+++ b/api/controllers/web/site.py
@@ -1,4 +1,4 @@
-from flask_restful import fields, marshal_with  # type: ignore
+from flask_restful import fields, marshal_with
 from werkzeug.exceptions import Forbidden
 
 from configs import dify_config

--- a/api/controllers/web/workflow.py
+++ b/api/controllers/web/workflow.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_restful import reqparse  # type: ignore
+from flask_restful import reqparse
 from werkzeug.exceptions import InternalServerError
 
 from controllers.web import api

--- a/api/controllers/web/wraps.py
+++ b/api/controllers/web/wraps.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from flask import request
-from flask_restful import Resource  # type: ignore
+from flask_restful import Resource
 from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 
 from controllers.web.error import WebSSOAuthRequiredError

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -9,7 +9,7 @@ import uuid
 from typing import Any, Optional, cast
 
 from flask import current_app
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from configs import dify_config

--- a/api/fields/annotation_fields.py
+++ b/api/fields/annotation_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/api_based_extension_fields.py
+++ b/api/fields/api_based_extension_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/app_fields.py
+++ b/api/fields/app_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from fields.workflow_fields import workflow_partial_fields
 from libs.helper import AppIconUrlField, TimestampField

--- a/api/fields/conversation_fields.py
+++ b/api/fields/conversation_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from fields.member_fields import simple_account_fields
 from libs.helper import TimestampField

--- a/api/fields/conversation_variable_fields.py
+++ b/api/fields/conversation_variable_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/data_source_fields.py
+++ b/api/fields/data_source_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/document_fields.py
+++ b/api/fields/document_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from fields.dataset_fields import dataset_fields
 from libs.helper import TimestampField

--- a/api/fields/end_user_fields.py
+++ b/api/fields/end_user_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 simple_end_user_fields = {
     "id": fields.String,

--- a/api/fields/file_fields.py
+++ b/api/fields/file_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/hit_testing_fields.py
+++ b/api/fields/hit_testing_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/installed_app_fields.py
+++ b/api/fields/installed_app_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import AppIconUrlField, TimestampField
 

--- a/api/fields/member_fields.py
+++ b/api/fields/member_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import AvatarUrlField, TimestampField
 

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from fields.conversation_fields import message_file_fields
 from libs.helper import TimestampField

--- a/api/fields/raws.py
+++ b/api/fields/raws.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from core.file import File
 

--- a/api/fields/segment_fields.py
+++ b/api/fields/segment_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from libs.helper import TimestampField
 

--- a/api/fields/tag_fields.py
+++ b/api/fields/tag_fields.py
@@ -1,3 +1,3 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 tag_fields = {"id": fields.String, "name": fields.String, "type": fields.String, "binding_count": fields.String}

--- a/api/fields/workflow_app_log_fields.py
+++ b/api/fields/workflow_app_log_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from fields.end_user_fields import simple_end_user_fields
 from fields.member_fields import simple_account_fields

--- a/api/fields/workflow_fields.py
+++ b/api/fields/workflow_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from core.helper import encrypter
 from core.variables import SecretVariable, SegmentType, Variable

--- a/api/fields/workflow_run_fields.py
+++ b/api/fields/workflow_run_fields.py
@@ -1,4 +1,4 @@
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from fields.end_user_fields import simple_end_user_fields
 from fields.member_fields import simple_account_fields

--- a/api/libs/external_api.py
+++ b/api/libs/external_api.py
@@ -3,7 +3,7 @@ import sys
 from typing import Any
 
 from flask import current_app, got_request_exception
-from flask_restful import Api, http_status_message  # type: ignore
+from flask_restful import Api, http_status_message
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import HTTPException
 

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from zoneinfo import available_timezones
 
 from flask import Response, stream_with_context
-from flask_restful import fields  # type: ignore
+from flask_restful import fields
 
 from configs import dify_config
 from core.app.features.rate_limiting.rate_limit import RateLimitGenerator

--- a/api/libs/oauth_data_source.py
+++ b/api/libs/oauth_data_source.py
@@ -3,7 +3,7 @@ import urllib.parse
 from typing import Any
 
 import requests
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 
 from extensions.ext_database import db
 from models.source import DataSourceOauthBinding

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -7,3 +7,10 @@ exclude = (?x)(
     | tests/
     | migrations/
   )
+
+[mypy-flask_login]
+ignore_missing_imports=True
+
+[mypy-flask_restful]
+ignore_missing_imports=True
+

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -14,3 +14,6 @@ ignore_missing_imports=True
 [mypy-flask_restful]
 ignore_missing_imports=True
 
+[mypy-flask_restful.inputs]
+ignore_missing_imports=True
+

--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -2,7 +2,7 @@ import threading
 from typing import Optional
 
 import pytz
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 
 import contexts
 from core.app.app_config.easy_ui_based_app.agent.manager import AgentConfigManager

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -3,7 +3,7 @@ import uuid
 from typing import cast
 
 import pandas as pd
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from sqlalchemy import or_
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import NotFound

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -3,7 +3,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Optional, cast
 
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from flask_sqlalchemy.pagination import Pagination
 
 from configs import dify_config

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -8,7 +8,7 @@ import uuid
 from collections import Counter
 from typing import Any, Optional
 
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -4,7 +4,7 @@ import os
 import uuid
 from typing import Any, Literal, Union
 
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 from configs import dify_config

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 from typing import Optional
 
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 
 from core.rag.index_processor.constant.built_in_field import BuiltInField, MetadataDataSource
 from extensions.ext_database import db

--- a/api/services/tag_service.py
+++ b/api/services/tag_service.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Optional
 
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 from sqlalchemy import func
 from werkzeug.exceptions import NotFound
 

--- a/api/services/website_service.py
+++ b/api/services/website_service.py
@@ -3,7 +3,7 @@ import json
 from typing import Any
 
 import requests
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 
 from core.helper import encrypter
 from core.rag.extractor.firecrawl.firecrawl_app import FirecrawlApp

--- a/api/services/workspace_service.py
+++ b/api/services/workspace_service.py
@@ -1,4 +1,4 @@
-from flask_login import current_user  # type: ignore
+from flask_login import current_user
 
 from configs import dify_config
 from extensions.ext_database import db

--- a/api/tests/integration_tests/tools/__mock_server/openapi_todo.py
+++ b/api/tests/integration_tests/tools/__mock_server/openapi_todo.py
@@ -1,5 +1,5 @@
 from flask import Flask, request
-from flask_restful import Api, Resource  # type: ignore
+from flask_restful import Api, Resource
 
 app = Flask(__name__)
 api = Api(app)


### PR DESCRIPTION
# Summary

- use `ignore_missing_imports` config on `flask_restful` and `flask_login` into `mypy.ini` configs, to avoid repeating unhelpful `type ignore` in imports

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

