### PR TITLE
minor fix: add parameters in error msg of Plugin service returned no options

### DIFF
--- a/api/core/plugin/impl/dynamic_select.py
+++ b/api/core/plugin/impl/dynamic_select.py
@@ -42,4 +42,4 @@ class DynamicSelectClient(BasePluginClient):
         for options in response:
             return options
 
-        raise ValueError("Plugin service returned no options")
+        raise ValueError(f"Plugin service returned no options for parameter '{parameter}' in provider '{provider}'")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR improves error messaging in the Plugin service by adding more detailed context to the error message when no options are returned. The change enhances debugging capabilities by including the specific parameter and provider information in the error message, making it easier for developers to identify and troubleshoot issues.

**Changes made:**
- Modified the error message in `api/core/plugin/impl/dynamic_select.py` to include parameter and provider details
- Changed from generic "Plugin service returned no options" to more descriptive "Plugin service returned no options for parameter '{parameter}' in provider '{provider}'"

This is a minor enhancement that improves the developer experience when working with plugin dynamic select functionality.

## Screenshots

| Before | After |
|--------|-------|
| `ValueError("Plugin service returned no options")` | `ValueError(f"Plugin service returned no options for parameter '{parameter}' in provider '{provider}'")` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods