### PR TITLE
fix: prevent app type description from overflowing the card

### DIFF
--- a/web/app/components/app/create-app-modal/index.tsx
+++ b/web/app/components/app/create-app-modal/index.tsx
@@ -298,7 +298,7 @@ function AppTypeCard({ icon, title, description, active, onClick }: AppTypeCardP
   >
     {icon}
     <div className='system-sm-semibold mb-0.5 mt-2 text-text-secondary'>{title}</div>
-    <div className='system-xs-regular text-text-tertiary'>{description}</div>
+    <div className='system-xs-regular line-clamp-2 text-text-tertiary' title={description}>{description}</div>
   </div>
 }
 


### PR DESCRIPTION
## Summary

Prevent app type description from overflowing the card

## Screenshots

| Before | After |
|--------|-------|
| <img width="530" height="306" alt="image" src="https://github.com/user-attachments/assets/55435dc7-ce0d-45f8-9eb0-b1d525c50d3e" /> | <img width="548" height="338" alt="image" src="https://github.com/user-attachments/assets/42a54b7c-753d-4dd3-b122-382bed4b9390" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
