### PR TITLE
Fix 500 error

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -18,6 +18,7 @@ from flask_restful import fields
 from configs import dify_config
 from core.app.features.rate_limiting.rate_limit import RateLimitGenerator
 from core.file import helpers as file_helpers
+from core.model_runtime.utils.encoders import jsonable_encoder
 from extensions.ext_redis import redis_client
 
 if TYPE_CHECKING:
@@ -196,7 +197,7 @@ def generate_text_hash(text: str) -> str:
 
 def compact_generate_response(response: Union[Mapping, Generator, RateLimitGenerator]) -> Response:
     if isinstance(response, dict):
-        return Response(response=json.dumps(response), status=200, mimetype="application/json")
+        return Response(response=json.dumps(jsonable_encoder(response)), status=200, mimetype="application/json")
     else:
 
         def generate() -> Generator:


### PR DESCRIPTION
## Summary

I meet below 500 error in today's main version, it should be introduced in last 24 hours.

Fix https://github.com/langgenius/dify/issues/20626

# AI fix (notice it's maybe wrong)
_Exported on 6/4/2025 at 10:11:25 GMT+8 from Cursor (0.50.7)_

---

**User**

TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='影响'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='电脑'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='性能'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='。\n'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='</think>'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='\n\n'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='未'), TextPromptMessageContent(type=<PromptMessageContentType.TEXT: 'text'>, data='找到')]
Model: qwen3:30b
Usage: prompt_tokens=113 prompt_unit_price=Decimal('0') prompt_price_unit=Decimal('0') prompt_price=Decimal('0') completion_tokens=316 completion_unit_price=Decimal('0') completion_price_unit=Decimal('0') completion_price=Decimal('0') total_tokens=429 total_price=Decimal('0') currency='USD' latency=3.2926986489910632
System Fingerprint: None

[NodeRunSucceededEvent]
Node ID: llm
Node Title: LLM
Type: llm
Inputs: 
Process Data: {'model_mode': 'chat', 'prompts': [{'role': 'system', 'text': '你是一个合同智能录入审查助手，这是一份合同：\n\n``````\n[]\n``````\n\n\n请帮我选择“合同类型”；\n合同类型选项包括：\n经营合同\n备案合同\n文本制作、模型效果图、晒图费合同\n战略协议\n``````\n输出选项，不要包含“合同类型是……”类似的表述；\n如果无法提取，输出“未找到”；\n输出结果时，不要包含任何XML标签或其他格式标记。\n``````', 'files': []}, {'role': 'user', 'text': '电脑速度慢', 'files': []}], 'model_provider': 'langgenius/ollama/ollama', 'model_name': 'qwen3:30b'}
Outputs: {'text': '<think>\n好的，用户现在说“电脑速度慢”，我需要分析这个问题。首先，用户之前提到的是合同智能录入审查助手，但现在的查询是关于电脑速度慢的。这可能意味着用户可能在使用某个软件或系统时遇到了性能问题，导致合同处理变慢。\n\n接下来，我需要考虑用户可能的场景。用户可能在使用合同管理软件，或者是在处理大量合同数据时，电脑响应变慢。也有可能用户在使用某个特定的工具，比如Excel或其他文档处理软件，导致电脑速度下降。\n\n用户的身份可能是企业员工、自由职业者或管理者，他们需要处理合同，但电脑性能不足影响了工作效率。用户的需求不仅仅是解决电脑速度慢的问题，可能还希望确保合同处理流程不受影响，或者需要优化系统以提高效率。\n\n深层需求可能包括：希望快速诊断电脑问题，找到根本原因，比如硬件不足、软件冲突、病毒或后台进程占用资源。用户可能需要具体的解决方案，比如升级硬件、清理磁盘、关闭不必要的程序，或者检查是否有恶意软件。\n\n另外，用户可能没有明确说明电脑的具体情况，比如操作系统、硬件配置、是否最近安装了新软件等，这些信息对诊断问题很重要。但用户可能不了解技术细节，所以需要简单易懂的建议。\n\n最后，我需要确保回答准确，提供可行的步骤，同时避免使用专业术语，让用户容易理解。可能还需要提醒用户如果问题持续，可能需要专业帮助，或者检查是否有其他因素影响电脑性能。\n</think>\n\n未找到', 'usage': {'prompt_tokens': 113, 'prompt_unit_price': '0', 'prompt_price_unit': '0', 'prompt_price': '0', 'completion_tokens': 316, 'completion_unit_price': '0', 'completion_price_unit': '0', 'completion_price': '0', 'total_tokens': 429, 'total_price': '0', 'currency': 'USD', 'latency': 3.2926986489910632}, 'finish_reason': 'stop', 'files': []}
Metadata: {'total_tokens': 429, 'total_price': '0', 'currency': 'USD'}

[NodeRunStartedEvent]
Node ID: answer
Node Title: 直接回复
Type: answer

