### PR TITLE
Release db.session connection before workflow new thread long time operation

### DIFF
--- a/api/core/app/apps/workflow/app_generator.py
+++ b/api/core/app/apps/workflow/app_generator.py
@@ -219,6 +219,9 @@ class WorkflowAppGenerator(BaseAppGenerator):
         # new thread with request context and contextvars
         context = contextvars.copy_context()
 
+        # release database connection, because the following new thread operations may take a long time
+        db.session.close()
+        
         worker_thread = threading.Thread(
             target=self._generate_worker,
             kwargs={

--- a/api/core/app/apps/workflow/app_generator.py
+++ b/api/core/app/apps/workflow/app_generator.py
@@ -221,7 +221,7 @@ class WorkflowAppGenerator(BaseAppGenerator):
 
         # release database connection, because the following new thread operations may take a long time
         db.session.close()
-        
+
         worker_thread = threading.Thread(
             target=self._generate_worker,
             kwargs={


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #21176

In `workflow/app_generator.py`, although `db.session.close()` is called within `_generate_worker.WorkflowAppRunner.run`, the method call of `self._generate_worker` occurs in a new thread, causing the database connection to remain invalidly occupied before the call to `self._generate_worker`. Therefore, `db.session.close()` is also called once before starting the new thread to release the connection.

## Screenshots

Before
150 concurret requests result. (A simple workflow with a node that executes time.sleep(5) code.)
![image](https://github.com/user-attachments/assets/d94c009f-edb4-4527-bb4e-5afb59ec27eb)

After
150 concurret requests result. not perfect, but solve some problems
![image](https://github.com/user-attachments/assets/f365a931-9491-49a5-ae5c-b79307e21783)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
