### PR TITLE
fix: i18n options too long breaks plugin setting ui

### DIFF
--- a/web/app/components/plugins/reference-setting-modal/modal.tsx
+++ b/web/app/components/plugins/reference-setting-modal/modal.tsx
@@ -50,9 +50,9 @@ const PluginSettingModal: FC<Props> = ({
       isShow
       onClose={onHide}
       closable
-      className='w-[480px] !p-0'
+      className='w-[600px] max-w-[600px] !p-0'
     >
-      <div className='shadows-shadow-xl flex w-[480px] flex-col items-start rounded-2xl border border-components-panel-border bg-components-panel-bg'>
+      <div className='shadows-shadow-xl flex w-full flex-col items-start rounded-2xl border border-components-panel-border bg-components-panel-bg'>
         <div className='flex items-start gap-2 self-stretch pb-3 pl-6 pr-14 pt-6'>
           <span className='title-2xl-semi-bold self-stretch text-text-primary'>{t(`${i18nPrefix}.title`)}</span>
         </div>

--- a/web/app/components/plugins/reference-setting-modal/modal.tsx
+++ b/web/app/components/plugins/reference-setting-modal/modal.tsx
@@ -50,7 +50,7 @@ const PluginSettingModal: FC<Props> = ({
       isShow
       onClose={onHide}
       closable
-      className='w-[600px] max-w-[600px] !p-0'
+      className='w-[620px] max-w-[620px] !p-0'
     >
       <div className='shadows-shadow-xl flex w-full flex-col items-start rounded-2xl border border-components-panel-border bg-components-panel-bg'>
         <div className='flex items-start gap-2 self-stretch pb-3 pl-6 pr-14 pt-6'>


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
