### PR TITLE
chore: required pip and performance improvment in mypy checks

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -90,3 +90,4 @@
    ```bash
    uv run -P api bash dev/pytest/pytest_all_tests.sh
    ```
+

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -120,6 +120,7 @@ dev = [
     "types-defusedxml~=0.7.0",
     "types-deprecated~=1.2.15",
     "types-docutils~=0.21.0",
+    "types-jsonschema~=4.23.0",
     "types-flask-cors~=5.0.0",
     "types-flask-migrate~=4.1.0",
     "types-gevent~=24.11.0",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1261,6 +1261,7 @@ dev = [
     { name = "types-gevent" },
     { name = "types-greenlet" },
     { name = "types-html5lib" },
+    { name = "types-jsonschema" },
     { name = "types-markdown" },
     { name = "types-oauthlib" },
     { name = "types-objgraph" },
@@ -1431,6 +1432,7 @@ dev = [
     { name = "types-gevent", specifier = "~=24.11.0" },
     { name = "types-greenlet", specifier = "~=3.1.0" },
     { name = "types-html5lib", specifier = "~=1.1.11" },
+    { name = "types-jsonschema", specifier = "~=4.23.0" },
     { name = "types-markdown", specifier = "~=3.7.0" },
     { name = "types-oauthlib", specifier = "~=3.2.0" },
     { name = "types-objgraph", specifier = "~=3.6.0" },
@@ -5610,6 +5612,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/9d/f6fbcc8246f5e46845b4f989c4e17e6fb3ce572f7065b185e515bf8a3be7/types-html5lib-1.1.11.20241018.tar.gz", hash = "sha256:98042555ff78d9e3a51c77c918b1041acbb7eb6c405408d8a9e150ff5beccafa", size = 11370, upload-time = "2024-10-18T02:44:50.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/7c/f862b1dc31268ef10fe95b43dcdf216ba21a592fafa2d124445cd6b92e93/types_html5lib-1.1.11.20241018-py3-none-any.whl", hash = "sha256:3f1e064d9ed2c289001ae6392c84c93833abb0816165c6ff0abfc304a779f403", size = 17292, upload-time = "2024-10-18T02:44:48.503Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.23.0.20241208"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/e6/9e5cd771687086844caa43dbb211ec0d1cfa899d17c110f3220efcd46e83/types_jsonschema-4.23.0.20241208.tar.gz", hash = "sha256:e8b15ad01f290ecf6aea53f93fbdf7d4730e4600313e89e8a7f95622f7e87b7c", size = 14770, upload-time = "2024-12-08T03:02:21.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/64/4b2fba8b7cb0104ba013f2a1bf6f39a98e927e14befe1ef947d373b25218/types_jsonschema-4.23.0.20241208-py3-none-any.whl", hash = "sha256:87934bd9231c99d8eff94cacfc06ba668f7973577a9bd9e1f9de957c5737313e", size = 15021, upload-time = "2024-12-08T03:02:20.528Z" },
 ]
 
 [[package]]

--- a/dev/mypy-check
+++ b/dev/mypy-check
@@ -4,4 +4,4 @@ set -x
 
 # run mypy checks
 uv run --directory api --dev --with pip \
-  python -m mypy --install-types --non-interactive --cache-fine-grained .
+  python -m mypy --install-types --non-interactive --cache-fine-grained --sqlite-cache .

--- a/dev/mypy-check
+++ b/dev/mypy-check
@@ -3,5 +3,5 @@
 set -x
 
 # run mypy checks
-uv run --directory api --dev \
-  python -m mypy --install-types --non-interactive .
+uv run --directory api --dev --with pip \
+  python -m mypy --install-types --non-interactive --cache-fine-grained .


### PR DESCRIPTION
# Summary

- to close #19222
- by default, uv doesn't provide pip module as it's not declared as dependency. but mypy requires pip modules to dynamicly install the missing stubs. On the other hand, pip should not be pinned as dependency in project wide. Therefore, the best way to resolve this problem is using `--with pip` in uv commands for running mypy checks to bring `pip` module available in mypy checks.
- new configs added to mypy commands for performance
    - adding `--cache-fine-grained` config to speed up incremental mypy checks. The cached size will increase from ~350MB to ~430MB. docs: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-cache-fine-grained
    - adding `--sqlite-cache` to ultilize sqlite for caching, skipping plain json cache parsing and loading time cost , also help to merge all the cache data into single sqlite file.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

