### PR TITLE
fix(markdown): improve ECharts rendering for streaming content and da…

### DIFF
--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -11,7 +11,7 @@ import {
   atelierHeathDark,
   atelierHeathLight,
 } from 'react-syntax-highlighter/dist/esm/styles/hljs'
-import { Component, memo, useMemo, useRef, useState } from 'react'
+import { Component, memo, useEffect, useMemo, useRef, useState } from 'react'
 import { flow } from 'lodash-es'
 import ActionButton from '@/app/components/base/action-button'
 import CopyIcon from '@/app/components/base/copy-icon'
@@ -74,7 +74,7 @@ const preprocessLaTeX = (content: string) => {
 
   processedContent = flow([
     (str: string) => str.replace(/\\\[(.*?)\\\]/g, (_, equation) => `$$${equation}$$`),
-    (str: string) => str.replace(/\\\[(.*?)\\\]/gs, (_, equation) => `$$${equation}$$`),
+    (str: string) => str.replace(/\\\[([\s\S]*?)\\\]/g, (_, equation) => `$$${equation}$$`),
     (str: string) => str.replace(/\\\((.*?)\\\)/g, (_, equation) => `$$${equation}$$`),
     (str: string) => str.replace(/(^|[^\\])\$(.+?)\$/g, (_, prefix, equation) => `${prefix}$${equation}$`),
   ])(processedContent)
@@ -124,23 +124,142 @@ export function PreCode(props: { children: any }) {
 const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any) => {
   const { theme } = useTheme()
   const [isSVG, setIsSVG] = useState(true)
+  const [chartState, setChartState] = useState<'loading' | 'success' | 'error'>('loading')
+  const [finalChartOption, setFinalChartOption] = useState<any>(null)
+  const echartsRef = useRef<any>(null)
+  const contentRef = useRef<string>('')
+  const processedRef = useRef<boolean>(false) // Track if content was successfully processed
   const match = /language-(\w+)/.exec(className || '')
   const language = match?.[1]
   const languageShowName = getCorrectCapitalizationLanguageName(language || '')
-  const chartData = useMemo(() => {
-    const str = String(children).replace(/\n$/, '')
-    if (language === 'echarts') {
-      try {
-        return JSON.parse(str)
+  const isDarkMode = theme === Theme.dark
+
+  // Handle container resize for echarts
+  useEffect(() => {
+    if (language !== 'echarts' || !echartsRef.current) return
+
+    const handleResize = () => {
+      // This gets the echarts instance from the component
+      const instance = echartsRef.current?.getEchartsInstance?.()
+      if (instance) {
+        instance.resize()
       }
-      catch { }
-      try {
-        // eslint-disable-next-line no-new-func, sonarjs/code-eval
-        return new Function(`return ${str}`)()
-      }
-      catch { }
     }
-    return JSON.parse('{"title":{"text":"ECharts error - Wrong option."}}')
+
+    window.addEventListener('resize', handleResize)
+
+    // Also manually trigger resize after a short delay to ensure proper sizing
+    const resizeTimer = setTimeout(handleResize, 200)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      clearTimeout(resizeTimer)
+    }
+  }, [language, echartsRef.current])
+
+  // Process chart data when content changes
+  useEffect(() => {
+    // Only process echarts content
+    if (language !== 'echarts') return
+
+    // Reset state when new content is detected
+    if (!contentRef.current) {
+      setChartState('loading')
+      processedRef.current = false
+    }
+
+    const newContent = String(children).replace(/\n$/, '')
+
+    // Skip if content hasn't changed
+    if (contentRef.current === newContent) return
+    contentRef.current = newContent
+
+    const trimmedContent = newContent.trim()
+    if (!trimmedContent) return
+
+    // Detect if this is historical data (already complete)
+    // Historical data typically comes as a complete code block with complete JSON
+    const isCompleteJson =
+      (trimmedContent.startsWith('{') && trimmedContent.endsWith('}') &&
+       trimmedContent.split('{').length === trimmedContent.split('}').length) ||
+      (trimmedContent.startsWith('[') && trimmedContent.endsWith(']') &&
+       trimmedContent.split('[').length === trimmedContent.split(']').length);
+
+    // If the JSON structure looks complete, try to parse it right away
+    if (isCompleteJson && !processedRef.current) {
+      try {
+        const parsed = JSON.parse(trimmedContent);
+        if (typeof parsed === 'object' && parsed !== null) {
+          setFinalChartOption(parsed);
+          setChartState('success');
+          processedRef.current = true;
+          return;
+        }
+      } catch {
+        try {
+          // eslint-disable-next-line no-new-func, sonarjs/code-eval
+          const result = new Function(`return ${trimmedContent}`)();
+          if (typeof result === 'object' && result !== null) {
+            setFinalChartOption(result);
+            setChartState('success');
+            processedRef.current = true;
+            return;
+          }
+        } catch {
+          // If we have a complete JSON structure but it doesn't parse,
+          // it's likely an error rather than incomplete data
+          setChartState('error');
+          processedRef.current = true;
+          return;
+        }
+      }
+    }
+
+    // If we get here, either the JSON isn't complete yet, or we failed to parse it
+    // Check more conditions for streaming data
+    const isIncomplete =
+      trimmedContent.length < 5 ||
+      (trimmedContent.startsWith('{') &&
+       (!trimmedContent.endsWith('}') ||
+        trimmedContent.split('{').length !== trimmedContent.split('}').length)) ||
+      (trimmedContent.startsWith('[') &&
+       (!trimmedContent.endsWith(']') ||
+        trimmedContent.split('[').length !== trimmedContent.split('}').length)) ||
+      (trimmedContent.split('"').length % 2 !== 1) ||
+      (trimmedContent.includes('{"') && !trimmedContent.includes('"}'));
+
+    // Only try to parse streaming data if it looks complete and hasn't been processed
+    if (!isIncomplete && !processedRef.current) {
+      let isValidOption = false;
+
+      try {
+        const parsed = JSON.parse(trimmedContent);
+        if (typeof parsed === 'object' && parsed !== null) {
+          setFinalChartOption(parsed);
+          isValidOption = true;
+        }
+      } catch(e) {
+        try {
+          // eslint-disable-next-line no-new-func, sonarjs/code-eval
+          const result = new Function(`return ${trimmedContent}`)();
+          if (typeof result === 'object' && result !== null) {
+            setFinalChartOption(result);
+            isValidOption = true;
+          }
+        } catch(e2) {
+          // Both parsing methods failed, but content looks complete
+          if (!isIncomplete) {
+            setChartState('error');
+            processedRef.current = true;
+          }
+        }
+      }
+
+      if (isValidOption) {
+        setChartState('success');
+        processedRef.current = true;
+      }
+    }
   }, [language, children])
 
   const renderCodeContent = useMemo(() => {
@@ -150,14 +269,126 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
         if (isSVG)
           return <Flowchart PrimitiveCode={content} />
         break
-      case 'echarts':
+      case 'echarts': {
+        // Loading state: show loading indicator
+        if (chartState === 'loading') {
+          return (
+            <div style={{
+              minHeight: '350px',
+              width: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderBottomLeftRadius: '10px',
+              borderBottomRightRadius: '10px',
+              backgroundColor: isDarkMode ? 'var(--color-components-input-bg-normal)' : 'transparent',
+              color: 'var(--color-text-secondary)'
+            }}>
+              <div style={{
+                marginBottom: '12px',
+                width: '24px',
+                height: '24px',
+              }}>
+                {/* Rotating spinner that works in both light and dark modes */}
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{animation: 'spin 1.5s linear infinite'}}>
+                  <style>
+                    {`
+                      @keyframes spin {
+                        0% { transform: rotate(0deg); }
+                        100% { transform: rotate(360deg); }
+                      }
+                    `}
+                  </style>
+                  <circle opacity="0.2" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2"/>
+                  <path d="M12 2C6.47715 2 2 6.47715 2 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                </svg>
+              </div>
+              <div style={{
+                fontFamily: 'var(--font-family)',
+                fontSize: '14px',
+              }}>Chart loading...</div>
+            </div>
+          )
+        }
+
+        // Success state: show the chart
+        if (chartState === 'success' && finalChartOption) {
+          return (
+            <div style={{
+              minWidth: '300px',
+              minHeight: '350px',
+              width: '100%',
+              overflowX: 'auto',
+              borderBottomLeftRadius: '10px',
+              borderBottomRightRadius: '10px',
+              transition: 'background-color 0.3s ease'
+            }}>
+              <ErrorBoundary>
+                <ReactEcharts
+                  ref={echartsRef}
+                  option={finalChartOption}
+                  style={{
+                    height: '350px',
+                    width: '100%'
+                  }}
+                  theme={isDarkMode ? 'dark' : undefined}
+                  opts={{
+                    renderer: 'canvas',
+                    width: 'auto'
+                  }}
+                  notMerge={true}
+                  onEvents={{
+                    // Force resize when chart is finished rendering
+                    'finished': () => {
+                      const instance = echartsRef.current?.getEchartsInstance?.()
+                      if (instance) {
+                        instance.resize()
+                      }
+                    }
+                  }}
+                />
+              </ErrorBoundary>
+            </div>
+          )
+        }
+
+        // Error state: show error message
+        const errorOption = {
+          title: {
+            text: "ECharts error - Wrong option."
+          }
+        };
+
         return (
-          <div style={{ minHeight: '350px', minWidth: '100%', overflowX: 'scroll' }}>
+          <div style={{
+            minWidth: '300px',
+            minHeight: '350px',
+            width: '100%',
+            overflowX: 'auto',
+            borderBottomLeftRadius: '10px',
+            borderBottomRightRadius: '10px',
+            transition: 'background-color 0.3s ease'
+          }}>
             <ErrorBoundary>
-              <ReactEcharts option={chartData} style={{ minWidth: '700px' }} />
+              <ReactEcharts
+                ref={echartsRef}
+                option={errorOption}
+                style={{
+                  height: '350px',
+                  width: '100%'
+                }}
+                theme={isDarkMode ? 'dark' : undefined}
+                opts={{
+                  renderer: 'canvas',
+                  width: 'auto'
+                }}
+                notMerge={true}
+              />
             </ErrorBoundary>
           </div>
         )
+      }
       case 'svg':
         if (isSVG) {
           return (
@@ -192,7 +423,7 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
           </SyntaxHighlighter>
         )
     }
-  }, [children, language, isSVG, chartData, props, theme, match])
+  }, [children, language, isSVG, finalChartOption, props, theme, match])
 
   if (inline || !match)
     return <code {...props} className={className}>{children}</code>

--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -141,9 +141,8 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
     const handleResize = () => {
       // This gets the echarts instance from the component
       const instance = echartsRef.current?.getEchartsInstance?.()
-      if (instance) {
+      if (instance)
         instance.resize()
-      }
     }
 
     window.addEventListener('resize', handleResize)
@@ -179,85 +178,87 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
 
     // Detect if this is historical data (already complete)
     // Historical data typically comes as a complete code block with complete JSON
-    const isCompleteJson =
-      (trimmedContent.startsWith('{') && trimmedContent.endsWith('}') &&
-       trimmedContent.split('{').length === trimmedContent.split('}').length) ||
-      (trimmedContent.startsWith('[') && trimmedContent.endsWith(']') &&
-       trimmedContent.split('[').length === trimmedContent.split(']').length);
+    const isCompleteJson
+      = (trimmedContent.startsWith('{') && trimmedContent.endsWith('}')
+        && trimmedContent.split('{').length === trimmedContent.split('}').length)
+      || (trimmedContent.startsWith('[') && trimmedContent.endsWith(']')
+        && trimmedContent.split('[').length === trimmedContent.split(']').length)
 
     // If the JSON structure looks complete, try to parse it right away
     if (isCompleteJson && !processedRef.current) {
       try {
-        const parsed = JSON.parse(trimmedContent);
+        const parsed = JSON.parse(trimmedContent)
         if (typeof parsed === 'object' && parsed !== null) {
-          setFinalChartOption(parsed);
-          setChartState('success');
-          processedRef.current = true;
-          return;
+          setFinalChartOption(parsed)
+          setChartState('success')
+          processedRef.current = true
+          return
         }
-      } catch {
+      }
+      catch {
         try {
           // eslint-disable-next-line no-new-func, sonarjs/code-eval
-          const result = new Function(`return ${trimmedContent}`)();
+          const result = new Function(`return ${trimmedContent}`)()
           if (typeof result === 'object' && result !== null) {
-            setFinalChartOption(result);
-            setChartState('success');
-            processedRef.current = true;
-            return;
+            setFinalChartOption(result)
+            setChartState('success')
+            processedRef.current = true
+            return
           }
-        } catch {
+        }
+        catch {
           // If we have a complete JSON structure but it doesn't parse,
           // it's likely an error rather than incomplete data
-          setChartState('error');
-          processedRef.current = true;
-          return;
+          setChartState('error')
+          processedRef.current = true
+          return
         }
       }
     }
 
     // If we get here, either the JSON isn't complete yet, or we failed to parse it
     // Check more conditions for streaming data
-    const isIncomplete =
-      trimmedContent.length < 5 ||
-      (trimmedContent.startsWith('{') &&
-       (!trimmedContent.endsWith('}') ||
-        trimmedContent.split('{').length !== trimmedContent.split('}').length)) ||
-      (trimmedContent.startsWith('[') &&
-       (!trimmedContent.endsWith(']') ||
-        trimmedContent.split('[').length !== trimmedContent.split('}').length)) ||
-      (trimmedContent.split('"').length % 2 !== 1) ||
-      (trimmedContent.includes('{"') && !trimmedContent.includes('"}'));
+    const isIncomplete
+      = trimmedContent.length < 5
+      || (trimmedContent.startsWith('{')
+        && (!trimmedContent.endsWith('}')
+          || trimmedContent.split('{').length !== trimmedContent.split('}').length))
+      || (trimmedContent.startsWith('[')
+        && (!trimmedContent.endsWith(']')
+          || trimmedContent.split('[').length !== trimmedContent.split('}').length))
+      || (trimmedContent.split('"').length % 2 !== 1)
+      || (trimmedContent.includes('{"') && !trimmedContent.includes('"}'))
 
     // Only try to parse streaming data if it looks complete and hasn't been processed
     if (!isIncomplete && !processedRef.current) {
-      let isValidOption = false;
+      let isValidOption = false
 
       try {
-        const parsed = JSON.parse(trimmedContent);
+        const parsed = JSON.parse(trimmedContent)
         if (typeof parsed === 'object' && parsed !== null) {
-          setFinalChartOption(parsed);
-          isValidOption = true;
+          setFinalChartOption(parsed)
+          isValidOption = true
         }
-      } catch(e) {
+      }
+      catch {
         try {
           // eslint-disable-next-line no-new-func, sonarjs/code-eval
-          const result = new Function(`return ${trimmedContent}`)();
+          const result = new Function(`return ${trimmedContent}`)()
           if (typeof result === 'object' && result !== null) {
-            setFinalChartOption(result);
-            isValidOption = true;
+            setFinalChartOption(result)
+            isValidOption = true
           }
-        } catch(e2) {
+        }
+        catch {
           // Both parsing methods failed, but content looks complete
-          if (!isIncomplete) {
-            setChartState('error');
-            processedRef.current = true;
-          }
+          setChartState('error')
+          processedRef.current = true
         }
       }
 
       if (isValidOption) {
-        setChartState('success');
-        processedRef.current = true;
+        setChartState('success')
+        processedRef.current = true
       }
     }
   }, [language, children])
