### PR TITLE
hotfix: clear_all_annotations should also execute delete_annotation_index_task just like delete_app_annotation

### DIFF
--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -452,7 +452,7 @@ class AppAnnotationService:
         if not app:
             raise NotFound("App not found")
 
-        # if annotation reply is enabled , delete annotation index
+        # if annotation reply is enabled, delete annotation index
         app_annotation_setting = (
             db.session.query(AppAnnotationSetting).where(AppAnnotationSetting.app_id == app_id).first()
         )

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -465,7 +465,7 @@ class AppAnnotationService:
             for annotation_hit_history in annotation_hit_histories_query.yield_per(100):
                 db.session.delete(annotation_hit_history)
 
-            # if annotation reply is enabled , delete annotation index
+            # if annotation reply is enabled, delete annotation index
             if app_annotation_setting:
                 delete_annotation_index_task.delay(
                     annotation.id, app_id, current_user.current_tenant_id, app_annotation_setting.collection_binding_id


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

clear_all_annotations should also execute delete_annotation_index_task just like delete_app_annotation

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
