### PR TITLE
fix(code-editor): optimize the loading style of the CodeEditor component in dark mode (#21116)

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
@@ -140,6 +140,7 @@ const CodeEditor: FC<Props> = ({
         language={languageMap[language] || 'javascript'}
         theme={isMounted ? theme : 'default-theme'} // sometimes not load the default theme
         value={outPutValue}
+        loading={<span className='text-text-primary'>Loading...</span>}
         onChange={handleEditorChange}
         // https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IEditorOptions.html
         options={{


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add a loading property to the CodeEditor component to display the loading state  
- Use the `text-text-primary` class style to unify the appearance of the loading text

Fixes #21116

## Screenshots

| Before | After |
|--------|-------|
|![64626763d3c9124ae68a940f8e79949](https://github.com/user-attachments/assets/11da2379-a74a-42ad-b842-8c1b4aa553be)   | ![c2399b34b58fe18fa6bae891680684d](https://github.com/user-attachments/assets/8ff3224a-721f-4ab9-aead-643dc60d729b)  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
