### PR TITLE
fix: improve boolean field handling in plugin configuration forms

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/endpoint-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/endpoint-modal.tsx
@@ -47,19 +47,18 @@ const EndpointModal: FC<Props> = ({
         return
       }
     }
-    
+
     // Fix: Process boolean fields to ensure they are sent as proper boolean values
     const processedCredential = { ...tempCredential }
     formSchemas.forEach((field) => {
       if (field.type === 'boolean' && processedCredential[field.name] !== undefined) {
         const value = processedCredential[field.name]
-        if (typeof value === 'string') {
+        if (typeof value === 'string')
           processedCredential[field.name] = value === 'true' || value === '1' || value === 'True'
-        } else if (typeof value === 'number') {
+         else if (typeof value === 'number')
           processedCredential[field.name] = value === 1
-        } else if (typeof value === 'boolean') {
+         else if (typeof value === 'boolean')
           processedCredential[field.name] = value
-        }
       }
     })
 

--- a/web/app/components/plugins/plugin-detail-panel/endpoint-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/endpoint-modal.tsx
@@ -47,7 +47,23 @@ const EndpointModal: FC<Props> = ({
         return
       }
     }
-    onSaved(tempCredential)
+    
+    // Fix: Process boolean fields to ensure they are sent as proper boolean values
+    const processedCredential = { ...tempCredential }
+    formSchemas.forEach((field) => {
+      if (field.type === 'boolean' && processedCredential[field.name] !== undefined) {
+        const value = processedCredential[field.name]
+        if (typeof value === 'string') {
+          processedCredential[field.name] = value === 'true' || value === '1' || value === 'True'
+        } else if (typeof value === 'number') {
+          processedCredential[field.name] = value === 1
+        } else if (typeof value === 'boolean') {
+          processedCredential[field.name] = value
+        }
+      }
+    })
+
+    onSaved(processedCredential)
   }
 
   return (

--- a/web/app/components/tools/utils/to-form-schema.ts
+++ b/web/app/components/tools/utils/to-form-schema.ts
@@ -63,6 +63,17 @@ export const addDefaultValue = (value: Record<string, any>, formSchemas: { varia
     const itemValue = value[formSchema.variable]
     if ((formSchema.default !== undefined) && (value === undefined || itemValue === null || itemValue === '' || itemValue === undefined))
       newValues[formSchema.variable] = formSchema.default
+    
+    // Fix: Convert boolean field values to proper boolean type
+    if (formSchema.type === 'boolean' && itemValue !== undefined && itemValue !== null && itemValue !== '') {
+      if (typeof itemValue === 'string') {
+        newValues[formSchema.variable] = itemValue === 'true' || itemValue === '1' || itemValue === 'True'
+      } else if (typeof itemValue === 'number') {
+        newValues[formSchema.variable] = itemValue === 1
+      } else if (typeof itemValue === 'boolean') {
+        newValues[formSchema.variable] = itemValue
+      }
+    }
   })
   return newValues
 }

--- a/web/app/components/tools/utils/to-form-schema.ts
+++ b/web/app/components/tools/utils/to-form-schema.ts
@@ -63,16 +63,15 @@ export const addDefaultValue = (value: Record<string, any>, formSchemas: { varia
     const itemValue = value[formSchema.variable]
     if ((formSchema.default !== undefined) && (value === undefined || itemValue === null || itemValue === '' || itemValue === undefined))
       newValues[formSchema.variable] = formSchema.default
-    
+
     // Fix: Convert boolean field values to proper boolean type
     if (formSchema.type === 'boolean' && itemValue !== undefined && itemValue !== null && itemValue !== '') {
-      if (typeof itemValue === 'string') {
+      if (typeof itemValue === 'string')
         newValues[formSchema.variable] = itemValue === 'true' || itemValue === '1' || itemValue === 'True'
-      } else if (typeof itemValue === 'number') {
+       else if (typeof itemValue === 'number')
         newValues[formSchema.variable] = itemValue === 1
-      } else if (typeof itemValue === 'boolean') {
+       else if (typeof itemValue === 'boolean')
         newValues[formSchema.variable] = itemValue
-      }
     }
   })
   return newValues


### PR DESCRIPTION
Summary

This PR fixes an Internal Server Error that occurs when configuring endpoints in the Slack bot extension. The error was caused by improper handling of boolean fields in plugin configuration forms, where boolean values were being sent to the backend as strings or numbers instead of proper boolean types.

Problem

When users try to configure the Slack bot endpoint, they encounter an "Internal Server Error" message because:

Form fields with boolean type are being submitted as strings ("true", "false") or numbers (1, 0) instead of actual boolean values
The backend validation rejects these malformed boolean data types, causing the server to return a 500 error
This prevents users from successfully configuring Slack bot endpoints

Solution

The fix implements proper boolean field handling in two key areas:

Form Schema Processing (web/app/components/tools/utils/to-form-schema.ts):

Added boolean field conversion logic in addDefaultValue function
Converts string values ('true', '1', 'True') to proper boolean true
Converts number values (1) to boolean true, others to false

Preserves existing boolean values

Endpoint Configuration (web/app/components/plugins/plugin-detail-panel/endpoint-modal.tsx):
Added boolean field processing in handleSave function before calling onSaved
Creates a processed copy of form data with correct boolean types
Ensures all boolean fields are properly typed before sending to backend

Impact

✅ Fixes: Internal Server Error when configuring Slack bot endpoints
✅ Improves: Plugin configuration form reliability and user experience
✅ Maintains: Backward compatibility with existing functionality
✅ Enables: Users to successfully configure Slack bot endpoints without errors

Testing

Tested with Slack bot endpoint configuration forms
Verified boolean fields are properly converted from string/number to boolean
Confirmed no more Internal Server Error when saving endpoint configuration
Validated that existing functionality remains intact