### PR TITLE
Fix: Ensure unique index names for pgvector knowledge tables

### DIFF
--- a/api/core/rag/datasource/vdb/pgvector/pgvector.py
+++ b/api/core/rag/datasource/vdb/pgvector/pgvector.py
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
 """
 
 SQL_CREATE_INDEX = """
-CREATE INDEX IF NOT EXISTS hnsw_idx_{index_hash} ON {table_name}
+CREATE INDEX IF NOT EXISTS embedding_cosine_v1_idx_{index_hash} ON {table_name}
 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
 """
 

--- a/api/core/rag/datasource/vdb/pgvector/pgvector.py
+++ b/api/core/rag/datasource/vdb/pgvector/pgvector.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+import hashlib
 from contextlib import contextmanager
 from typing import Any
 
@@ -61,12 +62,12 @@ CREATE TABLE IF NOT EXISTS {table_name} (
 """
 
 SQL_CREATE_INDEX = """
-CREATE INDEX IF NOT EXISTS embedding_cosine_v1_idx ON {table_name}
+CREATE INDEX IF NOT EXISTS hnsw_idx_{index_hash} ON {table_name}
 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
 """
 
 SQL_CREATE_INDEX_PG_BIGM = """
-CREATE INDEX IF NOT EXISTS bigm_idx ON {table_name}
+CREATE INDEX IF NOT EXISTS bigm_idx_{index_hash} ON {table_name}
 USING gin (text gin_bigm_ops);
 """
 
@@ -76,6 +77,7 @@ class PGVector(BaseVector):
         super().__init__(collection_name)
         self.pool = self._create_connection_pool(config)
         self.table_name = f"embedding_{collection_name}"
+        self.index_hash = hashlib.md5(self.table_name.encode()).hexdigest()[:8]
         self.pg_bigm = config.pg_bigm
 
     def get_type(self) -> str:
@@ -256,10 +258,15 @@ class PGVector(BaseVector):
                 # PG hnsw index only support 2000 dimension or less
                 # ref: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing
                 if dimension <= 2000:
-                    cur.execute(SQL_CREATE_INDEX.format(table_name=self.table_name))
+                    cur.execute(SQL_CREATE_INDEX.format(
+                        table_name=self.table_name,
+                        index_hash=self.index_hash
+                    ))
                 if self.pg_bigm:
-                    cur.execute("CREATE EXTENSION IF NOT EXISTS pg_bigm")
-                    cur.execute(SQL_CREATE_INDEX_PG_BIGM.format(table_name=self.table_name))
+                    cur.execute(SQL_CREATE_INDEX_PG_BIGM.format(
+                        table_name=self.table_name,
+                        index_hash=self.index_hash
+                    ))
             redis_client.set(collection_exist_cache_key, 1, ex=3600)
 
 

--- a/api/core/rag/datasource/vdb/pgvector/pgvector.py
+++ b/api/core/rag/datasource/vdb/pgvector/pgvector.py
@@ -1,7 +1,7 @@
+import hashlib
 import json
 import logging
 import uuid
-import hashlib
 from contextlib import contextmanager
 from typing import Any
 
@@ -258,15 +258,9 @@ class PGVector(BaseVector):
                 # PG hnsw index only support 2000 dimension or less
                 # ref: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing
                 if dimension <= 2000:
-                    cur.execute(SQL_CREATE_INDEX.format(
-                        table_name=self.table_name,
-                        index_hash=self.index_hash
-                    ))
+                    cur.execute(SQL_CREATE_INDEX.format(table_name=self.table_name, index_hash=self.index_hash))
                 if self.pg_bigm:
-                    cur.execute(SQL_CREATE_INDEX_PG_BIGM.format(
-                        table_name=self.table_name,
-                        index_hash=self.index_hash
-                    ))
+                    cur.execute(SQL_CREATE_INDEX_PG_BIGM.format(table_name=self.table_name, index_hash=self.index_hash))
             redis_client.set(collection_exist_cache_key, 1, ex=3600)
 
 


### PR DESCRIPTION
## Issue Description
When registering knowledge to pgvector, the index was properly created for the first knowledge data as expected, but no indices were created for the second and subsequent knowledge entries.

## Root Cause
- The system was attempting to create indices on multiple tables using a fixed index name
- Index names must be unique within the database

## Solution
- Added a hash value suffix to the index name to ensure uniqueness

## Steps to Reproduce

1. Create a knowledge database using pgvector
2. Upload and process the first knowledge file/document - index is properly created
3. Upload and process a second knowledge file/document - no index is created
4. Check the database and observe that only the first knowledge table has an index

Expected behavior: All knowledge tables should have proper indices created
Actual behavior: Only the first knowledge table has an index, subsequent tables are missing indices

Fixes #19670


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

