### PR TITLE
fix(web): Optimize AppInfo Component Layout (#22212)

### DIFF
--- a/web/app/components/app-sidebar/app-info.tsx
+++ b/web/app/components/app-sidebar/app-info.tsx
@@ -308,13 +308,11 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
             operations={operations}
           />
         </div>
-        <div className='flex flex-1'>
-          <CardView
-            appId={appDetail.id}
-            isInPanel={true}
-            className='flex grow flex-col gap-2 overflow-auto px-2 py-1'
-          />
-        </div>
+        <CardView
+          appId={appDetail.id}
+          isInPanel={true}
+          className='flex flex-1 flex-col gap-2 overflow-auto px-2 py-1'
+        />
         <Divider />
         <div className='flex min-h-fit shrink-0 flex-col items-start justify-center gap-3 self-stretch border-t-[0.5px] border-divider-subtle p-2'>
           <Button


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Remove unnecessary div container outside the CardView component
- Adjust the class name of the CardView component to directly use flex-1 instead of flex grow

Fixes #22212 

## Screenshots

| Before | After |
|--------|-------|
| <img width="915" height="1263" alt="image" src="https://github.com/user-attachments/assets/5e4c1dc6-8839-4837-a33e-84332c7411a7" />   | <img width="761" height="1227" alt="image" src="https://github.com/user-attachments/assets/347ae3a0-4f79-4bee-9dc3-996f3853f3e5" />   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
