### PR TITLE
feat: add select-none class to tag filter components to prevent text selection

### DIFF
--- a/web/app/components/base/tag-management/filter.tsx
+++ b/web/app/components/base/tag-management/filter.tsx
@@ -79,7 +79,7 @@ const TagFilter: FC<TagFilterProps> = ({
           className='block'
         >
           <div className={cn(
-            'flex h-8 cursor-pointer items-center gap-1 rounded-lg border-[0.5px] border-transparent bg-components-input-bg-normal px-2',
+            'flex h-8 cursor-pointer select-none items-center gap-1 rounded-lg border-[0.5px] border-transparent bg-components-input-bg-normal px-2',
             !open && !!value.length && 'shadow-xs',
             open && !!value.length && 'shadow-xs',
           )}>
@@ -123,7 +123,7 @@ const TagFilter: FC<TagFilterProps> = ({
               {filteredTagList.map(tag => (
                 <div
                   key={tag.id}
-                  className='flex cursor-pointer items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover'
+                  className='flex cursor-pointer select-none items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover'
                   onClick={() => selectTag(tag)}
                 >
                   <div title={tag.name} className='grow truncate text-sm leading-5 text-text-tertiary'>{tag.name}</div>
@@ -139,7 +139,7 @@ const TagFilter: FC<TagFilterProps> = ({
             </div>
             <div className='border-t-[0.5px] border-divider-regular' />
             <div className='p-1'>
-              <div className='flex cursor-pointer items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover' onClick={() => {
+              <div className='flex cursor-pointer select-none items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover' onClick={() => {
                 setShowTagManagementModal(true)
                 setOpen(false)
               }}>

--- a/web/app/components/plugins/marketplace/search-box/tags-filter.tsx
+++ b/web/app/components/plugins/marketplace/search-box/tags-filter.tsx
@@ -54,7 +54,7 @@ const TagsFilter = ({
         onClick={() => setOpen(v => !v)}
       >
         <div className={cn(
-          'ml-0.5 mr-1.5 flex  items-center text-text-tertiary ',
+          'ml-0.5 mr-1.5 flex  select-none items-center text-text-tertiary',
           size === 'large' && 'h-8 py-1',
           size === 'small' && 'h-7 py-0.5 ',
           // selectedTagsLength && 'text-text-secondary',
@@ -80,7 +80,7 @@ const TagsFilter = ({
               filteredOptions.map(option => (
                 <div
                   key={option.name}
-                  className='flex h-7 cursor-pointer items-center rounded-lg px-2 py-1.5 hover:bg-state-base-hover'
+                  className='flex h-7 cursor-pointer select-none items-center rounded-lg px-2 py-1.5 hover:bg-state-base-hover'
                   onClick={() => handleCheck(option.name)}
                 >
                   <Checkbox

--- a/web/app/components/plugins/plugin-page/filter-management/tag-filter.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/tag-filter.tsx
@@ -48,7 +48,7 @@ const TagsFilter = ({
     >
       <PortalToFollowElemTrigger onClick={() => setOpen(v => !v)}>
         <div className={cn(
-          'flex h-8 cursor-pointer items-center rounded-lg bg-components-input-bg-normal px-2 py-1 text-text-tertiary hover:bg-state-base-hover-alt',
+          'flex h-8 cursor-pointer select-none items-center rounded-lg bg-components-input-bg-normal px-2 py-1 text-text-tertiary hover:bg-state-base-hover-alt',
           selectedTagsLength && 'text-text-secondary',
           open && 'bg-state-base-hover',
         )}>
@@ -99,7 +99,7 @@ const TagsFilter = ({
               filteredOptions.map(option => (
                 <div
                   key={option.name}
-                  className='flex h-7 cursor-pointer items-center rounded-lg px-2 py-1.5 hover:bg-state-base-hover'
+                  className='flex h-7 cursor-pointer select-none items-center rounded-lg px-2 py-1.5 hover:bg-state-base-hover'
                   onClick={() => handleCheck(option.name)}
                 >
                   <Checkbox

--- a/web/app/components/tools/labels/filter.tsx
+++ b/web/app/components/tools/labels/filter.tsx
@@ -67,7 +67,7 @@ const LabelFilter: FC<LabelFilterProps> = ({
           className='block'
         >
           <div className={cn(
-            'flex h-8 cursor-pointer items-center gap-1 rounded-lg border-[0.5px] border-transparent bg-components-input-bg-normal px-2 hover:bg-components-input-bg-hover',
+            'flex h-8 cursor-pointer select-none items-center gap-1 rounded-lg border-[0.5px] border-transparent bg-components-input-bg-normal px-2 hover:bg-components-input-bg-hover',
             !open && !!value.length && 'shadow-xs',
             open && !!value.length && 'shadow-xs',
           )}>
@@ -111,7 +111,7 @@ const LabelFilter: FC<LabelFilterProps> = ({
               {filteredLabelList.map(label => (
                 <div
                   key={label.name}
-                  className='flex cursor-pointer items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover'
+                  className='flex cursor-pointer select-none items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover'
                   onClick={() => selectLabel(label)}
                 >
                   <div title={label.label} className='grow truncate text-sm leading-5 text-text-secondary'>{label.label}</div>


### PR DESCRIPTION
Fixes #23773

## Summary

This PR adds the `select-none` CSS class to tag filter components to prevent unintended text selection when users click or double-click on filter tags. This improves the user experience by ensuring a more polished interaction with tag filter elements.

After thorough investigation, we found and fixed all tag filter components that display clickable text across the entire application.

### Changes Made:
- Added `select-none` class to plugin-page/filter-management/tag-filter.tsx (displays "All Tags" text)
- Added `select-none` class to marketplace search-box/tags-filter.tsx trigger elements
- Added `select-none` class to base/tag-management/filter.tsx (used by apps and datasets pages, displays "All Tags" placeholder)
- Added `select-none` class to tools/labels/filter.tsx (displays "All Tags" placeholder)

### Files Modified:
- `web/app/components/plugins/plugin-page/filter-management/tag-filter.tsx`
- `web/app/components/plugins/marketplace/search-box/tags-filter.tsx` 
- `web/app/components/base/tag-management/filter.tsx`
- `web/app/components/tools/labels/filter.tsx`

### Pages Affected:
- Apps page (uses base/tag-management/filter.tsx)
- Datasets page (uses base/tag-management/filter.tsx)
- Plugins page (uses plugin-page/filter-management/tag-filter.tsx)
- Plugin Marketplace page (uses marketplace/search-box/tags-filter.tsx)
- Tools page (uses tools/labels/filter.tsx)

## Screenshots

| Before | After |
|--------|-------|
| Text could be selected when clicking on tag filters | Text selection is now prevented for better UX |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods