### PR TITLE
fix: correct tracing for workflows and chatflows for phoenix

### DIFF
--- a/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
+++ b/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry import trace
@@ -238,7 +238,7 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
 
                 try:
                     if node_execution.node_type == "llm":
-                        llm_attributes = {
+                        llm_attributes: dict[str, Any] = {
                             SpanAttributes.INPUT_VALUE: json.dumps(process_data.get("prompts", []), ensure_ascii=False),
                         }
                         provider = process_data.get("model_provider")
@@ -247,7 +247,9 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
                             llm_attributes[SpanAttributes.LLM_PROVIDER] = provider
                         if model:
                             llm_attributes[SpanAttributes.LLM_MODEL_NAME] = model
-                        outputs = json.loads(node_execution.outputs).get("usage", {}) if "outputs" in node_execution else {}
+                        outputs = (
+                            json.loads(node_execution.outputs).get("usage", {}) if "outputs" in node_execution else {}
+                        )
                         usage_data = (
                             process_data.get("usage", {}) if "usage" in process_data else outputs.get("usage", {})
                         )
@@ -705,7 +707,7 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
         )
         return workflow_nodes
 
-    def _construct_llm_attributes(self, prompts: dict | list | str) -> dict:
+    def _construct_llm_attributes(self, prompts: dict | list | str | None) -> dict[str, str]:
         """Helper method to construct LLM attributes with passed prompts."""
         attributes = {}
         if isinstance(prompts, list):

--- a/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
+++ b/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
@@ -143,7 +143,7 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
 
     def workflow_trace(self, trace_info: WorkflowTraceInfo):
         workflow_metadata = {
-            "workflow_id": trace_info.workflow_run_id or "",
+            "workflow_run_id": trace_info.workflow_run_id or "",
             "message_id": trace_info.message_id or "",
             "workflow_app_log_id": trace_info.workflow_app_log_id or "",
             "status": trace_info.workflow_run_status or "",
@@ -153,7 +153,7 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
         }
         workflow_metadata.update(trace_info.metadata)
 
-        trace_id = uuid_to_trace_id(trace_info.message_id)
+        trace_id = uuid_to_trace_id(trace_info.workflow_run_id)
         span_id = RandomIdGenerator().generate_span_id()
         context = SpanContext(
             trace_id=trace_id,

--- a/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
+++ b/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
@@ -233,6 +233,7 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
                         SpanAttributes.SESSION_ID: trace_info.conversation_id or "",
                     },
                     start_time=datetime_to_nanos(created_at),
+                    context=trace.set_span_in_context(trace.NonRecordingSpan(context)),
                 )
 
                 try:

--- a/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
+++ b/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
@@ -142,9 +142,6 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
             raise
 
     def workflow_trace(self, trace_info: WorkflowTraceInfo):
-        if trace_info.message_data is None:
-            return
-
         workflow_metadata = {
             "workflow_id": trace_info.workflow_run_id or "",
             "message_id": trace_info.message_id or "",


### PR DESCRIPTION
## Summary

This PR fixes the issue where workflows and chatflows cannot be traced by Phoenix.
This PR makes the following changes (see the corresponding commits for details):

- Remove the guard logic from the `workflow_trace` method
  - In my environment, `message_data` is always None, which causes the method to return immediately.
  - By removing the guard logic (as done in Langfuse), workflows and chatflows can now be traced.
- Use `workflow_run_id` as `trace_id` instead of `message_id`
  - `message_id` is empty for workflows, so using it as `trace_id` causes missing IDs for workflow traces.
  - By using `workflow_run_id` as `trace_id` (as in Langfuse traces), `trace_id` is always unique.
- Use consistent context for each node execution
  - In the current implementation, node executions are traced without context. This causes each execution not to be grouped into a single span, losing relationships.
  - By adding the correct context for each node execution, a single span now contains all traces for each node execution.
- Support input attributes for LLM node execution
  - The current implementation does not trace any prompts for LLM nodes.
  - Attributes for LLM nodes have been fixed, and prompts are now traced.

Closes #22504 

## Screenshots

| Before | After |
|--------|-------|
| ![](https://github.com/user-attachments/assets/fa42516c-4d10-4707-b6c2-e666bbdc3c07) | <img width="1175" height="1297" alt="image" src="https://github.com/user-attachments/assets/6baeca9a-43ca-4e66-971c-59164a1e238f" /><br><img width="1362" height="890" alt="image" src="https://github.com/user-attachments/assets/4982f836-8f90-4876-b4f0-8487c838ded9" /><img width="1411" height="645" alt="image" src="https://github.com/user-attachments/assets/e587609b-7d49-469a-a535-f7bdb7ed97fe" />  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
