### PR TITLE
Fix: incorrect array element validation in SegmentType

### DIFF
--- a/api/core/variables/types.py
+++ b/api/core/variables/types.py
@@ -109,7 +109,7 @@ class SegmentType(StrEnum):
         elif array_validation == ArrayValidation.FIRST:
             return element_type.is_valid(value[0])
         else:
-            return all([element_type.is_valid(i, array_validation=ArrayValidation.NONE)] for i in value)
+            return all(element_type.is_valid(i, array_validation=ArrayValidation.NONE) for i in value)
 
     def is_valid(self, value: Any, array_validation: ArrayValidation = ArrayValidation.FIRST) -> bool:
         """
@@ -152,7 +152,7 @@ class SegmentType(StrEnum):
 
 
 _ARRAY_ELEMENT_TYPES_MAPPING: Mapping[SegmentType, SegmentType] = {
-    # ARRAY_ANY does not have correpond element type.
+    # ARRAY_ANY does not have corresponding element type.
     SegmentType.ARRAY_STRING: SegmentType.STRING,
     SegmentType.ARRAY_NUMBER: SegmentType.NUMBER,
     SegmentType.ARRAY_OBJECT: SegmentType.OBJECT,

--- a/api/tests/unit_tests/core/variables/test_segment_type.py
+++ b/api/tests/unit_tests/core/variables/test_segment_type.py
@@ -1,4 +1,4 @@
-from core.variables.types import SegmentType
+from core.variables.types import ArrayValidation, SegmentType
 
 
 class TestSegmentTypeIsArrayType:
@@ -17,7 +17,6 @@ class TestSegmentTypeIsArrayType:
         value is tested for the is_array_type method.
         """
         # Arrange
-        all_segment_types = set(SegmentType)
         expected_array_types = [
             SegmentType.ARRAY_ANY,
             SegmentType.ARRAY_STRING,
@@ -58,3 +57,27 @@ class TestSegmentTypeIsArrayType:
         for seg_type in enum_values:
             is_array = seg_type.is_array_type()
             assert isinstance(is_array, bool), f"is_array_type does not return a boolean for segment type {seg_type}"
+
+
+class TestSegmentTypeIsValidArrayValidation:
+    """
+    Test SegmentType.is_valid with array types using different validation strategies.
+    """
+
+    def test_array_validation_all_success(self):
+        value = ["hello", "world", "foo"]
+        assert SegmentType.ARRAY_STRING.is_valid(value, array_validation=ArrayValidation.ALL)
+
+    def test_array_validation_all_fail(self):
+        value = ["hello", 123, "world"]
+        # Should return False, since 123 is not a string
+        assert not SegmentType.ARRAY_STRING.is_valid(value, array_validation=ArrayValidation.ALL)
+
+    def test_array_validation_first(self):
+        value = ["hello", 123, None]
+        assert SegmentType.ARRAY_STRING.is_valid(value, array_validation=ArrayValidation.FIRST)
+
+    def test_array_validation_none(self):
+        value = [1, 2, 3]
+        # validation is None, skip
+        assert SegmentType.ARRAY_STRING.is_valid(value, array_validation=ArrayValidation.NONE)


### PR DESCRIPTION
Fixed a bug in `SegmentType._validate_array` where 
`all([...]) for i in value` was used incorrectly.
The code always returned True because it produced
a list of truthy values (e.g., `[[True], [False]]`), causing `all()` 
to succeed regardless of element validity. 
Now replaced with a correct generator expression.

Added tests to ensure invalid elements are properly 
detected when using `ArrayValidation.ALL`.

Fixed a typo and removed one line of unused code.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
