### PR TITLE
feat: store mcp_config when switch agent strategy

### DIFF
--- a/web/app/components/workflow/nodes/agent/panel.tsx
+++ b/web/app/components/workflow/nodes/agent/panel.tsx
@@ -102,7 +102,6 @@ const AgentPanel: FC<NodePanelProps<AgentNodeType>> = (props) => {
             agent_strategy_label: strategy?.agent_strategy_label,
             output_schema: strategy!.agent_output_schema,
             plugin_unique_identifier: strategy!.plugin_unique_identifier,
-            agent_parameters: {},
           })
           resetEditor(Date.now())
         }}

--- a/web/app/components/workflow/nodes/agent/use-config.ts
+++ b/web/app/components/workflow/nodes/agent/use-config.ts
@@ -85,12 +85,13 @@ const useConfig = (id: string, payload: AgentNodeType) => {
     enabled: Boolean(pluginId),
   })
   const formData = useMemo(() => {
+    const paramNameList = (currentStrategy?.parameters || []).map(item => item.name)
     return Object.fromEntries(
-      Object.entries(inputs.agent_parameters || {}).map(([key, value]) => {
+      Object.entries(inputs.agent_parameters || {}).filter(([name]) => paramNameList.includes(name)).map(([key, value]) => {
         return [key, value.value]
       }),
     )
-  }, [inputs.agent_parameters])
+  }, [inputs.agent_parameters, currentStrategy?.parameters])
   const onFormChange = (value: Record<string, any>) => {
     const res: ToolVarInputs = {}
     Object.entries(value).forEach(([key, val]) => {


### PR DESCRIPTION
# Summary

store mcp_config & llm eg. when switch agent strategy, when I switch strategy.

> close #19290 


# Screenshots

| Before | After |
|--------|-------|
|![2025-05-06 18 01 14](https://github.com/user-attachments/assets/e4da8876-1908-451d-baad-7844538a35a1)|![2025-05-06 18 05 43](https://github.com/user-attachments/assets/8fadefcc-a597-469f-8cb9-25b333920f8b)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

