### PR TITLE
fix: fix wrong unicodechar regx

### DIFF
--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -103,7 +103,7 @@ function unicodeToChar(text: string) {
   if (!text)
     return ''
 
-  return text.replace(/\\u[0-9a-f]{4}/g, (_match, p1) => {
+  return text.replace(/\\u([0-9a-f]{4})/g, (_match, p1) => {
     return String.fromCharCode(Number.parseInt(p1, 16))
   })
 }


### PR DESCRIPTION
## Summary

fix wrong unicodechar regx

## Screenshots

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/c3b77914-1de7-412a-8b46-056d9a06051a)|<img width="403" height="368" alt="image" src="https://github.com/user-attachments/assets/3cc82f3f-77e7-4291-83e2-e7d203e94525" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
