### PR TITLE
fix: save logs when there is an error in workflow

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -564,6 +564,8 @@ class AdvancedChatAppGenerateTaskPipeline:
                     err = self._base_task_pipeline._handle_error(
                         event=err_event, session=session, message_id=self._message_id
                     )
+                    self._save_message(session=session, graph_runtime_state=graph_runtime_state)
+                    session.commit()
 
                 yield workflow_finish_resp
                 yield self._base_task_pipeline._error_to_stream_response(err)


### PR DESCRIPTION
Fixed #21121 
fix https://github.com/langgenius/dify/issues/20984
## Summary
save logs when the workflow has an error

## Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/91a3af9e-b045-4b2f-a7e7-dd0ce7f3823a)| ![image](https://github.com/user-attachments/assets/7f0bc709-10e6-48a6-be18-c9cad6002728)|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
