### PR TITLE
fix: image use not config host caused page crash

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -13,7 +13,8 @@ const withMDX = require('@next/mdx')({
   },
 })
 
-const remoteImageURL = new URL(`${process.env.NEXT_PUBLIC_WEB_PREFIX}/**`)
+// the default url to prevent parse url error when running jest
+const remoteImageURL = new URL(`${process.env.NEXT_PUBLIC_WEB_PREFIX || 'http://localhost:3000'}/**`)
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -13,6 +13,8 @@ const withMDX = require('@next/mdx')({
   },
 })
 
+const remoteImageURL = new URL(`${process.env.NEXT_PUBLIC_WEB_PREFIX}/**`)
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   basePath,
@@ -24,6 +26,16 @@ const nextConfig = {
   productionBrowserSourceMaps: false, // enable browser source map generation during the production build
   // Configure pageExtensions to include md and mdx
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
+  // https://nextjs.org/docs/messages/next-image-unconfigured-host
+  images: {
+    remotePatterns: [{
+      protocol: remoteImageURL.protocol.replace(':', ''),
+      hostname: remoteImageURL.hostname,
+      port: remoteImageURL.port,
+      pathname: remoteImageURL.pathname,
+      search: '',
+    }],
+  },
   experimental: {
   },
   // fix all before production. Now it slow the develop speed.


### PR DESCRIPTION
# Summary

In development mode,  creating app cause page cause. The reason is that the image [uses the not config url](https://nextjs.org/docs/messages/next-image-unconfigured-host).
```tsx
<Image 
    src={`${WEB_PREFIX}/screenshots/${theme}/${modeToImageMap[mode]}.png`}
    ...
/>
```


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

