### PR TITLE
It is conflicted with new Dark theme.

### DIFF
--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react'
 import type { ChatItem } from '../types'
 import type { Theme } from '../embedded-chatbot/theme/theme-context'
-import { CssTransform } from '../embedded-chatbot/theme/utils'
 import ContentSwitch from './content-switch'
 import { User } from '@/app/components/base/icons/src/public/avatar'
 import { Markdown } from '@/app/components/base/markdown'
@@ -117,8 +116,7 @@ const Question: FC<QuestionProps> = ({
         </div>
         <div
           ref={contentRef}
-          className='w-full rounded-2xl bg-[#D1E9FF]/50 px-4 py-3 text-sm text-gray-900'
-          style={theme?.chatBubbleColorStyle ? CssTransform(theme.chatBubbleColorStyle) : {}}
+          className='w-full rounded-2xl bg-chat-bubble-bg px-4 py-3 text-sm text-gray-900'
         >
           {
             !!message_files?.length && (

--- a/web/app/components/base/chat/embedded-chatbot/theme/theme-context.ts
+++ b/web/app/components/base/chat/embedded-chatbot/theme/theme-context.ts
@@ -12,7 +12,6 @@ export class Theme {
   public colorPathOnHeader = 'text-text-primary-on-surface'
   public backgroundButtonDefaultColorStyle = 'backgroundColor: #1C64F2'
   public roundedBackgroundColorStyle = 'backgroundColor: rgb(245 248 255)'
-  public chatBubbleColorStyle = 'backgroundColor: rgb(225 239 254)'
   public chatBubbleColor = 'rgb(225 239 254)'
 
   constructor(chatColorTheme: string | null = null, chatColorThemeInverted = false) {
@@ -28,7 +27,6 @@ export class Theme {
       this.backgroundHeaderColorStyle = `backgroundColor: ${this.primaryColor}`
       this.backgroundButtonDefaultColorStyle = `backgroundColor: ${this.primaryColor}; color: ${this.colorFontOnHeaderStyle};`
       this.roundedBackgroundColorStyle = `backgroundColor: ${hexToRGBA(this.primaryColor, 0.05)}`
-      this.chatBubbleColorStyle = `backgroundColor: ${hexToRGBA(this.primaryColor, 0.15)}`
       this.chatBubbleColor = `${hexToRGBA(this.primaryColor, 0.15)}`
     }
   }


### PR DESCRIPTION
# Summary

Try to fix the background color problem in Dark theme.

Fix https://github.com/langgenius/dify/issues/19801


# Screenshots

## Before
<img width="491" alt="WeChatWorkScreenshot_f4446d7b-4c92-4041-868f-c0f8d49e0c98" src="https://github.com/user-attachments/assets/72f2d9ed-42b9-4b2e-a21f-6cdf2f131d64" />

## After
<img width="511" alt="WeChatWorkScreenshot_a2486c66-e68d-4a77-be01-295506e58a35" src="https://github.com/user-attachments/assets/614172b6-13b2-411f-a983-df09dbd5514d" />


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change not requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

