### PR TITLE
chore: cancel enforcing uppercase of the text of plugin navigation button on the header bar

### DIFF
--- a/web/app/components/header/plugins-nav/index.tsx
+++ b/web/app/components/header/plugins-nav/index.tsx
@@ -31,7 +31,7 @@ const PluginsNav = ({
     )}>
       <div
         className={classNames(
-          'relative flex flex-row h-8 p-1.5 gap-0.5 border border-transparent items-center justify-center rounded-xl system-sm-medium-uppercase',
+          'relative flex flex-row h-8 p-1.5 gap-0.5 border border-transparent items-center justify-center rounded-xl system-sm-medium',
           activated && 'border-components-main-nav-nav-button-border bg-components-main-nav-nav-button-bg-active shadow-md text-components-main-nav-nav-button-text',
           !activated && 'text-text-tertiary hover:bg-state-base-hover hover:text-text-secondary',
           (isInstallingWithError || isFailed) && !activated && 'border-components-panel-border-subtle',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- to fix #20889

## Screenshots

| Before | After |
|--------|-------|
| <img width="500" alt="Image" src="https://github.com/user-attachments/assets/6c0fe37d-c2c1-4359-bf38-b21861016fb7" />    |  <img width="1094" alt="image" src="https://github.com/user-attachments/assets/68854d7f-201d-4497-94f2-ffc2561c8bdc" />   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
