### PR TITLE
fix: resolve Docker file URL networking issue for plugins (#21334)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -17,6 +17,11 @@ APP_WEB_URL=http://127.0.0.1:3000
 # Files URL
 FILES_URL=http://127.0.0.1:5001
 
+# INTERNAL_FILES_URL is used for plugin daemon communication within Docker network.
+# Set this to the internal Docker service URL for proper plugin file access.
+# Example: INTERNAL_FILES_URL=http://api:5001
+INTERNAL_FILES_URL=http://127.0.0.1:5001
+
 # The time in seconds after the signature is rejected
 FILES_ACCESS_TIMEOUT=300
 

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -237,6 +237,13 @@ class FileAccessConfig(BaseSettings):
         default="",
     )
 
+    INTERNAL_FILES_URL: str = Field(
+        description="Internal base URL for file access within Docker network,"
+        " used for plugin daemon and internal service communication."
+        " Falls back to FILES_URL if not specified.",
+        default="",
+    )
+
     FILES_ACCESS_TIMEOUT: int = Field(
         description="Expiration time in seconds for file access URLs",
         default=300,

--- a/api/core/file/helpers.py
+++ b/api/core/file/helpers.py
@@ -21,7 +21,9 @@ def get_signed_file_url(upload_file_id: str) -> str:
 
 
 def get_signed_file_url_for_plugin(filename: str, mimetype: str, tenant_id: str, user_id: str) -> str:
-    url = f"{dify_config.FILES_URL}/files/upload/for-plugin"
+    # Plugin access should use internal URL for Docker network communication
+    base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+    url = f"{base_url}/files/upload/for-plugin"
 
     if user_id is None:
         user_id = "DEFAULT-USER"

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -5,13 +5,12 @@ import os
 import time
 
 from configs import dify_config
-
-
 def sign_tool_file(tool_file_id: str, extension: str) -> str:
     """
-    sign file to get a temporary url
+    sign file to get a temporary url for plugin access
     """
-    base_url = dify_config.FILES_URL
+    # Use internal URL for plugin/tool file access in Docker environments
+    base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
     file_preview_url = f"{base_url}/files/tools/{tool_file_id}{extension}"
 
     timestamp = str(int(time.time()))

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -5,6 +5,8 @@ import os
 import time
 
 from configs import dify_config
+
+
 def sign_tool_file(tool_file_id: str, extension: str) -> str:
     """
     sign file to get a temporary url for plugin access

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -19,7 +19,6 @@ from extensions.ext_storage import storage
 from models.model import MessageFile
 from models.tools import ToolFile
 
-
 logger = logging.getLogger(__name__)
 
 from sqlalchemy.engine import Engine

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -19,6 +19,7 @@ from extensions.ext_storage import storage
 from models.model import MessageFile
 from models.tools import ToolFile
 
+
 logger = logging.getLogger(__name__)
 
 from sqlalchemy.engine import Engine
@@ -35,9 +36,10 @@ class ToolFileManager:
     @staticmethod
     def sign_file(tool_file_id: str, extension: str) -> str:
         """
-        sign file to get a temporary url
+        sign file to get a temporary url for plugin access
         """
-        base_url = dify_config.FILES_URL
+        # Use internal URL for plugin/tool file access in Docker environments
+        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
         file_preview_url = f"{base_url}/files/tools/{tool_file_id}{extension}"
 
         timestamp = str(int(time.time()))

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -47,6 +47,11 @@ APP_WEB_URL=
 #   ensuring port 5001 is externally accessible (see docker-compose.yaml).
 FILES_URL=
 
+# INTERNAL_FILES_URL is used for plugin daemon communication within Docker network.
+# Set this to the internal Docker service URL for proper plugin file access.
+# Example: INTERNAL_FILES_URL=http://api:5001
+INTERNAL_FILES_URL=
+
 # ------------------------------
 # Server Configuration
 # ------------------------------

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,6 +11,7 @@ x-shared-env: &shared-api-worker-env
   APP_API_URL: ${APP_API_URL:-}
   APP_WEB_URL: ${APP_WEB_URL:-}
   FILES_URL: ${FILES_URL:-}
+  INTERNAL_FILES_URL: ${INTERNAL_FILES_URL:-}
   LOG_LEVEL: ${LOG_LEVEL:-INFO}
   LOG_FILE: ${LOG_FILE:-/app/logs/server.log}
   LOG_FILE_MAX_SIZE: ${LOG_FILE_MAX_SIZE:-20}


### PR DESCRIPTION
Fixes #21334

### Problem
Using `STORAGE_TYPE=local` and `FILES_URL=http://localhost` no longer works in Docker environments. Plugin daemon cannot access files uploaded by users.

### Solution  
- Added `INTERNAL_FILES_URL` config for Docker network communication
- Plugin file access now uses internal Docker service URLs (e.g., `http://api:5001`)
- User downloads continue using external URLs (e.g., `http://localhost:5001`)
- Simple fallback: uses `FILES_URL` if `INTERNAL_FILES_URL` not set

### Configuration
Add to Docker environment:
```bash
INTERNAL_FILES_URL=http://api:5001
```

### Testing
- ✅ Plugin file access works in Docker
- ✅ User file downloads work from browser  
- ✅ Backward compatible with existing setups