### PR TITLE
fix(dataset): remove extra Session in _update_external_knowledge_binding (#22263)

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 from flask_login import current_user
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from configs import dify_config
@@ -384,13 +383,12 @@ class DatasetService:
             external_knowledge_id: External knowledge identifier
             external_knowledge_api_id: External knowledge API identifier
         """
-        with Session(db.engine) as session:
-            external_knowledge_binding = (
-                session.query(ExternalKnowledgeBindings).filter_by(dataset_id=dataset_id).first()
-            )
+        external_knowledge_binding = (
+            db.session.query(ExternalKnowledgeBindings).filter_by(dataset_id=dataset_id).first()
+        )
 
-            if not external_knowledge_binding:
-                raise ValueError("External knowledge binding not found.")
+        if not external_knowledge_binding:
+            raise ValueError("External knowledge binding not found.")
 
         # Update binding if values have changed
         if (
@@ -399,7 +397,6 @@ class DatasetService:
         ):
             external_knowledge_binding.external_knowledge_id = external_knowledge_id
             external_knowledge_binding.external_knowledge_api_id = external_knowledge_api_id
-            db.session.add(external_knowledge_binding)
 
     @staticmethod
     def _update_internal_dataset(dataset, data, user):

--- a/api/tests/unit_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_update_dataset.py
@@ -119,7 +119,7 @@ class TestDatasetServiceUpdateDataset:
     @pytest.fixture
     def mock_external_provider_dependencies(self):
         """Mock setup for external provider tests."""
-        with patch("services.dataset_service.Session") as mock_session:
+        with patch("sqlalchemy.orm.Session") as mock_session:
             from extensions.ext_database import db
 
             with patch.object(db.__class__, "engine", new_callable=Mock):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. I have read the [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 2. There is an associated issue and I have been assigned to it.
> 3. Fixes #22263

## Summary

Remove the redundant `Session(db.engine)` in  
`DatasetService._update_external_knowledge_binding`.

* The binding row was queried with a **temporary Session**, closed (object becomes *detached*),  
  then re-attached to the global `db.session` for update.  
  This adds an unnecessary connection/transaction and can raise  
  `InvalidRequestError` if the row is already present in the identity-map.
* Now we reuse the surrounding `db.session` to query and update, ensuring the whole
  update flow stays in one atomic transaction.

_No new dependencies introduced._

## Screenshots

| Before | After |
|----------------------|-------|


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed if there's no linked issue or discussion.
- [x] I've added/updated tests where reasonable, and kept the change atomic.
- [x] I've updated documentation if necessary (N/A for this bug fix).
- [x] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) with no lint errors.