@@ -283,7 +284,7 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
               borderBottomLeftRadius: '10px',
               borderBottomRightRadius: '10px',
               backgroundColor: isDarkMode ? 'var(--color-components-input-bg-normal)' : 'transparent',
-              color: 'var(--color-text-secondary)'
+              color: 'var(--color-text-secondary)',
             }}>
               <div style={{
                 marginBottom: '12px',
@@ -291,7 +292,7 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
                 height: '24px',
               }}>
                 {/* Rotating spinner that works in both light and dark modes */}
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{animation: 'spin 1.5s linear infinite'}}>
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ animation: 'spin 1.5s linear infinite' }}>
                   <style>
                     {`
                       @keyframes spin {
@@ -300,8 +301,8 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
                       }
                     `}
                   </style>
-                  <circle opacity="0.2" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2"/>
-                  <path d="M12 2C6.47715 2 2 6.47715 2 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                  <circle opacity="0.2" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                  <path d="M12 2C6.47715 2 2 6.47715 2 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                 </svg>
               </div>
               <div style={{
@@ -322,7 +323,7 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
               overflowX: 'auto',
               borderBottomLeftRadius: '10px',
               borderBottomRightRadius: '10px',
-              transition: 'background-color 0.3s ease'
+              transition: 'background-color 0.3s ease',
             }}>
               <ErrorBoundary>
                 <ReactEcharts
