### PR TITLE
fix: Remove the custom comparison function from the memo HOC(#19679)

### DIFF
--- a/web/app/components/base/chat/chat/answer/index.tsx
+++ b/web/app/components/base/chat/chat/answer/index.tsx
@@ -234,6 +234,4 @@ const Answer: FC<AnswerProps> = ({
   )
 }
 
-export default memo(Answer, (prevProps, nextProps) =>
-  prevProps.responding === false && nextProps.responding === false,
-)
+export default memo(Answer)


### PR DESCRIPTION
# Summary

- Remove the custom comparison function from the memo HOC in the Answer component (#19679)


> - Fixes #19679
> - Relates #18389

It will not re-render the component even when other important props like item, question, or content change — as long as responding remains false, which would cause bug: #19679

# Screenshots

| Before | After |
|--------|-------|
![image](https://github.com/user-attachments/assets/691a4513-150a-4150-9f4c-b47bfb078c6c) | ![image](https://github.com/user-attachments/assets/d0bd1973-531f-4ab5-9028-133e3cae1a65) |

**Can't reproduce**:
> And I can't reproduce #18110 & #17818 after I removed the function, so I think we can remove this comparison functionfrom the memo HOC in the Answer component.

| #17818 | #18110 |
|--------|-------| 
![image](https://github.com/user-attachments/assets/0c7c1b9d-f2dc-487b-9611-d16859912c1c) | ![image](https://github.com/user-attachments/assets/1e64dc53-c2e5-464a-ace2-59a9f3f09090)|


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

