### PR TITLE
fix: reset password page dark style

### DIFF
--- a/web/app/reset-password/set-password/page.tsx
+++ b/web/app/reset-password/set-password/page.tsx
@@ -105,7 +105,7 @@ const ChangePasswordForm = () => {
           </div>
 
           <div className="mx-auto mt-6 w-full">
-            <div className="bg-white">
+            <div>
               {/* Password */}
               <div className='mb-5'>
                 <label htmlFor="password" className="system-md-semibold my-2 text-text-secondary">


### PR DESCRIPTION

# Summary

fixed #20349


# Screenshots

| Before | After |
|--------|-------|
| ![f6e1bd24c6578310d87b035292d0d44](https://github.com/user-attachments/assets/20ba9d20-daa5-426b-a7b2-ef5ad05f4a97)    | ![4a6c1c5011bff0a28a474840ccc4f53](https://github.com/user-attachments/assets/34c6239f-8d3d-4859-b051-d047d827c59b)   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

