### PR TITLE
fix:  #21427 correct segment settings when creating documents via API

### DIFF
--- a/web/app/components/datasets/create/step-two/index.tsx
+++ b/web/app/components/datasets/create/step-two/index.tsx
@@ -507,14 +507,13 @@ const StepTwo = ({
       const separator = rules.segmentation.separator
       const max = rules.segmentation.max_tokens
       const overlap = rules.segmentation.chunk_overlap
+      const isHierarchicalDocument = documentDetail.doc_form === 'hierarchical_model'
+                              || (rules.parent_mode && rules.subchunk_segmentation)
       setSegmentIdentifier(separator)
       setMaxChunkLength(max)
       setOverlap(overlap!)
       setRules(rules.pre_processing_rules)
       setDefaultConfig(rules)
-
-      const isHierarchicalDocument = documentDetail.doc_form === 'hierarchical_model'
-                              || (rules.parent_mode && rules.subchunk_segmentation)
 
       if (isHierarchicalDocument) {
         setParentChildConfig({

--- a/web/app/components/datasets/create/step-two/index.tsx
+++ b/web/app/components/datasets/create/step-two/index.tsx
@@ -513,7 +513,10 @@ const StepTwo = ({
       setRules(rules.pre_processing_rules)
       setDefaultConfig(rules)
 
-      if (documentDetail.dataset_process_rule.mode === 'hierarchical') {
+      const isHierarchicalDocument = documentDetail.doc_form === 'hierarchical_model'
+                              || (rules.parent_mode && rules.subchunk_segmentation)
+
+      if (isHierarchicalDocument) {
         setParentChildConfig({
           chunkForContext: rules.parent_mode || 'paragraph',
           parent: {

--- a/web/app/components/datasets/create/step-two/index.tsx
+++ b/web/app/components/datasets/create/step-two/index.tsx
@@ -507,7 +507,7 @@ const StepTwo = ({
       const separator = rules.segmentation.separator
       const max = rules.segmentation.max_tokens
       const overlap = rules.segmentation.chunk_overlap
-      const isHierarchicalDocument = documentDetail.doc_form === 'hierarchical_model'
+      const isHierarchicalDocument = documentDetail.doc_form === ChunkingMode.parentChild
                               || (rules.parent_mode && rules.subchunk_segmentation)
       setSegmentIdentifier(separator)
       setMaxChunkLength(max)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
fixes #21427

- Fix segment mode not being set to 'full-doc' as specified in API request
- Fix subchunk_segmentation max_tokens not being set to correct value
- Ensure API-created documents respect process_rule configuration


## Screenshots
Before:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/402a9b06-c40f-4034-ba16-f6b12e0d5308" />

After:
<img width="910" alt="image" src="https://github.com/user-attachments/assets/e863f482-1a4e-4d10-980f-5d1086c93537" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
