### PR TITLE
feat: refactor: test_dataset unit tests #21499

### DIFF
--- a/api/tests/unit_tests/services/test_dataset_permission.py
+++ b/api/tests/unit_tests/services/test_dataset_permission.py
@@ -8,151 +8,298 @@ from services.dataset_service import DatasetService
 from services.errors.account import NoPermissionError
 
 
+class DatasetPermissionTestDataFactory:
+    """Factory class for creating test data and mock objects for dataset permission tests."""
+
+    @staticmethod
+    def create_dataset_mock(
+        dataset_id: str = "dataset-123",
+        tenant_id: str = "test-tenant-123",
+        created_by: str = "creator-456",
+        permission: DatasetPermissionEnum = DatasetPermissionEnum.ONLY_ME,
+        **kwargs,
+    ) -> Mock:
+        """Create a mock dataset with specified attributes."""
+        dataset = Mock(spec=Dataset)
+        dataset.id = dataset_id
+        dataset.tenant_id = tenant_id
+        dataset.created_by = created_by
+        dataset.permission = permission
+        for key, value in kwargs.items():
+            setattr(dataset, key, value)
+        return dataset
+
+    @staticmethod
+    def create_user_mock(
+        user_id: str = "user-789",
+        tenant_id: str = "test-tenant-123",
+        role: TenantAccountRole = TenantAccountRole.NORMAL,
+        **kwargs,
+    ) -> Mock:
+        """Create a mock user with specified attributes."""
+        user = Mock(spec=Account)
+        user.id = user_id
+        user.current_tenant_id = tenant_id
+        user.current_role = role
+        for key, value in kwargs.items():
+            setattr(user, key, value)
+        return user
+
+    @staticmethod
+    def create_dataset_permission_mock(
+        dataset_id: str = "dataset-123",
+        account_id: str = "user-789",
+        **kwargs,
+    ) -> Mock:
+        """Create a mock dataset permission record."""
+        permission = Mock(spec=DatasetPermission)
+        permission.dataset_id = dataset_id
+        permission.account_id = account_id
+        for key, value in kwargs.items():
+            setattr(permission, key, value)
+        return permission
+
+
 class TestDatasetPermissionService:
-    """Test cases for dataset permission checking functionality"""
+    """
+    Comprehensive unit tests for DatasetService.check_dataset_permission method.
 
-    def setup_method(self):
-        """Set up test fixtures"""
-        # Mock tenant and user
-        self.tenant_id = "test-tenant-123"
-        self.creator_id = "creator-456"
-        self.normal_user_id = "normal-789"
-        self.owner_user_id = "owner-999"
+    This test suite covers all permission scenarios including:
+    - Cross-tenant access restrictions
+    - Owner privilege checks
+    - Different permission levels (ONLY_ME, ALL_TEAM, PARTIAL_TEAM)
+    - Explicit permission checks for PARTIAL_TEAM
+    - Error conditions and logging
+    """
 
-        # Mock dataset
-        self.dataset = Mock(spec=Dataset)
-        self.dataset.id = "dataset-123"
-        self.dataset.tenant_id = self.tenant_id
-        self.dataset.created_by = self.creator_id
+    @pytest.fixture
+    def mock_dataset_service_dependencies(self):
+        """Common mock setup for dataset service dependencies."""
+        with patch("services.dataset_service.db.session") as mock_session:
+            yield {
+                "db_session": mock_session,
+            }
 
-        # Mock users
-        self.creator_user = Mock(spec=Account)
-        self.creator_user.id = self.creator_id
-        self.creator_user.current_tenant_id = self.tenant_id
-        self.creator_user.current_role = TenantAccountRole.EDITOR
+    @pytest.fixture
+    def mock_logging_dependencies(self):
+        """Mock setup for logging tests."""
+        with patch("services.dataset_service.logging") as mock_logging:
+            yield {
+                "logging": mock_logging,
+            }
 
-        self.normal_user = Mock(spec=Account)
-        self.normal_user.id = self.normal_user_id
-        self.normal_user.current_tenant_id = self.tenant_id
-        self.normal_user.current_role = TenantAccountRole.NORMAL
-
-        self.owner_user = Mock(spec=Account)
-        self.owner_user.id = self.owner_user_id
-        self.owner_user.current_tenant_id = self.tenant_id
-        self.owner_user.current_role = TenantAccountRole.OWNER
-
-    def test_permission_check_different_tenant_should_fail(self):
-        """Test that users from different tenants cannot access dataset"""
-        self.normal_user.current_tenant_id = "different-tenant"
-
-        with pytest.raises(NoPermissionError, match="You do not have permission to access this dataset."):
-            DatasetService.check_dataset_permission(self.dataset, self.normal_user)
-
-    def test_owner_can_access_any_dataset(self):
-        """Test that tenant owners can access any dataset regardless of permission"""
-        self.dataset.permission = DatasetPermissionEnum.ONLY_ME
-
+    def _assert_permission_check_passes(self, dataset: Mock, user: Mock):
+        """Helper method to verify that permission check passes without raising exceptions."""
         # Should not raise any exception
-        DatasetService.check_dataset_permission(self.dataset, self.owner_user)
+        DatasetService.check_dataset_permission(dataset, user)
 
-    def test_only_me_permission_creator_can_access(self):
-        """Test ONLY_ME permission allows only creator to access"""
-        self.dataset.permission = DatasetPermissionEnum.ONLY_ME
+    def _assert_permission_check_fails(
+        self, dataset: Mock, user: Mock, expected_message: str = "You do not have permission to access this dataset."
+    ):
+        """Helper method to verify that permission check fails with expected error."""
+        with pytest.raises(NoPermissionError, match=expected_message):
+            DatasetService.check_dataset_permission(dataset, user)
 
-        # Creator should be able to access
-        DatasetService.check_dataset_permission(self.dataset, self.creator_user)
+    def _assert_database_query_called(self, mock_session: Mock, dataset_id: str, account_id: str):
+        """Helper method to verify database query calls for permission checks."""
+        mock_session.query().filter_by.assert_called_with(dataset_id=dataset_id, account_id=account_id)
 
-    def test_only_me_permission_others_cannot_access(self):
-        """Test ONLY_ME permission denies access to non-creators"""
-        self.dataset.permission = DatasetPermissionEnum.ONLY_ME
-
-        with pytest.raises(NoPermissionError, match="You do not have permission to access this dataset."):
-            DatasetService.check_dataset_permission(self.dataset, self.normal_user)
-
-    def test_all_team_permission_allows_access(self):
-        """Test ALL_TEAM permission allows any team member to access"""
-        self.dataset.permission = DatasetPermissionEnum.ALL_TEAM
-
-        # Should not raise any exception for team members
-        DatasetService.check_dataset_permission(self.dataset, self.normal_user)
-        DatasetService.check_dataset_permission(self.dataset, self.creator_user)
-
-    @patch("services.dataset_service.db.session")
-    def test_partial_team_permission_creator_can_access(self, mock_session):
-        """Test PARTIAL_TEAM permission allows creator to access"""
-        self.dataset.permission = DatasetPermissionEnum.PARTIAL_TEAM
-
-        # Should not raise any exception for creator
-        DatasetService.check_dataset_permission(self.dataset, self.creator_user)
-
-        # Should not query database for creator
+    def _assert_database_query_not_called(self, mock_session: Mock):
+        """Helper method to verify that database query was not called."""
         mock_session.query.assert_not_called()
 
