### PR TITLE
fix: Correct and enhance the doc on CELERY_BROKER_URL in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -283,11 +283,12 @@ REDIS_CLUSTERS_PASSWORD=
 # Celery Configuration
 # ------------------------------
 
-# Use redis as the broker, and redis db 1 for celery broker.
-# Format as follows: `redis://<redis_username>:<redis_password>@<redis_host>:<redis_port>/<redis_database>`
+# Use standalone redis as the broker, and redis db 1 for celery broker. (redis_username is usually set by defualt as empty)
+# Format as follows: `redis://<redis_username>:<redis_password>@<redis_host>:<redis_port>/<redis_database>`.
 # Example: redis://:difyai123456@redis:6379/1
-# If use Redis Sentinel, format as follows: `sentinel://<sentinel_username>:<sentinel_password>@<sentinel_host>:<sentinel_port>/<redis_database>`
-# Example: sentinel://localhost:26379/1;sentinel://localhost:26380/1;sentinel://localhost:26381/1
+# If use Redis Sentinel, format as follows: `sentinel://<redis_username>:<redis_password>@<sentinel_host1>:<sentinel_port>/<redis_database>`
+# For high availability, you can configure multiple Sentinel nodes (if provided) separated by semicolons like below example:
+# Example: sentinel://:difyai123456@localhost:26379/1;sentinel://:difyai12345@localhost:26379/1;sentinel://:difyai12345@localhost:26379/1
 CELERY_BROKER_URL=redis://:difyai123456@redis:6379/1
 CELERY_BACKEND=redis
 BROKER_USE_SSL=false


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
fix: https://github.com/langgenius/dify/issues/22691

Fixes misleading Redis Sentinel configuration in .env and documentation. The original guidance incorrectly suggests using REDIS_SENTINEL_PASSWORD in CELERY_BROKER_URL, which causes Celery workers to fail due to authentication errors. This PR clarifies that the Redis master password should be used in CELERY_BROKER_URL, and introduces the separate CELERY_SENTINEL_PASSWORD variable for sentinel_kwargs. Also ensures CELERY_SENTINEL_MASTER_NAME is explicitly set. This prevents common issues when deploying Dify with Redis Sentinel in production.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| 
<img width="2300" height="610" alt="image" src="https://github.com/user-attachments/assets/193bc446-fbe7-40b9-bca1-8e1363119040" />
   | 
<img width="1112" height="284" alt="image" src="https://github.com/user-attachments/assets/d4a76c37-0303-4e7b-bfa5-3e6493dcabbc" />
  |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
