### PR TITLE
fix(housekeeping): exclude files that are used as app icons or avatar images from being removed

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -846,6 +846,9 @@ def clear_orphaned_file_records(force: bool):
         {"type": "text", "table": "workflow_node_executions", "column": "outputs"},
         {"type": "text", "table": "conversations", "column": "introduction"},
         {"type": "text", "table": "conversations", "column": "system_instruction"},
+        {"type": "text", "table": "accounts", "column": "avatar"},
+        {"type": "text", "table": "apps", "column": "icon"},
+        {"type": "text", "table": "sites", "column": "icon"},
         {"type": "json", "table": "messages", "column": "inputs"},
         {"type": "json", "table": "messages", "column": "message"},
     ]


### PR DESCRIPTION
## Summary

This PR updates the housekeeping commands to prevent them from removing images that are in use as app icons or avatar images, by additionally gathering files on following columns in tables:

- `avatar` column in `accounts` table
- `icon` column in `apps` and `sites` tables

Closes #20531

## Screenshots

**Before**: The command removes app icon and avator images.

```bash
> docker exec -it docker-api-1 flask clear-orphaned-file-records
...
Starting orphaned file records cleanup.
- Listing message_files records where message_id doesn't exist in messages table
No orphaned message_files records found. There is nothing to delete.
- Listing file records in table upload_files
- Listing file records in table tool_files
Found 2 files in tables.
- Listing file ids in column upload_file_id in table message_files
- Listing file-id-like strings in column data_source_info in table documents
- Listing file-id-like strings in column content in table document_segments
- Listing file-id-like strings in column answer in table messages
- Listing file-id-like strings in column inputs in table workflow_node_executions
- Listing file-id-like strings in column process_data in table workflow_node_executions
- Listing file-id-like strings in column outputs in table workflow_node_executions
- Listing file-id-like strings in column introduction in table conversations
- Listing file-id-like strings in column system_instruction in table conversations
- Listing file-id-like JSON string in column inputs in table messages
- Listing file-id-like JSON string in column message in table messages
Found 0 file ids in tables.
Found 2 orphaned file records.     👈👈👈
- orphaned file id: b28c6aac-cacd-428d-89eb-634856670ce4
- orphaned file id: c139c5f7-c1e1-400d-9e4c-816defae395a
Do you want to proceed to delete all 2 orphaned file records? [y/N]: y
- Deleting orphaned file records in table upload_files
- Deleting orphaned file records in table tool_files
Removed 2 orphaned file records.     👈👈👈
```

**After**: The command keeps images for the app icon, site icon, and avator image.

```bash
> docker exec -it docker-api-1 flask clear-orphaned-file-records
...
Starting orphaned file records cleanup.
- Listing message_files records where message_id doesn't exist in messages table
No orphaned message_files records found. There is nothing to delete.
- Listing file records in table upload_files
- Listing file records in table tool_files
Found 3 files in tables.
- Listing file ids in column upload_file_id in table message_files
- Listing file-id-like strings in column data_source_info in table documents
- Listing file-id-like strings in column content in table document_segments
- Listing file-id-like strings in column answer in table messages
- Listing file-id-like strings in column inputs in table workflow_node_executions
- Listing file-id-like strings in column process_data in table workflow_node_executions
- Listing file-id-like strings in column outputs in table workflow_node_executions
- Listing file-id-like strings in column introduction in table conversations
- Listing file-id-like strings in column system_instruction in table conversations
- Listing file-id-like strings in column avatar in table accounts     👈👈👈
- Listing file-id-like strings in column icon in table apps     👈👈👈
- Listing file-id-like strings in column icon in table sites     👈👈👈
- Listing file-id-like JSON string in column inputs in table messages
- Listing file-id-like JSON string in column message in table messages
Found 3 file ids in tables.
No orphaned file records found. There is nothing to delete.     👈👈👈
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