-    @patch("services.dataset_service.db.session")
-    def test_partial_team_permission_with_explicit_permission(self, mock_session):
-        """Test PARTIAL_TEAM permission allows users with explicit permission"""
-        self.dataset.permission = DatasetPermissionEnum.PARTIAL_TEAM
+    # ==================== Cross-Tenant Access Tests ====================
+
+    def test_permission_check_different_tenant_should_fail(self):
+        """Test that users from different tenants cannot access dataset regardless of other permissions."""
+        # Create dataset and user from different tenants
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(
+            tenant_id="tenant-123", permission=DatasetPermissionEnum.ALL_TEAM
+        )
+        user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="user-789", tenant_id="different-tenant-456", role=TenantAccountRole.EDITOR
+        )
+
+        # Should fail due to different tenant
+        self._assert_permission_check_fails(dataset, user)
+
+    # ==================== Owner Privilege Tests ====================
+
+    def test_owner_can_access_any_dataset(self):
+        """Test that tenant owners can access any dataset regardless of permission level."""
+        # Create dataset with restrictive permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(permission=DatasetPermissionEnum.ONLY_ME)
+
+        # Create owner user
+        owner_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="owner-999", role=TenantAccountRole.OWNER
+        )
+
+        # Owner should have access regardless of dataset permission
+        self._assert_permission_check_passes(dataset, owner_user)
+
+    # ==================== ONLY_ME Permission Tests ====================
+
+    def test_only_me_permission_creator_can_access(self):
+        """Test ONLY_ME permission allows only the dataset creator to access."""
+        # Create dataset with ONLY_ME permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(
+            created_by="creator-456", permission=DatasetPermissionEnum.ONLY_ME
+        )
+
+        # Create creator user
+        creator_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="creator-456", role=TenantAccountRole.EDITOR
+        )
+
+        # Creator should be able to access
+        self._assert_permission_check_passes(dataset, creator_user)
+
+    def test_only_me_permission_others_cannot_access(self):
+        """Test ONLY_ME permission denies access to non-creators."""
+        # Create dataset with ONLY_ME permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(
+            created_by="creator-456", permission=DatasetPermissionEnum.ONLY_ME
+        )
+
+        # Create normal user (not the creator)
+        normal_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="normal-789", role=TenantAccountRole.NORMAL
+        )
+
+        # Non-creator should be denied access
+        self._assert_permission_check_fails(dataset, normal_user)
+
+    # ==================== ALL_TEAM Permission Tests ====================
+
+    def test_all_team_permission_allows_access(self):
+        """Test ALL_TEAM permission allows any team member to access the dataset."""
+        # Create dataset with ALL_TEAM permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(permission=DatasetPermissionEnum.ALL_TEAM)
+
+        # Create different types of team members
+        normal_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="normal-789", role=TenantAccountRole.NORMAL
+        )
+        editor_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="editor-456", role=TenantAccountRole.EDITOR
+        )
+
+        # All team members should have access
+        self._assert_permission_check_passes(dataset, normal_user)
+        self._assert_permission_check_passes(dataset, editor_user)
+
+    # ==================== PARTIAL_TEAM Permission Tests ====================
+
+    def test_partial_team_permission_creator_can_access(self, mock_dataset_service_dependencies):
+        """Test PARTIAL_TEAM permission allows creator to access without database query."""
+        # Create dataset with PARTIAL_TEAM permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(
+            created_by="creator-456", permission=DatasetPermissionEnum.PARTIAL_TEAM
+        )
+
+        # Create creator user
+        creator_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="creator-456", role=TenantAccountRole.EDITOR
+        )
+
+        # Creator should have access without database query
+        self._assert_permission_check_passes(dataset, creator_user)
+        self._assert_database_query_not_called(mock_dataset_service_dependencies["db_session"])
+
+    def test_partial_team_permission_with_explicit_permission(self, mock_dataset_service_dependencies):
+        """Test PARTIAL_TEAM permission allows users with explicit permission records."""
+        # Create dataset with PARTIAL_TEAM permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(permission=DatasetPermissionEnum.PARTIAL_TEAM)
+
+        # Create normal user (not the creator)
+        normal_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="normal-789", role=TenantAccountRole.NORMAL
+        )
 
         # Mock database query to return a permission record
-        mock_permission = Mock(spec=DatasetPermission)
-        mock_session.query().filter_by().first.return_value = mock_permission
+        mock_permission = DatasetPermissionTestDataFactory.create_dataset_permission_mock(
+            dataset_id=dataset.id, account_id=normal_user.id
+        )
+        mock_dataset_service_dependencies["db_session"].query().filter_by().first.return_value = mock_permission
 
-        # Should not raise any exception
-        DatasetService.check_dataset_permission(self.dataset, self.normal_user)
+        # User with explicit permission should have access
+        self._assert_permission_check_passes(dataset, normal_user)
+        self._assert_database_query_called(mock_dataset_service_dependencies["db_session"], dataset.id, normal_user.id)
 
-        # Verify database was queried correctly
-        mock_session.query().filter_by.assert_called_with(dataset_id=self.dataset.id, account_id=self.normal_user.id)
+    def test_partial_team_permission_without_explicit_permission(self, mock_dataset_service_dependencies):
+        """Test PARTIAL_TEAM permission denies users without explicit permission records."""
+        # Create dataset with PARTIAL_TEAM permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(permission=DatasetPermissionEnum.PARTIAL_TEAM)
 
-    @patch("services.dataset_service.db.session")
-    def test_partial_team_permission_without_explicit_permission(self, mock_session):
-        """Test PARTIAL_TEAM permission denies users without explicit permission"""
-        self.dataset.permission = DatasetPermissionEnum.PARTIAL_TEAM
+        # Create normal user (not the creator)
+        normal_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="normal-789", role=TenantAccountRole.NORMAL
+        )
 
         # Mock database query to return None (no permission record)
-        mock_session.query().filter_by().first.return_value = None
+        mock_dataset_service_dependencies["db_session"].query().filter_by().first.return_value = None
 
-        with pytest.raises(NoPermissionError, match="You do not have permission to access this dataset."):
-            DatasetService.check_dataset_permission(self.dataset, self.normal_user)
+        # User without explicit permission should be denied access
+        self._assert_permission_check_fails(dataset, normal_user)
+        self._assert_database_query_called(mock_dataset_service_dependencies["db_session"], dataset.id, normal_user.id)
 
-        # Verify database was queried correctly
-        mock_session.query().filter_by.assert_called_with(dataset_id=self.dataset.id, account_id=self.normal_user.id)
-
-    @patch("services.dataset_service.db.session")
-    def test_partial_team_permission_non_creator_without_permission_fails(self, mock_session):
-        """Test that non-creators without explicit permission are denied access"""
-        self.dataset.permission = DatasetPermissionEnum.PARTIAL_TEAM
+    def test_partial_team_permission_non_creator_without_permission_fails(self, mock_dataset_service_dependencies):
+        """Test that non-creators without explicit permission are denied access to PARTIAL_TEAM datasets."""
+        # Create dataset with PARTIAL_TEAM permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(
+            created_by="creator-456", permission=DatasetPermissionEnum.PARTIAL_TEAM
+        )
 
         # Create a different user (not the creator)
-        other_user = Mock(spec=Account)
-        other_user.id = "other-user-123"
-        other_user.current_tenant_id = self.tenant_id
-        other_user.current_role = TenantAccountRole.NORMAL
+        other_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="other-user-123", role=TenantAccountRole.NORMAL
+        )
 
         # Mock database query to return None (no permission record)
