### PR TITLE
fix: improve max active requests calculation logic

### DIFF
--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -130,9 +130,22 @@ class AppGenerateService:
 
     @staticmethod
     def _get_max_active_requests(app_model: App) -> int:
-        max_active_requests = app_model.max_active_requests
-        if max_active_requests is None:
-            max_active_requests = int(dify_config.APP_MAX_ACTIVE_REQUESTS)
+        """
+        Get the maximum number of active requests allowed for an app.
+
+        If the app has a custom max_active_requests setting, it will be used
+        unless the global APP_MAX_ACTIVE_REQUESTS config is non-zero, in which
+        case the minimum of the two values is returned to enforce the global limit.
+
+        Args:
+            app_model: The App model instance
+
+        Returns:
+            The maximum number of active requests allowed
+        """
+        max_active_requests = app_model.max_active_requests or dify_config.APP_MAX_ACTIVE_REQUESTS
+        if dify_config.APP_MAX_ACTIVE_REQUESTS != 0:
+            return min(max_active_requests, dify_config.APP_MAX_ACTIVE_REQUESTS)
         return max_active_requests
 
     @classmethod

--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -129,7 +129,7 @@ class AppGenerateService:
                 rate_limit.exit(request_id)
 
     @staticmethod
-    def _get_max_active_requests(app_model: App) -> int:
+    def _get_max_active_requests(app: App) -> int:
         """
         Get the maximum number of active requests allowed for an app.
 
@@ -137,12 +137,12 @@ class AppGenerateService:
         A value of 0 means infinite (no limit).
 
         Args:
-            app_model: The App model instance
+            app: The App model instance
 
         Returns:
             The maximum number of active requests allowed
         """
-        app_limit = app_model.max_active_requests or 0
+        app_limit = app.max_active_requests or 0
         config_limit = dify_config.APP_MAX_ACTIVE_REQUESTS
 
         # Filter out infinite (0) values and return the minimum, or 0 if both are infinite


### PR DESCRIPTION
- Use app model's max_active_requests or fall back to global config
- When global APP_MAX_ACTIVE_REQUESTS is non-zero, enforce it as a hard limit
- Add comprehensive docstring explaining the behavior

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
related to #22098

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
