### PR TITLE
In workflow preview mode, the invoking tool app passes the parameter coversationId with history, and the invocation reports an error

### DIFF
--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -113,7 +113,7 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
         conversation_id = args.get("conversation_id")
         if conversation_id:
             conversation = ConversationService.get_conversation(
-                app_model=app_model, conversation_id=conversation_id, user=user
+                app_model=app_model, conversation_id=conversation_id, user=user,invoke_from=invoke_from
             )
 
         # parse files

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -145,7 +145,7 @@ class ConversationService:
         return conversation
 
     @classmethod
-    def get_conversation(cls, app_model: App, conversation_id: str, user: Optional[Union[Account, EndUser]],invoke_from: InvokeFrom =None):
+    def get_conversation(cls, app_model: App, conversation_id: str, user: Optional[Union[Account, EndUser]], invoke_from: InvokeFrom = None):
         if invoke_from and invoke_from == InvokeFrom.SERVICE_API:
             conversation = (
                 db.session.query(Conversation)

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -146,7 +146,7 @@ class ConversationService:
 
     @classmethod
     def get_conversation(cls, app_model: App, conversation_id: str, user: Optional[Union[Account, EndUser]],invoke_from: InvokeFrom =None):
-        if invoke_from and  invoke_from==invoke_from.SERVICE_API:
+        if invoke_from and invoke_from == InvokeFrom.SERVICE_API:
             conversation = (
                 db.session.query(Conversation)
                 .filter(

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -145,19 +145,32 @@ class ConversationService:
         return conversation
 
     @classmethod
-    def get_conversation(cls, app_model: App, conversation_id: str, user: Optional[Union[Account, EndUser]]):
-        conversation = (
-            db.session.query(Conversation)
-            .filter(
-                Conversation.id == conversation_id,
-                Conversation.app_id == app_model.id,
-                Conversation.from_source == ("api" if isinstance(user, EndUser) else "console"),
-                Conversation.from_end_user_id == (user.id if isinstance(user, EndUser) else None),
-                Conversation.from_account_id == (user.id if isinstance(user, Account) else None),
-                Conversation.is_deleted == False,
+    def get_conversation(cls, app_model: App, conversation_id: str, user: Optional[Union[Account, EndUser]],invoke_from: InvokeFrom =None):
+        if invoke_from and  invoke_from==invoke_from.SERVICE_API:
+            conversation = (
+                db.session.query(Conversation)
+                .filter(
+                    Conversation.id == conversation_id,
+                    Conversation.app_id == app_model.id,
+                    Conversation.from_source == "api",
+                    Conversation.from_end_user_id == user.id ,
+                    Conversation.is_deleted == False,
+                )
+                .first()
             )
-            .first()
-        )
+        else:
+            conversation = (
+                db.session.query(Conversation)
+                .filter(
+                    Conversation.id == conversation_id,
+                    Conversation.app_id == app_model.id,
+                    Conversation.from_source == ("api" if isinstance(user, EndUser) else "console"),
+                    Conversation.from_end_user_id == (user.id if isinstance(user, EndUser) else None),
+                    Conversation.from_account_id == (user.id if isinstance(user, Account) else None),
+                    Conversation.is_deleted == False,
+                )
+                .first()
+            )
 
         if not conversation:
             raise ConversationNotExistsError()


### PR DESCRIPTION
[!IMPORTANT]
	1.	Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
	2.	Ensure there is an associated issue and you have been assigned to it
	3.	Use the correct syntax to link this PR: Fixes #<issue number>.

Summary

Fixed the problem where an error was reported when calling a tool app in workflow preview mode:
When the conversationId is passed in along with the history, an exception occurs in the interface request. The root cause is that the conversationId is included in the calling parameters, while the backend tool's calling path does not support conversation context information in preview mode.

Problem recurrence path:
	1. Create a plugin that includes a utility class App;
	2. Plug-in development call passed in conversation_id
	        invoke_value = self.session.app.chat.invoke(app_id=app_agent_app_id,query= query_,inputs= inputs,conversation_id=sub_conversation_id)
3. Upload the plug-in, and create a new chatflow and choose to change the plug-in
4. Click on Workflow Preview;
5. 	Enter two sessions
6. Request error.

Repair content:
	•	Determine if it is a service-api, and when querying conversation under service-api, always use end_user.
Screenshots
before modifying
![image](https://github.com/user-attachments/assets/ae80feb1-a85b-4db3-ab66-612ca93165ac)
after Modified
![image](https://github.com/user-attachments/assets/4b188005-493c-40fe-8a4d-ca8c0c5c8d14)

Checklist
	•	This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
	•	I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn’t apply to typos!)
	•	I’ve added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
	•	I’ve updated the documentation accordingly.
	•	I ran dev/reformat(backend) and cd web && npx lint-staged(frontend) to appease the lint gods

⸻