### PR TITLE
fix: apps/annotation missing 1 required positional argument: 'end_user'

### DIFF
--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -9,13 +9,13 @@ from fields.annotation_fields import (
     annotation_fields,
 )
 from libs.login import current_user
-from models.model import App, EndUser
+from models.model import App
 from services.annotation_service import AppAnnotationService
 
 
 class AnnotationReplyActionApi(Resource):
     @validate_app_token
-    def post(self, app_model: App, end_user: EndUser, action):
+    def post(self, app_model: App, action):
         parser = reqparse.RequestParser()
         parser.add_argument("score_threshold", required=True, type=float, location="json")
         parser.add_argument("embedding_provider_name", required=True, type=str, location="json")
@@ -32,7 +32,7 @@ class AnnotationReplyActionApi(Resource):
 
 class AnnotationReplyActionStatusApi(Resource):
     @validate_app_token
-    def get(self, app_model: App, end_user: EndUser, job_id, action):
+    def get(self, app_model: App, job_id, action):
         job_id = str(job_id)
         app_annotation_job_key = "{}_app_annotation_job_{}".format(action, str(job_id))
         cache_result = redis_client.get(app_annotation_job_key)
@@ -50,7 +50,7 @@ class AnnotationReplyActionStatusApi(Resource):
 
 class AnnotationListApi(Resource):
     @validate_app_token
-    def get(self, app_model: App, end_user: EndUser):
+    def get(self, app_model: App):
         page = request.args.get("page", default=1, type=int)
         limit = request.args.get("limit", default=20, type=int)
         keyword = request.args.get("keyword", default="", type=str)
@@ -67,7 +67,7 @@ class AnnotationListApi(Resource):
 
     @validate_app_token
     @marshal_with(annotation_fields)
-    def post(self, app_model: App, end_user: EndUser):
+    def post(self, app_model: App):
         parser = reqparse.RequestParser()
         parser.add_argument("question", required=True, type=str, location="json")
         parser.add_argument("answer", required=True, type=str, location="json")
@@ -79,7 +79,7 @@ class AnnotationListApi(Resource):
 class AnnotationUpdateDeleteApi(Resource):
     @validate_app_token
     @marshal_with(annotation_fields)
-    def put(self, app_model: App, end_user: EndUser, annotation_id):
+    def put(self, app_model: App, annotation_id):
         if not current_user.is_editor:
             raise Forbidden()
 
@@ -92,7 +92,7 @@ class AnnotationUpdateDeleteApi(Resource):
         return annotation
 
     @validate_app_token
-    def delete(self, app_model: App, end_user: EndUser, annotation_id):
+    def delete(self, app_model: App, annotation_id):
         if not current_user.is_editor:
             raise Forbidden()
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: Fixes #20427 , Fixes #20409

## Summary
this pr #20240 remove  `validate_app_token` attribute `fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.JSON)`
resulting in null `end_user`

`end_user: EndUser`is not in use ,remove it to fix bug

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| <img width="591" alt="image" src="https://github.com/user-attachments/assets/28fb68b9-2dab-4034-a808-4cfb1fa7cc4e" />  | <img width="713" alt="image" src="https://github.com/user-attachments/assets/81e04266-9fd3-425f-bc5e-db81dd69f476" />  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
