### PR TITLE
ability to select same type sub item by preserving children of both f…

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -165,16 +165,18 @@ const findExceptVarInObject = (obj: any, filterVar: (payload: Var, selector: Val
       const filteredObj = findExceptVarInObject(item, filterVar, [...value_selector, item.variable], false)
       return {
         ...item,
-        children: filteredObj.children
+        children: filteredObj.children,
       }
     })
 
-    if (isFile && Array.isArray(childrenResult))
-      if (childrenResult.length === 0)
+    if (isFile && Array.isArray(childrenResult)) {
+      if (childrenResult.length === 0) {
         childrenResult = OUTPUT_FILE_SUB_VARIABLES.map((key) => ({
           variable: key,
           type: key === 'size' ? VarType.number : VarType.string,
         }))
+      }
+    }
   }
   else {
     childrenResult = []

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -561,7 +561,7 @@ const formatItem = (
     const { children } = (() => {
       if (isFile) {
         return {
-          children: OUTPUT_FILE_SUB_VARIABLES.map((key) => {
+          children: OUTPUT_FILE_SUB_VARIABLES.map(key => {
             return {
               variable: key,
               type: key === 'size' ? VarType.number : VarType.string,

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -172,7 +172,7 @@ const findExceptVarInObject = (obj: any, filterVar: (payload: Var, selector: Val
         return {
           item,
           filteredObj,
-          passesFilter
+          passesFilter,
         }
       })
       .filter(({ passesFilter }) => passesFilter)

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -156,7 +156,7 @@ const findExceptVarInObject = (obj: any, filterVar: (payload: Var, selector: Val
           return {
             item,
             filteredObj: null,
-            passesFilter: filterVar(item, currSelector)
+            passesFilter: filterVar(item, currSelector),
           }
         }
 

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -171,7 +171,7 @@ const findExceptVarInObject = (obj: any, filterVar: (payload: Var, selector: Val
 
     if (isFile && Array.isArray(childrenResult)) {
       if (childrenResult.length === 0) {
-        childrenResult = OUTPUT_FILE_SUB_VARIABLES.map((key) => ({
+        childrenResult = OUTPUT_FILE_SUB_VARIABLES.map(key => ({
           variable: key,
           type: key === 'size' ? VarType.number : VarType.string,
         }))
@@ -561,7 +561,7 @@ const formatItem = (
     const { children } = (() => {
       if (isFile) {
         return {
-          children: OUTPUT_FILE_SUB_VARIABLES.map(key => {
+          children: OUTPUT_FILE_SUB_VARIABLES.map((key) => {
             return {
               variable: key,
               type: key === 'size' ? VarType.number : VarType.string,

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -149,8 +149,8 @@ const findExceptVarInObject = (obj: any, filterVar: (payload: Var, selector: Val
 
       const filteredObj = findExceptVarInObject(item, filterVar, currSelector, false)
       const hasValidChildren = filteredObj.children && (
-        (Array.isArray(filteredObj.children) && filteredObj.children.length > 0) ||
-        (!Array.isArray(filteredObj.children) && Object.keys((filteredObj.children as StructuredOutput)?.schema?.properties || {}).length > 0)
+        (Array.isArray(filteredObj.children) && filteredObj.children.length > 0)
+        || (!Array.isArray(filteredObj.children) && Object.keys((filteredObj.children as StructuredOutput)?.schema?.properties || {}).length > 0)
       )
 
       if ((item.type === VarType.object || item.type === VarType.file) && itemChildren)


### PR DESCRIPTION
…ilteredObj and StructuredOutput schema

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/22567

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

before
<img width="715" height="491" alt="467486124-889f4e2c-f50e-4e36-8021-16c7e9d01d6b" src="https://github.com/user-attachments/assets/3a82caf0-e65f-4f56-a76c-16d7e584daf0" />

after change we can select sub item of same type
<img width="881" height="406" alt="Screenshot 2025-07-27 at 12 03 38 AM" src="https://github.com/user-attachments/assets/d3cb85f3-2503-4381-9ca7-248baac8d975" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
