### PR TITLE
chore: fix some security issues in markdown

### DIFF
--- a/web/app/components/base/markdown-blocks/button.tsx
+++ b/web/app/components/base/markdown-blocks/button.tsx
@@ -1,7 +1,7 @@
 import { useChatContext } from '@/app/components/base/chat/chat/context'
 import Button from '@/app/components/base/button'
 import cn from '@/utils/classnames'
-
+import { isValidUrl } from './utils'
 const MarkdownButton = ({ node }: any) => {
   const { onSend } = useChatContext()
   const variant = node.properties.dataVariant
@@ -9,25 +9,17 @@ const MarkdownButton = ({ node }: any) => {
   const link = node.properties.dataLink
   const size = node.properties.dataSize
 
-  function is_valid_url(url: string): boolean {
-    try {
-      const parsed_url = new URL(url)
-      return ['http:', 'https:'].includes(parsed_url.protocol)
-    }
-    catch {
-      return false
-    }
-  }
-
   return <Button
     variant={variant}
     size={size}
     className={cn('!h-auto min-h-8 select-none whitespace-normal !px-3')}
     onClick={() => {
-      if (is_valid_url(link)) {
+      if (isValidUrl(link)) {
         window.open(link, '_blank')
         return
       }
+      if(!message)
+        return
       onSend?.(message)
     }}
   >

--- a/web/app/components/base/markdown-blocks/link.tsx
+++ b/web/app/components/base/markdown-blocks/link.tsx
@@ -5,6 +5,7 @@
  */
 import React from 'react'
 import { useChatContext } from '@/app/components/base/chat/chat/context'
+import { isValidUrl } from './utils'
 
 const Link = ({ node, children, ...props }: any) => {
   const { onSend } = useChatContext()
@@ -14,7 +15,11 @@ const Link = ({ node, children, ...props }: any) => {
     return <abbr className="cursor-pointer underline !decoration-primary-700 decoration-dashed" onClick={() => onSend?.(hidden_text)} title={node.children[0]?.value || ''}>{node.children[0]?.value || ''}</abbr>
   }
   else {
-    return <a {...props} target="_blank" className="cursor-pointer underline !decoration-primary-700 decoration-dashed">{children || 'Download'}</a>
+    const href = props.href || node.properties?.href
+    if(!isValidUrl(href))
+      return <span>{children}</span>
+
+    return <a href={href} target="_blank" className="cursor-pointer underline !decoration-primary-700 decoration-dashed">{children || 'Download'}</a>
   }
 }
 

--- a/web/app/components/base/markdown-blocks/utils.ts
+++ b/web/app/components/base/markdown-blocks/utils.ts
@@ -1,9 +1,3 @@
 export const isValidUrl = (url: string): boolean => {
-  try {
-    const parsed_url = new URL(url)
-    return ['http:', 'https:'].includes(parsed_url.protocol)
-  }
-  catch {
-    return false
-  }
+  return ['http:', 'https:', '//', 'mailto:'].some(prefix => url.startsWith(prefix))
 }

--- a/web/app/components/base/markdown-blocks/utils.ts
+++ b/web/app/components/base/markdown-blocks/utils.ts
@@ -1,0 +1,9 @@
+export const isValidUrl = (url: string): boolean => {
+  try {
+    const parsed_url = new URL(url)
+    return ['http:', 'https:'].includes(parsed_url.protocol)
+  }
+  catch {
+    return false
+  }
+}


### PR DESCRIPTION
Fixed the following issues in the Markdown:
1. If  Button element is missing the `data-message` attribute, which causes the page to crash.
2. Passing the `style` and other props to the A element which may introduce security vulnerabilities.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
