### PR TITLE
Remove redundant acceptedKeys check

### DIFF
--- a/web/utils/completion-params.ts
+++ b/web/utils/completion-params.ts
@@ -7,7 +7,6 @@ export const mergeValidCompletionParams = (
   if (!oldParams || Object.keys(oldParams).length === 0)
     return { params: {}, removedDetails: {} }
 
-  const acceptedKeys = new Set(rules.map(r => r.name))
   const ruleMap: Record<string, ModelParameterRule> = {}
   rules.forEach((r) => {
     ruleMap[r.name] = r
@@ -17,11 +16,6 @@ export const mergeValidCompletionParams = (
   const removedDetails: Record<string, string> = {}
 
   Object.entries(oldParams).forEach(([key, value]) => {
-    if (!acceptedKeys.has(key)) {
-      removedDetails[key] = 'unsupported'
-      return
-    }
-
     const rule = ruleMap[key]
     if (!rule) {
       removedDetails[key] = 'unsupported'


### PR DESCRIPTION
Fixes #23890 

Currently, `mergeValidCompletionParams` maintains both `acceptedKeys` (a Set of rule names) and `ruleMap` (a mapping from rule name to rule object) to check whether a key is supported. Both data structures are built from the same rules array, so their existence checks are equivalent. This results in duplicate maintenance and redundant logic.

This change removes the acceptedKeys set and relies solely on ruleMap[key] to determine support, reducing code duplication and maintenance overhead.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
