### PR TITLE
fix(loop-variables): validate variable name input

### DIFF
--- a/web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx
@@ -10,6 +10,8 @@ import type {
   LoopVariable,
   LoopVariablesComponentShape,
 } from '@/app/components/workflow/nodes/loop/types'
+import { checkKeys, replaceSpaceWithUnderscreInVarNameInput } from '@/utils/var'
+import Toast from '@/app/components/base/toast'
 
 type ItemProps = {
   item: LoopVariable
@@ -21,7 +23,22 @@ const Item = ({
   handleUpdateLoopVariable,
 }: ItemProps) => {
   const { t } = useTranslation()
+
+  const checkVariableName = (value: string) => {
+    const { isValid, errorMessageKey } = checkKeys([value], false)
+    if (!isValid) {
+      Toast.notify({
+        type: 'error',
+        message: t(`appDebug.varKeyError.${errorMessageKey}`, { key: t('workflow.env.modal.name') }),
+      })
+      return false
+    }
+    return true
+  }
   const handleUpdateItemLabel = useCallback((e: any) => {
+    replaceSpaceWithUnderscreInVarNameInput(e.target)
+    if (!!e.target.value && !checkVariableName(e.target.value))
+      return
     handleUpdateLoopVariable(item.id, { label: e.target.value })
   }, [item.id, handleUpdateLoopVariable])
 
@@ -44,6 +61,7 @@ const Item = ({
           <Input
             value={item.label}
             onChange={handleUpdateItemLabel}
+            onBlur={e => checkVariableName(e.target.value)}
             autoFocus={!item.label}
             placeholder={t('workflow.nodes.loop.variableName')}
           />


### PR DESCRIPTION
## Summary

Add validation for loop variable names to prevent invalid characters and replace spaces with underscores. Show error toast when validation fails.

## Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/33a5dbce-b69b-467f-84dd-5bfc849e1d8d)  | ![0e1a77c4cf2499489fbc8250948b29f](https://github.com/user-attachments/assets/158947c0-47eb-43f8-8bdd-ae8218a54967) |
|   | ![4641b2ea86df45d117ce03aee8e5c9e](https://github.com/user-attachments/assets/fdb467c1-b4d6-4d06-b652-c41d3b27d13e) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
