### PR TITLE
chore: speed up api service startup time by defering the imports for trace services 

### DIFF
--- a/api/core/ops/entities/config_entity.py
+++ b/api/core/ops/entities/config_entity.py
@@ -1,9 +1,9 @@
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, ValidationInfo, field_validator
 
 
-class TracingProviderEnum(Enum):
+class TracingProviderEnum(StrEnum):
     LANGFUSE = "langfuse"
     LANGSMITH = "langsmith"
     OPIK = "opik"

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -33,9 +33,7 @@ from core.ops.entities.trace_entity import (
     TraceTaskName,
     WorkflowTraceInfo,
 )
-from core.ops.langsmith_trace.langsmith_trace import LangSmithDataTrace
 from core.ops.utils import get_message_data
-from core.ops.weave_trace.weave_trace import WeaveDataTrace
 from extensions.ext_database import db
 from extensions.ext_storage import storage
 from models.model import App, AppModelConfig, Conversation, Message, MessageFile, TraceAppConfig
@@ -56,33 +54,37 @@ def build_langsmith_trace_instance(config: LangfuseConfig):
 
 
 def build_opik_trace_instance(config: LangSmithConfig):
+    from core.ops.langsmith_trace.langsmith_trace import LangSmithDataTrace
+
     return LangSmithDataTrace(config)
 
 
 def build_weave_trace_instance(config: WeaveConfig):
