### PR TITLE
feat: Add support for type="hidden" input elements in Markdown forms

### DIFF
--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -39,11 +39,10 @@ const MarkdownForm = ({ node }: any) => {
     const initialValues: { [key: string]: any } = {}
     node.children.forEach((child: any) => {
       if ([SUPPORTED_TAGS.INPUT, SUPPORTED_TAGS.TEXTAREA].includes(child.tagName)) {
-        if (child.tagName === SUPPORTED_TAGS.INPUT && child.properties.type === SUPPORTED_TYPES.HIDDEN) {
-          initialValues[child.properties.name] = child.properties.value || ''
-        } else {
-          initialValues[child.properties.name] = child.properties.value
-        }
+        initialValues[child.properties.name] = 
+          (child.tagName === SUPPORTED_TAGS.INPUT && child.properties.type === SUPPORTED_TYPES.HIDDEN)
+            ? (child.properties.value || '')
+            : child.properties.value
       }
     })
     setFormValues(initialValues)

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -28,6 +28,7 @@ enum SUPPORTED_TYPES {
   DATETIME = 'datetime',
   CHECKBOX = 'checkbox',
   SELECT = 'select',
+  HIDDEN = 'hidden',
 }
 const MarkdownForm = ({ node }: any) => {
   const { onSend } = useChatContext()
@@ -37,8 +38,14 @@ const MarkdownForm = ({ node }: any) => {
   useEffect(() => {
     const initialValues: { [key: string]: any } = {}
     node.children.forEach((child: any) => {
-      if ([SUPPORTED_TAGS.INPUT, SUPPORTED_TAGS.TEXTAREA].includes(child.tagName))
-        initialValues[child.properties.name] = child.properties.value
+      if ([SUPPORTED_TAGS.INPUT, SUPPORTED_TAGS.TEXTAREA].includes(child.tagName)) {
+        // Always set initial value for hidden inputs
+        if (child.tagName === SUPPORTED_TAGS.INPUT && child.properties.type === SUPPORTED_TYPES.HIDDEN) {
+          initialValues[child.properties.name] = child.properties.value || ''
+        } else {
+          initialValues[child.properties.name] = child.properties.value
+        }
+      }
     })
     setFormValues(initialValues)
   }, [node.children])
@@ -176,6 +183,19 @@ const MarkdownForm = ({ node }: any) => {
                     [child.properties.name]: item.value,
                   }))
                 }}
+              />
+            )
+          }
+
+          if (child.properties.type === SUPPORTED_TYPES.HIDDEN) {
+            // Hidden input is not displayed but maintains form value
+            return (
+              <input
+                key={index}
+                type="hidden"
+                name={child.properties.name}
+                value={formValues[child.properties.name] || child.properties.value || ''}
+                readOnly
               />
             )
           }

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -39,8 +39,8 @@ const MarkdownForm = ({ node }: any) => {
     const initialValues: { [key: string]: any } = {}
     node.children.forEach((child: any) => {
       if ([SUPPORTED_TAGS.INPUT, SUPPORTED_TAGS.TEXTAREA].includes(child.tagName)) {
-        initialValues[child.properties.name] = 
-          (child.tagName === SUPPORTED_TAGS.INPUT && child.properties.type === SUPPORTED_TYPES.HIDDEN)
+        initialValues[child.properties.name]
+          = (child.tagName === SUPPORTED_TAGS.INPUT && child.properties.type === SUPPORTED_TYPES.HIDDEN)
             ? (child.properties.value || '')
             : child.properties.value
       }

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -39,7 +39,6 @@ const MarkdownForm = ({ node }: any) => {
     const initialValues: { [key: string]: any } = {}
     node.children.forEach((child: any) => {
       if ([SUPPORTED_TAGS.INPUT, SUPPORTED_TAGS.TEXTAREA].includes(child.tagName)) {
-        // Always set initial value for hidden inputs
         if (child.tagName === SUPPORTED_TAGS.INPUT && child.properties.type === SUPPORTED_TYPES.HIDDEN) {
           initialValues[child.properties.name] = child.properties.value || ''
         } else {
@@ -188,7 +187,6 @@ const MarkdownForm = ({ node }: any) => {
           }
 
           if (child.properties.type === SUPPORTED_TYPES.HIDDEN) {
-            // Hidden input is not displayed but maintains form value
             return (
               <input
                 key={index}

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -193,7 +193,6 @@ const MarkdownForm = ({ node }: any) => {
                 type="hidden"
                 name={child.properties.name}
                 value={formValues[child.properties.name] || child.properties.value || ''}
-                readOnly
               />
             )
           }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR implements support for `type="hidden"` input elements in Dify's MarkdownForm component to address the need for invisible form fields that carry metadata, session tracking information, and plugin-specific data.

**Fixes #21675**

### Changes Made:
- Added `HIDDEN = 'hidden'` to the `SUPPORTED_TYPES` enum
- Implemented hidden input initialization in form processing
- Added hidden input rendering logic that creates invisible `<input type="hidden">` elements
- Ensured hidden inputs are included in form submission data

### Motivation:
Plugin developers and integrators need a way to pass invisible metadata through Markdown forms without requiring user interaction. This feature enables:
- Session tracking and user context preservation
- Plugin-specific metadata transmission
- Integration with external systems requiring hidden parameters
- Maintaining form state across submissions

### Technical Implementation:
The implementation follows the existing pattern used for other input types in the MarkdownForm component, ensuring consistency with the current architecture while maintaining backward compatibility.

## Screenshots

| Before | After |
|--------|-------|
| Hidden inputs were not supported ![image](https://github.com/user-attachments/assets/74859265-c4b8-4fc7-8db5-b06326e53cca) | Hidden inputs are now fully supported and included in form submissions![image](https://github.com/user-attachments/assets/9ba4e279-da12-4254-b583-9b5803ecc33a)|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods