### PR TITLE
chore(i18n): sync missing keys in zh-Hans and ja-JP

### DIFF
--- a/web/i18n/ja-JP/app-annotation.ts
+++ b/web/i18n/ja-JP/app-annotation.ts
@@ -83,6 +83,16 @@ const translation = {
     configConfirmBtn: '保存',
   },
   embeddingModelSwitchTip: '注釈テキストのベクトル化モデルです。モデルを切り替えると再埋め込みが行われ、追加のコストが発生します。',
+  list: {
+    delete: {
+      title: '本当に削除しますか？',
+    },
+  },
+  batchAction: {
+    cancel: 'キャンセル',
+    delete: '削除する',
+    selected: '選択された',
+  },
 }
 
 export default translation

--- a/web/i18n/zh-Hans/time.ts
+++ b/web/i18n/zh-Hans/time.ts
@@ -26,11 +26,11 @@ const translation = {
     now: '此刻',
     ok: '确定',
     cancel: '取消',
+    pickDate: '选择日期',
   },
   title: {
     pickTime: '选择时间',
   },
-  pickDate: '选择日期',
   defaultPlaceholder: '请选择时间...',
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix nested structure issues and add missing keys in zh-Hans and ja-JP

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
