### PR TITLE
feat(k8s): Add pure migration option for `api` component

### DIFF
--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -5,12 +5,11 @@ set -e
 if [[ "${MIGRATION_ENABLED}" == "true" ]]; then
   echo "Running migrations"
   flask upgrade-db
-fi
-
-# Pure migration mode
-if [[ "${MODE}" == "migration" ]]; then
+  # Pure migration mode
+  if [[ "${MODE}" == "migration" ]]; then
   echo "Migration completed, exiting normally"
   exit 0
+  fi
 fi
 
 if [[ "${MODE}" == "worker" ]]; then

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -7,6 +7,12 @@ if [[ "${MIGRATION_ENABLED}" == "true" ]]; then
   flask upgrade-db
 fi
 
+# Pure migration mode
+if [[ "${MODE}" == "migration" ]]; then
+  echo "Migration completed, exiting normally"
+  exit 0
+fi
+
 if [[ "${MODE}" == "worker" ]]; then
 
   # Get the number of available CPU cores


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
This PR ease maintenance in k8s scenario by adding pure migration mode that execute data migration logic and exit normally without launching the web server. This is useful when upgrading `dify` version, as it enable the maintainer to launch a separate container that execute the `flask upgrade-db` logic via `entrypoint.sh` instead of tampering with the actual `api` or `worker`

Without this mode, this logic will be executed in both `api` and `worker` component instead of a standalone, single replica logic. This will case dead lock in case there are multiple replica of `api` or `worker`, or if the `worker` starts before `api` and tries to execute the migration logic that end up with issues like https://github.com/langgenius/dify/issues/19910. With this migration only mode, it's possible to disable auto migration for `api` and `worker` and bring up a standalone container that does the migration beforehand (via a `Job` defined with pre-installation hook annotation that recognized by `Helm`).
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| Server will launch after `flask upgrade-db` | Run `flask upgrade-db` only without launching server when `MODE=migration`   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
