### PR TITLE
fix: handle Agent Node raising Attribute Error

### DIFF
--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -159,7 +159,15 @@ class AgentNode(ToolNode):
                 # variable_pool.convert_template returns a string,
                 # so we need to convert it back to a dictionary
                 try:
-                    parameter_value = json.loads(parameter_value)
+                    import re
+
+                    def sanitize_json_string(s):
+                        # Replace smart quotes, sanitize control characters if needed
+                        s = s.replace("\x00", "")  # Null byte
+                        s = re.sub(r"[\x01-\x1F]+", "", s)  # Strip most control characters
+                        return s
+
+                    parameter_value = json.loads(sanitize_json_string(parameter_value))
                 except json.JSONDecodeError:
                     parameter_value = parameter_value
             else:


### PR DESCRIPTION
## Summary
- to close https://github.com/langgenius/dify/issues/20406
- handles parameter_value in case received invalid JSON string as an input to Node Agent
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
