### PR TITLE
fix: fix item.join is undefined, page broke down

### DIFF
--- a/web/app/components/workflow/utils/workflow.ts
+++ b/web/app/components/workflow/utils/workflow.ts
@@ -392,7 +392,7 @@ export const getNotExistVariablesByArray = (array: string[][], varMap: Record<st
       return
     if (['sys'].includes(item[0]))
       return
-    const var_warning = varMap[item.join('.')]
+    const var_warning = varMap[item.join?.('.')]
     if (var_warning)
       return
     const arr = [...item]


### PR DESCRIPTION
# Summary

fix item.join is undefined, it makes page breaking
Fix https://github.com/langgenius/dify/issues/19784

# Screenshots

| Before | After |
|--------|-------|
|
![image](https://github.com/user-attachments/assets/ec3adff9-4fb4-4ede-8c11-9da8d359d43e)
| ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

