### PR TITLE
fix: The HTTP request node supports non-standard spaces in JSON request data

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import re
 import secrets
 import string
 from collections.abc import Mapping
@@ -177,6 +178,9 @@ class Executor:
                     if len(data) != 1:
                         raise RequestBodyError("json body type should have exactly one item")
                     json_string = self.variable_pool.convert_template(data[0].value).text
+                    # Compatible with non-standard spaces
+                    pattern = r"[\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]"
+                    json_string = re.sub(pattern, " ", json_string)
                     try:
                         json_object = json.loads(json_string, strict=False)
                     except json.JSONDecodeError as e:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #20703 

## Screenshots

| Before | After |
|--------|-------|
| ...    | ![ScreenShot_20250616201326](https://github.com/user-attachments/assets/98d27f83-188f-4cab-9710-6de3016622d8)  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
