### PR TITLE
fix #17085: streaming response issue with nested condition nodes  

### DIFF
--- a/api/core/workflow/nodes/answer/answer_stream_processor.py
+++ b/api/core/workflow/nodes/answer/answer_stream_processor.py
@@ -71,7 +71,7 @@ class AnswerStreamProcessor(StreamProcessor):
         self.route_position = {}
         for answer_node_id, route_chunks in self.generate_routes.answer_generate_route.items():
             self.route_position[answer_node_id] = 0
-        self.rest_node_ids = self.graph.node_ids.copy()
+        self.rest_node_ids = set(self.graph.node_ids)
         self.current_stream_chunk_generating_node_ids = {}
 
     def _generate_stream_outputs_when_node_finished(

--- a/api/core/workflow/nodes/end/end_stream_processor.py
+++ b/api/core/workflow/nodes/end/end_stream_processor.py
@@ -80,7 +80,7 @@ class EndStreamProcessor(StreamProcessor):
         self.route_position = {}
         for end_node_id, _ in self.end_stream_param.end_stream_variable_selector_mapping.items():
             self.route_position[end_node_id] = 0
-        self.rest_node_ids = self.graph.node_ids.copy()
+        self.rest_node_ids = set(self.graph.node_ids)
         self.current_stream_chunk_generating_node_ids = {}
 
     def _generate_stream_outputs_when_node_finished(


### PR DESCRIPTION
# Summary

Fix https://github.com/langgenius/dify/issues/17085

Due to nested condition nodes, `reachable_nodes` may not be fully fetched, which can lead to LLM nodes being removed from `self.rest_node_ids`.

To address this, I updated the logic to add the currently fetched `reachable_nodes` back into `self.rest_node_ids`, ensuring that accidentally removed nodes can be recovered. Additionally, I changed `self.rest_node_ids` from a list to a set to improve lookup efficiency.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

