### PR TITLE
feat: Support selecting variables in conditional filtering in list operations.

### DIFF
--- a/api/core/workflow/nodes/list_operator/node.py
+++ b/api/core/workflow/nodes/list_operator/node.py
@@ -299,7 +299,7 @@ def _endswith(value: str) -> Callable[[str], bool]:
 
 
 def _is(value: str) -> Callable[[str], bool]:
-    return lambda x: x is value
+    return lambda x: x == value
 
 
 def _in(value: str | Sequence[str]) -> Callable[[str], bool]:

--- a/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
+++ b/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
@@ -84,8 +84,8 @@ const FilterCondition: FC<Props> = ({
   }, [condition, onChange, isArrayValue])
 
   const handleSubVariableChange = useCallback((value: string) => {
-    const operators = getOperators(expectedVarType ?? VarType.string, { key: value });
-    const newOperator = operators.length > 0 ? operators[0] : ComparisonOperator.equal;
+    const operators = getOperators(expectedVarType ?? VarType.string, { key: value })
+    const newOperator = operators.length > 0 ? operators[0] : ComparisonOperator.equal
     onChange({
       key: value,
       comparison_operator: newOperator,
@@ -143,7 +143,7 @@ const FilterCondition: FC<Props> = ({
             ) : (
               <input
                 type={(condition.key === 'size' || expectedVarType === VarType.number) ? 'number' : 'text'}
-                className={`${sharedInputStyles} border-components-input-border-hover bg-components-input-bg-normal`}
+                className='grow rounded-lg border border-components-input-border-hover bg-components-input-bg-normal px-3 py-[6px]'
                 value={condition.value}
                 onChange={e => handleChange('value')(e.target.value)}
                 readOnly={readOnly}

--- a/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
+++ b/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
@@ -1,36 +1,60 @@
 'use client'
 import type { FC } from 'react'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ConditionOperator from '../../if-else/components/condition-list/condition-operator'
-import { VarType } from '../../../types'
 import type { Condition } from '../types'
 import { ComparisonOperator } from '../../if-else/types'
 import { comparisonOperatorNotRequireValue, getOperators } from '../../if-else/utils'
 import SubVariablePicker from './sub-variable-picker'
-import Input from '@/app/components/base/input'
 import { FILE_TYPE_OPTIONS, TRANSFER_METHOD } from '@/app/components/workflow/nodes/constants'
 import { SimpleSelect as Select } from '@/app/components/base/select'
+import Input from '@/app/components/workflow/nodes/_base/components/input-support-select-var'
+import useAvailableVarList from '@/app/components/workflow/nodes/_base/hooks/use-available-var-list'
+import cn from '@/utils/classnames'
+import { VarType } from '../../../types'
 
 const optionNameI18NPrefix = 'workflow.nodes.ifElse.optionName'
+
+const VAR_INPUT_SUPPORTED_KEYS: Record<string, VarType> = {
+  name: VarType.string,
+  url: VarType.string,
+  extension: VarType.string,
+  mime_type: VarType.string,
+  related_id: VarType.number,
+}
+
 type Props = {
   condition: Condition
   onChange: (condition: Condition) => void
-  varType: VarType
   hasSubVariable: boolean
   readOnly: boolean
+  nodeId: string
 }
 
 const FilterCondition: FC<Props> = ({
   condition = { key: '', comparison_operator: ComparisonOperator.equal, value: '' },
-  varType,
   onChange,
   hasSubVariable,
   readOnly,
+  nodeId,
 }) => {
   const { t } = useTranslation()
+  const [isFocus, setIsFocus] = useState(false)
+
+  const expectedVarType = VAR_INPUT_SUPPORTED_KEYS[condition.key]
+  const supportVariableInput = !!expectedVarType
+
+  const { availableVars, availableNodesWithParent } = useAvailableVarList(nodeId, {
+    onlyLeafNodeVar: false,
+    filterVar: (varPayload) => {
+      return expectedVarType ? varPayload.type === expectedVarType : true
+    },
+  })
+
   const isSelect = [ComparisonOperator.in, ComparisonOperator.notIn, ComparisonOperator.allOf].includes(condition.comparison_operator)
   const isArrayValue = condition.key === 'transfer_method' || condition.key === 'type'
+
   const selectOptions = useMemo(() => {
     if (isSelect) {
       if (condition.key === 'type' || condition.comparison_operator === ComparisonOperator.allOf) {
@@ -49,6 +73,7 @@ const FilterCondition: FC<Props> = ({
     }
     return []
   }, [condition.comparison_operator, condition.key, isSelect, t])
+
   const handleChange = useCallback((key: string) => {
     return (value: any) => {
       onChange({
@@ -59,12 +84,13 @@ const FilterCondition: FC<Props> = ({
   }, [condition, onChange, isArrayValue])
 
   const handleSubVariableChange = useCallback((value: string) => {
+    const newOperator = getOperators(expectedVarType ?? VarType.string, { key: value })[0]
     onChange({
       key: value,
-      comparison_operator: getOperators(varType, { key: value })[0],
+      comparison_operator: newOperator,
       value: '',
     })
-  }, [onChange, varType])
+  }, [onChange, expectedVarType])
 
   return (
     <div>
@@ -78,7 +104,7 @@ const FilterCondition: FC<Props> = ({
       <div className='flex space-x-1'>
         <ConditionOperator
           className='h-8 bg-components-input-bg-normal'
-          varType={varType}
+          varType={expectedVarType ?? VarType.string}
           value={condition.comparison_operator}
           onSelect={handleChange('comparison_operator')}
           file={hasSubVariable ? { key: condition.key } : undefined}
@@ -86,7 +112,7 @@ const FilterCondition: FC<Props> = ({
         />
         {!comparisonOperatorNotRequireValue(condition.comparison_operator) && (
           <>
-            {isSelect && (
+            {isSelect ? (
               <Select
                 items={selectOptions}
                 defaultValue={isArrayValue ? (condition.value as string[])[0] : condition.value as string}
@@ -95,13 +121,31 @@ const FilterCondition: FC<Props> = ({
                 wrapperClassName='grow h-8'
                 placeholder='Select value'
               />
-            )}
-            {!isSelect && (
+            ) : supportVariableInput ? (
               <Input
-                type={((hasSubVariable && condition.key === 'size') || (!hasSubVariable && varType === VarType.number)) ? 'number' : 'text'}
-                className='grow'
+                instanceId='filter-condition-input'
+                className={cn(
+                  isFocus
+                    ? 'border-components-input-border-active bg-components-input-bg-active shadow-xs'
+                    : 'border-components-input-border-hover bg-components-input-bg-normal',
+                  'w-0 grow rounded-lg border px-3 py-[6px]'
+                )}
+                value={condition.value}
+                onChange={handleChange('value')}
+                readOnly={readOnly}
+                nodesOutputVars={availableVars}
+                availableNodes={availableNodesWithParent}
+                onFocusChange={setIsFocus}
+                placeholder={!readOnly ? t('workflow.nodes.http.extractListPlaceholder')! : ''}
+                placeholderClassName='!leading-[21px]'
+              />
+            ) : (
+              <input
+                type={(condition.key === 'size' || expectedVarType === VarType.number) ? 'number' : 'text'}
+                className='grow px-3 py-[6px] border rounded-lg border-components-input-border-hover bg-components-input-bg-normal'
                 value={condition.value}
                 onChange={e => handleChange('value')(e.target.value)}
+                readOnly={readOnly}
               />
             )}
           </>
@@ -110,4 +154,5 @@ const FilterCondition: FC<Props> = ({
     </div>
   )
 }
+
 export default React.memo(FilterCondition)

--- a/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
+++ b/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
@@ -143,7 +143,7 @@ const FilterCondition: FC<Props> = ({
             ) : (
               <input
                 type={(condition.key === 'size' || expectedVarType === VarType.number) ? 'number' : 'text'}
-                className='grow rounded-lg border border-components-input-border-hover bg-components-input-bg-normal px-3 py-[6px]'
+                className={`${sharedInputStyles} border-components-input-border-hover bg-components-input-bg-normal`}
                 value={condition.value}
                 onChange={e => handleChange('value')(e.target.value)}
                 readOnly={readOnly}

--- a/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
+++ b/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
@@ -84,7 +84,8 @@ const FilterCondition: FC<Props> = ({
   }, [condition, onChange, isArrayValue])
 
   const handleSubVariableChange = useCallback((value: string) => {
-    const newOperator = getOperators(expectedVarType ?? VarType.string, { key: value })[0]
+    const operators = getOperators(expectedVarType ?? VarType.string, { key: value });
+    const newOperator = operators.length > 0 ? operators[0] : ComparisonOperator.equal;
     onChange({
       key: value,
       comparison_operator: newOperator,

--- a/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
+++ b/web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx
@@ -128,7 +128,7 @@ const FilterCondition: FC<Props> = ({
                   isFocus
                     ? 'border-components-input-border-active bg-components-input-bg-active shadow-xs'
                     : 'border-components-input-border-hover bg-components-input-bg-normal',
-                  'w-0 grow rounded-lg border px-3 py-[6px]'
+                  'w-0 grow rounded-lg border px-3 py-[6px]',
                 )}
                 value={condition.value}
                 onChange={handleChange('value')}
@@ -142,7 +142,7 @@ const FilterCondition: FC<Props> = ({
             ) : (
               <input
                 type={(condition.key === 'size' || expectedVarType === VarType.number) ? 'number' : 'text'}
-                className='grow px-3 py-[6px] border rounded-lg border-components-input-border-hover bg-components-input-bg-normal'
+                className='grow rounded-lg border border-components-input-border-hover bg-components-input-bg-normal px-3 py-[6px]'
                 value={condition.value}
                 onChange={e => handleChange('value')(e.target.value)}
                 readOnly={readOnly}

--- a/web/app/components/workflow/nodes/list-operator/panel.tsx
+++ b/web/app/components/workflow/nodes/list-operator/panel.tsx
@@ -78,6 +78,7 @@ const Panel: FC<NodePanelProps<ListFilterNodeType>> = ({
                 varType={itemVarType}
                 hasSubVariable={hasSubVariable}
                 readOnly={readOnly}
+                nodeId={id}
               />
             )
             : null}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`

## Summary

### feat: Support selecting variables in conditional filtering in list-operation node.
PS: support for condition of `name,url,extension,mime_type,related_id`
### fix:  `is` condition not taking effect in condition filter of list-operation node.
Fixes https://github.com/langgenius/dify/issues/23032
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |
<img width="2244" height="992" alt="图片" src="https://github.com/user-attachments/assets/24255550-4703-4879-a247-6119099dbea2" />
<img width="544" height="561" alt="图片" src="https://github.com/user-attachments/assets/5d42ec80-5f8f-418a-a7cf-fcd514662324" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
