### PR TITLE
Fix: correct misplaced `ensure_ascii=False`

### DIFF
--- a/api/core/workflow/nodes/question_classifier/question_classifier_node.py
+++ b/api/core/workflow/nodes/question_classifier/question_classifier_node.py
@@ -385,9 +385,8 @@ class QuestionClassifierNode(BaseNode):
                 text=QUESTION_CLASSIFIER_COMPLETION_PROMPT.format(
                     histories=memory_str,
                     input_text=input_text,
-                    categories=json.dumps(categories),
+                    categories=json.dumps(categories, ensure_ascii=False),
                     classification_instructions=instruction,
-                    ensure_ascii=False,
                 )
             )
 


### PR DESCRIPTION
In class `QuestionClassifierNode`, `ensure_ascii=False` was incorrectly passed to `str.format()` instead of `json.dumps()`.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
