### PR TITLE
fix: resolve plugin model.position parsing in legacy DSL (≤0.1.5)

### DIFF
--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -810,7 +810,7 @@ class ProviderConfiguration(BaseModel):
 
         def get_sort_key(model: ModelWithProviderEntity):
             # Get the position list for the current model type
-            positions = model_type_positions.get(model.model_type.value, [])
+            positions = model_type_positions.get(model.model_type.value, []) or []
 
             # If the model name is in the position list, use its index for sorting
             # Otherwise use a large value (list length) to place undefined models at the end

--- a/api/core/model_runtime/entities/provider_entities.py
+++ b/api/core/model_runtime/entities/provider_entities.py
@@ -135,7 +135,7 @@ class ProviderEntity(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     # position from plugin _position.yaml
-    position: Optional[dict[str, list[str]]] = {}
+    position: Optional[dict[str, Optional[list[str]]]] = {}
 
     @field_validator("models", mode="before")
     @classmethod


### PR DESCRIPTION
# Summary

Fixes https://github.com/langgenius/dify/issues/20081
Fixes https://github.com/langgenius/dify/issues/19219
Fixes https://github.com/langgenius/dify/issues/20346

Reason: The `ModelPosition` definition in the following file is of type `Optional[list[str]]`:

https://github.com/langgenius/dify-plugin-sdks/blob/main/python/dify_plugin/entities/model/provider.py#L156

Whereas in `api/../provider_entities.py`, the `position` is defined as `list[str]` type (non-optional). 

In other words:
- In provider.py: `position: Optional[list[str]]`
- In provider_entities.py: `position: list[str]`



Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| <img width="802" alt="before" src="https://github.com/user-attachments/assets/0a612ac5-a68d-4d33-8133-b8512beb41fa" />| <img width="700" alt="after" src="https://github.com/user-attachments/assets/c1aa8e19-4aa9-4868-85eb-c12d707a7d9f" />|

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

