### PR TITLE
fix: the text/icon shows wrong color in darkmode

### DIFF
--- a/web/app/components/app/app-access-control/access-control-dialog.tsx
+++ b/web/app/components/app/app-access-control/access-control-dialog.tsx
@@ -47,7 +47,7 @@ const AccessControlDialog = ({
           >
             <Dialog.Panel className={cn('relative h-auto min-h-[323px] w-[600px] overflow-y-auto rounded-2xl bg-components-panel-bg p-0 shadow-xl transition-all', className)}>
               <div onClick={() => close()} className="absolute right-5 top-5 z-10 flex h-8 w-8 cursor-pointer items-center justify-center">
-                <RiCloseLine className='h-5 w-5' />
+                <RiCloseLine className='h-5 w-5 text-text-tertiary' />
               </div>
               {children}
             </Dialog.Panel>

--- a/web/app/components/app/app-access-control/index.tsx
+++ b/web/app/components/app/app-access-control/index.tsx
@@ -72,7 +72,7 @@ export default function AccessControl(props: AccessControlProps) {
       </div>
       <div className='flex flex-col gap-y-1 px-6 pb-3'>
         <div className='leading-6'>
-          <p className='system-sm-medium'>{t('app.accessControlDialog.accessLabel')}</p>
+          <p className='system-sm-medium text-text-tertiary'>{t('app.accessControlDialog.accessLabel')}</p>
         </div>
         <AccessControlItem type={AccessMode.ORGANIZATION}>
           <div className='flex items-center p-3'>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
