### PR TITLE
feat: Support allOf in OpenAPI properties inside schema #22946

### DIFF
--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -105,6 +105,28 @@ class ApiBasedToolSchemaParser:
                             # overwrite the content
                             interface["operation"]["requestBody"]["content"][content_type]["schema"] = root
 
+                            # handle allOf reference in schema properties
+                            for prop_dict in root.get("properties", {}).values():
+                                for item in prop_dict.get("allOf", []):
+                                    if "$ref" in item:
+                                        ref_schema = openapi
+                                        reference = item["$ref"].split("/")[1:]
+                                        for ref in reference:
+                                            ref_schema = ref_schema[ref]
+                                    else:
+                                        ref_schema = item
+                                    for key, value in ref_schema.items():
+                                        if isinstance(value, list):
+                                            if key not in prop_dict:
+                                                prop_dict[key] = []
+                                            # extends list field
+                                            prop_dict[key] += value
+                                        elif key not in prop_dict:
+                                            # add new field
+                                            prop_dict[key] = value
+                                if "allOf" in prop_dict:
+                                    del prop_dict["allOf"]
+
                     # parse body parameters
                     if "schema" in interface["operation"]["requestBody"]["content"][content_type]:
                         body_schema = interface["operation"]["requestBody"]["content"][content_type]["schema"]

--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -120,7 +120,8 @@ class ApiBasedToolSchemaParser:
                                             if key not in prop_dict:
                                                 prop_dict[key] = []
                                             # extends list field
-                                            prop_dict[key] += value
+                                            if isinstance(prop_dict[key], list):
+                                                prop_dict[key].extend(value)
                                         elif key not in prop_dict:
                                             # add new field
                                             prop_dict[key] = value

--- a/api/tests/unit_tests/core/tools/utils/test_parser.py
+++ b/api/tests/unit_tests/core/tools/utils/test_parser.py
@@ -54,3 +54,58 @@ def test_parse_openapi_to_tool_bundle_operation_id(app):
     assert tool_bundles[0].operation_id == "<root>_get"
     assert tool_bundles[1].operation_id == "apiresources_get"
     assert tool_bundles[2].operation_id == "createResource"
+
+
+def test_parse_openapi_to_tool_bundle_properties_all_of(app):
+    openapi = {
+        "openapi": "3.0.0",
+        "info": {"title": "Simple API", "version": "1.0.0"},
+        "servers": [{"url": "http://localhost:3000"}],
+        "paths": {
+            "/api/resource": {
+                "get": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Request",
+                                },
+                            },
+                        },
+                        "required": True,
+                    },
+                },
+            },
+        },
+        "components": {
+            "schemas": {
+                "Request": {
+                    "type": "object",
+                    "properties": {
+                        "prop1": {
+                            "enum": ["option1"],
+                            "description": "desc prop1",
+                            "allOf": [
+                                {"$ref": "#/components/schemas/AllOfItem"},
+                                {
+                                    "enum": ["option2"],
+                                },
+                            ],
+                        },
+                    },
+                },
+                "AllOfItem": {
+                    "type": "string",
+                    "enum": ["option3"],
+                    "description": "desc allOf item",
+                },
+            }
+        },
+    }
+    with app.test_request_context():
+        tool_bundles = ApiBasedToolSchemaParser.parse_openapi_to_tool_bundle(openapi)
+
+    assert tool_bundles[0].parameters[0].type == "string"
+    assert tool_bundles[0].parameters[0].llm_description == "desc prop1"
+    # TODO: support enum in OpenAPI
+    # assert set(tool_bundles[0].parameters[0].options) == {"option1", "option2", "option3"}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR

## Summary

Currently the OpenAPI parser does not handles `allOf` keyword in the `properties` of a OpenAPI schema object, this PR tries to implement it.

Basically the key-value pairs of each obj defined inside `allOf` is merged into the original property, with some special considerations listed as follows:
- if the value to be merged is a list, those items are concatenated
- if the value type is not a list, it got merged only if the original property does not have that key

Fix: #22946

## Screenshots

Not available since its a backend-specific change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
