### PR TITLE
fix(plugins_select): Adjust z-index, fix issue where options cannot be displayed (#22873)

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-popup.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-popup.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { FC } from 'react'
+import type { FC, JSX } from 'react'
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useBoolean } from 'ahooks'

--- a/web/app/components/app-sidebar/app-operations.tsx
+++ b/web/app/components/app-sidebar/app-operations.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import type { JSX } from 'react'
 import { cloneElement, useCallback } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -7,7 +7,7 @@ import { PortalToFollowElem, PortalToFollowElemContent, PortalToFollowElemTrigge
 import { RiMoreLine } from '@remixicon/react'
 
 export type Operation = {
-  id: string; title: string; icon: ReactElement; onClick: () => void
+  id: string; title: string; icon: JSX.Element; onClick: () => void
 }
 
 const AppOperations = ({ operations, gap }: {
@@ -47,7 +47,7 @@ const AppOperations = ({ operations, gap }: {
         updatedEntries[id] = true
         width += gap + childWidth
       }
- else {
+      else {
         if (i === childrens.length - 1 && width + childWidth <= containerWidth)
           updatedEntries[id] = true
         else

--- a/web/app/components/base/select/pure.tsx
+++ b/web/app/components/base/select/pure.tsx
@@ -91,7 +91,7 @@ const PureSelect = ({
       triggerPopupSameWidth={triggerPopupSameWidth}
     >
       <PortalToFollowElemTrigger
-        onClick={() => handleOpenChange(!mergedOpen)}
+        onClick={() => !disabled && handleOpenChange(!mergedOpen)}
         asChild
       >
         <div
@@ -116,7 +116,7 @@ const PureSelect = ({
         </div>
       </PortalToFollowElemTrigger>
       <PortalToFollowElemContent className={cn(
-        'z-10',
+        'z-[9999]',
         popupWrapperClassName,
       )}>
         <div


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Replace `z-10` className with `z-[9999]` in pure.tsx to increase z-index priority
- Update React type references in config-popup.tsx and app-operations.tsx to fix type errors

Fixes #22873
Fix https://github.com/langgenius/dify/issues/22904

## Screenshots

| Before | After |
|--------|-------|
| <img width="1205" height="359" alt="image" src="https://github.com/user-attachments/assets/0b2bd9c3-2b43-4635-a716-66f5de6e02d6" />    | <img width="1107" height="375" alt="1753338787213" src="https://github.com/user-attachments/assets/7338922d-b1ef-4328-9352-1b67066561b1" />   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
