### PR TITLE
Fix/footer behavior

### DIFF
--- a/web/app/components/apps/footer.tsx
+++ b/web/app/components/apps/footer.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Link from 'next/link'
-import { RiCloseLine, RiDiscordFill, RiGithubFill } from '@remixicon/react'
+import { RiDiscordFill, RiGithubFill } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 
 type CustomLinkProps = {
@@ -26,24 +26,9 @@ const CustomLink = React.memo(({
 
 const Footer = () => {
   const { t } = useTranslation()
-  const [isVisible, setIsVisible] = useState(true)
-
-  const handleClose = () => {
-    setIsVisible(false)
-  }
-
-  if (!isVisible)
-    return null
 
   return (
     <footer className='relative shrink-0 grow-0 px-12 py-2'>
-      <button
-        onClick={handleClose}
-        className='absolute right-2 top-2 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full transition-colors duration-200 ease-in-out hover:bg-components-main-nav-nav-button-bg-active'
-        aria-label="Close footer"
-      >
-        <RiCloseLine className='h-4 w-4 text-text-tertiary hover:text-text-secondary' />
-      </button>
       <h3 className='text-gradient text-xl font-semibold leading-tight'>{t('app.join')}</h3>
       <p className='system-sm-regular mt-1 text-text-tertiary'>{t('app.communityIntro')}</p>
       <div className='mt-3 flex items-center gap-2'>

--- a/web/app/components/apps/index.tsx
+++ b/web/app/components/apps/index.tsx
@@ -1,14 +1,11 @@
 'use client'
 import { useEducationInit } from '@/app/education-apply/hooks'
-import { useGlobalPublicStore } from '@/context/global-public-context'
 import List from './list'
-import Footer from './footer'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { useTranslation } from 'react-i18next'
 
 const Apps = () => {
   const { t } = useTranslation()
-  const { systemFeatures } = useGlobalPublicStore()
 
   useDocumentTitle(t('common.menus.apps'))
   useEducationInit()
@@ -16,9 +13,6 @@ const Apps = () => {
   return (
     <div className='relative flex h-0 shrink-0 grow flex-col overflow-y-auto bg-background-body'>
       <List />
-      {!systemFeatures.branding.enabled && (
-        <Footer />
-      )}
     </div >
   )
 }

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -32,6 +32,8 @@ import TagFilter from '@/app/components/base/tag-management/filter'
 import CheckboxWithLabel from '@/app/components/datasets/create/website/base/checkbox-with-label'
 import dynamic from 'next/dynamic'
 import Empty from './empty'
+import Footer from './footer'
+import { useGlobalPublicStore } from '@/context/global-public-context'
 
 const TagManagementModal = dynamic(() => import('@/app/components/base/tag-management'), {
   ssr: false,
@@ -66,6 +68,7 @@ const getKey = (
 
 const List = () => {
   const { t } = useTranslation()
+    const { systemFeatures } = useGlobalPublicStore()
   const router = useRouter()
   const { isCurrentWorkspaceEditor, isCurrentWorkspaceDatasetOperator } = useAppContext()
   const showTagManagementModal = useTagStore(s => s.showTagManagementModal)
@@ -228,6 +231,9 @@ const List = () => {
             <RiDragDropLine className="h-4 w-4" />
             <span className="system-xs-regular">{t('app.newApp.dropDSLToCreateApp')}</span>
           </div>
+        )}
+        {!systemFeatures.branding.enabled && (
+          <Footer />
         )}
         <CheckModal />
         <div ref={anchorRef} className='h-0'> </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

part of https://github.com/langgenius/dify/pull/22927

This pull request refactors how the `Footer` component is rendered in the apps section. The logic for conditionally displaying the footer based on branding settings has been moved from the `Apps` component to the `List` component. Additionally, the footer's close button and its associated state management have been removed, making the footer always visible when rendered.

**Refactoring and component logic changes:**

* Moved the conditional rendering of the `Footer` component from `web/app/components/apps/index.tsx` to `web/app/components/apps/list.tsx`, centralizing the logic and simplifying the parent component. [[1]](diffhunk://#diff-7bcea1d284a1ab634161ce066bc80ed318d12a187fe58a612bbbc8697e72b532L3-L21) [[2]](diffhunk://#diff-93f7af05c419974ddd0d9400b68700fde76d128636f9620d15440a4f2704283eR35-R36) [[3]](diffhunk://#diff-93f7af05c419974ddd0d9400b68700fde76d128636f9620d15440a4f2704283eR235-R237)
* Updated `web/app/components/apps/list.tsx` to import `Footer` and `useGlobalPublicStore`, and to use the `systemFeatures.branding.enabled` flag to control footer visibility. [[1]](diffhunk://#diff-93f7af05c419974ddd0d9400b68700fde76d128636f9620d15440a4f2704283eR35-R36) [[2]](diffhunk://#diff-93f7af05c419974ddd0d9400b68700fde76d128636f9620d15440a4f2704283eR71) [[3]](diffhunk://#diff-93f7af05c419974ddd0d9400b68700fde76d128636f9620d15440a4f2704283eR235-R237)

**Footer component simplification:**

* Removed the close button and related state (`isVisible`, `setIsVisible`, and `handleClose`) from the `Footer` component, so the footer is always displayed when rendered. [[1]](diffhunk://#diff-ef7c32c5a63d5f55b451f89439f7248ed4009ecb0467f956f8b86a53a44c4e60L1-R3) [[2]](diffhunk://#diff-ef7c32c5a63d5f55b451f89439f7248ed4009ecb0467f956f8b86a53a44c4e60L29-L46)

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
