### PR TITLE
fix: support custom file types in workflow Start node

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -169,13 +169,55 @@ def _extract_text_by_file_extension(*, file_content: bytes, file_extension: str)
     """Extract text from a file based on its file extension."""
     match file_extension:
         case (
-            ".txt" | ".markdown" | ".md" | ".html" | ".htm" | ".xml" |
-            ".c" | ".h" | ".cpp" | ".hpp" | ".cc" | ".cxx" | ".c++" |
-            ".py" | ".js" | ".ts" | ".jsx" | ".tsx" | ".java" | ".php" | ".rb" |
-            ".go" | ".rs" | ".swift" | ".kt" | ".scala" | ".sh" | ".bash" |
-            ".bat" | ".ps1" | ".sql" | ".r" | ".m" | ".pl" | ".lua" | ".vim" |
-            ".asm" | ".s" | ".css" | ".scss" | ".less" | ".sass" |
-            ".ini" | ".cfg" | ".conf" | ".toml" | ".env" | ".log" | ".vtt"
+            ".txt"
+            | ".markdown"
+            | ".md"
+            | ".html"
+            | ".htm"
+            | ".xml"
+            | ".c"
+            | ".h"
+            | ".cpp"
+            | ".hpp"
+            | ".cc"
+            | ".cxx"
+            | ".c++"
+            | ".py"
+            | ".js"
+            | ".ts"
+            | ".jsx"
+            | ".tsx"
+            | ".java"
+            | ".php"
+            | ".rb"
+            | ".go"
+            | ".rs"
+            | ".swift"
+            | ".kt"
+            | ".scala"
+            | ".sh"
+            | ".bash"
+            | ".bat"
+            | ".ps1"
+            | ".sql"
+            | ".r"
+            | ".m"
+            | ".pl"
+            | ".lua"
+            | ".vim"
+            | ".asm"
+            | ".s"
+            | ".css"
+            | ".scss"
+            | ".less"
+            | ".sass"
+            | ".ini"
+            | ".cfg"
+            | ".conf"
+            | ".toml"
+            | ".env"
+            | ".log"
+            | ".vtt"
         ):
             return _extract_text_from_plain_text(file_content)
         case ".json":

--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -168,7 +168,15 @@ def _extract_text_by_mime_type(*, file_content: bytes, mime_type: str) -> str:
 def _extract_text_by_file_extension(*, file_content: bytes, file_extension: str) -> str:
     """Extract text from a file based on its file extension."""
     match file_extension:
-        case ".txt" | ".markdown" | ".md" | ".html" | ".htm" | ".xml":
+        case (
+            ".txt" | ".markdown" | ".md" | ".html" | ".htm" | ".xml" |
+            ".c" | ".h" | ".cpp" | ".hpp" | ".cc" | ".cxx" | ".c++" |
+            ".py" | ".js" | ".ts" | ".jsx" | ".tsx" | ".java" | ".php" | ".rb" |
+            ".go" | ".rs" | ".swift" | ".kt" | ".scala" | ".sh" | ".bash" |
+            ".bat" | ".ps1" | ".sql" | ".r" | ".m" | ".pl" | ".lua" | ".vim" |
+            ".asm" | ".s" | ".css" | ".scss" | ".less" | ".sass" |
+            ".ini" | ".cfg" | ".conf" | ".toml" | ".env" | ".log" | ".vtt"
+        ):
             return _extract_text_from_plain_text(file_content)
         case ".json":
             return _extract_text_from_json(file_content)
@@ -194,8 +202,6 @@ def _extract_text_by_file_extension(*, file_content: bytes, file_extension: str)
             return _extract_text_from_eml(file_content)
         case ".msg":
             return _extract_text_from_msg(file_content)
-        case ".vtt":
-            return _extract_text_from_vtt(file_content)
         case ".properties":
             return _extract_text_from_properties(file_content)
         case _:

--- a/web/app/components/workflow/nodes/_base/components/before-run-form/form-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/before-run-form/form-item.tsx
@@ -181,7 +181,7 @@ const FormItem: FC<Props> = ({
             value={singleFileValue}
             onChange={handleSingleFileChange}
             fileConfig={{
-              allowed_file_types: inStepRun
+              allowed_file_types: inStepRun && (!payload.allowed_file_types || payload.allowed_file_types.length === 0)
                 ? [
                   SupportUploadFileTypes.image,
                   SupportUploadFileTypes.document,
@@ -189,7 +189,7 @@ const FormItem: FC<Props> = ({
                   SupportUploadFileTypes.video,
                 ]
                 : payload.allowed_file_types,
-              allowed_file_extensions: inStepRun
+              allowed_file_extensions: inStepRun && (!payload.allowed_file_extensions || payload.allowed_file_extensions.length === 0)
                 ? [
                   ...FILE_EXTS[SupportUploadFileTypes.image],
                   ...FILE_EXTS[SupportUploadFileTypes.document],
@@ -208,7 +208,7 @@ const FormItem: FC<Props> = ({
             value={value}
             onChange={files => onChange(files)}
             fileConfig={{
-              allowed_file_types: (inStepRun || isIteratorItemFile)
+              allowed_file_types: (inStepRun || isIteratorItemFile) && (!payload.allowed_file_types || payload.allowed_file_types.length === 0)
                 ? [
                   SupportUploadFileTypes.image,
                   SupportUploadFileTypes.document,
@@ -216,7 +216,7 @@ const FormItem: FC<Props> = ({
                   SupportUploadFileTypes.video,
                 ]
                 : payload.allowed_file_types,
-              allowed_file_extensions: (inStepRun || isIteratorItemFile)
+              allowed_file_extensions: (inStepRun || isIteratorItemFile) && (!payload.allowed_file_extensions || payload.allowed_file_extensions.length === 0)
                 ? [
                   ...FILE_EXTS[SupportUploadFileTypes.image],
                   ...FILE_EXTS[SupportUploadFileTypes.document],


### PR DESCRIPTION
- Fix frontend file upload config override in run mode
- Add support for code file extensions (.c, .h, etc) in document extractor
- Merge plain text file types into unified case statement

Fixes #23658

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
