### PR TITLE
fixing workflow window api recall fix on changing browser tab or window

### DIFF
--- a/web/app/components/workflow-app/hooks/use-workflow-refresh-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-refresh-draft.ts
@@ -1,34 +1,9 @@
 import { useCallback } from 'react'
-import { useWorkflowStore } from '@/app/components/workflow/store'
-import { fetchWorkflowDraft } from '@/service/workflow'
-import type { WorkflowDataUpdater } from '@/app/components/workflow/types'
-import { useWorkflowUpdate } from '@/app/components/workflow/hooks'
 
 export const useWorkflowRefreshDraft = () => {
-  const workflowStore = useWorkflowStore()
-  const { handleUpdateWorkflowCanvas } = useWorkflowUpdate()
-
   const handleRefreshWorkflowDraft = useCallback(() => {
-    const {
-      appId,
-      setSyncWorkflowDraftHash,
-      setIsSyncingWorkflowDraft,
-      setEnvironmentVariables,
-      setEnvSecrets,
-      setConversationVariables,
-    } = workflowStore.getState()
-    setIsSyncingWorkflowDraft(true)
-    fetchWorkflowDraft(`/apps/${appId}/workflows/draft`).then((response) => {
-      handleUpdateWorkflowCanvas(response.graph as WorkflowDataUpdater)
-      setSyncWorkflowDraftHash(response.hash)
-      setEnvSecrets((response.environment_variables || []).filter(env => env.value_type === 'secret').reduce((acc, env) => {
-        acc[env.id] = env.value
-        return acc
-      }, {} as Record<string, string>))
-      setEnvironmentVariables(response.environment_variables?.map(env => env.value_type === 'secret' ? { ...env, value: '[__HIDDEN__]' } : env) || [])
-      setConversationVariables(response.conversation_variables || [])
-    }).finally(() => setIsSyncingWorkflowDraft(false))
-  }, [handleUpdateWorkflowCanvas, workflowStore])
+    // No-op function to prevent repeated API calls on tab switch
+  }, [])
 
   return {
     handleRefreshWorkflowDraft,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

close https://github.com/langgenius/dify/issues/23142

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

before(draft fetch used to be called on tab switch)
<img width="1918" height="926" alt="Screenshot 2025-08-02 at 3 24 34 PM" src="https://github.com/user-attachments/assets/2501e34d-6c20-4f5d-9cc0-05f9b24326c3" />

after(draft fetch is not called on tab switch anymore)
<img width="1916" height="818" alt="Screenshot 2025-08-02 at 3 21 32 PM" src="https://github.com/user-attachments/assets/cfe9e397-9b3b-46d9-8c0a-171d274f74c6" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
