### PR TITLE
fix: redirect to apps page if current user has no permission to visit dataset page

### DIFF
--- a/web/app/(commonLayout)/datasets/layout.tsx
+++ b/web/app/(commonLayout)/datasets/layout.tsx
@@ -1,9 +1,23 @@
 'use client'
 
+import Loading from '@/app/components/base/loading'
+import { useAppContext } from '@/context/app-context'
 import { ExternalApiPanelProvider } from '@/context/external-api-panel-context'
 import { ExternalKnowledgeApiProvider } from '@/context/external-knowledge-api-context'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 export default function DatasetsLayout({ children }: { children: React.ReactNode }) {
+  const { isCurrentWorkspaceEditor } = useAppContext()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isCurrentWorkspaceEditor)
+      router.replace('/apps')
+  }, [isCurrentWorkspaceEditor, router])
+
+  if (!isCurrentWorkspaceEditor)
+    return <Loading type='app' />
   return (
     <ExternalKnowledgeApiProvider>
       <ExternalApiPanelProvider>


### PR DESCRIPTION
… dataset page

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
