### PR TITLE
Fix doc bug workflow

### DIFF
--- a/web/app/components/develop/template/template_workflow.en.mdx
+++ b/web/app/components/develop/template/template_workflow.en.mdx
@@ -90,7 +90,7 @@ Workflow applications offers non-session support and is ideal for translation, a
     Each streaming chunk starts with `data:`, separated by two newline characters `\n\n`, as shown below:
     <CodeGroup>
     ```streaming {{ title: 'Response' }}
-    data: {"event": "message", "task_id": "900bbd43-dc0b-4383-a372-aa6e6c414227", "id": "663c5084-a254-4040-8ad3-51f2a3c1a77c", "answer": "Hi", "created_at": 1705398420}\n\n
+    data: {"event": "text_chunk", "workflow_run_id": "b85e5fc5-751b-454d-b14e-dc5f240b0a31", "task_id": "bd029338-b068-4d34-a331-fc85478922c2", "data": {"text": "\u4e3a\u4e86", "from_variable_selector": ["1745912968134", "text"]}}\n\n
     ```
     </CodeGroup>
     The structure of the streaming chunks varies depending on the `event`:

--- a/web/app/components/develop/template/template_workflow.en.mdx
+++ b/web/app/components/develop/template/template_workflow.en.mdx
@@ -116,6 +116,13 @@ Workflow applications offers non-session support and is ideal for translation, a
         - `predecessor_node_id` (string) optional Prefix node ID, used for canvas display execution path
         - `inputs` (object) Contents of all preceding node variables used in the node
         - `created_at` (timestamp) timestamp of start, e.g., 1705395332
+    - `event: text_chunk` Text fragment  
+      - `task_id` (string) Task ID, used for request tracking and the below Stop Generate API 
+      - `workflow_run_id` (string) Unique ID of workflow execution 
+      - `event` (string) fixed to `text_chunk`
+      - `data` (object) detail
+        - `text` (string) Text content
+        - `from_variable_selector` (array) Text source path, helping developers understand which node and variable generated the text
     - `event: node_finished` node execution ends, success or failure in different states in the same event
       - `task_id` (string) Task ID, used for request tracking and the below Stop Generate API
       - `workflow_run_id` (string) Unique ID of workflow execution

--- a/web/app/components/develop/template/template_workflow.ja.mdx
+++ b/web/app/components/develop/template/template_workflow.ja.mdx
@@ -119,6 +119,13 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
         - `predecessor_node_id` (string) オプションのプレフィックスノードID、キャンバス表示実行パスに使用
         - `inputs` (object) ノードで使用されるすべての前のノード変数の内容
         - `created_at` (timestamp) 開始のタイムスタンプ、例：1705395332
+    - `event: text_chunk` テキストフラグメント
+      - `task_id` (string) タスクID、リクエスト追跡と以下のStop Generate APIに使用
+      - `workflow_run_id` (string) ワークフロー実行の一意のID
+      - `event` (string) `text_chunk`に固定
+      - `data` (object) 詳細
+        - `text` (string) テキスト内容
+        - `from_variable_selector` (array) テキスト生成元パス（開発者がどのノードのどの変数から生成されたかを理解するための情報）
     - `event: node_finished` ノード実行終了、同じイベントで異なる状態で成功または失敗
       - `task_id` (string) タスクID、リクエスト追跡と以下のStop Generate APIに使用
       - `workflow_run_id` (string) ワークフロー実行の一意のID

--- a/web/app/components/develop/template/template_workflow.ja.mdx
+++ b/web/app/components/develop/template/template_workflow.ja.mdx
@@ -93,7 +93,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
     各ストリーミングチャンクは`data:`で始まり、2つの改行文字`\n\n`で区切られます。以下のように表示されます：
     <CodeGroup>
     ```streaming {{ title: '応答' }}
-    data: {"event": "message", "task_id": "900bbd43-dc0b-4383-a372-aa6e6c414227", "id": "663c5084-a254-4040-8ad3-51f2a3c1a77c", "answer": "Hi", "created_at": 1705398420}\n\n
+    data: {"event": "text_chunk", "workflow_run_id": "b85e5fc5-751b-454d-b14e-dc5f240b0a31", "task_id": "bd029338-b068-4d34-a331-fc85478922c2", "data": {"text": "\u4e3a\u4e86", "from_variable_selector": ["1745912968134", "text"]}}\n\n
     ```
     </CodeGroup>
     ストリーミングチャンクの構造は`event`に応じて異なります：

--- a/web/app/components/develop/template/template_workflow.zh.mdx
+++ b/web/app/components/develop/template/template_workflow.zh.mdx
@@ -87,7 +87,7 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
     每个流式块均为 data: 开头，块之间以 `\n\n` 即两个换行符分隔，如下所示：
     <CodeGroup>
     ```streaming {{ title: 'Response' }}
-    data: {"event": "message", "task_id": "900bbd43-dc0b-4383-a372-aa6e6c414227", "id": "663c5084-a254-4040-8ad3-51f2a3c1a77c", "answer": "Hi", "created_at": 1705398420}\n\n
+    data: {"event": "text_chunk", "workflow_run_id": "b85e5fc5-751b-454d-b14e-dc5f240b0a31", "task_id": "bd029338-b068-4d34-a331-fc85478922c2", "data": {"text": "\u4e3a\u4e86", "from_variable_selector": ["1745912968134", "text"]}}\n\n
     ```
     </CodeGroup>
     流式块中根据 `event` 不同，结构也不同，包含以下类型：
@@ -113,6 +113,13 @@ Workflow 应用无会话支持，适合用于翻译/文章写作/总结 AI 等�
         - `predecessor_node_id` (string) 前置节点 ID，用于画布展示执行路径
         - `inputs` (object) 节点中所有使用到的前置节点变量内容
         - `created_at` (timestamp) 开始时间
+    - `event: text_chunk` 文本片段
+      - `task_id` (string) 任务 ID，用于请求跟踪和下方的停止响应接口
+      - `workflow_run_id` (string) workflow 执行 ID
+      - `event` (string) 固定为 `text_chunk`
+      - `data` (object) 详细内容
+        - `text` (string) 文本内容
+        - `from_variable_selector` (array) 文本来源路径，帮助开发者了解文本是由哪个节点的哪个变量生成的
     - `event: node_finished` node 执行结束，成功失败同一事件中不同状态
       - `task_id` (string) 任务 ID，用于请求跟踪和下方的停止响应接口
       - `workflow_run_id` (string) workflow 执行 ID


### PR DESCRIPTION
# Summary

1. add a description of the data structure related to `event: text_chunk` in the documentation of the workflow application type access interface.
2. update the example of workflow streaming output data chunks

Resolves #19267 

# Screenshots

![image](https://github.com/user-attachments/assets/55d9b6f5-86d6-4f91-bcb0-9b25d958ebb8)


# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

