### PR TITLE
feat(end_stream_processor): support streaming output of all configure…

### DIFF
--- a/api/core/workflow/nodes/end/end_stream_processor.py
+++ b/api/core/workflow/nodes/end/end_stream_processor.py
@@ -42,23 +42,26 @@ class EndStreamProcessor(StreamProcessor):
                     yield event
                     continue
 
-                if event.route_node_state.node_id in self.current_stream_chunk_generating_node_ids:
-                    stream_out_end_node_ids = self.current_stream_chunk_generating_node_ids[
-                        event.route_node_state.node_id
-                    ]
-                else:
-                    stream_out_end_node_ids = self._get_stream_out_end_node_ids(event)
-                    self.current_stream_chunk_generating_node_ids[event.route_node_state.node_id] = (
-                        stream_out_end_node_ids
-                    )
-
-                if stream_out_end_node_ids:
-                    if self.has_output and event.node_id not in self.output_node_ids:
-                        event.chunk_content = "\n" + event.chunk_content
-
-                    self.output_node_ids.add(event.node_id)
-                    self.has_output = True
-                    yield event
+                # Iterate all variable selectors for all end nodes; stream if matched
+                matched = False  # Flag to indicate if a match is found
+                for end_node_id, value_selectors_list in self.end_stream_param.end_stream_variable_selector_mapping.items():
+                    # Loop through all variable selectors configured for the current end node
+                    for value_selector in value_selectors_list:
+                        # Check if the current event's from_variable_selector matches the configured selector
+                        if event.from_variable_selector == value_selector:
+                            # If there was previous output and this node hasn't output yet, prepend a newline
+                            if self.has_output and event.node_id not in self.output_node_ids:
+                                event.chunk_content = "\n" + event.chunk_content
+                            # Mark this node as having output to avoid duplicate newlines
+                            self.output_node_ids.add(event.node_id)
+                            # Set the flag indicating output has occurred
+                            self.has_output = True
+                            # Stream the current event
+                            yield event
+                            matched = True  # Set matched flag to break out of loops
+                            break  # Exit inner loop after match
+                    if matched:
+                        break  # Exit outer loop after match
             elif isinstance(event, NodeRunSucceededEvent):
                 yield event
                 if event.route_node_state.node_id in self.current_stream_chunk_generating_node_ids:

--- a/docker/Dockerfile.patch
+++ b/docker/Dockerfile.patch
@@ -1,8 +1,6 @@
 FROM langgenius/dify-api:1.5.1
 
-USER root
 RUN apt-get update && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
-USER app
 
 # docker build -f docker/Dockerfile.patch -t land007/dify-api:1.5.1 .

--- a/docker/Dockerfile.patch
+++ b/docker/Dockerfile.patch
@@ -3,4 +3,7 @@ FROM langgenius/dify-api:1.5.1
 RUN apt-get update && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
 
+COPY my_endnode_streaming.patch /app/my_endnode_streaming.patch
+RUN git apply my_endnode_streaming.patch
+
 # docker build -f docker/Dockerfile.patch -t land007/dify-api:1.5.1 .

--- a/docker/Dockerfile.patch
+++ b/docker/Dockerfile.patch
@@ -1,0 +1,8 @@
+FROM langgenius/dify-api:1.5.1
+
+USER root
+RUN apt-get update && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+USER app
+
+# docker build -f docker/Dockerfile.patch -t land007/dify-api:1.5.1 .

--- a/docker/Dockerfile.patch
+++ b/docker/Dockerfile.patch
@@ -4,6 +4,6 @@ RUN apt-get update && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY my_endnode_streaming.patch /app/my_endnode_streaming.patch
-RUN git apply my_endnode_streaming.patch
+RUN cd /app && git apply my_endnode_streaming.patch
 
 # docker build -f docker/Dockerfile.patch -t land007/dify-api:1.5.1 .

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -517,7 +517,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: land007/dify-api:1.5.1
+    image: langgenius/dify-api:1.5.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -537,15 +537,8 @@ services:
       redis:
         condition: service_started
     volumes:
+      # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-      - ../my_endnode_streaming.patch:/app/my_endnode_streaming.patch
-    command: >
-      sh -c "if [ -f /app/my_endnode_streaming.patch ]; then \
-        cd /app && \
-        git apply --check my_endnode_streaming.patch && \
-        git apply my_endnode_streaming.patch || echo 'Patch already applied or not applicable'; \
-      fi; \
-      exec /start-api.sh"
     networks:
       - ssrf_proxy_network
       - default
@@ -571,15 +564,8 @@ services:
       redis:
         condition: service_started
     volumes:
+      # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-      - ../my_endnode_streaming.patch:/app/my_endnode_streaming.patch
-    command: >
-      sh -c "if [ -f /app/my_endnode_streaming.patch ]; then \
-        cd /app && \
-        git apply --check my_endnode_streaming.patch && \
-        git apply my_endnode_streaming.patch || echo 'Patch already applied or not applicable'; \
-      fi; \
-      exec /start-worker.sh"
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -537,8 +537,15 @@ services:
       redis:
         condition: service_started
     volumes:
-      # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
+      - ../my_endnode_streaming.patch:/app/my_endnode_streaming.patch
+    command: >
+      sh -c "if [ -f /app/my_endnode_streaming.patch ]; then \
+        cd /app && \
+        git apply --check my_endnode_streaming.patch && \
+        git apply my_endnode_streaming.patch || echo 'Patch already applied or not applicable'; \
+      fi; \
+      exec /start-api.sh"
     networks:
       - ssrf_proxy_network
       - default
@@ -564,8 +571,15 @@ services:
       redis:
         condition: service_started
     volumes:
-      # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
+      - ../my_endnode_streaming.patch:/app/my_endnode_streaming.patch
+    command: >
+      sh -c "if [ -f /app/my_endnode_streaming.patch ]; then \
+        cd /app && \
+        git apply --check my_endnode_streaming.patch && \
+        git apply my_endnode_streaming.patch || echo 'Patch already applied or not applicable'; \
+      fi; \
+      exec /start-worker.sh"
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -517,7 +517,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:1.5.1
+    image: land007/dify-api:1.5.1
     restart: always
     environment:
       # Use the shared environment variables.

--- a/my_endnode_streaming.patch
+++ b/my_endnode_streaming.patch
@@ -1,0 +1,48 @@
+diff --git a/api/core/workflow/nodes/end/end_stream_processor.py b/api/core/workflow/nodes/end/end_stream_processor.py
+index a6fb2ffc1..fcf4011da 100644
+--- a/api/core/workflow/nodes/end/end_stream_processor.py
++++ b/api/core/workflow/nodes/end/end_stream_processor.py
+@@ -42,23 +42,26 @@ class EndStreamProcessor(StreamProcessor):
+                     yield event
+                     continue
+ 
+-                if event.route_node_state.node_id in self.current_stream_chunk_generating_node_ids:
+-                    stream_out_end_node_ids = self.current_stream_chunk_generating_node_ids[
+-                        event.route_node_state.node_id
+-                    ]
+-                else:
+-                    stream_out_end_node_ids = self._get_stream_out_end_node_ids(event)
+-                    self.current_stream_chunk_generating_node_ids[event.route_node_state.node_id] = (
+-                        stream_out_end_node_ids
+-                    )
+-
+-                if stream_out_end_node_ids:
+-                    if self.has_output and event.node_id not in self.output_node_ids:
+-                        event.chunk_content = "\n" + event.chunk_content
+-
+-                    self.output_node_ids.add(event.node_id)
+-                    self.has_output = True
+-                    yield event
++                # Iterate all variable selectors for all end nodes; stream if matched
++                matched = False  # Flag to indicate if a match is found
++                for end_node_id, value_selectors_list in self.end_stream_param.end_stream_variable_selector_mapping.items():
++                    # Loop through all variable selectors configured for the current end node
++                    for value_selector in value_selectors_list:
++                        # Check if the current event's from_variable_selector matches the configured selector
++                        if event.from_variable_selector == value_selector:
++                            # If there was previous output and this node hasn't output yet, prepend a newline
++                            if self.has_output and event.node_id not in self.output_node_ids:
++                                event.chunk_content = "\n" + event.chunk_content
++                            # Mark this node as having output to avoid duplicate newlines
++                            self.output_node_ids.add(event.node_id)
++                            # Set the flag indicating output has occurred
++                            self.has_output = True
++                            # Stream the current event
++                            yield event
++                            matched = True  # Set matched flag to break out of loops
++                            break  # Exit inner loop after match
++                    if matched:
++                        break  # Exit outer loop after match
+             elif isinstance(event, NodeRunSucceededEvent):
+                 yield event
+                 if event.route_node_state.node_id in self.current_stream_chunk_generating_node_ids:


### PR DESCRIPTION
## Summary

This PR modifies the End node's streaming logic to support streaming output for all configured variables (e.g., `text`, `text1`, `text2`), not just the first one.

**Motivation:**  
In advanced workflow scenarios, users may need to stream output from multiple LLM nodes or multiple content branches simultaneously. The current implementation only streams the first configured variable, which limits flexibility.  
This change iterates all variable selectors for all end nodes and streams if matched, enabling more flexible and powerful workflow designs.

No additional dependencies are required for this change.

---

## Changes

- Iterate all variable selectors for all end nodes and stream if matched.
- Add detailed English comments explaining each step of the logic.
- This enables streaming output for multiple variables (e.g., `text`, `text1`, `text2`...) instead of only the first one.

---

## Testing

I have manually tested this change in my own environment and confirmed that it works as expected.  
**Note:** There is no formal automated test report for this PR.

---

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

---

## Screenshots

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/dc82a67b-60ee-451b-a77b-fb317ce6d8f0)    | ![image](https://github.com/user-attachments/assets/f80c6b7a-76f3-4b69-aef9-9d16e4d544e3)  |

---

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

---

If you need any more information or adjustments, please let me know. Thank you for reviewing!