### PR TITLE
fix: common prerequisite node workflow remove reachable node that failed to streaming llm…

### DIFF
--- a/api/core/workflow/nodes/answer/base_stream_processor.py
+++ b/api/core/workflow/nodes/answer/base_stream_processor.py
@@ -95,7 +95,12 @@ class StreamProcessor(ABC):
         if node_id not in self.rest_node_ids:
             return
 
+        if node_id in reachable_node_ids:
+            return
+
         self.rest_node_ids.remove(node_id)
+        self.rest_node_ids.extend(set(reachable_node_ids) - set(self.rest_node_ids))
+
         for edge in self.graph.edge_mapping.get(node_id, []):
             if edge.target_node_id in reachable_node_ids:
                 continue


### PR DESCRIPTION
# Summary

Fix #17626 
Fix #16882 
Fix #16826 
Fix #15700 
Fix #13264  
(Maybe #17085) 

LLM stream output needs node in [self.rest_node_ids](https://github.com/langgenius/dify/blob/14cd71ed0adbd60e1a51cd67f30572a3b650fefe/api/core/workflow/nodes/answer/answer_stream_processor.py#L42C16-L53C32), but nodes is actually [removed](https://github.com/langgenius/dify/blob/14cd71ed0adbd60e1a51cd67f30572a3b650fefe/api/core/workflow/nodes/answer/base_stream_processor.py#L23) after common prerequisite branch node is executed. This should be solved by changing `base_stream_processor.py/_remove_node_ids_in_unreachable_branch`.

The change is very simple, figuring out where to fix it takes some time. Please take a look.

TODO:
- [ ]  add test case

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

