### PR TITLE
fix(workflow): Fix the expand/collapse animation effect

### DIFF
--- a/web/app/components/workflow/run/iteration-log/iteration-result-panel.tsx
+++ b/web/app/components/workflow/run/iteration-log/iteration-result-panel.tsx
@@ -109,8 +109,10 @@ const IterationResultPanel: FC<Props> = ({
               className="h-px grow bg-divider-subtle"
             ></div>}
             <div className={cn(
-              'overflow-hidden transition-all duration-200',
-              expandedIterations[index] ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0',
+              'transition-all duration-200',
+              expandedIterations[index]
+                ? 'opacity-100'
+                : 'max-h-0 opacity-0 overflow-hidden',
             )}>
               <TracingPanel
                 list={iteration}

--- a/web/app/components/workflow/run/loop-log/loop-result-panel.tsx
+++ b/web/app/components/workflow/run/loop-log/loop-result-panel.tsx
@@ -115,8 +115,10 @@ const LoopResultPanel: FC<Props> = ({
               className="h-px grow bg-divider-subtle"
             ></div>}
             <div className={cn(
-              'overflow-hidden transition-all duration-200',
-              expandedLoops[index] ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0',
+              'transition-all duration-200',
+              expandedLoops[index]
+                ? 'opacity-100'
+                : 'max-h-0 opacity-0 overflow-hidden',
             )}>
               {
                 loopVariableMap?.[index] && (

--- a/web/app/components/workflow/run/loop-result-panel.tsx
+++ b/web/app/components/workflow/run/loop-result-panel.tsx
@@ -82,8 +82,10 @@ const LoopResultPanel: FC<Props> = ({
               className="h-px grow bg-divider-subtle"
             ></div>}
             <div className={cn(
-              'overflow-hidden transition-all duration-200',
-              expandedLoops[index] ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0',
+              'transition-all duration-200',
+              expandedLoops[index]
+                ? 'opacity-100'
+                : 'max-h-0 opacity-0 overflow-hidden',
             )}>
               <TracingPanel
                 list={loop}


### PR DESCRIPTION
- Optimized the expand/collapse animation effect of the iteration log, loop log, and loop result panels

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


Fixes #17746

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