-        mock_session.query().filter_by().first.return_value = None
+        mock_dataset_service_dependencies["db_session"].query().filter_by().first.return_value = None
 
-        with pytest.raises(NoPermissionError, match="You do not have permission to access this dataset."):
-            DatasetService.check_dataset_permission(self.dataset, other_user)
+        # Non-creator without explicit permission should be denied access
+        self._assert_permission_check_fails(dataset, other_user)
+        self._assert_database_query_called(mock_dataset_service_dependencies["db_session"], dataset.id, other_user.id)
+
+    # ==================== Enum Usage Tests ====================
 
     def test_partial_team_permission_uses_correct_enum(self):
-        """Test that the method correctly uses DatasetPermissionEnum.PARTIAL_TEAM"""
-        # This test ensures we're using the enum instead of string literals
-        self.dataset.permission = DatasetPermissionEnum.PARTIAL_TEAM
+        """Test that the method correctly uses DatasetPermissionEnum.PARTIAL_TEAM instead of string literals."""
+        # Create dataset with PARTIAL_TEAM permission using enum
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(
+            created_by="creator-456", permission=DatasetPermissionEnum.PARTIAL_TEAM
+        )
 
-        # Creator should always have access
-        DatasetService.check_dataset_permission(self.dataset, self.creator_user)
+        # Create creator user
+        creator_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="creator-456", role=TenantAccountRole.EDITOR
+        )
 
-    @patch("services.dataset_service.logging")
-    @patch("services.dataset_service.db.session")
-    def test_permission_denied_logs_debug_message(self, mock_session, mock_logging):
-        """Test that permission denied events are logged"""
-        self.dataset.permission = DatasetPermissionEnum.PARTIAL_TEAM
-        mock_session.query().filter_by().first.return_value = None
+        # Creator should always have access regardless of permission level
+        self._assert_permission_check_passes(dataset, creator_user)
 
+    # ==================== Logging Tests ====================
+
+    def test_permission_denied_logs_debug_message(self, mock_dataset_service_dependencies, mock_logging_dependencies):
+        """Test that permission denied events are properly logged for debugging purposes."""
+        # Create dataset with PARTIAL_TEAM permission
+        dataset = DatasetPermissionTestDataFactory.create_dataset_mock(permission=DatasetPermissionEnum.PARTIAL_TEAM)
+
+        # Create normal user (not the creator)
+        normal_user = DatasetPermissionTestDataFactory.create_user_mock(
+            user_id="normal-789", role=TenantAccountRole.NORMAL
+        )
+
+        # Mock database query to return None (no permission record)
+        mock_dataset_service_dependencies["db_session"].query().filter_by().first.return_value = None
+
+        # Attempt permission check (should fail)
         with pytest.raises(NoPermissionError):
-            DatasetService.check_dataset_permission(self.dataset, self.normal_user)
+            DatasetService.check_dataset_permission(dataset, normal_user)
 