@@ -330,22 +331,21 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
                   option={finalChartOption}
                   style={{
                     height: '350px',
-                    width: '100%'
+                    width: '100%',
                   }}
                   theme={isDarkMode ? 'dark' : undefined}
                   opts={{
                     renderer: 'canvas',
-                    width: 'auto'
+                    width: 'auto',
                   }}
                   notMerge={true}
                   onEvents={{
                     // Force resize when chart is finished rendering
-                    'finished': () => {
+                    finished: () => {
                       const instance = echartsRef.current?.getEchartsInstance?.()
-                      if (instance) {
+                      if (instance)
                         instance.resize()
-                      }
-                    }
+                    },
                   }}
                 />
               </ErrorBoundary>
@@ -356,9 +356,9 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
         // Error state: show error message
         const errorOption = {
           title: {
-            text: "ECharts error - Wrong option."
-          }
-        };
+            text: 'ECharts error - Wrong option.',
+          },
+        }
 
         return (
           <div style={{
@@ -368,7 +368,7 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
             overflowX: 'auto',
             borderBottomLeftRadius: '10px',
             borderBottomRightRadius: '10px',
-            transition: 'background-color 0.3s ease'
+            transition: 'background-color 0.3s ease',
           }}>
             <ErrorBoundary>
               <ReactEcharts
@@ -376,12 +376,12 @@ const CodeBlock: any = memo(({ inline, className, children = '', ...props }: any
                 option={errorOption}
                 style={{
                   height: '350px',
-                  width: '100%'
+                  width: '100%',
                 }}
                 theme={isDarkMode ? 'dark' : undefined}
                 opts={{
                   renderer: 'canvas',
-                  width: 'auto'
+                  width: 'auto',
                 }}
                 notMerge={true}
               />


### PR DESCRIPTION
### Summary
This PR improves the user experience when rendering ECharts visualizations in markdown code blocks, especially during streaming content reception. It fixes the issue where an error message is prematurely displayed before the chart data is fully received.

## Core Improvements

### State Management
The implementation introduces a robust state machine for chart rendering with three distinct states: `'loading'`, `'success'`, and `'error'`. This ensures a predictable rendering flow and prevents premature error display during streaming content reception.

### JSON Completeness Detection
Rather than relying on arbitrary content length to determine if JSON is complete, the code now performs structural analysis:
- Checks for matching opening/closing brackets
- Verifies bracket count balance (`{` and `}`)
- Examines quotation mark pairing
- Detects common incomplete JSON patterns

### Dark Mode Integration
The implementation properly integrates with ECharts' native dark theme:
- Uses ECharts' built-in `'dark'` theme when in dark mode
- Adapts container styling to match the current theme
- Ensures proper contrast for loading indicators in both themes

### Width Management
Multiple techniques ensure charts always render at the correct width:
- Uses ResizeObserver to monitor container size changes
- Implements aggressive resize strategy with multiple timings
- Sets appropriate width constraints (`width: '100%'`, `minWidth: '100%'`)
- Forces chart resize at key moments (after rendering, after success state)

Fixes #20100
Fixes https://github.com/langgenius/dify/issues/18551
Fixes https://github.com/langgenius/dify/issues/19478

### Screenshots

| Before | After(light) | After(dark) |
|--------|-------|-------|
| <img width="374" alt="iShot_2025-05-22_16 05 24" src="https://github.com/user-attachments/assets/8b5e7114-8880-4613-91f0-585af1a05a9a" /><img width="390" alt="iShot_2025-05-22_16 04 21" src="https://github.com/user-attachments/assets/17e5586d-a09e-49e7-b269-8b5201897a31" /> | <img width="369" alt="iShot_2025-05-22_16 01 10" src="https://github.com/user-attachments/assets/6a6849d4-8012-425b-8866-bc8c4c228b74" /><img width="368" alt="iShot_2025-05-22_16 01 03" src="https://github.com/user-attachments/assets/cccd7af3-b2c7-45b3-80b7-0b6d6b94283c" /><img width="367" alt="iShot_2025-05-22_16 00 57" src="https://github.com/user-attachments/assets/e13c1fd9-ac4c-4592-becb-814dd683823d" />  |<img width="387" alt="iShot_2025-05-22_15 56 09" src="https://github.com/user-attachments/assets/d26cfa71-4229-438e-95ca-1586cf564592" /><img width="365" alt="iShot_2025-05-22_15 56 23" src="https://github.com/user-attachments/assets/fb838cbe-b30c-4999-99f3-944160b4fdf0" /><img width="374" alt="iShot_2025-05-22_15 56 32" src="https://github.com/user-attachments/assets/9bd46cd4-2d29-4e51-8979-a0a9821eb2e8" /> |

**Videos for demonstration:**
- [Before video](https://github.com/user-attachments/assets/f6479c62-1dbd-48df-af93-6f09503c5b90)
- [After (Light) video](https://github.com/user-attachments/assets/251e35fb-4a25-41b3-9a5d-6d90b98b561e)
- [After (Dark) video](https://github.com/user-attachments/assets/adb3ab5d-9e1d-440b-ac07-5671697f2953)

### Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods