### PR TITLE
test(api): fix flaky tests in TestWorkflowDraftVariableService

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_workflow_draft_variable_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_draft_variable_service.py
@@ -263,7 +263,7 @@ class TestWorkflowDraftVariableService:
         fake = Faker()
         app = self._create_test_app(db_session_with_containers, mock_external_service_dependencies, fake=fake)
         for i in range(5):
-            test_value = StringSegment(value=fake.numerify("value##"))
+            test_value = StringSegment(value=fake.numerify("value######"))
             self._create_test_variable(
                 db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, fake.word(), test_value, fake=fake
             )
@@ -480,7 +480,7 @@ class TestWorkflowDraftVariableService:
         fake = Faker()
         app = self._create_test_app(db_session_with_containers, mock_external_service_dependencies, fake=fake)
         for i in range(3):
-            test_value = StringSegment(value=fake.numerify("value##"))
+            test_value = StringSegment(value=fake.numerify("value######"))
             self._create_test_variable(
                 db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, fake.word(), test_value, fake=fake
             )
@@ -515,7 +515,7 @@ class TestWorkflowDraftVariableService:
         app = self._create_test_app(db_session_with_containers, mock_external_service_dependencies, fake=fake)
         node_id = fake.word()
         for i in range(2):
-            test_value = StringSegment(value=fake.numerify("node_value##"))
+            test_value = StringSegment(value=fake.numerify("node_value######"))
             self._create_test_variable(
                 db_session_with_containers, app.id, node_id, fake.word(), test_value, "node", fake=fake
             )


### PR DESCRIPTION
## Summary

Fix flaky test
`TestWorkflowDraftVariableService.test_list_variables_without_values_success` caused by low entropy in test data generation that led to duplicate values violating unique constraints.

Also improve data generation in other tests within `TestWorkflowDraftVariableService` to reduce the likelihood of generating duplicate test data.

Closes #23742.

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
