### PR TITLE
fix: Japanese dateTimeFormat

### DIFF
--- a/web/app/(commonLayout)/apps/AppCard.tsx
+++ b/web/app/(commonLayout)/apps/AppCard.tsx
@@ -306,7 +306,7 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
   const EditTimeText = useMemo(() => {
     const timeText = formatTime({
       date: (app.updated_at || app.created_at) * 1000,
-      dateFormat: 'MM/DD/YYYY h:mm',
+      dateFormat: `${t('datasetDocuments.segment.dateTimeFormat')}`,
     })
     return `${t('datasetDocuments.segment.editedAt')} ${timeText}`
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/app/components/datasets/documents/detail/completed/child-segment-detail.tsx
+++ b/web/app/components/datasets/documents/detail/completed/child-segment-detail.tsx
@@ -66,7 +66,7 @@ const ChildSegmentDetail: FC<IChildSegmentDetailProps> = ({
   const EditTimeText = useMemo(() => {
     const timeText = formatTime({
       date: (childChunkInfo?.updated_at ?? 0) * 1000,
-      dateFormat: 'MM/DD/YYYY h:mm:ss',
+      dateFormat: `${t('datasetDocuments.segment.dateTimeFormat')}`,
     })
     return `${t('datasetDocuments.segment.editedAt')} ${timeText}`
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -74,7 +74,7 @@ const ChildSegmentDetail: FC<IChildSegmentDetailProps> = ({
 
   return (
     <div className={'flex h-full flex-col'}>
-      <div className={classNames('flex items-center justify-between', fullScreen ? 'py-3 pr-4 pl-6 border border-divider-subtle' : 'pt-3 pr-3 pl-4')}>
+      <div className={classNames('flex items-center justify-between', fullScreen ? 'border border-divider-subtle py-3 pl-6 pr-4' : 'pl-4 pr-3 pt-3')}>
         <div className='flex flex-col'>
           <div className='system-xl-semibold text-text-primary'>{t('datasetDocuments.segment.editChildChunk')}</div>
           <div className='flex items-center gap-x-2'>
@@ -107,8 +107,8 @@ const ChildSegmentDetail: FC<IChildSegmentDetailProps> = ({
           </div>
         </div>
       </div>
-      <div className={classNames('flex grow w-full', fullScreen ? 'flex-row justify-center px-6 pt-6' : 'py-3 px-4')}>
-        <div className={classNames('break-all overflow-hidden whitespace-pre-line h-full', fullScreen ? 'w-1/2' : 'w-full')}>
+      <div className={classNames('flex w-full grow', fullScreen ? 'flex-row justify-center px-6 pt-6' : 'px-4 py-3')}>
+        <div className={classNames('h-full overflow-hidden whitespace-pre-line break-all', fullScreen ? 'w-1/2' : 'w-full')}>
           <ChunkContent
             docForm={docForm}
             question={content}

--- a/web/i18n/de-DE/dataset-documents.ts
+++ b/web/i18n/de-DE/dataset-documents.ts
@@ -384,6 +384,7 @@ const translation = {
     chunkAdded: '1 Stück hinzugefügt',
     expandChunks: 'Blöcke erweitern',
     editedAt: 'Bearbeitet am',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     addChunk: 'Block hinzufügen',
     addAnother: 'Fügen Sie eine weitere hinzu',
     regeneratingTitle: 'Regenerieren von untergeordneten Blöcken',

--- a/web/i18n/en-US/dataset-documents.ts
+++ b/web/i18n/en-US/dataset-documents.ts
@@ -390,6 +390,7 @@ const translation = {
     regenerationSuccessMessage: 'You can close this window.',
     edited: 'EDITED',
     editedAt: 'Edited at',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     expandChunks: 'Expand chunks',
     collapseChunks: 'Collapse chunks',
   },

--- a/web/i18n/es-ES/dataset-documents.ts
+++ b/web/i18n/es-ES/dataset-documents.ts
@@ -377,6 +377,7 @@ const translation = {
     editChildChunk: 'Editar fragmento secundario',
     regeneratingTitle: 'Regeneración de fragmentos secundarios',
     editedAt: 'Editado en',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     searchResults_zero: 'RESULTADO',
     clearFilter: 'Borrar filtro',
     newChildChunk: 'Nuevo fragmento secundario',

--- a/web/i18n/fa-IR/dataset-documents.ts
+++ b/web/i18n/fa-IR/dataset-documents.ts
@@ -356,6 +356,7 @@ const translation = {
     chunks_other: 'تکه',
     characters_one: 'شخصیت',
     editedAt: 'ویرایش شده در',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     parentChunks_other: 'تکه های والدین',
     editChunk: 'ویرایش تکه',
     collapseChunks: 'جمع کردن تکه ها',

--- a/web/i18n/fr-FR/dataset-documents.ts
+++ b/web/i18n/fr-FR/dataset-documents.ts
@@ -374,6 +374,7 @@ const translation = {
     expandChunks: 'Développer des blocs',
     characters_other: 'caractères',
     editedAt: 'Édité le',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     searchResults_other: 'RÉSULTATS',
     regenerationSuccessMessage: 'Vous pouvez fermer cette fenêtre.',
     parentChunks_one: 'MORCEAU PARENT',

--- a/web/i18n/hi-IN/dataset-documents.ts
+++ b/web/i18n/hi-IN/dataset-documents.ts
@@ -373,6 +373,7 @@ const translation = {
     addChunk: 'चंक जोड़ें',
     editChildChunk: 'संपादित करें बाल चंक',
     editedAt: 'पर संपादित',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     childChunk: 'चाइल्ड-चंक',
     parentChunk: 'माता-पिता-चंक',
     empty: 'कोई हिस्सा नहीं मिला',

--- a/web/i18n/it-IT/dataset-documents.ts
+++ b/web/i18n/it-IT/dataset-documents.ts
@@ -380,6 +380,7 @@ const translation = {
     regenerationConfirmTitle: 'Si desidera rigenerare i blocchi figlio?',
     chunks_other: 'BLOCCHI',
     editedAt: 'A cura di',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     collapseChunks: 'Comprimi blocchi',
     clearFilter: 'Cancella filtro',
     chunks_one: 'PEZZO',

--- a/web/i18n/ja-JP/app-log.ts
+++ b/web/i18n/ja-JP/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'ログ',
   description: 'ログは、アプリケーションの実行状態を記録します。ユーザーの入力や AI の応答などが含まれます。',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'YYYY/MM/DD hh:mm A',
   table: {
     header: {
       updatedTime: '更新時間',

--- a/web/i18n/ja-JP/dataset-documents.ts
+++ b/web/i18n/ja-JP/dataset-documents.ts
@@ -388,6 +388,7 @@ const translation = {
     regenerationSuccessMessage: 'ウィンドウを閉じても大丈夫です',
     edited: '編集済み',
     editedAt: '編集日時',
+    dateTimeFormat: 'YYYY/MM/DD HH:mm',
     expandChunks: 'チャンクを展開',
     collapseChunks: 'チャンクを折りたたむ',
     keywordDuplicate: 'そのキーワードは既に存在しています',

--- a/web/i18n/ja-JP/dataset-hit-testing.ts
+++ b/web/i18n/ja-JP/dataset-hit-testing.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: '検索テスト',
   desc: '与えられたクエリテキストに基づいたナレッジのヒット効果をテストします。',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'YYYY/MM/DD hh:mm A',
   records: '記録',
   table: {
     header: {

--- a/web/i18n/ko-KR/dataset-documents.ts
+++ b/web/i18n/ko-KR/dataset-documents.ts
@@ -371,6 +371,7 @@ const translation = {
     childChunks_one: '자식 청크 (CHILD CHUNK)',
     regenerationSuccessTitle: '재생이 완료되었습니다.',
     editedAt: '편집 위치',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     addAnother: '다른 항목 추가',
     chunkAdded: '청크 1 개 추가됨',
     searchResults_one: '결과',

--- a/web/i18n/pl-PL/dataset-documents.ts
+++ b/web/i18n/pl-PL/dataset-documents.ts
@@ -369,6 +369,7 @@ const translation = {
     regenerationSuccessTitle: 'Regeneracja zakończona',
     edited: 'EDYTOWANE',
     editedAt: 'Zredagowane w',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     collapseChunks: 'Zwijanie fragmentów',
     empty: 'Nie znaleziono fragmentu',
     newChunk: 'Nowy fragment',

--- a/web/i18n/pt-BR/dataset-documents.ts
+++ b/web/i18n/pt-BR/dataset-documents.ts
@@ -376,6 +376,7 @@ const translation = {
     regeneratingMessage: 'Isso pode demorar um pouco, por favor aguarde...',
     edited: 'EDIÇÃO',
     editedAt: 'Editado em',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     expandChunks: 'Expandir pedaços',
     collapseChunks: 'Recolher partes',
     regenerationConfirmMessage: 'A regeneração de partes filhas substituirá as partes filhas atuais, incluindo partes editadas e partes recém-adicionadas. A regeneração não pode ser desfeita.',

--- a/web/i18n/ro-RO/dataset-documents.ts
+++ b/web/i18n/ro-RO/dataset-documents.ts
@@ -362,6 +362,7 @@ const translation = {
     characters_one: 'caracter',
     regenerationSuccessTitle: 'Regenerare finalizată',
     editedAt: 'Editat la',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     addChunk: 'Adăugați o bucată',
     chunk: 'Bucată',
     chunks_one: 'BUCATĂ',

--- a/web/i18n/ru-RU/dataset-documents.ts
+++ b/web/i18n/ru-RU/dataset-documents.ts
@@ -365,6 +365,7 @@ const translation = {
     parentChunks_one: 'РОДИТЕЛЬСКИЙ БЛОК',
     childChunk: 'Чайлд-Чанк',
     editedAt: 'Отредактировано в',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     editChildChunk: 'Редактирование дочернего фрагмента',
     parentChunks_other: 'РОДИТЕЛЬСКИЕ БЛОКИ',
     regenerationSuccessTitle: 'Регенерация завершена',

--- a/web/i18n/sl-SI/dataset-documents.ts
+++ b/web/i18n/sl-SI/dataset-documents.ts
@@ -358,6 +358,7 @@ const translation = {
     expandChunks: 'Razširitev kosov',
     childChunk: 'Otroški kos',
     editedAt: 'Urejeno na',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     edited: 'UREJATI',
     addAnother: 'Dodajanje še enega',
     childChunks_one: 'OTROŠKI KOS',

--- a/web/i18n/th-TH/dataset-documents.ts
+++ b/web/i18n/th-TH/dataset-documents.ts
@@ -363,6 +363,7 @@ const translation = {
     edited: 'แก้ไข',
     addChunk: 'เพิ่มก้อน',
     editedAt: 'แก้ไขที่',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     childChunks_other: 'ก้อนเด็ก',
     editChildChunk: 'แก้ไข Child Chunk',
     parentChunk: 'ผู้ปกครอง-ก้อน',

--- a/web/i18n/tr-TR/dataset-documents.ts
+++ b/web/i18n/tr-TR/dataset-documents.ts
@@ -389,6 +389,7 @@ const translation = {
     searchResults_zero: 'SONUÇ',
     chunks_other: 'Parçalar',
     editedAt: 'Şurada düzenlendi:',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     addChildChunk: 'Alt Parça Ekle',
     keywordDuplicate: 'Anahtar kelime zaten var',
     keywordEmpty: 'Anahtar kelime boş olamaz',

--- a/web/i18n/uk-UA/dataset-documents.ts
+++ b/web/i18n/uk-UA/dataset-documents.ts
@@ -369,6 +369,7 @@ const translation = {
     empty: 'Шматок не знайдено',
     chunks_other: 'ШМАТКИ',
     editedAt: 'За редакцією',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     searchResults_zero: 'РЕЗУЛЬТАТ',
     collapseChunks: 'Згортання шматків',
     childChunkAdded: 'Додано 1 дочірній фрагмент',

--- a/web/i18n/vi-VN/dataset-documents.ts
+++ b/web/i18n/vi-VN/dataset-documents.ts
@@ -369,6 +369,7 @@ const translation = {
     expandChunks: 'Mở rộng các đoạn',
     chunks_other: 'KHỐI',
     editedAt: 'Chỉnh sửa tại',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     addAnother: 'Thêm một cái khác',
     regenerationConfirmTitle: 'Bạn có muốn tái tạo các chunk con không?',
     searchResults_one: 'KẾT QUẢ',

--- a/web/i18n/zh-Hans/dataset-documents.ts
+++ b/web/i18n/zh-Hans/dataset-documents.ts
@@ -387,6 +387,7 @@ const translation = {
     regenerationSuccessMessage: '可以关闭窗口',
     edited: '已编辑',
     editedAt: '编辑于',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     expandChunks: '展开分段',
     collapseChunks: '折叠分段',
     keywordEmpty: '关键词不能为空',

--- a/web/i18n/zh-Hans/dataset-documents.ts
+++ b/web/i18n/zh-Hans/dataset-documents.ts
@@ -387,7 +387,7 @@ const translation = {
     regenerationSuccessMessage: '可以关闭窗口',
     edited: '已编辑',
     editedAt: '编辑于',
-    dateTimeFormat: 'MM/DD/YYYY h:mm',
+    dateTimeFormat: 'YYYY/MM/DD HH:mm',
     expandChunks: '展开分段',
     collapseChunks: '折叠分段',
     keywordEmpty: '关键词不能为空',

--- a/web/i18n/zh-Hant/dataset-documents.ts
+++ b/web/i18n/zh-Hant/dataset-documents.ts
@@ -369,7 +369,7 @@ const translation = {
     expandChunks: '擴展塊',
     chunkAdded: '添加了 1 個數據塊',
     editedAt: '編輯於',
-    dateTimeFormat: 'MM/DD/YYYY h:mm',
+    dateTimeFormat: 'YYYY/MM/DD HH:mm',
     regeneratingMessage: '這可能需要一些時間，請稍候...',
     editChunk: '編輯數據塊',
     regenerationSuccessMessage: '您可以關閉此視窗。',

--- a/web/i18n/zh-Hant/dataset-documents.ts
+++ b/web/i18n/zh-Hant/dataset-documents.ts
@@ -369,6 +369,7 @@ const translation = {
     expandChunks: '擴展塊',
     chunkAdded: '添加了 1 個數據塊',
     editedAt: '編輯於',
+    dateTimeFormat: 'MM/DD/YYYY h:mm',
     regeneratingMessage: '這可能需要一些時間，請稍候...',
     editChunk: '編輯數據塊',
     regenerationSuccessMessage: '您可以關閉此視窗。',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The date and time format for Japanese has been adjusted to match the commonly used format in Japan.
Some parts were not i18n-compliant, so I have added i18n support for those sections.
Also, to use a common localization format, the seconds have been removed from the dateTimeFormat in the child chunk page.

All differences except for the dateFormat change in `child-segment-detail.tsx` were made by the linter.

## Screenshots

### Add dateTimeFormat i18n

| Lang | Before | After |
|----|--------|-------|
| `ja-JP` | <img width="1040" height="360" alt="スクリーンショット 2025-07-17 9 27 26" src="https://github.com/user-attachments/assets/2f7e4682-79a1-4fc0-b88a-c87306d3c4b3" />  | <img width="1040" height="361" alt="スクリーンショット 2025-07-17 9 26 14" src="https://github.com/user-attachments/assets/7886fd89-61ac-4800-8491-0b2c97229b86" /> |
| `ja-JP` | <img width="1449" height="406" alt="スクリーンショット 2025-07-17 9 33 16" src="https://github.com/user-attachments/assets/d022d278-40b7-4f15-b2ad-7bd23931c2ff" /> | <img width="1457" height="398" alt="スクリーンショット 2025-07-17 9 31 47" src="https://github.com/user-attachments/assets/4d604c39-f837-44ab-89c3-607302bf5301" /> |
| other | <img width="730" height="315" alt="スクリーンショット 2025-07-17 10 28 00" src="https://github.com/user-attachments/assets/c4b7eb3c-c2ab-4246-a395-333184455d07" /> | <img width="736" height="319" alt="スクリーンショット 2025-07-17 10 26 43" src="https://github.com/user-attachments/assets/b00bdf71-91c0-453a-acea-9d823982510a" /> |
| other | <img width="1453" height="237" alt="スクリーンショット 2025-07-17 10 25 01" src="https://github.com/user-attachments/assets/ce0f00cc-f000-4fe5-a8b4-5a8b1339fa4c" /> | <img width="1451" height="253" alt="スクリーンショット 2025-07-17 10 19 25" src="https://github.com/user-attachments/assets/becb3dd9-d05e-4962-b32f-0b45a7dee6ea" /> |

### Fix Japaneses dateTimeFormat

FIx `ja-JP` only.

| Before | After |
|--------|-------|
| <img width="1162" height="337" alt="スクリーンショット 2025-07-17 9 55 59" src="https://github.com/user-attachments/assets/69b60b97-0c16-4a9c-b8bb-4c3edbe4eb28" />  | <img width="1172" height="364" alt="スクリーンショット 2025-07-17 9 57 04" src="https://github.com/user-attachments/assets/497a1e41-25a2-4ea9-901e-8068f869b2c6" /> |
| <img width="1453" height="253" alt="スクリーンショット 2025-07-17 9 59 06" src="https://github.com/user-attachments/assets/345c96b7-2d0a-4c87-8f30-76e31b048737" /> | <img width="1458" height="260" alt="スクリーンショット 2025-07-17 10 01 51" src="https://github.com/user-attachments/assets/52e84743-8165-4803-9908-0b9ae6eb8ee8" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
