### PR TITLE
fix: empty arrays should convert to empty string in LLM prompts

### DIFF
--- a/api/core/variables/segments.py
+++ b/api/core/variables/segments.py
@@ -120,6 +120,13 @@ class ObjectSegment(Segment):
 
 class ArraySegment(Segment):
     @property
+    def text(self) -> str:
+        # Return empty string for empty arrays instead of "[]"
+        if not self.value:
+            return ""
+        return super().text
+
+    @property
     def markdown(self) -> str:
         items = []
         for item in self.value:
@@ -155,6 +162,9 @@ class ArrayStringSegment(ArraySegment):
 
     @property
     def text(self) -> str:
+        # Return empty string for empty arrays instead of "[]"
+        if not self.value:
+            return ""
         return json.dumps(self.value, ensure_ascii=False)
 
 


### PR DESCRIPTION
## Summary
- Fixed empty array variables displaying as `[]` in LLM prompts
- Empty arrays now correctly convert to empty strings

## Changes
- Override `text` property in `ArraySegment` class to return empty string for empty arrays
- Update `ArrayStringSegment.text` to return empty string instead of `json.dumps([])` for empty arrays

## Testing
Tested all array segment types to ensure:
- Empty arrays convert to empty strings
- Non-empty arrays continue to work correctly
- Template conversion with `{{#sys.files#}}` produces clean output

## Related Issues
Fixes #23589

## Example
**Before:**
```
Template: "Your files: {{#sys.files#}}"
Result: "Your files: []"
```

**After:**
```
Template: "Your files: {{#sys.files#}}"  
Result: "Your files: "
```