### PR TITLE
fix: Adjust tool selector popup styles (#22622)

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
@@ -265,7 +265,7 @@ const ToolSelector: FC<Props> = ({
             />
           )}
         </PortalToFollowElemTrigger>
-        <PortalToFollowElemContent>
+        <PortalToFollowElemContent className='z-10'>
           <div className={cn('relative max-h-[642px] min-h-20 w-[361px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur pb-4 shadow-lg backdrop-blur-sm', 'overflow-y-auto pb-2')}>
             <>
               <div className='system-xl-semibold px-4 pb-1 pt-3.5 text-text-primary'>{t(`plugin.detailPanel.toolSelector.${isEdit ? 'toolSetting' : 'title'}`)}</div>
@@ -309,15 +309,15 @@ const ToolSelector: FC<Props> = ({
               {currentProvider && currentProvider.type === CollectionType.builtIn && currentProvider.allow_delete && (
                 <>
                   <Divider className='my-1 w-full' />
-                    <div className='px-4 py-2'>
-                      <PluginAuthInAgent
-                        pluginPayload={{
-                          provider: currentProvider.name,
-                          category: AuthCategory.tool,
-                        }}
-                        credentialId={value?.credential_id}
-                        onAuthorizationItemClick={handleAuthorizationItemClick}
-                      />
+                  <div className='px-4 py-2'>
+                    <PluginAuthInAgent
+                      pluginPayload={{
+                        provider: currentProvider.name,
+                        category: AuthCategory.tool,
+                      }}
+                      credentialId={value?.credential_id}
+                      onAuthorizationItemClick={handleAuthorizationItemClick}
+                    />
                   </div>
                 </>
               )}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add z-10 class name to PortalToFollowElemContent

Fixes #22622


According to #19930, since we have already set the limit to 99. Perhaps we also need to modify the code here: https://github.com/langgenius/dify-official-plugins/blob/main/agent-strategies/cot_agent/strategies/function_calling.yaml, to ensure that the agent's `maximum_iterations` to be consistent.
<img width="1799" height="1265" alt="image" src="https://github.com/user-attachments/assets/ba7e710d-8246-4599-b1b1-ece37a47122b" />



## Screenshots

| Before | After |
|--------|-------|
| <img width="1023" height="709" alt="56b60bc93d59d2b2ba172ee86749ec5" src="https://github.com/user-attachments/assets/455e8d65-b5e9-4f32-a1cd-e9ead9cc70b0" />   | <img width="969" height="655" alt="eddc527a62b2118ce898408f7d61b4e" src="https://github.com/user-attachments/assets/8bf6357b-c7a1-421a-be09-e0daeaeef7cd" />   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
