### PR TITLE
Fix: Remove ${basePath} from the <Link> tag's href attribute.

### DIFF
--- a/web/app/(commonLayout)/datasets/NewDatasetCard.tsx
+++ b/web/app/(commonLayout)/datasets/NewDatasetCard.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { useTranslation } from 'react-i18next'
-import { basePath } from '@/utils/var'
 import {
   RiAddLine,
   RiArrowRightLine,
@@ -18,7 +17,7 @@ const CreateAppCard = ({ ref }: CreateAppCardProps) => {
     <div className='bg-background-default-dimm flex min-h-[160px] flex-col rounded-xl border-[0.5px]
       border-components-panel-border transition-all duration-200 ease-in-out'
     >
-      <Link ref={ref} className='group flex grow cursor-pointer items-start p-4' href={`${basePath}/datasets/create`}>
+      <Link ref={ref} className='group flex grow cursor-pointer items-start p-4' href='/datasets/create'>
         <div className='flex items-center gap-3'>
           <div className='flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-divider-regular bg-background-default-lighter
             p-2 group-hover:border-solid group-hover:border-effects-highlight group-hover:bg-background-default-dodge'
@@ -29,7 +28,7 @@ const CreateAppCard = ({ ref }: CreateAppCardProps) => {
         </div>
       </Link>
       <div className='system-xs-regular p-4 pt-0 text-text-tertiary'>{t('dataset.createDatasetIntro')}</div>
-      <Link className='group flex cursor-pointer items-center gap-1 rounded-b-xl border-t-[0.5px] border-divider-subtle p-4' href={`${basePath}/datasets/connect`}>
+      <Link className='group flex cursor-pointer items-center gap-1 rounded-b-xl border-t-[0.5px] border-divider-subtle p-4' href='/datasets/connect'>
         <div className='system-xs-medium text-text-tertiary group-hover:text-text-accent'>{t('dataset.connectDataset')}</div>
         <RiArrowRightLine className='h-3.5 w-3.5 text-text-tertiary group-hover:text-text-accent' />
       </Link>

--- a/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
@@ -14,7 +14,6 @@ import Loading from '@/app/components/base/loading'
 import Badge from '@/app/components/base/badge'
 import { useKnowledge } from '@/hooks/use-knowledge'
 import cn from '@/utils/classnames'
-import { basePath } from '@/utils/var'
 
 export type ISelectDataSetProps = {
   isShow: boolean
@@ -112,7 +111,7 @@ const SelectDataSet: FC<ISelectDataSetProps> = ({
           }}
         >
           <span className='text-text-tertiary'>{t('appDebug.feature.dataSet.noDataSet')}</span>
-          <Link href={`${basePath}/datasets/create`} className='font-normal text-text-accent'>{t('appDebug.feature.dataSet.toCreate')}</Link>
+          <Link href='/datasets/create' className='font-normal text-text-accent'>{t('appDebug.feature.dataSet.toCreate')}</Link>
         </div>
       )}
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #22517
A fix for Commit db20f9b. According to the [Next.js documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath), next/link automatically prepends the basePath. Manually adding ${basePath} again in the href will cause incorrect URLs when deploying Dify under a subpath using basePath.

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