-        # Verify debug message was logged
-        mock_logging.debug.assert_called_with(
-            f"User {self.normal_user.id} does not have permission to access dataset {self.dataset.id}"
+        # Verify debug message was logged with correct user and dataset information
+        mock_logging_dependencies["logging"].debug.assert_called_with(
+            f"User {normal_user.id} does not have permission to access dataset {dataset.id}"
         )

--- a/api/tests/unit_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_update_dataset.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any, Optional
 
 # Mock redis_client before importing dataset_service
 from unittest.mock import Mock, patch
@@ -10,6 +11,77 @@ from models.dataset import Dataset, ExternalKnowledgeBindings
 from services.dataset_service import DatasetService
 from services.errors.account import NoPermissionError
 from tests.unit_tests.conftest import redis_mock
+
+
+class DatasetUpdateTestDataFactory:
+    """Factory class for creating test data and mock objects for dataset update tests."""
+
+    @staticmethod
+    def create_dataset_mock(
+        dataset_id: str = "dataset-123",
+        provider: str = "vendor",
+        name: str = "old_name",
+        description: str = "old_description",
+        indexing_technique: str = "high_quality",
+        retrieval_model: str = "old_model",
+        embedding_model_provider: Optional[str] = None,
+        embedding_model: Optional[str] = None,
+        collection_binding_id: Optional[str] = None,
+        **kwargs,
+    ) -> Mock:
+        """Create a mock dataset with specified attributes."""
+        dataset = Mock(spec=Dataset)
+        dataset.id = dataset_id
+        dataset.provider = provider
+        dataset.name = name
+        dataset.description = description
+        dataset.indexing_technique = indexing_technique
+        dataset.retrieval_model = retrieval_model
+        dataset.embedding_model_provider = embedding_model_provider
+        dataset.embedding_model = embedding_model
+        dataset.collection_binding_id = collection_binding_id
+        for key, value in kwargs.items():
+            setattr(dataset, key, value)
+        return dataset
+
+    @staticmethod
+    def create_user_mock(user_id: str = "user-789") -> Mock:
+        """Create a mock user."""
+        user = Mock()
+        user.id = user_id
+        return user
+
+    @staticmethod
+    def create_external_binding_mock(
+        external_knowledge_id: str = "old_knowledge_id", external_knowledge_api_id: str = "old_api_id"
+    ) -> Mock:
+        """Create a mock external knowledge binding."""
+        binding = Mock(spec=ExternalKnowledgeBindings)
+        binding.external_knowledge_id = external_knowledge_id
+        binding.external_knowledge_api_id = external_knowledge_api_id
+        return binding
+
+    @staticmethod
+    def create_embedding_model_mock(model: str = "text-embedding-ada-002", provider: str = "openai") -> Mock:
+        """Create a mock embedding model."""
+        embedding_model = Mock()
+        embedding_model.model = model
+        embedding_model.provider = provider
+        return embedding_model
+
+    @staticmethod
+    def create_collection_binding_mock(binding_id: str = "binding-456") -> Mock:
+        """Create a mock collection binding."""
+        binding = Mock()
+        binding.id = binding_id
+        return binding
+
+    @staticmethod
+    def create_current_user_mock(tenant_id: str = "tenant-123") -> Mock:
+        """Create a mock current user."""
+        current_user = Mock()
+        current_user.current_tenant_id = tenant_id
+        return current_user
 
 
 class TestDatasetServiceUpdateDataset:
@@ -24,222 +96,180 @@ class TestDatasetServiceUpdateDataset:
     - Error conditions and edge cases
     """
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_external_dataset_success(self, mock_datetime, mock_check_permission, mock_get_dataset, mock_db):
-        """
-        Test successful update of external dataset.
-
-        Verifies that:
-        1. External dataset attributes are updated correctly
-        2. External knowledge binding is updated when values change
-        3. Database changes are committed
-        4. Permission check is performed
-        """
-        from unittest.mock import Mock, patch
-
-        from extensions.ext_database import db
-
-        with patch.object(db.__class__, "engine", new_callable=Mock):
-            # Create mock dataset
-            mock_dataset = Mock(spec=Dataset)
-            mock_dataset.id = "dataset-123"
-            mock_dataset.provider = "external"
-            mock_dataset.name = "old_name"
-            mock_dataset.description = "old_description"
-            mock_dataset.retrieval_model = "old_model"
-
-            # Create mock user
-            mock_user = Mock()
-            mock_user.id = "user-789"
-
-            # Create mock external knowledge binding
-            mock_binding = Mock(spec=ExternalKnowledgeBindings)
-            mock_binding.external_knowledge_id = "old_knowledge_id"
-            mock_binding.external_knowledge_api_id = "old_api_id"
-
-            # Set up mock return values
+    @pytest.fixture
+    def mock_dataset_service_dependencies(self):
+        """Common mock setup for dataset service dependencies."""
+        with (
+            patch("services.dataset_service.DatasetService.get_dataset") as mock_get_dataset,
+            patch("services.dataset_service.DatasetService.check_dataset_permission") as mock_check_perm,
+            patch("extensions.ext_database.db.session") as mock_db,
+            patch("services.dataset_service.datetime") as mock_datetime,
+        ):
             current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
             mock_datetime.datetime.now.return_value = current_time
             mock_datetime.UTC = datetime.UTC
 
-            # Mock dataset retrieval
-            mock_get_dataset.return_value = mock_dataset
+            yield {
+                "get_dataset": mock_get_dataset,
+                "check_permission": mock_check_perm,
+                "db_session": mock_db,
+                "datetime": mock_datetime,
+                "current_time": current_time,
+            }
 
-            # Mock external knowledge binding query
-            with patch("services.dataset_service.Session") as mock_session:
-                mock_session_instance = Mock()
-                mock_session.return_value.__enter__.return_value = mock_session_instance
-                mock_session_instance.query.return_value.filter_by.return_value.first.return_value = mock_binding
+    @pytest.fixture
+    def mock_external_provider_dependencies(self):
+        """Mock setup for external provider tests."""
+        with patch("services.dataset_service.Session") as mock_session:
+            from extensions.ext_database import db
 
-                # Test data
-                update_data = {
-                    "name": "new_name",
-                    "description": "new_description",
-                    "external_retrieval_model": "new_model",
-                    "permission": "only_me",
-                    "external_knowledge_id": "new_knowledge_id",
-                    "external_knowledge_api_id": "new_api_id",
-                }
+            with patch.object(db.__class__, "engine", new_callable=Mock):
+                session_mock = Mock()
+                mock_session.return_value.__enter__.return_value = session_mock
+                yield session_mock
 
-                # Call the method
-                result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
+    @pytest.fixture
+    def mock_internal_provider_dependencies(self):
+        """Mock setup for internal provider tests."""
+        with (
+            patch("services.dataset_service.ModelManager") as mock_model_manager,
+            patch(
+                "services.dataset_service.DatasetCollectionBindingService.get_dataset_collection_binding"
+            ) as mock_get_binding,
+            patch("services.dataset_service.deal_dataset_vector_index_task") as mock_task,
+            patch("services.dataset_service.current_user") as mock_current_user,
+        ):
+            mock_current_user.current_tenant_id = "tenant-123"
+            yield {
+                "model_manager": mock_model_manager,
+                "get_binding": mock_get_binding,
+                "task": mock_task,
+                "current_user": mock_current_user,
+            }
 
-                # Verify permission check was called
-                mock_check_permission.assert_called_once_with(mock_dataset, mock_user)
+    def _assert_database_update_called(self, mock_db, dataset_id: str, expected_updates: dict[str, Any]):
+        """Helper method to verify database update calls."""
+        mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_updates)
+        mock_db.commit.assert_called_once()
 
-                # Verify dataset attributes were updated
-                assert mock_dataset.name == "new_name"
-                assert mock_dataset.description == "new_description"
-                assert mock_dataset.retrieval_model == "new_model"
+    def _assert_external_dataset_update(self, mock_dataset, mock_binding, update_data: dict[str, Any]):
+        """Helper method to verify external dataset updates."""
+        assert mock_dataset.name == update_data.get("name", mock_dataset.name)
+        assert mock_dataset.description == update_data.get("description", mock_dataset.description)
+        assert mock_dataset.retrieval_model == update_data.get("external_retrieval_model", mock_dataset.retrieval_model)
 
-                # Verify external knowledge binding was updated
-                assert mock_binding.external_knowledge_id == "new_knowledge_id"
-                assert mock_binding.external_knowledge_api_id == "new_api_id"
+        if "external_knowledge_id" in update_data:
+            assert mock_binding.external_knowledge_id == update_data["external_knowledge_id"]
+        if "external_knowledge_api_id" in update_data:
+            assert mock_binding.external_knowledge_api_id == update_data["external_knowledge_api_id"]
 
-                # Verify database operations
-                mock_db.add.assert_any_call(mock_dataset)
-                mock_db.add.assert_any_call(mock_binding)
-                mock_db.commit.assert_called_once()
+    # ==================== External Dataset Tests ====================
 
-                # Verify return value
-                assert result == mock_dataset
+    def test_update_external_dataset_success(
+        self, mock_dataset_service_dependencies, mock_external_provider_dependencies
+    ):
+        """Test successful update of external dataset."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(
+            provider="external", name="old_name", description="old_description", retrieval_model="old_model"
+        )
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    def test_update_external_dataset_missing_knowledge_id_error(self, mock_check_permission, mock_get_dataset, mock_db):
-        """
-        Test error when external knowledge id is missing.
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.provider = "external"
+        user = DatasetUpdateTestDataFactory.create_user_mock()
+        binding = DatasetUpdateTestDataFactory.create_external_binding_mock()
 
-        # Create mock user
-        mock_user = Mock()
+        # Mock external knowledge binding query
+        mock_external_provider_dependencies.query.return_value.filter_by.return_value.first.return_value = binding
 
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
+        update_data = {
+            "name": "new_name",
+            "description": "new_description",
+            "external_retrieval_model": "new_model",
+            "permission": "only_me",
+            "external_knowledge_id": "new_knowledge_id",
+            "external_knowledge_api_id": "new_api_id",
+        }
 
-        # Test data without external_knowledge_id
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
+
+        # Verify permission check was called
+        mock_dataset_service_dependencies["check_permission"].assert_called_once_with(dataset, user)
+
+        # Verify dataset and binding updates
+        self._assert_external_dataset_update(dataset, binding, update_data)
+
+        # Verify database operations
+        mock_db = mock_dataset_service_dependencies["db_session"]
+        mock_db.add.assert_any_call(dataset)
+        mock_db.add.assert_any_call(binding)
+        mock_db.commit.assert_called_once()
+
+        # Verify return value
+        assert result == dataset
+
+    def test_update_external_dataset_missing_knowledge_id_error(self, mock_dataset_service_dependencies):
+        """Test error when external knowledge id is missing."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="external")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
+
+        user = DatasetUpdateTestDataFactory.create_user_mock()
         update_data = {"name": "new_name", "external_knowledge_api_id": "api_id"}
 
-        # Call the method and expect ValueError
         with pytest.raises(ValueError) as context:
-            DatasetService.update_dataset("dataset-123", update_data, mock_user)
+            DatasetService.update_dataset("dataset-123", update_data, user)
 
         assert "External knowledge id is required" in str(context.value)
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    def test_update_external_dataset_missing_api_id_error(self, mock_check_permission, mock_get_dataset, mock_db):
-        """
-        Test error when external knowledge api id is missing.
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.provider = "external"
+    def test_update_external_dataset_missing_api_id_error(self, mock_dataset_service_dependencies):
+        """Test error when external knowledge api id is missing."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="external")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-        # Create mock user
-        mock_user = Mock()
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Test data without external_knowledge_api_id
+        user = DatasetUpdateTestDataFactory.create_user_mock()
         update_data = {"name": "new_name", "external_knowledge_id": "knowledge_id"}
 
