### PR TITLE
fix: update auto translations for days of the week(#21279)

### DIFF
--- a/web/i18n/zh-Hant/time.ts
+++ b/web/i18n/zh-Hant/time.ts
@@ -1,12 +1,12 @@
 const translation = {
   daysInWeek: {
-    Tue: '星期二',
-    Wed: '星期三',
-    Fri: '自由',
-    Mon: '懷念',
-    Sun: '太陽',
-    Sat: '星期六',
-    Thu: '星期四',
+    Sun: '日',
+    Mon: '一',
+    Tue: '二',
+    Wed: '三',
+    Thu: '四',
+    Fri: '五',
+    Sat: '六',
   },
   months: {
     January: '一月',


### PR DESCRIPTION
> [!IMPORTANT]
>
>Fixes #21279

## Summary
The en-US base language uses abbreviations, which leads to incorrect automatic translation
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots
![image](https://github.com/user-attachments/assets/ad614eb5-6cff-4d5a-a5e8-19a2497b9139)
![image](https://github.com/user-attachments/assets/095a93dc-c989-46a8-8721-e9d47f7239a4)


| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
