### PR TITLE
fix: not permitted schema of markdown link cause page crash

### DIFF
--- a/web/app/components/base/markdown-blocks/link.tsx
+++ b/web/app/components/base/markdown-blocks/link.tsx
@@ -16,7 +16,7 @@ const Link = ({ node, children, ...props }: any) => {
   }
   else {
     const href = props.href || node.properties?.href
-    if(!isValidUrl(href))
+    if(!href || !isValidUrl(href))
       return <span>{children}</span>
 
     return <a href={href} target="_blank" className="cursor-pointer underline !decoration-primary-700 decoration-dashed">{children || 'Download'}</a>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fix https://github.com/langgenius/dify/issues/21252

the code [here](https://github.com/langgenius/dify/blob/6b1ad634f15459bd8792ee8df7895735ccf0d511/web/app/components/base/markdown/markdown-utils.ts#L58)    valid the schema of a markdown url
not permitted schema cause the link to a `undefined`  and the page crash

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
