### PR TITLE
docs: Add text_to_speech left out in the API response

### DIFF
--- a/web/app/components/develop/template/template_advanced_chat.en.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.en.mdx
@@ -1165,6 +1165,13 @@ Chat applications support session persistence, allowing previous chat history to
       - `enabled` (bool) Whether it is enabled
     - `speech_to_text` (object) Speech to text
       - `enabled` (bool) Whether it is enabled
+    - `text_to_speech` (object) Text to speech
+      - `enabled` (bool) Whether it is enabled
+      - `voice` (string) Voice type
+      - `language` (string) Language
+      - `autoPlay` (string) Auto play
+        - `enabled`   Enabled
+        - `disabled`  Disabled
     - `retriever_resource` (object) Citation and Attribution
       - `enabled` (bool) Whether it is enabled
     - `annotation_reply` (object) Annotation reply
@@ -1219,6 +1226,12 @@ Chat applications support session persistence, allowing previous chat history to
       },
       "speech_to_text": {
           "enabled": true
+      },
+      "text_to_speech": {
+          "enabled": true,
+          "voice": "sambert-zhinan-v1",
+          "language": "zh-Hans",
+          "autoPlay": "disabled"
       },
       "retriever_resource": {
           "enabled": true

--- a/web/app/components/develop/template/template_advanced_chat.ja.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.ja.mdx
@@ -1165,6 +1165,13 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       - `enabled` (bool) 有効かどうか
     - `speech_to_text` (object) 音声からテキストへ
       - `enabled` (bool) 有効かどうか
+    - `text_to_speech` (object) テキストから音声へ
+      - `enabled` (bool) 有効かどうか
+      - `voice` (string) 音声タイプ
+      - `language` (string) 言語
+      - `autoPlay` (string) 自動再生
+        - `enabled`  有効
+        - `disabled` 無効
     - `retriever_resource` (object) 引用と帰属
       - `enabled` (bool) 有効かどうか
     - `annotation_reply` (object) 注釈返信
@@ -1219,6 +1226,12 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       },
       "speech_to_text": {
           "enabled": true
+      },
+      "text_to_speech": {
+          "enabled": true,
+          "voice": "sambert-zhinan-v1",
+          "language": "zh-Hans",
+          "autoPlay": "disabled"
       },
       "retriever_resource": {
           "enabled": true

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -1199,6 +1199,13 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       - `enabled` (bool) 是否开启
     - `speech_to_text` (object) 语音转文本
       - `enabled` (bool) 是否开启
+    - `text_to_speech` (object) 文本转语音
+      - `enabled` (bool) 是否开启
+      - `voice` (string) 语音类型
+      - `language` (string) 语言
+      - `autoPlay` (string) 自动播放
+        - `enabled`  开启
+        - `disabled` 关闭
     - `retriever_resource` (object) 引用和归属
       - `enabled` (bool) 是否开启
     - `annotation_reply` (object) 标记回复

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -1201,6 +1201,13 @@ Chat applications support session persistence, allowing previous chat history to
       - `enabled` (bool) Whether it is enabled
     - `speech_to_text` (object) Speech to text
       - `enabled` (bool) Whether it is enabled
+    - `text_to_speech` (object) Text to speech
+      - `enabled` (bool) Whether it is enabled
+      - `voice` (string) Voice type
+      - `language` (string) Language
+      - `autoPlay` (string) Auto play
+        - `enabled`   Enabled
+        - `disabled`  Disabled
     - `retriever_resource` (object) Citation and Attribution
       - `enabled` (bool) Whether it is enabled
     - `annotation_reply` (object) Annotation reply
@@ -1255,6 +1262,12 @@ Chat applications support session persistence, allowing previous chat history to
       },
       "speech_to_text": {
           "enabled": true
+      },
+      "text_to_speech": {
+          "enabled": true,
+          "voice": "sambert-zhinan-v1",
+          "language": "zh-Hans",
+          "autoPlay": "disabled"
       },
       "retriever_resource": {
           "enabled": true

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -1192,6 +1192,13 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       - `enabled` (bool) 有効かどうか
     - `speech_to_text` (object) 音声からテキストへ
       - `enabled` (bool) 有効かどうか
+    - `text_to_speech` (object) テキストから音声へ
+      - `enabled` (bool) 有効かどうか
+      - `voice` (string) 音声タイプ
+      - `language` (string) 言語
+      - `autoPlay` (string) 自動再生
+        - `enabled`  有効
+        - `disabled` 無効
     - `retriever_resource` (object) 引用と帰属
       - `enabled` (bool) 有効かどうか
     - `annotation_reply` (object) 注釈返信
@@ -1246,6 +1253,12 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       },
       "speech_to_text": {
           "enabled": true
+      },
+      "text_to_speech": {
+          "enabled": true,
+          "voice": "sambert-zhinan-v1",
+          "language": "zh-Hans",
+          "autoPlay": "disabled"
       },
       "retriever_resource": {
           "enabled": true

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -1204,6 +1204,13 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       - `enabled` (bool) 是否开启
     - `speech_to_text` (object) 语音转文本
       - `enabled` (bool) 是否开启
+    - `text_to_speech` (object) 文本转语音
+      - `enabled` (bool) 是否开启
+      - `voice` (string) 语音类型
+      - `language` (string) 语言
+      - `autoPlay` (string) 自动播放
+        - `enabled`  开启
+        - `disabled` 关闭
     - `retriever_resource` (object) 引用和归属
       - `enabled` (bool) 是否开启
     - `annotation_reply` (object) 标记回复


### PR DESCRIPTION
# Summary

Fixes #19861 
Fixed missing text about text_to_speech in API documentation for /parameters interface


# Screenshots

| Before | After |
|--------|-------|
|<img width="1205" alt="image" src="https://github.com/user-attachments/assets/a5e05de8-a883-4186-a86b-44b705ee3e38" />|<img width="1224" alt="image" src="https://github.com/user-attachments/assets/7b7c77d9-f669-4002-b29f-fd24198c0ac3" />|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

