### PR TITLE
Allow Variable Aggregator to aggregate all

### DIFF
--- a/api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py
+++ b/api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Any
 
 from core.workflow.entities.node_entities import NodeRunResult

--- a/api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py
+++ b/api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
+from typing import Any
 
-from core.variables.segments import Segment
 from core.workflow.entities.node_entities import NodeRunResult
 from core.workflow.entities.workflow_node_execution import WorkflowNodeExecutionStatus
 from core.workflow.nodes.base import BaseNode
@@ -8,8 +8,12 @@ from core.workflow.nodes.enums import NodeType
 from core.workflow.nodes.variable_aggregator.entities import VariableAssignerNodeData
 
 
-class VariableAggregatorNode(BaseNode[VariableAssignerNodeData]):
-    _node_data_cls = VariableAssignerNodeData
+class VariableAggregatorNodeData(VariableAssignerNodeData):
+    aggregate_all: bool = False
+
+
+class VariableAggregatorNode(BaseNode[VariableAggregatorNodeData]):
+    _node_data_cls = VariableAggregatorNodeData
     _node_type = NodeType.VARIABLE_AGGREGATOR
 
     @classmethod
@@ -18,25 +22,50 @@ class VariableAggregatorNode(BaseNode[VariableAssignerNodeData]):
 
     def _run(self) -> NodeRunResult:
         # Get variables
-        outputs: dict[str, Segment | Mapping[str, Segment]] = {}
-        inputs = {}
+        outputs: dict[str, Any] = {}
+        inputs: dict[str, Any] = {}
 
-        if not self.node_data.advanced_settings or not self.node_data.advanced_settings.group_enabled:
-            for selector in self.node_data.variables:
-                variable = self.graph_runtime_state.variable_pool.get(selector)
-                if variable is not None:
-                    outputs = {"output": variable}
-
-                    inputs = {".".join(selector[1:]): variable.to_object()}
-                    break
-        else:
-            for group in self.node_data.advanced_settings.groups:
-                for selector in group.variables:
+        # if aggregate_all is not configured, aggregate only first variables
+        if not getattr(self.node_data, "aggregate_all", False):
+            if not self.node_data.advanced_settings or not self.node_data.advanced_settings.group_enabled:
+                for selector in self.node_data.variables:
                     variable = self.graph_runtime_state.variable_pool.get(selector)
-
                     if variable is not None:
-                        outputs[group.group_name] = {"output": variable}
-                        inputs[".".join(selector[1:])] = variable.to_object()
+                        outputs = {"output": variable}
+
+                        inputs = {".".join(selector[1:]): variable.to_object()}
                         break
+            else:
+                for group in self.node_data.advanced_settings.groups:
+                    for selector in group.variables:
+                        variable = self.graph_runtime_state.variable_pool.get(selector)
+
+                        if variable is not None:
+                            outputs[group.group_name] = {"output": variable}
+                            inputs[".".join(selector[1:])] = variable.to_object()
+                            break
+        else:
+            # if aggregate_all is configured, aggregate all variables
+            if not self.node_data.advanced_settings or not self.node_data.advanced_settings.group_enabled:
+                aggregated_values = []
+                for selector in self.node_data.variables:
+                    variable = self.graph_runtime_state.variable_pool.get(selector)
+                    if variable is not None:
+                        aggregated_values.append(variable.to_object())
+                        inputs[".".join(selector[1:])] = variable.to_object()
+
+                if aggregated_values:
+                    outputs = {"output": aggregated_values}
+            else:
+                for group in self.node_data.advanced_settings.groups:
+                    aggregated_values = []
+                    for selector in group.variables:
+                        variable = self.graph_runtime_state.variable_pool.get(selector)
+                        if variable is not None:
+                            aggregated_values.append(variable.to_object())
+                            inputs[".".join(selector[1:])] = variable.to_object()
+
+                    if aggregated_values:
+                        outputs[group.group_name] = {"output": aggregated_values}
 
         return NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED, outputs=outputs, inputs=inputs)

--- a/web/app/components/workflow/nodes/variable-assigner/panel.tsx
+++ b/web/app/components/workflow/nodes/variable-assigner/panel.tsx
@@ -35,6 +35,7 @@ const Panel: FC<NodePanelProps<VariableAssignerNodeType>> = ({
     onRemoveVarConfirm,
     getAvailableVars,
     filterVar,
+    handleAggregateAllChange,
   } = useConfig(id, data)
 
   return (
@@ -95,26 +96,41 @@ const Panel: FC<NodePanelProps<VariableAssignerNodeType>> = ({
             />
           }
         />
+        <Field
+          title={t(`${i18nPrefix}.aggregateAll`)}
+          tooltip={t(`${i18nPrefix}.aggregateAllTip`)!}
+          operations={
+            <Switch
+              defaultValue={inputs.aggregate_all}
+              onChange={handleAggregateAllChange}
+              size='md'
+              disabled={readOnly}
+            />
+          }
+        />
       </div>
-      {isEnableGroup && (
+      <Split />
+      <OutputVars>
         <>
-          <Split />
-          <OutputVars>
-            <>
-              {inputs.advanced_settings?.groups.map((item, index) => (
-                <VarItem
-                  key={index}
-                  name={`${item.group_name}.output`}
-                  type={item.output_type}
-                  description={t(`${i18nPrefix}.outputVars.varDescribe`, {
-                    groupName: item.group_name,
-                  })}
-                />
-              ))}
-            </>
-          </OutputVars>
+          {isEnableGroup
+            ? inputs.advanced_settings?.groups.map((item, index) => (
+              <VarItem
+                key={index}
+                name={`${item.group_name}.output`}
+                type={item.output_type}
+                description={t(`${i18nPrefix}.outputVars.varDescribe`, {
+                  groupName: item.group_name,
+                })}
+              />
+            ))
+            : (
+              <VarItem
+                name='output'
+                type={inputs.output_type}
+              />
+            )}
         </>
-      )}
+      </OutputVars>
       <RemoveEffectVarConfirm
         isShow={isShowRemoveVarConfirm}
         onCancel={hideRemoveVarConfirm}

--- a/web/app/components/workflow/nodes/variable-assigner/types.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/types.ts
@@ -5,6 +5,7 @@ export type VarGroupItem = {
   variables: ValueSelector[]
 }
 export type VariableAssignerNodeType = CommonNodeType & VarGroupItem & {
+  aggregate_all?: boolean
   advanced_settings: {
     group_enabled: boolean
     groups: ({

--- a/web/app/components/workflow/nodes/variable-assigner/use-config.ts
+++ b/web/app/components/workflow/nodes/variable-assigner/use-config.ts
@@ -33,6 +33,13 @@ const useConfig = (id: string, payload: VariableAssignerNodeType) => {
     })
   }, [inputs, setInputs])
 
+  const handleAggregateAllChange = useCallback((checked: boolean) => {
+    const newInputs = produce(inputs, (draft) => {
+      draft.aggregate_all = checked
+    })
+    setInputs(newInputs)
+  }, [inputs, setInputs])
+
   const handleListOrTypeChangeInGroup = useCallback((groupId: string) => {
     return (payload: VarGroupItem) => {
       const index = inputs.advanced_settings.groups.findIndex(item => item.groupId === groupId)
@@ -208,6 +215,7 @@ const useConfig = (id: string, payload: VariableAssignerNodeType) => {
     onRemoveVarConfirm,
     getAvailableVars,
     filterVar,
+    handleAggregateAllChange,
   }
 }
 

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -626,6 +626,8 @@ const translation = {
       },
       aggregationGroup: 'Aggregation Group',
       aggregationGroupTip: 'Enabling this feature allows the variable aggregator to aggregate multiple sets of variables.',
+      aggregateAll: 'Aggregate All',
+      aggregateAllTip: 'Enabling this feature allows the variable aggregator to aggregate all input variables into an array, otherwise it will aggregate first arrival variables into the array.',
       addGroup: 'Add Group',
       outputVars: {
         varDescribe: '{{groupName}} output',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -627,6 +627,8 @@ const translation = {
       },
       aggregationGroup: '聚合分组',
       aggregationGroupTip: '开启该功能后，变量聚合器内可以同时聚合多组变量',
+      aggregateAll: '聚合所有',
+      aggregateAllTip: '开启该功能后，变量聚合器将聚合所有输入变量到一个数组中，否则只会聚合第一个变量',
       addGroup: '添加分组',
       outputVars: {
         varDescribe: '{{groupName}}的输出变量',


### PR DESCRIPTION

feat(workflow): Allow Variable Aggregator to aggregate all inputs


  Problem


  Currently, the variable-aggregator node in the workflow operates on a "first-come, first-served" basis.
  When it receives inputs from multiple upstream branches, it only processes the first non-empty variable it
   encounters and then immediately stops. This behavior causes all subsequent inputs from other branches to
  be ignored.


  This limitation restricts scenarios where it is necessary to merge results from multiple sources, such as
  combining outputs from several Knowledge Retrieval nodes, HTTP requests, or other tools.


  Solution


  To address this, this pull request introduces a new configuration option for the variable-aggregator node:
   an aggregate_all switch.


   - When `aggregate_all` is disabled (default behavior): The node maintains its original logic, capturing
     only the first valid input it receives.
   - When `aggregate_all` is enabled: The node iterates through all connected input branches, collects every
     valid variable, and aggregates them into a single list as its final output.

  Implementation Details


   1. Backend (API):
       - In api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py:
           - Added the aggregate_all: bool field to the VariableAggregatorNodeData model.
           - Modified the _run method: when aggregate_all is true, the break statement is removed, and the
             logic is updated to collect all incoming variables into a list for output.


   2. Frontend (Web):
       - Since the variable-aggregator node reuses the frontend components of the variable-assigner, the
         changes were made in the web/app/components/workflow/nodes/variable-assigner/ directory.
       - `panel.tsx`: Added a new "Aggregate All" Switch UI control to the node's configuration panel.
       - `types.ts`: Updated the VariableAssignerNodeType definition to include the optional aggregate_all:
         boolean property.
       - `use-config.ts`: Implemented the handleAggregateAllChange function to manage the state of the new
         switch.
       - `web/i18n/`: Added corresponding labels and tooltips for the new switch in the zh-Hans and en-US
         workflow.ts translation files.

  How to Test

   1. Create a new workflow.
   2. Add two or more Knowledge Retrieval nodes and configure them with different Knowledge Bases.
   3. Add a Variable Aggregator node and connect the outputs of the Knowledge Retrieval nodes to it.
   4. Connect an End node after the aggregator to inspect the final output.
   5. Test Default Behavior: Run the workflow. Check the output at the End node. It should contain the
      retrieval results from only one of the Knowledge Bases.
   6. Test New Feature:
       - Click the Variable Aggregator node to open its configuration panel.
       - Find and enable the new "Aggregate All" switch.
       - Run the workflow again.
       - Check the output at the End node. It should now be an array containing the retrieval results from all
          connected Knowledge Bases.
		  


## Screenshots

| After 
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/2f4d707d-3a36-48af-87b5-ec1ae631f582" />



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
