### PR TITLE
Fix: add missing db.session.close() to ensure proper session cleanup

### DIFF
--- a/api/tasks/add_document_to_index_task.py
+++ b/api/tasks/add_document_to_index_task.py
@@ -32,6 +32,7 @@ def add_document_to_index_task(dataset_document_id: str):
         return
 
     if dataset_document.indexing_status != "completed":
+        db.session.close()
         return
 
     indexing_cache_key = f"document_{dataset_document.id}_indexing"
@@ -112,3 +113,4 @@ def add_document_to_index_task(dataset_document_id: str):
         db.session.commit()
     finally:
         redis_client.delete(indexing_cache_key)
+        db.session.close()

--- a/api/tasks/create_segment_to_index_task.py
+++ b/api/tasks/create_segment_to_index_task.py
@@ -31,6 +31,7 @@ def create_segment_to_index_task(segment_id: str, keywords: Optional[list[str]] 
         return
 
     if segment.status != "waiting":
+        db.session.close()
         return
 
     indexing_cache_key = f"segment_{segment.id}_indexing"

--- a/api/tasks/document_indexing_sync_task.py
+++ b/api/tasks/document_indexing_sync_task.py
@@ -113,3 +113,5 @@ def document_indexing_sync_task(dataset_id: str, document_id: str):
                 logging.info(click.style(str(ex), fg="yellow"))
             except Exception:
                 logging.exception("document_indexing_sync_task failed, document_id: %s", document_id)
+            finally:
+                db.session.close()


### PR DESCRIPTION
## Summary
This change ensures that SQLAlchemy sessions are not left open in `add_document_to_index_task`, `create_segment_to_index_task` and `document_indexing_sync_task`, which could otherwise lead to connection pool exhaustion or unexpected transactional behavior.

Related PR: #23094 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
