### PR TITLE
fix: Optimize the event handling for inserting variable shortcuts, resolving incorrect blur issues (#22981)

### DIFF
--- a/web/app/components/workflow/nodes/tool/components/mixed-variable-text-input/placeholder.tsx
+++ b/web/app/components/workflow/nodes/tool/components/mixed-variable-text-input/placeholder.tsx
@@ -31,7 +31,8 @@ const Placeholder = () => {
         <div className='system-kbd mx-0.5 flex h-4 w-4 items-center justify-center rounded bg-components-kbd-bg-gray text-text-placeholder'>/</div>
         <div
           className='system-sm-regular cursor-pointer text-components-input-text-placeholder underline decoration-dotted decoration-auto underline-offset-auto hover:text-text-tertiary'
-          onClick={((e) => {
+          onMouseDown={((e) => {
+            e.preventDefault()
             e.stopPropagation()
             handleInsert('/')
           })}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Change `onClick` event to `onMouseDown` event
- Add `e.preventDefault()` to prevent default behavior

Fixes #22981

## Screenshots

### Before

https://github.com/user-attachments/assets/abe7fb21-64c3-40e4-88c1-5f91a4bd0fb2


### After

https://github.com/user-attachments/assets/349cb673-cf15-4a25-abfa-a704e1054b75


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
