### PR TITLE
feat(web): Add keyboard navigation for quick jumps

### DIFF
--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -25,6 +25,7 @@ const GotoAnything: FC<Props> = ({
   const defaultLocale = useGetLanguage()
   const [show, setShow] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState<number>(-1)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const [activePlugin, setActivePlugin] = useState<Plugin>()
@@ -108,12 +109,42 @@ const GotoAnything: FC<Props> = ({
 
     return parts.map((part, index) =>
       regex.test(part) ? (
-        <mark key={index} className='rounded bg-yellow-200 px-0.5 text-yellow-900'>
+        <mark key={index} className='rounded bg-yellow-200 text-yellow-900'>
           {part}
         </mark>
       ) : part,
     )
   }, [])
+
+  useKeyPress(['downarrow'], (e) => {
+    e.preventDefault()
+    if (searchResults.length > 0) {
+      if (selectedIndex >= 0 && selectedIndex < searchResults.length - 1)
+        setSelectedIndex(selectedIndex + 1)
+      else if (selectedIndex < 0)
+        setSelectedIndex(0)
+    }
+  })
+
+  useKeyPress(['uparrow'], (e) => {
+    e.preventDefault()
+    if (searchResults.length > 0 && selectedIndex > 0)
+      setSelectedIndex(selectedIndex - 1)
+  })
+
+  useKeyPress(['enter'], (e) => {
+    e.preventDefault()
+    if (searchResults.length > 0 && selectedIndex >= 0)
+      handleNavigate(searchResults[selectedIndex])
+  })
+
+  useEffect(() => {
+    if (selectedIndex !== null && searchResults.length > 0) {
+      const activeElement = document.querySelector(`[data-index="${selectedIndex}"]`)
+      if (activeElement)
+        activeElement.scrollIntoView({ block: 'nearest', inline: 'start' })
+    }
+  }, [selectedIndex, searchResults])
 
   const searchResult = useMemo(() => {
     if (!searchResults.length)
@@ -121,11 +152,13 @@ const GotoAnything: FC<Props> = ({
 
     return (
       <div className='p-2'>
-        {searchResults.map(result => (
+        {searchResults.map((result, index) => (
           <div
             key={`${result.type}-${result.id}`}
+            data-index={index}
             className={cn(
               'flex cursor-pointer items-center gap-3 rounded-md p-3 hover:bg-state-base-hover',
+              selectedIndex === index ? 'bg-state-base-hover' : '',
             )}
             onClick={() => handleNavigate(result)}
           >
@@ -147,7 +180,7 @@ const GotoAnything: FC<Props> = ({
         ))}
       </div>
     )
-  }, [searchResults])
+  }, [searchResults, selectedIndex])
 
   const emptyResult = useMemo(() => {
     if (searchResults.length || !searchQueryDebouncedValue.trim())
@@ -187,6 +220,9 @@ const GotoAnything: FC<Props> = ({
       requestAnimationFrame(() => {
         inputRef.current?.focus()
       })
+    }
+ else {
+      setSelectedIndex(-1)
     }
   }, [show])
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add event handling for down arrow, up arrow, and enter keys
- Implement highlighting of search results and scroll positioning
- Optimize the user experience of navigating with the keyboard

## Screenshots

https://github.com/user-attachments/assets/b09d841c-f6e8-414f-ac83-42f27480cd43


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
