### PR TITLE
feat: Show models are used in which app

### DIFF
--- a/api/services/entities/model_provider_entities.py
+++ b/api/services/entities/model_provider_entities.py
@@ -162,6 +162,7 @@ class ModelWithProviderEntityResponse(ProviderModelWithStatusEntity):
     """
 
     provider: SimpleProviderEntityResponse
+    used_by_workflows: list = []
 
     def __init__(self, tenant_id: str, model: ModelWithProviderEntity) -> None:
         dump_model = model.model_dump()

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -97,7 +97,12 @@ class ModelProviderService:
                 graph = json.loads(workflow.graph)
                 for node in graph.get("nodes", []):
                     node_data = node.get("data", {})
-                    if node_data.get("type") in {"llm", "knowledge-retrieval", "agent"}:
+                    if node_data.get("type") in {"llm",
+                                                 "knowledge-retrieval",
+                                                 "agent",
+                                                 "question-classifier",
+                                                 "parameter-extractor"
+                                                 }:
                         model_info = node_data.get("model", {})
                         if model_info.get("provider") == provider:
                             if model_name := model_info.get("name"):

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -97,12 +97,13 @@ class ModelProviderService:
                 graph = json.loads(workflow.graph)
                 for node in graph.get("nodes", []):
                     node_data = node.get("data", {})
-                    if node_data.get("type") in {"llm",
-                                                 "knowledge-retrieval",
-                                                 "agent",
-                                                 "question-classifier",
-                                                 "parameter-extractor"
-                                                 }:
+                    if node_data.get("type") in {
+                        "llm",
+                        "knowledge-retrieval",
+                        "agent",
+                        "question-classifier",
+                        "parameter-extractor",
+                    }:
                         model_info = node_data.get("model", {})
                         if model_info.get("provider") == provider:
                             if model_name := model_info.get("name"):

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional, Dict, List
 
 from core.entities.model_entities import ModelStatus, ModelWithProviderEntity, ProviderModelWithStatusEntity
 from core.model_runtime.entities.model_entities import ModelType, ParameterRule
@@ -79,7 +79,7 @@ class ModelProviderService:
 
         return provider_responses
 
-    def _find_models_in_workflows(self, tenant_id: str, provider: str) -> dict:
+    def _find_models_in_workflows(self, tenant_id: str, provider: str) -> Dict[str, List[Dict[str, Any]]]:
         """Find model usages in workflows."""
         from models.model import App
         from models.workflow import Workflow
@@ -91,7 +91,7 @@ class ModelProviderService:
             .all()
         )
 
-        model_usages = {}
+        model_usages: Dict[str, List[Dict[str, Any]]] = {}
         for workflow, app_name in results:
             try:
                 graph = json.loads(workflow.graph)
@@ -110,7 +110,7 @@ class ModelProviderService:
 
         return model_usages
 
-    def _find_models_in_app_configs(self, tenant_id: str, provider: str) -> dict:
+    def _find_models_in_app_configs(self, tenant_id: str, provider: str) -> Dict[str, List[Dict[str, Any]]]:
         """Find model usages in app configurations."""
         from models.model import App
 
@@ -123,7 +123,7 @@ class ModelProviderService:
             .all()
         )
 
-        model_usages = {}
+        model_usages: Dict[str, List[Dict[str, Any]]] = {}
         for app_config, app_name in results:
             # find model in model_id
             if app_config.provider == provider and (model_name := app_config.model_id):
@@ -157,7 +157,7 @@ class ModelProviderService:
         app_config_usages = self._find_models_in_app_configs(tenant_id, provider)
 
         # Merge usages, removing duplicates by app_id
-        all_usages = {}
+        all_usages: Dict[str, Dict[str, Any]] = {}
         for source in [workflow_usages, app_config_usages]:
             for model_name, usages in source.items():
                 if model_name not in all_usages:

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Optional, Dict, List
+from typing import Any, Optional
 
 from core.entities.model_entities import ModelStatus, ModelWithProviderEntity, ProviderModelWithStatusEntity
 from core.model_runtime.entities.model_entities import ModelType, ParameterRule
@@ -79,7 +79,7 @@ class ModelProviderService:
 
         return provider_responses
 
-    def _find_models_in_workflows(self, tenant_id: str, provider: str) -> Dict[str, List[Dict[str, Any]]]:
+    def _find_models_in_workflows(self, tenant_id: str, provider: str) -> dict[str, list[dict[str, Any]]]:
         """Find model usages in workflows."""
         from models.model import App
         from models.workflow import Workflow
@@ -91,7 +91,7 @@ class ModelProviderService:
             .all()
         )
 
-        model_usages: Dict[str, List[Dict[str, Any]]] = {}
+        model_usages: dict[str, list[dict[str, Any]]] = {}
         for workflow, app_name in results:
             try:
                 graph = json.loads(workflow.graph)
@@ -110,7 +110,7 @@ class ModelProviderService:
 
         return model_usages
 
-    def _find_models_in_app_configs(self, tenant_id: str, provider: str) -> Dict[str, List[Dict[str, Any]]]:
+    def _find_models_in_app_configs(self, tenant_id: str, provider: str) -> dict[str, list[dict[str, Any]]]:
         """Find model usages in app configurations."""
         from models.model import App
 
@@ -123,7 +123,7 @@ class ModelProviderService:
             .all()
         )
 
-        model_usages: Dict[str, List[Dict[str, Any]]] = {}
+        model_usages: dict[str, list[dict[str, Any]]] = {}
         for app_config, app_name in results:
             # find model in model_id
             if app_config.provider == provider and (model_name := app_config.model_id):
@@ -157,7 +157,7 @@ class ModelProviderService:
         app_config_usages = self._find_models_in_app_configs(tenant_id, provider)
 
         # Merge usages, removing duplicates by app_id
-        all_usages: Dict[str, Dict[str, Any]] = {}
+        all_usages: dict[str, dict[str, Any]] = {}
         for source in [workflow_usages, app_config_usages]:
             for model_name, usages in source.items():
                 if model_name not in all_usages:

--- a/web/app/components/header/account-setting/model-provider-page/declarations.ts
+++ b/web/app/components/header/account-setting/model-provider-page/declarations.ts
@@ -153,6 +153,7 @@ export type ModelItem = {
   model_properties: Record<string, string | number>
   load_balancing_enabled: boolean
   deprecated?: boolean
+  used_by_workflows?: { app_id: string; name: string }[];
 }
 
 export enum PreferredProviderTypeEnum {

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list-item.tsx
@@ -84,7 +84,9 @@ const ModelListItem = ({ model, provider, isConfigurable, onConfig, onModifyLoad
           }
           offset={{ mainAxis: 4 }}
         >
-          <span className='ml-2 text-xs text-gray-400'>({model.used_by_workflows.length})</span>
+          <span className='ml-2'>
+            <ModelBadge className='text-xs text-gray-400'>{model.used_by_workflows.length}</ModelBadge>
+          </span>
         </Tooltip>
       )}
       <div className='flex shrink-0 items-center'>

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list-item.tsx
@@ -72,6 +72,21 @@ const ModelListItem = ({ model, provider, isConfigurable, onConfig, onModifyLoad
           </ModelBadge>
         )}
       </ModelName>
+     {model.used_by_workflows && model.used_by_workflows.length > 0 && (
+        <Tooltip
+          popupContent={
+            <div className='text-xs text-gray-500'>
+              <p>{t('common.modelProvider.usedByWorkflows')}:</p>
+              {model.used_by_workflows.map((workflow, index) => (
+                <p key={index} className='ml-2'>- {workflow.name}</p>
+              ))}
+            </div>
+          }
+          offset={{ mainAxis: 4 }}
+        >
+          <span className='ml-2 text-xs text-gray-400'>({model.used_by_workflows.length})</span>
+        </Tooltip>
+      )}
       <div className='flex shrink-0 items-center'>
         {
           model.fetch_from === ConfigurationMethodEnum.customizableModel

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -486,6 +486,7 @@ const translation = {
     discoverMore: 'Discover more in ',
     emptyProviderTitle: 'Model provider not set up',
     emptyProviderTip: 'Please install a model provider first.',
+    usedByWorkflows: 'Used by App',
   },
   dataSource: {
     add: 'Add a data source',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -486,6 +486,7 @@ const translation = {
     discoverMore: '发现更多就在',
     emptyProviderTitle: '尚未安装模型供应商',
     emptyProviderTip: '请安装模型供应商。',
+    usedByWorkflows: '被以下App使用',
   },
   dataSource: {
     add: '添加数据源',


### PR DESCRIPTION
fix #23056
fix https://github.com/langgenius/dify/issues/23225

## Summary

This providing a way to display model is used in which APP.

Modify the function '**get_models_by_provider**' in 'api/services/model_provider_service.py'


## Screenshots

<img width="762" height="200" alt="image" src="https://github.com/user-attachments/assets/db0b6348-0187-4b4b-abca-566e593253cd" />



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