+    from core.ops.weave_trace.weave_trace import WeaveDataTrace
+
     return WeaveDataTrace(config)
 
 
 provider_config_map: dict[str, dict[str, Any]] = {
-    TracingProviderEnum.LANGFUSE.value: {
+    TracingProviderEnum.LANGFUSE: {
         "config_class": LangfuseConfig,
         "secret_keys": ["public_key", "secret_key"],
         "other_keys": ["host", "project_key"],
         "trace_instance": lambda config: build_langfuse_trace_instance(config),
     },
-    TracingProviderEnum.LANGSMITH.value: {
+    TracingProviderEnum.LANGSMITH: {
         "config_class": LangSmithConfig,
         "secret_keys": ["api_key"],
         "other_keys": ["project", "endpoint"],
         "trace_instance": lambda config: build_langsmith_trace_instance(config),
     },
-    TracingProviderEnum.OPIK.value: {
+    TracingProviderEnum.OPIK: {
         "config_class": OpikConfig,
         "secret_keys": ["api_key"],
         "other_keys": ["project", "url", "workspace"],
         "trace_instance": lambda config: build_opik_trace_instance(config),
     },
-    TracingProviderEnum.WEAVE.value: {
+    TracingProviderEnum.WEAVE: {
         "config_class": WeaveConfig,
         "secret_keys": ["api_key"],
         "other_keys": ["project", "entity", "endpoint"],

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -33,9 +33,7 @@ from core.ops.entities.trace_entity import (
     TraceTaskName,
     WorkflowTraceInfo,
 )
-from core.ops.langfuse_trace.langfuse_trace import LangFuseDataTrace
 from core.ops.langsmith_trace.langsmith_trace import LangSmithDataTrace
-from core.ops.opik_trace.opik_trace import OpikDataTrace
 from core.ops.utils import get_message_data
 from core.ops.weave_trace.weave_trace import WeaveDataTrace
 from extensions.ext_database import db
@@ -45,8 +43,24 @@ from models.workflow import WorkflowAppLog, WorkflowRun
 from tasks.ops_trace_task import process_trace_tasks
 
 
-def build_opik_trace_instance(config: OpikConfig):
-    return OpikDataTrace(config)
+def build_langfuse_trace_instance(config: LangfuseConfig):
+    from core.ops.langfuse_trace.langfuse_trace import LangFuseDataTrace
+
+    return LangFuseDataTrace(config)
+
+
+def build_langsmith_trace_instance(config: LangfuseConfig):
+    from core.ops.langfuse_trace.langfuse_trace import LangFuseDataTrace
+
+    return LangFuseDataTrace(config)
+
+
+def build_opik_trace_instance(config: LangSmithConfig):
+    return LangSmithDataTrace(config)
+
+
+def build_weave_trace_instance(config: WeaveConfig):
+    return WeaveDataTrace(config)
 
 
 provider_config_map: dict[str, dict[str, Any]] = {
@@ -54,13 +68,13 @@ provider_config_map: dict[str, dict[str, Any]] = {
         "config_class": LangfuseConfig,
         "secret_keys": ["public_key", "secret_key"],
         "other_keys": ["host", "project_key"],
-        "trace_instance": LangFuseDataTrace,
+        "trace_instance": lambda config: build_langfuse_trace_instance(config),
     },
     TracingProviderEnum.LANGSMITH.value: {
         "config_class": LangSmithConfig,
         "secret_keys": ["api_key"],
         "other_keys": ["project", "endpoint"],
-        "trace_instance": LangSmithDataTrace,
+        "trace_instance": lambda config: build_langsmith_trace_instance(config),
     },
     TracingProviderEnum.OPIK.value: {
         "config_class": OpikConfig,
@@ -72,7 +86,7 @@ provider_config_map: dict[str, dict[str, Any]] = {
         "config_class": WeaveConfig,
         "secret_keys": ["api_key"],
         "other_keys": ["project", "entity", "endpoint"],
-        "trace_instance": WeaveDataTrace,
+        "trace_instance": lambda config: build_weave_trace_instance(config),
     },
 }
 

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -16,11 +16,7 @@ from sqlalchemy.orm import Session
 from core.helper.encrypter import decrypt_token, encrypt_token, obfuscated_token
 from core.ops.entities.config_entity import (
     OPS_FILE_PATH,
-    LangfuseConfig,
-    LangSmithConfig,
-    OpikConfig,
     TracingProviderEnum,
-    WeaveConfig,
 )
 from core.ops.entities.trace_entity import (
     DatasetRetrievalTraceInfo,
@@ -41,56 +37,58 @@ from models.workflow import WorkflowAppLog, WorkflowRun
 from tasks.ops_trace_task import process_trace_tasks
 
 
-def build_langfuse_trace_instance(config: LangfuseConfig):
-    from core.ops.langfuse_trace.langfuse_trace import LangFuseDataTrace
+class OpsTraceProviderConfigMap(dict[str, dict[str, Any]]):
+    def __getitem__(self, provider: str) -> dict[str, Any]:
+        match provider:
+            case TracingProviderEnum.LANGFUSE:
+                from core.ops.entities.config_entity import LangfuseConfig
+                from core.ops.langfuse_trace.langfuse_trace import LangFuseDataTrace
 
-    return LangFuseDataTrace(config)
+                return {
+                    "config_class": LangfuseConfig,
+                    "secret_keys": ["public_key", "secret_key"],
+                    "other_keys": ["host", "project_key"],
+                    "trace_instance": LangFuseDataTrace,
+                }
+
+            case TracingProviderEnum.LANGSMITH:
+                from core.ops.entities.config_entity import LangSmithConfig
+                from core.ops.langsmith_trace.langsmith_trace import LangSmithDataTrace
+
+                return {
+                    "config_class": LangSmithConfig,
+                    "secret_keys": ["api_key"],
+                    "other_keys": ["project", "endpoint"],
+                    "trace_instance": LangSmithDataTrace,
+                }
+
+            case TracingProviderEnum.OPIK:
+                from core.ops.entities.config_entity import OpikConfig
+                from core.ops.opik_trace.opik_trace import OpikDataTrace
+
+                return {
+                    "config_class": OpikConfig,
+                    "secret_keys": ["api_key"],
+                    "other_keys": ["project", "url", "workspace"],
+                    "trace_instance": OpikDataTrace,
+                }
+
+            case TracingProviderEnum.WEAVE:
+                from core.ops.entities.config_entity import WeaveConfig
+                from core.ops.weave_trace.weave_trace import WeaveDataTrace
+
+                return {
+                    "config_class": WeaveConfig,
+                    "secret_keys": ["api_key"],
+                    "other_keys": ["project", "entity", "endpoint"],
+                    "trace_instance": WeaveDataTrace,
+                }
+
+            case _:
+                raise KeyError(f"Unsupported tracing provider: {provider}")
 
 
-def build_langsmith_trace_instance(config: LangfuseConfig):
-    from core.ops.langfuse_trace.langfuse_trace import LangFuseDataTrace
-
-    return LangFuseDataTrace(config)
-
-
-def build_opik_trace_instance(config: LangSmithConfig):
-    from core.ops.langsmith_trace.langsmith_trace import LangSmithDataTrace
-
-    return LangSmithDataTrace(config)
-
-
-def build_weave_trace_instance(config: WeaveConfig):
-    from core.ops.weave_trace.weave_trace import WeaveDataTrace
-
-    return WeaveDataTrace(config)
-
-
-provider_config_map: dict[str, dict[str, Any]] = {
-    TracingProviderEnum.LANGFUSE: {
-        "config_class": LangfuseConfig,
-        "secret_keys": ["public_key", "secret_key"],
-        "other_keys": ["host", "project_key"],
-        "trace_instance": lambda config: build_langfuse_trace_instance(config),
-    },
-    TracingProviderEnum.LANGSMITH: {
-        "config_class": LangSmithConfig,
-        "secret_keys": ["api_key"],
-        "other_keys": ["project", "endpoint"],
-        "trace_instance": lambda config: build_langsmith_trace_instance(config),
-    },
-    TracingProviderEnum.OPIK: {
-        "config_class": OpikConfig,
-        "secret_keys": ["api_key"],
-        "other_keys": ["project", "url", "workspace"],
-        "trace_instance": lambda config: build_opik_trace_instance(config),
-    },
-    TracingProviderEnum.WEAVE: {
-        "config_class": WeaveConfig,
-        "secret_keys": ["api_key"],
-        "other_keys": ["project", "entity", "endpoint"],
-        "trace_instance": lambda config: build_weave_trace_instance(config),
-    },
-}
+provider_config_map: dict[str, dict[str, Any]] = OpsTraceProviderConfigMap()
 
 
 class OpsTraceManager:


### PR DESCRIPTION
# Summary
- to close #19505

- saving 40% API service launch time (4627.76 ms -> 2812.27 ms on MacOS M4 Max), by deferring imports of tracing classes and SDK, which also helps to skip unnecessary network requests on starting introduced by Litellm from opik.

- Before this PR:
  - `ext_import_modules` process takes 3406.33 ms
  ```
  ...
  ^[[A2025-05-11 15:43:27,216 INFO [_client.py:1038]  HTTP Request: GET https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json "HTTP/1.1 200 OK"
  2025-05-11 15:43:28,581 INFO [app_factory.py:99]  Loaded ext_import_modules (3406.33 ms)
  ...
  2025-05-11 15:43:29,115 INFO [app_factory.py:35]  Finished create_app (4627.76 ms)
  ```

- With this PR:
  - `ext_import_modules` process takes 1548.72 ms
  ```
  ...
  2025-05-11 15:53:33,174 INFO [app_factory.py:99]  Loaded ext_import_modules (1548.72 ms)
  ...
  2025-05-11 15:53:33,703 INFO [app_factory.py:35]  Finished create_app (2812.27 ms)
  ```

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

