### PR TITLE
Fix TiDB vector configuration comment to correctly use 'tidb_vector'

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -478,7 +478,7 @@ ANALYTICDB_PORT=5432
 ANALYTICDB_MIN_CONNECTION=1
 ANALYTICDB_MAX_CONNECTION=5
 
-# TiDB vector configurations, only available when VECTOR_STORE is `tidb`
+# TiDB vector configurations, only available when VECTOR_STORE is `tidb_vector`
 TIDB_VECTOR_HOST=tidb
 TIDB_VECTOR_PORT=4000
 TIDB_VECTOR_USER=


### PR DESCRIPTION
# Summary

This pull request includes a minor update to the `docker/.env.example` file to clarify the configuration for TiDB vector storage.

* Updated the comment for TiDB vector configurations to specify that they are applicable when `VECTOR_STORE` is set to `tidb_vector` instead of `tidb`. (`[docker/.env.exampleL481-R481](diffhunk://#diff-ec10582dde9af6c0c622084d3244b29d496260613491c430ec8958565e2f31b4L481-R481)`)

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

Fixes #19579 