### PR TITLE
fix: missing conversation and environment variables in DSL importing.

### DIFF
--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -119,6 +119,8 @@ export const Workflow: FC<WorkflowProps> = memo(({
     setShowConfirm,
     setControlPromptEditorRerenderKey,
     setSyncWorkflowDraftHash,
+    setConversationVariables,
+    setEnvironmentVariables,
   } = workflowStore.getState()
   const {
     handleSyncWorkflowDraft,
@@ -138,6 +140,12 @@ export const Workflow: FC<WorkflowProps> = memo(({
 
       if (v.payload.hash)
         setSyncWorkflowDraftHash(v.payload.hash)
+
+      if (v.payload.conversation_variables)
+        setConversationVariables(v.payload.conversation_variables)
+
+      if (v.payload.environment_variables)
+        setEnvironmentVariables(v.payload.environment_variables)
 
       onWorkflowDataUpdate?.(v.payload)
 

--- a/web/app/components/workflow/update-dsl-modal.tsx
+++ b/web/app/components/workflow/update-dsl-modal.tsx
@@ -86,6 +86,8 @@ const UpdateDSLModal = ({
       graph,
       features,
       hash,
+      conversation_variables,
+      environment_variables,
     } = await fetchWorkflowDraft(`/apps/${app_id}/workflows/draft`)
 
     const { nodes, edges, viewport } = graph
@@ -122,6 +124,8 @@ const UpdateDSLModal = ({
         viewport,
         features: newFeatures,
         hash,
+        conversation_variables: conversation_variables || [],
+        environment_variables: environment_variables || [],
       },
     } as any)
   }, [eventEmitter])


### PR DESCRIPTION
## Summary
Fixes #21039

In the `handleWorkflowUpdate` function, although data is retrieved from the draft workflow, the conversation variables and environment variables are not included when sending the `WORKFLOW_DATA_UPDATE` event.  
Currently, only the graph, features, and hash are sent and updated to the frontend, while the **conversation variables** and **environment variables** are **omitted**.

### Solution

This PR updates the `handleWorkflowUpdate` function to ensure that both conversation variables and environment variables from the draft workflow are included in the `WORKFLOW_DATA_UPDATE` event payload, so they can be properly updated on the frontend.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
