### PR TITLE
feat:conversation variable support file array

### DIFF
--- a/api/core/workflow/nodes/variable_assigner/v2/constants.py
+++ b/api/core/workflow/nodes/variable_assigner/v2/constants.py
@@ -8,4 +8,5 @@ EMPTY_VALUE_MAPPING = {
     SegmentType.ARRAY_STRING: [],
     SegmentType.ARRAY_NUMBER: [],
     SegmentType.ARRAY_OBJECT: [],
+    SegmentType.ARRAY_FILE: [],
 }

--- a/api/core/workflow/nodes/variable_assigner/v2/helpers.py
+++ b/api/core/workflow/nodes/variable_assigner/v2/helpers.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from core.file import File
 from core.variables import SegmentType
 
 from .enums import Operation
@@ -85,6 +86,8 @@ def is_input_value_valid(*, variable_type: SegmentType, operation: Operation, va
             return isinstance(value, int | float)
         case SegmentType.ARRAY_OBJECT if operation == Operation.APPEND:
             return isinstance(value, dict)
+        case SegmentType.ARRAY_FILE if operation == Operation.APPEND:
+            return isinstance(value, File)
 
         # Array & Extend / Overwrite
         case SegmentType.ARRAY_ANY if operation in {Operation.EXTEND, Operation.OVER_WRITE}:
@@ -95,6 +98,8 @@ def is_input_value_valid(*, variable_type: SegmentType, operation: Operation, va
             return isinstance(value, list) and all(isinstance(item, int | float) for item in value)
         case SegmentType.ARRAY_OBJECT if operation in {Operation.EXTEND, Operation.OVER_WRITE}:
             return isinstance(value, list) and all(isinstance(item, dict) for item in value)
+        case SegmentType.ARRAY_FILE if operation in {Operation.EXTEND, Operation.OVER_WRITE}:
+            return isinstance(value, list) and all(isinstance(item, File) for item in value)
 
         case _:
             return False

--- a/api/factories/variable_factory.py
+++ b/api/factories/variable_factory.py
@@ -101,6 +101,8 @@ def _build_variable_from_mapping(*, mapping: Mapping[str, Any], selector: Sequen
             result = ArrayNumberVariable.model_validate(mapping)
         case SegmentType.ARRAY_OBJECT if isinstance(value, list):
             result = ArrayObjectVariable.model_validate(mapping)
+        case SegmentType.ARRAY_FILE if isinstance(value, list):
+            result = ArrayFileVariable.model_validate(mapping)
         case _:
             raise VariableError(f"not supported value type {value_type}")
     if result.size > dify_config.MAX_VARIABLE_SIZE:

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.tsx
@@ -37,6 +37,7 @@ const typeList = [
   ChatVarType.ArrayString,
   ChatVarType.ArrayNumber,
   ChatVarType.ArrayObject,
+  ChatVarType.ArrayFile,
 ]
 
 const objectPlaceholder = `#  example
@@ -127,6 +128,7 @@ const ChatVariableModal = ({
       case ChatVarType.ArrayString:
       case ChatVarType.ArrayNumber:
       case ChatVarType.ArrayObject:
+      case ChatVarType.ArrayFile:
         return value?.filter(Boolean) || []
     }
   }
@@ -294,84 +296,86 @@ const ChatVariableModal = ({
           </div>
         </div>
         {/* default value */}
-        <div className='mb-4'>
-          <div className='system-sm-semibold mb-1 flex h-6 items-center justify-between text-text-secondary'>
-            <div>{t('workflow.chatVariable.modal.value')}</div>
-            {(type === ChatVarType.ArrayString || type === ChatVarType.ArrayNumber) && (
-              <Button
-                variant='ghost'
-                size='small'
-                className='text-text-tertiary'
-                onClick={() => handleEditorChange(!editInJSON)}
-              >
-                {editInJSON ? <RiInputField className='mr-1 h-3.5 w-3.5' /> : <RiDraftLine className='mr-1 h-3.5 w-3.5' />}
-                {editInJSON ? t('workflow.chatVariable.modal.oneByOne') : t('workflow.chatVariable.modal.editInJSON')}
-              </Button>
-            )}
-            {type === ChatVarType.Object && (
-              <Button
-                variant='ghost'
-                size='small'
-                className='text-text-tertiary'
-                onClick={() => handleEditorChange(!editInJSON)}
-              >
-                {editInJSON ? <RiInputField className='mr-1 h-3.5 w-3.5' /> : <RiDraftLine className='mr-1 h-3.5 w-3.5' />}
-                {editInJSON ? t('workflow.chatVariable.modal.editInForm') : t('workflow.chatVariable.modal.editInJSON')}
-              </Button>
-            )}
-          </div>
-          <div className='flex'>
-            {type === ChatVarType.String && (
-              // Input will remove \n\r, so use Textarea just like description area
-              <textarea
-                className='system-sm-regular placeholder:system-sm-regular block h-20 w-full resize-none appearance-none rounded-lg border border-transparent bg-components-input-bg-normal p-2 caret-primary-600 outline-none placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs'
-                value={value}
-                placeholder={t('workflow.chatVariable.modal.valuePlaceholder') || ''}
-                onChange={e => setValue(e.target.value)}
-              />
-            )}
-            {type === ChatVarType.Number && (
-              <Input
-                placeholder={t('workflow.chatVariable.modal.valuePlaceholder') || ''}
-                value={value}
-                onChange={e => setValue(Number(e.target.value))}
-                type='number'
-              />
-            )}
-            {type === ChatVarType.Object && !editInJSON && (
-              <ObjectValueList
-                list={objectValue}
-                onChange={setObjectValue}
-              />
-            )}
-            {type === ChatVarType.ArrayString && !editInJSON && (
-              <ArrayValueList
-                isString
-                list={value || [undefined]}
-                onChange={setValue}
-              />
-            )}
-            {type === ChatVarType.ArrayNumber && !editInJSON && (
-              <ArrayValueList
-                isString={false}
-                list={value || [undefined]}
-                onChange={setValue}
-              />
-            )}
-            {editInJSON && (
-              <div className='w-full rounded-[10px] bg-components-input-bg-normal py-2 pl-3 pr-1' style={{ height: editorMinHeight }}>
-                <CodeEditor
-                  isExpand
-                  noWrapper
-                  language={CodeLanguage.json}
-                  value={editorContent}
-                  placeholder={<div className='whitespace-pre'>{placeholder}</div>}
-                  onChange={handleEditorValueChange}
+        {type !== ChatVarType.ArrayFile && (
+          <div className='mb-4'>
+            <div className='system-sm-semibold mb-1 flex h-6 items-center justify-between text-text-secondary'>
+              <div>{t('workflow.chatVariable.modal.value')}</div>
+              {(type === ChatVarType.ArrayString || type === ChatVarType.ArrayNumber) && (
+                <Button
+                  variant='ghost'
+                  size='small'
+                  className='text-text-tertiary'
+                  onClick={() => handleEditorChange(!editInJSON)}
+                >
+                  {editInJSON ? <RiInputField className='mr-1 h-3.5 w-3.5' /> : <RiDraftLine className='mr-1 h-3.5 w-3.5' />}
+                  {editInJSON ? t('workflow.chatVariable.modal.oneByOne') : t('workflow.chatVariable.modal.editInJSON')}
+                </Button>
+              )}
+              {type === ChatVarType.Object && (
+                <Button
+                  variant='ghost'
+                  size='small'
+                  className='text-text-tertiary'
+                  onClick={() => handleEditorChange(!editInJSON)}
+                >
+                  {editInJSON ? <RiInputField className='mr-1 h-3.5 w-3.5' /> : <RiDraftLine className='mr-1 h-3.5 w-3.5' />}
+                  {editInJSON ? t('workflow.chatVariable.modal.editInForm') : t('workflow.chatVariable.modal.editInJSON')}
+                </Button>
+              )}
+            </div>
+            <div className='flex'>
+              {type === ChatVarType.String && (
+                // Input will remove \n\r, so use Textarea just like description area
+                <textarea
+                  className='system-sm-regular placeholder:system-sm-regular block h-20 w-full resize-none appearance-none rounded-lg border border-transparent bg-components-input-bg-normal p-2 caret-primary-600 outline-none placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs'
+                  value={value}
+                  placeholder={t('workflow.chatVariable.modal.valuePlaceholder') || ''}
+                  onChange={e => setValue(e.target.value)}
                 />
-              </div>
-            )}
+              )}
+              {type === ChatVarType.Number && (
+                <Input
+                  placeholder={t('workflow.chatVariable.modal.valuePlaceholder') || ''}
+                  value={value}
+                  onChange={e => setValue(Number(e.target.value))}
+                  type='number'
+                />
+              )}
+              {type === ChatVarType.Object && !editInJSON && (
+                <ObjectValueList
+                  list={objectValue}
+                  onChange={setObjectValue}
+                />
+              )}
+              {type === ChatVarType.ArrayString && !editInJSON && (
+                <ArrayValueList
+                  isString
+                  list={value || [undefined]}
+                  onChange={setValue}
+                />
+              )}
+              {type === ChatVarType.ArrayNumber && !editInJSON && (
+                <ArrayValueList
+                  isString={false}
+                  list={value || [undefined]}
+                  onChange={setValue}
+                />
+              )}
+              {editInJSON && (
+                <div className='w-full rounded-[10px] bg-components-input-bg-normal py-2 pl-3 pr-1' style={{ height: editorMinHeight }}>
+                  <CodeEditor
+                    isExpand
+                    noWrapper
+                    language={CodeLanguage.json}
+                    value={editorContent}
+                    placeholder={<div className='whitespace-pre'>{placeholder}</div>}
+                    onChange={handleEditorValueChange}
+                  />
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
         {/* description */}
         <div className=''>
           <div className='system-sm-semibold mb-1 flex h-6 items-center text-text-secondary'>{t('workflow.chatVariable.modal.description')}</div>

--- a/web/app/components/workflow/panel/chat-variable-panel/type.ts
+++ b/web/app/components/workflow/panel/chat-variable-panel/type.ts
@@ -5,4 +5,5 @@ export enum ChatVarType {
   ArrayString = 'array[string]',
   ArrayNumber = 'array[number]',
   ArrayObject = 'array[object]',
+  ArrayFile = 'array[file]',
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
In a multimodal chat flow scenario, there may be instances where it is necessary to use previously uploaded images or images generated by tools in subsequent rounds of conversation. For example, in situations like "Please help me further analyze the third image"
So conversation variable need to support file types.

related issue: fix #21170 

## Screenshots
![456408958-ff70228f-4bae-4b29-8847-76b7a0d4731e](https://github.com/user-attachments/assets/3f6f03e8-c679-434f-8343-80b262eb3811)



## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [x] I have tested the new feature in local