### PR TITLE
fix(ui): no hover effect in copy button of code node

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/editor/base.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/base.tsx
@@ -15,6 +15,7 @@ import {
 import useToggleExpend from '@/app/components/workflow/nodes/_base/hooks/use-toggle-expend'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import FileListInLog from '@/app/components/base/file-uploader/file-list-in-log'
+import ActionButton from '@/app/components/base/action-button'
 
 type Props = {
   className?: string
@@ -88,15 +89,16 @@ const Base: FC<Props> = ({
                 <CodeGeneratorButton onGenerated={onGenerated} codeLanguages={codeLanguages} />
               </div>
             )}
-            {!isCopied
-              ? (
-                <Clipboard className='mx-1 h-3.5 w-3.5 cursor-pointer text-text-tertiary' onClick={handleCopy} />
-              )
-              : (
-                <ClipboardCheck className='mx-1 h-3.5 w-3.5 text-text-tertiary' />
-              )
-            }
-
+            <ActionButton className='ml-1' onClick={handleCopy}>
+              {!isCopied
+                ? (
+                  <Clipboard className='h-4 w-4 cursor-pointer' />
+                )
+                : (
+                  <ClipboardCheck className='h-4 w-4' />
+                )
+              }
+            </ActionButton>
             <div className='ml-1'>
               <ToggleExpandBtn isExpand={isExpand} onExpandChange={setIsExpand} />
             </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Use ActionButton component to wrap clipboard icons for consistent styling and improved click target area. The change maintains the same functionality while enhancing user interaction.

## Screenshots

| Before | After |
|--------|-------|
| ![fb89825e94767dd90fdd12eff281459](https://github.com/user-attachments/assets/4f344cad-4505-4cf7-a404-90635654729a) | ![b0cb964205e285188fd30b40c945e8a](https://github.com/user-attachments/assets/fdf6c473-e347-4d3e-b8eb-9677219c0641) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
