### PR TITLE
fix localtime_to_timestamp tool throws 'no attribute localize error' when it executes without specifying a timezone parameter

### DIFF
--- a/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py
+++ b/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py
@@ -37,12 +37,12 @@ class LocaltimeToTimestampTool(BuiltinTool):
     @staticmethod
     def localtime_to_timestamp(localtime: str, time_format: str, local_tz=None) -> int | None:
         try:
-            if local_tz is None:
-                local_tz = datetime.now().astimezone().tzinfo
-            if isinstance(local_tz, str):
-                local_tz = pytz.timezone(local_tz)
             local_time = datetime.strptime(localtime, time_format)
-            localtime = local_tz.localize(local_time)  # type: ignore
+            if local_tz is None:
+                localtime = local_time.astimezone()
+            elif isinstance(local_tz, str):
+                local_tz = pytz.timezone(local_tz)
+                localtime = local_tz.localize(local_time)  # type: ignore
             timestamp = int(localtime.timestamp())  # type: ignore
             return timestamp
         except Exception as e:

--- a/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py
+++ b/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py
@@ -39,7 +39,7 @@ class LocaltimeToTimestampTool(BuiltinTool):
         try:
             local_time = datetime.strptime(localtime, time_format)
             if local_tz is None:
-                localtime = local_time.astimezone()
+                localtime = local_time.astimezone()  # type: ignore
             elif isinstance(local_tz, str):
                 local_tz = pytz.timezone(local_tz)
                 localtime = local_tz.localize(local_time)  # type: ignore


### PR DESCRIPTION
fix localtime_to_timestamp tool throws no attribute localize when it executes without specifying a timezone parameter


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
fixed https://github.com/langgenius/dify/issues/23531

When the user uses the localtime_to_timestamp tool, if the timezone field input box on the page is clicked, but no content input, the timezone parameter received by the backend server of the tool is an empty string, while the following code sets the timezone parameter to None

https://github.com/langgenius/dify/blob/c95761f4e6234a27a31446bec768da72826d3324/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py#L25-L27

When the timezone parameter is None, the 'local_tz' is the instance of 'datetime.timezone' which no attribute localize

https://github.com/langgenius/dify/blob/c95761f4e6234a27a31446bec768da72826d3324/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py#L40-L45

## Screenshots

| Before | After |
|--------|-------|
| <img width="409" height="307" alt="image" src="https://github.com/user-attachments/assets/c9805132-19df-4014-813d-7a3b27678e15" />  | <img width="414" height="468" alt="image" src="https://github.com/user-attachments/assets/9083fbc4-88ea-459f-bbb2-3869f5e39cd7" />  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
