### PR TITLE
fix: markdown_extractor lost chunks if it starts without a header(#21308)

### DIFF
--- a/api/core/rag/extractor/markdown_extractor.py
+++ b/api/core/rag/extractor/markdown_extractor.py
@@ -68,22 +68,17 @@ class MarkdownExtractor(BaseExtractor):
                 continue
             header_match = re.match(r"^#+\s", line)
             if header_match:
-                if current_header is not None:
-                    markdown_tups.append((current_header, current_text))
-
+                markdown_tups.append((current_header, current_text))
                 current_header = line
                 current_text = ""
             else:
                 current_text += line + "\n"
         markdown_tups.append((current_header, current_text))
 
-        if current_header is not None:
-            # pass linting, assert keys are defined
-            markdown_tups = [
-                (re.sub(r"#", "", cast(str, key)).strip(), re.sub(r"<.*?>", "", value)) for key, value in markdown_tups
-            ]
-        else:
-            markdown_tups = [(key, re.sub("\n", "", value)) for key, value in markdown_tups]
+        markdown_tups = [
+            (re.sub(r"#", "", cast(str, key)).strip() if key else None, re.sub(r"<.*?>", "", value))
+            for key, value in markdown_tups
+        ]
 
         return markdown_tups
 

--- a/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
@@ -1,0 +1,20 @@
+from core.rag.extractor.markdown_extractor import MarkdownExtractor
+
+
+def test_markdown_to_tups():
+    markdown = """
+this is some text without header
+
+# title 1
+this is balabala text
+
+## title 2
+this is more specific text.
+        """
+    extractor = MarkdownExtractor(file_path="dummy_path")
+    updated_output = extractor.markdown_to_tups(markdown)
+    assert len(updated_output) == 3
+    key, _ = updated_output[0]
+    _, value = updated_output[1]
+    assert key == None
+    assert value.strip() == 'this is balabala text'

--- a/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
@@ -14,7 +14,9 @@ this is more specific text.
     extractor = MarkdownExtractor(file_path="dummy_path")
     updated_output = extractor.markdown_to_tups(markdown)
     assert len(updated_output) == 3
-    key, _ = updated_output[0]
-    _, value = updated_output[1]
+    key, header_value = updated_output[0]
     assert key == None
-    assert value.strip() == 'this is balabala text'
+    assert header_value.strip() == "this is some text without header"
+    title_1, value = updated_output[1]
+    assert title_1.strip() == "title 1"
+    assert value.strip() == "this is balabala text"


### PR DESCRIPTION
Fixes: https://github.com/langgenius/dify/issues/21308

more details see issue description
## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
