### PR TITLE
fix: generate deterministic operationId for root endpoints without one

### DIFF
--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -1,5 +1,4 @@
 import re
-import uuid
 from json import dumps as json_dumps
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
@@ -147,7 +146,7 @@ class ApiBasedToolSchemaParser:
                 # remove special characters like / to ensure the operation id is valid ^[a-zA-Z0-9_-]{1,64}$
                 path = re.sub(r"[^a-zA-Z0-9_-]", "", path)
                 if not path:
-                    path = str(uuid.uuid4())
+                    path = "<root>"
 
                 interface["operation"]["operationId"] = f"{path}_{interface['method']}"
 

--- a/api/tests/unit_tests/core/tools/utils/test_parser.py
+++ b/api/tests/unit_tests/core/tools/utils/test_parser.py
@@ -1,0 +1,56 @@
+import pytest
+from flask import Flask
+
+from core.tools.utils.parser import ApiBasedToolSchemaParser
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    return app
+
+
+def test_parse_openapi_to_tool_bundle_operation_id(app):
+    openapi = {
+        "openapi": "3.0.0",
+        "info": {"title": "Simple API", "version": "1.0.0"},
+        "servers": [{"url": "http://localhost:3000"}],
+        "paths": {
+            "/": {
+                "get": {
+                    "summary": "Root endpoint",
+                    "responses": {
+                        "200": {
+                            "description": "Successful response",
+                        }
+                    },
+                }
+            },
+            "/api/resources": {
+                "get": {
+                    "summary": "Non-root endpoint without an operationId",
+                    "responses": {
+                        "200": {
+                            "description": "Successful response",
+                        }
+                    },
+                },
+                "post": {
+                    "summary": "Non-root endpoint with an operationId",
+                    "operationId": "createResource",
+                    "responses": {
+                        "201": {
+                            "description": "Resource created",
+                        }
+                    },
+                },
+            },
+        },
+    }
+    with app.test_request_context():
+        tool_bundles = ApiBasedToolSchemaParser.parse_openapi_to_tool_bundle(openapi)
+
+    assert len(tool_bundles) == 3
+    assert tool_bundles[0].operation_id == "<root>_get"
+    assert tool_bundles[1].operation_id == "apiresources_get"
+    assert tool_bundles[2].operation_id == "createResource"


### PR DESCRIPTION
# Summary

- Fixes #19887 
- This PR ensures that a deterministic operation ID will be generated for root endpoints without one.
- If a user modifies the Swagger schema of an existing custom tool, names of some endpoints may change (e.g. `bbe8b55e-b7e0-4b62-9c76-9cea64cfbbba_get` -> `<root>_get`) and they will have to modify existing apps that use those endpoints. 

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ![invalid_tool_name](https://github.com/user-attachments/assets/ae9e0e44-36e7-45d0-802a-48fa19e6abd3) | ![after_fix](https://github.com/user-attachments/assets/e5415fdf-2da1-49f2-8101-5fddf3e8a43a) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

