### PR TITLE
fix: ensure Decimal values in metadata are JSON serializable (fixes #19936)

### DIFF
--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -172,7 +172,9 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
         db_model.status = domain_model.status
         db_model.error = domain_model.error
         db_model.elapsed_time = domain_model.elapsed_time
-        db_model.execution_metadata = json.dumps(jsonable_encoder(domain_model.metadata)) if domain_model.metadata else None
+        db_model.execution_metadata = (
+            json.dumps(jsonable_encoder(domain_model.metadata)) if domain_model.metadata else None
+        )
         db_model.created_at = domain_model.created_at
         db_model.created_by_role = self._creator_user_role
         db_model.created_by = self._creator_user_id

--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -11,6 +11,7 @@ from sqlalchemy import UnaryExpression, asc, delete, desc, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
+from core.model_runtime.utils.encoders import jsonable_encoder
 from core.workflow.entities.node_entities import NodeRunMetadataKey
 from core.workflow.entities.node_execution_entities import (
     NodeExecution,
@@ -171,7 +172,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
         db_model.status = domain_model.status
         db_model.error = domain_model.error
         db_model.elapsed_time = domain_model.elapsed_time
-        db_model.execution_metadata = json.dumps(domain_model.metadata) if domain_model.metadata else None
+        db_model.execution_metadata = json.dumps(jsonable_encoder(domain_model.metadata)) if domain_model.metadata else None
         db_model.created_at = domain_model.created_at
         db_model.created_by_role = self._creator_user_role
         db_model.created_by = self._creator_user_id

--- a/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
+++ b/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
@@ -4,8 +4,8 @@ Unit tests for the SQLAlchemy implementation of WorkflowNodeExecutionRepository.
 
 import json
 from datetime import datetime
-from unittest.mock import MagicMock, PropertyMock
 from decimal import Decimal
+from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 from pytest_mock import MockerFixture

--- a/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
+++ b/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
@@ -300,8 +300,7 @@ def test_to_db_model(repository):
         status=NodeExecutionStatus.RUNNING,
         error=None,
         elapsed_time=1.5,
-        metadata={NodeRunMetadataKey.TOTAL_TOKENS: 100, 
-                  NodeRunMetadataKey.TOTAL_PRICE: Decimal("0.0")},
+        metadata={NodeRunMetadataKey.TOTAL_TOKENS: 100, NodeRunMetadataKey.TOTAL_PRICE: Decimal("0.0")},
         created_at=datetime.now(),
         finished_at=None,
     )

--- a/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
+++ b/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
@@ -5,11 +5,13 @@ Unit tests for the SQLAlchemy implementation of WorkflowNodeExecutionRepository.
 import json
 from datetime import datetime
 from unittest.mock import MagicMock, PropertyMock
+from decimal import Decimal
 
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session, sessionmaker
 
+from core.model_runtime.utils.encoders import jsonable_encoder
 from core.repositories import SQLAlchemyWorkflowNodeExecutionRepository
 from core.workflow.entities.node_entities import NodeRunMetadataKey
 from core.workflow.entities.node_execution_entities import NodeExecution, NodeExecutionStatus
@@ -298,7 +300,8 @@ def test_to_db_model(repository):
         status=NodeExecutionStatus.RUNNING,
         error=None,
         elapsed_time=1.5,
-        metadata={NodeRunMetadataKey.TOTAL_TOKENS: 100},
+        metadata={NodeRunMetadataKey.TOTAL_TOKENS: 100, 
+                  NodeRunMetadataKey.TOTAL_PRICE: Decimal("0.0")},
         created_at=datetime.now(),
         finished_at=None,
     )
@@ -324,7 +327,7 @@ def test_to_db_model(repository):
     assert db_model.inputs_dict == domain_model.inputs
     assert db_model.process_data_dict == domain_model.process_data
     assert db_model.outputs_dict == domain_model.outputs
-    assert db_model.execution_metadata_dict == domain_model.metadata
+    assert db_model.execution_metadata_dict == jsonable_encoder(domain_model.metadata)
 
     assert db_model.status == domain_model.status
     assert db_model.error == domain_model.error


### PR DESCRIPTION
# Summary

This PR fixes a bug where metadata containing `Decimal` values in `NodeRunResult.metadata` causes `TypeError: Object of type Decimal is not JSON serializable` during the saving process to the database.

* Workflow node metadata such as `total_price` may contain `Decimal` values from LLM billing logic.
* These values were directly passed to `json.dumps(...)` in `to_db_model` function, causing serialization failures.
* This fix ensures all metadata is passed through `jsonable_encoder(...)` to ensure full compatibility with `json`.

## Fixes

Fixes #19936 

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

