### PR TITLE
fix: tablestore TypeError when vector is missing

### DIFF
--- a/api/core/rag/datasource/vdb/tablestore/tablestore_vector.py
+++ b/api/core/rag/datasource/vdb/tablestore/tablestore_vector.py
@@ -296,12 +296,21 @@ class TableStoreVector(BaseVector):
         documents = []
         for search_hit in search_response.search_hits:
             if search_hit.score > score_threshold:
-                metadata = json.loads(search_hit.row[1][0][1])
+                ots_column_map = {}
+                for col in search_hit.row[1]:
+                    ots_column_map[col[0]] = col[1]
+
+                vector_str = ots_column_map.get(Field.VECTOR.value)
+                metadata_str = ots_column_map.get(Field.METADATA_KEY.value)
+
+                vector = json.loads(vector_str) if vector_str else None
+                metadata = json.loads(metadata_str) if metadata_str else None
                 metadata["score"] = search_hit.score
+
                 documents.append(
                     Document(
-                        page_content=search_hit.row[1][2][1],
-                        vector=json.loads(search_hit.row[1][3][1]),
+                        page_content=ots_column_map.get(Field.CONTENT_KEY.value),
+                        vector=vector,
                         metadata=metadata,
                     )
                 )
@@ -329,11 +338,20 @@ class TableStoreVector(BaseVector):
 
         documents = []
         for search_hit in search_response.search_hits:
+            ots_column_map = {}
+            for col in search_hit.row[1]:
+                ots_column_map[col[0]] = col[1]
+
+            vector_str = ots_column_map.get(Field.VECTOR.value)
+            metadata_str = ots_column_map.get(Field.METADATA_KEY.value)
+            vector = json.loads(vector_str) if vector_str else None
+            metadata = json.loads(metadata_str) if metadata_str else None
+
             documents.append(
                 Document(
-                    page_content=search_hit.row[1][2][1],
-                    vector=json.loads(search_hit.row[1][3][1]),
-                    metadata=json.loads(search_hit.row[1][0][1]),
+                    page_content=ots_column_map.get(Field.CONTENT_KEY.value),
+                    vector=vector,
+                    metadata=metadata,
                 )
             )
         return documents

--- a/api/core/rag/datasource/vdb/tablestore/tablestore_vector.py
+++ b/api/core/rag/datasource/vdb/tablestore/tablestore_vector.py
@@ -304,12 +304,13 @@ class TableStoreVector(BaseVector):
                 metadata_str = ots_column_map.get(Field.METADATA_KEY.value)
 
                 vector = json.loads(vector_str) if vector_str else None
-                metadata = json.loads(metadata_str) if metadata_str else None
+                metadata = json.loads(metadata_str) if metadata_str else {}
+
                 metadata["score"] = search_hit.score
 
                 documents.append(
                     Document(
-                        page_content=ots_column_map.get(Field.CONTENT_KEY.value),
+                        page_content=ots_column_map.get(Field.CONTENT_KEY.value) or "",
                         vector=vector,
                         metadata=metadata,
                     )
@@ -345,11 +346,11 @@ class TableStoreVector(BaseVector):
             vector_str = ots_column_map.get(Field.VECTOR.value)
             metadata_str = ots_column_map.get(Field.METADATA_KEY.value)
             vector = json.loads(vector_str) if vector_str else None
-            metadata = json.loads(metadata_str) if metadata_str else None
+            metadata = json.loads(metadata_str) if metadata_str else {}
 
             documents.append(
                 Document(
-                    page_content=ots_column_map.get(Field.CONTENT_KEY.value),
+                    page_content=ots_column_map.get(Field.CONTENT_KEY.value) or "",
                     vector=vector,
                     metadata=metadata,
                 )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
When embedding fails and the written vector data is empty, the full-text search returns data without the vector field, leading to an exception.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
