### PR TITLE
fix: add dark mode support for embedded modal option icons

### DIFF
--- a/web/app/components/app/overview/embedded/style.module.css
+++ b/web/app/components/app/overview/embedded/style.module.css
@@ -18,3 +18,13 @@
 .pluginInstallIcon {
   background-image: url(../assets/chromeplugin-install.svg);
 }
+
+:global(html[data-theme="dark"]) .iframeIcon,
+:global(html[data-theme="dark"]) .scriptsIcon,
+:global(html[data-theme="dark"]) .chromePluginIcon {
+  filter: invert(0.86) hue-rotate(180deg) saturate(0.5) brightness(0.95);
+}
+
+:global(html[data-theme="dark"]) .pluginInstallIcon {
+  filter: invert(0.9);
+}


### PR DESCRIPTION
## Summary

This PR adds dark mode support for the embedded modal option icons (iframe, scripts, chrome plugin) using CSS filters. The icons now properly adapt to the theme when switched to dark mode.

Fixes #23892 

## Screenshots

| Before | After |
|--------|-------|
| <img width="616" height="298" alt="image" src="https://github.com/user-attachments/assets/319dbb19-58e8-46a5-a58e-94b46ea67c00" /> |  <img width="626" height="306" alt="image" src="https://github.com/user-attachments/assets/1481ebb7-8564-463a-8cf4-8a06541dc798" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods