### PR TITLE
fix(i18n) update Japanese translation for "optional"

### DIFF
--- a/web/i18n/ja-JP/app.ts
+++ b/web/i18n/ja-JP/app.ts
@@ -79,7 +79,7 @@ const translation = {
     appCreateDSLErrorTitle: 'バージョンの非互換性',
     appCreateDSLWarning: '注意:DSL のバージョンの違いは、特定の機能に影響を与える可能性があります',
     appCreateDSLErrorPart1: 'DSL バージョンに大きな違いが検出されました。インポートを強制すると、アプリケーションが誤動作する可能性があります。',
-    optional: '随意',
+    optional: '任意',
     forBeginners: '初心者向けの基本的なアプリタイプ',
     noTemplateFoundTip: '別のキーワードを使用して検索してみてください。',
     agentShortDescription: '推論と自律的なツールの使用を備えたインテリジェントエージェント',

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -229,7 +229,7 @@ const translation = {
     permanentlyDeleteButton: 'アカウントを完全に削除',
     feedbackTitle: 'フィードバック',
     feedbackLabel: 'アカウントを削除した理由を教えてください。',
-    feedbackPlaceholder: '随意',
+    feedbackPlaceholder: '任意',
     sendVerificationButton: '確認コードの送信',
     editWorkspaceInfo: 'ワークスペース情報を編集',
     workspaceName: 'ワークスペース名',


### PR DESCRIPTION
Changed "随意" to "任意" for better clarity in Japanese UI. The term "任意" is more commonly used and understood in Japanese software interfaces for optional fields or actions.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
  - Updated Japanese translation for the term "optional" from "随意" to "任意"
  - Applied changes in both `app.ts` and `common.ts` files

  ## Context
  The term "随意" while technically correct, is less commonly used in Japanese software interfaces. "任意" is the standard term used for optional fields and actions in Japanese UI/UX, making it more intuitive for Japanese
  users.

  ## Changes
  - `web/i18n/ja-JP/app.ts`: Line 82
  - `web/i18n/ja-JP/common.ts`: Line 232

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
