### PR TITLE
feat: add APOLLO_NAMESPACES support for ApolloSettingsSource

### DIFF
--- a/api/configs/remote_settings_sources/apollo/python_3x.py
+++ b/api/configs/remote_settings_sources/apollo/python_3x.py
@@ -27,7 +27,6 @@ def http_request(url, timeout, headers={}):
         return res.code, body
     except HTTPError as e:
         if e.code == 304:
-            logger.warning("http_request error,code is 304, maybe you should check secret")
             return 304, None
         logger.warning("http_request error,code is %d, msg is %s", e.code, e.msg)
         raise e


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- add APOLLO_NAMESPACES support for ApolloSettingsSource
- Remove unnecessary HTTP 304 warning in apollo client.
    304 means that there is no change in the configuration data.
    see also https://www.apolloconfig.com/#/zh/client/other-language-client-user-guide


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
