### PR TITLE
minor fix: translation for pause

### DIFF
--- a/web/i18n/fa-IR/dataset-documents.ts
+++ b/web/i18n/fa-IR/dataset-documents.ts
@@ -29,7 +29,7 @@ const translation = {
       delete: 'حذف',
       enableWarning: 'فایل بایگانی شده نمی‌تواند فعال شود',
       sync: 'همگام‌سازی',
-      resume: 'رزومه',
+      resume: 'ادامه',
       pause: 'مکث',
     },
     index: {

--- a/web/i18n/ja-JP/dataset-documents.ts
+++ b/web/i18n/ja-JP/dataset-documents.ts
@@ -31,7 +31,7 @@ const translation = {
       enableWarning: 'アーカイブされたファイルは有効にできません',
       sync: '同期',
       pause: '一時停止',
-      resume: '履歴書',
+      resume: '再開',
     },
     index: {
       enable: '有効にする',

--- a/web/i18n/ro-RO/dataset-documents.ts
+++ b/web/i18n/ro-RO/dataset-documents.ts
@@ -29,7 +29,7 @@ const translation = {
       enableWarning: 'Fișierul arhivat nu poate fi activat',
       sync: 'Sincronizează',
       pause: 'Pauză',
-      resume: 'Relua',
+      resume: 'Reia',
     },
     index: {
       enable: 'Activează',

--- a/web/i18n/ru-RU/dataset-documents.ts
+++ b/web/i18n/ru-RU/dataset-documents.ts
@@ -29,7 +29,7 @@ const translation = {
       delete: 'Удалить',
       enableWarning: 'Архивный файл не может быть включен',
       sync: 'Синхронизировать',
-      resume: 'Резюме',
+      resume: 'Продовжити',
       pause: 'Пауза',
     },
     index: {

--- a/web/i18n/sl-SI/dataset-documents.ts
+++ b/web/i18n/sl-SI/dataset-documents.ts
@@ -29,8 +29,8 @@ const translation = {
       delete: 'Izbriši',
       enableWarning: 'Arhivirane datoteke ni mogoče omogočiti',
       sync: 'Sinhroniziraj',
-      pause: 'Pavza',
-      resume: 'Življenjepis',
+      pause: 'Zaustavi',
+      resume: 'Nadaljuj',
     },
     index: {
       enable: 'Omogoči',
@@ -334,7 +334,7 @@ const translation = {
     previewTip: 'Predogled odstavkov bo na voljo po zaključku vdelave',
     hierarchical: 'Starš-otrok',
     childMaxTokens: 'Otrok',
-    pause: 'Pavza',
+    pause: 'Zaustavi',
     parentMaxTokens: 'Starš',
   },
   segment: {

--- a/web/i18n/tr-TR/dataset-documents.ts
+++ b/web/i18n/tr-TR/dataset-documents.ts
@@ -30,7 +30,7 @@ const translation = {
       enableWarning: 'Arşivlenmiş dosya etkinleştirilemez',
       sync: 'Senkronize et',
       pause: 'Duraklat',
-      resume: 'Özgeçmiş',
+      resume: 'Devam Et',
     },
     index: {
       enable: 'Etkinleştir',

--- a/web/i18n/uk-UA/dataset-documents.ts
+++ b/web/i18n/uk-UA/dataset-documents.ts
@@ -29,7 +29,7 @@ const translation = {
       enableWarning: 'Архівований файл неможливо активувати',
       sync: 'Синхронізувати',
       pause: 'Пауза',
-      resume: 'Резюме',
+      resume: 'Продовжити',
     },
     index: {
       enable: 'Активувати',


### PR DESCRIPTION
# Pull Request Template

> [!IMPORTANT]
> 
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR introduces minor fixes to translations across multiple languages in the `translation` file. Specifically, it updates the terms for "resume" and "pause" in several languages to ensure consistency and accuracy. These changes were made to improve the user experience and maintain linguistic precision.

### Changes:
- Updated translation for "resume" across Arabic, Japanese, Romanian, Russian, Slovenian, Turkish, and Ukrainian.
- Updated translation for "pause" in Slovenian.



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods.
