### PR TITLE
minor fix: using the same AccountInFreezeError

### DIFF
--- a/api/controllers/console/auth/error.py
+++ b/api/controllers/console/auth/error.py
@@ -115,7 +115,4 @@ class MemberNotInTenantError(BaseHTTPException):
     code = 400
 
 
-class AccountInFreezeError(BaseHTTPException):
-    error_code = "account_in_freeze"
-    description = "This email is temporarily unavailable."
-    code = 400
+

--- a/api/controllers/console/auth/error.py
+++ b/api/controllers/console/auth/error.py
@@ -113,6 +113,3 @@ class MemberNotInTenantError(BaseHTTPException):
     error_code = "member_not_in_tenant"
     description = "The member is not in the workspace."
     code = 400
-
-
-

--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -9,14 +9,13 @@ from configs import dify_config
 from constants.languages import supported_language
 from controllers.console import api
 from controllers.console.auth.error import (
-    AccountInFreezeError,
     EmailAlreadyInUseError,
     EmailChangeLimitError,
     EmailCodeError,
     InvalidEmailError,
     InvalidTokenError,
 )
-from controllers.console.error import AccountNotFound, EmailSendIpLimitError
+from controllers.console.error import AccountInFreezeError, AccountNotFound, EmailSendIpLimitError
 from controllers.console.workspace.error import (
     AccountAlreadyInitedError,
     CurrentPasswordIncorrectError,


### PR DESCRIPTION
# PR Documentation

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR makes a minor fix by ensuring that the `AccountInFreezeError` is correctly imported from the `controllers.console.error` module instead of being defined in the `controllers.console.auth.error` module. This change addresses the issue of having duplicate definitions and improves code organization. 

### Issue Fixed
- This PR fixes the issue related to the incorrect placement of the `AccountInFreezeError` class.

### Motivation
- To maintain a clean and organized codebase by avoiding duplicate error classes.

### Dependencies
- No additional dependencies are required for this change.

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods.