### PR TITLE
fixes #19634

### DIFF
--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -28,7 +28,8 @@ class SMTPClient:
             else:
                 smtp = smtplib.SMTP(self.server, self.port, timeout=10)
 
-            if self.username and self.password:
+            # Only authenticate if both username and password are non-empty
+            if self.username and self.password and self.username.strip() and self.password.strip():
                 smtp.login(self.username, self.password)
 
             msg = MIMEMultipart()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
This MR fixes an issue where SMTP authentication is attempted even when SMTP_USERNAME and SMTP_PASSWORD are not set, causing failures with SMTP servers that don't support AUTH. The logic is updated to skip smtp.login() when credentials are empty, allowing successful email delivery in such environments. This ensures better compatibility for self-hosted deployments using unauthenticated SMTP relays.

fixes #19634 

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
