### PR TITLE
fix: remove misleading clear buttons and improve SimpleSelect UX

### DIFF
--- a/web/app/components/base/select/index.tsx
+++ b/web/app/components/base/select/index.tsx
@@ -192,6 +192,7 @@ const SimpleSelect: FC<ISelectProps> = ({
   const localPlaceholder = placeholder || t('common.placeholder.select')
 
   const [selectedItem, setSelectedItem] = useState<Item | null>(null)
+  const [open, setOpen] = useState(false)
 
   useEffect(() => {
     let defaultSelect = null
@@ -220,8 +221,11 @@ const SimpleSelect: FC<ISelectProps> = ({
           <ListboxButton onClick={() => {
               // get data-open, use setTimeout to ensure the attribute is set
               setTimeout(() => {
-                if (listboxRef.current)
-                  onOpenChange?.(listboxRef.current.getAttribute('data-open') !== null)
+                if (listboxRef.current) {
+                  const isOpen = listboxRef.current.getAttribute('data-open') !== null
+                  setOpen(isOpen)
+                  onOpenChange?.(isOpen)
+                }
               })
           }} className={classNames(`flex h-full w-full items-center rounded-lg border-0 bg-components-input-bg-normal pl-3 pr-10 focus-visible:bg-state-base-hover-alt focus-visible:outline-none group-hover/simple-select:bg-state-base-hover-alt sm:text-sm sm:leading-6 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`, className)}>
             <span className={classNames('system-sm-regular block truncate text-left text-components-input-text-filled', !selectedItem?.name && 'text-components-input-text-placeholder')}>{selectedItem?.name ?? localPlaceholder}</span>
@@ -240,10 +244,17 @@ const SimpleSelect: FC<ISelectProps> = ({
                   />
                 )
                 : (
-                  <ChevronDownIcon
-                    className="h-4 w-4 text-text-quaternary group-hover/simple-select:text-text-secondary"
-                    aria-hidden="true"
-                  />
+                  open ? (
+                    <ChevronUpIcon
+                      className="h-4 w-4 text-text-quaternary group-hover/simple-select:text-text-secondary"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <ChevronDownIcon
+                      className="h-4 w-4 text-text-quaternary group-hover/simple-select:text-text-secondary"
+                      aria-hidden="true"
+                    />
+                  )
                 )}
             </span>
           </ListboxButton>

--- a/web/app/components/header/account-setting/language-page/index.tsx
+++ b/web/app/components/header/account-setting/language-page/index.tsx
@@ -70,6 +70,7 @@ export default function LanguagePage() {
           items={languages.filter(item => item.supported)}
           onSelect={item => handleSelectLanguage(item)}
           disabled={editing}
+          notClearable={true}
         />
       </div>
       <div className='mb-8'>
@@ -79,6 +80,7 @@ export default function LanguagePage() {
           items={timezones}
           onSelect={item => handleSelectTimezone(item)}
           disabled={editing}
+          notClearable={true}
         />
       </div>
     </>


### PR DESCRIPTION
> [\!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #23790`.

Fixes #23790 
## Summary

This PR fixes misleading clear buttons in language/timezone settings and improves SimpleSelect component UX.

**Changes:**
1. **Remove clear buttons from required settings**: Add `notClearable={true}` to language and timezone selectors to prevent users from triggering invalid API calls
2. **Improve SimpleSelect visual feedback**: Add dynamic chevron icon toggle (↓/↑) based on dropdown open/close state

**Issue Fixed:**
- Users could click X buttons on required settings, causing "is not a valid language" errors
- SimpleSelect chevron remained static (always ↓) regardless of dropdown state

## Screenshots

| Before | After |
|--------|-------|
| X buttons visible on required settings, static down arrow | No X buttons on required settings, dynamic up/down arrows |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos\!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods