### PR TITLE
docs: Optimize Response data array object indentation for the /messages interface

### DIFF
--- a/web/app/components/develop/template/template_advanced_chat.en.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.en.mdx
@@ -635,22 +635,22 @@ Chat applications support session persistence, allowing previous chat history to
 
     ### Response
     - `data` (array[object]) Message list
-    - `id` (string) Message ID
-    - `conversation_id` (string) Conversation ID
-    - `inputs` (object) User input parameters.
-    - `query` (string) User input / question content.
-    - `message_files` (array[object]) Message files
-      - `id` (string) ID
-      - `type` (string) File type, image for images
-      - `url` (string) Preview image URL
-      - `belongs_to` (string) belongs to，user orassistant
-    - `answer` (string) Response message content
-    - `created_at` (timestamp) Creation timestamp, e.g., 1705395332
-    - `feedback` (object) Feedback information
-      - `rating` (string) Upvote as `like` / Downvote as `dislike`
-    - `retriever_resources` (array[RetrieverResource]) Citation and Attribution List
-  - `has_more` (bool) Whether there is a next page
-  - `limit` (int) Number of returned items, if input exceeds system limit, returns system limit amount
+      - `id` (string) Message ID
+      - `conversation_id` (string) Conversation ID
+      - `inputs` (object) User input parameters.
+      - `query` (string) User input / question content.
+      - `message_files` (array[object]) Message files
+        - `id` (string) ID
+        - `type` (string) File type, image for images
+        - `url` (string) Preview image URL
+        - `belongs_to` (string) belongs to，user orassistant
+      - `answer` (string) Response message content
+      - `created_at` (timestamp) Creation timestamp, e.g., 1705395332
+      - `feedback` (object) Feedback information
+        - `rating` (string) Upvote as `like` / Downvote as `dislike`
+      - `retriever_resources` (array[RetrieverResource]) Citation and Attribution List
+    - `has_more` (bool) Whether there is a next page
+    - `limit` (int) Number of returned items, if input exceeds system limit, returns system limit amount
 
   </Col>
   <Col sticky>

--- a/web/app/components/develop/template/template_advanced_chat.ja.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.ja.mdx
@@ -636,22 +636,22 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
 
     ### 応答
     - `data` (array[object]) メッセージリスト
-    - `id` (string) メッセージID
-    - `conversation_id` (string) 会話ID
-    - `inputs` (object) ユーザー入力パラメータ。
-    - `query` (string) ユーザー入力/質問内容。
-    - `message_files` (array[object]) メッセージファイル
-      - `id` (string) ID
-      - `type` (string) ファイルタイプ、画像の場合はimage
-      - `url` (string) プレビュー画像URL
-      - `belongs_to` (string) 所属、userまたはassistant
-    - `answer` (string) 応答メッセージ内容
-    - `created_at` (timestamp) 作成タイムスタンプ、例：1705395332
-    - `feedback` (object) フィードバック情報
-      - `rating` (string) アップボートは`like` / ダウンボートは`dislike`
-    - `retriever_resources` (array[RetrieverResource]) 引用と帰属リスト
-  - `has_more` (bool) 次のページがあるかどうか
-  - `limit` (int) 返された項目数、入力がシステム制限を超える場合、システム制限数を返します
+      - `id` (string) メッセージID
+      - `conversation_id` (string) 会話ID
+      - `inputs` (object) ユーザー入力パラメータ。
+      - `query` (string) ユーザー入力/質問内容。
+      - `message_files` (array[object]) メッセージファイル
+        - `id` (string) ID
+        - `type` (string) ファイルタイプ、画像の場合はimage
+        - `url` (string) プレビュー画像URL
+        - `belongs_to` (string) 所属、userまたはassistant
+      - `answer` (string) 応答メッセージ内容
+      - `created_at` (timestamp) 作成タイムスタンプ、例：1705395332
+      - `feedback` (object) フィードバック情報
+        - `rating` (string) アップボートは`like` / ダウンボートは`dislike`
+      - `retriever_resources` (array[RetrieverResource]) 引用と帰属リスト
+    - `has_more` (bool) 次のページがあるかどうか
+    - `limit` (int) 返された項目数、入力がシステム制限を超える場合、システム制限数を返します
 
   </Col>
   <Col sticky>

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -643,22 +643,22 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
 
     ### Response
     - `data` (array[object])  消息列表
-    - `id`  (string) 消息 ID
-    - `conversation_id` (string)  会话 ID
-    - `inputs` (object) 用户输入参数。
-    - `query`  (string) 用户输入 / 提问内容。
-    - `message_files` (array[object]) 消息文件
-      - `id` (string) ID
-      - `type` (string) 文件类型，image 图片
-      - `url` (string) 预览图片地址
-      - `belongs_to` (string) 文件归属方，user 或 assistant
-    - `answer` (string)  回答消息内容
-    - `created_at`  (timestamp) 创建时间
-    - `feedback` (object) 反馈信息
-      - `rating` (string) 点赞 like / 点踩 dislike
-    - `retriever_resources` (array[RetrieverResource]) 引用和归属分段列表
-  - `has_more` (bool) 是否存在下一页
-  - `limit` (int) 返回条数，若传入超过系统限制，返回系统限制数量
+      - `id`  (string) 消息 ID
+      - `conversation_id` (string)  会话 ID
+      - `inputs` (object) 用户输入参数。
+      - `query`  (string) 用户输入 / 提问内容。
+      - `message_files` (array[object]) 消息文件
+        - `id` (string) ID
+        - `type` (string) 文件类型，image 图片
+        - `url` (string) 预览图片地址
+        - `belongs_to` (string) 文件归属方，user 或 assistant
+      - `answer` (string)  回答消息内容
+      - `created_at`  (timestamp) 创建时间
+      - `feedback` (object) 反馈信息
+        - `rating` (string) 点赞 like / 点踩 dislike
+      - `retriever_resources` (array[RetrieverResource]) 引用和归属分段列表
+    - `has_more` (bool) 是否存在下一页
+    - `limit` (int) 返回条数，若传入超过系统限制，返回系统限制数量
   </Col>
   <Col sticky>
     ### Request Example

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -598,33 +598,33 @@ Chat applications support session persistence, allowing previous chat history to
 
     ### Response
     - `data` (array[object]) Message list
-    - `id` (string) Message ID
-    - `conversation_id` (string) Conversation ID
-    - `inputs` (object) User input parameters.
-    - `query` (string) User input / question content.
-    - `message_files` (array[object]) Message files
-      - `id` (string) ID
-      - `type` (string) File type, image for images
-      - `url` (string) Preview image URL
-      - `belongs_to` (string) belongs to，user or assistant
-    - `agent_thoughts` (array[object]) Agent thought（Empty if it's a Basic Assistant）
-      - `id` (string) Agent thought ID, every iteration has a unique agent thought ID
-      - `message_id` (string) Unique message ID
-      - `position` (int) Position of current agent thought, each message may have multiple thoughts in order.
-      - `thought` (string) What LLM is thinking about
-      - `observation` (string) Response from tool calls
-      - `tool` (string) A list of tools represents which tools are called，split by ;
-      - `tool_input` (string) Input of tools in JSON format. Like: `{"dalle3": {"prompt": "a cute cat"}}`.
-      - `created_at` (int) Creation timestamp, e.g., 1705395332
-      - `message_files` (array[string])  Refer to message_file event
-        - `file_id` (string) File ID
-    - `answer` (string) Response message content
-    - `created_at` (timestamp) Creation timestamp, e.g., 1705395332
-    - `feedback` (object) Feedback information
-      - `rating` (string) Upvote as `like` / Downvote as `dislike`
-    - `retriever_resources` (array[RetrieverResource]) Citation and Attribution List
-  - `has_more` (bool) Whether there is a next page
-  - `limit` (int) Number of returned items, if input exceeds system limit, returns system limit amount
+      - `id` (string) Message ID
+      - `conversation_id` (string) Conversation ID
+      - `inputs` (object) User input parameters.
+      - `query` (string) User input / question content.
+      - `message_files` (array[object]) Message files
+        - `id` (string) ID
+        - `type` (string) File type, image for images
+        - `url` (string) Preview image URL
+        - `belongs_to` (string) belongs to，user or assistant
+      - `agent_thoughts` (array[object]) Agent thought（Empty if it's a Basic Assistant）
+        - `id` (string) Agent thought ID, every iteration has a unique agent thought ID
+        - `message_id` (string) Unique message ID
+        - `position` (int) Position of current agent thought, each message may have multiple thoughts in order.
+        - `thought` (string) What LLM is thinking about
+        - `observation` (string) Response from tool calls
+        - `tool` (string) A list of tools represents which tools are called，split by ;
+        - `tool_input` (string) Input of tools in JSON format. Like: `{"dalle3": {"prompt": "a cute cat"}}`.
+        - `created_at` (int) Creation timestamp, e.g., 1705395332
+        - `message_files` (array[string])  Refer to message_file event
+          - `file_id` (string) File ID
+      - `answer` (string) Response message content
+      - `created_at` (timestamp) Creation timestamp, e.g., 1705395332
+      - `feedback` (object) Feedback information
+        - `rating` (string) Upvote as `like` / Downvote as `dislike`
+      - `retriever_resources` (array[RetrieverResource]) Citation and Attribution List
+    - `has_more` (bool) Whether there is a next page
+    - `limit` (int) Number of returned items, if input exceeds system limit, returns system limit amount
 
   </Col>
   <Col sticky>

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -599,33 +599,33 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
 
     ### 応答
     - `data` (array[object]) メッセージリスト
-    - `id` (string) メッセージID
-    - `conversation_id` (string) 会話ID
-    - `inputs` (object) ユーザー入力パラメータ。
-    - `query` (string) ユーザー入力/質問内容。
-    - `message_files` (array[object]) メッセージファイル
-      - `id` (string) ID
-      - `type` (string) ファイルタイプ、画像の場合はimage
-      - `url` (string) プレビュー画像URL
-      - `belongs_to` (string) 所属、ユーザーまたはアシスタント
-    - `agent_thoughts` (array[object]) エージェントの思考（基本アシスタントの場合は空）
-      - `id` (string) エージェント思考ID、各反復には一意のエージェント思考IDがあります
-      - `message_id` (string) 一意のメッセージID
-      - `position` (int) 現在のエージェント思考の位置、各メッセージには順番に複数の思考が含まれる場合があります。
-      - `thought` (string) LLMが考えていること
-      - `observation` (string) ツール呼び出しからの応答
-      - `tool` (string) 呼び出されたツールのリスト、;で区切られます
-      - `tool_input` (string) ツールの入力、JSON形式。例：`{"dalle3": {"prompt": "a cute cat"}}`。
-      - `created_at` (int) 作成タイムスタンプ、例：1705395332
-      - `message_files` (array[string]) message_fileイベントを参照
-        - `file_id` (string) ファイルID
-    - `answer` (string) 応答メッセージ内容
-    - `created_at` (timestamp) 作成タイムスタンプ、例：1705395332
-    - `feedback` (object) フィードバック情報
-      - `rating` (string) アップボートは`like` / ダウンボートは`dislike`
-    - `retriever_resources` (array[RetrieverResource]) 引用と帰属リスト
-  - `has_more` (bool) 次のページがあるかどうか
-  - `limit` (int) 返されたアイテムの数、入力がシステム制限を超える場合、システム制限の数を返します
+      - `id` (string) メッセージID
+      - `conversation_id` (string) 会話ID
+      - `inputs` (object) ユーザー入力パラメータ。
+      - `query` (string) ユーザー入力/質問内容。
+      - `message_files` (array[object]) メッセージファイル
+        - `id` (string) ID
+        - `type` (string) ファイルタイプ、画像の場合はimage
+        - `url` (string) プレビュー画像URL
+        - `belongs_to` (string) 所属、ユーザーまたはアシスタント
+      - `agent_thoughts` (array[object]) エージェントの思考（基本アシスタントの場合は空）
+        - `id` (string) エージェント思考ID、各反復には一意のエージェント思考IDがあります
+        - `message_id` (string) 一意のメッセージID
+        - `position` (int) 現在のエージェント思考の位置、各メッセージには順番に複数の思考が含まれる場合があります。
+        - `thought` (string) LLMが考えていること
+        - `observation` (string) ツール呼び出しからの応答
+        - `tool` (string) 呼び出されたツールのリスト、;で区切られます
+        - `tool_input` (string) ツールの入力、JSON形式。例：`{"dalle3": {"prompt": "a cute cat"}}`。
+        - `created_at` (int) 作成タイムスタンプ、例：1705395332
+        - `message_files` (array[string]) message_fileイベントを参照
+          - `file_id` (string) ファイルID
+      - `answer` (string) 応答メッセージ内容
+      - `created_at` (timestamp) 作成タイムスタンプ、例：1705395332
+      - `feedback` (object) フィードバック情報
+        - `rating` (string) アップボートは`like` / ダウンボートは`dislike`
+      - `retriever_resources` (array[RetrieverResource]) 引用と帰属リスト
+    - `has_more` (bool) 次のページがあるかどうか
+    - `limit` (int) 返されたアイテムの数、入力がシステム制限を超える場合、システム制限の数を返します
 
   </Col>
   <Col sticky>

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -612,34 +612,34 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
 
     ### Response
     - `data` (array[object])  消息列表
