### PR TITLE
chore: Optimize dark mode styles (#23222)

### DIFF
--- a/web/app/components/base/emoji-picker/Inner.tsx
+++ b/web/app/components/base/emoji-picker/Inner.tsx
@@ -149,7 +149,8 @@ const EmojiPickerInner: FC<IEmojiPickerInnerProps> = ({
     {/* Color Select */}
     <div className={cn('flex items-center justify-between p-3 pb-0')}>
       <p className='system-xs-medium-uppercase mb-2 text-text-primary'>Choose Style</p>
-      {showStyleColors ? <ChevronDownIcon className='h-4 w-4' onClick={() => setShowStyleColors(!showStyleColors)} /> : <ChevronUpIcon className='h-4 w-4' onClick={() => setShowStyleColors(!showStyleColors)} />}
+      {showStyleColors ? <ChevronDownIcon className='h-4 w-4 cursor-pointer text-text-quaternary' onClick={() => setShowStyleColors(!showStyleColors)} />
+        : <ChevronUpIcon className='h-4 w-4 cursor-pointer text-text-quaternary' onClick={() => setShowStyleColors(!showStyleColors)} />}
     </div>
     {showStyleColors && <div className='grid w-full grid-cols-8 gap-1 px-3'>
       {backgroundColors.map((color) => {

--- a/web/app/components/plugins/marketplace/empty/index.tsx
+++ b/web/app/components/plugins/marketplace/empty/index.tsx
@@ -46,7 +46,7 @@ const Empty = ({
       }
       <div className='absolute left-1/2 top-1/2 z-[2] flex -translate-x-1/2 -translate-y-1/2 flex-col items-center'>
         <div className='relative mb-3 flex h-14 w-14 items-center justify-center rounded-xl border border-dashed border-divider-deep bg-components-card-bg shadow-lg'>
-          <Group className='h-5 w-5' />
+          <Group className='h-5 w-5 text-text-primary' />
           <Line className='absolute right-[-1px] top-1/2 -translate-y-1/2' />
           <Line className='absolute left-[-1px] top-1/2 -translate-y-1/2' />
           <Line className='absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 rotate-90' />

--- a/web/app/components/tools/add-tool-modal/empty.tsx
+++ b/web/app/components/tools/add-tool-modal/empty.tsx
@@ -5,6 +5,7 @@ import { RiArrowRightUpLine } from '@remixicon/react'
 import Link from 'next/link'
 import cn from '@/utils/classnames'
 import { NoToolPlaceholder } from '../../base/icons/src/vender/other'
+import useTheme from '@/hooks/use-theme'
 type Props = {
   type?: ToolTypeEnum
   isAgent?: boolean
@@ -25,6 +26,7 @@ const Empty = ({
   isAgent,
 }: Props) => {
   const { t } = useTranslation()
+  const { theme } = useTheme()
 
   const hasLink = type && [ToolTypeEnum.Custom, ToolTypeEnum.MCP].includes(type)
   const Comp = (hasLink ? Link : 'div') as any
@@ -34,7 +36,7 @@ const Empty = ({
 
   return (
     <div className='flex h-[336px] flex-col items-center justify-center'>
-      <NoToolPlaceholder />
+      <NoToolPlaceholder className={theme === 'dark' ? 'invert' : ''} />
       <div className='mb-1 mt-2 text-[13px] font-medium leading-[18px] text-text-primary'>
         {hasTitle ? t(`tools.addToolModal.${renderType}.title`) : 'No tools available'}
       </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add cursor-pointer class and text-text-quaternary color to expand/collapse icons in EmojiPicker
- Add text-text-primary color to Marketplace empty state icons
- Dynamically adjust the color of AddToolModal empty state icons based on theme

Resolves #23222

## Screenshots

| Before | After |
|--------|-------|
| <img width="2399" height="507" alt="458614667b3337e08b98a630bec1e11" src="https://github.com/user-attachments/assets/1f1bce38-9ba8-429f-adb1-ac80d8281a08" />    | <img width="1875" height="639" alt="bb6b557901b4f1160c5fc72b7efba81" src="https://github.com/user-attachments/assets/7bfe4d29-0d23-4710-ad89-24fb7a27471f" />   |
| <img width="2519" height="1005" alt="2968a901f85c1aeab752824a4174662" src="https://github.com/user-attachments/assets/040418aa-8a2c-4caf-9393-6550d0e38478" />  | <img width="2527" height="1063" alt="50f388d272436b9e79add2300262518" src="https://github.com/user-attachments/assets/458f12d3-7efa-4905-99bd-bcaa3ccba4d1" />  |
| <img width="677" height="837" alt="e06ed0875191992999bc7a82c7da95b" src="https://github.com/user-attachments/assets/4f914b01-b2ab-469e-875e-7ba8d2fbc612" />  | <img width="769" height="963" alt="37f9fdf13eb6de063f581cc683a2b73" src="https://github.com/user-attachments/assets/0882b2cb-2080-4117-a7bf-a05f664bb40c" />  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
