### PR TITLE
fix: inner invoke llm token too long

### DIFF
--- a/api/core/plugin/backwards_invocation/model.py
+++ b/api/core/plugin/backwards_invocation/model.py
@@ -58,6 +58,7 @@ class PluginModelBackwardsInvocation(BaseBackwardsInvocation):
                         LLMNode.deduct_llm_quota(
                             tenant_id=tenant.id, model_instance=model_instance, usage=chunk.delta.usage
                         )
+                    chunk.prompt_messages = []
                     yield chunk
 
             return handle()
@@ -68,7 +69,7 @@ class PluginModelBackwardsInvocation(BaseBackwardsInvocation):
             def handle_non_streaming(response: LLMResult) -> Generator[LLMResultChunk, None, None]:
                 yield LLMResultChunk(
                     model=response.model,
-                    prompt_messages=response.prompt_messages,
+                    prompt_messages=[],
                     system_fingerprint=response.system_fingerprint,
                     delta=LLMResultChunkDelta(
                         index=0,


### PR DESCRIPTION
# Summary

Since Agent Node calls the inner model invoke API, the Dify backend returns both LLMChunkResult and LLMChunk with the original prompt_messages included. This causes responses to become extremely lengthy during multi-turn conversations, eventually exceeding the Plugin Daemon service scanner's default 32k read limit. While this issue has been resolved in the regular Invoke model, it still persists in the inner invoke implementation.
Example scenario in Agent Node:

First query → Returns first query + answer (~100 bytes) + tool invocation (20k)
Second query → Returns first query + answer + tool results + second answer (~22k) + tool invocation (20k)
Third query → Returns accumulated content from rounds 1-2 + third answer (LLM fails to output because scanner data exceeds 32k limit and returns empty, causing Agent Node to return nothing)

Solution: We have removed the Prompt Messages from the response payload to prevent this accumulation issue.

Fixes #20037
Fixes https://github.com/langgenius/dify/issues/19489
Fixes https://github.com/langgenius/dify/issues/19978

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

