### PR TITLE
Fix incorrect assert type in the AgentNode class

### DIFF
--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -47,10 +47,10 @@ from models.model import Conversation
 from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 
 from .exc import (
-    AgentNodeError,
     AgentInputTypeError,
     AgentInvocationError,
     AgentMessageTransformError,
+    AgentNodeError,
     AgentVariableNotFoundError,
     AgentVariableTypeError,
     ToolFileNotFoundError,

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -47,6 +47,7 @@ from models.model import Conversation
 from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 
 from .exc import (
+    AgentNodeError,
     AgentInputTypeError,
     AgentInvocationError,
     AgentMessageTransformError,
@@ -593,7 +594,14 @@ class AgentNode(BaseNode):
                     variables[variable_name] = variable_value
             elif message.type == ToolInvokeMessage.MessageType.FILE:
                 assert message.meta is not None
-                assert isinstance(message.meta, File)
+                assert isinstance(message.meta, dict)
+                # Validate that meta contains a 'file' key
+                if "file" not in message.meta:
+                    raise AgentNodeError("File message is missing 'file' key in meta")
+
+                # Validate that the file is an instance of File
+                if not isinstance(message.meta["file"], File):
+                    raise AgentNodeError(f"Expected File object but got {type(message.meta['file']).__name__}")
                 files.append(message.meta["file"])
             elif message.type == ToolInvokeMessage.MessageType.LOG:
                 assert isinstance(message.message, ToolInvokeMessage.LogMessage)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #22784

This PR addresses the same issue described in #22784 for the `AgentNode` class as previously identified in the `ToolNode` class. Specifically, the problem is with the incorrect assumption that `message.meta` is of type `File`, whereas in reality, its type is `dict`. This may lead to unexpected behavior or runtime errors. Ref code: https://github.com/langgenius/dify/blob/main/api/core/tools/entities/tool_entities.py#L216

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
