### PR TITLE
Chore: use `Workflow.VERSION_DRAFT` instead of hardcoded `draft`

### DIFF
--- a/api/core/tools/workflow_as_tool/tool.py
+++ b/api/core/tools/workflow_as_tool/tool.py
@@ -142,7 +142,7 @@ class WorkflowTool(Tool):
         if not version:
             workflow = (
                 db.session.query(Workflow)
-                .where(Workflow.app_id == app_id, Workflow.version != "draft")
+                .where(Workflow.app_id == app_id, Workflow.version != Workflow.VERSION_DRAFT)
                 .order_by(Workflow.created_at.desc())
                 .first()
             )

--- a/api/services/workflow/workflow_converter.py
+++ b/api/services/workflow/workflow_converter.py
@@ -185,7 +185,7 @@ class WorkflowConverter:
             tenant_id=app_model.tenant_id,
             app_id=app_model.id,
             type=WorkflowType.from_app_mode(new_app_mode).value,
-            version="draft",
+            version=Workflow.VERSION_DRAFT,
             graph=json.dumps(graph),
             features=json.dumps(features),
             created_by=account_id,

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -382,9 +382,9 @@ class WorkflowService:
             tenant_id=app_model.tenant_id,
         )
 
-        eclosing_node_type_and_id = draft_workflow.get_enclosing_node_type_and_id(node_config)
-        if eclosing_node_type_and_id:
-            _, enclosing_node_id = eclosing_node_type_and_id
+        enclosing_node_type_and_id = draft_workflow.get_enclosing_node_type_and_id(node_config)
+        if enclosing_node_type_and_id:
+            _, enclosing_node_id = enclosing_node_type_and_id
         else:
             enclosing_node_id = None
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -105,7 +105,7 @@ class WorkflowService:
         workflow = (
             db.session.query(Workflow)
             .where(
-                Workflow.tenant_id == app_model.tenant_id, Workflow.app_id == app_model.id, Workflow.version == "draft"
+                Workflow.tenant_id == app_model.tenant_id, Workflow.app_id == app_model.id, Workflow.version == Workflow.VERSION_DRAFT
             )
             .first()
         )
@@ -219,7 +219,7 @@ class WorkflowService:
                 tenant_id=app_model.tenant_id,
                 app_id=app_model.id,
                 type=WorkflowType.from_app_mode(app_model.mode).value,
-                version="draft",
+                version=Workflow.VERSION_DRAFT,
                 graph=json.dumps(graph),
                 features=json.dumps(features),
                 created_by=account.id,
@@ -257,7 +257,7 @@ class WorkflowService:
         draft_workflow_stmt = select(Workflow).where(
             Workflow.tenant_id == app_model.tenant_id,
             Workflow.app_id == app_model.id,
-            Workflow.version == "draft",
+            Workflow.version == Workflow.VERSION_DRAFT,
         )
         draft_workflow = session.scalar(draft_workflow_stmt)
         if not draft_workflow:
@@ -644,7 +644,7 @@ class WorkflowService:
             raise ValueError(f"Workflow with ID {workflow_id} not found")
 
         # Check if workflow is a draft version
-        if workflow.version == "draft":
+        if workflow.version == Workflow.VERSION_DRAFT:
             raise DraftWorkflowDeletionError("Cannot delete draft workflow versions")
 
         # Check if this workflow is currently referenced by an app

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -105,7 +105,9 @@ class WorkflowService:
         workflow = (
             db.session.query(Workflow)
             .where(
-                Workflow.tenant_id == app_model.tenant_id, Workflow.app_id == app_model.id, Workflow.version == Workflow.VERSION_DRAFT
+                Workflow.tenant_id == app_model.tenant_id,
+                Workflow.app_id == app_model.id,
+                Workflow.version == Workflow.VERSION_DRAFT,
             )
             .first()
         )


### PR DESCRIPTION
- Refactor code to use `Workflow.VERSION_DRAFT` constant in place of the hardcoded `draft` string.
- Fix typos: eclosing_node_type_and_id -> enclosing_node_type_and_id

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>
## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
