### PR TITLE
fix: prevent save when default max_iteration has value in agent node

### DIFF
--- a/web/app/components/workflow/nodes/agent/default.ts
+++ b/web/app/components/workflow/nodes/agent/default.ts
@@ -126,7 +126,7 @@ const nodeDefault: NodeDefault<AgentNodeType> = {
         }
       }
       // common params
-      if (param.required && !payload.agent_parameters?.[param.name]?.value) {
+      if (param.required && !(payload.agent_parameters?.[param.name]?.value || param.default)) {
         return {
           isValid: false,
           errorMessage: t('workflow.errorMsg.fieldRequired', { field: renderI18nObject(param.label, language) }),


### PR DESCRIPTION
# Summary

fix prevent saving when default max_iteration has value in agent node

> [!Tip]
> close #20210 


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

