### PR TITLE
Fix potential leak

### DIFF
--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -194,7 +194,7 @@ class BaseSession(
         if self._receiver_future:
             try:
                 self._receiver_future.result(timeout=5.0)  # Wait up to 5 seconds
-            except Exception:
+            except concurrent.futures.TimeoutError:
                 # If the receiver loop is still running after timeout, we'll force shutdown
                 pass
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix #22168 

This PR addresses a potential ThreadPool leakage issue in the `base_session.py` file within the MCP (Model Context Protocol) session management module. The fix ensures proper initialization and cleanup of thread pool executors and receiver futures to prevent resource leaks.

**Key Changes:**
- Initialize `_executor` and `_receiver_future` attributes to `None` in the constructor for proper cleanup checks
- Enhanced the `__exit__` method to properly wait for receiver loop completion with a 5-second timeout
- Added graceful shutdown of the ThreadPoolExecutor with timeout handling
- Improved resource management to prevent potential memory leaks and hanging threads

**Motivation:**
Without proper cleanup of ThreadPool resources, the application could experience memory leaks and resource exhaustion over time, especially in long-running scenarios where multiple sessions are created and destroyed.

## Screenshots

| Before | After |
|--------|-------|
| ThreadPool resources not properly cleaned up, potential memory leaks | Proper initialization and cleanup of ThreadPool resources with timeout handling |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods