### PR TITLE
fix: update integration tests to use 2-element variable selectors

### DIFF
--- a/api/tests/integration_tests/workflow/nodes/test_code.py
+++ b/api/tests/integration_tests/workflow/nodes/test_code.py
@@ -55,8 +55,8 @@ def init_code_node(code_config: dict):
         environment_variables=[],
         conversation_variables=[],
     )
-    variable_pool.add(["code", "123", "args1"], 1)
-    variable_pool.add(["code", "123", "args2"], 2)
+    variable_pool.add(["code", "args1"], 1)
+    variable_pool.add(["code", "args2"], 2)
 
     node = CodeNode(
         id=str(uuid.uuid4()),
@@ -96,9 +96,9 @@ def test_execute_code(setup_code_executor_mock):
             "variables": [
                 {
                     "variable": "args1",
-                    "value_selector": ["1", "123", "args1"],
+                    "value_selector": ["1", "args1"],
                 },
-                {"variable": "args2", "value_selector": ["1", "123", "args2"]},
+                {"variable": "args2", "value_selector": ["1", "args2"]},
             ],
             "answer": "123",
             "code_language": "python3",
@@ -107,8 +107,8 @@ def test_execute_code(setup_code_executor_mock):
     }
 
     node = init_code_node(code_config)
-    node.graph_runtime_state.variable_pool.add(["1", "123", "args1"], 1)
-    node.graph_runtime_state.variable_pool.add(["1", "123", "args2"], 2)
+    node.graph_runtime_state.variable_pool.add(["1", "args1"], 1)
+    node.graph_runtime_state.variable_pool.add(["1", "args2"], 2)
 
     # execute node
     result = node._run()
@@ -142,9 +142,9 @@ def test_execute_code_output_validator(setup_code_executor_mock):
             "variables": [
                 {
                     "variable": "args1",
-                    "value_selector": ["1", "123", "args1"],
+                    "value_selector": ["1", "args1"],
                 },
-                {"variable": "args2", "value_selector": ["1", "123", "args2"]},
+                {"variable": "args2", "value_selector": ["1", "args2"]},
             ],
             "answer": "123",
             "code_language": "python3",
@@ -153,8 +153,8 @@ def test_execute_code_output_validator(setup_code_executor_mock):
     }
 
     node = init_code_node(code_config)
-    node.graph_runtime_state.variable_pool.add(["1", "123", "args1"], 1)
-    node.graph_runtime_state.variable_pool.add(["1", "123", "args2"], 2)
+    node.graph_runtime_state.variable_pool.add(["1", "args1"], 1)
+    node.graph_runtime_state.variable_pool.add(["1", "args2"], 2)
 
     # execute node
     result = node._run()
@@ -217,9 +217,9 @@ def test_execute_code_output_validator_depth():
             "variables": [
                 {
                     "variable": "args1",
-                    "value_selector": ["1", "123", "args1"],
+                    "value_selector": ["1", "args1"],
                 },
-                {"variable": "args2", "value_selector": ["1", "123", "args2"]},
+                {"variable": "args2", "value_selector": ["1", "args2"]},
             ],
             "answer": "123",
             "code_language": "python3",
@@ -307,9 +307,9 @@ def test_execute_code_output_object_list():
             "variables": [
                 {
                     "variable": "args1",
-                    "value_selector": ["1", "123", "args1"],
+                    "value_selector": ["1", "args1"],
                 },
-                {"variable": "args2", "value_selector": ["1", "123", "args2"]},
+                {"variable": "args2", "value_selector": ["1", "args2"]},
             ],
             "answer": "123",
             "code_language": "python3",

--- a/api/tests/integration_tests/workflow/nodes/test_http.py
+++ b/api/tests/integration_tests/workflow/nodes/test_http.py
@@ -49,8 +49,8 @@ def init_http_node(config: dict):
         environment_variables=[],
         conversation_variables=[],
     )
-    variable_pool.add(["a", "b123", "args1"], 1)
-    variable_pool.add(["a", "b123", "args2"], 2)
+    variable_pool.add(["a", "args1"], 1)
+    variable_pool.add(["a", "args2"], 2)
 
     node = HttpRequestNode(
         id=str(uuid.uuid4()),

--- a/api/tests/integration_tests/workflow/nodes/test_http.py
+++ b/api/tests/integration_tests/workflow/nodes/test_http.py
@@ -171,7 +171,7 @@ def test_template(setup_http_mock):
                 "title": "http",
                 "desc": "",
                 "method": "get",
-                "url": "http://example.com/{{#a.b123.args2#}}",
+                "url": "http://example.com/{{#a.args2#}}",
                 "authorization": {
                     "type": "api-key",
                     "config": {
@@ -180,8 +180,8 @@ def test_template(setup_http_mock):
                         "header": "api-key",
                     },
                 },
-                "headers": "X-Header:123\nX-Header2:{{#a.b123.args2#}}",
-                "params": "A:b\nTemplate:{{#a.b123.args2#}}",
+                "headers": "X-Header:123\nX-Header2:{{#a.args2#}}",
+                "params": "A:b\nTemplate:{{#a.args2#}}",
                 "body": None,
             },
         }
