### PR TITLE
fix(markdown): Ensure abbr: links render correctly in react-markdown v9+

### DIFF
--- a/web/app/components/base/markdown/index.tsx
+++ b/web/app/components/base/markdown/index.tsx
@@ -7,7 +7,7 @@ import RemarkGfm from 'remark-gfm'
 import RehypeRaw from 'rehype-raw'
 import { flow } from 'lodash-es'
 import cn from '@/utils/classnames'
-import { preprocessLaTeX, preprocessThinkTag } from './markdown-utils'
+import { preprocessLaTeX, preprocessThinkTag, customUrlTransform } from './markdown-utils'
 import {
   AudioBlock,
   CodeBlock,
@@ -65,6 +65,7 @@ export function Markdown(props: { content: string; className?: string; customDis
             }
           },
         ]}
+        urlTransform={customUrlTransform}
         disallowedElements={['iframe', 'head', 'html', 'meta', 'link', 'style', 'body', ...(props.customDisallowedElements || [])]}
         components={{
           code: CodeBlock,

--- a/web/app/components/base/markdown/index.tsx
+++ b/web/app/components/base/markdown/index.tsx
@@ -7,7 +7,7 @@ import RemarkGfm from 'remark-gfm'
 import RehypeRaw from 'rehype-raw'
 import { flow } from 'lodash-es'
 import cn from '@/utils/classnames'
-import { preprocessLaTeX, preprocessThinkTag, customUrlTransform } from './markdown-utils'
+import { customUrlTransform, preprocessLaTeX, preprocessThinkTag } from './markdown-utils'
 import {
   AudioBlock,
   CodeBlock,

--- a/web/app/components/base/markdown/markdown-utils.ts
+++ b/web/app/components/base/markdown/markdown-utils.ts
@@ -55,38 +55,33 @@ export const preprocessThinkTag = (content: string) => {
  *    signal that the URI should be removed/disallowed by react-markdown.
  */
 export const customUrlTransform = (uri: string): string | undefined => {
-  const PERMITTED_SCHEME_REGEX = /^(https?|ircs?|mailto|xmpp|abbr):$/i;
+  const PERMITTED_SCHEME_REGEX = /^(https?|ircs?|mailto|xmpp|abbr):$/i
 
-  if (uri.startsWith('#')) {
-    return uri;
-  }
+  if (uri.startsWith('#'))
+    return uri
 
-  if (uri.startsWith('//')) {
-    return uri;
-  }
+  if (uri.startsWith('//'))
+    return uri
 
-  const colonIndex = uri.indexOf(':');
+  const colonIndex = uri.indexOf(':')
 
-  if (colonIndex === -1) {
-    return uri;
-  }
+  if (colonIndex === -1)
+    return uri
 
-  const slashIndex = uri.indexOf('/');
-  const questionMarkIndex = uri.indexOf('?');
-  const hashIndex = uri.indexOf('#');
+  const slashIndex = uri.indexOf('/')
+  const questionMarkIndex = uri.indexOf('?')
+  const hashIndex = uri.indexOf('#')
 
   if (
     (slashIndex !== -1 && colonIndex > slashIndex) ||
     (questionMarkIndex !== -1 && colonIndex > questionMarkIndex) ||
     (hashIndex !== -1 && colonIndex > hashIndex)
-  ) {
-    return uri;
-  }
+  )
+    return uri
 
-  const scheme = uri.substring(0, colonIndex + 1).toLowerCase();
-  if (PERMITTED_SCHEME_REGEX.test(scheme)) {
-    return uri;
-  }
+  const scheme = uri.substring(0, colonIndex + 1).toLowerCase()
+  if (PERMITTED_SCHEME_REGEX.test(scheme))
+    return uri
 
-  return undefined;
+  return undefined
 }

--- a/web/app/components/base/markdown/markdown-utils.ts
+++ b/web/app/components/base/markdown/markdown-utils.ts
@@ -73,9 +73,9 @@ export const customUrlTransform = (uri: string): string | undefined => {
   const hashIndex = uri.indexOf('#')
 
   if (
-    (slashIndex !== -1 && colonIndex > slashIndex) ||
-    (questionMarkIndex !== -1 && colonIndex > questionMarkIndex) ||
-    (hashIndex !== -1 && colonIndex > hashIndex)
+    (slashIndex !== -1 && colonIndex > slashIndex)
+    || (questionMarkIndex !== -1 && colonIndex > questionMarkIndex)
+    || (hashIndex !== -1 && colonIndex > hashIndex)
   )
     return uri
 

--- a/web/app/components/base/markdown/markdown-utils.ts
+++ b/web/app/components/base/markdown/markdown-utils.ts
@@ -36,3 +36,57 @@ export const preprocessThinkTag = (content: string) => {
     (str: string) => str.replace(/(<\/details>)(?![^\S\r\n]*[\r\n])(?![^\S\r\n]*$)/g, '$1\n'),
   ])(content)
 }
+
+/**
+ * Transforms a URI for use in react-markdown, ensuring security and compatibility.
+ * This function is designed to work with react-markdown v9+ which has stricter
+ * default URL handling.
+ *
+ * Behavior:
+ * 1. Always allows the custom 'abbr:' protocol.
+ * 2. Always allows page-local fragments (e.g., "#some-id").
+ * 3. Always allows protocol-relative URLs (e.g., "//example.com/path").
+ * 4. Always allows purely relative paths (e.g., "path/to/file", "/abs/path").
+ * 5. Allows absolute URLs if their scheme is in a permitted list (case-insensitive):
+ *    'http:', 'https:', 'mailto:', 'xmpp:', 'irc:', 'ircs:'.
+ * 6. Intelligently distinguishes colons used for schemes from colons within
+ *    paths, query parameters, or fragments of relative-like URLs.
+ * 7. Returns the original URI if allowed, otherwise returns `undefined` to
+ *    signal that the URI should be removed/disallowed by react-markdown.
+ */
+export const customUrlTransform = (uri: string): string | undefined => {
+  const PERMITTED_SCHEME_REGEX = /^(https?|ircs?|mailto|xmpp|abbr):$/i;
+
+  if (uri.startsWith('#')) {
+    return uri;
+  }
+
+  if (uri.startsWith('//')) {
+    return uri;
+  }
+
+  const colonIndex = uri.indexOf(':');
+
+  if (colonIndex === -1) {
+    return uri;
+  }
+
+  const slashIndex = uri.indexOf('/');
+  const questionMarkIndex = uri.indexOf('?');
+  const hashIndex = uri.indexOf('#');
+
+  if (
+    (slashIndex !== -1 && colonIndex > slashIndex) ||
+    (questionMarkIndex !== -1 && colonIndex > questionMarkIndex) ||
+    (hashIndex !== -1 && colonIndex > hashIndex)
+  ) {
+    return uri;
+  }
+
+  const scheme = uri.substring(0, colonIndex + 1).toLowerCase();
+  if (PERMITTED_SCHEME_REGEX.test(scheme)) {
+    return uri;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Fixes #16243

## Summary

In the early Dify version 0.15.3 (using react-markdown: "^8.0.6"), custom URL schemes like [next advice](abbr:next%20advice) and [advice](abbr:advice) rendered as interactive links as intended. However, when later Dify versions upgraded to React-Markdown v9+, stricter default URL filtering (a security improvement) inadvertently removed support for schemes like abbr:. Consequently, these links no longer render interactively, impacting user experience.

This commit introduces a `customUrlTransform` function, now strategically located in `web/app/components/base/markdown/markdown-utils.ts` for better code organization. This function is passed to the `ReactMarkdown` component's `urlTransform` prop.

The `customUrlTransform` function ensures that:
- The custom 'abbr:' protocol is explicitly allowed, restoring its functionality.
- Standard safe web protocols (http, https, mailto, xmpp, irc, ircs) continue to be permitted.
- Page-local fragments (#), protocol-relative URLs (//), and all purely relative paths are correctly handled and allowed.
- Other potentially unsafe or unsupported URL schemes are disallowed by returning `undefined`, prompting `react-markdown` to remove the link or `href` attribute.

This change restores the intended functionality for 'abbr:' links, allowing users to interact with them as designed, while maintaining robust URL handling and security for the Markdown rendering component. The solution is self-contained and does not rely on external dummy URLs for parsing, making it suitable for self-hosted deployments.

## Screenshots

https://github.com/user-attachments/assets/6e41763c-7e80-4300-a84c-ea4480341a92

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. *(自测已覆盖多种URL场景)*
- [] I've updated the documentation accordingly. *(如果此更改不直接影响用户文档，则此项可能不适用，或指内部开发者文档)*
- [] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods