### PR TITLE
fix: set the func.coalesce() second paramter default value #21239

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -140,7 +140,7 @@ class Dataset(Base):
     def word_count(self):
         return (
             db.session.query(Document)
-            .with_entities(func.coalesce(func.sum(Document.word_count)))
+            .with_entities(func.coalesce(func.sum(Document.word_count), 0))
             .filter(Document.dataset_id == self.id)
             .scalar()
         )
@@ -448,7 +448,7 @@ class Document(Base):
     def hit_count(self):
         return (
             db.session.query(DocumentSegment)
-            .with_entities(func.coalesce(func.sum(DocumentSegment.hit_count)))
+            .with_entities(func.coalesce(func.sum(DocumentSegment.hit_count), 0))
             .filter(DocumentSegment.document_id == self.id)
             .scalar()
         )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #21239

fix the func.coalesce() have not second default bug

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
