### PR TITLE
fix: Update trigger styles for disabled state in PureSelect component

### DIFF
--- a/web/app/components/base/select/pure.tsx
+++ b/web/app/components/base/select/pure.tsx
@@ -92,12 +92,13 @@ const PureSelect = ({
     >
       <PortalToFollowElemTrigger
         onClick={() => !disabled && handleOpenChange(!mergedOpen)}
-        asChild
-      >
+        asChild >
         <div
           className={cn(
-            'system-sm-regular group flex h-8 cursor-pointer items-center rounded-lg bg-components-input-bg-normal px-2 text-components-input-text-filled hover:bg-state-base-hover-alt',
-            mergedOpen && 'bg-state-base-hover-alt',
+            'system-sm-regular group flex h-8 items-center rounded-lg bg-components-input-bg-normal px-2 text-components-input-text-filled',
+            !disabled && 'cursor-pointer hover:bg-state-base-hover-alt',
+            disabled && 'cursor-not-allowed opacity-50',
+            mergedOpen && !disabled && 'bg-state-base-hover-alt',
             triggerClassName,
           )}
         >


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The PureSelect component's disabled state was visually misleading (appearing clickable when disabled), preventing dropdown interaction on Dify's plugin and authorization configuration pages; I fixed this by updating the trigger div's className in pure.tsx.

close https://github.com/langgenius/dify/issues/22884

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
|<img width="594" height="465" alt="image" src="https://github.com/user-attachments/assets/e2900bb3-dea1-4994-9550-a5718aeafdc4" />  | <img width="575" height="246" alt="image" src="https://github.com/user-attachments/assets/837c6038-dfb8-4b88-bdb0-93d0bafda512" />|



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
