### PR TITLE
Fix: hide view chat setting button when no inputs form

### DIFF
--- a/web/app/components/base/chat/chat-with-history/header-in-mobile.tsx
+++ b/web/app/components/base/chat/chat-with-history/header-in-mobile.tsx
@@ -27,6 +27,7 @@ const HeaderInMobile = () => {
     handleDeleteConversation,
     handleRenameConversation,
     conversationRenaming,
+    inputsForms,
   } = useChatWithHistoryContext()
   const { t } = useTranslation()
   const isPin = pinnedConversationList.some(item => item.id === currentConversationId)
@@ -99,6 +100,7 @@ const HeaderInMobile = () => {
         <MobileOperationDropdown
           handleResetChat={handleNewConversation}
           handleViewChatSettings={() => setShowChatSettings(true)}
+          hideViewChatSettings={inputsForms.length < 1}
         />
       </div>
       {showSidebar && (

--- a/web/app/components/base/chat/chat-with-history/header/mobile-operation-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/mobile-operation-dropdown.tsx
@@ -9,11 +9,13 @@ import ActionButton, { ActionButtonState } from '@/app/components/base/action-bu
 type Props = {
   handleResetChat: () => void
   handleViewChatSettings: () => void
+  hideViewChatSettings?: boolean
 }
 
 const MobileOperationDropdown = ({
   handleResetChat,
   handleViewChatSettings,
+  hideViewChatSettings = false,
 }: Props) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -42,9 +44,11 @@ const MobileOperationDropdown = ({
           <div className='system-md-regular flex cursor-pointer items-center space-x-1 rounded-lg px-3 py-1.5 text-text-secondary hover:bg-state-base-hover' onClick={handleResetChat}>
             <span className='grow'>{t('share.chat.resetChat')}</span>
           </div>
-          <div className='system-md-regular flex cursor-pointer items-center space-x-1 rounded-lg px-3 py-1.5 text-text-secondary hover:bg-state-base-hover' onClick={handleViewChatSettings}>
-            <span className='grow'>{t('share.chat.viewChatSettings')}</span>
-          </div>
+          {!hideViewChatSettings && (
+            <div className='system-md-regular flex cursor-pointer items-center space-x-1 rounded-lg px-3 py-1.5 text-text-secondary hover:bg-state-base-hover' onClick={handleViewChatSettings}>
+              <span className='grow'>{t('share.chat.viewChatSettings')}</span>
+            </div>
+          )}
         </div>
       </PortalToFollowElemContent>
     </PortalToFollowElem>


### PR DESCRIPTION
# Summary

fix #18871

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

