### PR TITLE
test(web): add password regexp test case

### DIFF
--- a/web/config/index.spec.ts
+++ b/web/config/index.spec.ts
@@ -1,0 +1,56 @@
+import { validPassword } from './index'
+
+describe('validPassword Tests', () => {
+  const passwordRegex = validPassword
+
+  // Valid passwords
+  test('Valid passwords: contains letter+digit, length ≥8', () => {
+    expect(passwordRegex.test('password1')).toBe(true)
+    expect(passwordRegex.test('PASSWORD1')).toBe(true)
+    expect(passwordRegex.test('12345678a')).toBe(true)
+    expect(passwordRegex.test('a1b2c3d4')).toBe(true)
+    expect(passwordRegex.test('VeryLongPassword123')).toBe(true)
+    expect(passwordRegex.test('short1')).toBe(false)
+  })
+
+  // Missing letter
+  test('Invalid passwords: missing letter', () => {
+    expect(passwordRegex.test('12345678')).toBe(false)
+    expect(passwordRegex.test('!@#$%^&*123')).toBe(false)
+  })
+
+  // Missing digit
+  test('Invalid passwords: missing digit', () => {
+    expect(passwordRegex.test('password')).toBe(false)
+    expect(passwordRegex.test('PASSWORD')).toBe(false)
+    expect(passwordRegex.test('AbCdEfGh')).toBe(false)
+  })
+
+  // Too short
+  test('Invalid passwords: less than 8 characters', () => {
+    expect(passwordRegex.test('pass1')).toBe(false)
+    expect(passwordRegex.test('abc123')).toBe(false)
+    expect(passwordRegex.test('1a')).toBe(false)
+  })
+
+  // Boundary test
+  test('Boundary test: exactly 8 characters', () => {
+    expect(passwordRegex.test('abc12345')).toBe(true)
+    expect(passwordRegex.test('1abcdefg')).toBe(true)
+  })
+
+  // Special characters
+  test('Special characters: non-whitespace special chars allowed', () => {
+    expect(passwordRegex.test('pass@123')).toBe(true)
+    expect(passwordRegex.test('p@$$w0rd')).toBe(true)
+    expect(passwordRegex.test('!1aBcDeF')).toBe(true)
+  })
+
+  // Contains whitespace
+  test('Invalid passwords: contains whitespace', () => {
+    expect(passwordRegex.test('pass word1')).toBe(false)
+    expect(passwordRegex.test('password1 ')).toBe(false)
+    expect(passwordRegex.test(' password1')).toBe(false)
+    expect(passwordRegex.test('pass\tword1')).toBe(false)
+  })
+})


### PR DESCRIPTION
centralize password validation regex in config  &  reject whitespace characters in password check regexp


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Screenshots

issue reproduction 
resolve https://github.com/langgenius/dify/issues/22267

resolved https://github.com/langgenius/dify/pull/22232

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
