### PR TITLE
fix: db.session.query(TenantAccountJoin)

### DIFF
--- a/api/models/account.py
+++ b/api/models/account.py
@@ -52,7 +52,7 @@ class Account(UserMixin, Base):
     @current_tenant.setter
     def current_tenant(self, value: "Tenant"):
         tenant = value
-        ta = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, account_id=self.id).first()
+        ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=self.id).first()
         if ta:
             tenant.current_role = ta.role
         else:

--- a/api/schedule/mail_clean_document_notify_task.py
+++ b/api/schedule/mail_clean_document_notify_task.py
@@ -47,7 +47,9 @@ def mail_clean_document_notify_task():
                 if not tenant:
                     continue
                 # check current owner
-                current_owner_join = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, role="owner").first()
+                current_owner_join = (
+                    db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, role="owner").first()
+                )
                 if not current_owner_join:
                     continue
                 account = Account.query.filter(Account.id == current_owner_join.account_id).first()

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -822,6 +822,9 @@ class TenantService:
             db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=member.id).first()
         )
 
+        if not target_member_join:
+            raise MemberNotInTenantError("Member not in tenant.")
+
         if target_member_join.role == new_role:
             raise RoleAlreadyAssignedError("The provided role is already assigned to the member.")
 
@@ -830,7 +833,8 @@ class TenantService:
             current_owner_join = (
                 db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, role="owner").first()
             )
-            current_owner_join.role = "admin"
+            if current_owner_join:
+                current_owner_join.role = "admin"
 
         # Update the role of the target member
         target_member_join.role = new_role

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -672,11 +672,7 @@ class TenantService:
         if not tenant:
             raise TenantNotFoundError("Tenant not found.")
 
-        ta = (
-            db.session.query(TenantAccountJoin)
-            .filter_by(tenant_id=tenant.id, account_id=account.id)
-            .first()
-        )
+        ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=account.id).first()
         if ta:
             tenant.role = ta.role
         else:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -615,7 +615,10 @@ class TenantService:
     ):
         """Check if user have a workspace or not"""
         available_ta = (
-            TenantAccountJoin.query.filter_by(account_id=account.id).order_by(TenantAccountJoin.id.asc()).first()
+            db.session.query(TenantAccountJoin)
+            .filter_by(account_id=account.id)
+            .order_by(TenantAccountJoin.id.asc())
+            .first()
         )
 
         if available_ta:
@@ -669,7 +672,7 @@ class TenantService:
         if not tenant:
             raise TenantNotFoundError("Tenant not found.")
 
-        ta = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, account_id=account.id).first()
+        ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=account.id).first()
         if ta:
             tenant.role = ta.role
         else:
@@ -698,7 +701,7 @@ class TenantService:
         if not tenant_account_join:
             raise AccountNotLinkTenantError("Tenant not found or account is not a member of the tenant.")
         else:
-            TenantAccountJoin.query.filter(
+            db.session.query(TenantAccountJoin).filter(
                 TenantAccountJoin.account_id == account.id, TenantAccountJoin.tenant_id != tenant_id
             ).update({"current": False})
             tenant_account_join.current = True
@@ -790,7 +793,7 @@ class TenantService:
             if operator.id == member.id:
                 raise CannotOperateSelfError("Cannot operate self.")
 
-        ta_operator = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, account_id=operator.id).first()
+        ta_operator = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=operator.id).first()
 
         if not ta_operator or ta_operator.role not in perms[action]:
             raise NoPermissionError(f"No permission to {action} member.")
@@ -803,7 +806,7 @@ class TenantService:
 
         TenantService.check_member_permission(tenant, operator, account, "remove")
 
-        ta = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, account_id=account.id).first()
+        ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=account.id).first()
         if not ta:
             raise MemberNotInTenantError("Member not in tenant.")
 
@@ -815,14 +818,18 @@ class TenantService:
         """Update member role"""
         TenantService.check_member_permission(tenant, operator, member, "update")
 
-        target_member_join = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, account_id=member.id).first()
+        target_member_join = (
+            db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=member.id).first()
+        )
 
         if target_member_join.role == new_role:
             raise RoleAlreadyAssignedError("The provided role is already assigned to the member.")
 
         if new_role == "owner":
             # Find the current owner and change their role to 'admin'
-            current_owner_join = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, role="owner").first()
+            current_owner_join = (
+                db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, role="owner").first()
+            )
             current_owner_join.role = "admin"
 
         # Update the role of the target member
@@ -962,7 +969,7 @@ class RegisterService:
             TenantService.switch_tenant(account, tenant.id)
         else:
             TenantService.check_member_permission(tenant, inviter, account, "add")
-            ta = TenantAccountJoin.query.filter_by(tenant_id=tenant.id, account_id=account.id).first()
+            ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=account.id).first()
 
             if not ta:
                 TenantService.create_tenant_member(tenant, account, role)

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -672,7 +672,11 @@ class TenantService:
         if not tenant:
             raise TenantNotFoundError("Tenant not found.")
 
-        ta = db.session.query(TenantAccountJoin).filter_by(tenant_id=tenant.id, account_id=account.id).first()
+        ta = (
+            db.session.query(TenantAccountJoin)
+            .filter_by(tenant_id=tenant.id, account_id=account.id)
+            .first()
+        )
         if ta:
             tenant.role = ta.role
         else:


### PR DESCRIPTION
# Summary

This pull request refactors database query operations across multiple files to ensure consistency and improve maintainability. The changes replace direct calls to `TenantAccountJoin.query` with `db.session.query(TenantAccountJoin)`. This standardization aligns query operations with the preferred usage of `db.session` for database interactions.

### Database Query Standardization:

* Updated `current_tenant` setter in `api/models/account.py` to use `db.session.query(TenantAccountJoin)` instead of `TenantAccountJoin.query` for retrieving tenant account join records.
* Refactored `mail_clean_document_notify_task` in `api/schedule/mail_clean_document_notify_task.py` to use `db.session.query(TenantAccountJoin)` for querying the current owner join.
* Modified `create_owner_tenant_if_not_exist` in `api/services/account_service.py` to replace `TenantAccountJoin.query` with `db.session.query(TenantAccountJoin)` for fetching available tenant account joins.
* Standardized tenant-related queries in various functions within `api/services/account_service.py`, including `get_current_tenant_by_account`, `switch_tenant`, `check_member_permission`, `remove_member_from_tenant`, `update_member_role`, and `invite_new_member`, to use `db.session.query(TenantAccountJoin)`. [[1]](diffhunk://#diff-ba864b532147ba53f5755d51601eb64b50d6373f8d5f9f9da2db41613cee310cL672-R675) [[2]](diffhunk://#diff-ba864b532147ba53f5755d51601eb64b50d6373f8d5f9f9da2db41613cee310cL701-R704) [[3]](diffhunk://#diff-ba864b532147ba53f5755d51601eb64b50d6373f8d5f9f9da2db41613cee310cL793-R796) [[4]](diffhunk://#diff-ba864b532147ba53f5755d51601eb64b50d6373f8d5f9f9da2db41613cee310cL806-R809) [[5]](diffhunk://#diff-ba864b532147ba53f5755d51601eb64b50d6373f8d5f9f9da2db41613cee310cL818-R832) [[6]](diffhunk://#diff-ba864b532147ba53f5755d51601eb64b50d6373f8d5f9f9da2db41613cee310cL965-R972)

Fix https://github.com/langgenius/dify/issues/19458



# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

