### PR TITLE
feat: clean chunk content after add

### DIFF
--- a/web/app/components/datasets/documents/detail/completed/new-child-segment.tsx
+++ b/web/app/components/datasets/documents/detail/completed/new-child-segment.tsx
@@ -91,6 +91,7 @@ const NewChildSegmentModal: FC<NewChildSegmentModalProps> = ({
           customComponent: isFullDocMode && CustomButton,
         })
         handleCancel('add')
+        setContent('')
         if (isFullDocMode) {
           refreshTimer.current = setTimeout(() => {
             onSave()

--- a/web/app/components/datasets/documents/detail/new-segment.tsx
+++ b/web/app/components/datasets/documents/detail/new-segment.tsx
@@ -118,6 +118,9 @@ const NewSegmentModal: FC<NewSegmentModalProps> = ({
           customComponent: CustomButton,
         })
         handleCancel('add')
+        setQuestion('')
+        setAnswer('')
+        setKeywords([])
         refreshTimer.current = setTimeout(() => {
           onSave()
         }, 3000)


### PR DESCRIPTION
# Summary
to clean content when add chunk with "Add another".  same content in "add chunk" is meaningless.

# Screenshots

| Before | After |
|--------|-------|
|  ![CleanShot 2025-05-15 at 21 24 02](https://github.com/user-attachments/assets/5049ae13-039b-4bf1-bd5b-e16b550b3a2c)  | ![CleanShot 2025-05-15 at 21 20 00](https://github.com/user-attachments/assets/62cf2791-1b1d-4c1b-9610-84aae7cf972b)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

