### PR TITLE
fix: can not find file

### DIFF
--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -68,6 +68,7 @@ export const useFile = (fileConfig: FileUpload) => {
         }
         return true
       }
+      case SupportUploadFileTypes.custom:
       case SupportUploadFileTypes.document: {
         if (fileSize > docSizeLimit) {
           notify({
@@ -101,19 +102,6 @@ export const useFile = (fileConfig: FileUpload) => {
             message: t('common.fileUploader.uploadFromComputerLimit', {
               type: SupportUploadFileTypes.video,
               size: formatFileSize(videoSizeLimit),
-            }),
-          })
-          return false
-        }
-        return true
-      }
-      case SupportUploadFileTypes.custom: {
-        if (fileSize > docSizeLimit) {
-          notify({
-            type: 'error',
-            message: t('common.fileUploader.uploadFromComputerLimit', {
-              type: SupportUploadFileTypes.document,
-              size: formatFileSize(docSizeLimit),
             }),
           })
           return false

--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -231,7 +231,7 @@ export const useFile = (fileConfig: FileUpload) => {
         url: res.url,
       }
       if (!isAllowedFileExtension(res.name, res.mime_type, fileConfig.allowed_file_types || [], fileConfig.allowed_file_extensions || [])) {
-        notify({ type: 'error', message: `${t('common.fileUploader.fileExtensionNotSupport')} ${file.type}` })
+        notify({ type: 'error', message: `${t('common.fileUploader.fileExtensionNotSupport')} ${newFile.type}` })
         handleRemoveFile(uploadingFile.id)
       }
       if (!checkSizeLimit(newFile.supportFileType, newFile.size))


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request makes a minor fix to the file uploader notification logic. The error message now correctly displays the file type of the newly uploaded file instead of the original file object.

* Fixed the error notification in the file uploader hook to display `newFile.type` instead of `file.type` for unsupported file extensions.
## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
