### PR TITLE
chore: add dev scripts to start api and worker service with uv run

### DIFF
--- a/dev/start-api
+++ b/dev/start-api
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/.."
+
+
+uv --directory api run \
+  flask run --host 0.0.0.0 --port=5001 --debug

--- a/dev/start-worker
+++ b/dev/start-worker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR/.."
+
+
+uv --directory api run \
+  celery -A app.celery worker \
+  -P gevent -c 1 --loglevel INFO -Q dataset,generation,mail,ops_trace,app_deletion


### PR DESCRIPTION
# Summary

- add scripts to to start api and worker service with `uv run`
   - it auto-syncs the dependency by uv and very handy when switching between branches without manually installation of Python dependencies


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

