### PR TITLE
Simplify `execution_metadata` Handling for `WorkflowNodeExecution`

### DIFF
--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -103,10 +103,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
         inputs = db_model.inputs_dict
         process_data = db_model.process_data_dict
         outputs = db_model.outputs_dict
-        if db_model.execution_metadata_dict:
-            metadata = {NodeRunMetadataKey(k): v for k, v in db_model.execution_metadata_dict.items()}
-        else:
-            metadata = {}
+        metadata = {NodeRunMetadataKey(k): v for k, v in db_model.execution_metadata_dict.items()}
 
         # Convert status to domain enum
         status = NodeExecutionStatus(db_model.status)

--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -666,8 +666,11 @@ class WorkflowNodeExecution(Base):
         return json.loads(self.process_data) if self.process_data else None
 
     @property
-    def execution_metadata_dict(self) -> dict[str, Any] | None:
-        return json.loads(self.execution_metadata) if self.execution_metadata else None
+    def execution_metadata_dict(self) -> dict[str, Any]:
+        # When the metadata is unset, we return an empty dictionary instead of `None`.
+        # This approach streamlines the logic for the caller, making it easier to handle
+        # cases where metadata is absent.
+        return json.loads(self.execution_metadata) if self.execution_metadata else {}
 
     @property
     def extras(self):

--- a/api/tests/unit_tests/models/test_workflow.py
+++ b/api/tests/unit_tests/models/test_workflow.py
@@ -1,10 +1,11 @@
+import json
 from unittest import mock
 from uuid import uuid4
 
 import contexts
 from constants import HIDDEN_VALUE
 from core.variables import FloatVariable, IntegerVariable, SecretVariable, StringVariable
-from models.workflow import Workflow
+from models.workflow import Workflow, WorkflowNodeExecution
 
 
 def test_environment_variables():
@@ -137,3 +138,14 @@ def test_to_dict():
         workflow_dict = workflow.to_dict(include_secret=True)
         assert workflow_dict["environment_variables"][0]["value"] == "secret"
         assert workflow_dict["environment_variables"][1]["value"] == "text"
+
+
+class TestWorkflowNodeExecution:
+    def test_execution_metadata_dict(self):
+        node_exec = WorkflowNodeExecution()
+        node_exec.execution_metadata = None
+        assert node_exec.execution_metadata_dict == {}
+
+        original = {"a": 1, "b": ["2"]}
+        node_exec.execution_metadata = json.dumps(original)
+        assert node_exec.execution_metadata_dict == original


### PR DESCRIPTION
# Summary

Currently, `WorkflowNodeExecution.execution_metadata_dict` returns `None` when metadata is absent in the database. This requires all callers to perform `None` checks when processing metadata, leading to more complex caller-side logic.

This pull request updates the `execution_metadata_dict` method to return an empty dictionary instead of `None` when metadata is absent. This change would simplify the caller logic, as it removes the need for explicit `None` checks and provides a more consistent data structure to work with.

The change described above could also be applied to `inputs_dict`, `process_data_dict`, and `outputs_dict`. However, doing so would require thoroughly reviewing all callers to ensure that existing logic is not unintentionally disrupted. These adjustments are deferred to future pull requests.

Closes #20061.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

