### PR TITLE
fix(web): fix the issue where the detail drawer content does not te after editing custom tools

### DIFF
--- a/web/app/components/tools/provider-list.tsx
+++ b/web/app/components/tools/provider-list.tsx
@@ -53,7 +53,10 @@ const ProviderList = () => {
     })
   }, [activeTab, tagFilterValue, keywords, collectionList])
 
-  const [currentProvider, setCurrentProvider] = useState<Collection | undefined>()
+  const [currentProviderId, setCurrentProviderId] = useState<string | undefined>()
+  const currentProvider = useMemo<Collection | undefined>(() => {
+    return filteredCollectionList.find(collection => collection.id === currentProviderId)
+  }, [currentProviderId, filteredCollectionList])
   const { data: pluginList } = useInstalledPluginList()
   const invalidateInstalledPluginList = useInvalidateInstalledPluginList()
   const currentPluginDetail = useMemo(() => {
@@ -70,14 +73,14 @@ const ProviderList = () => {
         >
           <div className={cn(
             'sticky top-0 z-20 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-2 pt-4 leading-[56px]',
-            currentProvider && 'pr-6',
+            currentProviderId && 'pr-6',
           )}>
             <TabSliderNew
               value={activeTab}
               onChange={(state) => {
                 setActiveTab(state)
                 if (state !== activeTab)
-                  setCurrentProvider(undefined)
+                  setCurrentProviderId(undefined)
               }}
               options={options}
             />
@@ -102,12 +105,12 @@ const ProviderList = () => {
               {filteredCollectionList.map(collection => (
                 <div
                   key={collection.id}
-                  onClick={() => setCurrentProvider(collection)}
+                  onClick={() => setCurrentProviderId(collection.id)}
                 >
                   <Card
                     className={cn(
                       'cursor-pointer border-[1.5px] border-transparent',
-                      currentProvider?.id === collection.id && 'border-components-option-card-option-selected-border',
+                      currentProviderId === collection.id && 'border-components-option-card-option-selected-border',
                     )}
                     hideCornerMark
                     payload={{
@@ -146,14 +149,14 @@ const ProviderList = () => {
       {currentProvider && !currentProvider.plugin_id && (
         <ProviderDetail
           collection={currentProvider}
-          onHide={() => setCurrentProvider(undefined)}
+          onHide={() => setCurrentProviderId(undefined)}
           onRefreshData={refetch}
         />
       )}
       <PluginDetailPanel
         detail={currentPluginDetail}
         onUpdate={() => invalidateInstalledPluginList()}
-        onHide={() => setCurrentProvider(undefined)}
+        onHide={() => setCurrentProviderId(undefined)}
       />
     </>
   )


### PR DESCRIPTION
# Summary

- Use the `useMemo` hook to compute `currentProvider` based on `currentProviderId` and `filteredCollectionList`
- This allows the detail drawer content to **automatically update** when `filteredCollectionList` changes

This change ensures that the `currentProvider` value in the detail drawer (e.g., used by `ProviderDetail`) reflects the latest data from the list after operations like refetching or editing a tool.

Fixes #18082


# Screenshots

| Before | After |
|--------|-------|
|![9e5cd59a52f31cf2d25fd8c2f0bdb2a](https://github.com/user-attachments/assets/38b6e442-4ddc-424b-b255-74b460ced534)|![ec847f4d974044ea548305c5513a8fa](https://github.com/user-attachments/assets/712f67a3-bd35-4981-9f9d-db41107a84ff)|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

