### PR TITLE
Feat/15534 support replacing the bot in chat input placeholder with the bots name

### DIFF
--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
@@ -99,7 +99,15 @@ const DebugWithMultipleModel = () => {
   }, [twoLine, threeLine, fourLine])
 
   const setShowAppConfigureFeaturesModal = useAppStore(s => s.setShowAppConfigureFeaturesModal)
-  const inputsForm = modelConfig.configs.prompt_variables.filter(item => item.type !== 'api').map(item => ({ ...item, label: item.name, variable: item.key })) as InputForm[]
+  const inputsForm = modelConfig.configs.prompt_variables
+    .filter(item => item.type !== 'api')
+    .map(item => ({
+      ...item,
+      label: item.name,
+      variable: item.key,
+      hide: item.hide ?? false,
+      required: item.required ?? false,
+    })) as InputForm[]
 
   return (
     <div className='flex h-full flex-col'>

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
@@ -133,6 +133,7 @@ const DebugWithMultipleModel = () => {
       {isChatMode && (
         <div className='shrink-0 px-6 pb-0'>
           <ChatInputArea
+            botName='Bot'
             showFeatureBar
             showFileUpload={false}
             onFeatureBarClick={setShowAppConfigureFeaturesModal}

--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -29,6 +29,7 @@ import type { FileUpload } from '@/app/components/base/features/types'
 import { TransferMethod } from '@/types/app'
 
 type ChatInputAreaProps = {
+  botName?: string
   showFeatureBar?: boolean
   showFileUpload?: boolean
   featureBarDisabled?: boolean
@@ -43,6 +44,7 @@ type ChatInputAreaProps = {
   disabled?: boolean
 }
 const ChatInputArea = ({
+  botName,
   showFeatureBar,
   showFileUpload,
   featureBarDisabled,
@@ -192,7 +194,7 @@ const ChatInputArea = ({
                 className={cn(
                   'body-lg-regular w-full resize-none bg-transparent p-1 leading-6 text-text-tertiary outline-none',
                 )}
-                placeholder={t('common.chat.inputPlaceholder') || ''}
+                placeholder={t('common.chat.inputPlaceholder', { botName }) || ''}
                 autoFocus
                 minRows={1}
                 onResize={handleTextareaResize}

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -303,6 +303,7 @@ const Chat: FC<ChatProps> = ({
             {
               !noChatInput && (
                 <ChatInputArea
+                  botName={appData?.site.title || ''}
                   disabled={inputDisabled}
                   showFeatureBar={showFeatureBar}
                   showFileUpload={showFileUpload}

--- a/web/i18n/de-DE/common.ts
+++ b/web/i18n/de-DE/common.ts
@@ -550,7 +550,7 @@ const translation = {
       vectorHash: 'Vektorhash:',
       hitScore: 'Abrufwertung:',
     },
-    inputPlaceholder: 'Sprechen Sie mit dem Bot',
+    inputPlaceholder: 'Sprechen Sie mit dem {{botName}}',
     thought: 'Gedanke',
     thinking: 'Denken...',
     resend: 'Erneut senden',

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -569,7 +569,7 @@ const translation = {
       vectorHash: 'Vector hash:',
       hitScore: 'Retrieval Score:',
     },
-    inputPlaceholder: 'Talk to Bot',
+    inputPlaceholder: 'Talk to {{botName}}',
     thinking: 'Thinking...',
     thought: 'Thought',
     resend: 'Resend',

--- a/web/i18n/es-ES/common.ts
+++ b/web/i18n/es-ES/common.ts
@@ -554,7 +554,7 @@ const translation = {
       vectorHash: 'Hash de vector:',
       hitScore: 'Puntuación de recuperación:',
     },
-    inputPlaceholder: 'Hablar con el bot',
+    inputPlaceholder: 'Hablar con el {{botName}}',
     thinking: 'Pensamiento...',
     thought: 'Pensamiento',
     resend: 'Reenviar',

--- a/web/i18n/fr-FR/common.ts
+++ b/web/i18n/fr-FR/common.ts
@@ -550,7 +550,7 @@ const translation = {
       vectorHash: 'Hachage vectoriel:',
       hitScore: 'Score de Récupération:',
     },
-    inputPlaceholder: 'Parler au bot',
+    inputPlaceholder: 'Parler au {{botName}}',
     thinking: 'Pensée...',
     thought: 'Pensée',
     resend: 'Renvoyer',

--- a/web/i18n/it-IT/common.ts
+++ b/web/i18n/it-IT/common.ts
@@ -581,7 +581,7 @@ const translation = {
       vectorHash: 'Hash del vettore:',
       hitScore: 'Punteggio di recupero:',
     },
-    inputPlaceholder: 'Parla con il bot',
+    inputPlaceholder: 'Parla con il {{botName}}',
     thinking: 'Pensante...',
     thought: 'Pensiero',
     resend: 'Reinvia',

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -570,7 +570,7 @@ const translation = {
       vectorHash: 'ベクトルハッシュ:',
       hitScore: '検索スコア:',
     },
-    inputPlaceholder: 'ボットと話す',
+    inputPlaceholder: '{{botName}} と話す',
     thought: '思考',
     thinking: '考え中...',
     resend: '再送信してください',

--- a/web/i18n/pl-PL/common.ts
+++ b/web/i18n/pl-PL/common.ts
@@ -565,7 +565,7 @@ const translation = {
       vectorHash: 'Wektor hash:',
       hitScore: 'Wynik trafień:',
     },
-    inputPlaceholder: 'Porozmawiaj z botem',
+    inputPlaceholder: 'Porozmawiaj z {{botName}}',
     thought: 'Myśl',
     thinking: 'Myślenie...',
     resend: 'Prześlij ponownie',

--- a/web/i18n/pt-BR/common.ts
+++ b/web/i18n/pt-BR/common.ts
@@ -550,7 +550,7 @@ const translation = {
       vectorHash: 'Hash de vetor:',
       hitScore: 'Pontuação de recuperação:',
     },
-    inputPlaceholder: 'Fale com o bot',
+    inputPlaceholder: 'Fale com o {{botName}}',
     thinking: 'Pensante...',
     thought: 'Pensamento',
     resend: 'Reenviar',

--- a/web/i18n/ro-RO/common.ts
+++ b/web/i18n/ro-RO/common.ts
@@ -550,7 +550,7 @@ const translation = {
       vectorHash: 'Hash vector:',
       hitScore: 'Scor de recuperare:',
     },
-    inputPlaceholder: 'Vorbește cu Bot',
+    inputPlaceholder: 'Vorbește cu {{botName}}',
     thinking: 'Gândire...',
     thought: 'Gând',
     resend: 'Reexpediați',

--- a/web/i18n/tr-TR/common.ts
+++ b/web/i18n/tr-TR/common.ts
@@ -554,7 +554,7 @@ const translation = {
       vectorHash: 'Vektör Hash:',
       hitScore: 'Geri Alım Skoru:',
     },
-    inputPlaceholder: 'Bot ile konuş',
+    inputPlaceholder: '{{botName}} ile konuş',
     thought: 'Düşünce',
     thinking: 'Düşünü...',
     resend: 'Yeniden gönder',

--- a/web/i18n/vi-VN/common.ts
+++ b/web/i18n/vi-VN/common.ts
@@ -550,7 +550,7 @@ const translation = {
       vectorHash: 'Vector hash:',
       hitScore: 'Điểm truy xuất:',
     },
-    inputPlaceholder: 'Nói chuyện với Bot',
+    inputPlaceholder: 'Nói chuyện với {{botName}}',
     thought: 'Tư duy',
     thinking: 'Suy nghĩ...',
     resend: 'Gửi lại',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -569,7 +569,7 @@ const translation = {
       vectorHash: '向量哈希：',
       hitScore: '召回得分：',
     },
-    inputPlaceholder: '和机器人聊天',
+    inputPlaceholder: '和 {{botName}} 聊天',
     thinking: '深度思考中...',
     thought: '已深度思考',
     resend: '重新发送',

--- a/web/i18n/zh-Hant/common.ts
+++ b/web/i18n/zh-Hant/common.ts
@@ -552,7 +552,7 @@ const translation = {
       vectorHash: '向量雜湊：',
       hitScore: '召回得分：',
     },
-    inputPlaceholder: '與 Bot 對話',
+    inputPlaceholder: '與 {{botName}} 對話',
     thinking: '思維。。。',
     thought: '思想',
     resend: '重新發送',

--- a/web/models/debug.ts
+++ b/web/models/debug.ts
@@ -59,6 +59,7 @@ export type PromptVariable = {
   config?: Record<string, any>
   icon?: string
   icon_background?: string
+  hide?: boolean // used in frontend to hide variable
 }
 
 export type CompletionParams = {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

to close #15534
## Summary
This pull request introduces enhancements to the chatbot configuration and user interface, focusing on improved customization and localization. The key changes include adding support for hiding and marking prompt variables as required, passing a customizable bot name to the chat input area, and updating translations to reflect this new functionality.

### Chatbot Configuration Enhancements:
* Updated `PromptVariable` type in `web/models/debug.ts` to include `hide` and `required` properties, enabling frontend customization for hiding variables and marking them as required.
* Modified `inputsForm` in `DebugWithMultipleModel` to map `hide` and `required` properties from `PromptVariable`.

### Chat Input Area Improvements:
* Added a `botName` property to the `ChatInputAreaProps` type in `web/app/components/base/chat/chat/chat-input-area/index.tsx`, allowing the placeholder text in the chat input to dynamically include the bot's name. [[1]](diffhunk://#diff-0f2fea1c6856ffaf8e9ad3be67d02e176e4ed92c585847813210b58a642c2767R32) [[2]](diffhunk://#diff-0f2fea1c6856ffaf8e9ad3be67d02e176e4ed92c585847813210b58a642c2767R47)
* Updated the placeholder in `ChatInputArea` to use the new `botName` property, enhancing user experience by personalizing the input field.

### Localization Updates:
* Updated the `inputPlaceholder` translation in multiple language files (e.g., `de-DE`, `en-US`, `es-ES`, etc.) to support dynamic insertion of the bot name using the `{{botName}}` placeholder. [[1]](diffhunk://#diff-7a9194266549a82aaf21ea87274cc9c268661980f0e668c0e4bfd0efb6219c3cL553-R553) [[2]](diffhunk://#diff-834afc54ad67c45f7cbcaf316e0fddab37b61a7dd741a2abff1a34e4ffdcb620L572-R572) [[3]](diffhunk://#diff-f7c6ddefe609696ace4faad8199532279489f4d909cf6d49520a5670c575cdb4L557-R557) [[4]](diffhunk://#diff-95501ca2adeda02b95aa49958bcbff0be8159993143c4d8a1bfe666f56e7218fL553-R553) and others)

### Integration with Chat Components:
* Passed the bot name (`appData?.site.title || 'Bot'`) to `ChatInputArea` in the `Chat` component and `DebugWithMultipleModel` component to ensure the bot name is used consistently across the application. [[1]](diffhunk://#diff-1997e9de3191a3a5147e5a628bb6b4bec22e6af48b4e3907a56d4a7fbcac73c4R306) [[2]](diffhunk://#diff-519d314e38314e3a4be322e9e2e72a53412d2ee9064341c1502d3c204f4fd8daR144)

## Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/aa4f568b-a4ee-40af-8f3e-def594e4383a) | ![image](https://github.com/user-attachments/assets/6190f7c2-b6d7-48ea-81f1-7444cf201eaa) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
