### PR TITLE
fix(i18n): "道具" into "ツール"

### DIFF
--- a/web/i18n/ja-JP/plugin.ts
+++ b/web/i18n/ja-JP/plugin.ts
@@ -2,7 +2,7 @@ const translation = {
   category: {
     extensions: '拡張機能',
     all: 'すべて',
-    tools: '道具',
+    tools: 'ツール',
     bundles: 'バンドル',
     agents: 'エージェント戦略',
     models: 'モデル',
@@ -11,7 +11,7 @@ const translation = {
     agent: 'エージェント戦略',
     model: 'モデル',
     bundle: 'バンドル',
-    tool: '道具',
+    tool: 'ツール',
     extension: '拡張',
   },
   list: {
@@ -60,7 +60,7 @@ const translation = {
       uninstalledTitle: 'ツールがインストールされていません',
       empty: 'ツールを追加するには「+」ボタンをクリックしてください。複数のツールを追加できます。',
       paramsTip1: 'LLM 推論パラメータを制御します。',
-      toolLabel: '道具',
+      toolLabel: 'ツール',
       unsupportedTitle: 'サポートされていないアクション',
       toolSetting: 'ツール設定',
       unsupportedMCPTool: '現在選択されているエージェント戦略プラグインのバージョンはMCPツールをサポートしていません。',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -887,7 +887,7 @@ const translation = {
       modelNotSelected: 'モデルが選択されていません',
       toolNotAuthorizedTooltip: '{{tool}} 認可されていません',
       toolNotInstallTooltip: '{{tool}}はインストールされていません',
-      tools: '道具',
+      tools: 'ツール',
       learnMore: 'もっと学ぶ',
       configureModel: 'モデルを設定する',
       model: 'モデル',


### PR DESCRIPTION
The word '道具' (dougu) is often used as a Japanese translation for 'tool', but in software contexts, the word 'tool' is more commonly used
   as a katakana 'ツール' (tsūru). These words would also be more appropriate as 'ツール' rather than '道具'.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

  This PR updates Japanese translations to use 'ツール' instead of '道具' for software tool-related terms, making the
  terminology more consistent with common Japanese software conventions.

  The word '道具' (dougu) is often used as a Japanese translation for 'tool', but in software contexts, the word 'tool'
  is more commonly used as katakana 'ツール' (tsūru). These words would also be more appropriate as 'ツール' rather than
   '道具'.

  ### Changes:
  - Updated 4 occurrences in `web/i18n/ja-JP/plugin.ts`
  - Updated 1 occurrence in `web/i18n/ja-JP/workflow.ts`

  ## Screenshots

  Not applicable for translation changes.

  ## Checklist

  - [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply
  to typos!)
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic
  change.
  - [x] I've updated the documentation accordingly.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods