### PR TITLE
Browser Password Suggestion Behavior on Model Provider Page

### DIFF
--- a/web/app/components/base/input/index.tsx
+++ b/web/app/components/base/input/index.tsx
@@ -46,6 +46,7 @@ const Input = ({
   placeholder,
   onChange = noop,
   unit,
+  type = "text"
   ...props
 }: InputProps) => {
   const { t } = useTranslation()
@@ -73,6 +74,7 @@ const Input = ({
         value={value}
         onChange={onChange}
         disabled={disabled}
+        type={type}
         {...props}
       />
       {showClearIcon && value && !disabled && !destructive && (


### PR DESCRIPTION
# Summary

On the Model Provider page, after focusing on a box like an 'API Key' with the type value set to password, when focus is shifted to any other input field, the input box behaves like a password field, prompting the browser to suggest user passwords.

# Screenshots
![test](https://github.com/user-attachments/assets/3ea52697-6ce4-44c2-a93f-84196460eb5e)

# Browser
 - Zen Browser

# Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

