### PR TITLE
fix: resolve unstable scrolling in workflow debug panel with multiple input fields #19697

### DIFF
--- a/web/app/components/workflow/panel/debug-and-preview/user-input.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/user-input.tsx
@@ -33,7 +33,7 @@ const UserInput = () => {
     return null
 
   return (
-    <div className={cn('sticky top-0 z-[1] rounded-xl border-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg shadow-xs')}>
+    <div className={cn('relative z-[1] rounded-xl border-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg shadow-xs')}>
       <div className='px-4 pb-4 pt-3'>
         {variables.map((variable, index) => (
           <div


### PR DESCRIPTION
fix: resolve unstable scrolling in workflow debug panel with multiple input fields

# Summary

The issue is caused by a positioning conflict. The input form container uses `position: sticky` with `top: 0`, which attempts to keep the form container at the top of its scrolling container. When a user clicks on a field at the bottom, the browser tries to scroll to make that field visible, but the sticky positioning tries to keep the container at the top, resulting in an unstable scrolling experience.

Fixes #19697

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

