### PR TITLE
fix: uninitialized variable error on empty knowledge retrieval(agent)

### DIFF
--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -182,7 +182,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                                     score=record.score,
                                 )
                             )
-                    
+
                     if self.return_resource:
                         for record in records:
                             segment = record.segment

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -125,6 +125,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                 return ""
             # get retrieval model , if the model is not setting , using default
             retrieval_model: dict[str, Any] = dataset.retrieval_model or default_retrieval_model
+            retrieval_resource_list = []
             if dataset.indexing_technique == "economy":
                 # use keyword table query
                 documents = RetrievalService.retrieve(
@@ -181,7 +182,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                                     score=record.score,
                                 )
                             )
-                    retrieval_resource_list = []
+                    
                     if self.return_resource:
                         for record in records:
                             segment = record.segment


### PR DESCRIPTION
# Summary

Address the UnboundLocalError caused by accessing uninitialized retrieval_resource_list during empty knowledge base queries in Agent mode. This fix ensures robustness against empty retrieval scenarios.

🧾 Problem Analysis
When knowledge base queries return no results, the retrieval_resource_list variable was conditionally initialized inside a branch, leading to runtime errors:
`tool invoke error: cannot access local variable 'retrieval_resource_list' where it is not associated with a value  `


🔧 Fix Implementation
Scope Adjustment : Move` retrieval_resource_list` initialization to the top of the function scope

📦 Impact Assessment
Scope : Only adjusts variable initialization logic, without involving changes to functional logic
Compatibility : Fully backward-compatible with existing workflows
Benefit : Eliminates crash risk during edge-case scenarios while maintaining normal functionality

Resolves issues similar to #14691 

# Screenshots

Before 
![image](https://github.com/user-attachments/assets/5d6dec25-66b4-4545-b88a-fee823ac9d97)


After 
![image](https://github.com/user-attachments/assets/6262de46-bed0-4f88-9c80-8853e50654aa)


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

