### PR TITLE
fix: prevent X button flying to screen corners in dataset settings modal

### DIFF
--- a/web/app/components/datasets/rename-modal/index.tsx
+++ b/web/app/components/datasets/rename-modal/index.tsx
@@ -69,9 +69,11 @@ const RenameDatasetModal = ({ show, dataset, onSuccess, onClose }: RenameDataset
       isShow={show}
       onClose={noop}
     >
-      <div className='relative pb-2 text-xl font-medium leading-[30px] text-text-primary'>{t('datasetSettings.title')}</div>
-      <div className='absolute right-4 top-4 cursor-pointer p-2' onClick={onClose}>
-        <RiCloseLine className='h-4 w-4 text-text-tertiary' />
+      <div className='flex items-center justify-between pb-2'>
+        <div className='text-xl font-medium leading-[30px] text-text-primary'>{t('datasetSettings.title')}</div>
+        <div className='cursor-pointer p-2' onClick={onClose}>
+          <RiCloseLine className='h-4 w-4 text-text-tertiary' />
+        </div>
       </div>
       <div>
         <div className={cn('flex flex-wrap items-center justify-between py-4')}>


### PR DESCRIPTION
## Summary

Fixes #23787

This PR fixes a visual bug where the X button in the dataset settings modal flies to the screen corner during modal animations. The issue was caused by absolute positioning conflicting with modal animation transitions.

## Screenshots

| Before | After |
|--------|-------|
| X button flies to screen corner during animation | X button stays properly positioned in modal header |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods