### PR TITLE
fix: correct typo in function name paser_docx_part -> parser_docx_part

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -305,7 +305,7 @@ def _extract_text_from_doc(file_content: bytes) -> str:
         raise TextExtractionError(f"Failed to extract text from DOC: {str(e)}") from e
 
 
-def paser_docx_part(block, doc: Document, content_items, i):
+def parser_docx_part(block, doc: Document, content_items, i):
     if isinstance(block, CT_P):
         content_items.append((i, "paragraph", Paragraph(block, doc)))
     elif isinstance(block, CT_Tbl):
@@ -329,7 +329,7 @@ def _extract_text_from_docx(file_content: bytes) -> str:
         part = next(it, None)
         i = 0
         while part is not None:
-            paser_docx_part(part, doc, content_items, i)
+            parser_docx_part(part, doc, content_items, i)
             i = i + 1
             part = next(it, None)
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed a typo in function name paser_docx_part to parser_docx_part. This is a simple spelling correction that doesn't affect functionality but improves code readability and follows proper naming conventions.

## Screenshots

Not applicable for this typo fix.

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
