### PR TITLE
fix(devcontainer): uv sync fail

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/python:3.12
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install libgmp-dev libmpfr-dev libmpc-dev


### PR DESCRIPTION

# Summary
The `gmpy2` sync failed due to missing required libraries: libgmp-dev, libmpfr-dev, and libmpc-dev.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

Before
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/a1516d49-1bae-4fa6-8bae-badd96584d5e" />
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/62140d91-95d4-45d1-8ffd-b532ec906782" />
 
After 
<img width="662" alt="image" src="https://github.com/user-attachments/assets/de650abf-62f1-41ae-a19c-d7541dae7e7b" />

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

