### PR TITLE
fix: add environment variable POSTGRES_USER

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -816,6 +816,8 @@ TEXT_GENERATION_TIMEOUT_MS=60000
 # ------------------------------
 
 PGUSER=${DB_USERNAME}
+# The name of the default postgres user.
+POSTGRES_USER=${DB_USERNAME}
 # The password for the default postgres user.
 POSTGRES_PASSWORD=${DB_PASSWORD}
 # The name of the default postgres database.

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -85,6 +85,7 @@ services:
     restart: always
     environment:
       PGUSER: ${PGUSER:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-difyai123456}
       POSTGRES_DB: ${POSTGRES_DB:-dify}
       PGDATA: ${PGDATA:-/var/lib/postgresql/data/pgdata}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -357,6 +357,7 @@ x-shared-env: &shared-api-worker-env
   MAX_ITERATIONS_NUM: ${MAX_ITERATIONS_NUM:-99}
   TEXT_GENERATION_TIMEOUT_MS: ${TEXT_GENERATION_TIMEOUT_MS:-60000}
   PGUSER: ${PGUSER:-${DB_USERNAME}}
+  POSTGRES_USER: ${POSTGRES_USER:-${DB_USERNAME}}
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-${DB_PASSWORD}}
   POSTGRES_DB: ${POSTGRES_DB:-${DB_DATABASE}}
   PGDATA: ${PGDATA:-/var/lib/postgresql/data/pgdata}
@@ -591,6 +592,7 @@ services:
     restart: always
     environment:
       PGUSER: ${PGUSER:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-difyai123456}
       POSTGRES_DB: ${POSTGRES_DB:-dify}
       PGDATA: ${PGDATA:-/var/lib/postgresql/data/pgdata}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fixes #9888
follow-up #12139

> Connection errors were generated when I ran docker compose locally (cannot connect as user postgres)
> The Postgres docker doc clearly states that the user name should be POSTGRES_USER:
> https://hub.docker.com/_/postgres

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
