### PR TITLE
fix create_tracing_app_config error (#19884)

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -234,7 +234,11 @@ class OpsTraceManager:
             return None
 
         tracing_provider = app_ops_trace_config.get("tracing_provider")
-        if tracing_provider is None or tracing_provider not in provider_config_map:
+        if tracing_provider is None:
+            return None
+        try:
+            provider_config_map[tracing_provider]
+        except KeyError:
             return None
 
         # decrypt_token


### PR DESCRIPTION
Summary

Fixes #19884 

This pull request addresses an issue where trace was not functioning as expected due to improper handling of the tracing_provider configuration in the app_ops_trace_config. Previously, when tracing_provider was either missing or not present in the provider_config_map, the function logic could continue inappropriately, leading to unintended behavior or runtime errors.

Key Changes:
	•	Added proper None checks and key existence validations for tracing_provider.
	•	Introduced defensive programming logic to return early if the provider is invalid or not configured.

This fix ensures that tracing will only proceed if a valid provider is explicitly configured and recognized.

Code Summary:

return None

tracing_provider = app_ops_trace_config.get("tracing_provider")
if tracing_provider is None:
    return None
try:
    provider_config_map[tracing_provider]
except KeyError:
    return None

# decrypt_token

Motivation:

Trace configuration should fail gracefully and silently when misconfigured, rather than causing errors or silently failing without indication.

Dependencies:

No new dependencies introduced.
