### PR TITLE
minor fix: wrong position of retry_document_indexing_task time elapsed

### DIFF
--- a/api/tasks/retry_document_indexing_task.py
+++ b/api/tasks/retry_document_indexing_task.py
@@ -95,8 +95,8 @@ def retry_document_indexing_task(dataset_id: str, document_ids: list[str]):
                 logging.info(click.style(str(ex), fg="yellow"))
                 redis_client.delete(retry_indexing_cache_key)
                 logging.exception("retry_document_indexing_task failed, document_id: %s", document_id)
-            end_at = time.perf_counter()
-            logging.info(click.style(f"Retry dataset: {dataset_id} latency: {end_at - start_at}", fg="green"))
+        end_at = time.perf_counter()
+        logging.info(click.style(f"Retry dataset: {dataset_id} latency: {end_at - start_at}", fg="green"))
     except Exception as e:
         logging.exception(
             "retry_document_indexing_task failed, dataset_id: %s, document_ids: %s", dataset_id, document_ids


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix wrong position of retry_document_indexing_task time elapsed, should be at the end not each doc

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
