### PR TITLE
Fix hover button contrast in dark mode for app and dataset cards

### DIFF
--- a/web/app/(commonLayout)/datasets/dataset-card.tsx
+++ b/web/app/(commonLayout)/datasets/dataset-card.tsx
@@ -216,8 +216,8 @@ const DatasetCard = ({
               }
               btnClassName={open =>
                 cn(
-                  open ? '!bg-black/5 !shadow-none' : '!bg-transparent',
-                  'h-8 w-8 rounded-md border-none !p-2 hover:!bg-black/5',
+                  open ? '!bg-state-base-hover !shadow-none' : '!bg-transparent',
+                  'h-8 w-8 rounded-md border-none !p-2 hover:!bg-state-base-hover',
                 )
               }
               className={'!z-20 h-fit !w-[128px]'}

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -407,8 +407,8 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
                   }
                   btnClassName={open =>
                     cn(
-                      open ? '!bg-black/5 !shadow-none' : '!bg-transparent',
-                      'h-8 w-8 rounded-md border-none !p-2 hover:!bg-black/5',
+                      open ? '!bg-state-base-hover !shadow-none' : '!bg-transparent',
+                      'h-8 w-8 rounded-md border-none !p-2 hover:!bg-state-base-hover',
                     )
                   }
                   popupClassName={


### PR DESCRIPTION
## Summary

Fixes #23954

This PR improves the hover button contrast in dark mode for app-card and dataset-card components by replacing `hover:!bg-black/5` with `hover:!bg-state-base-hover` to ensure proper accessibility and consistency with other hover effects.

**Changes made:**
- Updated app-card three dots button hover styles in `/web/app/components/apps/app-card.tsx`
- Updated dataset-card three dots button hover styles in `/web/app/(commonLayout)/datasets/dataset-card.tsx`
- Replaced `!bg-black/5` with `!bg-state-base-hover` for both hover and active states

## Screenshots

| Before | After |
|--------|-------|
| <img width="140" height="93" alt="image" src="https://github.com/user-attachments/assets/fdd3ea04-d1dc-49de-9de4-2c2f55d633ff" /> | <img width="152" height="95" alt="image" src="https://github.com/user-attachments/assets/2cf0a45c-b92d-41f1-826a-a7dc2cf31401" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods