### PR TITLE
Fix builtin_providers for tools.

### DIFF
--- a/api/core/tools/builtin_tool/_position.yaml
+++ b/api/core/tools/builtin_tool/_position.yaml
@@ -1,3 +1,4 @@
+- audio
 - code
 - time
-- qrcode
+- webscraper


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
1 : should add builtin_providers .
![image](https://github.com/user-attachments/assets/e0a1b9c0-6531-489d-a3f6-b08b14c5e3ab)

2:   "qrcode" is deleted , and lack “audio,webscraper” 
![image](https://github.com/user-attachments/assets/95e54a46-ffc2-44a2-8705-fdd24c77f6f6)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
