### PR TITLE
The s3 signature_version supports transparent passing of environment …

### DIFF
--- a/api/configs/middleware/storage/amazon_s3_storage_config.py
+++ b/api/configs/middleware/storage/amazon_s3_storage_config.py
@@ -43,3 +43,8 @@ class S3StorageConfig(BaseSettings):
         description="Use AWS managed IAM roles for authentication instead of access/secret keys",
         default=False,
     )
+    
+    S3_SIGNATURE_VERSION: str = Field(
+        description="S3 signature version: 'unsigned', 's3', 's3v4'",
+        default="s3",
+    )


### PR DESCRIPTION
# The s3 signature_version supports transparent passing of environment variables

This update modifies the `api/extensions/storage/aws_s3_storage.py` file to handle the `signature_version` parameter dynamically. The changes include adding support for the `S3_SIGNATURE_VERSION` environment variable, which can be set to `'unsigned'`, `'s3'`, `'s3v4'`, or any custom input. The code now checks the environment variable `dif_config.S3_SIGNATURE_VERSION` and defaults to `'s3'` if not specified. While `'unsigned'` is handled as a special case, other values are transparently passed to the boto3 client configuration without additional processing, offering flexibility for advanced setups. This enhancement provides greater control and adaptability for S3 storage operations.