### PR TITLE
fix: support non-ascii charactors in filename of the tool files

### DIFF
--- a/api/controllers/files/tool_files.py
+++ b/api/controllers/files/tool_files.py
@@ -7,6 +7,7 @@ from controllers.files.error import UnsupportedFileTypeError
 from core.tools.signature import verify_tool_file_signature
 from core.tools.tool_file_manager import ToolFileManager
 from models import db as global_db
+from urllib.parse import quote
 
 
 class ToolFilePreviewApi(Resource):
@@ -46,7 +47,8 @@ class ToolFilePreviewApi(Resource):
         if tool_file.size > 0:
             response.headers["Content-Length"] = str(tool_file.size)
         if args["as_attachment"]:
-            response.headers["Content-Disposition"] = f"attachment; filename={tool_file.name}"
+            encoded_filename = quote(tool_file.name)
+            response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
 
         return response
 

--- a/api/controllers/files/tool_files.py
+++ b/api/controllers/files/tool_files.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from flask import Response
 from flask_restful import Resource, reqparse  # type: ignore
 from werkzeug.exceptions import Forbidden, NotFound
@@ -7,7 +9,6 @@ from controllers.files.error import UnsupportedFileTypeError
 from core.tools.signature import verify_tool_file_signature
 from core.tools.tool_file_manager import ToolFileManager
 from models import db as global_db
-from urllib.parse import quote
 
 
 class ToolFilePreviewApi(Resource):

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -4,6 +4,7 @@ import hmac
 import logging
 import os
 import time
+from collections.abc import Generator
 from mimetypes import guess_extension, guess_type
 from typing import Optional, Union
 from uuid import uuid4
@@ -215,7 +216,7 @@ class ToolFileManager:
 
         return blob, tool_file.mimetype
 
-    def get_file_generator_by_tool_file_id(self, tool_file_id: str):
+    def get_file_generator_by_tool_file_id(self, tool_file_id: str) -> tuple[Optional[Generator], Optional[ToolFile]]:
         """
         get file binary
 


### PR DESCRIPTION
# Summary

- to fix #19229 for ToolFilePreviewApi , also similar to the fix #13843 for #13573 of ImagePreviewApi

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

