### PR TITLE
fix(node): fix unexpected extra equals sign in HTTP params

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -91,7 +91,7 @@ class Executor:
         self.auth = node_data.authorization
         self.timeout = timeout
         self.ssl_verify = node_data.ssl_verify
-        self.params = []
+        self.params = None
         self.headers = {}
         self.content = None
         self.files = None
@@ -139,7 +139,8 @@ class Executor:
                 (self.variable_pool.convert_template(key).text, self.variable_pool.convert_template(value_str).text)
             )
 
-        self.params = result
+        if result:
+            self.params = result
 
     def _init_headers(self):
         """

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -49,7 +49,7 @@ def test_executor_with_json_body_and_number_variable():
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/data"
     assert executor.headers == {"Content-Type": "application/json"}
-    assert executor.params == []
+    assert executor.params is None
     assert executor.json == {"number": 42}
     assert executor.data is None
     assert executor.files is None
@@ -102,7 +102,7 @@ def test_executor_with_json_body_and_object_variable():
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/data"
     assert executor.headers == {"Content-Type": "application/json"}
-    assert executor.params == []
+    assert executor.params is None
     assert executor.json == {"name": "John Doe", "age": 30, "email": "john@example.com"}
     assert executor.data is None
     assert executor.files is None
@@ -157,7 +157,7 @@ def test_executor_with_json_body_and_nested_object_variable():
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/data"
     assert executor.headers == {"Content-Type": "application/json"}
-    assert executor.params == []
+    assert executor.params is None
     assert executor.json == {"object": {"name": "John Doe", "age": 30, "email": "john@example.com"}}
     assert executor.data is None
     assert executor.files is None
@@ -245,7 +245,7 @@ def test_executor_with_form_data():
     assert executor.url == "https://api.example.com/upload"
     assert "Content-Type" in executor.headers
     assert "multipart/form-data" in executor.headers["Content-Type"]
-    assert executor.params == []
+    assert executor.params is None
     assert executor.json is None
     # '__multipart_placeholder__' is expected when no file inputs exist,
     # to ensure the request is treated as multipart/form-data by the backend.


### PR DESCRIPTION
The HTTP node was appending an unexpected '=' sign to query parameters, which caused the backend API to reject the request or return incorrect results.

This fix prevents adding '=' when parameters are empty or not needed, ensuring the HTTP request matches the remote endpoint expectations.

Fixes #23385

## Results

self-backend log
before: "GET /xxx/xxx.do?checkuser= HTTP/1.1"
after: "GET /xxx/xxx.do?checkuser HTTP/1.1"

## Summary

Fixes the issue where the HTTP node added an extra '=' sign at the end of query parameters when they were empty or missing. This caused incorrect API requests and failed responses.

The fix changes parameter defaults to 'None'(instead of []) to skip appending '=' when the value is empty.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
