### PR TITLE
fix(i18n): improve Japanese translations for technical terms "dupulicate"

### DIFF
--- a/web/app/(commonLayout)/datasets/template/template.ja.mdx
+++ b/web/app/(commonLayout)/datasets/template/template.ja.mdx
@@ -83,7 +83,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
             - <code>subchunk_segmentation</code> (object) 子チャンクルール
               - <code>separator</code> セグメンテーション識別子。現在は 1 つの区切り文字のみ許可。デフォルトは <code>***</code>
               - <code>max_tokens</code> 最大長 (トークン) は親チャンクの長さより短いことを検証する必要があります
-              - <code>chunk_overlap</code> 隣接するチャンク間の重複を定義 (オプション)
+              - <code>chunk_overlap</code> 隣接するチャンク間の重なりを定義 (オプション)
       </Property>
       <PropertyInstruction>ナレッジベースにパラメータが設定されていない場合、最初のアップロードには以下のパラメータを提供する必要があります。提供されない場合、デフォルトパラメータが使用されます。</PropertyInstruction>
       <Property name='retrieval_model' type='object' key='retrieval_model'>
@@ -218,7 +218,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
             - <code>subchunk_segmentation</code> (object) 子チャンクルール
               - <code>separator</code> セグメンテーション識別子。現在は 1 つの区切り文字のみ許可。デフォルトは <code>***</code>
               - <code>max_tokens</code> 最大長 (トークン) は親チャンクの長さより短いことを検証する必要があります
-              - <code>chunk_overlap</code> 隣接するチャンク間の重複を定義 (オプション)
+              - <code>chunk_overlap</code> 隣接するチャンク間の重なりを定義 (オプション)
       </Property>
       <Property name='file' type='multipart/form-data' key='file'>
         アップロードする必要があるファイル。
@@ -555,7 +555,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
             - <code>subchunk_segmentation</code> (object) 子チャンクルール
               - <code>separator</code> セグメンテーション識別子。現在は 1 つの区切り文字のみ許可。デフォルトは <code>***</code>
               - <code>max_tokens</code> 最大長 (トークン) は親チャンクの長さより短いことを検証する必要があります
-              - <code>chunk_overlap</code> 隣接するチャンク間の重複を定義 (オプション)
+              - <code>chunk_overlap</code> 隣接するチャンク間の重なりを定義 (オプション)
       </Property>
     </Properties>
   </Col>
@@ -657,7 +657,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty, PropertyInstructi
             - <code>subchunk_segmentation</code> (object) 子チャンクルール
               - <code>separator</code> セグメンテーション識別子。現在は 1 つの区切り文字のみ許可。デフォルトは <code>***</code>
               - <code>max_tokens</code> 最大長 (トークン) は親チャンクの長さより短いことを検証する必要があります
-              - <code>chunk_overlap</code> 隣接するチャンク間の重複を定義 (オプション)
+              - <code>chunk_overlap</code> 隣接するチャンク間の重なりを定義 (オプション)
       </Property>
     </Properties>
   </Col>

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -43,7 +43,7 @@ const translation = {
     log: 'ログ',
     learnMore: '詳細はこちら',
     params: 'パラメータ',
-    duplicate: '重複',
+    duplicate: '複製',
     rename: '名前の変更',
     audioSourceUnavailable: 'AudioSource が利用できません',
     zoomIn: 'ズームインする',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

 ## Summary
  - Fixed incorrect Japanese translations for technical terms in the application
  - Updated translation for "chunk overlap" from "重複" to "重なり"
  - Changed translation for "duplicate" from "重複" to "複製"

  ## Context
  The Japanese term "重複" was being used incorrectly for two different English concepts:
  1. **"chunk overlap"**: Should be "重なり" (partial overlapping) not "重複" (complete duplication)
  2. **"duplicate"**: Should be "複製" (copy/duplicate) to avoid confusion with overlap

  ## Changes
  ### Commit 1: Fix chunk overlap translation
  - Updated `web/app/(commonLayout)/datasets/template/template.ja.mdx`
  - Changed "重複" to "重なり" for chunk overlap concept
  - This correctly distinguishes between partial overlap (where chunks share some content for context) vs complete duplication

  ### Commit 2: Fix duplicate translation
  - Updated `web/i18n/ja-JP/common.ts`
  - Changed "重複" to "複製" for the duplicate action
  - Note: This translation key appears to be currently unused in the application

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
