### PR TITLE
fix: call checkOrSetAccessToken when app access mode is PUBLIC

### DIFF
--- a/web/app/components/app/overview/embedded/index.tsx
+++ b/web/app/components/app/overview/embedded/index.tsx
@@ -46,6 +46,12 @@ const OPTION_MAP = {
           ? `,
   baseUrl: '${url}${basePath}'`
           : ''},
+  inputs: {
+    // You can define the inputs from the Start node here
+    // key is the variable name
+    // e.g.
+    // name: "NAME"
+  },
   systemVariables: {
     // user_id: 'YOU CAN DEFINE USER ID HERE',
     // conversation_id: 'YOU CAN DEFINE CONVERSATION ID HERE, IT MUST BE A VALID UUID',

--- a/web/context/web-app-context.tsx
+++ b/web/context/web-app-context.tsx
@@ -61,20 +61,18 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const redirectUrlParam = searchParams.get('redirect_url')
-  const [shareCode, setShareCode] = useState<string | null>(null)
-  useEffect(() => {
-    const shareCodeFromRedirect = getShareCodeFromRedirectUrl(redirectUrlParam)
-    const shareCodeFromPathname = getShareCodeFromPathname(pathname)
-    const newShareCode = shareCodeFromRedirect || shareCodeFromPathname
-    setShareCode(newShareCode)
-    updateShareCode(newShareCode)
-  }, [pathname, redirectUrlParam, updateShareCode])
+
+  // Compute shareCode directly
+  const shareCode = getShareCodeFromRedirectUrl(redirectUrlParam) || getShareCodeFromPathname(pathname)
+  updateShareCode(shareCode)
+
   const { isFetching, data: accessModeResult } = useGetWebAppAccessModeByCode(shareCode)
-  const [isFetchingAccessToken, setIsFetchingAccessToken] = useState(true)
+  const [isFetchingAccessToken, setIsFetchingAccessToken] = useState(false)
+
   useEffect(() => {
     if (accessModeResult?.accessMode) {
       updateWebAppAccessMode(accessModeResult.accessMode)
-      if (accessModeResult?.accessMode === AccessMode.PUBLIC) {
+      if (accessModeResult.accessMode === AccessMode.PUBLIC) {
         setIsFetchingAccessToken(true)
         checkOrSetAccessToken(shareCode).finally(() => {
           setIsFetchingAccessToken(false)
@@ -84,7 +82,8 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
         setIsFetchingAccessToken(false)
       }
     }
-  }, [accessModeResult, updateWebAppAccessMode, setIsFetchingAccessToken, shareCode])
+  }, [accessModeResult, updateWebAppAccessMode, shareCode])
+
   if (isFetching || isFetchingAccessToken) {
     return <div className='flex h-full w-full items-center justify-center'>
       <Loading />

--- a/web/context/web-app-context.tsx
+++ b/web/context/web-app-context.tsx
@@ -61,8 +61,6 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const redirectUrlParam = searchParams.get('redirect_url')
-  const session = searchParams.get('session')
-  const sysUserId = searchParams.get('sys.user_id')
   const [shareCode, setShareCode] = useState<string | null>(null)
   useEffect(() => {
     const shareCodeFromRedirect = getShareCodeFromRedirectUrl(redirectUrlParam)
@@ -86,7 +84,7 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
         setIsFetchingAccessToken(false)
       }
     }
-  }, [accessModeResult, updateWebAppAccessMode, setIsFetchingAccessToken, shareCode, session, sysUserId])
+  }, [accessModeResult, updateWebAppAccessMode, setIsFetchingAccessToken, shareCode])
   if (isFetching || isFetchingAccessToken) {
     return <div className='flex h-full w-full items-center justify-center'>
       <Loading />

--- a/web/context/web-app-context.tsx
+++ b/web/context/web-app-context.tsx
@@ -76,7 +76,7 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (accessModeResult?.accessMode) {
       updateWebAppAccessMode(accessModeResult.accessMode)
-      if (accessModeResult?.accessMode === AccessMode.PUBLIC && session && sysUserId) {
+      if (accessModeResult?.accessMode === AccessMode.PUBLIC) {
         setIsFetchingAccessToken(true)
         checkOrSetAccessToken(shareCode).finally(() => {
           setIsFetchingAccessToken(false)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
