### PR TITLE
Add APIs for Knowledge Base Tag Management and Dataset Binding

### DIFF
--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -339,8 +339,11 @@ class DatasetTagsApi(DatasetApiResource):
 
         parser = reqparse.RequestParser()
         parser.add_argument(
-            "name", nullable=False, required=True, help="Name must be between 1 to 50 characters.",
-            type=DatasetTagsApi._validate_tag_name
+            "name",
+            nullable=False,
+            required=True,
+            help="Name must be between 1 to 50 characters.",
+            type=DatasetTagsApi._validate_tag_name,
         )
 
         args = parser.parse_args()
@@ -358,12 +361,13 @@ class DatasetTagsApi(DatasetApiResource):
 
         parser = reqparse.RequestParser()
         parser.add_argument(
-            "name", nullable=False, required=True, help="Name must be between 1 to 50 characters.",
-            type=DatasetTagsApi._validate_tag_name
+            "name",
+            nullable=False,
+            required=True,
+            help="Name must be between 1 to 50 characters.",
+            type=DatasetTagsApi._validate_tag_name,
         )
-        parser.add_argument(
-            "tag_id", nullable=False, required=True, help="Id of a tag.", type=str
-        )
+        parser.add_argument("tag_id", nullable=False, required=True, help="Id of a tag.", type=str)
         args = parser.parse_args()
         tag = TagService.update_tags(args, args.get("tag_id"))
 
@@ -379,9 +383,7 @@ class DatasetTagsApi(DatasetApiResource):
         if not current_user.is_editor:
             raise Forbidden()
         parser = reqparse.RequestParser()
-        parser.add_argument(
-            "tag_id", nullable=False, required=True, help="Id of a tag.", type=str
-        )
+        parser.add_argument("tag_id", nullable=False, required=True, help="Id of a tag.", type=str)
         args = parser.parse_args()
         TagService.delete_tag(args.get("tag_id"))
 
@@ -395,7 +397,6 @@ class DatasetTagsApi(DatasetApiResource):
 
 
 class DatasetTagBindingApi(DatasetApiResource):
-
     @validate_dataset_token
     def post(self, _, dataset_id):
         # The role of the current user in the ta table must be admin, owner, editor, or dataset_operator
@@ -407,8 +408,7 @@ class DatasetTagBindingApi(DatasetApiResource):
             "tag_ids", type=list, nullable=False, required=True, location="json", help="Tag IDs is required."
         )
         parser.add_argument(
-            "target_id", type=str, nullable=False, required=True, location="json",
-            help="Target Dataset ID is required."
+            "target_id", type=str, nullable=False, required=True, location="json", help="Target Dataset ID is required."
         )
 
         args = parser.parse_args()
@@ -419,7 +419,6 @@ class DatasetTagBindingApi(DatasetApiResource):
 
 
 class DatasetTagUnbindingApi(DatasetApiResource):
-
     @validate_dataset_token
     def post(self, _, dataset_id):
         # The role of the current user in the ta table must be admin, owner, editor, or dataset_operator
@@ -438,7 +437,6 @@ class DatasetTagUnbindingApi(DatasetApiResource):
 
 
 class DatasetTagsBindingStatusApi(DatasetApiResource):
-
     @validate_dataset_token
     def get(self, _, *args, **kwargs):
         """Get all knowledge type tags."""
@@ -447,6 +445,7 @@ class DatasetTagsBindingStatusApi(DatasetApiResource):
         tags_list = [{"id": tag.id, "name": tag.name} for tag in tags]
         response = {"data": tags_list, "total": len(tags)}
         return response, 200
+
 
 api.add_resource(DatasetListApi, "/datasets")
 api.add_resource(DatasetApi, "/datasets/<uuid:dataset_id>")

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -1,19 +1,21 @@
 from flask import request
-from flask_restful import marshal, reqparse
+from flask_restful import marshal, marshal_with, reqparse
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services.dataset_service
 from controllers.service_api import api
 from controllers.service_api.dataset.error import DatasetInUseError, DatasetNameDuplicateError
-from controllers.service_api.wraps import DatasetApiResource
+from controllers.service_api.wraps import DatasetApiResource, validate_dataset_token
 from core.model_runtime.entities.model_entities import ModelType
 from core.plugin.entities.plugin import ModelProviderID
 from core.provider_manager import ProviderManager
 from fields.dataset_fields import dataset_detail_fields
