### PR TITLE
minor fix: add secure cookie for production

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -712,6 +712,7 @@ class ToolPluginOAuthApi(Resource):
             context_id,
             httponly=True,
             samesite="Lax",
+            secure=dify_config.DEPLOY_ENV != "development",
             max_age=OAuthProxyService.__MAX_AGE__,
         )
         return response


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR adds secure cookie configuration for production environments in the OAuth proxy service. The change ensures that cookies are marked as secure when the application is not running in development mode, enhancing security by requiring HTTPS for cookie transmission in production deployments.

**Changes made:**
- Added `secure=dify_config.DEPLOY_ENV != "development"` parameter to the cookie configuration in the workspace controller
- The secure flag is automatically enabled for all environments except development
- This follows security best practices for cookie handling in production environments

**Motivation:**
Secure cookies help prevent man-in-the-middle attacks and ensure that authentication cookies are only transmitted over encrypted connections in production environments.

## Screenshots

| Before | After |
|--------|-------|
| Cookie without secure flag in production | Cookie with secure flag enabled for non-development environments |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods