### PR TITLE
feat: document avaliable after update failed

### DIFF
--- a/api/tasks/document_indexing_update_task.py
+++ b/api/tasks/document_indexing_update_task.py
@@ -33,30 +33,10 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
     document.indexing_status = "parsing"
     document.processing_started_at = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
     db.session.commit()
-
-    # delete all document segment and index
-    try:
-        dataset = db.session.query(Dataset).where(Dataset.id == dataset_id).first()
-        if not dataset:
-            raise Exception("Dataset not found")
-
-        # only delay delete segment because need retrive when update document
-        segments = db.session.query(DocumentSegment).where(DocumentSegment.document_id == document_id).all()
-        if segments:
-            for segment in segments:
-                db.session.delete(segment)
-            db.session.commit()
-        end_at = time.perf_counter()
-        logging.info(
-            click.style(
-                "Cleaned document when document update data source or process rule: {} latency: {}".format(
-                    document_id, end_at - start_at
-                ),
-                fg="green",
-            )
-        )
-    except Exception:
-        logging.exception("Cleaned document when document update data source or process rule failed")
+    dataset = db.session.query(Dataset).where(Dataset.id == dataset_id).first()
+    if not dataset:
+        raise Exception("Dataset not found")
+    segments = db.session.query(DocumentSegment).where(DocumentSegment.document_id == document_id).all()
 
     try:
         indexing_runner = IndexingRunner()
@@ -73,33 +53,41 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
     finally:
         db.session.close()
 
-def document_indexing_update_task_sync(dataset: Dataset, document: Document, old_segments: list[DocumentSegment], update_success: bool):
-    if not old_segments:
-        return
+
+def document_indexing_update_task_sync(
+    dataset: Dataset, document: Document, old_segments: list[DocumentSegment], update_success: bool
+):
     try:
         index_type = document.doc_form
         index_processor = IndexProcessorFactory(index_type).init_index_processor()
-        if update_success:
-            index_node_ids = [segment.index_node_id for segment in old_segments]
-
-            # delete from vector index
-            index_processor.clean(dataset, index_node_ids, with_keywords=True, delete_child_chunks=True)
-
-        else:
-            # delete all new document segment and index
-            segments = db.session.query(DocumentSegment).where(DocumentSegment.document_id == document.id).all()
-            if segments:
-                index_node_ids = [segment.index_node_id for segment in segments]
+        if update_success and document.indexing_status == "completed":
+            # delete all old document segment and index
+            if old_segments:
+                index_node_ids = [segment.index_node_id for segment in old_segments]
 
                 # delete from vector index
                 index_processor.clean(dataset, index_node_ids, with_keywords=True, delete_child_chunks=True)
 
-                for segment in segments:
+                for segment in old_segments:
                     db.session.delete(segment)
                 db.session.commit()
-            # revert segment
+        else:
+            # Restore the old segment status
             for segment in old_segments:
-                db.session.add(segment)
+                segment.status = "completed"
             db.session.commit()
+            # delete all new document segment and index
+            segments = db.session.query(DocumentSegment).where(DocumentSegment.document_id == document.id).all()
+            old_segment_ids = [s.id for s in old_segments]
+            new_segments = [s for s in segments if s.id not in old_segment_ids]
+            if new_segments:
+                index_node_ids = [segment.index_node_id for segment in new_segments]
+
+                # delete from vector index
+                index_processor.clean(dataset, index_node_ids, with_keywords=True, delete_child_chunks=True)
+
+                for segment in new_segments:
+                    db.session.delete(segment)
+                db.session.commit()
     except Exception:
         logging.exception("document_indexing_update_task_sync failed, document_id: %s", document.id)

--- a/api/tasks/document_indexing_update_task.py
+++ b/api/tasks/document_indexing_update_task.py
@@ -11,7 +11,7 @@ from extensions.ext_database import db
 from models.dataset import Dataset, Document, DocumentSegment
 
 
