### PR TITLE
fix: goto-anything command filter should only match shortcut

### DIFF
--- a/web/__tests__/goto-anything/command-selector.test.tsx
+++ b/web/__tests__/goto-anything/command-selector.test.tsx
@@ -37,7 +37,7 @@ describe('CommandSelector', () => {
     },
     knowledge: {
       key: '@knowledge',
-      shortcut: '@knowledge',
+      shortcut: '@kb',
       title: 'Search Knowledge',
       description: 'Search knowledge bases',
       search: jest.fn(),
@@ -75,7 +75,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.getByTestId('command-item-@app')).toBeInTheDocument()
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@kb')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@plugin')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@node')).toBeInTheDocument()
     })
@@ -90,7 +90,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.getByTestId('command-item-@app')).toBeInTheDocument()
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@kb')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@plugin')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@node')).toBeInTheDocument()
     })
@@ -107,7 +107,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.queryByTestId('command-item-@app')).not.toBeInTheDocument()
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@kb')).toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@plugin')).not.toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@node')).not.toBeInTheDocument()
     })
@@ -122,7 +122,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.getByTestId('command-item-@app')).toBeInTheDocument()
-      expect(screen.queryByTestId('command-item-@knowledge')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('command-item-@kb')).not.toBeInTheDocument()
       expect(screen.getByTestId('command-item-@plugin')).toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@node')).not.toBeInTheDocument()
     })
@@ -137,7 +137,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.getByTestId('command-item-@app')).toBeInTheDocument()
-      expect(screen.queryByTestId('command-item-@knowledge')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('command-item-@kb')).not.toBeInTheDocument()
     })
 
     it('should match partial strings', () => {
@@ -145,14 +145,14 @@ describe('CommandSelector', () => {
         <CommandSelector
           actions={mockActions}
           onCommandSelect={mockOnCommandSelect}
-          searchFilter="nowl"
+          searchFilter="od"
         />,
       )
 
       expect(screen.queryByTestId('command-item-@app')).not.toBeInTheDocument()
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.queryByTestId('command-item-@kb')).not.toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@plugin')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('command-item-@node')).not.toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@node')).toBeInTheDocument()
     })
   })
 
@@ -167,7 +167,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.queryByTestId('command-item-@app')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('command-item-@knowledge')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('command-item-@kb')).not.toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@plugin')).not.toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@node')).not.toBeInTheDocument()
 
@@ -210,7 +210,7 @@ describe('CommandSelector', () => {
         />,
       )
 
-      expect(mockOnCommandValueChange).toHaveBeenCalledWith('@knowledge')
+      expect(mockOnCommandValueChange).toHaveBeenCalledWith('@kb')
     })
 
     it('should not call onCommandValueChange if current value still exists', () => {
@@ -246,10 +246,10 @@ describe('CommandSelector', () => {
         />,
       )
 
-      const knowledgeItem = screen.getByTestId('command-item-@knowledge')
+      const knowledgeItem = screen.getByTestId('command-item-@kb')
       fireEvent.click(knowledgeItem)
 
-      expect(mockOnCommandSelect).toHaveBeenCalledWith('@knowledge')
+      expect(mockOnCommandSelect).toHaveBeenCalledWith('@kb')
     })
   })
 
@@ -276,7 +276,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.getByTestId('command-item-@app')).toBeInTheDocument()
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@kb')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@plugin')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@node')).toBeInTheDocument()
     })
@@ -312,7 +312,7 @@ describe('CommandSelector', () => {
       )
 
       expect(screen.getByTestId('command-item-@app')).toBeInTheDocument()
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@kb')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@plugin')).toBeInTheDocument()
       expect(screen.getByTestId('command-item-@node')).toBeInTheDocument()
     })
@@ -326,7 +326,7 @@ describe('CommandSelector', () => {
         />,
       )
 
-      expect(screen.getByTestId('command-item-@knowledge')).toBeInTheDocument()
+      expect(screen.getByTestId('command-item-@kb')).toBeInTheDocument()
       expect(screen.queryByTestId('command-item-@app')).not.toBeInTheDocument()
     })
   })

--- a/web/app/components/goto-anything/command-selector.tsx
+++ b/web/app/components/goto-anything/command-selector.tsx
@@ -20,7 +20,6 @@ const CommandSelector: FC<Props> = ({ actions, onCommandSelect, searchFilter, co
       return true
     const filterLower = searchFilter.toLowerCase()
     return action.shortcut.toLowerCase().includes(filterLower)
-      || action.key.toLowerCase().includes(filterLower)
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #23861

Fixed goto-anything command selector filtering logic to only match user-visible shortcuts instead of internal keys. This resolves the confusing behavior where typing @o would select @kb instead of @node.

**Changes:**
- Modified CommandSelector to filter only by action.shortcut 
- Removed dual matching of action.key and action.shortcut
- Updated tests to reflect new behavior

## Screenshots

| Before | After |
|--------|-------|
| <img width="481" height="298" alt="image" src="https://github.com/user-attachments/assets/fd897e83-914b-4724-beb8-69995498effe" /> | <img width="482" height="297" alt="image" src="https://github.com/user-attachments/assets/d8fc816d-f8ec-494f-a787-8b1261207669" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods