### PR TITLE
chore: image allow "data:" in csp

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -37,7 +37,7 @@ export function middleware(request: NextRequest) {
     style-src 'self' 'unsafe-inline' ${scheme_source} ${whiteList};
     worker-src 'self' ${scheme_source} ${csp} ${whiteList};
     media-src 'self' ${scheme_source} ${csp} ${whiteList};
-    img-src *;
+    img-src * data:;
     font-src 'self';
     object-src 'none';
     base-uri 'self';


### PR DESCRIPTION
# Summary
In chatbot, the image src would be transformed to `data:URIs` when uploaded. 

In CSP, the directive:
```
img-src *;
```
does not automatically allow data: URIs. So `data:`  must  be explicitly added to allow.

Fixes: #19722.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

