### PR TITLE
fix: hide opensource license link when custom branding is enabled

### DIFF
--- a/web/app/signin/invite-settings/page.tsx
+++ b/web/app/signin/invite-settings/page.tsx
@@ -17,9 +17,11 @@ import { activateMember, invitationCheck } from '@/service/common'
 import Loading from '@/app/components/base/loading'
 import Toast from '@/app/components/base/toast'
 import { noop } from 'lodash-es'
+import { useGlobalPublicStore } from '@/context/global-public-context'
 
 export default function InviteSettingsPage() {
   const { t } = useTranslation()
+  const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
   const docLink = useDocLink()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -150,7 +152,7 @@ export default function InviteSettingsPage() {
         </Button>
       </div>
     </form>
-    <div className="system-xs-regular mt-2 block w-full">
+    {!systemFeatures.branding.enabled && <div className="system-xs-regular mt-2 block w-full">
       {t('login.license.tip')}
       &nbsp;
       <Link
@@ -158,6 +160,6 @@ export default function InviteSettingsPage() {
         target='_blank' rel='noopener noreferrer'
         href={docLink('/policies/open-source')}
       >{t('login.license.link')}</Link>
-    </div>
+    </div>}
   </div>
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