-        # Call the method and expect ValueError
         with pytest.raises(ValueError) as context:
-            DatasetService.update_dataset("dataset-123", update_data, mock_user)
+            DatasetService.update_dataset("dataset-123", update_data, user)
 
         assert "External knowledge api id is required" in str(context.value)
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.Session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
     def test_update_external_dataset_binding_not_found_error(
-        self, mock_check_permission, mock_get_dataset, mock_session, mock_db
+        self, mock_dataset_service_dependencies, mock_external_provider_dependencies
     ):
-        from unittest.mock import Mock, patch
+        """Test error when external knowledge binding is not found."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="external")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-        from extensions.ext_database import db
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
-        with patch.object(db.__class__, "engine", new_callable=Mock):
-            # Create mock dataset
-            mock_dataset = Mock(spec=Dataset)
-            mock_dataset.provider = "external"
+        # Mock external knowledge binding query returning None
+        mock_external_provider_dependencies.query.return_value.filter_by.return_value.first.return_value = None
 
-            # Create mock user
-            mock_user = Mock()
+        update_data = {
+            "name": "new_name",
+            "external_knowledge_id": "knowledge_id",
+            "external_knowledge_api_id": "api_id",
+        }
 
-            # Mock dataset retrieval
-            mock_get_dataset.return_value = mock_dataset
+        with pytest.raises(ValueError) as context:
+            DatasetService.update_dataset("dataset-123", update_data, user)
 
-            # Mock external knowledge binding query returning None
-            mock_session_instance = Mock()
-            mock_session.return_value.__enter__.return_value = mock_session_instance
-            mock_session_instance.query.return_value.filter_by.return_value.first.return_value = None
+        assert "External knowledge binding not found" in str(context.value)
 
-            # Test data
-            update_data = {
-                "name": "new_name",
-                "external_knowledge_id": "knowledge_id",
-                "external_knowledge_api_id": "api_id",
-            }
+    # ==================== Internal Dataset Basic Tests ====================
 
-            # Call the method and expect ValueError
-            with pytest.raises(ValueError) as context:
-                DatasetService.update_dataset("dataset-123", update_data, mock_user)
+    def test_update_internal_dataset_basic_success(self, mock_dataset_service_dependencies):
+        """Test successful update of internal dataset with basic fields."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(
+            provider="vendor",
+            indexing_technique="high_quality",
+            embedding_model_provider="openai",
+            embedding_model="text-embedding-ada-002",
+            collection_binding_id="binding-123",
+        )
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-            assert "External knowledge binding not found" in str(context.value)
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_basic_success(
-        self, mock_datetime, mock_check_permission, mock_get_dataset, mock_db
-    ):
-        """
-        Test successful update of internal dataset with basic fields.
-
-        Verifies that:
-        1. Basic dataset attributes are updated correctly
-        2. Filtered data excludes None values except description
-        3. Timestamp fields are updated
-        4. Database changes are committed
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.name = "old_name"
-        mock_dataset.description = "old_description"
-        mock_dataset.indexing_technique = "high_quality"
-        mock_dataset.retrieval_model = "old_model"
-        mock_dataset.embedding_model_provider = "openai"
-        mock_dataset.embedding_model = "text-embedding-ada-002"
-        mock_dataset.collection_binding_id = "binding-123"
-
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
-
-        # Set up mock return values
-        current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = current_time
-        mock_datetime.UTC = datetime.UTC
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Test data
         update_data = {
             "name": "new_name",
             "description": "new_description",
@@ -249,11 +279,10 @@ class TestDatasetServiceUpdateDataset:
             "embedding_model": "text-embedding-ada-002",
         }
 
-        # Call the method
-        result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
 
         # Verify permission check was called
-        mock_check_permission.assert_called_once_with(mock_dataset, mock_user)
+        mock_dataset_service_dependencies["check_permission"].assert_called_once_with(dataset, user)
 
         # Verify database update was called with correct filtered data
         expected_filtered_data = {
@@ -263,361 +292,24 @@ class TestDatasetServiceUpdateDataset:
             "retrieval_model": "new_model",
             "embedding_model_provider": "openai",
             "embedding_model": "text-embedding-ada-002",
-            "updated_by": mock_user.id,
-            "updated_at": current_time.replace(tzinfo=None),
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
         }
 
-        mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_filtered_data)
-        mock_db.commit.assert_called_once()
-
-        # Verify return value
-        assert result == mock_dataset
-
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.deal_dataset_vector_index_task")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_indexing_technique_to_economy(
-        self, mock_datetime, mock_check_permission, mock_get_dataset, mock_task, mock_db
-    ):
-        """
-        Test updating internal dataset indexing technique to economy.
-
-        Verifies that:
-        1. Embedding model fields are cleared when switching to economy
-        2. Vector index task is triggered with 'remove' action
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "high_quality"
-
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
-
-        # Set up mock return values
-        current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = current_time
-        mock_datetime.UTC = datetime.UTC
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Test data
-        update_data = {"indexing_technique": "economy", "retrieval_model": "new_model"}
-
-        # Call the method
-        result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
-
-        # Verify database update was called with embedding model fields cleared
-        expected_filtered_data = {
-            "indexing_technique": "economy",
-            "embedding_model": None,
-            "embedding_model_provider": None,
-            "collection_binding_id": None,
-            "retrieval_model": "new_model",
-            "updated_by": mock_user.id,
-            "updated_at": current_time.replace(tzinfo=None),
-        }
-
-        mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_filtered_data)
-        mock_db.commit.assert_called_once()
-
-        # Verify vector index task was triggered
-        mock_task.delay.assert_called_once_with("dataset-123", "remove")
-
-        # Verify return value
-        assert result == mock_dataset
-
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    def test_update_dataset_not_found_error(self, mock_check_permission, mock_get_dataset, mock_db):
-        """
-        Test error when dataset is not found.
-        """
-        # Create mock user
-        mock_user = Mock()
-
-        # Mock dataset retrieval returning None
-        mock_get_dataset.return_value = None
-
-        # Test data
-        update_data = {"name": "new_name"}
-
-        # Call the method and expect ValueError
-        with pytest.raises(ValueError) as context:
-            DatasetService.update_dataset("dataset-123", update_data, mock_user)
-
-        assert "Dataset not found" in str(context.value)
-
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    def test_update_dataset_permission_error(self, mock_check_permission, mock_get_dataset, mock_db):
-        """
-        Test error when user doesn't have permission.
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-
-        # Create mock user
-        mock_user = Mock()
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Mock permission check to raise error
-        mock_check_permission.side_effect = NoPermissionError("No permission")
-
-        # Test data
-        update_data = {"name": "new_name"}
-
-        # Call the method and expect NoPermissionError
-        with pytest.raises(NoPermissionError):
-            DatasetService.update_dataset("dataset-123", update_data, mock_user)
-
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_keep_existing_embedding_model(
-        self, mock_datetime, mock_check_permission, mock_get_dataset, mock_db
-    ):
-        """
-        Test updating internal dataset without changing embedding model.
-
-        Verifies that:
-        1. Existing embedding model settings are preserved when not provided in update
-        2. No vector index task is triggered
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "high_quality"
-        mock_dataset.embedding_model_provider = "openai"
-        mock_dataset.embedding_model = "text-embedding-ada-002"
-        mock_dataset.collection_binding_id = "binding-123"
-
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
-
-        # Set up mock return values
-        current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = current_time
-        mock_datetime.UTC = datetime.UTC
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Test data without embedding model fields
-        update_data = {"name": "new_name", "indexing_technique": "high_quality", "retrieval_model": "new_model"}
-
-        # Call the method
-        result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
-
-        # Verify database update was called with existing embedding model preserved
-        expected_filtered_data = {
-            "name": "new_name",
-            "indexing_technique": "high_quality",
-            "embedding_model_provider": "openai",
-            "embedding_model": "text-embedding-ada-002",
-            "collection_binding_id": "binding-123",
-            "retrieval_model": "new_model",
-            "updated_by": mock_user.id,
-            "updated_at": current_time.replace(tzinfo=None),
-        }
-
-        mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_filtered_data)
-        mock_db.commit.assert_called_once()
-
-        # Verify return value
-        assert result == mock_dataset
-
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetCollectionBindingService.get_dataset_collection_binding")
-    @patch("services.dataset_service.ModelManager")
-    @patch("services.dataset_service.deal_dataset_vector_index_task")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_indexing_technique_to_high_quality(
-        self,
-        mock_datetime,
-        mock_check_permission,
-        mock_get_dataset,
-        mock_task,
-        mock_model_manager,
-        mock_collection_binding,
-        mock_db,
-    ):
-        """
-        Test updating internal dataset indexing technique to high_quality.
-
-        Verifies that:
-        1. Embedding model is validated and set
-        2. Collection binding is retrieved
-        3. Vector index task is triggered with 'add' action
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "economy"
-
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
-
-        # Set up mock return values
-        current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = current_time
-        mock_datetime.UTC = datetime.UTC
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Mock embedding model
-        mock_embedding_model = Mock()
-        mock_embedding_model.model = "text-embedding-ada-002"
-        mock_embedding_model.provider = "openai"
-
-        # Mock collection binding
-        mock_collection_binding_instance = Mock()
-        mock_collection_binding_instance.id = "binding-456"
-
-        # Mock model manager
-        mock_model_manager_instance = Mock()
-        mock_model_manager_instance.get_model_instance.return_value = mock_embedding_model
-        mock_model_manager.return_value = mock_model_manager_instance
-
-        # Mock collection binding service
-        mock_collection_binding.return_value = mock_collection_binding_instance
-
-        # Mock current_user
-        mock_current_user = Mock()
-        mock_current_user.current_tenant_id = "tenant-123"
-
-        # Test data
-        update_data = {
-            "indexing_technique": "high_quality",
-            "embedding_model_provider": "openai",
-            "embedding_model": "text-embedding-ada-002",
-            "retrieval_model": "new_model",
-        }
-
-        # Call the method with current_user mock
-        with patch("services.dataset_service.current_user", mock_current_user):
-            result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
-
-        # Verify embedding model was validated
-        mock_model_manager_instance.get_model_instance.assert_called_once_with(
-            tenant_id=mock_current_user.current_tenant_id,
-            provider="openai",
-            model_type=ModelType.TEXT_EMBEDDING,
-            model="text-embedding-ada-002",
+        self._assert_database_update_called(
+            mock_dataset_service_dependencies["db_session"], "dataset-123", expected_filtered_data
         )
 
-        # Verify collection binding was retrieved
-        mock_collection_binding.assert_called_once_with("openai", "text-embedding-ada-002")
-
-        # Verify database update was called with correct data
-        expected_filtered_data = {
-            "indexing_technique": "high_quality",
-            "embedding_model": "text-embedding-ada-002",
-            "embedding_model_provider": "openai",
-            "collection_binding_id": "binding-456",
-            "retrieval_model": "new_model",
-            "updated_by": mock_user.id,
-            "updated_at": current_time.replace(tzinfo=None),
-        }
-
-        mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_filtered_data)
-        mock_db.commit.assert_called_once()
-
-        # Verify vector index task was triggered
-        mock_task.delay.assert_called_once_with("dataset-123", "add")
-
         # Verify return value
-        assert result == mock_dataset
+        assert result == dataset
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    def test_update_internal_dataset_embedding_model_error(self, mock_check_permission, mock_get_dataset, mock_db):
-        """
-        Test error when embedding model is not available.
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "economy"
+    def test_update_internal_dataset_filter_none_values(self, mock_dataset_service_dependencies):
+        """Test that None values are filtered out except for description field."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="vendor", indexing_technique="high_quality")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Mock current_user
-        mock_current_user = Mock()
-        mock_current_user.current_tenant_id = "tenant-123"
-
-        # Mock model manager to raise error
-        with (
-            patch("services.dataset_service.ModelManager") as mock_model_manager,
-            patch("services.dataset_service.current_user", mock_current_user),
-        ):
-            mock_model_manager_instance = Mock()
-            mock_model_manager_instance.get_model_instance.side_effect = Exception("No Embedding Model available")
-            mock_model_manager.return_value = mock_model_manager_instance
-
-            # Test data
-            update_data = {
-                "indexing_technique": "high_quality",
-                "embedding_model_provider": "invalid_provider",
-                "embedding_model": "invalid_model",
-                "retrieval_model": "new_model",
-            }
-
-            # Call the method and expect ValueError
-            with pytest.raises(Exception) as context:
-                DatasetService.update_dataset("dataset-123", update_data, mock_user)
-
-            assert "No Embedding Model available".lower() in str(context.value).lower()
-
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_filter_none_values(
-        self, mock_datetime, mock_check_permission, mock_get_dataset, mock_db
-    ):
-        """
-        Test that None values are filtered out except for description field.
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "high_quality"
-
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
-
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
-
-        # Test data with None values
         update_data = {
             "name": "new_name",
             "description": None,  # Should be included
@@ -627,8 +319,7 @@ class TestDatasetServiceUpdateDataset:
             "embedding_model": None,  # Should be filtered out
         }
 
