### PR TITLE
fix(oauth): redis compatibility

### DIFF
--- a/api/services/plugin/oauth_service.py
+++ b/api/services/plugin/oauth_service.py
@@ -47,7 +47,9 @@ class OAuthProxyService(BasePluginClient):
         if not context_id:
             raise ValueError("context_id is required")
         # get data from redis
-        data = redis_client.getdel(f"{OAuthProxyService.__KEY_PREFIX__}{context_id}")
+        key = f"{OAuthProxyService.__KEY_PREFIX__}{context_id}"
+        data = redis_client.get(key)
         if not data:
             raise ValueError("context_id is invalid")
+        redis_client.delete(key)
         return json.loads(data)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
This pull request updates the logic for handling OAuth proxy context retrieval in the `use_proxy_context` function. The changes improve reliability by separating the read and delete operations for Redis keys.

Improvements to Redis key handling:

* Changed the Redis operation from `getdel` to separate `get` and `delete` calls, ensuring the key is deleted only after successful retrieval of data. (`api/services/plugin/oauth_service.py`)

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
