### PR TITLE
feat(api): validate and reject external datasets in document update

### DIFF
--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -210,6 +210,9 @@ class DocumentAddByFileApi(DatasetApiResource):
 
         if not dataset:
             raise ValueError("Dataset does not exist.")
+        
+        if dataset.provider == "external":
+            raise ValueError("External datasets are not supported.")
 
         indexing_technique = args.get("indexing_technique") or dataset.indexing_technique
         if not indexing_technique:
@@ -300,6 +303,9 @@ class DocumentUpdateByFileApi(DatasetApiResource):
 
         if not dataset:
             raise ValueError("Dataset does not exist.")
+        
+        if dataset.provider == "external":
+            raise ValueError("External datasets are not supported.")
 
         # indexing_technique is already set in dataset since this is an update
         args["indexing_technique"] = dataset.indexing_technique

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -210,7 +210,7 @@ class DocumentAddByFileApi(DatasetApiResource):
 
         if not dataset:
             raise ValueError("Dataset does not exist.")
-        
+
         if dataset.provider == "external":
             raise ValueError("External datasets are not supported.")
 
@@ -303,7 +303,7 @@ class DocumentUpdateByFileApi(DatasetApiResource):
 
         if not dataset:
             raise ValueError("Dataset does not exist.")
-        
+
         if dataset.provider == "external":
             raise ValueError("External datasets are not supported.")
 


### PR DESCRIPTION

## Summary

This PR adds logic to prevent the upload of external datasets. The change ensures that only allowed dataset sources can be uploaded, improving data security and compliance. No new dependencies were introduced.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
