### PR TITLE
fix: correct plugin indentation

### DIFF
--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -508,10 +508,10 @@ class BuiltinToolManageService:
                 oauth_params = encrypter.decrypt(user_client.oauth_params)
                 return oauth_params
 
-            # only verified provider can use custom oauth client
-            is_verified = not isinstance(provider, PluginToolProviderController) or PluginService.is_plugin_verified(
-                tenant_id, provider.plugin_unique_identifier
-            )
+            # only verified provider can use official oauth client
+            is_verified = not isinstance(
+                provider_controller, PluginToolProviderController
+            ) or PluginService.is_plugin_verified(tenant_id, provider_controller.plugin_unique_identifier)
             if not is_verified:
                 return oauth_params
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an assoc
This pull request updates the logic for determining whether a provider can use an OAuth client. The key change involves a shift in terminology and logic to clarify that only verified providers can use an official OAuth client.

### Authorization logic updates:

* [`api/services/tools/builtin_tools_manage_service.py`](diffhunk://#diff-ef2c34db030a36a74232a4dce4d1c934387ba68dfe40f8860603ef2a75e99288L511-R514): Updated the `is_verified` logic to replace the term "custom OAuth client" with "official OAuth client" and adjusted the variable `provider` to `provider_controller` for consistency and clarity.iated issue and you have been assigned to it
> Fixes [23227](https://github.com/langgenius/dify/issues/23227)

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
