### PR TITLE
fix: fix duplicate app lose custom image

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -180,6 +180,7 @@ class AppCopyApi(Resource):
         parser.add_argument("icon_type", type=str, location="json")
         parser.add_argument("icon", type=str, location="json")
         parser.add_argument("icon_background", type=str, location="json")
+        parser.add_argument("icon_url", type=str, location="json")
         args = parser.parse_args()
 
         with Session(db.engine) as session:
@@ -194,6 +195,7 @@ class AppCopyApi(Resource):
                 description=args.get("description"),
                 icon_type=args.get("icon_type"),
                 icon=args.get("icon"),
+                icon_url=args.get("icon_url"),
                 icon_background=args.get("icon_background"),
             )
             session.commit()

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -100,6 +100,7 @@ class PendingData(BaseModel):
     description: str | None
     icon_type: str | None
     icon: str | None
+    icon_url: str | None
     icon_background: str | None
     app_id: str | None
 
@@ -124,6 +125,7 @@ class AppDslService:
         description: Optional[str] = None,
         icon_type: Optional[str] = None,
         icon: Optional[str] = None,
+        icon_url: Optional[str] = None,
         icon_background: Optional[str] = None,
         app_id: Optional[str] = None,
     ) -> Import:
@@ -248,6 +250,7 @@ class AppDslService:
                     icon_type=icon_type,
                     icon=icon,
                     icon_background=icon_background,
+                    icon_url=icon_url,
                     app_id=app_id,
                 )
                 redis_client.setex(
@@ -288,6 +291,7 @@ class AppDslService:
                 description=description,
                 icon_type=icon_type,
                 icon=icon,
+                icon_url=icon_url,
                 icon_background=icon_background,
                 dependencies=check_dependencies_pending_data,
             )
@@ -409,6 +413,7 @@ class AppDslService:
         description: Optional[str] = None,
         icon_type: Optional[str] = None,
         icon: Optional[str] = None,
+        icon_url: Optional[str] = None,
         icon_background: Optional[str] = None,
         dependencies: Optional[list[PluginDependency]] = None,
     ) -> App:
@@ -421,12 +426,12 @@ class AppDslService:
 
         # Set icon type
         icon_type_value = icon_type or app_data.get("icon_type")
-        if icon_type_value in ["emoji", "link"]:
+        if icon_type_value in ["emoji", "link", "image"]:
             icon_type = icon_type_value
         else:
             icon_type = "emoji"
         icon = icon or str(app_data.get("icon", ""))
-
+        icon_url = icon_url or str(app_data.get("icon_url", ""))
         if app:
             # Update existing app
             app.name = name or app_data.get("name", app.name)
@@ -434,6 +439,7 @@ class AppDslService:
             app.icon_type = icon_type
             app.icon = icon
             app.icon_background = icon_background or app_data.get("icon_background", app.icon_background)
+            app.icon_url = icon_url or app_data.get("icon_url", app.icon_url)
             app.updated_by = account.id
         else:
             if account.current_tenant_id is None:

--- a/web/app/(commonLayout)/apps/AppCard.tsx
+++ b/web/app/(commonLayout)/apps/AppCard.tsx
@@ -106,14 +106,16 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
     }
   }, [app.id, mutateApps, notify, onRefresh, t])
 
-  const onCopy: DuplicateAppModalProps['onConfirm'] = async ({ name, icon_type, icon, icon_background }) => {
+  const onCopy: DuplicateAppModalProps['onConfirm'] = async ({ name, icon_type, icon, icon_background, icon_url }) => {
     try {
+      console.log('icon_url', icon_url)
       const newApp = await copyApp({
         appID: app.id,
         name,
         icon_type,
         icon,
         icon_background,
+        icon_url,
         mode: app.mode,
       })
       setShowDuplicateModal(false)

--- a/web/app/components/app/duplicate-modal/index.tsx
+++ b/web/app/components/app/duplicate-modal/index.tsx
@@ -24,6 +24,7 @@ export type DuplicateAppModalProps = {
   onConfirm: (info: {
     name: string
     icon_type: AppIconType
+    icon_url?: string | null
     icon: string
     icon_background?: string | null
   }) => Promise<void>
@@ -63,6 +64,7 @@ const DuplicateAppModal = ({
       name,
       icon_type: appIcon.type,
       icon: appIcon.type === 'emoji' ? appIcon.icon : appIcon.fileId,
+      icon_url: appIcon.type === 'image' ? appIcon.url : undefined,
       icon_background: appIcon.type === 'emoji' ? appIcon.background : undefined,
     })
     onHide()

--- a/web/service/apps.ts
+++ b/web/service/apps.ts
@@ -28,12 +28,12 @@ export const createApp: Fetcher<AppDetailResponse, { name: string; icon_type?: A
   return post<AppDetailResponse>('apps', { body: { name, icon_type, icon, icon_background, mode, description, model_config: config } })
 }
 
-export const updateAppInfo: Fetcher<AppDetailResponse, { appID: string; name: string; icon_type: AppIconType; icon: string; icon_background?: string; description: string; use_icon_as_answer_icon?: boolean }> = ({ appID, name, icon_type, icon, icon_background, description, use_icon_as_answer_icon }) => {
-  return put<AppDetailResponse>(`apps/${appID}`, { body: { name, icon_type, icon, icon_background, description, use_icon_as_answer_icon } })
+export const updateAppInfo: Fetcher<AppDetailResponse, { appID: string; name: string; icon_type: AppIconType; icon: string; icon_background?: string; icon_url?: string; description: string; use_icon_as_answer_icon?: boolean }> = ({ appID, name, icon_type, icon, icon_background, icon_url, description, use_icon_as_answer_icon }) => {
+  return put<AppDetailResponse>(`apps/${appID}`, { body: { name, icon_type, icon, icon_background, icon_url, description, use_icon_as_answer_icon } })
 }
 
-export const copyApp: Fetcher<AppDetailResponse, { appID: string; name: string; icon_type: AppIconType; icon: string; icon_background?: string | null; mode: AppMode; description?: string }> = ({ appID, name, icon_type, icon, icon_background, mode, description }) => {
-  return post<AppDetailResponse>(`apps/${appID}/copy`, { body: { name, icon_type, icon, icon_background, mode, description } })
+export const copyApp: Fetcher<AppDetailResponse, { appID: string; name: string; icon_type: AppIconType; icon: string; icon_background?: string | null; icon_url?: string | null; mode: AppMode; description?: string }> = ({ appID, name, icon_type, icon, icon_background, icon_url, mode, description }) => {
+  return post<AppDetailResponse>(`apps/${appID}/copy`, { body: { name, icon_type, icon, icon_background, icon_url, mode, description } })
 }
 
 export const exportAppConfig: Fetcher<{ data: string }, { appID: string; include?: boolean }> = ({ appID, include = false }) => {


### PR DESCRIPTION
# Summary

the PR fix lose custom image of app when duplicate app.

# Screenshots

| Before | After |
|--------|-------|
|  ![CleanShot 2025-05-15 at 20 11 53](https://github.com/user-attachments/assets/e66d7229-9a65-4c99-8552-aed58ade6362)  | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

