### PR TITLE
fix: exclude dev dependencies from production Docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
-RUN uv sync --locked
+RUN uv sync --locked --no-dev
 
 # production stage
 FROM base AS production


### PR DESCRIPTION
## Summary
- Fixes #23561
- Excludes development dependencies (pytest, mypy, ruff, etc.) from production Docker image

## Changes
Modified `api/Dockerfile` to use `uv sync --locked --no-dev` instead of `uv sync --locked` to prevent installation of development dependencies in the production image.

## Impact
- ✅ Smaller Docker image size
- ✅ Improved security (no dev tools in production)
- ✅ Faster build times

## Test Plan
- [ ] Build Docker image and verify dev dependencies are not installed
- [ ] Verify production functionality remains intact