### PR TITLE
fix: correct indentation in dataset retrieval model assignment

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -960,11 +960,11 @@ class DocumentService:
                         "score_threshold_enabled": False,
                     }
 
-                dataset.retrieval_model = (
-                    knowledge_config.retrieval_model.model_dump()
-                    if knowledge_config.retrieval_model
-                    else default_retrieval_model
-                )  # type: ignore
+                    dataset.retrieval_model = (
+                        knowledge_config.retrieval_model.model_dump()
+                        if knowledge_config.retrieval_model
+                        else default_retrieval_model
+                    )  # type: ignore
 
         documents = []
         if knowledge_config.original_document_id:


### PR DESCRIPTION
# Summary

Fix a bug that caused errors when uploading knowledge through the API by correcting the indentation level of the retrieval model assignment in dataset_service.py. The incorrect indentation was causing the retrieval model to be assigned outside the proper scope, leading to API errors during knowledge upload.

It appears that the indentation was unintentionally modified in the following Pull Request, which became the root cause of this bug:
https://github.com/langgenius/dify/pull/17932

Issue: fix https://github.com/langgenius/dify/issues/20039



> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

