### PR TITLE
fix(plugin): introduce response_type parameter in plugin list API to enable paginated response support

### DIFF
--- a/api/core/plugin/impl/plugin.py
+++ b/api/core/plugin/impl/plugin.py
@@ -36,7 +36,7 @@ class PluginInstaller(BasePluginClient):
             "GET",
             f"plugin/{tenant_id}/management/list",
             PluginListResponse,
-            params={"page": 1, "page_size": 256},
+            params={"page": 1, "page_size": 256, "response_type": "paged"},
         )
         return result.list
 
@@ -45,7 +45,7 @@ class PluginInstaller(BasePluginClient):
             "GET",
             f"plugin/{tenant_id}/management/list",
             PluginListResponse,
-            params={"page": page, "page_size": page_size},
+            params={"page": page, "page_size": page_size, "response_type": "paged"},
         )
 
     def upload_pkg(


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes https://github.com/langgenius/dify/issues/22250

During the upgrade process, we encountered an error (reference issue: xxx). I resolved this by introducing a new response_type parameter in the Plugin Daemon.

**Fix Details:**

1. Added an optional response_type parameter to the /plugin/{tenantId}/management/list API:
 -  If response_type=paged is specified, the endpoint returns a paginated response.
 -  Otherwise, it returns the legacy non-paginated format, ensuring backward compatibility with older versions of Dify.

2. In Dify v1.6.0, the response_type=paged parameter is now included by default when calling this endpoint, aligning it with the updated Plugin Daemon behavior.

**Recommended Upgrade Paths:**

- **For users who have not yet upgraded:**

It's recommended to upgrade Plugin Daemon first, followed by Dify. This ensures a smooth and error-free transition.

- **For users who have already upgraded:**

You should first upgrade Dify to v1.6.0 before upgrading Plugin Daemon, to ensure compatibility between components.

## Screenshots

| Before | After |
|--------|-------|
|   <img width="432" height="239" alt="dify_error" src="https://github.com/user-attachments/assets/782a2e1d-31a2-4d85-adb7-ec64c8401777" />|  No Error  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
