### PR TITLE
feat: add optional description field to tool and agent input parameters

### DIFF
--- a/api/core/workflow/nodes/agent/entities.py
+++ b/api/core/workflow/nodes/agent/entities.py
@@ -1,7 +1,7 @@
 from enum import Enum, StrEnum
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from core.prompt.entities.advanced_prompt_entities import MemoryConfig
 from core.tools.entities.tool_entities import ToolSelector
@@ -17,6 +17,7 @@ class AgentNodeData(BaseNodeData):
     class AgentInput(BaseModel):
         value: Union[list[str], list[ToolSelector], Any]
         type: Literal["mixed", "variable", "constant"]
+        description: str | None = Field(default=None, description="Optional description for this input parameter.")
 
     agent_parameters: dict[str, AgentInput]
 

--- a/api/core/workflow/nodes/tool/entities.py
+++ b/api/core/workflow/nodes/tool/entities.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, Field
 from pydantic_core.core_schema import ValidationInfo
 
 from core.tools.entities.tool_entities import ToolProviderType
@@ -35,6 +35,7 @@ class ToolNodeData(BaseNodeData, ToolEntity):
         # TODO: check this type
         value: Union[Any, list[str]]
         type: Literal["mixed", "variable", "constant"]
+        description: str | None = Field(default=None, description="Optional description for this input parameter.")
 
         @field_validator("type", mode="before")
         @classmethod

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_agent_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_agent_node.py
@@ -1,0 +1,11 @@
+def test_agent_input_description():
+    from core.workflow.nodes.agent.entities import AgentNodeData
+    # Description provided
+    input_with_desc = AgentNodeData.AgentInput(value=["foo"], type="mixed", description="A test description.")
+    assert input_with_desc.description == "A test description."
+    # Description omitted
+    input_without_desc = AgentNodeData.AgentInput(value=["bar"], type="mixed")
+    assert input_without_desc.description is None
+    # Serialization
+    data = input_with_desc.model_dump()
+    assert data["description"] == "A test description." 

--- a/api/tests/unit_tests/core/workflow/nodes/tool/test_tool_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/tool/test_tool_node.py
@@ -109,3 +109,16 @@ def test_tool_node_on_tool_invoke_error(monkeypatch: pytest.MonkeyPatch):
     assert "oops" in result.error
     assert "Failed to transform tool message:" in result.error
     assert result.error_type == "ToolInvokeError"
+
+
+def test_tool_input_description():
+    from core.workflow.nodes.tool.entities import ToolNodeData
+    # Description provided
+    input_with_desc = ToolNodeData.ToolInput(value="foo", type="mixed", description="A test description.")
+    assert input_with_desc.description == "A test description."
+    # Description omitted
+    input_without_desc = ToolNodeData.ToolInput(value="bar", type="mixed")
+    assert input_without_desc.description is None
+    # Serialization
+    data = input_with_desc.model_dump()
+    assert data["description"] == "A test description."


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #22441`.

## Summary

This PR adds an **optional `description` field** to both `ToolInput` and `AgentInput` models in the backend.  
- The new field allows for a human-readable description of each input parameter, which can be used by MCP, tools, and (optionally) the frontend/UI.
- Unit tests are included to verify the new field works as expected and is correctly serialized.
- The change is non-breaking and fully backward compatible.

**Fixes #22441**

## Screenshots

| Before | After |
|--------|-------|
| _No description field on input parameters_ | _Optional `description` field available on input parameters (backend)_ |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
