### PR TITLE
fix: resolve sidebar animation issues and improve app detail page UX

### DIFF
--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
@@ -56,33 +56,50 @@ const ExtraInfo = ({ isMobile, relatedApps, expand }: IExtraInfoProps) => {
   }, [isMobile, setShowTips])
 
   return <div>
-    {hasRelatedApps && (
-      <>
-        {!isMobile && (
-          <Tooltip
-            position='right'
-            noDecoration
-            popupContent={
-              <LinkedAppsPanel
-                relatedApps={relatedApps.data}
-                isMobile={isMobile}
-              />
-            }
-          >
-            <div className='system-xs-medium-uppercase inline-flex cursor-pointer items-center space-x-1 text-text-secondary'>
-              <span>{relatedAppsTotal || '--'} {t('common.datasetMenus.relatedApp')}</span>
-              <RiInformation2Line className='h-4 w-4' />
-            </div>
-          </Tooltip>
-        )}
+    {/* Related apps for desktop */}
+    <div className={classNames(
+      'transition-all duration-200 ease-in-out',
+      (hasRelatedApps && !isMobile)
+        ? 'w-auto opacity-100'
+        : 'pointer-events-none h-0 w-0 overflow-hidden opacity-0',
+    )}>
+      <Tooltip
+        position='right'
+        noDecoration
+        popupContent={
+          <LinkedAppsPanel
+            relatedApps={relatedApps?.data || []}
+            isMobile={isMobile}
+          />
+        }
+      >
+        <div className='system-xs-medium-uppercase inline-flex cursor-pointer items-center space-x-1 whitespace-nowrap text-text-secondary'>
+          <span>{relatedAppsTotal || '--'} {t('common.datasetMenus.relatedApp')}</span>
+          <RiInformation2Line className='h-4 w-4' />
+        </div>
+      </Tooltip>
+    </div>
 
-        {isMobile && <div className={classNames('pb-2 pt-4 text-xs font-medium uppercase text-text-tertiary', 'flex items-center justify-center gap-1 !px-0')}>
-          {relatedAppsTotal || '--'}
-          <PaperClipIcon className='h-4 w-4 text-text-secondary' />
-        </div>}
-      </>
-    )}
-    {!hasRelatedApps && !expand && (
+    {/* Related apps for mobile */}
+    <div className={classNames(
+      'transition-all duration-200 ease-in-out',
+      (hasRelatedApps && isMobile)
+        ? 'w-auto opacity-100'
+        : 'pointer-events-none h-0 w-0 overflow-hidden opacity-0',
+    )}>
+      <div className={classNames('pb-2 pt-4 text-xs font-medium uppercase text-text-tertiary', 'flex items-center justify-center gap-1 whitespace-nowrap !px-0')}>
+        {relatedAppsTotal || '--'}
+        <PaperClipIcon className='h-4 w-4 text-text-secondary' />
+      </div>
+    </div>
+
+    {/* No related apps tooltip */}
+    <div className={classNames(
+      'transition-all duration-200 ease-in-out',
+      (!hasRelatedApps && !expand)
+        ? 'w-auto opacity-100'
+        : 'pointer-events-none h-0 w-0 overflow-hidden opacity-0',
+    )}>
       <Tooltip
         position='right'
         noDecoration
@@ -103,12 +120,12 @@ const ExtraInfo = ({ isMobile, relatedApps, expand }: IExtraInfoProps) => {
           </div>
         }
       >
-        <div className='system-xs-medium-uppercase inline-flex cursor-pointer items-center space-x-1 text-text-secondary'>
+        <div className='system-xs-medium-uppercase inline-flex cursor-pointer items-center space-x-1 whitespace-nowrap text-text-secondary'>
           <span>{t('common.datasetMenus.noRelatedApp')}</span>
           <RiInformation2Line className='h-4 w-4' />
         </div>
       </Tooltip>
-    )}
+    </div>
   </div>
 }
 

--- a/web/app/components/app-sidebar/dataset-info.tsx
+++ b/web/app/components/app-sidebar/dataset-info.tsx
@@ -29,15 +29,17 @@ const DatasetInfo: FC<Props> = ({
       <div className='mr-3 shrink-0'>
         <AppIcon innerIcon={DatasetSvg} className='!border-[0.5px] !border-indigo-100 !bg-indigo-25' />
       </div>
-      {expand && (
-        <div className='mt-2'>
-          <div className='system-md-semibold text-text-secondary'>
-            {name}
-          </div>
-          <div className='system-2xs-medium-uppercase mt-1 text-text-tertiary'>{isExternal ? t('dataset.externalTag') : t('dataset.localDocs')}</div>
-          <div className='system-xs-regular  my-3 text-text-tertiary first-letter:capitalize'>{description}</div>
+      <div className={`transition-all duration-200 ease-in-out ${
+        expand
+          ? 'mt-2 w-auto opacity-100'
+          : 'pointer-events-none h-0 w-0 overflow-hidden opacity-0'
+      }`}>
+        <div className='system-md-semibold truncate whitespace-nowrap text-text-secondary'>
+          {name}
         </div>
-      )}
+        <div className='system-2xs-medium-uppercase mt-1 whitespace-nowrap text-text-tertiary'>{isExternal ? t('dataset.externalTag') : t('dataset.localDocs')}</div>
+        <div className='system-xs-regular my-3 whitespace-nowrap text-text-tertiary first-letter:capitalize'>{description}</div>
+      </div>
       {extraInfo}
     </div>
   )


### PR DESCRIPTION
Summary

This PR addresses sidebar animation problems in dataset pages following the pattern established in PR #23221 for consistent smooth transitions.

Issues Fixed:
- Text squeeze animation issues in datasets sidebar components
- Inconsistent conditional rendering causing layout shifts

Technical Implementation:
- Replace conditional rendering with CSS-controlled visibility using `opacity` and `width` transitions
- Apply consistent `transition-all duration-200 ease-in-out` across components
- Use `pointer-events-none` for hidden states to prevent unwanted interactions
- Maintain `whitespace-nowrap` to prevent text wrapping issues

Files Modified:
- `web/app/components/app-sidebar/dataset-info.tsx` - Fixed text squeeze animation
- `web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx` - Resolved ExtraInfo conditional rendering

Related to commit a82b55005b8f3d4532d17e1181fa894a9987288a which established the animation pattern for similar fixes.

Screenshots

Before	After	
Text squeeze animations causing jarring UX	Smooth CSS transitions with stable positioning	

Checklist

- This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- I've updated the documentation accordingly.
- I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods