### PR TITLE
feat: Web <video> and <audio> element support src attribute

### DIFF
--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -216,16 +216,24 @@ CodeBlock.displayName = 'CodeBlock'
 
 const VideoBlock: any = memo(({ node }: any) => {
   const srcs = node.children.filter((child: any) => 'properties' in child).map((child: any) => (child as any).properties.src)
-  if (srcs.length === 0)
+  if (srcs.length === 0) {
+    const src = node.properties?.src
+    if (src)
+      return <VideoGallery key={src} srcs={[src]} />
     return null
+  }
   return <VideoGallery key={srcs.join()} srcs={srcs} />
 })
 VideoBlock.displayName = 'VideoBlock'
 
 const AudioBlock: any = memo(({ node }: any) => {
   const srcs = node.children.filter((child: any) => 'properties' in child).map((child: any) => (child as any).properties.src)
-  if (srcs.length === 0)
+  if (srcs.length === 0) {
+    const src = node.properties?.src
+    if (src)
+      return <AudioGallery key={src} srcs={[src]} />
     return null
+  }
   return <AudioGallery key={srcs.join()} srcs={srcs} />
 })
 AudioBlock.displayName = 'AudioBlock'


### PR DESCRIPTION
Web `<video>` and `<audio>` element support `src` attribute

# Summary

The current system supports the element but does not support the src attribute, which causes video display failure.

```html
<!-- Not supported-->
<video src="xxx" />

<!-- Supported -->
<video>
    <source src="xxx" type="video/mp4" />
</video>
```

# Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/112fcd88-e943-4d5e-811a-1d42adb0a44b)  | ![image](https://github.com/user-attachments/assets/238d99e8-6632-4fc0-b842-e0447d05ddd2)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

