### PR TITLE
check zilliz cloud of full-text search

### DIFF
--- a/api/core/rag/datasource/vdb/milvus/milvus_vector.py
+++ b/api/core/rag/datasource/vdb/milvus/milvus_vector.py
@@ -97,6 +97,10 @@ class MilvusVector(BaseVector):
 
         try:
             milvus_version = self._client.get_server_version()
+            # Check if it's Zilliz Cloud - it supports full-text search with Milvus 2.5 compatibility
+            if "Zilliz Cloud" in milvus_version:
+                return True
+            # For standard Milvus installations, check version number
             return version.parse(milvus_version).base_version >= version.parse("2.5.0").base_version
         except Exception as e:
             logger.warning(f"Failed to check Milvus version: {str(e)}. Disabling hybrid search.")


### PR DESCRIPTION
Zilliz Cloud currently support full-text search ability. In the `_check_hybrid_search_support()` method, when the Milvus server is Zilliz Cloud, the return of `self._client.get_server_version()` is kindof str like this : 
![image](https://github.com/user-attachments/assets/a798d276-34de-4dd9-b546-88f834d3e669)

So we add the zilliz cloud compatibility here to support dify & zilliz integration with fulltext search and hybrid search.
