### PR TITLE
fix: conversation pinned filter returns incorrect results when no conversations are pinned

### DIFF
--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -50,12 +50,16 @@ class ConversationService:
             Conversation.from_account_id == (user.id if isinstance(user, Account) else None),
             or_(Conversation.invoke_from.is_(None), Conversation.invoke_from == invoke_from.value),
         )
-        # Check if include_ids is not None and not empty to avoid WHERE false condition
-        if include_ids is not None and len(include_ids) > 0:
+        # Check if include_ids is not None to apply filter
+        if include_ids is not None:
+            if len(include_ids) == 0:
+                # If include_ids is empty, return empty result
+                return InfiniteScrollPagination(data=[], limit=limit, has_more=False)
             stmt = stmt.where(Conversation.id.in_(include_ids))
-        # Check if exclude_ids is not None and not empty to avoid WHERE false condition
-        if exclude_ids is not None and len(exclude_ids) > 0:
-            stmt = stmt.where(~Conversation.id.in_(exclude_ids))
+        # Check if exclude_ids is not None to apply filter
+        if exclude_ids is not None:
+            if len(exclude_ids) > 0:
+                stmt = stmt.where(~Conversation.id.in_(exclude_ids))
 
         # define sort fields and directions
         sort_field, sort_direction = cls._get_sort_params(sort_by)

--- a/api/tests/unit_tests/services/test_conversation_service.py
+++ b/api/tests/unit_tests/services/test_conversation_service.py
@@ -1,0 +1,127 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from core.app.entities.app_invoke_entities import InvokeFrom
+from services.conversation_service import ConversationService
+
+
+class TestConversationService:
+    def test_pagination_with_empty_include_ids(self):
+        """Test that empty include_ids returns empty result"""
+        mock_session = MagicMock()
+        mock_app_model = MagicMock(id=str(uuid.uuid4()))
+        mock_user = MagicMock(id=str(uuid.uuid4()))
+
+        result = ConversationService.pagination_by_last_id(
+            session=mock_session,
+            app_model=mock_app_model,
+            user=mock_user,
+            last_id=None,
+            limit=20,
+            invoke_from=InvokeFrom.WEB_APP,
+            include_ids=[],  # Empty include_ids should return empty result
+            exclude_ids=None,
+        )
+
+        assert result.data == []
+        assert result.has_more is False
+        assert result.limit == 20
+
+    def test_pagination_with_non_empty_include_ids(self):
+        """Test that non-empty include_ids filters properly"""
+        mock_session = MagicMock()
+        mock_app_model = MagicMock(id=str(uuid.uuid4()))
+        mock_user = MagicMock(id=str(uuid.uuid4()))
+
+        # Mock the query results
+        mock_conversations = [MagicMock(id=str(uuid.uuid4())) for _ in range(3)]
+        mock_session.scalars.return_value.all.return_value = mock_conversations
+        mock_session.scalar.return_value = 0
+
+        with patch("services.conversation_service.select") as mock_select:
+            mock_stmt = MagicMock()
+            mock_select.return_value = mock_stmt
+            mock_stmt.where.return_value = mock_stmt
+            mock_stmt.order_by.return_value = mock_stmt
+            mock_stmt.limit.return_value = mock_stmt
+            mock_stmt.subquery.return_value = MagicMock()
+
+            result = ConversationService.pagination_by_last_id(
+                session=mock_session,
+                app_model=mock_app_model,
+                user=mock_user,
+                last_id=None,
+                limit=20,
+                invoke_from=InvokeFrom.WEB_APP,
+                include_ids=["conv1", "conv2"],  # Non-empty include_ids
+                exclude_ids=None,
+            )
+
+            # Verify the where clause was called with id.in_
+            assert mock_stmt.where.called
+
+    def test_pagination_with_empty_exclude_ids(self):
+        """Test that empty exclude_ids doesn't filter"""
+        mock_session = MagicMock()
+        mock_app_model = MagicMock(id=str(uuid.uuid4()))
+        mock_user = MagicMock(id=str(uuid.uuid4()))
+
+        # Mock the query results
+        mock_conversations = [MagicMock(id=str(uuid.uuid4())) for _ in range(5)]
+        mock_session.scalars.return_value.all.return_value = mock_conversations
+        mock_session.scalar.return_value = 0
+
+        with patch("services.conversation_service.select") as mock_select:
+            mock_stmt = MagicMock()
+            mock_select.return_value = mock_stmt
+            mock_stmt.where.return_value = mock_stmt
+            mock_stmt.order_by.return_value = mock_stmt
+            mock_stmt.limit.return_value = mock_stmt
+            mock_stmt.subquery.return_value = MagicMock()
+
+            result = ConversationService.pagination_by_last_id(
+                session=mock_session,
+                app_model=mock_app_model,
+                user=mock_user,
+                last_id=None,
+                limit=20,
+                invoke_from=InvokeFrom.WEB_APP,
+                include_ids=None,
+                exclude_ids=[],  # Empty exclude_ids should not filter
+            )
+
+            # Result should contain the mocked conversations
+            assert len(result.data) == 5
+
+    def test_pagination_with_non_empty_exclude_ids(self):
+        """Test that non-empty exclude_ids filters properly"""
+        mock_session = MagicMock()
+        mock_app_model = MagicMock(id=str(uuid.uuid4()))
+        mock_user = MagicMock(id=str(uuid.uuid4()))
+
+        # Mock the query results
+        mock_conversations = [MagicMock(id=str(uuid.uuid4())) for _ in range(3)]
+        mock_session.scalars.return_value.all.return_value = mock_conversations
+        mock_session.scalar.return_value = 0
+
+        with patch("services.conversation_service.select") as mock_select:
+            mock_stmt = MagicMock()
+            mock_select.return_value = mock_stmt
+            mock_stmt.where.return_value = mock_stmt
+            mock_stmt.order_by.return_value = mock_stmt
+            mock_stmt.limit.return_value = mock_stmt
+            mock_stmt.subquery.return_value = MagicMock()
+
+            result = ConversationService.pagination_by_last_id(
+                session=mock_session,
+                app_model=mock_app_model,
+                user=mock_user,
+                last_id=None,
+                limit=20,
+                invoke_from=InvokeFrom.WEB_APP,
+                include_ids=None,
+                exclude_ids=["conv1", "conv2"],  # Non-empty exclude_ids
+            )
+
+            # Verify the where clause was called for exclusion
+            assert mock_stmt.where.called


### PR DESCRIPTION
> [\!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes an issue where the conversation pinned filter API returns incorrect results when no conversations are pinned.

**Problem:**
- When calling `/api/conversations?pinned=true` with no pinned conversations, the API returns all conversations instead of returning an empty result
- The issue occurs in `services/conversation_service.py` where empty `include_ids` list is not properly handled

**Solution:**
- Added proper handling for empty `include_ids` list in the `pagination_by_last_id` method
- When `include_ids` is an empty list, immediately return an empty pagination result
- This ensures that `pinned=true` with no pinned conversations correctly returns no results

Fixes #23668

## Screenshots

### Before

<img width="228" height="175" alt="image" src="https://github.com/user-attachments/assets/87db4d24-a155-453a-9a51-b9cd12ac5922" />

### After

<img width="227" height="227" alt="image" src="https://github.com/user-attachments/assets/01a37546-3534-40b5-b45e-217be0cb8f4a" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods