### PR TITLE
chore: disable redis client-side caching by default

### DIFF
--- a/api/configs/middleware/cache/redis_config.py
+++ b/api/configs/middleware/cache/redis_config.py
@@ -91,5 +91,5 @@ class RedisConfig(BaseSettings):
 
     REDIS_ENABLE_CLIENT_SIDE_CACHE: bool = Field(
         description="Enable client side cache in redis",
-        default=True,
+        default=False,
     )


### PR DESCRIPTION
# Summary

- to resolve #19523
- It's reported that client-side caching requires Redis 7.4+ for better compatibility
![image](https://github.com/user-attachments/assets/46dee1c2-5ad0-4d7a-906d-f2c845d94f8a)

- disable redis client-side caching by default

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

