### PR TITLE
fix(api): fix flaky tests by generating unique variable names

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_workflow_draft_variable_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_draft_variable_service.py
@@ -12,6 +12,10 @@ from services.workflow_draft_variable_service import (
 )
 
 
+def _get_random_variable_name(fake: Faker):
+    return "".join(fake.random_letters(length=10))
+
+
 class TestWorkflowDraftVariableService:
     """
     Comprehensive integration tests for WorkflowDraftVariableService using testcontainers.
@@ -112,7 +116,14 @@ class TestWorkflowDraftVariableService:
         return workflow
 
     def _create_test_variable(
-        self, db_session_with_containers, app_id, node_id, name, value, variable_type="conversation", fake=None
+        self,
+        db_session_with_containers,
+        app_id,
+        node_id,
+        name,
+        value,
+        variable_type: DraftVariableType = DraftVariableType.CONVERSATION,
+        fake=None,
     ):
         """
         Helper method to create a test workflow draft variable with proper configuration.
@@ -227,7 +238,13 @@ class TestWorkflowDraftVariableService:
             db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, "var2", var2_value, fake=fake
         )
         var3 = self._create_test_variable(
-            db_session_with_containers, app.id, "test_node_1", "var3", var3_value, "node", fake=fake
+            db_session_with_containers,
+            app.id,
+            "test_node_1",
+            "var3",
+            var3_value,
+            variable_type=DraftVariableType.NODE,
+            fake=fake,
         )
         selectors = [
             [CONVERSATION_VARIABLE_NODE_ID, "var1"],
@@ -265,7 +282,12 @@ class TestWorkflowDraftVariableService:
         for i in range(5):
             test_value = StringSegment(value=fake.numerify("value######"))
             self._create_test_variable(
-                db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, fake.word(), test_value, fake=fake
+                db_session_with_containers,
+                app.id,
+                CONVERSATION_VARIABLE_NODE_ID,
+                _get_random_variable_name(fake),
+                test_value,
+                fake=fake,
             )
         service = WorkflowDraftVariableService(db_session_with_containers)
         result = service.list_variables_without_values(app.id, page=1, limit=3)
@@ -291,10 +313,32 @@ class TestWorkflowDraftVariableService:
         var1_value = StringSegment(value=fake.word())
         var2_value = StringSegment(value=fake.word())
         var3_value = StringSegment(value=fake.word())
-        self._create_test_variable(db_session_with_containers, app.id, node_id, "var1", var1_value, "node", fake=fake)
-        self._create_test_variable(db_session_with_containers, app.id, node_id, "var2", var3_value, "node", fake=fake)
         self._create_test_variable(
-            db_session_with_containers, app.id, "other_node", "var3", var2_value, "node", fake=fake
+            db_session_with_containers,
+            app.id,
+            node_id,
+            "var1",
+            var1_value,
+            variable_type=DraftVariableType.NODE,
+            fake=fake,
+        )
+        self._create_test_variable(
+            db_session_with_containers,
+            app.id,
+            node_id,
+            "var2",
+            var3_value,
+            variable_type=DraftVariableType.NODE,
+            fake=fake,
+        )
+        self._create_test_variable(
+            db_session_with_containers,
+            app.id,
+            "other_node",
+            "var3",
+            var2_value,
+            variable_type=DraftVariableType.NODE,
+            fake=fake,
         )
         service = WorkflowDraftVariableService(db_session_with_containers)
         result = service.list_node_variables(app.id, node_id)
@@ -328,7 +372,13 @@ class TestWorkflowDraftVariableService:
         )
         sys_var_value = StringSegment(value=fake.word())
         self._create_test_variable(
-            db_session_with_containers, app.id, SYSTEM_VARIABLE_NODE_ID, "sys_var", sys_var_value, "system", fake=fake
+            db_session_with_containers,
+            app.id,
+            SYSTEM_VARIABLE_NODE_ID,
+            "sys_var",
+            sys_var_value,
+            variable_type=DraftVariableType.SYS,
+            fake=fake,
         )
         service = WorkflowDraftVariableService(db_session_with_containers)
         result = service.list_conversation_variables(app.id)
@@ -482,12 +532,22 @@ class TestWorkflowDraftVariableService:
         for i in range(3):
             test_value = StringSegment(value=fake.numerify("value######"))
             self._create_test_variable(
-                db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, fake.word(), test_value, fake=fake
+                db_session_with_containers,
+                app.id,
+                CONVERSATION_VARIABLE_NODE_ID,
+                _get_random_variable_name(fake),
+                test_value,
+                fake=fake,
             )
         other_app = self._create_test_app(db_session_with_containers, mock_external_service_dependencies, fake=fake)
         other_value = StringSegment(value=fake.word())
         self._create_test_variable(
-            db_session_with_containers, other_app.id, CONVERSATION_VARIABLE_NODE_ID, fake.word(), other_value, fake=fake
+            db_session_with_containers,
+            other_app.id,
+            CONVERSATION_VARIABLE_NODE_ID,
+            _get_random_variable_name(fake),
+            other_value,
+            fake=fake,
         )
         from extensions.ext_database import db
 
