### PR TITLE
fix(document_extractor): xlsx file column int type error

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -451,7 +451,7 @@ def _extract_text_from_excel(file_content: bytes) -> str:
                 df = df.applymap(lambda x: " ".join(str(x).splitlines()) if isinstance(x, str) else x)  # type: ignore
 
                 # Combine multi-line text in column names into a single line
-                df.columns = pd.Index([" ".join(col.splitlines()) for col in df.columns])
+                df.columns = pd.Index([" ".join(str(col).splitlines()) for col in df.columns])
 
                 # Manually construct the Markdown table
                 markdown_table += _construct_markdown_table(df) + "\n\n"

--- a/api/tests/unit_tests/core/workflow/nodes/test_document_extractor_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_document_extractor_node.py
@@ -342,3 +342,26 @@ def test_extract_text_from_excel_all_sheets_fail(mock_excel_file):
     assert result == ""
 
     assert mock_excel_instance.parse.call_count == 2
+
+
+@patch("pandas.ExcelFile")
+def test_extract_text_from_excel_numeric_type_column(mock_excel_file):
+    """Test extracting text from Excel file with numeric column names."""
+
+    # Test number type column
+    data = {1: ["Test"], 1.1: ["Test"]}
+
+    df = pd.DataFrame(data)
+
+    # Mock ExcelFile
+    mock_excel_instance = Mock()
+    mock_excel_instance.sheet_names = ["Sheet1"]
+    mock_excel_instance.parse.return_value = df
+    mock_excel_file.return_value = mock_excel_instance
+
+    file_content = b"fake_excel_content"
+    result = _extract_text_from_excel(file_content)
+
+    expected_manual = "| 1.0 | 1.1 |\n| --- | --- |\n| Test | Test |\n\n"
+
+    assert expected_manual == result

--- a/api/tests/unit_tests/core/workflow/nodes/test_document_extractor_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_document_extractor_node.py
@@ -348,7 +348,7 @@ def test_extract_text_from_excel_all_sheets_fail(mock_excel_file):
 def test_extract_text_from_excel_numeric_type_column(mock_excel_file):
     """Test extracting text from Excel file with numeric column names."""
 
-    # Test number type column
+    # Test numeric type column
     data = {1: ["Test"], 1.1: ["Test"]}
 
     df = pd.DataFrame(data)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

fix #21397 
## Summary
ref this pr bug  #20625

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/1c8176e1-7257-42de-8f7a-dc3079c5a95a" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
