### PR TITLE
Fix model_setting_map key mismatch

### DIFF
--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -842,10 +842,10 @@ class ProviderConfiguration(BaseModel):
                 if m.model_type != model_type:
                     continue
 
-                status = ModelStatus.ACTIVE
-                model_setting = model_setting_map.get(m.model_type, {}).get(m.model)
-                if model_setting and model_setting.enabled is False:
-                    status = ModelStatus.DISABLED
+                if m.model_type in model_setting_map and m.model in model_setting_map[m.model_type]:
+                    model_setting = model_setting_map[m.model_type][m.model]
+                    if model_setting.enabled is False:
+                        status = ModelStatus.DISABLED
 
                 provider_models.append(
                     ModelWithProviderEntity(

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -843,10 +843,9 @@ class ProviderConfiguration(BaseModel):
                     continue
 
                 status = ModelStatus.ACTIVE
-                if m.model in model_setting_map:
-                    model_setting = model_setting_map[m.model_type][m.model]
-                    if model_setting.enabled is False:
-                        status = ModelStatus.DISABLED
+                model_setting = model_setting_map.get(m.model_type, {}).get(m.model)
+                if model_setting and model_setting.enabled is False:
+                    status = ModelStatus.DISABLED
 
                 provider_models.append(
                     ModelWithProviderEntity(

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -842,6 +842,7 @@ class ProviderConfiguration(BaseModel):
                 if m.model_type != model_type:
                     continue
 
+                status = ModelStatus.ACTIVE
                 if m.model_type in model_setting_map and m.model in model_setting_map[m.model_type]:
                     model_setting = model_setting_map[m.model_type][m.model]
                     if model_setting.enabled is False:


### PR DESCRIPTION
Fixes #23698 

Bug: Checked top-level with m.model, but the map is `{ModelType -> {model -> settings}}`, causing disabled models to appear active and risking KeyError.

Fix: check `if m.model_type in model_setting_map and m.model in model_setting_map[m.model_type]:`.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
