### PR TITLE
Support for copying nodes between workflows (This feature is unrelated to remove functions. When using the copy function, the browser will permanently retain the last copied node)."

### DIFF
--- a/web/app/components/workflow/store/workflow/workflow-slice.ts
+++ b/web/app/components/workflow/store/workflow/workflow-slice.ts
@@ -41,7 +41,7 @@ export const createWorkflowSlice: StateCreator<WorkflowSliceShape> = set => ({
     const storedElements = localStorage.getItem('clipboard_elements')
     return storedElements ? JSON.parse(storedElements) : []
   })(),
-  setClipboardElements: clipboardElements => {
+  setClipboardElements: (clipboardElements) => {
     localStorage.setItem('clipboard_elements', JSON.stringify(clipboardElements))
   },
   selection: null,

--- a/web/app/components/workflow/store/workflow/workflow-slice.ts
+++ b/web/app/components/workflow/store/workflow/workflow-slice.ts
@@ -37,8 +37,13 @@ export type WorkflowSliceShape = {
 export const createWorkflowSlice: StateCreator<WorkflowSliceShape> = set => ({
   workflowRunningData: undefined,
   setWorkflowRunningData: workflowRunningData => set(() => ({ workflowRunningData })),
-  clipboardElements: [],
-  setClipboardElements: clipboardElements => set(() => ({ clipboardElements })),
+  clipboardElements: (() => {
+    const storedElements = localStorage.getItem('clipboard_elements')
+    return storedElements ? JSON.parse(storedElements) : []
+  })(),
+  setClipboardElements: clipboardElements => {
+    localStorage.setItem('clipboard_elements', JSON.stringify(clipboardElements))
+  },
   selection: null,
   setSelection: selection => set(() => ({ selection })),
   bundleNodeSize: null,


### PR DESCRIPTION
# Summary


This pull request updates the clipboard functionality in the `workflow-slice.ts` file to persist clipboard elements in `localStorage`. The most important change involves initializing `clipboardElements` from `localStorage` and ensuring updates to it are saved back to `localStorage`.

Close https://github.com/langgenius/dify/issues/17566

### Clipboard persistence updates:

* `clipboardElements` now initializes by retrieving data from `localStorage` (`clipboard_elements` key) or defaults to an empty array if no data is found.
* `setClipboardElements` has been updated to save the provided clipboard elements to `localStorage` (`clipboard_elements` key) whenever it is called.

Support for copying nodes between workflows. Resolves #19545, see https://github.com/langgenius/dify/issues/19545