### PR TITLE
fix(docker): Specify default network for nginx & plugin_daemon

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -196,6 +196,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - default
 
   # ssrf_proxy server
   # for more information, please refer to

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -277,6 +277,8 @@ services:
     ports:
       - '${EXPOSE_NGINX_PORT:-80}:${NGINX_PORT:-80}'
       - '${EXPOSE_NGINX_SSL_PORT:-443}:${NGINX_SSL_PORT:-443}'
+    networks:
+      - default
 
   # The Weaviate vector store.
   weaviate:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -792,6 +792,8 @@ services:
     ports:
       - '${EXPOSE_NGINX_PORT:-80}:${NGINX_PORT:-80}'
       - '${EXPOSE_NGINX_SSL_PORT:-443}:${NGINX_SSL_PORT:-443}'
+    networks:
+      - default
 
   # The Weaviate vector store.
   weaviate:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -711,6 +711,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - default
 
   # ssrf_proxy server
   # for more information, please refer to


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Explicitly specify presence of `plugin_daemon` & `nginx` services in the `default` network. While `docker-compose` assumes and connects, `podman-compose` does not. This change makes it possible to use this project's default compose configuration without any further changes [as is my experience].

## Background

I was setting up Dify using [Dokploy](https://github.com/Dokploy/dokploy) (which utilizes `podman-compose`), and came across various errors in the NGINX logs regarding it not being able to lookup `api` and `plugin_daemon`:

```txt
... nginx: [emerg] host not found in upstream "api"
... nginx: [emerg] host not found in upstream "plugin_daemon" 
```

Tested this build and verified with nothing suspicious in the log files.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
