### PR TITLE
Fix: typo ja translation

### DIFF
--- a/web/i18n/ja-JP/app.ts
+++ b/web/i18n/ja-JP/app.ts
@@ -47,7 +47,7 @@ const translation = {
     advancedFor: '上級ユーザー向け',
     advancedDescription: 'ワークフロー オーケストレートは、ワークフロー形式でチャットボットをオーケストレートし、組み込みのプロンプトを編集する機能を含む高度なカスタマイズを提供します。経験豊富なユーザー向けです。',
     captionName: 'アプリのアイコンと名前',
-    appNamePlaceholder: 'アプリに名前を付ける',
+    appNamePlaceholder: 'アプリ名を入力してください',
     captionDescription: '説明',
     appDescriptionPlaceholder: 'アプリの説明を入力してください',
     useTemplate: 'このテンプレートを使用する',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -75,7 +75,7 @@ const translation = {
     exportJPEG: 'JPEGで出力',
     exportSVG: 'SVGで出力',
     model: 'モデル',
-    workflowAsTool: 'ワークフローをツールどして公開する',
+    workflowAsTool: 'ワークフローをツールとして公開する',
     configureRequired: '設定が必要',
     configure: '設定',
     manageInTools: 'ツールページで管理',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -147,7 +147,7 @@ const translation = {
       namePlaceholder: '変数名を入力',
       type: 'タイプ',
       value: 'デフォルト値',
-      valuePlaceholder: 'デフォルト値、設定しない場合は空白にしでください',
+      valuePlaceholder: 'デフォルト値、設定しない場合は空白にしてください',
       description: '説明',
       descriptionPlaceholder: '変数の説明を入力',
       editInJSON: 'JSONで編集',


### PR DESCRIPTION
# Summary

- Fixed two typos in the Japanese UI translations:
```diff
- ワークフローをツールどして公開する  
+ ワークフローをツールとして公開する
```

```diff
- 空白にしでください
+ 空白にしてください
```

- In web/i18n/ja-JP/app.ts, improved the placeholder text for app name

```diff
- アプリに名前を付ける  
+ アプリ名を入力してください
```

Fix https://github.com/langgenius/dify/issues/19582

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

