### PR TITLE
fix: the plugin order is not the same as passed to api in DSL

### DIFF
--- a/web/app/components/plugins/install-plugin/install-bundle/steps/install-multi.tsx
+++ b/web/app/components/plugins/install-plugin/install-bundle/steps/install-multi.tsx
@@ -83,7 +83,12 @@ const InstallByDSLList: FC<Props> = ({
 
   useEffect(() => {
     if (!isFetchingMarketplaceDataById && infoGetById?.data.plugins) {
-      const payloads = infoGetById?.data.plugins
+      const sortedList = allPlugins.filter(d => d.type === 'marketplace').map((d) => {
+        const p = d as GitHubItemAndMarketPlaceDependency
+        const id = p.value.marketplace_plugin_unique_identifier?.split(':')[0]
+        return infoGetById.data.plugins.find(item => item.plugin_id === id)!
+      })
+      const payloads = sortedList
       const failedIndex: number[] = []
       const nextPlugins = produce(pluginsRef.current, (draft) => {
         marketPlaceInDSLIndex.forEach((index, i) => {


### PR DESCRIPTION
Fixes #20514.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
