### PR TITLE
fix: resolve datasets container rounded corners disappearing during scroll

### DIFF
--- a/web/app/(commonLayout)/datasets/container.tsx
+++ b/web/app/(commonLayout)/datasets/container.tsx
@@ -86,7 +86,7 @@ const Container = () => {
   }, [currentWorkspace, router])
 
   return (
-    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl bg-components-panel-bg'>
+    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl bg-components-panel-bg outline-none'>
       <div className='sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular bg-components-panel-bg px-6 py-2'>
         <TabSliderNew
           value={activeTab}

--- a/web/app/(commonLayout)/datasets/container.tsx
+++ b/web/app/(commonLayout)/datasets/container.tsx
@@ -86,8 +86,8 @@ const Container = () => {
   }, [currentWorkspace, router])
 
   return (
-    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl bg-components-panel-bg outline-none'>
-      <div className='sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular bg-components-panel-bg px-6 py-2'>
+    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl bg-background-body outline-none'>
+      <div className='sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular bg-background-body px-6 py-2'>
         <TabSliderNew
           value={activeTab}
           onChange={newActiveTab => setActiveTab(newActiveTab)}

--- a/web/app/(commonLayout)/datasets/container.tsx
+++ b/web/app/(commonLayout)/datasets/container.tsx
@@ -87,7 +87,7 @@ const Container = () => {
 
   return (
     <div ref={containerRef} className={`scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl outline-none ${activeTab === 'dataset' ? 'bg-background-body' : 'bg-components-panel-bg'}`}>
-      <div className={`sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular px-6 py-2 ${activeTab === 'dataset' ? 'bg-background-body' : 'bg-components-panel-bg'}`}>
+      <div className={`sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl px-6 py-2 ${activeTab === 'api' ? 'border-b border-solid border-b-divider-regular' : ''} ${activeTab === 'dataset' ? 'bg-background-body' : 'bg-components-panel-bg'}`}>
         <TabSliderNew
           value={activeTab}
           onChange={newActiveTab => setActiveTab(newActiveTab)}

--- a/web/app/(commonLayout)/datasets/container.tsx
+++ b/web/app/(commonLayout)/datasets/container.tsx
@@ -86,8 +86,8 @@ const Container = () => {
   }, [currentWorkspace, router])
 
   return (
-    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl bg-background-body outline-none'>
-      <div className='sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular bg-background-body px-6 py-2'>
+    <div ref={containerRef} className={`scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl outline-none ${activeTab === 'dataset' ? 'bg-background-body' : 'bg-components-panel-bg'}`}>
+      <div className={`sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular px-6 py-2 ${activeTab === 'dataset' ? 'bg-background-body' : 'bg-components-panel-bg'}`}>
         <TabSliderNew
           value={activeTab}
           onChange={newActiveTab => setActiveTab(newActiveTab)}

--- a/web/app/(commonLayout)/datasets/container.tsx
+++ b/web/app/(commonLayout)/datasets/container.tsx
@@ -86,8 +86,8 @@ const Container = () => {
   }, [currentWorkspace, router])
 
   return (
-    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto bg-background-body'>
-      <div className='sticky top-0 z-10 flex h-[80px] shrink-0 flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-2 pt-4 leading-[56px]'>
+    <div ref={containerRef} className='scroll-container relative flex grow flex-col overflow-y-auto rounded-t-xl bg-components-panel-bg'>
+      <div className='sticky top-0 z-10 flex shrink-0 flex-wrap items-center justify-between gap-y-2 rounded-t-xl border-b border-solid border-b-divider-regular bg-components-panel-bg px-6 py-2'>
         <TabSliderNew
           value={activeTab}
           onChange={newActiveTab => setActiveTab(newActiveTab)}

--- a/web/app/(commonLayout)/datasets/doc.tsx
+++ b/web/app/(commonLayout)/datasets/doc.tsx
@@ -193,7 +193,7 @@ const Doc = ({ apiBaseUrl }: DocProps) => {
             </button>
           )}
       </div>
-      <article className={cn('prose-xl prose mx-1 rounded-t-xl bg-background-default px-4 pt-16 sm:mx-12', theme === Theme.dark && 'prose-invert')}>
+      <article className={cn('prose-xl prose', theme === Theme.dark && 'prose-invert')}>
         {Template}
       </article>
     </div>

--- a/web/app/components/base/tab-slider-new/index.tsx
+++ b/web/app/components/base/tab-slider-new/index.tsx
@@ -26,7 +26,7 @@ const TabSliderNew: FC<TabSliderProps> = ({
           onClick={() => onChange(option.value)}
           className={cn(
             'mr-1 flex h-[32px] cursor-pointer items-center rounded-lg border-[0.5px] border-transparent px-3 py-[7px] text-[13px] font-medium leading-[18px] text-text-tertiary hover:bg-components-main-nav-nav-button-bg-active',
-            value === option.value && 'border-components-main-nav-nav-button-border bg-components-main-nav-nav-button-bg-active text-components-main-nav-nav-button-text-active shadow-xs',
+            value === option.value && 'border-components-main-nav-nav-button-border bg-state-base-hover text-components-main-nav-nav-button-text-active shadow-xs',
           )}
         >
           {option.icon}

--- a/web/app/components/base/tab-slider-new/index.tsx
+++ b/web/app/components/base/tab-slider-new/index.tsx
@@ -25,7 +25,7 @@ const TabSliderNew: FC<TabSliderProps> = ({
           key={option.value}
           onClick={() => onChange(option.value)}
           className={cn(
-            'mr-1 flex h-[32px] cursor-pointer items-center rounded-lg border-[0.5px] border-transparent px-3 py-[7px] text-[13px] font-medium leading-[18px] text-text-tertiary hover:bg-components-main-nav-nav-button-bg-active',
+            'mr-1 flex h-[32px] cursor-pointer items-center rounded-lg border-[0.5px] border-transparent px-3 py-[7px] text-[13px] font-medium leading-[18px] text-text-tertiary hover:bg-state-base-hover',
             value === option.value && 'border-components-main-nav-nav-button-border bg-state-base-hover text-components-main-nav-nav-button-text-active shadow-xs',
           )}
         >

--- a/web/app/components/header/header-wrapper.tsx
+++ b/web/app/components/header/header-wrapper.tsx
@@ -13,7 +13,7 @@ const HeaderWrapper = ({
   children,
 }: HeaderWrapperProps) => {
   const pathname = usePathname()
-  const isBordered = ['/apps', '/datasets', '/datasets/create', '/tools'].includes(pathname)
+  const isBordered = ['/apps', '/datasets/create', '/tools'].includes(pathname)
   // Check if the current path is a workflow canvas & fullscreen
   const inWorkflowCanvas = pathname.endsWith('/workflow')
   const workflowCanvasMaximize = localStorage.getItem('workflow-canvas-maximize') === 'true'


### PR DESCRIPTION
> [\!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #23664`.

## Summary

This PR fixes the rounded corners disappearing issue when scrolling on the Knowledge Base API page. The main problem was that during scrolling, the article content would move behind a sticky header, causing the rounded corners to be visually clipped or masked, creating an appearance of straight corners instead of the intended rounded corners.

Additionally, this PR addresses an existing blue outline focus issue that wasn't mentioned in the original issue but was introduced during the fix process. When the container gained focus (e.g., when clicking on API Access tab), a blue browser default outline would appear around the rounded container.

**Key Changes:**
- Fixed rounded corners visual clipping during scroll by optimizing container and header styling
- Implemented conditional background colors for different tab contexts
- Removed unwanted blue focus outline from scroll container  
- Improved tab button hover styling for better visual feedback
- Optimized header spacing and border consistency

**Root Cause:** The original issue occurred because rounded containers would have their corners visually masked by sticky headers during scroll, and the container focus behavior caused additional blue outline issues.

Fixes #23664

## Screenshots

| Before | After |
|--------|-------|
| Rounded corners disappear during scroll, blue outline appears on focus | Consistent rounded corners maintained during scroll, clean focus behavior |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods