### PR TITLE
fix: resolve cross-page document selection issue in metadata batch edit

### DIFF
--- a/web/app/components/datasets/documents/index.tsx
+++ b/web/app/components/datasets/documents/index.tsx
@@ -164,7 +164,6 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
       if (totalPages < currPage + 1)
         setCurrPage(totalPages === 0 ? 0 : totalPages - 1)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [documentsRes])
 
   const invalidDocumentDetail = useInvalidDocumentDetailKey()
@@ -178,7 +177,6 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
       invalidChunkList()
       invalidChildChunkList()
     }, 5000)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const documentsWithProgress = useMemo(() => {
@@ -273,14 +271,13 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
 
   const documentsList = isDataSourceNotion ? documentsWithProgress?.data : documentsRes?.data
   const [selectedIds, setSelectedIds] = useState<string[]>([])
-  
+
   // Clear selection when search changes to avoid confusion
   useEffect(() => {
-    if (searchValue !== query.keyword) {
+    if (searchValue !== query.keyword)
       setSelectedIds([])
-    }
   }, [searchValue, query.keyword])
-  
+
   const { run: handleSearch } = useDebounceFn(() => {
     setSearchValue(inputValue)
   }, { wait: 500 })

--- a/web/app/components/datasets/documents/index.tsx
+++ b/web/app/components/datasets/documents/index.tsx
@@ -273,6 +273,14 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
 
   const documentsList = isDataSourceNotion ? documentsWithProgress?.data : documentsRes?.data
   const [selectedIds, setSelectedIds] = useState<string[]>([])
+  
+  // Clear selection when search changes to avoid confusion
+  useEffect(() => {
+    if (searchValue !== query.keyword) {
+      setSelectedIds([])
+    }
+  }, [searchValue, query.keyword])
+  
   const { run: handleSearch } = useDebounceFn(() => {
     setSearchValue(inputValue)
   }, { wait: 500 })

--- a/web/app/components/datasets/documents/list.tsx
+++ b/web/app/components/datasets/documents/list.tsx
@@ -458,7 +458,8 @@ const DocumentList: FC<IDocumentListProps> = ({
     handleSave,
   } = useBatchEditDocumentMetadata({
     datasetId,
-    docList: documents.filter(item => selectedIds.includes(item.id)),
+    docList: documents.filter(doc => selectedIds.includes(doc.id)),
+    selectedDocumentIds: selectedIds, // Pass all selected IDs separately
     onUpdate,
   })
 

--- a/web/app/components/datasets/metadata/hooks/use-batch-edit-document-metadata.ts
+++ b/web/app/components/datasets/metadata/hooks/use-batch-edit-document-metadata.ts
@@ -9,12 +9,14 @@ import { t } from 'i18next'
 type Props = {
   datasetId: string
   docList: SimpleDocumentDetail[]
+  selectedDocumentIds?: string[]
   onUpdate: () => void
 }
 
 const useBatchEditDocumentMetadata = ({
   datasetId,
   docList,
+  selectedDocumentIds,
   onUpdate,
 }: Props) => {
   const [isShowEditModal, {
@@ -79,9 +81,12 @@ const useBatchEditDocumentMetadata = ({
       return false
     })
 
-    const res: MetadataBatchEditToServer = docList.map((item, i) => {
-      // the new metadata will override the old one
-      const oldMetadataList = metaDataList[i]
+    // Use selectedDocumentIds if available, otherwise fall back to docList
+    const documentIds = selectedDocumentIds || docList.map(doc => doc.id)
+    const res: MetadataBatchEditToServer = documentIds.map((documentId) => {
+      // Find the document in docList to get its metadata
+      const docIndex = docList.findIndex(doc => doc.id === documentId)
+      const oldMetadataList = docIndex >= 0 ? metaDataList[docIndex] : []
       let newMetadataList: MetadataItemWithValue[] = [...oldMetadataList, ...addedList]
         .filter((item) => {
           return !removedList.find(removedItem => removedItem.id === item.id)
@@ -108,7 +113,7 @@ const useBatchEditDocumentMetadata = ({
       })
 
       return {
-        document_id: item.id,
+        document_id: documentId,
         metadata_list: newMetadataList,
       }
     })


### PR DESCRIPTION
- Fix DocumentList to pass all selectedDocumentIds to batch metadata hook
- Modify useBatchEditDocumentMetadata to handle documents not in current page
- Ensure all selected documents across pages are included in batch operations
- Resolves issue where only current page documents were sent to backend

Fixes #22952

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
