### PR TITLE
fix:  When var value changed, PromptEditor should be reset

### DIFF
--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-item.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-item.tsx
@@ -25,6 +25,7 @@ import { FILE_TYPE_OPTIONS, SUB_VARIABLES, TRANSFER_METHOD } from '../../../cons
 import ConditionWrap from '../condition-wrap'
 import ConditionOperator from './condition-operator'
 import ConditionInput from './condition-input'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 
 import ConditionVarSelector from './condition-var-selector'
 import type {
@@ -87,6 +88,11 @@ const ConditionItem = ({
   const isChatMode = useIsChatMode()
   const [isHovered, setIsHovered] = useState(false)
   const [open, setOpen] = useState(false)
+
+  const workflowStore = useWorkflowStore()
+  const {
+    setControlPromptEditorRerenderKey,
+  } = workflowStore.getState()
 
   const doUpdateCondition = useCallback((newCondition: Condition) => {
     if (isSubVariableKey)
@@ -208,10 +214,11 @@ const ConditionItem = ({
       draft.varType = resolvedVarType
       draft.value = ''
       draft.comparison_operator = getOperators(resolvedVarType)[0]
+      setTimeout(() => setControlPromptEditorRerenderKey(Date.now()))
     })
     doUpdateCondition(newCondition)
     setOpen(false)
-  }, [condition, doUpdateCondition, availableNodes, isChatMode])
+  }, [condition, doUpdateCondition, availableNodes, isChatMode, setControlPromptEditorRerenderKey])
 
   return (
     <div className={cn('mb-1 flex last-of-type:mb-0', className)}>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #22216 

## Screenshots




| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
