### PR TITLE
feat: add output structure in parameters api

### DIFF
--- a/api/controllers/common/fields.py
+++ b/api/controllers/common/fields.py
@@ -29,6 +29,7 @@ class Parameters(BaseModel):
     annotation_reply: JSONObject
     more_like_this: JSONObject
     user_input_form: list[JSONObject]
+    workflow_output_form: list[JSONObject]  # Added: workflow output schema
     sensitive_word_avoidance: JSONObject
     file_upload: JSONObject
     system_parameters: SystemParameters

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -59,6 +59,8 @@ class AppParameterApi(WebApiResource):
 
             features_dict = workflow.features_dict
             user_input_form = workflow.user_input_form(to_old_structure=True)
+            # Get workflow output form
+            workflow_output_form = workflow.output_form()
         else:
             app_model_config = app_model.app_model_config
             if app_model_config is None:
@@ -67,8 +69,11 @@ class AppParameterApi(WebApiResource):
             features_dict = app_model_config.to_dict()
 
             user_input_form = features_dict.get("user_input_form", [])
+            workflow_output_form = []
 
-        parameters = get_parameters_from_feature_dict(features_dict=features_dict, user_input_form=user_input_form)
+        parameters = get_parameters_from_feature_dict(
+            features_dict=features_dict, user_input_form=user_input_form, workflow_output_form=workflow_output_form
+        )
         return fields.Parameters.model_validate(parameters).model_dump(mode="json")
 
 

--- a/api/core/app/app_config/common/parameters_mapping/__init__.py
+++ b/api/core/app/app_config/common/parameters_mapping/__init__.py
@@ -6,7 +6,10 @@ from constants import DEFAULT_FILE_NUMBER_LIMITS
 
 
 def get_parameters_from_feature_dict(
-    *, features_dict: Mapping[str, Any], user_input_form: list[dict[str, Any]]
+    *,
+    features_dict: Mapping[str, Any],
+    user_input_form: list[dict[str, Any]],
+    workflow_output_form: list[dict[str, Any]] = [],
 ) -> Mapping[str, Any]:
     """
     Mapping from feature dict to webapp parameters
@@ -21,6 +24,7 @@ def get_parameters_from_feature_dict(
         "annotation_reply": features_dict.get("annotation_reply", {"enabled": False}),
         "more_like_this": features_dict.get("more_like_this", {"enabled": False}),
         "user_input_form": user_input_form,
+        "workflow_output_form": workflow_output_form,
         "sensitive_word_avoidance": features_dict.get(
             "sensitive_word_avoidance", {"enabled": False, "type": "", "configs": []}
         ),

--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -393,6 +393,48 @@ class Workflow(Base):  # bug
 
         return variables
 
+    def output_form(self) -> list:
+        """Get workflow output form from End nodes.
+
+        Workflow execution can branch and end at different End nodes. To help
+        callers map output schemas to their corresponding End nodes, this
+        method returns an array where each element contains the End node ID and
+        its output schema.
+
+        Return format:
+        [
+            { "end_id": "<end-node-id>", "outputs": [ ... ] },
+            ...
+        ]
+        """
+        if not self.graph:
+            return []
+
+        graph_dict = self.graph_dict
+        if "nodes" not in graph_dict:
+            return []
+
+        # Find all end nodes
+        end_nodes = [node for node in graph_dict["nodes"] if node["data"]["type"] == "end"]
+        if not end_nodes:
+            return []
+
+        # Collect outputs grouped by their End node
+        results = []
+        for end_node in end_nodes:
+            end_node_outputs = end_node.get("data", {}).get("outputs", [])
+            if not end_node_outputs:
+                # Skip End nodes without declared outputs
+                continue
+            results.append(
+                {
+                    "end_id": end_node.get("id"),
+                    "outputs": end_node_outputs,
+                }
+            )
+
+        return results
+
     @property
     def unique_hash(self) -> str:
         """

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -214,7 +214,34 @@ class TestAppParameterApi:
         """Test that get_parameters_from_feature_dict is called with workflow_output_form."""
         # Arrange
         mock_app_model.workflow = mock_workflow