+from fields.tag_fields import tag_fields
 from libs.login import current_user
 from models.dataset import Dataset, DatasetPermissionEnum
 from services.dataset_service import DatasetPermissionService, DatasetService
 from services.entities.knowledge_entities.knowledge_entities import RetrievalModel
+from services.tag_service import TagService
 
 
 def _validate_name(name):
@@ -320,5 +322,133 @@ class DatasetApi(DatasetApiResource):
             raise DatasetInUseError()
 
 
+class DatasetTagsApi(DatasetApiResource):
+    @validate_dataset_token
+    @marshal_with(tag_fields)
+    def get(self, _, dataset_id):
+        """Get all knowledge type tags."""
+        tags = TagService.get_tags("knowledge", current_user.current_tenant_id)
+
+        return tags, 200
+
+    @validate_dataset_token
+    def post(self, _, dataset_id):
+        """Add a knowledge type tag."""
+        if not (current_user.is_editor or current_user.is_dataset_editor):
+            raise Forbidden()
+
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "name", nullable=False, required=True, help="Name must be between 1 to 50 characters.",
+            type=_validate_name
+        )
+
+        args = parser.parse_args()
+        args["type"] = "knowledge"
+        tag = TagService.save_tags(args)
+
+        response = {"id": tag.id, "name": tag.name, "type": tag.type, "binding_count": 0}
+
+        return response, 200
+
+    @validate_dataset_token
+    def patch(self, _, dataset_id):
+        if not (current_user.is_editor or current_user.is_dataset_editor):
+            raise Forbidden()
+        def _validate_tag_name(name):
+            if not name or len(name) < 1 or len(name) > 50:
+                raise ValueError("Name must be between 1 to 50 characters.")
+            return name
+
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "name", nullable=False, required=True, help="Name must be between 1 to 50 characters.",
+            type=_validate_tag_name
+        )
+        parser.add_argument(
+            "tag_id", nullable=False, required=True, help="Id of a tag.", type=str
+        )
+        args = parser.parse_args()
+        tag = TagService.update_tags(args, args.get("tag_id"))
+
+        binding_count = TagService.get_tag_binding_count(args.get("tag_id"))
+
+        response = {"id": tag.id, "name": tag.name, "type": tag.type, "binding_count": binding_count}
+
+        return response, 200
+
+    @validate_dataset_token
+    def delete(self, _, dataset_id):
+        """Delete a knowledge type tag."""
+        if not current_user.is_editor:
+            raise Forbidden()
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "tag_id", nullable=False, required=True, help="Id of a tag.", type=str
+        )
+        args = parser.parse_args()
+        TagService.delete_tag(args.get("tag_id"))
+
+        return {"result": "success"}, 200
+
+
+class DatasetTagBindingApi(DatasetApiResource):
+
+    @validate_dataset_token
+    def post(self, _, dataset_id):
+        # The role of the current user in the ta table must be admin, owner, editor, or dataset_operator
+        if not (current_user.is_editor or current_user.is_dataset_editor):
+            raise Forbidden()
+
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "tag_ids", type=list, nullable=False, required=True, location="json", help="Tag IDs is required."
+        )
+        parser.add_argument(
+            "target_id", type=str, nullable=False, required=True, location="json",
+            help="Target Dataset ID is required."
+        )
+
+        args = parser.parse_args()
+        args["type"] = "knowledge"
+        TagService.save_tag_binding(args)
+
+        return {"result": "success"}, 200
+
+
+class DatasetTagUnbindingApi(DatasetApiResource):
+
+    @validate_dataset_token
+    def post(self, _, dataset_id):
+        # The role of the current user in the ta table must be admin, owner, editor, or dataset_operator
+        if not (current_user.is_editor or current_user.is_dataset_editor):
+            raise Forbidden()
+
+        parser = reqparse.RequestParser()
+        parser.add_argument("tag_id", type=str, nullable=False, required=True, help="Tag ID is required.")
+        parser.add_argument("target_id", type=str, nullable=False, required=True, help="Target ID is required.")
+
+        args = parser.parse_args()
+        args["type"] = "knowledge"
+        TagService.delete_tag_binding(args)
+
+        return {"result": "success"}, 200
+
+
+class DatasetTagsBindingStatusApi(DatasetApiResource):
+
+    @validate_dataset_token
+    def get(self, _, *args, **kwargs):
+        """Get all knowledge type tags."""
+        dataset_id = kwargs.get("dataset_id")
+        tags = TagService.get_tags_by_target_id("knowledge", current_user.current_tenant_id, str(dataset_id))
+        tags_list = [{"id": tag.id, "name": tag.name} for tag in tags]
+        response = {"data": tags_list, "total": len(tags)}
+        return response, 200
+
 api.add_resource(DatasetListApi, "/datasets")
 api.add_resource(DatasetApi, "/datasets/<uuid:dataset_id>")