-@shared_task(queue="dataset")
+@shared_task(queue="dataset_hz")
 def document_indexing_update_task(dataset_id: str, document_id: str):
     """
     Async update document
@@ -40,16 +40,9 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
         if not dataset:
             raise Exception("Dataset not found")
 
-        index_type = document.doc_form
-        index_processor = IndexProcessorFactory(index_type).init_index_processor()
-
+        # only delay delete segment because need retrive when update document
         segments = db.session.query(DocumentSegment).where(DocumentSegment.document_id == document_id).all()
         if segments:
-            index_node_ids = [segment.index_node_id for segment in segments]
-
-            # delete from vector index
-            index_processor.clean(dataset, index_node_ids, with_keywords=True, delete_child_chunks=True)
-
             for segment in segments:
                 db.session.delete(segment)
             db.session.commit()
@@ -70,9 +63,43 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
         indexing_runner.run([document])
         end_at = time.perf_counter()
         logging.info(click.style(f"update document: {document.id} latency: {end_at - start_at}", fg="green"))
+        document_indexing_update_task_sync(dataset, document, segments, True)
     except DocumentIsPausedError as ex:
         logging.info(click.style(str(ex), fg="yellow"))
+        document_indexing_update_task_sync(dataset, document, segments, False)
     except Exception:
         logging.exception("document_indexing_update_task failed, document_id: %s", document_id)
+        document_indexing_update_task_sync(dataset, document, segments, False)
     finally:
         db.session.close()
+
+def document_indexing_update_task_sync(dataset: Dataset, document: Document, old_segments: list[DocumentSegment], update_success: bool):
+    if not old_segments:
+        return
+    try:
+        index_type = document.doc_form
+        index_processor = IndexProcessorFactory(index_type).init_index_processor()
+        if update_success:
+            index_node_ids = [segment.index_node_id for segment in old_segments]
+
+            # delete from vector index
+            index_processor.clean(dataset, index_node_ids, with_keywords=True, delete_child_chunks=True)
+
+        else:
+            # delete all new document segment and index
+            segments = db.session.query(DocumentSegment).where(DocumentSegment.document_id == document.id).all()
+            if segments:
+                index_node_ids = [segment.index_node_id for segment in segments]
+
+                # delete from vector index
+                index_processor.clean(dataset, index_node_ids, with_keywords=True, delete_child_chunks=True)
+
+                for segment in segments:
+                    db.session.delete(segment)
+                db.session.commit()
+            # revert segment
+            for segment in old_segments:
+                db.session.add(segment)
+            db.session.commit()
+    except Exception:
+        logging.exception("document_indexing_update_task_sync failed, document_id: %s", document.id)

--- a/api/tasks/document_indexing_update_task.py
+++ b/api/tasks/document_indexing_update_task.py
@@ -73,7 +73,10 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
     finally:
         db.session.close()
 
-def document_indexing_update_task_sync(dataset: Dataset, document: Document, old_segments: list[DocumentSegment], update_success: bool):
+
+def document_indexing_update_task_sync(
+    dataset: Dataset, document: Document, old_segments: list[DocumentSegment], update_success: bool
+):
     if not old_segments:
         return
     try:

--- a/api/tasks/document_indexing_update_task.py
+++ b/api/tasks/document_indexing_update_task.py
@@ -11,7 +11,7 @@ from extensions.ext_database import db
 from models.dataset import Dataset, Document, DocumentSegment
 
 
-@shared_task(queue="dataset_hz")
+@shared_task(queue="dataset")
 def document_indexing_update_task(dataset_id: str, document_id: str):
     """
     Async update document


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Currently, the pipeline of updating documents in the knowledge base is to delete the old documents first, and then build the index of the new documents. However, this approach has the following drawbacks:

When the document update fails, the old document indexes will also be lost.

To this end, this PR was opened to resolve the above issues.
close https://github.com/langgenius/dify/issues/23940

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
