### PR TITLE
🐛 Fix(Gemini LLM): Support Gemini 0.2.x plugin on agent app

### DIFF
--- a/api/core/app/apps/base_app_runner.py
+++ b/api/core/app/apps/base_app_runner.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from collections.abc import Generator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
@@ -32,6 +33,8 @@ from models.model import App, AppMode, Message, MessageAnnotation
 
 if TYPE_CHECKING:
     from core.file.models import File
+
+_logger = logging.getLogger(__name__)
 
 
 class AppRunner:
@@ -298,7 +301,7 @@ class AppRunner:
         )
 
     def _handle_invoke_result_stream(
-        self, invoke_result: Generator, queue_manager: AppQueueManager, agent: bool
+        self, invoke_result: Generator[LLMResultChunk, None, None], queue_manager: AppQueueManager, agent: bool
     ) -> None:
         """
         Handle invoke result
@@ -317,25 +320,28 @@ class AppRunner:
             else:
                 queue_manager.publish(QueueAgentMessageEvent(chunk=result), PublishFrom.APPLICATION_MANAGER)
 
-            if isinstance(result.delta.message.content, str):
-                text += result.delta.message.content
-            elif isinstance(result.delta.message.content, list):
-                for content in result.delta.message.content:
+            message = result.delta.message
+            if isinstance(message.content, str):
+                text += message.content
+            elif isinstance(message.content, list):
+                for content in message.content:
                     if not isinstance(content, str):
+                        # TODO(QuantumGhost): Add multimodal output support for easy ui.
+                        _logger.warning("received multimodal output, type=%s", type(content))
                         text += content.data
                     else:
-                        text += str(content)  # failback to str
+                        text += content  # failback to str
 
             if not model:
                 model = result.model
 
             if not prompt_messages:
-                prompt_messages = result.prompt_messages
+                prompt_messages = list(result.prompt_messages)
 
             if result.delta.usage:
                 usage = result.delta.usage
 
-        if not usage:
+        if usage is None:
             usage = LLMUsage.empty_usage()
 
         llm_result = LLMResult(

--- a/api/core/app/apps/base_app_runner.py
+++ b/api/core/app/apps/base_app_runner.py
@@ -317,7 +317,14 @@ class AppRunner:
             else:
                 queue_manager.publish(QueueAgentMessageEvent(chunk=result), PublishFrom.APPLICATION_MANAGER)
 
-            text += result.delta.message.content
+            if isinstance(result.delta.message.content, str):
+                text += result.delta.message.content
+            elif isinstance(result.delta.message.content, list):
+                for content in result.delta.message.content:
+                    if not isinstance(content, str):
+                        text += content.data
+                    else:
+                        text += str(content)  # failback to str
 
             if not model:
                 model = result.model

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -48,6 +48,7 @@ from core.model_manager import ModelInstance
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from core.model_runtime.entities.message_entities import (
     AssistantPromptMessage,
+    TextPromptMessageContent,
 )
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.ops.entities.trace_entity import TraceTaskName
@@ -309,6 +310,23 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
                 delta_text = chunk.delta.message.content
                 if delta_text is None:
                     continue
+                if isinstance(chunk.delta.message.content, list):
+                    delta_text = ""
+                    for content in chunk.delta.message.content:
+                        logger.debug(
+                            "The content type %s in LLM chunk delta message content.: %r", type(content), content
+                        )
+                        if isinstance(content, TextPromptMessageContent):
+                            delta_text += content.data
+                        elif isinstance(content, str):
+                            delta_text += content  # failback to str
+                        else:
+                            logger.warning(
+                                "Unsupported content type %s in LLM chunk delta message content.: %r",
+                                type(content),
+                                content,
+                            )
+                            continue
 
                 if not self._task_state.llm_result.prompt_messages:
                     self._task_state.llm_result.prompt_messages = chunk.prompt_messages


### PR DESCRIPTION
Fixes #20204
## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed chat agent app with Gemini plugin 0.2.x doesn't work.

## Screenshots
![image](https://github.com/user-attachments/assets/a2704bb5-6b27-4e69-81e8-87dcc4f9a3d9)

| Before | After |
|--------|-------|
|None from Chat box. |Any response from LLM. |

On docker compose logs
```
api-1            | 2025-06-08 05:16:07.035 ERROR [Thread-5 (worker_with_context)] [app_generator.py:247] - Unknown Error when generating
api-1            | Traceback (most recent call last):
api-1            |   File "/app/api/core/app/apps/chat/app_generator.py", line 227, in _generate_worker
api-1            |     runner.run(
api-1            |   File "/app/api/core/app/apps/chat/app_runner.py", line 217, in run
api-1            |     self._handle_invoke_result(
api-1            |   File "/app/api/core/app/apps/base_app_runner.py", line 279, in _handle_invoke_result
api-1            |     self._handle_invoke_result_stream(invoke_result=invoke_result, queue_manager=queue_manager, agent=agent)
api-1            |   File "/app/api/core/app/apps/base_app_runner.py", line 320, in _handle_invoke_result_stream
api-1            |     text += result.delta.message.content
api-1            | TypeError: can only concatenate str (not "list") to str
nginx-1          | 172.16.18.1 - - [08/Jun/2025:05:16:07 +0000] "POST /console/api/apps/6febf05c-fab0-4f97-bd81-468d24333ffb/chat-messages HTTP/1.1" 500 141 "https://dify.on-o.com/app/6febf05c-fab0-4f97-bd81-468d24333ffb/configuration" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" "240d:1a:17c:3a00:d756:78e4:b069:6921"
api-1            | [2025-06-08 05:16:07 +0000] [19] [ERROR] Error handling request /console/api/apps/6febf05c-fab0-4f97-bd81-468d24333ffb/chat-messages
api-1            | Traceback (most recent call last):
api-1            |   File "/app/api/.venv/lib/python3.12/site-packages/gunicorn/workers/base_async.py", line 54, in handle
api-1            |     self.handle_request(listener_name, req, client, addr)
api-1            |   File "/app/api/.venv/lib/python3.12/site-packages/gunicorn/workers/ggevent.py", line 127, in handle_request
api-1            |     super().handle_request(listener_name, req, sock, addr)
api-1            |   File "/app/api/.venv/lib/python3.12/site-packages/gunicorn/workers/base_async.py", line 114, in handle_request
api-1            |     for item in respiter:
api-1            |                 ^^^^^^^^
api-1            |   File "/app/api/.venv/lib/python3.12/site-packages/werkzeug/wsgi.py", line 256, in __next__
api-1            |     return self._next()
api-1            |            ^^^^^^^^^^^^
api-1            |   File "/app/api/.venv/lib/python3.12/site-packages/werkzeug/wrappers/response.py", line 32, in _iter_encoded
api-1            |     for item in iterable:
api-1            |                 ^^^^^^^^
api-1            |   File "/app/api/.venv/lib/python3.12/site-packages/flask/helpers.py", line 125, in generator
api-1            |     yield from gen
api-1            |   File "/app/api/libs/helper.py", line 203, in generate
api-1            |     yield from response
api-1            |   File "/app/api/core/app/features/rate_limiting/rate_limit.py", line 116, in __next__
api-1            |     return next(self.generator)
api-1            |            ^^^^^^^^^^^^^^^^^^^^
api-1            |   File "/app/api/core/app/apps/base_app_generator.py", line 155, in gen
api-1            |     for message in generator:
api-1            |                    ^^^^^^^^^
api-1            |   File "/app/api/core/app/apps/base_app_generate_response_converter.py", line 25, in _generate_full_response
api-1            |     yield from cls.convert_stream_full_response(response)
api-1            |   File "/app/api/core/app/apps/chat/generate_response_converter.py", line 62, in convert_stream_full_response
api-1            |     for chunk in stream_response:
api-1            |                  ^^^^^^^^^^^^^^^
api-1            |   File "/app/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py", line 182, in _to_stream_response
api-1            |     for stream_response in generator:
api-1            |                            ^^^^^^^^^
api-1            |   File "/app/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py", line 221, in _wrapper_process_stream_response
api-1            |     for response in self._process_stream_response(publisher=publisher, trace_manager=trace_manager):
api-1            |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1            |   File "/app/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py", line 317, in _process_stream_response
api-1            |     current_content += cast(str, delta_text)
api-1            | TypeError: can only concatenate str (not "list") to str
```


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
