### PR TITLE
Optimize tencent_vector knowledge base deletion error handling with batch processing support

### DIFF
--- a/api/core/rag/datasource/vdb/tencent/tencent_vector.py
+++ b/api/core/rag/datasource/vdb/tencent/tencent_vector.py
@@ -206,20 +206,18 @@ class TencentVector(BaseVector):
     def delete_by_ids(self, ids: list[str]) -> None:
         if not ids:
             return
-        
+
         total_count = len(ids)
         batch_size = self._client_config.max_upsert_batch_size
         batch = math.ceil(total_count / batch_size)
-        
+
         for j in range(batch):
             start_idx = j * batch_size
             end_idx = min(total_count, (j + 1) * batch_size)
             batch_ids = ids[start_idx:end_idx]
-            
+
             self._client.delete(
-                database_name=self._client_config.database, 
-                collection_name=self.collection_name, 
-                document_ids=batch_ids
+                database_name=self._client_config.database, collection_name=self.collection_name, document_ids=batch_ids
             )
 
     def delete_by_metadata_field(self, key: str, value: str) -> None:


### PR DESCRIPTION
## Summary

This PR fixes the batch size limitation error in Tencent Vector Database deletion operations by implementing batch processing logic similar to the existing add_texts method.

**Issue Fixed**: Resolves #22725 - ServerInternalError when deleting large numbers of vector indexes (https://github.com/langgenius/dify/issues/22725)

**Context**: During knowledge base document retry operations, the system attempts to delete old indexes in bulk. However, when the number of indexes exceeds the API's batch size limit (1000), it causes a server error.

**Dependencies**: No additional dependencies required for this change.


## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
