### PR TITLE
Fix multipart/form-data boundary issue in HTTP Call node

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -284,7 +284,12 @@ class Executor:
         if body and body.type == "form-data":
             # For multipart/form-data with files (including placeholder files),
             # remove any manually set Content-Type header to let httpx handle
-            # Content-Type and boundary automatically
+            # For multipart/form-data, if any files are present (including placeholder files),
+            # we must remove any manually set Content-Type header. This is because httpx needs to
+            # automatically set the Content-Type and boundary for multipart encoding whenever files
+            # are included, even if they are placeholders, to avoid boundary issues and ensure correct
+            # file upload behaviour. Manually setting Content-Type can cause httpx to fail to set the
+            # boundary, resulting in invalid requests.
             if self.files:
                 # Remove Content-Type if it was manually set to avoid boundary issues
                 headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -249,7 +249,7 @@ def test_executor_with_form_data():
     # to ensure the request is treated as multipart/form-data by the backend.
     assert executor.files == [("__multipart_placeholder__", ("", b"", "application/octet-stream"))]
     assert executor.content is None
-    
+
     # After fix for #23829: When placeholder files exist, Content-Type is removed
     # to let httpx handle Content-Type and boundary automatically
     headers = executor._assembling_headers()

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_http_request_executor.py
@@ -243,14 +243,17 @@ def test_executor_with_form_data():
     # Check the executor's data
     assert executor.method == "post"
     assert executor.url == "https://api.example.com/upload"
-    assert "Content-Type" in executor.headers
-    assert "multipart/form-data" in executor.headers["Content-Type"]
     assert executor.params is None
     assert executor.json is None
     # '__multipart_placeholder__' is expected when no file inputs exist,
     # to ensure the request is treated as multipart/form-data by the backend.
     assert executor.files == [("__multipart_placeholder__", ("", b"", "application/octet-stream"))]
     assert executor.content is None
+    
+    # After fix for #23829: When placeholder files exist, Content-Type is removed
+    # to let httpx handle Content-Type and boundary automatically
+    headers = executor._assembling_headers()
+    assert "Content-Type" not in headers or "multipart/form-data" not in headers.get("Content-Type", "")
 
     # Check that the form data is correctly loaded in executor.data
     assert isinstance(executor.data, dict)


### PR DESCRIPTION
- Fix parsing of form values containing colons using split(':', 1)
- Filter out empty field names to prevent name='' in multipart requests
- Let httpx handle Content-Type boundary generation automatically
- Add test case for values with colons and empty fields validation

Fixes #23829

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
