### PR TITLE
fix: broken behavior of rendering

### DIFF
--- a/web/app/components/workflow/nodes/assigner/default.ts
+++ b/web/app/components/workflow/nodes/assigner/default.ts
@@ -51,11 +51,12 @@ const nodeDefault: NodeDefault<AssignerNodeType> = {
 
   checkVarValid(payload: AssignerNodeType, varMap: Record<string, Var>, t: any) {
     const errorMessageArr: string[] = []
-    const variables_warnings = getNotExistVariablesByArray(payload.items.map(item => item.variable_selector ?? []) ?? [], varMap)
+    const items = payload.items ?? []
+    const variables_warnings = getNotExistVariablesByArray(items.map(item => item.variable_selector ?? []) ?? [], varMap)
     if (variables_warnings.length)
       errorMessageArr.push(`${t('workflow.nodes.assigner.assignedVariable')} ${t('workflow.common.referenceVar')}${variables_warnings.join('、')}${t('workflow.common.noExist')}`)
 
-    const value_warnings = getNotExistVariablesByArray(payload.items.map(item => item.value ?? []) ?? [], varMap)
+    const value_warnings = getNotExistVariablesByArray(items.map(item => item.value ?? []) ?? [], varMap)
     if (value_warnings.length)
       errorMessageArr.push(`${t('workflow.nodes.assigner.setVariable')} ${t('workflow.common.referenceVar')}${value_warnings.join('、')}${t('workflow.common.noExist')}`)
 


### PR DESCRIPTION
# Summary

This pull request includes a small refactor in the `checkVarValid` method of the `NodeDefault` object in `web/app/components/workflow/nodes/assigner/default.ts`. The change introduces a local `items` variable to simplify and improve the readability of the code by avoiding repeated nullish coalescing operations on `payload.items`.

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

