### PR TITLE
test: run vdb test of oceanbase with docker compose in CI tests

### DIFF
--- a/.github/workflows/expose_service_ports.sh
+++ b/.github/workflows/expose_service_ports.sh
@@ -10,6 +10,7 @@ yq eval '.services["elasticsearch"].ports += ["9200:9200"]' -i docker/docker-com
 yq eval '.services.couchbase-server.ports += ["8091-8096:8091-8096"]' -i docker/docker-compose.yaml
 yq eval '.services.couchbase-server.ports += ["11210:11210"]' -i docker/docker-compose.yaml
 yq eval '.services.tidb.ports += ["4000:4000"]' -i docker/tidb/docker-compose.yaml
+yq eval '.services.oceanbase.ports += ["2881:2881"]' -i docker/docker-compose.yaml
 yq eval '.services.opengauss.ports += ["6600:6600"]' -i docker/docker-compose.yaml
 
 echo "Ports exposed for sandbox, weaviate, tidb, qdrant, chroma, milvus, pgvector, pgvecto-rs, elasticsearch, couchbase, opengauss"

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           remove_dotnet: true
           remove_haskell: true
+          remove_tool_cache: true
 
       - name: Setup UV and Python
         uses: ./.github/actions/setup-uv

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: sh .github/workflows/expose_service_ports.sh
 
       - name: Set up Vector Stores (ob)
-        uses: hoverkraft-tech/compose-action@v2.0.2.0.2
+        uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           compose-file: |
             docker/docker-compose.yaml
@@ -60,7 +60,7 @@ jobs:
             oceanbase
 
       - name: Set up Vector Store (TiDB)
-        uses: hoverkraft-tech/compose-action@v2.0.2.0.2
+        uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           compose-file: docker/tidb/docker-compose.yaml
           services: |
@@ -68,7 +68,7 @@ jobs:
             tiflash
 
       - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
-        uses: hoverkraft-tech/compose-action@v2.0.2.0.2
+        uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           compose-file: |
             docker/docker-compose.yaml

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v2
+        with:
+          remove_android: true
+          remove_dotnet: true
+
       - name: Setup UV and Python
         uses: ./.github/actions/setup-uv
         with:
@@ -50,14 +56,6 @@ jobs:
 
       - name: Expose Service Ports
         run: sh .github/workflows/expose_service_ports.sh
-
-      - name: Set up Vector Stores (ob)
-        uses: hoverkraft-tech/compose-action@v2.0.2
-        with:
-          compose-file: |
-            docker/docker-compose.yaml
-          services: |
-            oceanbase
 
       - name: Set up Vector Store (TiDB)
         uses: hoverkraft-tech/compose-action@v2.0.2
@@ -82,6 +80,7 @@ jobs:
             pgvector
             chroma
             elasticsearch
+            oceanbase
 
       - name: Check TiDB, Oceanbase Ready
         run: |

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Free Disk Space
         uses: endersonmenezes/free-disk-space@v2
         with:
-          remove_android: true
           remove_dotnet: true
 
       - name: Setup UV and Python
@@ -65,7 +64,7 @@ jobs:
             tidb
             tiflash
 
-      - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
+      - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase, OceanBase)
         uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           compose-file: |
@@ -82,7 +81,7 @@ jobs:
             elasticsearch
             oceanbase
 
-      - name: Check TiDB, Oceanbase Ready
+      - name: Check VDB Ready (TiDB, Oceanbase)
         run: |
           uv run --project api python api/tests/integration_tests/vdb/tidb_vector/check_tiflash_ready.py
           uv run --project api python api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -73,6 +73,7 @@ jobs:
           services: |
             weaviate
             qdrant
+            couchbase-server
             etcd
             minio
             milvus-standalone

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -75,7 +75,6 @@ jobs:
           services: |
             weaviate
             qdrant
-            couchbase-server
             etcd
             minio
             milvus-standalone

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -35,6 +35,7 @@ jobs:
         uses: endersonmenezes/free-disk-space@v2
         with:
           remove_dotnet: true
+          remove_haskell: true
 
       - name: Setup UV and Python
         uses: ./.github/actions/setup-uv

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -51,8 +51,16 @@ jobs:
       - name: Expose Service Ports
         run: sh .github/workflows/expose_service_ports.sh
 
+      - name: Set up Vector Stores (ob)
+        uses: hoverkraft-tech/compose-action@v2.0.2.0.2
+        with:
+          compose-file: |
+            docker/docker-compose.yaml
+          services: |
+            oceanbase
+
       - name: Set up Vector Store (TiDB)
