### PR TITLE
fix: Once the memory is activated, it cannot be deactivated.

### DIFF
--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -33,6 +33,9 @@ class TokenBufferMemory:
         :param max_token_limit: max token limit
         :param message_limit: message limit
         """
+        if not message_limit or message_limit <= 0:
+            return []
+
         app_record = self.conversation.app
 
         # fetch limited messages, and return reversed
@@ -52,10 +55,7 @@ class TokenBufferMemory:
             .order_by(Message.created_at.desc())
         )
 
-        if message_limit and message_limit > 0:
-            message_limit = min(message_limit, 500)
-        else:
-            message_limit = 500
+        message_limit = min(message_limit, 500)
 
         messages = query.limit(message_limit).all()
 


### PR DESCRIPTION
- Avoid misleading front-end users into choosing whether to turn off or keep the memory function enabled after selecting it.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
