### PR TITLE
fix wrongly remove reset nodes

### DIFF
--- a/api/core/workflow/nodes/answer/base_stream_processor.py
+++ b/api/core/workflow/nodes/answer/base_stream_processor.py
@@ -57,7 +57,6 @@ class StreamProcessor(ABC):
 
                     # The branch_identify parameter is added to ensure that
                     # only nodes in the correct logical branch are included.
-                    reachable_node_ids.append(edge.target_node_id)
                     ids = self._fetch_node_ids_in_reachable_branch(edge.target_node_id, run_result.edge_source_handle)
                     reachable_node_ids.extend(ids)
                 else:
@@ -74,6 +73,8 @@ class StreamProcessor(ABC):
                 self._remove_node_ids_in_unreachable_branch(node_id, reachable_node_ids)
 
     def _fetch_node_ids_in_reachable_branch(self, node_id: str, branch_identify: Optional[str] = None) -> list[str]:
+        if node_id not in self.rest_node_ids:
+            self.rest_node_ids.append(node_id)
         node_ids = []
         for edge in self.graph.edge_mapping.get(node_id, []):
             if edge.target_node_id == self.graph.root_node_id:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

reproduce:
![image](https://github.com/user-attachments/assets/819e6ecb-e48e-4c52-a68f-7be9792529b8)
![image](https://github.com/user-attachments/assets/4813ffd3-a342-4339-96b0-e355b5e8c92a)
expect:  the final answer node print streamly
![image](https://github.com/user-attachments/assets/cd0854e7-2b70-40fc-b8d1-61e4e492ec45)

truth:
1. when first chat.   first ifelse node execute. 
2. ```_fetch_node_ids_in_reachable_branch``` can not fetch all node when the second ifelse's branch_identify is not match.
for the ifelse2 node' branch_identify is a uuid but the ifelse1 node's branch_identify is true. so the node link break.
![image](https://github.com/user-attachments/assets/77699ba4-af14-47d1-a3d7-42d5f7330998)
3.  then ```_remove_node_ids_in_unreachable_branch``` with a 'wrong' reachable_node_ids.  this method will remove all nodes 
![image](https://github.com/user-attachments/assets/282a276e-959a-4c4d-845d-356126b498eb)
4. cause the wrong  rest_node_ids, then cause the final answer node can not print stream. replaced with blocking answer. 