@@ -517,15 +577,32 @@ class TestWorkflowDraftVariableService:
         for i in range(2):
             test_value = StringSegment(value=fake.numerify("node_value######"))
             self._create_test_variable(
-                db_session_with_containers, app.id, node_id, fake.word(), test_value, "node", fake=fake
+                db_session_with_containers,
+                app.id,
+                node_id,
+                _get_random_variable_name(fake),
+                test_value,
+                variable_type=DraftVariableType.NODE,
+                fake=fake,
             )
         other_node_value = StringSegment(value=fake.word())
         self._create_test_variable(
-            db_session_with_containers, app.id, "other_node", fake.word(), other_node_value, "node", fake=fake
+            db_session_with_containers,
+            app.id,
+            "other_node",
+            _get_random_variable_name(fake),
+            other_node_value,
+            variable_type=DraftVariableType.NODE,
+            fake=fake,
         )
         conv_value = StringSegment(value=fake.word())
         self._create_test_variable(
-            db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, fake.word(), conv_value, fake=fake
+            db_session_with_containers,
+            app.id,
+            CONVERSATION_VARIABLE_NODE_ID,
+            _get_random_variable_name(fake),
+            conv_value,
+            fake=fake,
         )
         from extensions.ext_database import db
 
@@ -627,7 +704,7 @@ class TestWorkflowDraftVariableService:
             SYSTEM_VARIABLE_NODE_ID,
             "conversation_id",
             conv_id_value,
-            "system",
+            variable_type=DraftVariableType.SYS,
             fake=fake,
         )
         service = WorkflowDraftVariableService(db_session_with_containers)
@@ -664,10 +741,22 @@ class TestWorkflowDraftVariableService:
         sys_var1_value = StringSegment(value=fake.word())
         sys_var2_value = StringSegment(value=fake.word())
         sys_var1 = self._create_test_variable(
-            db_session_with_containers, app.id, SYSTEM_VARIABLE_NODE_ID, "sys_var1", sys_var1_value, "system", fake=fake
+            db_session_with_containers,
+            app.id,
+            SYSTEM_VARIABLE_NODE_ID,
+            "sys_var1",
+            sys_var1_value,
+            variable_type=DraftVariableType.SYS,
+            fake=fake,
         )
         sys_var2 = self._create_test_variable(
-            db_session_with_containers, app.id, SYSTEM_VARIABLE_NODE_ID, "sys_var2", sys_var2_value, "system", fake=fake
+            db_session_with_containers,
+            app.id,
+            SYSTEM_VARIABLE_NODE_ID,
+            "sys_var2",
+            sys_var2_value,
+            variable_type=DraftVariableType.SYS,
+            fake=fake,
         )
         conv_var_value = StringSegment(value=fake.word())
         self._create_test_variable(
@@ -701,10 +790,22 @@ class TestWorkflowDraftVariableService:
             db_session_with_containers, app.id, CONVERSATION_VARIABLE_NODE_ID, "test_conv_var", test_value, fake=fake
         )
         sys_var = self._create_test_variable(
-            db_session_with_containers, app.id, SYSTEM_VARIABLE_NODE_ID, "test_sys_var", test_value, "system", fake=fake
+            db_session_with_containers,
+            app.id,
+            SYSTEM_VARIABLE_NODE_ID,
+            "test_sys_var",
+            test_value,
+            variable_type=DraftVariableType.SYS,
+            fake=fake,
         )
         node_var = self._create_test_variable(
-            db_session_with_containers, app.id, "test_node", "test_node_var", test_value, "node", fake=fake
+            db_session_with_containers,
+            app.id,
+            "test_node",
+            "test_node_var",
+            test_value,
+            variable_type=DraftVariableType.NODE,
+            fake=fake,
         )
         service = WorkflowDraftVariableService(db_session_with_containers)
         retrieved_conv_var = service.get_conversation_variable(app.id, "test_conv_var")


### PR DESCRIPTION
## Summary

Fix TestWorkflowDraftVariableService flaky tests caused by duplicate variable 
names violating the unique constraint on (app_id, node_id, variable_name).

The previous fix in PR #23749 incorrectly targeted variable values instead 
of variable names. This commit properly addresses the root cause by using 
longer random strings for variable name generation to ensure uniqueness.

Closes #23767.

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
