### PR TITLE
feat: support to upload files for visual model call when running LLM node for debugging in a single step

### DIFF
--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Generator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
-from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity, InvokeFrom
+from core.app.entities.app_invoke_entities import InvokeFrom, ModelConfigWithCredentialsEntity
 from core.file import FileType, file_manager
 from core.helper.code_executor import CodeExecutor, CodeLanguage
 from core.llm_generator.output_parser.errors import OutputParserError

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Generator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
-from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity
+from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity, InvokeFrom
 from core.file import FileType, file_manager
 from core.helper.code_executor import CodeExecutor, CodeLanguage
 from core.llm_generator.output_parser.errors import OutputParserError

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -194,6 +194,17 @@ class LLMNode(BaseNode):
                 else []
             )
 
+            # single step run fetch file from sys files
+            if not files and self.invoke_from == InvokeFrom.DEBUGGER and not self.previous_node_id:
+                files = (
+                    llm_utils.fetch_files(
+                        variable_pool=variable_pool,
+                        selector=["sys", "files"],
+                    )
+                    if self._node_data.vision.enabled
+                    else []
+                )
+            
             if files:
                 node_inputs["#files#"] = [file.to_dict() for file in files]
 

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -204,7 +204,7 @@ class LLMNode(BaseNode):
                     if self._node_data.vision.enabled
                     else []
                 )
-            
+
             if files:
                 node_inputs["#files#"] = [file.to_dict() for file in files]
 


### PR DESCRIPTION
…node for debugging in a single step

feat: support to upload files for visual model call when running LLM node for debugging in a single step

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
close https://github.com/langgenius/dify/issues/23541

After the vision mode is enabled, the LLM node allows the file to be uploaded, but the file is not passed into the finnal prompt. The reason is that the uploaded file is in the sys files of the variable pool, and the code does not get the file

## Screenshots

| Before | After |
|--------|-------|
| <img width="494" height="290" alt="image" src="https://github.com/user-attachments/assets/9c373e85-5a6e-48f1-bd69-6fcd1e96ae2f" />    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
