### PR TITLE
fix(ui): prevent var icon hidden when only one var in list of start node

### DIFF
--- a/web/app/components/workflow/nodes/start/components/var-item.tsx
+++ b/web/app/components/workflow/nodes/start/components/var-item.tsx
@@ -23,7 +23,8 @@ type Props = {
   onRemove?: () => void
   rightContent?: React.JSX.Element
   varKeys?: string[]
-  showLegacyBadge?: boolean
+  showLegacyBadge?: boolean,
+  canDrag?: boolean,
 }
 
 const VarItem: FC<Props> = ({
@@ -35,6 +36,7 @@ const VarItem: FC<Props> = ({
   rightContent,
   varKeys = [],
   showLegacyBadge = false,
+  canDrag,
 }) => {
   const { t } = useTranslation()
 
@@ -52,7 +54,7 @@ const VarItem: FC<Props> = ({
   return (
     <div ref={ref} className={cn('flex h-8 cursor-pointer items-center justify-between rounded-lg border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg px-2.5 shadow-xs hover:shadow-md', className)}>
       <div className='flex w-0 grow items-center space-x-1'>
-        <Variable02 className='h-3.5 w-3.5 text-text-accent group-hover:opacity-0' />
+        <Variable02 className={cn('h-3.5 w-3.5 text-text-accent', canDrag && 'group-hover:opacity-0')} />
         <div title={payload.variable} className='max-w-[130px] shrink-0 truncate text-[13px] font-medium text-text-secondary'>{payload.variable}</div>
         {payload.label && (<><div className='shrink-0 text-xs font-medium text-text-quaternary'>·</div>
           <div title={payload.label as string} className='max-w-[130px] truncate text-[13px] font-medium text-text-tertiary'>{payload.label as string}</div>

--- a/web/app/components/workflow/nodes/start/components/var-list.tsx
+++ b/web/app/components/workflow/nodes/start/components/var-list.tsx
@@ -91,6 +91,7 @@ const VarList: FC<Props> = ({
               onChange={handleVarChange(index)}
               onRemove={handleVarRemove(index)}
               varKeys={list.map(item => item.variable)}
+              canDrag={canDrag}
             />
             {canDrag && <RiDraggable className={cn(
               'handle absolute left-3 top-2.5 hidden h-3 w-3 cursor-pointer text-text-tertiary',


### PR DESCRIPTION
## Summary

fix(ui): prevent var icon hidden when only one var in list of start node

## Screenshots

### Before

https://github.com/user-attachments/assets/17dd004d-bd4b-4477-8ded-ba4dc1115082

feat(workflow): add drag-and-drop support for variable list items for start node (#22150)

### After

https://github.com/user-attachments/assets/5d2812ae-b520-4a18-a582-d6942a3d3ef7


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
