### PR TITLE
fix(web): add workspace selector overflow auto

### DIFF
--- a/web/app/components/header/account-dropdown/workplace-selector/index.tsx
+++ b/web/app/components/header/account-dropdown/workplace-selector/index.tsx
@@ -61,7 +61,8 @@ const WorkplaceSelector = () => {
               <MenuItems
                 className={cn(
                   `
-                    shadows-shadow-lg absolute left-[-15px] mt-1 flex w-[280px] flex-col items-start rounded-xl bg-components-panel-bg-blur backdrop-blur-[5px]
+                    shadows-shadow-lg absolute left-[-15px] mt-1 flex max-h-[400px] w-[280px] flex-col items-start overflow-y-auto rounded-xl
+                    bg-components-panel-bg-blur backdrop-blur-[5px]
                   `,
                 )}
               >


### PR DESCRIPTION
# Summary

This pull request addresses the issue #19247 where the workspaces list lacks dragging support when there are numerous workspaces.

# Screenshots

| Before | After |
|--------|-------|
|![before](https://github.com/user-attachments/assets/83b04447-25c7-4413-8da2-b3c57af116c2)|![after](https://github.com/user-attachments/assets/b63fa6c7-a64c-4d72-b4e7-9c14520fab30)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