-        # Call the method
-        result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
 
         # Verify database update was called with filtered data
         expected_filtered_data = {
@@ -636,173 +327,238 @@ class TestDatasetServiceUpdateDataset:
             "description": None,  # Description should be included even if None
             "indexing_technique": "high_quality",
             "retrieval_model": "new_model",
-            "updated_by": mock_user.id,
-            "updated_at": mock_db.query.return_value.filter_by.return_value.update.call_args[0][0]["updated_at"],
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
         }
 
-        actual_call_args = mock_db.query.return_value.filter_by.return_value.update.call_args[0][0]
+        actual_call_args = mock_dataset_service_dependencies[
+            "db_session"
+        ].query.return_value.filter_by.return_value.update.call_args[0][0]
         # Remove timestamp for comparison as it's dynamic
         del actual_call_args["updated_at"]
         del expected_filtered_data["updated_at"]
 
-        del actual_call_args["collection_binding_id"]
-        del actual_call_args["embedding_model"]
-        del actual_call_args["embedding_model_provider"]
-
         assert actual_call_args == expected_filtered_data
 
         # Verify return value
-        assert result == mock_dataset
+        assert result == dataset
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.deal_dataset_vector_index_task")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_embedding_model_update(
-        self, mock_datetime, mock_check_permission, mock_get_dataset, mock_task, mock_db
+    # ==================== Indexing Technique Switch Tests ====================
+
+    def test_update_internal_dataset_indexing_technique_to_economy(
+        self, mock_dataset_service_dependencies, mock_internal_provider_dependencies
     ):
