### PR TITLE
fix(emoji-picker): Adjust the style of the emoji picker (#22161)

### DIFF
--- a/web/app/components/base/emoji-picker/Inner.tsx
+++ b/web/app/components/base/emoji-picker/Inner.tsx
@@ -101,7 +101,7 @@ const EmojiPickerInner: FC<IEmojiPickerInnerProps> = ({
     </div>
     <Divider className='my-3' />
 
-    <div className="w-full flex-1 overflow-y-auto overflow-x-hidden px-3">
+    <div className="max-h-[200px] w-full overflow-y-auto overflow-x-hidden px-3">
       {isSearching && <>
         <div key={'category-search'} className='flex flex-col'>
           <p className='system-xs-medium-uppercase mb-1 text-text-primary'>Search</p>
@@ -170,7 +170,7 @@ const EmojiPickerInner: FC<IEmojiPickerInnerProps> = ({
             'flex h-8 w-8 items-center justify-center rounded-lg p-1',
           )
           } style={{ background: color }}>
-          {selectedEmoji !== '' && <em-emoji id={selectedEmoji} />}
+            {selectedEmoji !== '' && <em-emoji id={selectedEmoji} />}
           </div>
         </div>
       })}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Set the maximum height of the emoji list container to 200px to limit the scrollable area

Fixes #22161

## Screenshots

| Before | After |
|--------|-------|
| <img width="1009" height="1219" alt="image" src="https://github.com/user-attachments/assets/b90cc55e-4378-4736-a0d7-7f94330d9228" />    | <img width="891" height="863" alt="image" src="https://github.com/user-attachments/assets/437623ad-f1c0-41c1-ac22-530e73eadbad" />   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