-        mock_get_params.return_value = {"parameters": "test"}
+        mock_get_params.return_value = {
+            "opening_statement": None,
+            "suggested_questions": [],
+            "suggested_questions_after_answer": {"enabled": False},
+            "speech_to_text": {"enabled": False},
+            "text_to_speech": {"enabled": False},
+            "retriever_resource": {"enabled": False},
+            "annotation_reply": {"enabled": False},
+            "more_like_this": {"enabled": False},
+            "user_input_form": [],
+            "workflow_output_form": [],
+            "sensitive_word_avoidance": {"enabled": False, "type": "", "configs": []},
+            "file_upload": {
+                "image": {
+                    "enabled": False,
+                    "number_limits": 3,
+                    "detail": "high",
+                    "transfer_methods": ["remote_url", "local_file"],
+                }
+            },
+            "system_parameters": {
+                "image_file_size_limit": "10",
+                "video_file_size_limit": "100",
+                "audio_file_size_limit": "50",
+                "file_size_limit": "15",
+                "workflow_file_upload_limit": "10",
+            },
+        }
 
         # Act
         with app.app_context():
@@ -241,7 +268,34 @@ class TestAppParameterApi:
         mock_app_model_config = MagicMock()
         mock_app_model_config.to_dict.return_value = {"feature1": "value1", "user_input_form": []}
         mock_app_model.app_model_config = mock_app_model_config
