### PR TITLE
fix: mime_type could be None

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -248,6 +248,8 @@ def _get_remote_file_info(url: str):
 
     # Initialize mime_type from filename as fallback
     mime_type, _ = mimetypes.guess_type(filename)
+    if mime_type is None:
+        mime_type = ""
 
     resp = ssrf_proxy.head(url, follow_redirects=True)
     resp = cast(httpx.Response, resp)
@@ -256,7 +258,12 @@ def _get_remote_file_info(url: str):
             filename = str(content_disposition.split("filename=")[-1].strip('"'))
             # Re-guess mime_type from updated filename
             mime_type, _ = mimetypes.guess_type(filename)
+            if mime_type is None:
+                mime_type = ""
         file_size = int(resp.headers.get("Content-Length", file_size))
+        # Fallback to Content-Type header if mime_type is still empty
+        if not mime_type:
+            mime_type = resp.headers.get("Content-Type", "")
 
     return mime_type, filename, file_size
 

--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -263,7 +263,7 @@ def _get_remote_file_info(url: str):
         file_size = int(resp.headers.get("Content-Length", file_size))
         # Fallback to Content-Type header if mime_type is still empty
         if not mime_type:
-            mime_type = resp.headers.get("Content-Type", "")
+            mime_type = resp.headers.get("Content-Type", "").split(';')[0].strip()
 
     return mime_type, filename, file_size
 

--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -263,7 +263,7 @@ def _get_remote_file_info(url: str):
         file_size = int(resp.headers.get("Content-Length", file_size))
         # Fallback to Content-Type header if mime_type is still empty
         if not mime_type:
-            mime_type = resp.headers.get("Content-Type", "").split(';')[0].strip()
+            mime_type = resp.headers.get("Content-Type", "").split(";")[0].strip()
 
     return mime_type, filename, file_size
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Related https://github.com/langgenius/dify/pull/23127

This pull request improves the robustness of MIME type detection in the `_get_remote_file_info` function in `api/factories/file_factory.py`. The changes ensure that the function handles cases where the MIME type cannot be determined from the filename, and provides a fallback using the HTTP response headers.

Improvements to MIME type detection:

* Ensured that `mime_type` is set to an empty string if it cannot be determined from the filename, preventing possible errors from `None` values.
* Added a fallback to use the `Content-Type` header from the HTTP response if the MIME type is still empty after attempting to guess it from the filename.

## Screenshots

| Before | After |
|--------|-------|
| ...    | <img width="2156" height="1678" alt="image" src="https://github.com/user-attachments/assets/9d68b40a-690d-41de-81c9-7312be23e2e3" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
