### PR TITLE
fix(auth): Clear login rate limit after password reset

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -27,7 +27,7 @@ from models.dataset import Dataset, DatasetCollectionBinding, DatasetMetadata, D
 from models.dataset import Document as DatasetDocument
 from models.model import Account, App, AppAnnotationSetting, AppMode, Conversation, MessageAnnotation
 from models.provider import Provider, ProviderModel
-from services.account_service import RegisterService, TenantService
+from services.account_service import AccountService, RegisterService, TenantService
 from services.clear_free_plan_tenant_expired_logs import ClearFreePlanTenantExpiredLogs
 from services.plugin.data_migration import PluginDataMigration
 from services.plugin.plugin_migration import PluginMigration
@@ -68,6 +68,7 @@ def reset_password(email, new_password, password_confirm):
     account.password = base64_password_hashed
     account.password_salt = base64_salt
     db.session.commit()
+    AccountService.reset_login_error_rate_limit(email)
     click.echo(click.style("Password reset successfully.", fg="green"))
 
 


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #20925

This Pull Request addresses a bug where a user remains locked out of their account even after a successful password reset. The issue occurs if the user had previously triggered the login rate limit due to multiple failed password attempts.

**Problem:**
The `flask reset-password` command did not clear the Redis cache key responsible for tracking login attempt failures. As a result, even with a new, correct password, the system still considered the account locked, preventing successful login and showing a "Too many attempts" error.

**Solution:**
The fix is to explicitly clear the login rate limit for the user's email immediately after the password has been successfully updated in the database. I've added a call to `AccountService.reset_login_error_rate_limit(email)` within the `reset_password` command in `api/commands.py`.

This ensures that any stale login restriction is removed, allowing the user to log in seamlessly with their new password right after a reset.

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