@@ -223,7 +223,7 @@ def test_json(setup_http_mock):
                         {
                             "key": "",
                             "type": "text",
-                            "value": '{"a": "{{#a.b123.args1#}}"}',
+                            "value": '{"a": "{{#a.args1#}}"}',
                         },
                     ],
                 },
@@ -264,12 +264,12 @@ def test_x_www_form_urlencoded(setup_http_mock):
                         {
                             "key": "a",
                             "type": "text",
-                            "value": "{{#a.b123.args1#}}",
+                            "value": "{{#a.args1#}}",
                         },
                         {
                             "key": "b",
                             "type": "text",
-                            "value": "{{#a.b123.args2#}}",
+                            "value": "{{#a.args2#}}",
                         },
                     ],
                 },
@@ -310,12 +310,12 @@ def test_form_data(setup_http_mock):
                         {
                             "key": "a",
                             "type": "text",
-                            "value": "{{#a.b123.args1#}}",
+                            "value": "{{#a.args1#}}",
                         },
                         {
                             "key": "b",
                             "type": "text",
-                            "value": "{{#a.b123.args2#}}",
+                            "value": "{{#a.args2#}}",
                         },
                     ],
                 },

--- a/api/tests/integration_tests/workflow/nodes/test_parameter_extractor.py
+++ b/api/tests/integration_tests/workflow/nodes/test_parameter_extractor.py
@@ -71,8 +71,8 @@ def init_parameter_extractor_node(config: dict):
         environment_variables=[],
         conversation_variables=[],
     )
-    variable_pool.add(["a", "b123", "args1"], 1)
-    variable_pool.add(["a", "b123", "args2"], 2)
+    variable_pool.add(["a", "args1"], 1)
+    variable_pool.add(["a", "args2"], 2)
 
     node = ParameterExtractorNode(
         id=str(uuid.uuid4()),

--- a/api/tests/integration_tests/workflow/nodes/test_template_transform.py
+++ b/api/tests/integration_tests/workflow/nodes/test_template_transform.py
@@ -26,9 +26,9 @@ def test_execute_code(setup_code_executor_mock):
             "variables": [
                 {
                     "variable": "args1",
-                    "value_selector": ["1", "123", "args1"],
+                    "value_selector": ["1", "args1"],
                 },
-                {"variable": "args2", "value_selector": ["1", "123", "args2"]},
+                {"variable": "args2", "value_selector": ["1", "args2"]},
             ],
             "template": code,
         },
@@ -66,8 +66,8 @@ def test_execute_code(setup_code_executor_mock):
         environment_variables=[],
         conversation_variables=[],
     )
-    variable_pool.add(["1", "123", "args1"], 1)
-    variable_pool.add(["1", "123", "args2"], 3)
+    variable_pool.add(["1", "args1"], 1)
+    variable_pool.add(["1", "args2"], 3)
 
     node = TemplateTransformNode(
         id=str(uuid.uuid4()),

--- a/api/tests/integration_tests/workflow/nodes/test_tool.py
+++ b/api/tests/integration_tests/workflow/nodes/test_tool.py
@@ -81,7 +81,7 @@ def test_tool_variable_invoke():
 
     ToolParameterConfigurationManager.decrypt_tool_parameters = MagicMock(return_value={"format": "%Y-%m-%d %H:%M:%S"})
 
-    node.graph_runtime_state.variable_pool.add(["1", "123", "args1"], "1+1")
+    node.graph_runtime_state.variable_pool.add(["1", "args1"], "1+1")
 
     # execute node
     result = node._run()


### PR DESCRIPTION
## Problem

After the VariablePool refactoring in commit `577062b93`, 24 integration tests are failing with the error:

```
ValueError: Invalid selector: expected 2 elements (node_id, variable_name), got 3 elements
```

This is blocking multiple PRs from being merged as CI consistently fails on the integration test phase.

## Root Cause

The VariablePool API was refactored to only accept 2-element variable selectors, but the integration tests were not updated to match this change.

**What changed:**
- **Before**: `["node_id", "node_title", "variable_name"]` ✅ (3 elements)
- **After**: `["node_id", "variable_name"]` ✅ (2 elements only)

**Why the original refactor PR passed CI:**
1. Unit tests were properly updated by the author
2. Integration tests still used the old 3-element format
3. Integration tests likely failed silently due to Docker environment issues or CI configuration problems

## Solution

Remove the middle element (node_title) from all variable selectors in integration tests, keeping only the essential node_id and variable_name.

**Example fixes:**
```python
# Before (❌)
variable_pool.add(["code", "123", "args1"], 1)
"value_selector": ["1", "123", "args1"]

# After (✅)
variable_pool.add(["code", "args1"], 1)  
"value_selector": ["1", "args1"]
```

## Files Changed

- `api/tests/integration_tests/workflow/nodes/test_code.py`
- `api/tests/integration_tests/workflow/nodes/test_http.py`
- `api/tests/integration_tests/workflow/nodes/test_template_transform.py`
- `api/tests/integration_tests/workflow/nodes/test_parameter_extractor.py`
- `api/tests/integration_tests/workflow/nodes/test_tool.py`

## Impact

- ✅ Fixes 24 failing integration tests
- ✅ Unblocks CI for all pending PRs
- ✅ Maintains test semantic correctness (node_id is sufficient for identification)
- ✅ Aligns tests with the new VariablePool architecture

This fix restores the integration test suite to working condition and allows normal development workflow to resume. 

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
