### PR TITLE
fix: wrong token number when using qa_model and answer is updated.

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -2207,6 +2207,7 @@ class SegmentService:
 
                     # calc embedding use tokens
                     if document.doc_form == "qa_model":
+                        segment.answer = args.answer
                         tokens = embedding_model.get_text_embedding_num_tokens(texts=[content + segment.answer])[0]
                     else:
                         tokens = embedding_model.get_text_embedding_num_tokens(texts=[content])[0]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request fixes an issue where the wrong token number was calculated when using the `qa_model` and the segment answer is updated. Previously, the token count did not include the updated answer in the calculation, which could cause inaccuracies in embedding operations. The fix ensures that the updated `segment.answer` is included in the token calculation when the document's `doc_form` is set to `"qa_model"`.

**Issue fixed:**  
- Fix https://github.com/langgenius/dify/issues/21573

**Motivation and context:**  
The fix ensures that token calculations are accurate when the `qa_model` is used and the answer is updated. This is critical for proper embedding operations in scenarios where the updated answer is necessary for downstream processes.

**Dependencies:**  
No additional dependencies are required for this change.

## Screenshots

| Before | After |
|--------|-------|
| The token calculation did not include the updated `segment.answer` | The token calculation now includes the updated `segment.answer` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods.
