### PR TITLE
fix: prevent nodes from being unintentionally deleted by pressing the backspace key.

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -165,6 +165,7 @@ const ComponentPicker = ({
                         isSupportFileVar={isSupportFileVar}
                         onClose={handleClose}
                         onBlur={handleClose}
+                        autoFocus={false}
                       />
                     </div>
                   )

--- a/web/app/components/workflow/hooks/use-shortcuts.ts
+++ b/web/app/components/workflow/hooks/use-shortcuts.ts
@@ -61,7 +61,7 @@ export const useShortcuts = (): void => {
     return !showFeaturesPanel && !isEventTargetInputArea(e.target as HTMLElement)
   }, [workflowStore])
 
-  useKeyPress(['delete', 'backspace'], (e) => {
+  useKeyPress(['delete'], (e) => {
     if (shouldHandleShortcut(e)) {
       e.preventDefault()
       handleNodesDelete()

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -260,6 +260,7 @@ type Props = {
   maxHeightClass?: string
   onClose?: () => void
   onBlur?: () => void
+  autoFocus?: boolean
 }
 const VarReferenceVars: FC<Props> = ({
   hideSearch,
@@ -271,6 +272,7 @@ const VarReferenceVars: FC<Props> = ({
   maxHeightClass,
   onClose,
   onBlur,
+  autoFocus = true,
 }) => {
   const { t } = useTranslation()
   const [searchText, setSearchText] = useState('')
@@ -323,7 +325,7 @@ const VarReferenceVars: FC<Props> = ({
                 onKeyDown={handleKeyDown}
                 onClear={() => setSearchText('')}
                 onBlur={onBlur}
-                autoFocus
+                autoFocus={autoFocus}
               />
             </div>
             <div className='relative left-[-4px] h-[0.5px] bg-black/5' style={{


### PR DESCRIPTION
## Summary

When editing a workflow or chatflow, pressing the Backspace key to edit text can sometimes delete a node instead if the focus isn’t where we expect.

Also, in the prompt editor of the LLM node, when we type a slash and the picker menu appears, starting from the second time we use it, the picker starts to take focus. As a result, if we keep pressing the Backspace key to delete text, we might accidentally delete a node instead of just deleting text.

This PR fixes these problems with three changes:

- The Backspace key can no longer be used as a shortcut to delete nodes. Now, only the Delete key can be used to remove nodes. (means partially reverts https://github.com/langgenius/dify/pull/6863)
- The variable filter input no longer always has `autoFocus` enabled; it's now optional and enabled by default to avoid unexpected side effects.
- `autoFocus` is now disabled for the variable filter picker in the prompt editor.

Thanks to these changes, users can safely press Backspace to delete characters without losing focus or accidentally deleting nodes.

Closes https://github.com/langgenius/dify/issues/20404

## Screenshots

| Before | After |
|--------|-------|
| ![without_pr](https://github.com/user-attachments/assets/9426f3e6-96e7-41fb-9716-0fdbbc5a5afc)    | ![with_pr](https://github.com/user-attachments/assets/724b9ad7-4d1e-4b50-8fd2-402b3718b783)   |


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
