### PR TITLE
fix: handle EndpointSetupFailedError in BasePluginClient

### DIFF
--- a/api/core/plugin/endpoint/exc.py
+++ b/api/core/plugin/endpoint/exc.py
@@ -1,0 +1,6 @@
+class EndpointSetupFailedError(ValueError):
+    """
+    Endpoint setup failed error
+    """
+
+    pass

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -17,6 +17,7 @@ from core.model_runtime.errors.invoke import (
     InvokeServerUnavailableError,
 )
 from core.model_runtime.errors.validate import CredentialsValidateFailedError
+from core.plugin.endpoint.exc import EndpointSetupFailedError
 from core.plugin.entities.plugin_daemon import PluginDaemonBasicResponse, PluginDaemonError, PluginDaemonInnerError
 from core.plugin.impl.exc import (
     PluginDaemonBadRequestError,
@@ -219,6 +220,8 @@ class BasePluginClient:
                         raise InvokeServerUnavailableError(description=args.get("description"))
                     case CredentialsValidateFailedError.__name__:
                         raise CredentialsValidateFailedError(error_object.get("message"))
+                    case EndpointSetupFailedError.__name__:
+                        raise EndpointSetupFailedError(error_object.get("message"))
                     case _:
                         raise PluginInvokeError(description=message)
             case PluginDaemonInternalServerError.__name__:


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Related PRs:
- https://github.com/langgenius/dify-plugin-daemon/pull/282
- https://github.com/langgenius/dify-plugin-sdks/pull/138

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

