### PR TITLE
fix: var inspect doc link error

### DIFF
--- a/web/app/components/workflow/variable-inspect/empty.tsx
+++ b/web/app/components/workflow/variable-inspect/empty.tsx
@@ -15,7 +15,7 @@ const Empty: FC = () => {
         <div className='system-xs-regular text-text-tertiary'>{t('workflow.debug.variableInspect.emptyTip')}</div>
         <a
           className='system-xs-regular cursor-pointer text-text-accent'
-          href='https://docs.dify.ai/guides/workflow/debug-and-preview/variable-inspect'
+          href='https://docs.dify.ai/en/guides/workflow/debug-and-preview/variable-inspect'
           target='_blank'
           rel='noopener noreferrer'>
             {t('workflow.debug.variableInspect.emptyLink')}


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
