### PR TITLE
Update clean_document_task.py

### DIFF
--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -73,7 +73,7 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
             DatasetMetadataBinding.document_id == document_id,
         ).delete()
         db.session.commit()
-        
+
         end_at = time.perf_counter()
         logging.info(
             click.style(

--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -72,7 +72,8 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
             DatasetMetadataBinding.dataset_id == dataset_id,
             DatasetMetadataBinding.document_id == document_id,
         ).delete()
-
+        db.session.commit()
+        
         end_at = time.perf_counter()
         logging.info(
             click.style(


### PR DESCRIPTION
Fixed: Deleting a document also deletes the associated metadata
close #22089 