### PR TITLE
[Observability] Update counter to include http method and target

### DIFF
--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -56,10 +56,11 @@ def init_app(app: DifyApp):
                 status_code = int(status)
                 status_class = f"{status_code // 100}xx"
                 attributes: dict[str, str | int] = {"status_code": status_code, "status_class": status_class}
-                if flask.request and flask.request.url_rule:
-                    attributes[SpanAttributes.HTTP_TARGET] = str(flask.request.url_rule.rule)
-                if flask.request and flask.request.method:
-                    attributes[SpanAttributes.HTTP_METHOD] = str(flask.request.method)
+                request = flask.request
+                if request and request.url_rule:
+                    attributes[SpanAttributes.HTTP_TARGET] = str(request.url_rule.rule)
+                if request and request.method:
+                    attributes[SpanAttributes.HTTP_METHOD] = str(request.method)
                 _http_response_counter.add(1, attributes)
 
         instrumentor = FlaskInstrumentor()

--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -41,8 +41,7 @@ def init_app(app: DifyApp):
         meter = get_meter("http_metrics", version=dify_config.CURRENT_VERSION)
         _http_response_counter = meter.create_counter(
             "http.server.response.count",
-            description="Total number of HTTP responses by status code, \
-            method and target",
+            description="Total number of HTTP responses by status code, method and target",
             unit="{response}",
         )
 

--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -6,6 +6,7 @@ import socket
 import sys
 from typing import Union
 
+import flask
 from celery.signals import worker_init  # type: ignore
 from flask_login import user_loaded_from_request, user_logged_in  # type: ignore
 
@@ -27,6 +28,8 @@ def on_user_loaded(_sender, user):
 
 
 def init_app(app: DifyApp):
+    from opentelemetry.semconv.trace import SpanAttributes
+
     def is_celery_worker():
         return "celery" in sys.argv[0].lower()
 
@@ -37,7 +40,10 @@ def init_app(app: DifyApp):
     def init_flask_instrumentor(app: DifyApp):
         meter = get_meter("http_metrics", version=dify_config.CURRENT_VERSION)
         _http_response_counter = meter.create_counter(
-            "http.server.response.count", description="Total number of HTTP responses by status code", unit="{response}"
+            "http.server.response.count",
+            description="Total number of HTTP responses by status code, \
+            method and target",
+            unit="{response}",
         )
 
         def response_hook(span: Span, status: str, response_headers: list):
@@ -50,7 +56,12 @@ def init_app(app: DifyApp):
                 status = status.split(" ")[0]
                 status_code = int(status)
                 status_class = f"{status_code // 100}xx"
-                _http_response_counter.add(1, {"status_code": status_code, "status_class": status_class})
+                attributes: dict[str, str | int] = {"status_code": status_code, "status_class": status_class}
+                if flask.request and flask.request.url_rule:
+                    attributes[SpanAttributes.HTTP_TARGET] = str(flask.request.url_rule.rule)
+                if flask.request and flask.request.method:
+                    attributes[SpanAttributes.HTTP_METHOD] = str(flask.request.method)
+                _http_response_counter.add(1, attributes)
 
         instrumentor = FlaskInstrumentor()
         if dify_config.DEBUG:


### PR DESCRIPTION
# Summary

This pull request enhances OpenTelemetry instrumentation in the `api/extensions/ext_otel.py` file, focusing on improving HTTP response metrics and adding support for additional attributes such as HTTP method and target. It also includes minor refactoring and new imports to support these changes.

### Improvements to HTTP response metrics:

* Updated the `_http_response_counter` description to include HTTP method and target, making the metrics more detailed and informative. (`[api/extensions/ext_otel.pyL40-R46](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6L40-R46)`)
* Enhanced the `response_hook` function to conditionally add `SpanAttributes.HTTP_TARGET` and `SpanAttributes.HTTP_METHOD` to the metric attributes, using data from the `flask.request` object. (`[api/extensions/ext_otel.pyL53-R64](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6L53-R64)`)

### Supporting changes:

* Added the `flask` import to enable access to the `flask.request` object. (`[api/extensions/ext_otel.pyR9](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6R9)`)
* Imported `SpanAttributes` from `opentelemetry.semconv.trace` to use predefined attribute keys for OpenTelemetry spans. (`[api/extensions/ext_otel.pyR31-R32](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6R31-R32)`)


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/ab3d7ee9-b4c0-4d8a-9e50-e0834fdee3fd)  | ![image](https://github.com/user-attachments/assets/11ac4bb8-5925-41bf-a0d6-332a2902f289)  |

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

