### PR TITLE
Bug fix: Invalid edge connection data causes the page to crash.

### DIFF
--- a/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-node-started.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-node-started.ts
@@ -67,9 +67,9 @@ export const useWorkflowNodeStarted = () => {
 
       incomeEdges.forEach((edge) => {
         const incomeNode = nodes.find(node => node.id === edge.source)!
-        if (!incomeNode || !('data' in incomeNode)) {
+        if (!incomeNode || !('data' in incomeNode))
            return
-        }
+
         if (
           (!incomeNode.data._runningBranchId && edge.sourceHandle === 'source')
           || (incomeNode.data._runningBranchId && edge.sourceHandle === incomeNode.data._runningBranchId)

--- a/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-node-started.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-node-started.ts
@@ -67,6 +67,9 @@ export const useWorkflowNodeStarted = () => {
 
       incomeEdges.forEach((edge) => {
         const incomeNode = nodes.find(node => node.id === edge.source)!
+        if (!incomeNode || !('data' in incomeNode)) {
+           return
+        }
         if (
           (!incomeNode.data._runningBranchId && edge.sourceHandle === 'source')
           || (incomeNode.data._runningBranchId && edge.sourceHandle === incomeNode.data._runningBranchId)


### PR DESCRIPTION
# Summary

Bug fix: During the process configuration, if the process is relatively complex, after multiple node additions and deletions, some edge connection data may become invalid. The source of these edges may point to non - existent nodes. In such cases, null checks are required. Otherwise, trying to retrieve data from an undefined object will result in a TypeError, which can further cause the page to crash due to display issues.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |
![1746496860172_CDFC6116-7246-4a7e-B329-18D84C51F625](https://github.com/user-attachments/assets/c4157826-d3c4-47e7-b093-1ac921248482)
![lQDPJwCxMxQGStfNBsDNCQCwXDHrcVi_MwEH-m5Lpg3XAA_2304_1728](https://github.com/user-attachments/assets/3c18b7f6-6084-4c50-8a57-f556f68a899a)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

