### PR TITLE
Optimize the event handling and rendering logic of the component picker

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -120,10 +120,8 @@ const ComponentPicker = ({
   }, [editor, checkForTriggerMatch, triggerString])
 
   const handleClose = useCallback(() => {
-    ReactDOM.flushSync(() => {
-      const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' })
-      editor.dispatchCommand(KEY_ESCAPE_COMMAND, escapeEvent)
-    })
+    const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' })
+    editor.dispatchCommand(KEY_ESCAPE_COMMAND, escapeEvent)
   }, [editor])
 
   const renderMenu = useCallback<MenuRenderFn<PickerBlockMenuOption>>((
@@ -132,7 +130,11 @@ const ComponentPicker = ({
   ) => {
     if (!(anchorElementRef.current && (allFlattenOptions.length || workflowVariableBlock?.show)))
       return null
-    refs.setReference(anchorElementRef.current)
+
+    setTimeout(() => {
+      if (anchorElementRef.current)
+        refs.setReference(anchorElementRef.current)
+    }, 0)
 
     return (
       <>
@@ -149,7 +151,6 @@ const ComponentPicker = ({
                   visibility: isPositioned ? 'visible' : 'hidden',
                 }}
                 ref={refs.setFloating}
-                data-testid="component-picker-container"
               >
                 {
                   workflowVariableBlock?.show && (
@@ -173,7 +174,7 @@ const ComponentPicker = ({
                     <div className='my-1 h-px w-full -translate-x-1 bg-divider-subtle'></div>
                   )
                 }
-                <div data-testid="options-list">
+                <div>
                   {
                     options.map((option, index) => (
                       <Fragment key={option.key}>


### PR DESCRIPTION
# Summary

Optimized the timing of setting the reference element using setTimeout to avoid state update conflicts during rendering.
Removed the usage of ReactDOM.flushSync.

Fixes #18928


# Screenshots

| Before | After |
|--------|-------|
| ![output](https://github.com/user-attachments/assets/9c5f8341-bb2b-4709-b5b6-cf286f207fc3) | ![output5-5](https://github.com/user-attachments/assets/49ae8b08-0ef6-4414-b1a8-6e281ee7dce1) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

