### PR TITLE
feat: add metadata support for external knowledge

### DIFF
--- a/web/app/components/datasets/settings/form/index.tsx
+++ b/web/app/components/datasets/settings/form/index.tsx
@@ -33,6 +33,10 @@ import { fetchMembers } from '@/service/common'
 import type { Member } from '@/models/common'
 import AlertTriangle from '@/app/components/base/icons/src/vender/solid/alertsAndFeedback/AlertTriangle'
 import { useDocLink } from '@/context/i18n'
+import { useInvalidDocumentList } from '@/service/knowledge/use-document'
+import useEditDatasetMetadata from '../../metadata/hooks/use-edit-dataset-metadata'
+import DatasetMetadataDrawer from '../../metadata/metadata-dataset/dataset-metadata-drawer'
+import { RiDraftLine } from '@remixicon/react'
 
 const rowClass = 'flex'
 const labelClass = `
@@ -170,6 +174,28 @@ const Form = () => {
     }
   }
 
+  const dataset = currentDataset
+  const datasetId = dataset!.id
+
+  const invalidDocumentList = useInvalidDocumentList(datasetId)
+
+  const {
+    isShowEditModal: isShowEditMetadataModal,
+    showEditModal: showEditMetadataModal,
+    hideEditModal: hideEditMetadataModal,
+    datasetMetaData,
+    handleAddMetaData,
+    handleRename,
+    handleDeleteMetaData,
+    builtInEnabled,
+    setBuiltInEnabled,
+    builtInMetaData,
+  } = useEditDatasetMetadata({
+    datasetId,
+    dataset,
+    onUpdateDocList: invalidDocumentList,
+  })
+
   return (
     <div className='flex w-full flex-col gap-y-4 px-14 py-8 sm:w-[880px]'>
       <div className={rowClass}>
@@ -301,6 +327,15 @@ const Form = () => {
               </div>
             </div>
           </div>
+          <div className={rowClass}>
+            <div className={labelClass}>
+              <div className='system-sm-semibold text-text-secondary'>{t('dataset.metadata.metadata')}</div>
+            </div>
+            <Button variant='secondary' className='shrink-0' onClick={showEditMetadataModal}>
+              <RiDraftLine className='mr-1 size-4' />
+              {t('dataset.metadata.metadata')}
+            </Button>
+          </div>
         </>
         : indexMethod
           ? <>
@@ -358,6 +393,18 @@ const Form = () => {
           </Button>
         </div>
       </div>
+      {isShowEditMetadataModal && (
+        <DatasetMetadataDrawer
+          userMetadata={datasetMetaData || []}
+          onClose={hideEditMetadataModal}
+          onAdd={handleAddMetaData}
+          onRename={handleRename}
+          onRemove={handleDeleteMetaData}
+          builtInMetadata={builtInMetaData || []}
+          isBuiltInEnabled={!!builtInEnabled}
+          onIsBuiltInEnabledChange={setBuiltInEnabled}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #16349 

Currently, Dify only supports metadata configuration and filtering for its built-in knowledge base. However, users working with external knowledge bases (such as Milvus, Qdrant, Weaviate, etc.) also need the ability to add, manage, and filter metadata for their documents. This feature is important for enabling more flexible and precise knowledge retrieval scenarios.

## Screenshots

| Before | After |
|--------|-------|
|<img width="1213" alt="image" src="https://github.com/user-attachments/assets/428da448-f697-4b58-80ed-ee822f167969" />|<img width="1193" alt="image" src="https://github.com/user-attachments/assets/fc0692b2-3f77-4501-a113-0db3480d4d06" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