-        mock_get_params.return_value = {"parameters": "test"}
+        mock_get_params.return_value = {
+            "opening_statement": None,
+            "suggested_questions": [],
+            "suggested_questions_after_answer": {"enabled": False},
+            "speech_to_text": {"enabled": False},
+            "text_to_speech": {"enabled": False},
+            "retriever_resource": {"enabled": False},
+            "annotation_reply": {"enabled": False},
+            "more_like_this": {"enabled": False},
+            "user_input_form": [],
+            "workflow_output_form": [],
+            "sensitive_word_avoidance": {"enabled": False, "type": "", "configs": []},
+            "file_upload": {
+                "image": {
+                    "enabled": False,
+                    "number_limits": 3,
+                    "detail": "high",
+                    "transfer_methods": ["remote_url", "local_file"],
+                }
+            },
+            "system_parameters": {
+                "image_file_size_limit": "10",
+                "video_file_size_limit": "100",
+                "audio_file_size_limit": "50",
+                "file_size_limit": "15",
+                "workflow_file_upload_limit": "10",
+            },
+        }
 
         # Act
         with app.app_context():

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -1,0 +1,431 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from controllers.web.app import AppParameterApi
+from controllers.web.error import AppUnavailableError
+from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
+from models.model import App, AppMode
+from models.workflow import Workflow
+
+
+class TestAppParameterApi:
+    """Test cases for AppParameterApi class."""
+
+    @pytest.fixture
+    def app(self):
+        """Create a Flask app for testing."""
+        app = Flask(__name__)
+        # Configure Flask-RESTX settings to avoid KeyError
+        app.config["RESTX_MASK_HEADER"] = "X-Fields"
+        app.config["RESTX_MASK_SWAGGER"] = False
+        return app
+
+    @pytest.fixture
+    def mock_app_model(self):
+        """Create a mock app model."""
+        app_model = MagicMock(spec=App)
+        app_model.mode = AppMode.WORKFLOW.value
+        return app_model
+
+    def _get_parameters_directly(self, app_model, end_user):
+        """Helper method to test the core logic without Flask-RESTX decorators."""
+        if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+            workflow = app_model.workflow
+            if workflow is None:
+                raise AppUnavailableError()
+
+            features_dict = workflow.features_dict
+            user_input_form = workflow.user_input_form(to_old_structure=True)
+            # Get workflow output form
+            workflow_output_form = workflow.output_form()
+        else:
+            app_model_config = app_model.app_model_config
+            if app_model_config is None:
+                raise AppUnavailableError()
+
+            features_dict = app_model_config.to_dict()
+
+            user_input_form = features_dict.get("user_input_form", [])
+            workflow_output_form = []
+
+        return get_parameters_from_feature_dict(
+            features_dict=features_dict, user_input_form=user_input_form, workflow_output_form=workflow_output_form
+        )
+
+    @pytest.fixture
+    def mock_workflow(self):
+        """Create a mock workflow with output form."""
+        workflow = MagicMock(spec=Workflow)
+
+        # Mock the output_form method to return test data
+        workflow.output_form.return_value = [
+            {
+                "end_id": "end1",
+                "outputs": [
+                    {"name": "output1", "type": "string", "description": "First output variable"},
+                ],
+            },
+            {
+                "end_id": "end2",
+                "outputs": [
+                    {"name": "output2", "type": "number", "description": "Second output variable"},
+                ],
+            },
+        ]
+
+        # Mock the user_input_form method
+        workflow.user_input_form.return_value = [
+            {"name": "input1", "type": "string", "description": "First input variable"}
+        ]
+
+        # Mock the features_dict property
+        workflow.features_dict = {"feature1": "value1", "feature2": "value2"}
+
+        return workflow
+
+    @pytest.fixture
+    def mock_end_user(self):
+        """Create a mock end user."""
+        return MagicMock()
+
+    def test_get_workflow_mode_with_output_form(self, app, mock_app_model, mock_workflow, mock_end_user):
+        """Test that workflow_output_form is correctly retrieved for workflow mode."""
+        # Arrange
+        mock_app_model.workflow = mock_workflow
+
+        # Act
+        with app.app_context():
+            result = self._get_parameters_directly(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        # Verify that output_form was called
+        mock_workflow.output_form.assert_called_once()
+        # Verify that user_input_form was called with correct parameter
+        mock_workflow.user_input_form.assert_called_once_with(to_old_structure=True)
+
+    def test_get_workflow_mode_without_workflow(self, app, mock_app_model, mock_end_user):
+        """Test that AppUnavailableError is raised when workflow is None."""
+        # Arrange
+        mock_app_model.workflow = None
+
+        # Act & Assert
+        with app.app_context():
+            with pytest.raises(AppUnavailableError):
+                self._get_parameters_directly(mock_app_model, mock_end_user)
+
+    def test_get_advanced_chat_mode_with_output_form(self, app, mock_app_model, mock_workflow, mock_end_user):
+        """Test that workflow_output_form is correctly retrieved for advanced chat mode."""
+        # Arrange
+        mock_app_model.mode = AppMode.ADVANCED_CHAT.value
+        mock_app_model.workflow = mock_workflow
+
+        # Act
+        with app.app_context():
+            result = self._get_parameters_directly(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        # Verify that output_form was called
+        mock_workflow.output_form.assert_called_once()
+
+    def test_get_non_workflow_mode(self, app, mock_app_model, mock_end_user):
+        """Test that empty workflow_output_form is returned for non-workflow modes."""
+        # Arrange
+        mock_app_model.mode = AppMode.CHAT.value
+        mock_app_model_config = MagicMock()
+        mock_app_model_config.to_dict.return_value = {
+            "feature1": "value1",
+            "user_input_form": [{"name": "input1", "type": "string"}],
+        }
+        mock_app_model.app_model_config = mock_app_model_config
+        # Ensure workflow is None for non-workflow modes
+        mock_app_model.workflow = None
+
+        # Act
+        with app.app_context():
+            result = self._get_parameters_directly(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        # Verify that workflow.output_form was not called
+        assert mock_app_model.workflow is None
+
+    def test_get_non_workflow_mode_without_config(self, app, mock_app_model, mock_end_user):
+        """Test that AppUnavailableError is raised when app_model_config is None for non-workflow modes."""
+        # Arrange
+        mock_app_model.mode = AppMode.CHAT.value
+        mock_app_model.app_model_config = None
+
+        # Act & Assert
+        with app.app_context():
+            with pytest.raises(AppUnavailableError):
+                self._get_parameters_directly(mock_app_model, mock_end_user)
+
+    def test_workflow_output_form_empty(self, app, mock_app_model, mock_workflow, mock_end_user):
+        """Test that empty output form is handled correctly."""
+        # Arrange
+        mock_workflow.output_form.return_value = []
+        mock_app_model.workflow = mock_workflow
+
+        # Act
+        with app.app_context():
+            result = self._get_parameters_directly(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        mock_workflow.output_form.assert_called_once()
+
+    def test_workflow_output_form_with_multiple_outputs(self, app, mock_app_model, mock_workflow, mock_end_user):
+        """Test that multiple outputs in workflow_output_form are handled correctly."""
+        # Arrange
+        mock_workflow.output_form.return_value = [
+            {
+                "end_id": "end1",
+                "outputs": [
+                    {"name": "output1", "type": "string", "description": "First output"},
+                    {"name": "output2", "type": "number", "description": "Second output"},
+                ],
+            },
+            {
+                "end_id": "end2",
+                "outputs": [
+                    {"name": "output3", "type": "boolean", "description": "Third output"},
+                ],
+            },
+        ]
+        mock_app_model.workflow = mock_workflow
+
+        # Act
+        with app.app_context():
+            result = self._get_parameters_directly(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        mock_workflow.output_form.assert_called_once()
+
+    @patch("controllers.web.app.get_parameters_from_feature_dict")
+    def test_get_parameters_from_feature_dict_called_with_output_form(
+        self, mock_get_params, app, mock_app_model, mock_workflow, mock_end_user
+    ):
+        """Test that get_parameters_from_feature_dict is called with workflow_output_form."""
+        # Arrange
+        mock_app_model.workflow = mock_workflow
+        mock_get_params.return_value = {"parameters": "test"}
+
+        # Act
+        with app.app_context():
+            with app.test_request_context():
+                api = AppParameterApi()
+                result = api.get(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        mock_get_params.assert_called_once()
+        call_args = mock_get_params.call_args
+        assert "workflow_output_form" in call_args.kwargs
+        assert call_args.kwargs["workflow_output_form"] == mock_workflow.output_form.return_value
+
+    @patch("controllers.web.app.get_parameters_from_feature_dict")
+    def test_get_parameters_from_feature_dict_called_without_output_form(
+        self, mock_get_params, app, mock_app_model, mock_end_user
+    ):
+        """
+        Test that get_parameters_from_feature_dict is called with empty workflow_output_form for non-workflow modes.
+        """
+        # Arrange
+        mock_app_model.mode = AppMode.CHAT.value
+        mock_app_model_config = MagicMock()
+        mock_app_model_config.to_dict.return_value = {"feature1": "value1", "user_input_form": []}
+        mock_app_model.app_model_config = mock_app_model_config
+        mock_get_params.return_value = {"parameters": "test"}
+
+        # Act
+        with app.app_context():
+            with app.test_request_context():
+                api = AppParameterApi()
+                result = api.get(mock_app_model, mock_end_user)
+
+        # Assert
+        assert result is not None
+        mock_get_params.assert_called_once()
+        call_args = mock_get_params.call_args
+        assert "workflow_output_form" in call_args.kwargs
+        assert call_args.kwargs["workflow_output_form"] == []
+
+
+class TestWorkflowOutputForm:
+    """Test cases specifically for the workflow output_form functionality."""
+
+    def test_workflow_output_form_method(self):
+        """Test the workflow output_form method directly."""
+        # Arrange
+        workflow = Workflow(
+            tenant_id="tenant_id",
+            app_id="app_id",
+            type="workflow",
+            version="draft",
+            graph=json.dumps(
+                {
+                    "nodes": [
+                        {"id": "start", "data": {"type": "start", "variables": [{"name": "input1", "type": "string"}]}},
+                        {
+                            "id": "end1",
+                            "data": {
+                                "type": "end",
+                                "outputs": [
+                                    {"name": "output1", "type": "string", "description": "First output"},
+                                    {"name": "output2", "type": "number", "description": "Second output"},
+                                ],
+                            },
+                        },
+                        {
+                            "id": "end2",
+                            "data": {
+                                "type": "end",
+                                "outputs": [{"name": "output3", "type": "boolean", "description": "Third output"}],
+                            },
+                        },
+                    ]
+                }
+            ),
+            features="{}",
+            created_by="account_id",
+            environment_variables=[],
+            conversation_variables=[],
+        )
+
+        # Act
+        result = workflow.output_form()
+
+        # Assert
+        expected_outputs = [
+            {
+                "end_id": "end1",
+                "outputs": [
+                    {"name": "output1", "type": "string", "description": "First output"},
+                    {"name": "output2", "type": "number", "description": "Second output"},
+                ],
+            },
+            {
+                "end_id": "end2",
+                "outputs": [
+                    {"name": "output3", "type": "boolean", "description": "Third output"},
+                ],
+            },
+        ]
+        assert result == expected_outputs
+
+    def test_workflow_output_form_empty_graph(self):
+        """Test output_form with empty graph."""
+        # Arrange
+        workflow = Workflow(
+            tenant_id="tenant_id",
+            app_id="app_id",
+            type="workflow",
+            version="draft",
+            graph="",
+            features="{}",
+            created_by="account_id",
+            environment_variables=[],
+            conversation_variables=[],
+        )
+
+        # Act
+        result = workflow.output_form()
+
+        # Assert
+        assert result == []
+
+    def test_workflow_output_form_no_nodes(self):
+        """Test output_form with graph containing no nodes."""
+        # Arrange
+        workflow = Workflow(
+            tenant_id="tenant_id",
+            app_id="app_id",
+            type="workflow",
+            version="draft",
+            graph=json.dumps({}),
+            features="{}",
+            created_by="account_id",
+            environment_variables=[],
+            conversation_variables=[],
+        )
+
+        # Act
+        result = workflow.output_form()
+
+        # Assert
+        assert result == []
+
+    def test_workflow_output_form_no_end_nodes(self):
+        """Test output_form with graph containing no end nodes."""
+        # Arrange
+        workflow = Workflow(
+            tenant_id="tenant_id",
+            app_id="app_id",
+            type="workflow",
+            version="draft",
+            graph=json.dumps(
+                {
+                    "nodes": [
+                        {"id": "start", "data": {"type": "start", "variables": []}},
+                        {"id": "llm", "data": {"type": "llm", "outputs": []}},
+                    ]
+                }
+            ),
+            features="{}",
+            created_by="account_id",
+            environment_variables=[],
+            conversation_variables=[],
+        )
+
+        # Act
+        result = workflow.output_form()
+
+        # Assert
+        assert result == []
+
+    def test_workflow_output_form_end_node_without_outputs(self):
+        """Test output_form with end node that has no outputs."""
+        # Arrange
+        workflow = Workflow(
+            tenant_id="tenant_id",
+            app_id="app_id",
+            type="workflow",
+            version="draft",
+            graph=json.dumps({"nodes": [{"id": "end1", "data": {"type": "end", "outputs": []}}]}),
+            features="{}",
+            created_by="account_id",
+            environment_variables=[],
+            conversation_variables=[],
+        )
+
+        # Act
+        result = workflow.output_form()
+
+        # Assert
+        assert result == []
+
+    def test_workflow_output_form_invalid_json(self):
+        """Test output_form with invalid JSON in graph."""
+        # Arrange
+        workflow = Workflow(
+            tenant_id="tenant_id",
+            app_id="app_id",
+            type="workflow",
+            version="draft",
+            graph="invalid json",
+            features="{}",
+            created_by="account_id",
+            environment_variables=[],
+            conversation_variables=[],
+        )
+
+        # Act & Assert
+        # The output_form method calls graph_dict which will raise JSONDecodeError for invalid JSON
+        with pytest.raises(json.JSONDecodeError):
+            workflow.output_form()


### PR DESCRIPTION
Resolves https://github.com/langgenius/dify/issues/23011

When integrating a Dify workflow into an external system — such as a batch scheduler that periodically triggers workflows — it’s essential for that system to understand the workflow’s input and output structures. This information enables proper execution and result handling.

🌐 Current Integration Pattern

In typical scenarios, we want to provide only a Dify application URL to the external system. Using that URL, we can call Dify’s public web APIs to retrieve workflow information and trigger executions — all without requiring login credentials.

Currently, we’re able to obtain the user_input_form from the /parameters API, which gives us the structure of the workflow’s inputs.

❗️Problem
• The workflow’s output structure is not available via any unauthenticated API;
• This makes it impossible for an external system to anticipate the output format when invoking a workflow;
• Without login, there’s no way to programmatically retrieve this information, creating a significant limitation for integration use cases.

✅ Suggested Solution

To address this issue, I propose either of the following:
1. Extend the existing /parameters API to include the output structure of the workflow;
2. Or, introduce a new unauthenticated API endpoint specifically for exposing output schema.

Here I go with the first one.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
