### PR TITLE
[Observability] Add type check and try-except in otel

### DIFF
--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -22,16 +22,20 @@ def on_user_loaded(_sender, user: Union["Account", "EndUser"]):
         from opentelemetry.trace import get_current_span
 
         if user:
-            current_span = get_current_span()
-            if isinstance(user, Account) and user.current_tenant_id:
-                tenant_id = user.current_tenant_id
-            elif isinstance(user, EndUser):
-                tenant_id = user.tenant_id
-            else:
-                return
-            if current_span:
-                current_span.set_attribute("service.tenant.id", tenant_id)
-                current_span.set_attribute("service.user.id", user.id)
+            try:
+                current_span = get_current_span()
+                if isinstance(user, Account) and user.current_tenant_id:
+                    tenant_id = user.current_tenant_id
+                elif isinstance(user, EndUser):
+                    tenant_id = user.tenant_id
+                else:
+                    return
+                if current_span:
+                    current_span.set_attribute("service.tenant.id", tenant_id)
+                    current_span.set_attribute("service.user.id", user.id)
+            except Exception:
+                logging.exception("Error setting tenant and user attributes")
+                pass
 
 
 def init_app(app: DifyApp):
@@ -54,21 +58,25 @@ def init_app(app: DifyApp):
 
         def response_hook(span: Span, status: str, response_headers: list):
             if span and span.is_recording():
-                if status.startswith("2"):
-                    span.set_status(StatusCode.OK)
-                else:
-                    span.set_status(StatusCode.ERROR, status)
+                try:
+                    if status.startswith("2"):
+                        span.set_status(StatusCode.OK)
+                    else:
+                        span.set_status(StatusCode.ERROR, status)
 
-                status = status.split(" ")[0]
-                status_code = int(status)
-                status_class = f"{status_code // 100}xx"
-                attributes: dict[str, str | int] = {"status_code": status_code, "status_class": status_class}
-                request = flask.request
-                if request and request.url_rule:
-                    attributes[SpanAttributes.HTTP_TARGET] = str(request.url_rule.rule)
-                if request and request.method:
-                    attributes[SpanAttributes.HTTP_METHOD] = str(request.method)
-                _http_response_counter.add(1, attributes)
+                    status = status.split(" ")[0]
+                    status_code = int(status)
+                    status_class = f"{status_code // 100}xx"
+                    attributes: dict[str, str | int] = {"status_code": status_code, "status_class": status_class}
+                    request = flask.request
+                    if request and request.url_rule:
+                        attributes[SpanAttributes.HTTP_TARGET] = str(request.url_rule.rule)
+                    if request and request.method:
+                        attributes[SpanAttributes.HTTP_METHOD] = str(request.method)
+                    _http_response_counter.add(1, attributes)
+                except Exception:
+                    logging.exception("Error setting status and attributes")
+                    pass
 
         instrumentor = FlaskInstrumentor()
         if dify_config.DEBUG:
@@ -99,7 +107,7 @@ def init_app(app: DifyApp):
     class ExceptionLoggingHandler(logging.Handler):
         """Custom logging handler that creates spans for logging.exception() calls"""
 
-        def emit(self, record):
+        def emit(self, record: logging.LogRecord):
             try:
                 if record.exc_info:
                     tracer = get_tracer_provider().get_tracer("dify.exception.logging")
@@ -114,9 +122,12 @@ def init_app(app: DifyApp):
                         },
                     ) as span:
                         span.set_status(StatusCode.ERROR)
-                        span.record_exception(record.exc_info[1])
-                        span.set_attribute("exception.type", record.exc_info[0].__name__)
-                        span.set_attribute("exception.message", str(record.exc_info[1]))
+                        if record.exc_info[1]:
+                            span.record_exception(record.exc_info[1])
+                            span.set_attribute("exception.message", str(record.exc_info[1]))
+                        if record.exc_info[0]:
+                            span.set_attribute("exception.type", record.exc_info[0].__name__)
+
             except Exception:
                 pass
 


### PR DESCRIPTION
# Summary

This pull request enhances error handling and logging in the `api/extensions/ext_otel.py` file to improve robustness and maintainability. The key changes include adding exception handling around telemetry operations, refining the `emit` method in the custom logging handler, and ensuring attributes are set conditionally to avoid potential errors.

### Error handling improvements:

* Added `try-except` blocks in `on_user_loaded` to handle exceptions when setting tenant and user attributes on the current span. Logs exceptions using `logging.exception` for better debugging. [[1]](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6R25) [[2]](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6R36-R38)
* Added `try-except` blocks in `response_hook` to handle errors when setting span status and attributes. Logs exceptions using `logging.exception`. [[1]](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6R61) [[2]](diffhunk://#diff-d9b99e6e386de2f18f686daf1e6fcb87ca02c20900826cbdc5892a5e81f362b6R77-R79)

### Logging enhancements:

* Updated the `emit` method in the custom `ExceptionLoggingHandler` to use type annotations (`record: logging.LogRecord`) for clarity.
* Improved the `emit` method to conditionally check and set attributes like `exception.type` and `exception.message` only when relevant parts of `exc_info` are available, preventing potential `NoneType` errors.


Follow-up #20303

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