-        """
-        Test updating internal dataset with new embedding model.
+        """Test updating internal dataset indexing technique to economy."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="vendor", indexing_technique="high_quality")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-        Verifies that:
-        1. Embedding model is updated when different from current
-        2. Vector index task is triggered with 'update' action
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "high_quality"
-        mock_dataset.embedding_model_provider = "openai"
-        mock_dataset.embedding_model = "text-embedding-ada-002"
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
+        update_data = {"indexing_technique": "economy", "retrieval_model": "new_model"}
 
-        # Set up mock return values
-        current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = current_time
-        mock_datetime.UTC = datetime.UTC
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
 
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
+        # Verify database update was called with embedding model fields cleared
+        expected_filtered_data = {
+            "indexing_technique": "economy",
+            "embedding_model": None,
+            "embedding_model_provider": None,
+            "collection_binding_id": None,
+            "retrieval_model": "new_model",
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
+        }
+
+        self._assert_database_update_called(
+            mock_dataset_service_dependencies["db_session"], "dataset-123", expected_filtered_data
+        )
+
+        # Verify return value
+        assert result == dataset
+
+    def test_update_internal_dataset_indexing_technique_to_high_quality(
+        self, mock_dataset_service_dependencies, mock_internal_provider_dependencies
+    ):
+        """Test updating internal dataset indexing technique to high_quality."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="vendor", indexing_technique="economy")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
+
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
         # Mock embedding model
-        mock_embedding_model = Mock()
-        mock_embedding_model.model = "text-embedding-3-small"
-        mock_embedding_model.provider = "openai"
+        embedding_model = DatasetUpdateTestDataFactory.create_embedding_model_mock()
+        mock_internal_provider_dependencies[
+            "model_manager"
+        ].return_value.get_model_instance.return_value = embedding_model
 
         # Mock collection binding
-        mock_collection_binding_instance = Mock()
-        mock_collection_binding_instance.id = "binding-789"
+        binding = DatasetUpdateTestDataFactory.create_collection_binding_mock()
+        mock_internal_provider_dependencies["get_binding"].return_value = binding
 
-        # Mock current_user
-        mock_current_user = Mock()
-        mock_current_user.current_tenant_id = "tenant-123"
+        update_data = {
+            "indexing_technique": "high_quality",
+            "embedding_model_provider": "openai",
+            "embedding_model": "text-embedding-ada-002",
+            "retrieval_model": "new_model",
+        }
 
-        # Mock model manager
-        with patch("services.dataset_service.ModelManager") as mock_model_manager:
-            mock_model_manager_instance = Mock()
-            mock_model_manager_instance.get_model_instance.return_value = mock_embedding_model
-            mock_model_manager.return_value = mock_model_manager_instance
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
 
-            # Mock collection binding service
-            with (
-                patch(
-                    "services.dataset_service.DatasetCollectionBindingService.get_dataset_collection_binding"
-                ) as mock_collection_binding,
-                patch("services.dataset_service.current_user", mock_current_user),
-            ):
-                mock_collection_binding.return_value = mock_collection_binding_instance
+        # Verify embedding model was validated
+        mock_internal_provider_dependencies["model_manager"].return_value.get_model_instance.assert_called_once_with(
+            tenant_id=mock_internal_provider_dependencies["current_user"].current_tenant_id,
+            provider="openai",
+            model_type=ModelType.TEXT_EMBEDDING,
+            model="text-embedding-ada-002",
+        )
 
-                # Test data
-                update_data = {
-                    "indexing_technique": "high_quality",
-                    "embedding_model_provider": "openai",
-                    "embedding_model": "text-embedding-3-small",
-                    "retrieval_model": "new_model",
-                }
+        # Verify collection binding was retrieved
+        mock_internal_provider_dependencies["get_binding"].assert_called_once_with("openai", "text-embedding-ada-002")
 
-                # Call the method
-                result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
+        # Verify database update was called with correct data
+        expected_filtered_data = {
+            "indexing_technique": "high_quality",
+            "embedding_model": "text-embedding-ada-002",
+            "embedding_model_provider": "openai",
+            "collection_binding_id": "binding-456",
+            "retrieval_model": "new_model",
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
+        }
 
-                # Verify embedding model was validated
-                mock_model_manager_instance.get_model_instance.assert_called_once_with(
-                    tenant_id=mock_current_user.current_tenant_id,
-                    provider="openai",
-                    model_type=ModelType.TEXT_EMBEDDING,
-                    model="text-embedding-3-small",
-                )
+        self._assert_database_update_called(
+            mock_dataset_service_dependencies["db_session"], "dataset-123", expected_filtered_data
+        )
 
-                # Verify collection binding was retrieved
-                mock_collection_binding.assert_called_once_with("openai", "text-embedding-3-small")
+        # Verify vector index task was triggered
+        mock_internal_provider_dependencies["task"].delay.assert_called_once_with("dataset-123", "add")
 
-                # Verify database update was called with correct data
-                expected_filtered_data = {
-                    "indexing_technique": "high_quality",
-                    "embedding_model": "text-embedding-3-small",
-                    "embedding_model_provider": "openai",
-                    "collection_binding_id": "binding-789",
-                    "retrieval_model": "new_model",
-                    "updated_by": mock_user.id,
-                    "updated_at": current_time.replace(tzinfo=None),
-                }
+        # Verify return value
+        assert result == dataset
 
-                mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_filtered_data)
-                mock_db.commit.assert_called_once()
+    # ==================== Embedding Model Update Tests ====================
 
-                # Verify vector index task was triggered
-                mock_task.delay.assert_called_once_with("dataset-123", "update")
+    def test_update_internal_dataset_keep_existing_embedding_model(self, mock_dataset_service_dependencies):
+        """Test updating internal dataset without changing embedding model."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(
+            provider="vendor",
+            indexing_technique="high_quality",
+            embedding_model_provider="openai",
+            embedding_model="text-embedding-ada-002",
+            collection_binding_id="binding-123",
+        )
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-                # Verify return value
-                assert result == mock_dataset
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
-    @patch("extensions.ext_database.db.session")
-    @patch("services.dataset_service.DatasetService.get_dataset")
-    @patch("services.dataset_service.DatasetService.check_dataset_permission")
-    @patch("services.dataset_service.datetime")
-    def test_update_internal_dataset_no_indexing_technique_change(
-        self, mock_datetime, mock_check_permission, mock_get_dataset, mock_db
+        update_data = {"name": "new_name", "indexing_technique": "high_quality", "retrieval_model": "new_model"}
+
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
+
+        # Verify database update was called with existing embedding model preserved
+        expected_filtered_data = {
+            "name": "new_name",
+            "indexing_technique": "high_quality",
+            "embedding_model_provider": "openai",
+            "embedding_model": "text-embedding-ada-002",
+            "collection_binding_id": "binding-123",
+            "retrieval_model": "new_model",
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
+        }
+
+        self._assert_database_update_called(
+            mock_dataset_service_dependencies["db_session"], "dataset-123", expected_filtered_data
+        )
+
+        # Verify return value
+        assert result == dataset
+
+    def test_update_internal_dataset_embedding_model_update(
+        self, mock_dataset_service_dependencies, mock_internal_provider_dependencies
     ):
-        """
-        Test updating internal dataset without changing indexing technique.
+        """Test updating internal dataset with new embedding model."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(
+            provider="vendor",
+            indexing_technique="high_quality",
+            embedding_model_provider="openai",
+            embedding_model="text-embedding-ada-002",
+        )
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
 
