### PR TITLE
Fix incorrect mcp method_name

### DIFF
--- a/api/core/mcp/mcp_client.py
+++ b/api/core/mcp/mcp_client.py
@@ -69,7 +69,7 @@ class MCPClient:
 
         parsed_url = urlparse(self.server_url)
         path = parsed_url.path or ""
-        method_name = path.removesuffix("/").lower()
+        method_name = path.rstrip("/").split("/")[-1] if path else ""
         if method_name in connection_methods:
             client_factory = connection_methods[method_name]
             self.connect_server(client_factory, method_name)


### PR DESCRIPTION

Fixes: #22734 

A brief explanation: `parsed_url.path` has a leading `/`, so we cannot simply `removesuffix`.
so @Nov1c444 's version is correct. 😺 

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
