### PR TITLE
fix: resolve plugin model providers lock contention issue #22227

### DIFF
--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -97,7 +97,7 @@ class ModelProviderFactory:
             plugin_providers_data = self.plugin_model_manager.fetch_model_providers(self.tenant_id)
         except Exception as e:
             # Handle potential exceptions from the HTTP request
-            logger.exception(f"Failed to fetch plugin model providers for tenant {self.tenant_id}")
+            logger.exception("Failed to fetch plugin model providers for tenant %s", self.tenant_id)
             return []
 
         # 3. Acquire lock ONLY to write to the shared cache
@@ -121,7 +121,7 @@ class ModelProviderFactory:
 
         except Exception as e:
             # Fallback to original implementation if Redis is not available
-            logger.warning(f"Redis lock failed, falling back to thread-local lock: {e}")
+            logger.warning("Redis lock failed, falling back to thread-local lock: %s", e)
 
             try:
                 with contexts.plugin_model_providers_lock.get():
@@ -142,7 +142,7 @@ class ModelProviderFactory:
                     return plugin_model_providers
             except Exception as fallback_error:
                 # If fallback also fails, log and return empty list
-                logger.exception(f"Both Redis lock and thread-local lock failed for tenant {self.tenant_id}")
+                logger.exception("Both Redis lock and thread-local lock failed for tenant %s", self.tenant_id)
                 return []
 
     def get_provider_schema(self, provider: str) -> ProviderEntity:


### PR DESCRIPTION
- Move HTTP requests outside of locks to prevent blocking
- Implement Redis distributed lock with fallback to thread-local lock
- Add double-checked locking pattern for better performance
- Fix logging to use logger.exception instead of logger.error
- Improve concurrency by allowing multiple threads to fetch data simultaneously
- Maintain cache consistency with Redis lock protecting cache writes

Closes #22227

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
