### PR TITLE
feat(question-classifier): add instanceId to class-item editor

### DIFF
--- a/web/app/components/workflow/nodes/question-classifier/components/class-item.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/components/class-item.tsx
@@ -1,11 +1,12 @@
 'use client'
 import type { FC } from 'react'
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Topic } from '../types'
 import Editor from '@/app/components/workflow/nodes/_base/components/prompt/editor'
 import useAvailableVarList from '@/app/components/workflow/nodes/_base/hooks/use-available-var-list'
 import type { ValueSelector, Var } from '@/app/components/workflow/types'
+import { uniqueId } from 'lodash-es'
 
 const i18nPrefix = 'workflow.nodes.questionClassifiers'
 
@@ -29,6 +30,11 @@ const ClassItem: FC<Props> = ({
   filterVar,
 }) => {
   const { t } = useTranslation()
+  const [instanceId, setInstanceId] = useState(uniqueId())
+
+  useEffect(() => {
+    setInstanceId(`${nodeId}-${uniqueId()}`)
+  }, [nodeId])
 
   const handleNameChange = useCallback((value: string) => {
     onChange({ ...payload, name: value })
@@ -52,6 +58,7 @@ const ClassItem: FC<Props> = ({
       nodesOutputVars={availableVars}
       availableNodes={availableNodesWithParent}
       readOnly={readonly} // ?
+      instanceId={instanceId}
       justVar // ?
       isSupportFileVar // ?
     />


### PR DESCRIPTION
## Summary

Ensure unique editor instance when nodeId changes by generating a new instanceId

fixed #22006

## Screenshots

| Before | After |
|--------|-------|
| ![148bd0a181e4749afc4fc06c472a8da](https://github.com/user-attachments/assets/3558ac8e-d0db-423d-895f-24ee2a2ea3ed)  | ![159159933bc95deb5139c785d16ca6a](https://github.com/user-attachments/assets/238df3b8-ada0-4032-a876-8da1adbc2641) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
