### PR TITLE
Improve: support custom model parameters in auto-generator

### DIFF
--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -1,5 +1,3 @@
-import os
-
 from flask_login import current_user
 from flask_restful import Resource, reqparse
 
@@ -29,15 +27,12 @@ class RuleGenerateApi(Resource):
         args = parser.parse_args()
 
         account = current_user
-        PROMPT_GENERATION_MAX_TOKENS = int(os.getenv("PROMPT_GENERATION_MAX_TOKENS", "512"))
-
         try:
             rules = LLMGenerator.generate_rule_config(
                 tenant_id=account.current_tenant_id,
                 instruction=args["instruction"],
                 model_config=args["model_config"],
                 no_variable=args["no_variable"],
-                rule_config_max_tokens=PROMPT_GENERATION_MAX_TOKENS,
             )
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
@@ -64,14 +59,12 @@ class RuleCodeGenerateApi(Resource):
         args = parser.parse_args()
 
         account = current_user
-        CODE_GENERATION_MAX_TOKENS = int(os.getenv("CODE_GENERATION_MAX_TOKENS", "1024"))
         try:
             code_result = LLMGenerator.generate_code(
                 tenant_id=account.current_tenant_id,
                 instruction=args["instruction"],
                 model_config=args["model_config"],
                 code_language=args["code_language"],
-                max_tokens=CODE_GENERATION_MAX_TOKENS,
             )
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -125,16 +125,13 @@ class LLMGenerator:
         return questions
 
     @classmethod
-    def generate_rule_config(
-        cls, tenant_id: str, instruction: str, model_config: dict, no_variable: bool, rule_config_max_tokens: int = 512
-    ) -> dict:
+    def generate_rule_config(cls, tenant_id: str, instruction: str, model_config: dict, no_variable: bool) -> dict:
         output_parser = RuleConfigGeneratorOutputParser()
 
         error = ""
         error_step = ""
         rule_config = {"prompt": "", "variables": [], "opening_statement": "", "error": ""}
-        model_parameters = {"max_tokens": rule_config_max_tokens, "temperature": 0.01}
-
+        model_parameters = model_config.get("completion_params", {})
         if no_variable:
             prompt_template = PromptTemplateParser(WORKFLOW_RULE_CONFIG_PROMPT_GENERATE_TEMPLATE)
 
@@ -276,12 +273,7 @@ class LLMGenerator:
 
     @classmethod
     def generate_code(
-        cls,
-        tenant_id: str,
-        instruction: str,
-        model_config: dict,
-        code_language: str = "javascript",
-        max_tokens: int = 1000,
+        cls, tenant_id: str, instruction: str, model_config: dict, code_language: str = "javascript"
     ) -> dict:
         if code_language == "python":
             prompt_template = PromptTemplateParser(PYTHON_CODE_GENERATOR_PROMPT_TEMPLATE)
@@ -305,8 +297,7 @@ class LLMGenerator:
         )
 
         prompt_messages = [UserPromptMessage(content=prompt)]
-        model_parameters = {"max_tokens": max_tokens, "temperature": 0.01}
-
+        model_parameters = model_config.get("completion_params", {})
         try:
             response = cast(
                 LLMResult,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

https://github.com/user-attachments/assets/a37fd55e-182f-4851-bec9-557c04ddd679



Fixes #22923

Refer to this  pr #21208 already support selecting model in auto generator 

## Changes
- Added custom model parameter configuration to prompt-generator and code-generator
- Removed `CODE_GENERATION_MAX_TOKENS` and `PROMPT_GENERATION_MAX_TOKENS` constants
- Users now control max_tokens .... directly through parameter input

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