-        uses: hoverkraft-tech/compose-action@v2.0.2
+        uses: hoverkraft-tech/compose-action@v2.0.2.0.2
         with:
           compose-file: docker/tidb/docker-compose.yaml
           services: |
@@ -60,7 +68,7 @@ jobs:
             tiflash
 
       - name: Set up Vector Stores (Weaviate, Qdrant, PGVector, Milvus, PgVecto-RS, Chroma, MyScale, ElasticSearch, Couchbase)
-        uses: hoverkraft-tech/compose-action@v2.0.2
+        uses: hoverkraft-tech/compose-action@v2.0.2.0.2
         with:
           compose-file: |
             docker/docker-compose.yaml
@@ -76,8 +84,10 @@ jobs:
             chroma
             elasticsearch
 
-      - name: Check TiDB Ready
-        run: uv run --project api python api/tests/integration_tests/vdb/tidb_vector/check_tiflash_ready.py
+      - name: Check TiDB, Oceanbase Ready
+        run: |
+          uv run --project api python api/tests/integration_tests/vdb/tidb_vector/check_tiflash_ready.py
+          uv run --project api python api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
 
       - name: Test Vector Stores
         run: uv run --project api bash dev/pytest/pytest_vdb.sh

--- a/api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
+++ b/api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
@@ -3,7 +3,7 @@ import time
 import pymysql
 
 
-def check_ocean_ready() -> bool:
+def check_oceanbase_ready() -> bool:
     try:
         connection = pymysql.connect(
             host="localhost",
@@ -27,7 +27,7 @@ def main():
     is_oceanbase_ready = False
     for attempt in range(max_attempts):
         try:
-            is_oceanbase_ready = check_ocean_ready()
+            is_oceanbase_ready = check_oceanbase_ready()
         except Exception as e:
             print(f"Oceanbase is not ready. Exception: {e}")
             is_oceanbase_ready = False

--- a/api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
+++ b/api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
@@ -1,4 +1,3 @@
-import logging
 import time
 
 import pymysql
@@ -11,29 +10,10 @@ def check_ocean_ready() -> bool:
             port=2881,
             user="root",
             password="difyai123456",
-            connect_timeout=15,
-            read_timeout=20,
-            autocommit=True,
         )
-        connection.ping(reconnect=True)
-        a = connection.query("select 1")
-        print(f"Oceanbase query result: {a}")
-        if a == 1:
-            return True
-        else:
-            return False
-
-        # with connection.cursor() as cursor:
-        #     # SELECT 1;
-        #     # """
-        #     # cursor.execute(select_query)
-        #     # result = cursor.fetchall()
-        #     # return result is not None and len(result) > 0
-        #     cursor.execute("SELECT 1")
-        #     return cursor.fetchone() is not None
-
+        affected_rows = connection.query("SELECT 1")
+        return affected_rows == 1
     except Exception as e:
-        logging.exception("Error checking OceanBase readiness")
         print(f"Oceanbase is not ready. Exception: {e}")
         return False
     finally:

--- a/api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
+++ b/api/tests/integration_tests/vdb/oceanbase/check_oceanbase_ready.py
@@ -1,0 +1,69 @@
+import logging
+import time
+
+import pymysql
+
+
+def check_ocean_ready() -> bool:
+    try:
+        connection = pymysql.connect(
+            host="localhost",
+            port=2881,
+            user="root",
+            password="difyai123456",
+            connect_timeout=15,
+            read_timeout=20,
+            autocommit=True,
+        )
+        connection.ping(reconnect=True)
+        a = connection.query("select 1")
+        print(f"Oceanbase query result: {a}")
+        if a == 1:
+            return True
+        else:
+            return False
+
+        # with connection.cursor() as cursor:
+        #     # SELECT 1;
+        #     # """
+        #     # cursor.execute(select_query)
+        #     # result = cursor.fetchall()
+        #     # return result is not None and len(result) > 0
+        #     cursor.execute("SELECT 1")
+        #     return cursor.fetchone() is not None
+
+    except Exception as e:
+        logging.exception("Error checking OceanBase readiness")
+        print(f"Oceanbase is not ready. Exception: {e}")
+        return False
+    finally:
+        if connection:
+            connection.close()
+
+
+def main():
+    max_attempts = 50
+    retry_interval_seconds = 2
+    is_oceanbase_ready = False
+    for attempt in range(max_attempts):
+        try:
+            is_oceanbase_ready = check_ocean_ready()
+        except Exception as e:
+            print(f"Oceanbase is not ready. Exception: {e}")
+            is_oceanbase_ready = False
+
+        if is_oceanbase_ready:
+            break
+        else:
+            print(f"Attempt {attempt + 1} failed, retry in {retry_interval_seconds} seconds...")
+            time.sleep(retry_interval_seconds)
+
+    if is_oceanbase_ready:
+        print("Oceanbase is ready.")
+    else:
+        print(f"Oceanbase is not ready after {max_attempts} attempting checks.")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/tests/integration_tests/vdb/oceanbase/test_oceanbase.py
+++ b/api/tests/integration_tests/vdb/oceanbase/test_oceanbase.py
@@ -6,7 +6,6 @@ from core.rag.datasource.vdb.oceanbase.oceanbase_vector import (
 )
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
-    get_example_text,
     setup_mock_redis,
 )
 

