### PR TITLE
fix: fix can't config Nth item in list Node

### DIFF
--- a/web/app/components/workflow/nodes/list-operator/panel.tsx
+++ b/web/app/components/workflow/nodes/list-operator/panel.tsx
@@ -97,16 +97,14 @@ const Panel: FC<NodePanelProps<ListFilterNodeType>> = ({
           {inputs.extract_by?.enabled
             ? (
               <div className='flex items-center justify-between'>
-                {hasSubVariable && (
-                  <div className='mr-2 grow'>
-                    <ExtractInput
-                      value={inputs.extract_by.serial as string}
-                      onChange={handleExtractsChange}
-                      readOnly={readOnly}
-                      nodeId={id}
-                    />
-                  </div>
-                )}
+                <div className='mr-2 grow'>
+                  <ExtractInput
+                    value={inputs.extract_by.serial as string}
+                    onChange={handleExtractsChange}
+                    readOnly={readOnly}
+                    nodeId={id}
+                  />
+                </div>
               </div>
             )
             : null}


### PR DESCRIPTION
# Summary

fix can't config Nth item in list Node

> close #19617 


# Screenshots

| Before | After |
|--------|-------|
|![2025-05-13 17 54 18](https://github.com/user-attachments/assets/96edb331-f066-4cdd-8225-8c66d926d741)|![2025-05-13 17 55 21](https://github.com/user-attachments/assets/786e1d18-1d3e-48f8-b124-fd0e12a8c46f)

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

