### PR TITLE
chore: Add fonts-noto-cjk dependency for pypdfium2

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -47,6 +47,8 @@ RUN \
         curl nodejs libgmp-dev libmpfr-dev libmpc-dev \
         # For Security
         expat libldap-2.5-0 perl libsqlite3-0 zlib1g \
+        # install fonts to support the use of tools like pypdfium2
+        fonts-noto-cjk \
         # install a package to improve the accuracy of guessing mime type and file extension
         media-types \
         # install libmagic to support the use of python-magic guess MIMETYPE


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes: #22358
This PR installs the fonts-noto-cjk package in the api/Dockerfile to fix a regression where text extraction from certain CJK (Chinese, Japanese, Korean) PDFs results in empty content.
 Problem:
  The PDF processing library, pypdfium2, requires system fonts to correctly render and extract text from PDFs that do not have their fonts embedded. Without these fonts, the text extraction process fails silently, marking the document as "completed" but with empty or incomplete
  content.

  Cause of Regression:
  This issue is a regression introduced in PR #15837, which removed the fonts-noto-cjk package. The removal was intended to clean up dependencies for the matplotlib tool after it was migrated to a plugin. However, this overlooked the implicit dependency that pypdfium2 has on these
  system fonts for its core functionality.

  Solution:
  By re-adding the fonts-noto-cjk package, this change ensures reliable text extraction for a wider range of PDF documents, restoring the previous functionality and resolving the regression. A comment has been added to the Dockerfile to clarify why this package is necessary, preventing
  future accidental removal.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
