### PR TITLE
fix: can not reset system variables

### DIFF
--- a/web/app/components/workflow/hooks/use-inspect-vars-crud.ts
+++ b/web/app/components/workflow/hooks/use-inspect-vars-crud.ts
@@ -11,12 +11,11 @@ import {
   useEditInspectorVar,
   useInvalidateConversationVarValues,
   useInvalidateSysVarValues,
-  useLastRun,
   useResetConversationVar,
   useResetToLastRunValue,
   useSysVarValues,
 } from '@/service/use-workflow'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 import { isConversationVar, isENV, isSystemVar } from '../nodes/_base/components/variable/utils'
 import produce from 'immer'
 import type { Node } from '@/app/components/workflow/types'
@@ -123,6 +122,7 @@ const useInspectVarsCrud = () => {
               nodeType: nodeInfo.data.type,
               title: nodeInfo.data.title,
               vars: payload,
+              nodePayload: nodeInfo.data,
             })
           }
           else {
@@ -180,16 +180,6 @@ const useInspectVarsCrud = () => {
       invalidateSysVarValues()
   }, [doEditInspectorVar, invalidateConversationVarValues, invalidateSysVarValues, setInspectVarValue])
 
-  const [currNodeId, setCurrNodeId] = useState<string | null>(null)
-  const [currEditVarId, setCurrEditVarId] = useState<string | null>(null)
-  const { data } = useLastRun(appId, currNodeId || '', !!currNodeId)
-  useEffect(() => {
-    if (data && currNodeId && currEditVarId) {
-      const inspectVar = getNodeInspectVars(currNodeId)?.vars?.find(item => item.id === currEditVarId)
-        resetToLastRunVarInStore(currNodeId, currEditVarId, data.outputs?.[inspectVar?.selector?.[1] || ''])
-    }
-  }, [data, currNodeId, currEditVarId, getNodeInspectVars, editInspectVarValue, resetToLastRunVarInStore])
-
   const renameInspectVarName = async (nodeId: string, oldName: string, newName: string) => {
     const varId = getVarId(nodeId, oldName)
     if (!varId)
@@ -212,9 +202,13 @@ const useInspectVarsCrud = () => {
   }, [getInspectVar])
 
   const resetToLastRunVar = async (nodeId: string, varId: string) => {
-    await doResetToLastRunValue(varId)
-    setCurrNodeId(nodeId)
-    setCurrEditVarId(varId)
+    const isSysVar = nodeId === 'sys'
+    const data = await doResetToLastRunValue(varId)
+
+    if(isSysVar)
+      invalidateSysVarValues()
+    else
+      resetToLastRunVarInStore(nodeId, varId, data.value)
   }
 
   return {

--- a/web/service/use-workflow.ts
+++ b/web/service/use-workflow.ts
@@ -139,7 +139,7 @@ export const useResetConversationVar = (appId: string) => {
 export const useResetToLastRunValue = (appId: string) => {
   return useMutation({
     mutationKey: [NAME_SPACE, 'reset to last run value', appId],
-    mutationFn: async (varId: string) => {
+    mutationFn: async (varId: string): Promise<{ value: any }> => {
       return put(`apps/${appId}/workflows/draft/variables/${varId}/reset`)
     },
   })


### PR DESCRIPTION
Reset system variables is not the same as reset normal variables.
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
