### PR TITLE
fix: emoji picker in dark mode

### DIFF
--- a/web/app/components/base/app-icon-picker/ImageInput.tsx
+++ b/web/app/components/base/app-icon-picker/ImageInput.tsx
@@ -94,7 +94,7 @@ const ImageInput: FC<UploaderProps> = ({
       <div
         className={classNames(
           isDragActive && 'border-primary-600',
-          'relative aspect-square bg-gray-50 border-[1.5px] border-gray-200 border-dashed rounded-lg flex flex-col justify-center items-center text-gray-500')}
+          'relative aspect-square border-[1.5px] border-dashed rounded-lg flex flex-col justify-center items-center text-gray-500')}
         onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/web/app/components/base/app-icon-picker/index.tsx
+++ b/web/app/components/base/app-icon-picker/index.tsx
@@ -115,7 +115,7 @@ const AppIconPicker: FC<AppIconPickerProps> = ({
     className={cn(s.container, '!w-[362px] !p-0')}
   >
     {!DISABLE_UPLOAD_IMAGE_AS_ICON && <div className="w-full p-2 pb-0">
-      <div className='flex items-center justify-center gap-2 rounded-xl bg-background-body p-1'>
+      <div className='flex items-center justify-center gap-2 rounded-xl bg-background-body p-1 text-text-primary'>
         {tabs.map(tab => (
           <button
             key={tab.key}

--- a/web/app/components/base/app-icon-picker/style.module.css
+++ b/web/app/components/base/app-icon-picker/style.module.css
@@ -4,9 +4,6 @@
     align-items: flex-start;
     width: 362px;
     max-height: 552px;
-
-    border: 0.5px solid #EAECF0;
     box-shadow: 0px 12px 16px -4px rgba(16, 24, 40, 0.08), 0px 4px 6px -2px rgba(16, 24, 40, 0.03);
     border-radius: 12px;
-    background: #fff;
 }


### PR DESCRIPTION
# Summary

# Screenshots

| Before | After |
|--------|-------|
| ...    | <img width="581" alt="image" src="https://github.com/user-attachments/assets/be7b49e3-f02f-4706-865f-cd0247847e35" /> |
| ...    | <img width="466" alt="image" src="https://github.com/user-attachments/assets/060234fb-ce63-4f92-82f0-eedeef9bb452" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

