### PR TITLE
ability to click classifier during workflow execution

### DIFF
--- a/web/app/components/workflow/nodes/question-classifier/components/class-list.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/components/class-list.tsx
@@ -64,55 +64,56 @@ const ClassList: FC<Props> = ({
   const handleSideWidth = 3
   // Todo Remove; edit topic name
   return (
-    <ReactSortable
-      list={list.map(item => ({ ...item }))}
-      setList={handleSortTopic}
-      handle='.handle'
-      ghostClass='bg-components-panel-bg'
-      animation={150}
-      disabled={readonly}
-      className='space-y-2'
-    >
-      {
-        list.map((item, index) => {
-          const canDrag = (() => {
-            if (readonly)
-              return false
+    <>
+      <ReactSortable
+        list={list.map(item => ({ ...item }))}
+        setList={handleSortTopic}
+        handle='.handle'
+        ghostClass='bg-components-panel-bg'
+        animation={150}
+        disabled={readonly}
+        className='space-y-2'
+      >
+        {
+          list.map((item, index) => {
+            const canDrag = (() => {
+              if (readonly)
+                return false
 
-            return topicCount >= 2
-          })()
-          return (
-            <div key={item.id}
-                className={cn(
-                  'group relative rounded-[10px] bg-components-panel-bg',
-                  `-ml-${handleSideWidth} min-h-[40px] px-0 py-0`,
-            )}>
-              <div >
-                <Item
-                  className={cn(canDrag && 'handle')}
-                  headerClassName={cn(canDrag && 'cursor-grab')}
-                  nodeId={nodeId}
-                  key={list[index].id}
-                  payload={item}
-                  onChange={handleClassChange(index)}
-                  onRemove={handleRemoveClass(index)}
-                  index={index + 1}
-                  readonly={readonly}
-                  filterVar={filterVar}
-                />
+              return topicCount >= 2
+            })()
+            return (
+              <div key={item.id}
+                  className={cn(
+                    'group relative rounded-[10px] bg-components-panel-bg',
+                    `-ml-${handleSideWidth} min-h-[40px] px-0 py-0`,
+              )}>
+                <div >
+                  <Item
+                    className={cn(canDrag && 'handle')}
+                    headerClassName={cn(canDrag && 'cursor-grab')}
+                    nodeId={nodeId}
+                    key={list[index].id}
+                    payload={item}
+                    onChange={handleClassChange(index)}
+                    onRemove={handleRemoveClass(index)}
+                    index={index + 1}
+                    readonly={readonly}
+                    filterVar={filterVar}
+                  />
+                </div>
               </div>
-            </div>
-          )
-        })
-      }
+            )
+          })
+        }
+      </ReactSortable>
       {!readonly && (
         <AddButton
           onClick={handleAddClass}
           text={t(`${i18nPrefix}.addClass`)}
         />
       )}
-
-    </ReactSortable>
+    </>
   )
 }
 export default React.memo(ClassList)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

close https://github.com/langgenius/dify/issues/23003

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

before (during classifier node execution if we click on it, we get below error)
<img width="1894" height="844" alt="Screenshot 2025-07-29 at 1 36 22 AM" src="https://github.com/user-attachments/assets/9418f193-151a-41d1-a46e-c6b4286631cf" />

after (during execution of classifier node we can click on it now)
<img width="1920" height="1080" alt="Screenshot 2025-07-29 at 1 41 11 AM (2)" src="https://github.com/user-attachments/assets/2b85433d-9bc8-4998-8ff0-6037a876c76e" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