-        Verifies that:
-        1. No vector index task is triggered when indexing technique doesn't change
-        2. Database update is performed normally
-        """
-        # Create mock dataset
-        mock_dataset = Mock(spec=Dataset)
-        mock_dataset.id = "dataset-123"
-        mock_dataset.provider = "vendor"
-        mock_dataset.indexing_technique = "high_quality"
-        mock_dataset.embedding_model_provider = "openai"
-        mock_dataset.embedding_model = "text-embedding-ada-002"
-        mock_dataset.collection_binding_id = "binding-123"
+        user = DatasetUpdateTestDataFactory.create_user_mock()
 
-        # Create mock user
-        mock_user = Mock()
-        mock_user.id = "user-789"
+        # Mock embedding model
+        embedding_model = DatasetUpdateTestDataFactory.create_embedding_model_mock("text-embedding-3-small")
+        mock_internal_provider_dependencies[
+            "model_manager"
+        ].return_value.get_model_instance.return_value = embedding_model
 
-        # Set up mock return values
-        current_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = current_time
-        mock_datetime.UTC = datetime.UTC
+        # Mock collection binding
+        binding = DatasetUpdateTestDataFactory.create_collection_binding_mock("binding-789")
+        mock_internal_provider_dependencies["get_binding"].return_value = binding
 
-        # Mock dataset retrieval
-        mock_get_dataset.return_value = mock_dataset
+        update_data = {
+            "indexing_technique": "high_quality",
+            "embedding_model_provider": "openai",
+            "embedding_model": "text-embedding-3-small",
+            "retrieval_model": "new_model",
+        }
 
-        # Test data with same indexing technique
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
+
+        # Verify embedding model was validated
+        mock_internal_provider_dependencies["model_manager"].return_value.get_model_instance.assert_called_once_with(
+            tenant_id=mock_internal_provider_dependencies["current_user"].current_tenant_id,
+            provider="openai",
+            model_type=ModelType.TEXT_EMBEDDING,
+            model="text-embedding-3-small",
+        )
+
+        # Verify collection binding was retrieved
+        mock_internal_provider_dependencies["get_binding"].assert_called_once_with("openai", "text-embedding-3-small")
+
+        # Verify database update was called with correct data
+        expected_filtered_data = {
+            "indexing_technique": "high_quality",
+            "embedding_model": "text-embedding-3-small",
+            "embedding_model_provider": "openai",
+            "collection_binding_id": "binding-789",
+            "retrieval_model": "new_model",
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
+        }
+
+        self._assert_database_update_called(
+            mock_dataset_service_dependencies["db_session"], "dataset-123", expected_filtered_data
+        )
+
+        # Verify vector index task was triggered
+        mock_internal_provider_dependencies["task"].delay.assert_called_once_with("dataset-123", "update")
+
+        # Verify return value
+        assert result == dataset
+
+    def test_update_internal_dataset_no_indexing_technique_change(self, mock_dataset_service_dependencies):
+        """Test updating internal dataset without changing indexing technique."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(
+            provider="vendor",
+            indexing_technique="high_quality",
+            embedding_model_provider="openai",
+            embedding_model="text-embedding-ada-002",
+            collection_binding_id="binding-123",
+        )
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
+
+        user = DatasetUpdateTestDataFactory.create_user_mock()
+
         update_data = {
             "name": "new_name",
             "indexing_technique": "high_quality",  # Same as current
             "retrieval_model": "new_model",
         }
 
-        # Call the method
-        result = DatasetService.update_dataset("dataset-123", update_data, mock_user)
+        result = DatasetService.update_dataset("dataset-123", update_data, user)
 
         # Verify database update was called with correct data
         expected_filtered_data = {
@@ -812,15 +568,66 @@ class TestDatasetServiceUpdateDataset:
             "embedding_model": "text-embedding-ada-002",
             "collection_binding_id": "binding-123",
             "retrieval_model": "new_model",
-            "updated_by": mock_user.id,
-            "updated_at": current_time.replace(tzinfo=None),
+            "updated_by": user.id,
+            "updated_at": mock_dataset_service_dependencies["current_time"].replace(tzinfo=None),
         }
 
-        mock_db.query.return_value.filter_by.return_value.update.assert_called_once_with(expected_filtered_data)
-        mock_db.commit.assert_called_once()
-
-        # Verify no vector index task was triggered
-        mock_db.query.return_value.filter_by.return_value.update.assert_called_once()
+        self._assert_database_update_called(
+            mock_dataset_service_dependencies["db_session"], "dataset-123", expected_filtered_data
+        )
 
         # Verify return value
-        assert result == mock_dataset
+        assert result == dataset
+
+    # ==================== Error Handling Tests ====================
+
+    def test_update_dataset_not_found_error(self, mock_dataset_service_dependencies):
+        """Test error when dataset is not found."""
+        mock_dataset_service_dependencies["get_dataset"].return_value = None
+
+        user = DatasetUpdateTestDataFactory.create_user_mock()
+        update_data = {"name": "new_name"}
+
+        with pytest.raises(ValueError) as context:
+            DatasetService.update_dataset("dataset-123", update_data, user)
+
+        assert "Dataset not found" in str(context.value)
+
+    def test_update_dataset_permission_error(self, mock_dataset_service_dependencies):
+        """Test error when user doesn't have permission."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock()
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
+
+        user = DatasetUpdateTestDataFactory.create_user_mock()
+        mock_dataset_service_dependencies["check_permission"].side_effect = NoPermissionError("No permission")
+
+        update_data = {"name": "new_name"}
+
+        with pytest.raises(NoPermissionError):
+            DatasetService.update_dataset("dataset-123", update_data, user)
+
+    def test_update_internal_dataset_embedding_model_error(
+        self, mock_dataset_service_dependencies, mock_internal_provider_dependencies
+    ):
+        """Test error when embedding model is not available."""
+        dataset = DatasetUpdateTestDataFactory.create_dataset_mock(provider="vendor", indexing_technique="economy")
+        mock_dataset_service_dependencies["get_dataset"].return_value = dataset
+
+        user = DatasetUpdateTestDataFactory.create_user_mock()
+
+        # Mock model manager to raise error
+        mock_internal_provider_dependencies["model_manager"].return_value.get_model_instance.side_effect = Exception(
+            "No Embedding Model available"
+        )
+
+        update_data = {
+            "indexing_technique": "high_quality",
+            "embedding_model_provider": "invalid_provider",
+            "embedding_model": "invalid_model",
+            "retrieval_model": "new_model",
+        }
+
+        with pytest.raises(Exception) as context:
+            DatasetService.update_dataset("dataset-123", update_data, user)
+
+        assert "No Embedding Model available".lower() in str(context.value).lower()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix https://github.com/langgenius/dify/issues/21499

refactor unit tests for dataset:
 - test_dataset_permission.py
 - test_dataset_service_batch_update_document_status.py
 - test_dataset_service_update_dataset.py

### Key Changes:
- Added `DataFactory` for creating mock objects with customizable attributes.
- Enhanced test cases to cover
- Replaced redundant mock setup code with reusable factory methods.
- Improved helper methods for asserting permission checks and database query behavior.

These changes improve test clarity and maintainability while ensuring robust validation of the `DatasetService` logic.

## Screenshots

| Before | After |
|--------|-------|
| Redundant mock setup in each test | Centralized mock creation via factory |
| Limited coverage of scenarios | Comprehensive coverage of all cases |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods.
