### PR TITLE
style(dark): Adjust chat bubble background color (langgenius#20990)

### DIFF
--- a/web/themes/dark.css
+++ b/web/themes/dark.css
@@ -386,7 +386,7 @@ html[data-theme="dark"] {
   --color-background-gradient-bg-fill-chat-bg-2: #1d1d20;
   --color-background-gradient-bg-fill-chat-bubble-bg-1: #c8ceda14;
   --color-background-gradient-bg-fill-chat-bubble-bg-2: #c8ceda05;
-  --color-background-gradient-bg-fill-chat-bubble-bg-3: #a5bddb;
+  --color-background-gradient-bg-fill-chat-bubble-bg-3: #27314d;
   --color-background-gradient-bg-fill-debug-bg-1: #c8ceda14;
   --color-background-gradient-bg-fill-debug-bg-2: #18181b0a;
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Changed the chat bubble background color from #a5bddb to #27314d
- This modification provides better visual appearance and readability for the chat bubble in dark theme

Fixes #20990

However I'm not sure what color the modal overlay should use in dark mode. I've noticed that in libraries like NextUI and shadcn/ui, the overlay doesn't seem to change much in appearance when switching to dark mode — it still looks pretty similar to the light mode version

| Light | Dark|
|--------|-------|
| ![image](https://github.com/user-attachments/assets/98500dac-f2cc-4f19-98f8-f2b467b0da0e)| ![image](https://github.com/user-attachments/assets/6079579f-0857-426a-9863-5d0d32ac7ed9)|


## Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/3a9e662e-66df-4a37-8fcd-0a62ddb8a136)| ![image](https://github.com/user-attachments/assets/499f017b-f051-4d45-9063-0d0c4986568f)| 

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
