### PR TITLE
fix(http): force multipart/form-data even without files(#20322)

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -377,7 +377,10 @@ class Executor:
             raw += f"{k}: {v}\r\n"
 
         body_string = ""
-        if self.files:
+        # Only log actual files if present.
+        # '__multipart_placeholder__' is inserted to force multipart encoding but is not a real file.
+        # This prevents logging meaningless placeholder entries.
+        if self.files and not all(f[0] == "__multipart_placeholder__" for f in self.files):
             for key, (filename, content, mime_type) in self.files:
                 body_string += f"--{boundary}\r\n"
                 body_string += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'

--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -235,6 +235,10 @@ class Executor:
                                 files[key].append(file_tuple)
 
                     # convert files to list for httpx request
+                    # If there are no actual files, we still need to force httpx to use `multipart/form-data`.
+                    # This is achieved by inserting a harmless placeholder file that will be ignored by the server.
+                    if not files:
+                        self.files = [("__multipart_placeholder__", ("", b"", "application/octet-stream"))]
                     if files:
                         self.files = []
                         for key, file_tuples in files.items():

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -246,7 +246,9 @@ def test_executor_with_form_data():
     assert "multipart/form-data" in executor.headers["Content-Type"]
     assert executor.params == []
     assert executor.json is None
-    assert executor.files is None
+    # '__multipart_placeholder__' is expected when no file inputs exist,
+    # to ensure the request is treated as multipart/form-data by the backend.
+    assert executor.files == [('__multipart_placeholder__', ('', b'', 'application/octet-stream'))]
     assert executor.content is None
 
     # Check that the form data is correctly loaded in executor.data

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -248,7 +248,7 @@ def test_executor_with_form_data():
     assert executor.json is None
     # '__multipart_placeholder__' is expected when no file inputs exist,
     # to ensure the request is treated as multipart/form-data by the backend.
-    assert executor.files == [('__multipart_placeholder__', ('', b'', 'application/octet-stream'))]
+    assert executor.files == [("__multipart_placeholder__", ("", b"", "application/octet-stream"))]
     assert executor.content is None
 
     # Check that the form data is correctly loaded in executor.data


### PR DESCRIPTION
<h1>Summary</h1>
<blockquote>
<p>This PR ensures that HTTP request nodes correctly trigger multipart/form-data encoding, even when no actual files are present.</p>
</blockquote>
<p>Previously, although the request appeared to be <code>multipart/form-data</code> in the request dump, the actual HTTP request was interpreted as <code>application/x-www-form-urlencoded</code> by backend servers.</p>
<p>To resolve this, i insert a harmless placeholder field named <code>__multipart_placeholder__</code> when no files are present. This forces <code>httpx</code> to properly set the <code>multipart/form-data</code> content type.</p>
<hr>
<p>As a developer working on API gateway infrastructure, I encountered this inconsistency while testing with  Dify and Spring. Tools like Postman properly preserve the multipart content-type even with empty forms, but Dify failed to do so.</p>
<p>To confirm this behavior, I created a Spring-based test controller that logged the actual <code>Content-Type</code> header and validated whether <code>MultipartHttpServletRequest</code> was recognized. Screenshots are attached below for both the &quot;before&quot; and &quot;after&quot; cases.</p>
<p>This change has been verified using a local test controller that replicates the server behavior. The added field is a harmless placeholder that is safely ignored by the server, ensuring full compatibility with existing behavior.</p>

Close #20322
<h1>Screenshots</h1>

| Phase   | Request 1 | Request 2 | Spring Server Log |
|---------|-----------|-----------|--------------------|
| **Before** | ![req1](https://github.com/user-attachments/assets/c5e53d6d-5c17-403a-8726-db2c4e7f6873) | ![req2](https://github.com/user-attachments/assets/e34fad8d-18d3-45a5-9ff1-272939f32265) | ![log1](https://github.com/user-attachments/assets/6aded5b7-7813-40a1-9a67-ef05f0bb6ba1) |
| **After**  | ![req3](https://github.com/user-attachments/assets/0deda12d-8d1c-4645-947a-1b1511b507b9) | ![req4](https://github.com/user-attachments/assets/618059d6-f5d6-4c40-b00b-c11192ef0e3d) | ![log2](https://github.com/user-attachments/assets/edd56841-ca1d-4a0e-9e88-e9fc301791e3) |




<h1>Checklist</h1>
<ul>
<li>[ ]  This change requires a documentation update, included: <a href="https://github.com/langgenius/dify-docs">Dify Document</a></li>
<li>[x]  I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)</li>
<li>[x]  I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.</li>
<li>[x]  I've updated the documentation accordingly.</li>
<li>[x]  I ran <code>dev/reformat</code> (backend) and <code>cd web &amp;&amp; npx lint-staged</code> (frontend) to appease the lint gods.</li>
</ul>