-    - `id`  (string) 消息 ID
-    - `conversation_id` (string)  会话 ID
-    - `inputs` (object) 用户输入参数。
-    - `query`  (string) 用户输入 / 提问内容。
-    - `message_files` (array[object]) 消息文件
-      - `id` (string) ID
-      - `type` (string) 文件类型，image 图片
-      - `url` (string) 预览图片地址
-      - `belongs_to` (string) 文件归属方，user 或 assistant
-      - `agent_thoughts` (array[object]) Agent思考内容（仅Agent模式下不为空）
-        - `id` (string) agent_thought ID，每一轮Agent迭代都会有一个唯一的id
-        - `message_id` (string) 消息唯一ID
-        - `position` (int) agent_thought在消息中的位置，如第一轮迭代position为1
-        - `thought` (string) agent的思考内容
-        - `observation` (string) 工具调用的返回结果
-        - `tool` (string) 使用的工具列表，以 ; 分割多个工具
-        - `tool_input` (string) 工具的输入，JSON格式的字符串(object)。如：`{"dalle3": {"prompt": "a cute cat"}}`
-        - `created_at` (int) 创建时间戳，如：1705395332
-        - `message_files` (array[string])  当前agent_thought 关联的文件ID
-          - `file_id` (string) 文件ID
-        - `conversation_id` (string) 会话ID
-    - `answer` (string)  回答消息内容
-    - `created_at`  (timestamp) 创建时间
-    - `feedback` (object) 反馈信息
-      - `rating` (string) 点赞 like / 点踩 dislike
-    - `retriever_resources` (array[RetrieverResource]) 引用和归属分段列表
-  - `has_more` (bool) 是否存在下一页
-  - `limit` (int) 返回条数，若传入超过系统限制，返回系统限制数量
+      - `id`  (string) 消息 ID
+      - `conversation_id` (string)  会话 ID
+      - `inputs` (object) 用户输入参数。
+      - `query`  (string) 用户输入 / 提问内容。
+      - `message_files` (array[object]) 消息文件
+        - `id` (string) ID
+        - `type` (string) 文件类型，image 图片
+        - `url` (string) 预览图片地址
+        - `belongs_to` (string) 文件归属方，user 或 assistant
+        - `agent_thoughts` (array[object]) Agent思考内容（仅Agent模式下不为空）
+          - `id` (string) agent_thought ID，每一轮Agent迭代都会有一个唯一的id
+          - `message_id` (string) 消息唯一ID
+          - `position` (int) agent_thought在消息中的位置，如第一轮迭代position为1
+          - `thought` (string) agent的思考内容
+          - `observation` (string) 工具调用的返回结果
+          - `tool` (string) 使用的工具列表，以 ; 分割多个工具
+          - `tool_input` (string) 工具的输入，JSON格式的字符串(object)。如：`{"dalle3": {"prompt": "a cute cat"}}`
+          - `created_at` (int) 创建时间戳，如：1705395332
+          - `message_files` (array[string])  当前agent_thought 关联的文件ID
+            - `file_id` (string) 文件ID
+          - `conversation_id` (string) 会话ID
+      - `answer` (string)  回答消息内容
+      - `created_at`  (timestamp) 创建时间
+      - `feedback` (object) 反馈信息
+        - `rating` (string) 点赞 like / 点踩 dislike
+      - `retriever_resources` (array[RetrieverResource]) 引用和归属分段列表
+    - `has_more` (bool) 是否存在下一页
+    - `limit` (int) 返回条数，若传入超过系统限制，返回系统限制数量
   </Col>
   <Col sticky>
     ### Request Example


### PR DESCRIPTION
…es interface

# Summary

Fixes #19921
data array objects are indented

# Screenshots

| Before | After |
|--------|-------|
|<img width="1280" alt="image" src="https://github.com/user-attachments/assets/eb2f9cca-14d1-4076-99c9-3807477fd0f4" /> | <img width="1491" alt="image" src="https://github.com/user-attachments/assets/5e0aa949-64bc-4664-8fbc-f1d52ad045cd" />|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

