### PR TITLE
Chore: Replace lodash/noop with lodash-es/noop

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
@@ -55,7 +55,7 @@ type Props = {
   value?: ToolValue
   selectedTools?: ToolValue[]
   onSelect: (tool: ToolValue) => void
-  onSelectMultiple: (tool: ToolValue[]) => void
+  onSelectMultiple?: (tool: ToolValue[]) => void
   isEdit?: boolean
   onDelete?: () => void
   supportEnableSwitch?: boolean
@@ -143,7 +143,7 @@ const ToolSelector: FC<Props> = ({
   }
   const handleSelectMultipleTool = (tool: ToolDefaultValue[]) => {
     const toolValues = tool.map(item => getToolValue(item))
-    onSelectMultiple(toolValues)
+    onSelectMultiple?.(toolValues)
   }
 
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
@@ -20,7 +20,7 @@ import { useRenderI18nObject } from '@/hooks/use-i18n'
 import type { NodeOutPutVar } from '../../../types'
 import type { Node } from 'reactflow'
 import type { PluginMeta } from '@/app/components/plugins/types'
-import { noop } from 'lodash'
+import { noop } from 'lodash-es'
 import { useDocLink } from '@/context/i18n'
 
 export type Strategy = {

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/hooks.ts
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/hooks.ts
@@ -6,7 +6,7 @@ import type { EditData } from './edit-card'
 import { ArrayType, type Field, Type } from '../../../types'
 import Toast from '@/app/components/base/toast'
 import { findPropertyWithPath } from '../../../utils'
-import _ from 'lodash'
+import { noop } from 'lodash-es'
 
 type ChangeEventParams = {
   path: string[],
@@ -21,7 +21,7 @@ type AddEventParams = {
 
 export const useSchemaNodeOperations = (props: VisualEditorProps) => {
   const { schema: jsonSchema, onChange: doOnChange } = props
-  const onChange = doOnChange || _.noop
+  const onChange = doOnChange || noop
   const backupSchema = useVisualEditorStore(state => state.backupSchema)
   const setBackupSchema = useVisualEditorStore(state => state.setBackupSchema)
   const isAddingNewField = useVisualEditorStore(state => state.isAddingNewField)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Make the onSelectMultiple property of the ToolSelector component optional to resolve type warning issues
- Use lodash-es instead of lodash in project code

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
