### PR TITLE
Chore: rm useless import and vars

### DIFF
--- a/api/tests/integration_tests/vdb/couchbase/test_couchbase.py
+++ b/api/tests/integration_tests/vdb/couchbase/test_couchbase.py
@@ -4,7 +4,6 @@ import time
 from core.rag.datasource.vdb.couchbase.couchbase_vector import CouchbaseConfig, CouchbaseVector
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
-    get_example_text,
     setup_mock_redis,
 )
 

--- a/api/tests/integration_tests/vdb/matrixone/test_matrixone.py
+++ b/api/tests/integration_tests/vdb/matrixone/test_matrixone.py
@@ -1,7 +1,6 @@
 from core.rag.datasource.vdb.matrixone.matrixone_vector import MatrixoneConfig, MatrixoneVector
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
-    get_example_text,
     setup_mock_redis,
 )
 

--- a/api/tests/integration_tests/vdb/opengauss/test_opengauss.py
+++ b/api/tests/integration_tests/vdb/opengauss/test_opengauss.py
@@ -5,7 +5,6 @@ import psycopg2  # type: ignore
 from core.rag.datasource.vdb.opengauss.opengauss import OpenGauss, OpenGaussConfig
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
-    get_example_text,
     setup_mock_redis,
 )
 

--- a/api/tests/integration_tests/vdb/pyvastbase/test_vastbase_vector.py
+++ b/api/tests/integration_tests/vdb/pyvastbase/test_vastbase_vector.py
@@ -1,7 +1,6 @@
 from core.rag.datasource.vdb.pyvastbase.vastbase_vector import VastbaseVector, VastbaseVectorConfig
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
-    get_example_text,
     setup_mock_redis,
 )
 

--- a/api/tests/integration_tests/workflow/nodes/test_llm.py
+++ b/api/tests/integration_tests/workflow/nodes/test_llm.py
@@ -1,5 +1,4 @@
 import json
-import os
 import time
 import uuid
 from collections.abc import Generator

--- a/api/tests/integration_tests/workflow/nodes/test_llm.py
+++ b/api/tests/integration_tests/workflow/nodes/test_llm.py
@@ -113,8 +113,6 @@ def test_execute_llm(flask_req_ctx):
         },
     )
 
-    credentials = {"openai_api_key": os.environ.get("OPENAI_API_KEY")}
-
     # Create a proper LLM result with real entities
     mock_usage = LLMUsage(
         prompt_tokens=30,

--- a/api/tests/unit_tests/factories/test_variable_factory.py
+++ b/api/tests/unit_tests/factories/test_variable_factory.py
@@ -14,9 +14,7 @@ from core.variables import (
     ArrayStringVariable,
     FloatVariable,
     IntegerVariable,
-    ObjectSegment,
     SecretVariable,
-    SegmentType,
     StringVariable,
 )
 from core.variables.exc import VariableError

--- a/api/tests/unit_tests/factories/test_variable_factory.py
+++ b/api/tests/unit_tests/factories/test_variable_factory.py
@@ -418,8 +418,6 @@ def test_build_segment_file_array_with_different_file_types():
 
 @st.composite
 def _generate_file(draw) -> File:
-    file_id = draw(st.text(min_size=1, max_size=10))
-    tenant_id = draw(st.text(min_size=1, max_size=10))
     file_type, mime_type, extension = draw(
         st.sampled_from(
             [

--- a/api/tests/unit_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_update_dataset.py
@@ -10,7 +10,6 @@ from core.model_runtime.entities.model_entities import ModelType
 from models.dataset import Dataset, ExternalKnowledgeBindings
 from services.dataset_service import DatasetService
 from services.errors.account import NoPermissionError
-from tests.unit_tests.conftest import redis_mock
 
 
 class DatasetUpdateTestDataFactory:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

These changes are auto-detected by 'pyflakes'
- Remove unused import `get_example_text` and `redis_mock`
- Remove unused var `credentials`, `file_id`, and `tenant_id`
- Remove repeated import `ObjectSegment` and `SegmentType`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
