### PR TITLE
Revert "Support for copying nodes between workflows (This feature is unrelated to remove functions. When using the copy function, the browser will permanently retain the last copied node).""

### DIFF
--- a/web/app/components/workflow/store/workflow/workflow-slice.ts
+++ b/web/app/components/workflow/store/workflow/workflow-slice.ts
@@ -37,13 +37,8 @@ export type WorkflowSliceShape = {
 export const createWorkflowSlice: StateCreator<WorkflowSliceShape> = set => ({
   workflowRunningData: undefined,
   setWorkflowRunningData: workflowRunningData => set(() => ({ workflowRunningData })),
-  clipboardElements: (() => {
-    const storedElements = localStorage.getItem('clipboard_elements')
-    return storedElements ? JSON.parse(storedElements) : []
-  })(),
-  setClipboardElements: (clipboardElements) => {
-    localStorage.setItem('clipboard_elements', JSON.stringify(clipboardElements))
-  },
+  clipboardElements: [],
+  setClipboardElements: clipboardElements => set(() => ({ clipboardElements })),
   selection: null,
   setSelection: selection => set(() => ({ selection })),
   bundleNodeSize: null,


### PR DESCRIPTION
Reverts langgenius/dify#19687