[NodeRunSucceededEvent]
Node ID: answer
Node Title: 直接回复
Type: answer
Inputs: 
Process Data: 
Outputs: {'answer': '<think>\n好的，用户现在说“电脑速度慢”，我需要分析这个问题。首先，用户之前提到的是合同智能录入审查助手，但现在的查询是关于电脑速度慢的。这可能意味着用户可能在使用某个软件或系统时遇到了性能问题，导致合同处理变慢。\n\n接下来，我需要考虑用户可能的场景。用户可能在使用合同管理软件，或者是在处理大量合同数据时，电脑响应变慢。也有可能用户在使用某个特定的工具，比如Excel或其他文档处理软件，导致电脑速度下降。\n\n用户的身份可能是企业员工、自由职业者或管理者，他们需要处理合同，但电脑性能不足影响了工作效率。用户的需求不仅仅是解决电脑速度慢的问题，可能还希望确保合同处理流程不受影响，或者需要优化系统以提高效率。\n\n深层需求可能包括：希望快速诊断电脑问题，找到根本原因，比如硬件不足、软件冲突、病毒或后台进程占用资源。用户可能需要具体的解决方案，比如升级硬件、清理磁盘、关闭不必要的程序，或者检查是否有恶意软件。\n\n另外，用户可能没有明确说明电脑的具体情况，比如操作系统、硬件配置、是否最近安装了新软件等，这些信息对诊断问题很重要。但用户可能不了解技术细节，所以需要简单易懂的建议。\n\n最后，我需要确保回答准确，提供可行的步骤，同时避免使用专业术语，让用户容易理解。可能还需要提醒用户如果问题持续，可能需要专业帮助，或者检查是否有其他因素影响电脑性能。\n</think>\n\n未找到', 'files': []}
Metadata: 

```
[GraphRunSucceededEvent]
2025-06-04 01:53:50,111 ERROR [completion.py:142] fed514204b internal server error.
Traceback (most recent call last):
  File "/home/dify/dify/api/controllers/service_api/app/completion.py", line 121, in post
    return helper.compact_generate_response(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/libs/helper.py", line 199, in compact_generate_response
    return Response(response=json.dumps(response), status=200, mimetype="application/json")
                             ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Decimal is not JSON serializable
2025-06-04 01:53:50,113 ERROR [app.py:875] fed514204b Exception on /v1/chat-messages [POST]
Traceback (most recent call last):
  File "/home/dify/dify/api/controllers/service_api/app/completion.py", line 121, in post
    return helper.compact_generate_response(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/libs/helper.py", line 199, in compact_generate_response
    return Response(response=json.dumps(response), status=200, mimetype="application/json")
                             ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Decimal is not JSON serializable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask_restful/__init__.py", line 489, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask_restful/__init__.py", line 604, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/controllers/service_api/wraps.py", line 109, in decorated_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/controllers/service_api/app/completion.py", line 143, in post
    raise InternalServerError()
werkzeug.exceptions.InternalServerError: 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
2025-06-04 01:53:50,116 INFO [_internal.py:97]  172.26.11.10 - - [04/Jun/2025 01:53:50] "POST /v1/chat-messages HTTP/1.1" 500 -
```

[on_llm_after_invoke]
Content: ```json
{
  "Language Type": "Chinese",
  "Your Reasoning": "输入为简体中文，表达了对电脑速度慢的关注。",
  "Your Output": "电脑提速方案"
}
```
Model: deepseek-chat
Usage: prompt_tokens=200 prompt_unit_price=Decimal('2') prompt_price_unit=Decimal('0.000001') prompt_price=Decimal('0.0004') completion_tokens=43 completion_unit_price=Decimal('8') completion_price_unit=Decimal('0.000001') completion_price=Decimal('0.000344') total_tokens=243 total_price=Decimal('0.000744') currency='RMB' latency=5.743470022978727
System Fingerprint: 


---

**Cursor**

I notice there's an error in the application related to JSON serialization of Decimal objects. Let me help investigate and fix this issue.

First, I'll search for relevant code that handles the response serialization:


I see the issue. The error occurs because we're trying to serialize a Decimal object directly to JSON, which isn't supported by default. Looking at the code, there's already a `jsonable_encoder` function in `dify/api/core/model_runtime/utils/encoders.py` that handles Decimal serialization, but it's not being used in the `compact_generate_response` function.

Let me modify the `compact_generate_response` function to use the proper encoder:


```python
// ... existing code ...
from core.model_runtime.utils.encoders import jsonable_encoder

def compact_generate_response(response: Union[Mapping, Generator, RateLimitGenerator]) -> Response:
    if isinstance(response, dict):
        return Response(response=json.dumps(jsonable_encoder(response)), status=200, mimetype="application/json")
    else:
        def generate() -> Generator:
            yield from response

        return Response(stream_with_context(generate()), status=200, mimetype="text/event-stream")
// ... existing code ...
```

I've modified the `compact_generate_response` function to use `jsonable_encoder` before JSON serialization. This encoder properly handles Decimal objects by converting them to strings using the format "f" (fixed-point notation).

The change should fix the JSON serialization error you're seeing. The error occurred because the response contained Decimal objects in the usage statistics (like `prompt_price`, `completion_price`, etc.), which can't be directly serialized to JSON. Now, these Decimal values will be properly converted to strings before JSON serialization.

Would you like me to help you test this change or is there anything else you'd like me to explain about the fix?


