### PR TITLE
revert weaviate-client version to speed up knowledge store search

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -199,6 +199,6 @@ vdb = [
     "tidb-vector==0.0.9",
     "upstash-vector==0.6.0",
     "volcengine-compat~=1.0.0",
-    "weaviate-client~=3.24.0",
+    "weaviate-client~=3.21.0",
     "xinference-client~=1.2.2",
 ]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -6383,16 +6383,17 @@ wheels = [
 
 [[package]]
 name = "weaviate-client"
-version = "3.24.2"
+version = "3.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "requests" },
+    { name = "tqdm" },
     { name = "validators" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/c1/3285a21d8885f2b09aabb65edb9a8e062a35c2d7175e1bb024fa096582ab/weaviate-client-3.24.2.tar.gz", hash = "sha256:6914c48c9a7e5ad0be9399271f9cb85d6f59ab77476c6d4e56a3925bf149edaa", size = 199332 }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a5/c6777a8507249d7a63f4f5d9696eb5f45beac87db0eddfa4438d408cc3b4/weaviate-client-3.21.0.tar.gz", hash = "sha256:ec94ac554883c765e94da8b2947c4f0fa4a0378ed3bbe9f3653df3a5b1745a6d", size = 186970 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/98/3136d05f93e30cf29e1db280eaadf766df18d812dfe7994bcced653b2340/weaviate_client-3.24.2-py3-none-any.whl", hash = "sha256:bc50ca5fcebcd48de0d00f66700b0cf7c31a97c4cd3d29b4036d77c5d1d9479b", size = 107968 },
+    { url = "https://files.pythonhosted.org/packages/df/5b/57b55ad36eb071b57e79f1ea7fba5bfe6a2fe49702607f56726569665d60/weaviate_client-3.21.0-py3-none-any.whl", hash = "sha256:420444ded7106fb000f4f8b2321b5f5fa2387825aa7a303d702accf61026f9d2", size = 99944 },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

In his PR(https://github.com/langgenius/dify/pull/19003) the weaviate-client bump the  from 3.21.0 to 3.24.2.

And the weaviate-client 3.24.0(https://github.com/weaviate/weaviate-python-client/commit/254cb85b2ebcc9500fd362adfeff4d4e3ae72528) introduce a new warning check to call pypi.org for getting latest verison when initing the client. The pypi HTTP request will take several seconds to finish, and even worse in CN(sometimes ~10 sec in my local test).
Here is the debug log for my local test:
```
2025-06-04 09:03:13.955 DEBUG [ThreadPoolExecutor-10_0] [connectionpool.py:241] - Starting new HTTP connection (1): weaviate:8080
2025-06-04 09:03:13.955 DEBUG [ThreadPoolExecutor-10_0] [connectionpool.py:544] - http://weaviate:8080 "GET /v1/meta HTTP/1.1" 200 64
2025-06-04 09:03:13.956 DEBUG [ThreadPoolExecutor-10_0] [connectionpool.py:1049] - Starting new HTTPS connection (1): pypi.org:443
2025-06-04 09:03:15.164 DEBUG [ThreadPoolExecutor-10_0] [connectionpool.py:544] - https://pypi.org:443 "GET /pypi/weaviate-client/json HTTP/1.1" 200 70887
```

There are several issues(https://github.com/langgenius/dify/issues/19839) reporting the slow knowledge store search for default weaviate setting after dify 1.4.0. 

Since the original PR to bump the  weaviate-client is irrelevance, we revert the verison in this PR. Another option is bump weaviate-client to >v3.24.2 which set th pypi http call timeout to 1 second,  or latest version v3.26.7 which remove the warning check,  but it will change lots of dependencies.

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
