### PR TITLE
fix: error parsing object type parameters for code node

### DIFF
--- a/api/core/helper/code_executor/template_transformer.py
+++ b/api/core/helper/code_executor/template_transformer.py
@@ -5,6 +5,8 @@ from base64 import b64encode
 from collections.abc import Mapping
 from typing import Any
 
+from core.variables.utils import SegmentJSONEncoder
+
 
 class TemplateTransformer(ABC):
     _code_placeholder: str = "{{code}}"
@@ -95,7 +97,7 @@ class TemplateTransformer(ABC):
 
     @classmethod
     def serialize_inputs(cls, inputs: Mapping[str, Any]) -> str:
-        inputs_json_str = json.dumps(inputs, ensure_ascii=False).encode()
+        inputs_json_str = json.dumps(inputs, ensure_ascii=False, cls=SegmentJSONEncoder).encode()
         input_base64_encoded = b64encode(inputs_json_str).decode("utf-8")
         return input_base64_encoded
 


### PR DESCRIPTION
## Summary

fix the error parsing object type parameters for code node

Fixes #21935

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
