### PR TITLE
fix(i18n): correct translation errors across multiple languages

### DIFF
--- a/web/i18n/de-DE/dataset-documents.ts
+++ b/web/i18n/de-DE/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: 'Synchronisieren',
       resume: 'Fortsetzen',
       pause: 'Pause',
+      download: 'Datei herunterladen',
     },
     index: {
       enable: 'Aktivieren',

--- a/web/i18n/de-DE/workflow.ts
+++ b/web/i18n/de-DE/workflow.ts
@@ -927,6 +927,7 @@ const translation = {
       deleteFailure: 'Version löschen fehlgeschlagen',
       restoreSuccess: 'Version wiederhergestellt',
       updateFailure: 'Aktualisierung der Version fehlgeschlagen',
+      copyIdSuccess: 'ID in die Zwischenablage kopiert',
     },
     latest: 'Neueste',
     nameThisVersion: 'Nennen Sie diese Version',
@@ -937,6 +938,7 @@ const translation = {
     editVersionInfo: 'Versionsinformationen bearbeiten',
     deletionTip: 'Die Löschung ist unumkehrbar, bitte bestätigen Sie.',
     restorationTip: 'Nach der Wiederherstellung der Version wird der aktuelle Entwurf überschrieben.',
+    copyId: 'ID kopieren',
   },
   debug: {
     noData: {

--- a/web/i18n/es-ES/dataset-documents.ts
+++ b/web/i18n/es-ES/dataset-documents.ts
@@ -31,6 +31,7 @@ const translation = {
       sync: 'Sincronizar',
       resume: 'Reanudar',
       pause: 'Pausa',
+      download: 'Descargar archivo',
     },
     index: {
       enable: 'Habilitar',

--- a/web/i18n/es-ES/workflow.ts
+++ b/web/i18n/es-ES/workflow.ts
@@ -927,6 +927,7 @@ const translation = {
       deleteFailure: 'Error al eliminar la versión',
       updateFailure: 'Error al actualizar la versión',
       restoreSuccess: 'Versión restaurada',
+      copyIdSuccess: 'ID copiado en el portapapeles',
     },
     releaseNotesPlaceholder: 'Describe lo que cambió',
     restorationTip: 'Después de la restauración de la versión, el borrador actual será sobrescrito.',
@@ -937,6 +938,7 @@ const translation = {
     currentDraft: 'Borrador Actual',
     editVersionInfo: 'Editar información de la versión',
     latest: 'Último',
+    copyId: 'Copiar ID',
   },
   debug: {
     noData: {

--- a/web/i18n/fa-IR/dataset-documents.ts
+++ b/web/i18n/fa-IR/dataset-documents.ts
@@ -31,6 +31,7 @@ const translation = {
       sync: 'همگام‌سازی',
       resume: 'ادامه',
       pause: 'مکث',
+      download: 'دانلود فایل',
     },
     index: {
       enable: 'فعال کردن',

--- a/web/i18n/fa-IR/workflow.ts
+++ b/web/i18n/fa-IR/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       deleteFailure: 'حذف نسخه موفق نبود',
       restoreFailure: 'بازگرداندن نسخه ناموفق بود',
       updateFailure: 'به‌روزرسانی نسخه ناموفق بود',
+      copyIdSuccess: 'شناسه در کلیپ بورد کپی شده است',
     },
     latest: 'آخرین',
     editVersionInfo: 'ویرایش اطلاعات نسخه',
@@ -940,6 +941,7 @@ const translation = {
     releaseNotesPlaceholder: 'شرح دهید چه چیزی تغییر کرده است',
     restorationTip: 'پس از بازیابی نسخه، پیش‌نویس فعلی بازنویسی خواهد شد.',
     deletionTip: 'حذف غیرقابل برگشت است، لطفا تأیید کنید.',
+    copyId: 'شناسه کپی',
   },
   debug: {
     noData: {

--- a/web/i18n/fr-FR/dataset-documents.ts
+++ b/web/i18n/fr-FR/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: 'Synchroniser',
       pause: 'Pause',
       resume: 'Reprendre',
+      download: 'Télécharger le fichier',
     },
     index: {
       enable: 'Activer',

--- a/web/i18n/fr-FR/workflow.ts
+++ b/web/i18n/fr-FR/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       deleteSuccess: 'Version supprimée',
       updateFailure: 'Échec de la mise à jour de la version',
       restoreFailure: 'Échec de la restauration de la version',
+      copyIdSuccess: 'ID copié dans le presse-papiers',
     },
     title: 'Versions',
     releaseNotesPlaceholder: 'Décrivez ce qui a changé',
@@ -940,6 +941,7 @@ const translation = {
     restorationTip: 'Après la restauration de la version, le brouillon actuel sera écrasé.',
     deletionTip: 'La suppression est irreversible, veuillez confirmer.',
     latest: 'Dernier',
+    copyId: 'Copier l’ID',
   },
   debug: {
     noData: {

--- a/web/i18n/hi-IN/dataset-documents.ts
+++ b/web/i18n/hi-IN/dataset-documents.ts
@@ -31,6 +31,7 @@ const translation = {
       sync: 'सिंक्रोनाइज़ करें',
       resume: 'रिज़्यूमे',
       pause: 'रोकें',
+      download: 'फ़ाइल डाउनलोड करें',
     },
     index: {
       enable: 'सक्रिय करें',

--- a/web/i18n/hi-IN/workflow.ts
+++ b/web/i18n/hi-IN/workflow.ts
@@ -950,6 +950,7 @@ const translation = {
       updateSuccess: 'संस्करण अपडेट किया गया',
       updateFailure: 'संस्करण अपडेट करने में विफल',
       restoreFailure: 'संस्करण को पुनर्स्थापित करने में विफल',
+      copyIdSuccess: 'आईडी क्लिपबोर्ड पर कॉपी हो गई',
     },
     latest: 'लेटेस्ट',
     editVersionInfo: 'संस्करण की जानकारी संपादित करें',
@@ -960,6 +961,7 @@ const translation = {
     restorationTip: 'संस्करण पुनर्स्थापन के बाद, वर्तमान ड्राफ्ट अधिलेखित किया जाएगा।',
     defaultName: 'अविभाजित संस्करण',
     deletionTip: 'हटाना अप्रतिबंधी है, कृपया पुष्टि करें।',
+    copyId: 'आईडी कॉपी करें',
   },
   debug: {
     noData: {

--- a/web/i18n/it-IT/dataset-documents.ts
+++ b/web/i18n/it-IT/dataset-documents.ts
@@ -29,8 +29,9 @@ const translation = {
       delete: 'Elimina',
       enableWarning: 'Il file archiviato non può essere abilitato',
       sync: 'Sincronizza',
-      resume: 'Riassumere',
+      resume: 'Riprendi',
       pause: 'Pausa',
+      download: 'Scarica file',
     },
     index: {
       enable: 'Abilita',

--- a/web/i18n/it-IT/workflow.ts
+++ b/web/i18n/it-IT/workflow.ts
@@ -956,6 +956,7 @@ const translation = {
       updateSuccess: 'Versione aggiornata',
       deleteFailure: 'Impossibile eliminare la versione',
       updateFailure: 'Impossibile aggiornare la versione',
+      copyIdSuccess: 'ID copiato negli appunti',
     },
     latest: 'Ultimo',
     defaultName: 'Versione senza titolo',
@@ -966,6 +967,7 @@ const translation = {
     currentDraft: 'Bozza attuale',
     restorationTip: 'Dopo il ripristino della versione, la bozza attuale verrà sovrascritta.',
     title: 'Versioni',
+    copyId: 'Copia ID',
   },
   debug: {
     noData: {

--- a/web/i18n/ja-JP/dataset-documents.ts
+++ b/web/i18n/ja-JP/dataset-documents.ts
@@ -32,6 +32,7 @@ const translation = {
       sync: '同期',
       pause: '一時停止',
       resume: '再開',
+      download: 'ファイルをダウンロード',
     },
     index: {
       enable: '有効にする',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -936,7 +936,9 @@ const translation = {
       deleteFailure: '削除に失敗しました',
       updateSuccess: '更新が完了しました',
       updateFailure: '更新に失敗しました',
+      copyIdSuccess: 'IDがクリップボードにコピーされました',
     },
+    copyId: 'IDをコピー',
   },
   debug: {
     noData: {

--- a/web/i18n/ko-KR/dataset-documents.ts
+++ b/web/i18n/ko-KR/dataset-documents.ts
@@ -28,8 +28,9 @@ const translation = {
       delete: '삭제',
       enableWarning: '아카이브된 파일은 활성화할 수 없습니다.',
       sync: '동기화',
-      resume: '이력서',
+      resume: '재개',
       pause: '일시 중지',
+      download: '파일 다운로드',
     },
     index: {
       enable: '활성화',

--- a/web/i18n/ko-KR/workflow.ts
+++ b/web/i18n/ko-KR/workflow.ts
@@ -977,6 +977,7 @@ const translation = {
       restoreFailure: '버전을 복원하지 못했습니다.',
       deleteFailure: '버전을 삭제하지 못했습니다.',
       updateSuccess: '버전이 업데이트되었습니다.',
+      copyIdSuccess: '클립보드에 복사된 ID',
     },
     editVersionInfo: '버전 정보 편집',
     latest: '최신',
@@ -987,6 +988,7 @@ const translation = {
     title: '버전 기록',
     deletionTip: '삭제는 되돌릴 수 없으니, 확인해 주시기 바랍니다.',
     restorationTip: '버전 복원 후 현재 초안이 덮어쓰여질 것입니다.',
+    copyId: 'ID 복사',
   },
   debug: {
     noData: {

--- a/web/i18n/pl-PL/dataset-documents.ts
+++ b/web/i18n/pl-PL/dataset-documents.ts
@@ -28,8 +28,9 @@ const translation = {
       delete: 'Usuń',
       enableWarning: 'Zarchiwizowany plik nie może zostać włączony',
       sync: 'Synchronizuj',
-      resume: 'Wznawiać',
+      resume: 'Wznów',
       pause: 'Pauza',
+      download: 'Pobierz plik',
     },
     index: {
       enable: 'Włącz',

--- a/web/i18n/pl-PL/workflow.ts
+++ b/web/i18n/pl-PL/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       deleteSuccess: 'Wersja usunięta',
       restoreSuccess: 'Wersja przywrócona',
       restoreFailure: 'Nie udało się przywrócić wersji',
+      copyIdSuccess: 'Identyfikator skopiowany do schowka',
     },
     currentDraft: 'Aktualny szkic',
     nameThisVersion: 'Nazwij tę wersję',
@@ -940,6 +941,7 @@ const translation = {
     editVersionInfo: 'Edytuj informacje o wersji',
     deletionTip: 'Usunięcie jest nieodwracalne, proszę potwierdzić.',
     restorationTip: 'Po przywróceniu wersji bieżący szkic zostanie nadpisany.',
+    copyId: 'Kopiuj ID',
   },
   debug: {
     noData: {

--- a/web/i18n/pt-BR/dataset-documents.ts
+++ b/web/i18n/pt-BR/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: 'Sincronizar',
       resume: 'Retomar',
       pause: 'Pausa',
+      download: 'Baixar arquivo',
     },
     index: {
       enable: 'Habilitar',

--- a/web/i18n/pt-BR/workflow.ts
+++ b/web/i18n/pt-BR/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       restoreFailure: 'Falha ao restaurar versão',
       restoreSuccess: 'Versão restaurada',
       deleteFailure: 'Falha ao deletar versão',
+      copyIdSuccess: 'ID copiado para a área de transferência',
     },
     title: 'Versões',
     latest: 'Último',
@@ -940,6 +941,7 @@ const translation = {
     restorationTip: 'Após a restauração da versão, o rascunho atual será substituído.',
     currentDraft: 'Rascunho Atual',
     deletionTip: 'A exclusão é irreversível, por favor confirme.',
+    copyId: 'Copiar ID',
   },
   debug: {
     noData: {

--- a/web/i18n/ro-RO/dataset-documents.ts
+++ b/web/i18n/ro-RO/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: 'Sincronizează',
       pause: 'Pauză',
       resume: 'Reia',
+      download: 'Descărcați fișierul',
     },
     index: {
       enable: 'Activează',

--- a/web/i18n/ro-RO/workflow.ts
+++ b/web/i18n/ro-RO/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       deleteFailure: 'Ștergerea versiunii a eșuat',
       updateSuccess: 'Versiune actualizată',
       updateFailure: 'Actualizarea versiunii a eșuat',
+      copyIdSuccess: 'ID copiat în clipboard',
     },
     latest: 'Cea mai recentă',
     title: 'Versiuni',
@@ -940,6 +941,7 @@ const translation = {
     releaseNotesPlaceholder: 'Descrie ce s-a schimbat',
     deletionTip: 'Ștergerea este irreversibilă, vă rugăm să confirmați.',
     currentDraft: 'Draftul curent',
+    copyId: 'Copiază ID',
   },
   debug: {
     noData: {

--- a/web/i18n/ru-RU/dataset-documents.ts
+++ b/web/i18n/ru-RU/dataset-documents.ts
@@ -29,8 +29,9 @@ const translation = {
       delete: 'Удалить',
       enableWarning: 'Архивный файл не может быть включен',
       sync: 'Синхронизировать',
-      resume: 'Продовжити',
+      resume: 'Возобновить',
       pause: 'Пауза',
+      download: 'Скачать файл',
     },
     index: {
       enable: 'Включить',

--- a/web/i18n/ru-RU/workflow.ts
+++ b/web/i18n/ru-RU/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       deleteSuccess: 'Версия удалена',
       updateFailure: 'Не удалось обновить версию',
       restoreFailure: 'Не удалось восстановить версию',
+      copyIdSuccess: 'ID скопирован в буфер обмена',
     },
     latest: 'Последний',
     restorationTip: 'После восстановления версии текущий черновик будет перезаписан.',
@@ -940,6 +941,7 @@ const translation = {
     currentDraft: 'Текущий проект',
     releaseNotesPlaceholder: 'Опишите, что изменилось',
     defaultName: 'Без названия версия',
+    copyId: 'Копировать ID',
   },
   debug: {
     noData: {

--- a/web/i18n/sl-SI/dataset-documents.ts
+++ b/web/i18n/sl-SI/dataset-documents.ts
@@ -31,6 +31,7 @@ const translation = {
       sync: 'Sinhroniziraj',
       pause: 'Zaustavi',
       resume: 'Nadaljuj',
+      download: 'Prenesi datoteko',
     },
     index: {
       enable: 'Omogoči',

--- a/web/i18n/sl-SI/workflow.ts
+++ b/web/i18n/sl-SI/workflow.ts
@@ -927,6 +927,7 @@ const translation = {
       restoreSuccess: 'Obnovljena različica',
       restoreFailure: 'Obnavljanje različice ni uspelo',
       updateSuccess: 'Različica posodobljena',
+      copyIdSuccess: 'ID kopiran v odložišče',
     },
     defaultName: 'Nepodpisana različica',
     deletionTip: 'Izbris je nepovraten, prosim potrdite.',
@@ -937,6 +938,7 @@ const translation = {
     nameThisVersion: 'Poimenujte to različico',
     releaseNotesPlaceholder: 'Opisujte, kaj se je spremenilo',
     restorationTip: 'Po obnovitvi različice bo trenutni osnutek prepisan.',
+    copyId: 'Kopiraj ID',
   },
   debug: {
     noData: {

--- a/web/i18n/th-TH/common.ts
+++ b/web/i18n/th-TH/common.ts
@@ -137,7 +137,7 @@ const translation = {
   menus: {
     status: 'Beta',
     explore: 'สํารวจ',
-    apps: 'เรียน',
+    apps: 'สตูดิโอ',
     plugins: 'ปลั๊กอิน',
     pluginsTips: 'รวมปลั๊กอินของบุคคลที่สามหรือสร้างปลั๊กอิน AI ที่เข้ากันได้กับ ChatGPT',
     datasets: 'ความรู้',

--- a/web/i18n/th-TH/dataset-documents.ts
+++ b/web/i18n/th-TH/dataset-documents.ts
@@ -31,6 +31,7 @@ const translation = {
       sync: 'ซิงค์',
       pause: 'หยุด',
       resume: 'ดำเนิน',
+      download: 'ดาวน์โหลดไฟล์',
     },
     index: {
       enable: 'เปิด',

--- a/web/i18n/th-TH/workflow.ts
+++ b/web/i18n/th-TH/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       restoreSuccess: 'เวอร์ชันที่กู้คืน',
       restoreFailure: 'ไม่สามารถกู้คืนเวอร์ชันได้',
       updateSuccess: 'อัปเดตเวอร์ชัน',
+      copyIdSuccess: 'คัดลอกรหัสไปยังคลิปบอร์ด',
     },
     releaseNotesPlaceholder: 'อธิบายว่าสิ่งที่เปลี่ยนแปลงไปคืออะไร',
     currentDraft: 'ร่างปัจจุบัน',
@@ -940,6 +941,7 @@ const translation = {
     nameThisVersion: 'ชื่อเวอร์ชันนี้',
     title: 'เวอร์ชัน',
     latest: 'ล่าสุด',
+    copyId: 'คัดลอก ID',
   },
   debug: {
     noData: {

--- a/web/i18n/tr-TR/dataset-documents.ts
+++ b/web/i18n/tr-TR/dataset-documents.ts
@@ -31,6 +31,7 @@ const translation = {
       sync: 'Senkronize et',
       pause: 'Duraklat',
       resume: 'Devam Et',
+      download: 'Dosyayı İndir',
     },
     index: {
       enable: 'Etkinleştir',

--- a/web/i18n/tr-TR/workflow.ts
+++ b/web/i18n/tr-TR/workflow.ts
@@ -931,6 +931,7 @@ const translation = {
       updateFailure: 'Sürüm güncellenemedi',
       updateSuccess: 'Sürüm güncellendi',
       deleteSuccess: 'Sürüm silindi',
+      copyIdSuccess: 'Kimlik panoya kopyalandı',
     },
     latest: 'Sonuncu',
     currentDraft: 'Mevcut Taslak',
@@ -941,6 +942,7 @@ const translation = {
     releaseNotesPlaceholder: 'Değişen şeyleri tanımlayın',
     nameThisVersion: 'Bu versiyona isim ver',
     deletionTip: 'Silme işlemi geri alınamaz, lütfen onaylayın.',
+    copyId: 'ID Kopyala',
   },
   debug: {
     noData: {

--- a/web/i18n/uk-UA/dataset-documents.ts
+++ b/web/i18n/uk-UA/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: 'Синхронізувати',
       pause: 'Пауза',
       resume: 'Продовжити',
+      download: 'Завантажити файл',
     },
     index: {
       enable: 'Активувати',

--- a/web/i18n/uk-UA/workflow.ts
+++ b/web/i18n/uk-UA/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       deleteSuccess: 'Версія видалена',
       restoreSuccess: 'Версія відновлена',
       updateFailure: 'Не вдалося оновити версію',
+      copyIdSuccess: 'ID скопійовано в буфер обміну',
     },
     defaultName: 'Без назви версія',
     restorationTip: 'Після відновлення версії нинішній проект буде перезаписано.',
@@ -940,6 +941,7 @@ const translation = {
     editVersionInfo: 'Редагувати інформацію про версію',
     nameThisVersion: 'Назвіть цю версію',
     latest: 'Останні новини',
+    copyId: 'Копіювати ідентифікатор',
   },
   debug: {
     noData: {

--- a/web/i18n/vi-VN/dataset-documents.ts
+++ b/web/i18n/vi-VN/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: 'Đồng bộ',
       pause: 'Tạm dừng',
       resume: 'Tiếp tục',
+      download: 'Tải xuống tập tin',
     },
     index: {
       enable: 'Kích hoạt',

--- a/web/i18n/vi-VN/workflow.ts
+++ b/web/i18n/vi-VN/workflow.ts
@@ -930,6 +930,7 @@ const translation = {
       updateSuccess: 'Phiên bản đã được cập nhật',
       restoreSuccess: 'Phiên bản đã được khôi phục',
       restoreFailure: 'Không thể khôi phục phiên bản',
+      copyIdSuccess: 'ID được sao chép vào khay nhớ tạm',
     },
     defaultName: 'Phiên bản không được đặt tên',
     releaseNotesPlaceholder: 'Mô tả những gì đã thay đổi',
@@ -940,6 +941,7 @@ const translation = {
     nameThisVersion: 'Đặt tên cho phiên bản này',
     restorationTip: 'Sau khi phục hồi phiên bản, bản nháp hiện tại sẽ bị ghi đè.',
     title: 'Các phiên bản',
+    copyId: 'Sao chép ID',
   },
   debug: {
     noData: {

--- a/web/i18n/zh-Hans/dataset-documents.ts
+++ b/web/i18n/zh-Hans/dataset-documents.ts
@@ -32,6 +32,7 @@ const translation = {
       sync: '同步',
       pause: '暂停',
       resume: '恢复',
+      download: '下载文件',
     },
     index: {
       enable: '启用中',

--- a/web/i18n/zh-Hant/dataset-documents.ts
+++ b/web/i18n/zh-Hant/dataset-documents.ts
@@ -30,6 +30,7 @@ const translation = {
       sync: '同步',
       resume: '恢復',
       pause: '暫停',
+      download: '下載檔案',
     },
     index: {
       enable: '啟用中',

--- a/web/i18n/zh-Hant/workflow.ts
+++ b/web/i18n/zh-Hant/workflow.ts
@@ -927,6 +927,7 @@ const translation = {
       updateSuccess: '版本已更新',
       deleteSuccess: '版本已刪除',
       deleteFailure: '無法刪除版本',
+      copyIdSuccess: 'ID 已複製到剪貼板',
     },
     nameThisVersion: '給這個版本命名',
     latest: '最新',
@@ -937,6 +938,7 @@ const translation = {
     deletionTip: '刪除是不可逆的，請確認。',
     releaseNotesPlaceholder: '描述發生了什麼變化',
     defaultName: '未命名版本',
+    copyId: '複製ID',
   },
   debug: {
     noData: {


### PR DESCRIPTION
## Summary

Fixed translation errors in dataset-documents and workflow files across multiple languages:

- Corrected semantic errors where "resume" was mistranslated (Korean: CV→continue, Russian: Ukrainian→Russian, etc.)
- Fixed button action translations to use proper imperative forms
- Added missing translations for download and copy ID functionality
- Ensured consistency with English source meanings

## Screenshots

N/A - Text-only translation fixes

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods