### PR TITLE
Fix: prevent KeyError in validate_api_list by correcting logical check

### DIFF
--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -46,9 +46,9 @@ class ExternalDatasetService:
     def validate_api_list(cls, api_settings: dict):
         if not api_settings:
             raise ValueError("api list is empty")
-        if "endpoint" not in api_settings and not api_settings["endpoint"]:
+        if not api_settings.get("endpoint"):
             raise ValueError("endpoint is required")
-        if "api_key" not in api_settings and not api_settings["api_key"]:
+        if not api_settings.get("api_key"):
             raise ValueError("api_key is required")
 
     @staticmethod


### PR DESCRIPTION
Previously, the condition:
`if "endpoint" not in api_settings or not api_settings["endpoint"]` 
would trigger a KeyError when 'endpoint' is missing from the dict.
This commit fixes the condition by using a safe and concise access pattern: 
`if not api_settings.get("endpoint")`

The same applies to 'api_key'.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
