### PR TITLE
feat: auto-fill MCP server description with app description #22443 

### DIFF
--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -35,16 +35,20 @@ class AppMCPServerController(Resource):
     @get_app_model
     @marshal_with(app_server_fields)
     def post(self, app_model):
-        # The role of the current user in the ta table must be editor, admin, or owner
         if not current_user.is_editor:
             raise NotFound()
         parser = reqparse.RequestParser()
-        parser.add_argument("description", type=str, required=True, location="json")
+        parser.add_argument("description", type=str, required=False, location="json")
         parser.add_argument("parameters", type=dict, required=True, location="json")
         args = parser.parse_args()
+
+        description = args.get("description")
+        if not description:
+            description = app_model.description or ""
+
         server = AppMCPServer(
             name=app_model.name,
-            description=args["description"],
+            description=description,
             parameters=json.dumps(args["parameters"], ensure_ascii=False),
             status=AppMCPServerStatus.ACTIVE,
             app_id=app_model.id,
@@ -65,14 +69,22 @@ class AppMCPServerController(Resource):
             raise NotFound()
         parser = reqparse.RequestParser()
         parser.add_argument("id", type=str, required=True, location="json")
-        parser.add_argument("description", type=str, required=True, location="json")
+        parser.add_argument("description", type=str, required=False, location="json")
         parser.add_argument("parameters", type=dict, required=True, location="json")
         parser.add_argument("status", type=str, required=False, location="json")
         args = parser.parse_args()
         server = db.session.query(AppMCPServer).filter(AppMCPServer.id == args["id"]).first()
         if not server:
             raise NotFound()
-        server.description = args["description"]
+
+        description = args.get("description")
+        if description is None:
+            pass
+        elif not description:
+            server.description = app_model.description or ""
+        else:
+            server.description = description
+
         server.parameters = json.dumps(args["parameters"], ensure_ascii=False)
         if args["status"]:
             if args["status"] not in [status.value for status in AppMCPServerStatus]:

--- a/web/app/components/tools/mcp/mcp-server-modal.tsx
+++ b/web/app/components/tools/mcp/mcp-server-modal.tsx
@@ -23,6 +23,7 @@ export type ModalProps = {
   data?: MCPServerDetail
   show: boolean
   onHide: () => void
+  appInfo?: any
 }
 
 const MCPServerModal = ({
@@ -31,13 +32,15 @@ const MCPServerModal = ({
   data,
   show,
   onHide,
+  appInfo,
 }: ModalProps) => {
   const { t } = useTranslation()
   const { mutateAsync: createMCPServer, isPending: creating } = useCreateMCPServer()
   const { mutateAsync: updateMCPServer, isPending: updating } = useUpdateMCPServer()
   const invalidateMCPServerDetail = useInvalidateMCPServerDetail()
 
-  const [description, setDescription] = React.useState(data?.description || '')
+  const defaultDescription = data?.description || appInfo?.description || ''
+  const [description, setDescription] = React.useState(defaultDescription)
   const [params, setParams] = React.useState(data?.parameters || {})
 
   const handleParamChange = (variable: string, value: string) => {
@@ -58,21 +61,27 @@ const MCPServerModal = ({
 
   const submit = async () => {
     if (!data) {
-      await createMCPServer({
+      const payload: any = {
         appID,
-        description,
         parameters: getParamValue(),
-      })
+      }
+
+      if (description.trim())
+        payload.description = description
+
+      await createMCPServer(payload)
       invalidateMCPServerDetail(appID)
       onHide()
     }
     else {
-      await updateMCPServer({
+      const payload: any = {
         appID,
         id: data.id,
-        description,
         parameters: getParamValue(),
-      })
+      }
+
+      payload.description = description
+      await updateMCPServer(payload)
       invalidateMCPServerDetail(appID)
       onHide()
     }

--- a/web/app/components/tools/mcp/mcp-service-card.tsx
+++ b/web/app/components/tools/mcp/mcp-service-card.tsx
@@ -223,6 +223,7 @@ function MCPServiceCard({
           data={serverPublished ? detail : undefined}
           latestParams={latestParams}
           onHide={handleServerModalHide}
+          appInfo={appInfo}
         />
       )}
       {/* button copy link/ button regenerate */}

--- a/web/service/use-tools.ts
+++ b/web/service/use-tools.ts
@@ -206,7 +206,7 @@ export const useCreateMCPServer = () => {
     mutationKey: [NAME_SPACE, 'create-mcp-server'],
     mutationFn: (payload: {
       appID: string
-      description: string
+      description?: string
       parameters?: Record<string, string>
     }) => {
       const { appID, ...rest } = payload


### PR DESCRIPTION
Fix #22443: MCP server description now defaults to app description
- Backend: Make description optional in MCP server API, auto-use app description when empty
- Frontend: Support auto-filling app description in MCP server modal
- Allow creating MCP servers without explicit description
- Improve user experience by reducing required input fields

Changes:
- api/controllers/console/app/mcp_server.py: Make description optional, auto-fill with app description
- web/service/use-tools.ts: Make description optional in API types
- web/app/components/tools/mcp/mcp-server-modal.tsx: Support app description auto-fill
- web/app/components/tools/mcp/mcp-service-card.tsx: Pass app info to modal

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