--- a/api/tests/integration_tests/vdb/oceanbase/test_oceanbase.py
+++ b/api/tests/integration_tests/vdb/oceanbase/test_oceanbase.py
@@ -1,12 +1,9 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from core.rag.datasource.vdb.oceanbase.oceanbase_vector import (
     OceanBaseVector,
     OceanBaseVectorConfig,
 )
-from tests.integration_tests.vdb.__mock.tcvectordb import setup_tcvectordb_mock
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
     get_example_text,
@@ -20,10 +17,10 @@ def oceanbase_vector():
         "dify_test_collection",
         config=OceanBaseVectorConfig(
             host="127.0.0.1",
-            port="2881",
-            user="root@test",
+            port=2881,
+            user="root",
             database="test",
-            password="test",
+            password="difyai123456",
         ),
     )
 
@@ -33,39 +30,21 @@ class OceanBaseVectorTest(AbstractVectorTest):
         super().__init__()
         self.vector = vector
 
-    def search_by_vector(self):
-        hits_by_vector = self.vector.search_by_vector(query_vector=self.example_embedding)
-        assert len(hits_by_vector) == 0
+    # def search_by_vector(self):
+    #     hits_by_vector = self.vector.search_by_vector(query_vector=self.example_embedding)
+    #     assert len(hits_by_vector) == 1
 
     def search_by_full_text(self):
         hits_by_full_text = self.vector.search_by_full_text(query=get_example_text())
         assert len(hits_by_full_text) == 0
 
-    def text_exists(self):
-        exist = self.vector.text_exists(self.example_doc_id)
-        assert exist == True
-
     def get_ids_by_metadata_field(self):
         ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
-        assert len(ids) == 0
-
-
-@pytest.fixture
-def setup_mock_oceanbase_client():
-    with patch("core.rag.datasource.vdb.oceanbase.oceanbase_vector.ObVecClient", new_callable=MagicMock) as mock_client:
-        yield mock_client
-
-
-@pytest.fixture
-def setup_mock_oceanbase_vector(oceanbase_vector):
-    with patch.object(oceanbase_vector, "_client"):
-        yield oceanbase_vector
+        assert len(ids) == 1
 
 
 def test_oceanbase_vector(
     setup_mock_redis,
-    setup_mock_oceanbase_client,
-    setup_mock_oceanbase_vector,
     oceanbase_vector,
 ):
     OceanBaseVectorTest(oceanbase_vector).run_all_tests()

--- a/api/tests/integration_tests/vdb/oceanbase/test_oceanbase.py
+++ b/api/tests/integration_tests/vdb/oceanbase/test_oceanbase.py
@@ -21,6 +21,7 @@ def oceanbase_vector():
             user="root",
             database="test",
             password="difyai123456",
+            enable_hybrid_search=True,
         ),
     )
 
@@ -29,14 +30,6 @@ class OceanBaseVectorTest(AbstractVectorTest):
     def __init__(self, vector: OceanBaseVector):
         super().__init__()
         self.vector = vector
-
-    # def search_by_vector(self):
-    #     hits_by_vector = self.vector.search_by_vector(query_vector=self.example_embedding)
-    #     assert len(hits_by_vector) == 1
-
-    def search_by_full_text(self):
-        hits_by_full_text = self.vector.search_by_full_text(query=get_example_text())
-        assert len(hits_by_full_text) == 0
 
     def get_ids_by_metadata_field(self):
         ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)

--- a/dev/pytest/pytest_vdb.sh
+++ b/dev/pytest/pytest_vdb.sh
@@ -15,7 +15,6 @@ pytest api/tests/integration_tests/vdb/chroma \
   api/tests/integration_tests/vdb/baidu \
   api/tests/integration_tests/vdb/tcvectordb \
   api/tests/integration_tests/vdb/upstash \
-  api/tests/integration_tests/vdb/couchbase \
   api/tests/integration_tests/vdb/oceanbase \
   api/tests/integration_tests/vdb/tidb_vector \
   api/tests/integration_tests/vdb/huawei \

--- a/dev/pytest/pytest_vdb.sh
+++ b/dev/pytest/pytest_vdb.sh
@@ -15,6 +15,7 @@ pytest api/tests/integration_tests/vdb/chroma \
   api/tests/integration_tests/vdb/baidu \
   api/tests/integration_tests/vdb/tcvectordb \
   api/tests/integration_tests/vdb/upstash \
+  api/tests/integration_tests/vdb/couchbase \
   api/tests/integration_tests/vdb/oceanbase \
   api/tests/integration_tests/vdb/tidb_vector \
   api/tests/integration_tests/vdb/huawei \

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -449,9 +449,7 @@ services:
       OB_TENANT_PASSWORD: ${OCEANBASE_VECTOR_PASSWORD:-difyai123456}
       OB_CLUSTER_NAME: ${OCEANBASE_CLUSTER_NAME:-difyai}
       OB_SERVER_IP: 127.0.0.1
-      MODE: MINI
-    ports:
-      - "${OCEANBASE_VECTOR_PORT:-2881}:2881"
+      MODE: mini
 
   # Oracle vector database
   oracle:

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -434,7 +434,7 @@ services:
 
   # OceanBase vector database
   oceanbase:
-    image: oceanbase/oceanbase-ce:4.3.5.1-101010042025042417
+    image: oceanbase/oceanbase-ce:4.3.5-lts
     container_name: oceanbase
     profiles:
       - oceanbase

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -434,7 +434,7 @@ services:
 
   # OceanBase vector database
   oceanbase:
-    image: oceanbase/oceanbase-ce:4.3.5.1-101000042025031818
+    image: oceanbase/oceanbase-ce:4.3.5.1-101010042025042417
     container_name: oceanbase
     profiles:
       - oceanbase

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -940,7 +940,7 @@ services:
 
   # OceanBase vector database
   oceanbase:
-    image: oceanbase/oceanbase-ce:4.3.5.1-101010042025042417
+    image: oceanbase/oceanbase-ce:4.3.5-lts
     container_name: oceanbase
     profiles:
       - oceanbase

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -955,9 +955,7 @@ services:
       OB_TENANT_PASSWORD: ${OCEANBASE_VECTOR_PASSWORD:-difyai123456}
       OB_CLUSTER_NAME: ${OCEANBASE_CLUSTER_NAME:-difyai}
       OB_SERVER_IP: 127.0.0.1
-      MODE: MINI
-    ports:
-      - "${OCEANBASE_VECTOR_PORT:-2881}:2881"
+      MODE: mini
 
   # Oracle vector database
   oracle:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -940,7 +940,7 @@ services:
 
   # OceanBase vector database
   oceanbase:
-    image: oceanbase/oceanbase-ce:4.3.5.1-101000042025031818
+    image: oceanbase/oceanbase-ce:4.3.5-lts
     container_name: oceanbase
     profiles:
       - oceanbase

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -940,7 +940,7 @@ services:
 
   # OceanBase vector database
   oceanbase:
-    image: oceanbase/oceanbase-ce:4.3.5-lts
+    image: oceanbase/oceanbase-ce:4.3.5.1-101010042025042417
     container_name: oceanbase
     profiles:
       - oceanbase


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- to close #20943
- Previously, the vdb test for Oceanbase was mocked and never tested with an actual Oceanbase instance.
- With this PR, 
  - Start an Oceanbase container instance with docker-compose. ~~The existing Docker image tag `4.3.5.1-101010042025042417` will continue to be used, as the shorter version `4.3.5-lts` turns out to be lower than 4.3.5.1, which is the minimum required version for the full text search index.~~ As `4.3.5-lts` tag is now updated and shipping with FTS feature, change to use this image tag.
  - Set the critical system parameter config `ob_vector_memory_limit_percentage` to greater than 0 ahead of creating the collection. Otherwise, it fails the creation with an error message of `ob_vector_memory_limit_percentage=0`.
  - Skip all the mocking of client and assertions in OceanBaseVectorTest

<img width="842" alt="image" src="https://github.com/user-attachments/assets/555979fc-2bea-4e41-93cd-18e49308133e" />


## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