+api.add_resource(DatasetTagsApi, "/datasets/tags")
+api.add_resource(DatasetTagBindingApi, "/datasets/tags/binding")
+api.add_resource(DatasetTagUnbindingApi, "/datasets/tags/unbinding")
+api.add_resource(DatasetTagsBindingStatusApi, "/datasets/<uuid:dataset_id>/tags")

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -387,7 +387,7 @@ class DatasetTagsApi(DatasetApiResource):
         args = parser.parse_args()
         TagService.delete_tag(args.get("tag_id"))
 
-        return {"result": "success"}, 200
+        return 204
 
     @staticmethod
     def _validate_tag_name(name):
@@ -415,7 +415,7 @@ class DatasetTagBindingApi(DatasetApiResource):
         args["type"] = "knowledge"
         TagService.save_tag_binding(args)
 
-        return {"result": "success"}, 200
+        return 204
 
 
 class DatasetTagUnbindingApi(DatasetApiResource):
@@ -433,7 +433,7 @@ class DatasetTagUnbindingApi(DatasetApiResource):
         args["type"] = "knowledge"
         TagService.delete_tag_binding(args)
 
-        return {"result": "success"}, 200
+        return 204
 
 
 class DatasetTagsBindingStatusApi(DatasetApiResource):

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -340,7 +340,7 @@ class DatasetTagsApi(DatasetApiResource):
         parser = reqparse.RequestParser()
         parser.add_argument(
             "name", nullable=False, required=True, help="Name must be between 1 to 50 characters.",
-            type=_validate_name
+            type=DatasetTagsApi._validate_tag_name
         )
 
         args = parser.parse_args()
@@ -355,15 +355,11 @@ class DatasetTagsApi(DatasetApiResource):
     def patch(self, _, dataset_id):
         if not (current_user.is_editor or current_user.is_dataset_editor):
             raise Forbidden()
