### PR TITLE
fix: delete the old provider_config_cache after refresh_credentials

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -237,7 +237,7 @@ class ToolManager:
                 if builtin_provider is None:
                     raise ToolProviderNotFoundError(f"builtin provider {provider_id} not found")
 
-            encrypter, _ = create_provider_encrypter(
+            encrypter, cache = create_provider_encrypter(
                 tenant_id=tenant_id,
                 config=[
                     x.to_basic_provider_config()
@@ -281,6 +281,7 @@ class ToolManager:
                 builtin_provider.expires_at = refreshed_credentials.expires_at
                 db.session.commit()
                 decrypted_credentials = refreshed_credentials.credentials
+                cache.delete()
 
             return cast(
                 BuiltinTool,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Problem

In `api/core/tools/tool_manager.py`, after
```
if builtin_provider.expires_at != -1 and (builtin_provider.expires_at - 60) < int(time.time()):
```
`get_tool_runtime` returns the refreshed credentials, but forgot to delete the previous `provider_config_cache`, resulting in retriving the old credentials from unfreshed cache the next time when `get_tool_runtime` is called.

### Resolution

Delete the previous `provider_config_cache` after credentials were updated.

### Related bug

Fixes #23028 

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
