### PR TITLE
fix(sqlalchemy_workflow_node_execution_repository): Missing `triggered_from` while querying WorkflowNodeExecution

### DIFF
--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -15,6 +15,7 @@ from models import (
     WorkflowRun,
     WorkflowRunTriggeredFrom,
 )
+from models.workflow import WorkflowNodeExecutionTriggeredFrom
 
 
 class WorkflowRunService:
@@ -140,14 +141,13 @@ class WorkflowRunService:
             session_factory=db.engine,
             user=user,
             app_id=app_model.id,
-            triggered_from=None,
+            triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
 
-        # Use the repository to get the node executions with ordering
+        # Use the repository to get the database models directly
         order_config = OrderConfig(order_by=["index"], order_direction="desc")
-        node_executions = repository.get_by_workflow_run(workflow_run_id=run_id, order_config=order_config)
-
-        # Convert domain models to database models
-        workflow_node_executions = [repository.to_db_model(node_execution) for node_execution in node_executions]
+        workflow_node_executions = repository.get_db_models_by_workflow_run(
+            workflow_run_id=run_id, order_config=order_config
+        )
 
         return workflow_node_executions


### PR DESCRIPTION


# Summary

fixes #19977

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