-        def _validate_tag_name(name):
-            if not name or len(name) < 1 or len(name) > 50:
-                raise ValueError("Name must be between 1 to 50 characters.")
-            return name
 
         parser = reqparse.RequestParser()
         parser.add_argument(
             "name", nullable=False, required=True, help="Name must be between 1 to 50 characters.",
-            type=_validate_tag_name
+            type=DatasetTagsApi._validate_tag_name
         )
         parser.add_argument(
             "tag_id", nullable=False, required=True, help="Id of a tag.", type=str
@@ -390,6 +386,12 @@ class DatasetTagsApi(DatasetApiResource):
         TagService.delete_tag(args.get("tag_id"))
 
         return {"result": "success"}, 200
+
+    @staticmethod
+    def _validate_tag_name(name):
+        if not name or len(name) < 1 or len(name) > 50:
+            raise ValueError("Name must be between 1 to 50 characters.")
+        return name
 
 
 class DatasetTagBindingApi(DatasetApiResource):

--- a/api/services/tag_service.py
+++ b/api/services/tag_service.py
@@ -45,7 +45,7 @@ class TagService:
         return results
 
     @staticmethod
-    def get_tag_by_tag_name(tag_type: str, current_tenant_id: str, tag_name: list) -> list:
+    def get_tag_by_tag_name(tag_type: str, current_tenant_id: str, tag_name: str) -> list:
         tags = (
             db.session.query(Tag)
             .filter(Tag.name == tag_name, Tag.tenant_id == current_tenant_id, Tag.type == tag_type)

--- a/api/services/tag_service.py
+++ b/api/services/tag_service.py
@@ -45,6 +45,17 @@ class TagService:
         return results
 
     @staticmethod
+    def get_tag_by_tag_name(tag_type: str, current_tenant_id: str, tag_name: list) -> list:
+        tags = (
+            db.session.query(Tag)
+            .filter(Tag.name == tag_name, Tag.tenant_id == current_tenant_id, Tag.type == tag_type)
+            .all()
+        )
+        if not tags:
+            return []
+        return tags
+
+    @staticmethod
     def get_tags_by_target_id(tag_type: str, current_tenant_id: str, target_id: str) -> list:
         tags = (
             db.session.query(Tag)
@@ -62,6 +73,8 @@ class TagService:
 
     @staticmethod
     def save_tags(args: dict) -> Tag:
+        if TagService.get_tag_by_tag_name(args["type"], current_user.current_tenant_id, args["name"]):
+            raise ValueError("Tag name already exists")
         tag = Tag(
             id=str(uuid.uuid4()),
             name=args["name"],
@@ -75,6 +88,8 @@ class TagService:
 
     @staticmethod
     def update_tags(args: dict, tag_id: str) -> Tag:
+        if TagService.get_tag_by_tag_name(args["type"], current_user.current_tenant_id, args["name"]):
+            raise ValueError("Tag name already exists")
         tag = db.session.query(Tag).filter(Tag.id == tag_id).first()
         if not tag:
             raise NotFound("Tag not found")

--- a/web/app/(commonLayout)/datasets/template/template.en.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.en.mdx
@@ -2246,6 +2246,316 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
 </Row>
 
 <hr className='ml-0 mr-0' />
+Okay, I will translate the Chinese text in your document while keeping all formatting and code content unchanged.
+
+<Heading
+  url='/datasets/tags'
+  method='POST'
+  title='Create New Knowledge Base Type Tag'
+  name='#create_new_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='name' type='string'>
+        (text) New tag name, required, maximum length 50
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"name": "testtag1"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "testtag1"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "id": "eddb66c2-04a1-4e3a-8cb2-75abd01e12a6", 
+        "name": "testtag1", 
+        "type": "knowledge", 
+        "binding_count": 0
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags'
+  method='GET'
+  title='Get Knowledge Base Type Tags'
+  name='#get_knowledge_type_tags'
+/>
+<Row>
+  <Col>
+    ### Request Body
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="GET"
+      label="/datasets/tags"
+      targetCode={`curl --location --request GET '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request GET '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' 
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    [
+        {
+            "id": "39d6934c-ed36-463d-b4a7-377fa1503dc0", 
+            "name": "testtag1", 
+            "type": "knowledge", 
+            "binding_count": "0"
+        }, 
+        ...
+    ]
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags'
+  method='PATCH'
+  title='Modify Knowledge Base Type Tag Name'
+  name='#modify_knowledge_tag_name'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='name' type='string'>
+        (text) Modified tag name, required, maximum length 50
+      </Property>
+      <Property name='tag_id' type='string'>
+        (text) Tag ID, required
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="PATCH"
+      label="/datasets/tags"
+      targetCode={`curl --location --request PATCH '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"name": "testtag2", "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request PATCH '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "testtag2", "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "id": "eddb66c2-04a1-4e3a-8cb2-75abd01e12a6", 
+        "name": "tag-renamed", 
+        "type": "knowledge", 
+        "binding_count": 0
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+
+<Heading
+  url='/datasets/tags'
+  method='DELETE'
+  title='Delete Knowledge Base Type Tag'
+  name='#delete_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_id' type='string'>
+        (text) Tag ID, required
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="DELETE"
+      label="/datasets/tags"
+      targetCode={`curl --location --request DELETE '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{ "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request DELETE '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+ 
+    {"result": "success"}
+    
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags/binding'
+  method='POST'
+  title='Bind Dataset to Knowledge Base Type Tag'
+  name='#bind_dataset_to_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_ids' type='list'>
+        (list) List of Tag IDs, required
+      </Property>
+      <Property name='target_id' type='string'>
+        (text) Dataset ID, required
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags/binding"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags/binding' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"tag_ids": ["65cc29be-d072-4e26-adf4-2f727644da29","1e5348f3-d3ff-42b8-a1b7-0a86d518001a"], "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags/binding' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_ids": ["65cc29be-d072-4e26-adf4-2f727644da29","1e5348f3-d3ff-42b8-a1b7-0a86d518001a"], "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {"result": "success"}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags/unbinding'
+  method='POST'
+  title='Unbind Dataset and Knowledge Base Type Tag'
+  name='#unbind_dataset_and_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_id' type='string'>
+        (text) Tag ID, required
+      </Property>
+      <Property name='target_id' type='string'>
+        (text) Dataset ID, required
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags/unbinding"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags/unbinding' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"tag_id": "1e5348f3-d3ff-42b8-a1b7-0a86d518001a", "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags/unbinding' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_id": "1e5348f3-d3ff-42b8-a1b7-0a86d518001a", "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {"result": "success"}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/<uuid:dataset_id>/tags'
+  method='POST'
+  title='Query Tags Bound to a Dataset'
+  name='#query_dataset_tags'
+/>
+<Row>
+  <Col>
+    ### Path
+    <Properties>
+      <Property name='dataset_id' type='string'>
+        (text) Dataset ID
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/<uuid:dataset_id>/tags"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/<uuid:dataset_id>/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/<uuid:dataset_id>/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "data": 
+        [
+          {"id": "4a601f4f-f8a2-4166-ae7c-58c3b252a524", 
+          "name": "123"
+          }, 
+          ...
+        ], 
+      "total": 3
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
 
 <Row>
   <Col>

--- a/web/app/(commonLayout)/datasets/template/template.ja.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.ja.mdx
@@ -1899,6 +1899,313 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
 </Row>
 
 <hr className='ml-0 mr-0' />
+<Heading
+  url='/datasets/tags'
+  method='POST'
+  title='ナレッジベースタイプタグの新規作成'
+  name='#create_new_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='name' type='string'>
+        (text) 新しいタグ名、必須、最大長50文字
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"name": "testtag1"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "testtag1"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "id": "eddb66c2-04a1-4e3a-8cb2-75abd01e12a6", 
+        "name": "testtag1", 
+        "type": "knowledge", 
+        "binding_count": 0
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags'
+  method='GET'
+  title='ナレッジベースタイプタグの取得'
+  name='#get_knowledge_type_tags'
+/>
+<Row>
+  <Col>
+    ### Request Body
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="GET"
+      label="/datasets/tags"
+      targetCode={`curl --location --request GET '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request GET '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' 
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    [
+        {
+            "id": "39d6934c-ed36-463d-b4a7-377fa1503dc0", 
+            "name": "testtag1", 
+            "type": "knowledge", 
+            "binding_count": "0"
+        }, 
+        ...
+    ]
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags'
+  method='PATCH'
+  title='ナレッジベースタイプタグ名の変更'
+  name='#modify_knowledge_tag_name'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='name' type='string'>
+        (text) 変更後のタグ名、必須、最大長50文字
+      </Property>
+      <Property name='tag_id' type='string'>
+        (text) タグID、必須
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="PATCH"
+      label="/datasets/tags"
+      targetCode={`curl --location --request PATCH '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"name": "testtag2", "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request PATCH '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "testtag2", "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "id": "eddb66c2-04a1-4e3a-8cb2-75abd01e12a6", 
+        "name": "tag-renamed", 
+        "type": "knowledge", 
+        "binding_count": 0
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+
+<Heading
+  url='/datasets/tags'
+  method='DELETE'
+  title='ナレッジベースタイプタグの削除'
+  name='#delete_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_id' type='string'>
+        (text) タグID、必須
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="DELETE"
+      label="/datasets/tags"
+      targetCode={`curl --location --request DELETE '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{ "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request DELETE '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+ 
+    {"result": "success"}
+    
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags/binding'
+  method='POST'
+  title='ナレッジベースをナレッジベースタイプタグに紐付け'
+  name='#bind_dataset_to_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_ids' type='list'>
+        (list) タグIDリスト、必須
+      </Property>
+      <Property name='target_id' type='string'>
+        (text) ナレッジベースID、必須
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags/binding"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags/binding' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"tag_ids": ["65cc29be-d072-4e26-adf4-2f727644da29","1e5348f3-d3ff-42b8-a1b7-0a86d518001a"], "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags/binding' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_ids": ["65cc29be-d072-4e26-adf4-2f727644da29","1e5348f3-d3ff-42b8-a1b7-0a86d518001a"], "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {"result": "success"}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags/unbinding'
+  method='POST'
+  title='ナレッジベースとナレッジベースタイプタグの紐付け解除'
+  name='#unbind_dataset_and_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_id' type='string'>
+        (text) タグID、必須
+      </Property>
+      <Property name='target_id' type='string'>
+        (text) ナレッジベースID、必須
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags/unbinding"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags/unbinding' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"tag_id": "1e5348f3-d3ff-42b8-a1b7-0a86d518001a", "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags/unbinding' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_id": "1e5348f3-d3ff-42b8-a1b7-0a86d518001a", "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {"result": "success"}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/<uuid:dataset_id>/tags'
+  method='POST'
+  title='ナレッジベースに紐付けられたタグの照会'
+  name='#query_dataset_tags'
+/>
+<Row>
+  <Col>
+    ### Path
+    <Properties>
+      <Property name='dataset_id' type='string'>
+        (text) ナレッジベースID
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/<uuid:dataset_id>/tags"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/<uuid:dataset_id>/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/<uuid:dataset_id>/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "data": 
+        [
+          {"id": "4a601f4f-f8a2-4166-ae7c-58c3b252a524", 
+          "name": "123"
+          }, 
+          ...
+        ], 
+      "total": 3
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
 
 <Row>
   <Col>

--- a/web/app/(commonLayout)/datasets/template/template.zh.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.zh.mdx
@@ -2289,6 +2289,314 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
 
 <hr className='ml-0 mr-0' />
 
+<Heading
+  url='/datasets/tags'
+  method='POST'
+  title='新增知识库类型标签'
+  name='#create_new_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='name' type='string'>
+        (text) 新标签名称，必填，最大长度为50
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"name": "testtag1"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "testtag1"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "id": "eddb66c2-04a1-4e3a-8cb2-75abd01e12a6", 
+        "name": "testtag1", 
+        "type": "knowledge", 
+        "binding_count": 0
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags'
+  method='GET'
+  title='获取知识库类型标签'
+  name='#get_knowledge_type_tags'
+/>
+<Row>
+  <Col>
+    ### Request Body
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="GET"
+      label="/datasets/tags"
+      targetCode={`curl --location --request GET '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request GET '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' 
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    [
+        {
+            "id": "39d6934c-ed36-463d-b4a7-377fa1503dc0", 
+            "name": "testtag1", 
+            "type": "knowledge", 
+            "binding_count": "0"
+        }, 
+        ...
+    ]
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags'
+  method='PATCH'
+  title='修改知识库类型标签名称'
+  name='#modify_knowledge_tag_name'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='name' type='string'>
+        (text) 修改后的标签名称，必填，最大长度为50
+      </Property>
+      <Property name='tag_id' type='string'>
+        (text) 标签ID，必填
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="PATCH"
+      label="/datasets/tags"
+      targetCode={`curl --location --request PATCH '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"name": "testtag2", "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request PATCH '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "testtag2", "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "id": "eddb66c2-04a1-4e3a-8cb2-75abd01e12a6", 
+        "name": "tag-renamed", 
+        "type": "knowledge", 
+        "binding_count": 0
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+
+<Heading
+  url='/datasets/tags'
+  method='DELETE'
+  title='删除知识库类型标签'
+  name='#delete_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_id' type='string'>
+        (text) 标签ID，必填
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="DELETE"
+      label="/datasets/tags"
+      targetCode={`curl --location --request DELETE '${props.apiBaseUrl}/datasets/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{ "tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request DELETE '${props.apiBaseUrl}/datasets/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_id": "e1a0a3db-ee34-4e04-842a-81555d5316fd"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+ 
+    {"result": "success"}
+    
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags/binding'
+  method='POST'
+  title='绑定知识库到知识库类型标签'
+  name='#bind_dataset_to_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_ids' type='list'>
+        (list) 标签ID列表，必填
+      </Property>
+      <Property name='target_id' type='string'>
+        (text) 知识库ID，必填
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags/binding"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags/binding' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"tag_ids": ["65cc29be-d072-4e26-adf4-2f727644da29","1e5348f3-d3ff-42b8-a1b7-0a86d518001a"], "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags/binding' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_ids": ["65cc29be-d072-4e26-adf4-2f727644da29","1e5348f3-d3ff-42b8-a1b7-0a86d518001a"], "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {"result": "success"}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/tags/unbinding'
+  method='POST'
+  title='解绑知识库和知识库类型标签'
+  name='#unbind_dataset_and_knowledge_tag'
+/>
+<Row>
+  <Col>
+    ### Request Body
+    <Properties>
+      <Property name='tag_id' type='string'>
+        (text) 标签ID，必填
+      </Property>
+      <Property name='target_id' type='string'>
+        (text) 知识库ID，必填
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/tags/unbinding"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/tags/unbinding' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"tag_id": "1e5348f3-d3ff-42b8-a1b7-0a86d518001a", "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/tags/unbinding' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"tag_id": "1e5348f3-d3ff-42b8-a1b7-0a86d518001a", "target_id": "a932ea9f-fae1-4b2c-9b65-71c56e2cacd6"}'
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {"result": "success"}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
+<Heading
+  url='/datasets/<uuid:dataset_id>/tags'
+  method='POST'
+  title='查询知识库已绑定的标签'
+  name='#query_dataset_tags'
+/>
+<Row>
+  <Col>
+    ### Path
+    <Properties>
+      <Property name='dataset_id' type='string'>
+        (text) 知识库ID
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/datasets/<uuid:dataset_id>/tags"
+      targetCode={`curl --location --request POST '${props.apiBaseUrl}/datasets/<uuid:dataset_id>/tags' \\\n--header 'Authorization: Bearer {api_key}' \\\n--header 'Content-Type: application/json' \\\n`}
+    >
+    ```bash {{ title: 'cURL' }}
+    curl --location --request POST '${props.apiBaseUrl}/datasets/<uuid:dataset_id>/tags' \
+    --header 'Authorization: Bearer {api_key}' \
+    --header 'Content-Type: application/json' \
+    ```
+    </CodeGroup>
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+      "data": 
+        [
+          {"id": "4a601f4f-f8a2-4166-ae7c-58c3b252a524", 
+          "name": "123"
+          }, 
+          ...
+        ], 
+      "total": 3
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+<hr className='ml-0 mr-0' />
+
 <Row>
   <Col>
     ### 错误信息


### PR DESCRIPTION

**Key Changes:**

This pull request introduces a comprehensive set of API endpoints for managing "Knowledge Base Type Tags" and their association with datasets (knowledge bases). This functionality allows users to organize, categorize, and retrieve their knowledge bases more effectively.

**New API Endpoints:**

1.  **Tag Management:**
    *   `POST /datasets/tags`: **Create New Knowledge Base Type Tag**
        *   Allows for the creation of a new tag.
        *   Request body requires `name` (the new tag name).
    *   `GET /datasets/tags`: **Get Knowledge Base Type Tags**
        *   Retrieves a list of all defined knowledge base type tags.
    *   `PATCH /datasets/tags`: **Modify Knowledge Base Type Tag Name**
        *   Updates the name of an existing tag.
        *   Request body requires `tag_id` (ID of the tag to modify) and `name` (the new tag name).
    *   `DELETE /datasets/tags`: **Delete Knowledge Base Type Tag**
        *   Removes an existing tag.
        *   Request body requires `tag_id` (ID of the tag to delete).

2.  **Tag-Dataset Binding:**
    *   `POST /datasets/tags/binding`: **Bind Dataset to Knowledge Base Type Tag**
        *   Associates one or more tags with a specific dataset.
        *   Request body requires `tag_ids` (list of tag IDs) and `target_id` (dataset ID).
    *   `POST /datasets/tags/unbinding`: **Unbind Dataset and Knowledge Base Type Tag**
        *   Removes the association between a specific dataset and a specific tag.
        *   Request body requires `tag_id` (tag ID) and `target_id` (dataset ID).
    *   `POST /datasets/<uuid:dataset_id>/tags`: **Query Tags Bound to a Dataset**
        *   Retrieves a list of all tags currently bound to the specified dataset.
        *   Path parameter includes `dataset_id` (dataset ID).



fix: #19674 

# Screenshots
![image](https://github.com/user-attachments/assets/0d333702-41e1-4859-8d99-7a060350469f)
![image](https://github.com/user-attachments/assets/ab8ef1d5-1387-4789-aa7c-358e6a4c64e2)
![image](https://github.com/user-attachments/assets/aa9c391a-2395-4b68-b905-1505a077057b)

docs:
![image](https://github.com/user-attachments/assets/b60d6241-3e12-49f9-9c98-d42ec7fa960e)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

