### PR TITLE
Fix: prevent SQL errors when metadata filter Constant value is None or blank

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -1010,6 +1010,9 @@ class DatasetRetrieval:
     def _process_metadata_filter_func(
         self, sequence: int, condition: str, metadata_name: str, value: Optional[Any], filters: list
     ):
+        if value is None:
+            return
+
         key = f"{metadata_name}_{sequence}"
         key_value = f"{metadata_name}_{sequence}_value"
         match condition:

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -490,6 +490,9 @@ class KnowledgeRetrievalNode(LLMNode):
     def _process_metadata_filter_func(
         self, sequence: int, condition: str, metadata_name: str, value: Optional[Any], filters: list
     ):
+        if value is None:
+            return
+
         key = f"{metadata_name}_{sequence}"
         key_value = f"{metadata_name}_{sequence}_value"
         match condition:


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Knowledge Retrieval Node throws a SQL error if a metadata filter is set to Constant and the value is left blank or None.

- Skips filter generation if the value is None in `_process_metadata_filter_func`
- Applies fix in both `knowledge_retrieval_node.py` and `dataset_retrieval.py`
- Improves robustness of the metadata filtering logic across all field types

Fixes #21800

## Screenshots

| Before | After |
|--------|-------|
| SQL error when Constant value is blank invalid input syntax for type double precision | App runs normally, filter is skipped when value is None |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
