### PR TITLE
chore: remove debug log statements from DifyAPIRepositoryFactory

### DIFF
--- a/api/repositories/factory.py
+++ b/api/repositories/factory.py
@@ -48,7 +48,6 @@ class DifyAPIRepositoryFactory(DifyCoreRepositoryFactory):
             RepositoryImportError: If the configured repository cannot be imported or instantiated
         """
         class_path = dify_config.API_WORKFLOW_NODE_EXECUTION_REPOSITORY
-        logger.debug("Creating DifyAPIWorkflowNodeExecutionRepository from: %s", class_path)
 
         try:
             repository_class = cls._import_class(class_path)
@@ -86,7 +85,6 @@ class DifyAPIRepositoryFactory(DifyCoreRepositoryFactory):
             RepositoryImportError: If the configured repository cannot be imported or instantiated
         """
         class_path = dify_config.API_WORKFLOW_RUN_REPOSITORY
-        logger.debug("Creating APIWorkflowRunRepository from: %s", class_path)
 
         try:
             repository_class = cls._import_class(class_path)


### PR DESCRIPTION
Fixes #23733

## Summary

Removing unnecessary debug log statements from the DifyAPIRepositoryFactory class that were logging repository creation paths.

## Screenshots

N/A - This is a code cleanup change with no visual impact.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods