### PR TITLE
test(vdb/huaweicloudvectordb): Fix the wrong import path

### DIFF
--- a/api/tests/integration_tests/vdb/__mock/huaweicloudvectordb.py
+++ b/api/tests/integration_tests/vdb/__mock/huaweicloudvectordb.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from api.core.rag.datasource.vdb.field import Field
+from core.rag.datasource.vdb.field import Field
 from elasticsearch import Elasticsearch
 
 

--- a/api/tests/integration_tests/vdb/__mock/huaweicloudvectordb.py
+++ b/api/tests/integration_tests/vdb/__mock/huaweicloudvectordb.py
@@ -2,8 +2,9 @@ import os
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from core.rag.datasource.vdb.field import Field
 from elasticsearch import Elasticsearch
+
+from core.rag.datasource.vdb.field import Field
 
 
 class MockIndicesClient:


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #19417

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

