### PR TITLE
fix(web): optimize the pop logic of the tool selector (#21558)

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/multiple-tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/multiple-tool-selector/index.tsx
@@ -117,6 +117,7 @@ const MultipleToolSelector = ({
         )}
         {!disabled && (
           <ActionButton className='mx-1' onClick={() => {
+            setCollapse(false)
             setOpen(!open)
             setPanelShowState(true)
           }}>
@@ -126,23 +127,6 @@ const MultipleToolSelector = ({
       </div>
       {!collapse && (
         <>
-          <ToolSelector
-            nodeId={nodeId}
-            nodeOutputVars={nodeOutputVars}
-            availableNodes={availableNodes}
-            scope={scope}
-            value={undefined}
-            selectedTools={value}
-            onSelect={handleAdd}
-            controlledState={open}
-            onControlledStateChange={setOpen}
-            trigger={
-              <div className=''></div>
-            }
-            panelShowState={panelShowState}
-            onPanelShowStateChange={setPanelShowState}
-            isEdit={false}
-          />
           {value.length === 0 && (
             <div className='system-xs-regular flex justify-center rounded-[10px] bg-background-section p-3 text-text-tertiary'>{t('plugin.detailPanel.toolSelector.empty')}</div>
           )}
@@ -164,6 +148,23 @@ const MultipleToolSelector = ({
           ))}
         </>
       )}
+      <ToolSelector
+        nodeId={nodeId}
+        nodeOutputVars={nodeOutputVars}
+        availableNodes={availableNodes}
+        scope={scope}
+        value={undefined}
+        selectedTools={value}
+        onSelect={handleAdd}
+        controlledState={open}
+        onControlledStateChange={setOpen}
+        trigger={
+          <div className=''></div>
+        }
+        panelShowState={panelShowState}
+        onPanelShowStateChange={setPanelShowState}
+        isEdit={false}
+      />
     </>
   )
 }

--- a/web/app/components/workflow/block-selector/types.ts
+++ b/web/app/components/workflow/block-selector/types.ts
@@ -36,7 +36,7 @@ export type ToolValue = {
   provider_name: string
   tool_name: string
   tool_label: string
-  tool_description: string
+  tool_description?: string
   settings?: Record<string, any>
   parameters?: Record<string, any>
   enabled?: boolean


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Adjust the display logic of the tool selector to ensure that the popover is not affected by collapse
- Improve the definition of tool value types to make the tool description field optional

Fixes #21558

## Screenshots

| Before | After |
|--------|-------|
| ...    |https://github.com/user-attachments/assets/9776b89e-cb37-438c-a8a9-98892c57f0cf |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
