### PR TITLE
chore: Reduce the invocation of the plugin interface

### DIFF
--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -754,7 +754,7 @@ class ProviderConfiguration(BaseModel):
         :param only_active: return active model only
         :return:
         """
-        provider_models = self.get_provider_models(model_type, only_active)
+        provider_models = self.get_provider_models(model_type, only_active, model)
 
         for provider_model in provider_models:
             if provider_model.model == model:
@@ -763,12 +763,13 @@ class ProviderConfiguration(BaseModel):
         return None
 
     def get_provider_models(
-        self, model_type: Optional[ModelType] = None, only_active: bool = False
+        self, model_type: Optional[ModelType] = None, only_active: bool = False, model: Optional[str] = None
     ) -> list[ModelWithProviderEntity]:
         """
         Get provider models.
         :param model_type: model type
         :param only_active: only active models
+        :param model: model name
         :return:
         """
         model_provider_factory = ModelProviderFactory(self.tenant_id)
@@ -791,7 +792,8 @@ class ProviderConfiguration(BaseModel):
             )
         else:
             provider_models = self._get_custom_provider_models(
-                model_types=model_types, provider_schema=provider_schema, model_setting_map=model_setting_map
+                model_types=model_types, provider_schema=provider_schema, model_setting_map=model_setting_map,
+                model = model
             )
 
         if only_active:
@@ -944,6 +946,7 @@ class ProviderConfiguration(BaseModel):
         model_types: Sequence[ModelType],
         provider_schema: ProviderEntity,
         model_setting_map: dict[ModelType, dict[str, ModelSettings]],
+        model: Optional[str] = None,
     ) -> list[ModelWithProviderEntity]:
         """
         Get custom provider models.
@@ -996,7 +999,8 @@ class ProviderConfiguration(BaseModel):
         for model_configuration in self.custom_configuration.models:
             if model_configuration.model_type not in model_types:
                 continue
-
+            if model and model != model_configuration.model:
+                continue
             try:
                 custom_model_schema = self.get_model_schema(
                     model_type=model_configuration.model_type,

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -792,8 +792,10 @@ class ProviderConfiguration(BaseModel):
             )
         else:
             provider_models = self._get_custom_provider_models(
-                model_types=model_types, provider_schema=provider_schema, model_setting_map=model_setting_map,
-                model = model
+                model_types=model_types,
+                provider_schema=provider_schema,
+                model_setting_map=model_setting_map,
+                model=model,
             )
 
         if only_active:


### PR DESCRIPTION
# Summary

Reduce the invocation of the plugin interface.

As shown in the figure, since we only need to specify the configuration of the model, for subsequent calls, it is not necessary to query all models; only this specific model needs to be queried.
For our configuration of 20 to 30 models, it is completely unnecessary to query all of them through the plugin service because we only need one.

<img width="781" alt="image" src="https://github.com/user-attachments/assets/dcadec69-4691-4700-a9bd-7672c7473b29" />


> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| Query all the model information through the plugin interface each time   | Only query the specific model information  |


## Azure

| Before | After |
|--------|-------|
| <img width="939" alt="image" src="https://github.com/user-attachments/assets/41bac0e8-8de2-483f-92c0-58a8adec6cd9" />| <img width="1006" alt="image" src="https://github.com/user-attachments/assets/98a245bc-9797-41ad-93b9-59ff7940d78f" />  |

## openai_api_compatible

| Before | After |
|--------|-------|
| <img width="1109" alt="image" src="https://github.com/user-attachments/assets/9b6a32e4-63a2-47d9-81c7-c4c172be5099" />  | <img width="977" alt="image" src="https://github.com/user-attachments/assets/bd6788c2-9320-4424-b68d-1c59c2da38eb" />  |

## bedrock

| Before | After |
|--------|-------|
| <img width="1082" alt="image" src="https://github.com/user-attachments/assets/95eadfa4-8bc8-42a5-b5f5-6c898354d89f" />  | No Change. Because ‘self.custom_configuration.models’ is an empty object, our changes did not affect bedrock. Moreover, it seems that before the modification, bedrock would only be invoked once.
<img width="576" alt="image" src="https://github.com/user-attachments/assets/30ecc477-15b2-4553-ad7b-daaa4658c17f" />
 |

## vertex_ai

| Before | After |
|--------|-------|
| <img width="1026" alt="image" src="https://github.com/user-attachments/assets/99779ad5-f533-4903-be9c-a21ab80ed475" />   | No Change. same bedrock |




# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

