### PR TITLE
fix: fix overflow when bot description too long

### DIFF
--- a/web/app/components/app-sidebar/app-info.tsx
+++ b/web/app/components/app-sidebar/app-info.tsx
@@ -247,7 +247,7 @@ const AppInfo = ({ expand }: IAppInfoProps) => {
           </div>
           {/* description */}
           {appDetail.description && (
-            <div className='system-xs-regular text-text-tertiary'>{appDetail.description}</div>
+            <div className='system-xs-regular overflow-wrap-anywhere w-full max-w-full whitespace-normal break-words text-text-tertiary'>{appDetail.description}</div>
           )}
           {/* operations */}
           <div className='flex flex-wrap items-center gap-1 self-stretch'>


### PR DESCRIPTION
# Summary
fix text overflow when bot description too long

# Screenshots
| Before | After |
|--------|-------|
| ![CleanShot 2025-05-16 at 11 15 47](https://github.com/user-attachments/assets/8f4db648-b554-47c4-aebb-92d3ad00c9df)   | ![CleanShot 2025-05-16 at 11 17 02](https://github.com/user-attachments/assets/e37ae68c-8bf7-4edc-aef2-6c083565bcf0) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

