### PR TITLE
FIX: dollar-sign escaping in preprocessLaTeX code‐block handling

### DIFF
--- a/web/app/components/base/markdown/markdown-utils.ts
+++ b/web/app/components/base/markdown/markdown-utils.ts
@@ -11,6 +11,7 @@ export const preprocessLaTeX = (content: string) => {
 
   const codeBlockRegex = /```[\s\S]*?```/g
   const codeBlocks = content.match(codeBlockRegex) || []
+  const escapeReplacement = (str: string) => str.replace(/\$/g, '_TMP_REPLACE_DOLLAR_')
   let processedContent = content.replace(codeBlockRegex, 'CODE_BLOCK_PLACEHOLDER')
 
   processedContent = flow([
@@ -21,8 +22,10 @@ export const preprocessLaTeX = (content: string) => {
   ])(processedContent)
 
   codeBlocks.forEach((block) => {
-    processedContent = processedContent.replace('CODE_BLOCK_PLACEHOLDER', block)
+    processedContent = processedContent.replace('CODE_BLOCK_PLACEHOLDER', escapeReplacement(block))
   })
+
+  processedContent = processedContent.replace(/_TMP_REPLACE_DOLLAR_/g, '$')
 
   return processedContent
 }


### PR DESCRIPTION
Title: Fix dollar-sign escaping in preprocessLaTeX code‐block handling
## Summary

close https://github.com/langgenius/dify/issues/20860
When a code block in `content` contains the dollar sign (`$`), the current placeholder-based reinsertion uses `String.replace()` directly, causing the `$` to be interpreted as a replacement pattern rather than a literal character. As a result, LaTeX fragments inside code blocks are mangled. This PR:

- Introduces an `escapeReplacement` helper to temporarily replace every `$` in a code block with a placeholder (`_TMP_REPLACE_DOLLAR_`).
- Ensures that when the `CODE_BLOCK_PLACEHOLDER` is swapped back, the literal dollar signs are restored properly.

## test cotent (between start and end)
------ start
若主查询使用 `REGEXP_REPLACE(dt.bag_name, ...)` 生成字段，`ORDER BY` 应使用相同表达式：
   ```sql
   ORDER BY REGEXP_REPLACE(dt.bag_name, '_reindex_lz4$'), dt.f_ts
   ```
### ✅ 最终修正版 SQL
```sql
WITH sampled_bags AS (
    SELECT 
        REGEXP_REPLACE(bag_name, '_reindex_lz4$') AS bag_name,
        bag_md5
    FROM ranked_bags
    WHERE rn <= 4000
)
SELECT 
    REGEXP_REPLACE(dt.bag_name, '_reindex_lz4$', '') AS bag_name,
    dt.timestamp
FROM data_table dt
ORDER BY REGEXP_REPLACE(dt.bag_name, '_reindex_lz4$'), dt.f_ts
```
------ end

## Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/cdb4128c-c228-4508-aa07-d41bda66ea32)    | ![image](https://github.com/user-attachments/assets/eb236cb8-f4b3-4854-907b-35969cc7471b)   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods