### PR TITLE
fix: type for ProviderConfig.default

### DIFF
--- a/api/core/entities/provider_entities.py
+++ b/api/core/entities/provider_entities.py
@@ -176,7 +176,7 @@ class ProviderConfig(BasicProviderConfig):
 
     scope: AppSelectorScope | ModelSelectorScope | ToolSelectorScope | None = None
     required: bool = False
-    default: Optional[Union[int, str]] = None
+    default: Optional[Union[int, str, float, bool]] = None
     options: Optional[list[Option]] = None
     label: Optional[I18nObject] = None
     help: Optional[I18nObject] = None


### PR DESCRIPTION
- add `bool` to ProviderConfig.default

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When a boolean parameter with a default value was set in the plugin Provider, the default would be incorrectly returned as 0. This issue has been solved by modifying the corresponding model.

## Screenshots

| Before | After |
|--------|-------|
|<img width="314" height="267" alt="image" src="https://github.com/user-attachments/assets/7774c816-497c-42ab-9fe1-12d4f986f679" />|<img width="265" height="252" alt="image" src="https://github.com/user-attachments/assets/b1cbb65a-8eb7-4fee-a0f0-a4e9a225ad5e" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
