### PR TITLE
fix(workflow): correct secret variable handling on restore and edit

### DIFF
--- a/api/controllers/console/app/workflow.py
+++ b/api/controllers/console/app/workflow.py
@@ -42,12 +42,13 @@ from services.workflow_service import DraftWorkflowDeletionError, WorkflowInUseE
 
 logger = logging.getLogger(__name__)
 
+
 # Define a custom type for environment variables to include 'from_version'
 def environment_variable(value):
     if not isinstance(value, dict):
         raise ValueError("Must be a dictionary")
     # Basic validation, can be expanded
-    if 'name' not in value or 'value_type' not in value:
+    if "name" not in value or "value_type" not in value:
         raise ValueError("Missing 'name' or 'value_type'")
     # 'from_version' is optional
     return value
@@ -115,7 +116,7 @@ class DraftWorkflowApi(Resource):
             parser.add_argument("features", type=dict, required=True, nullable=False, location="json")
             parser.add_argument("hash", type=str, required=False, location="json")
             parser.add_argument(
-                "environment_variables", type=environment_variable, required=True, location="json", action='append'
+                "environment_variables", type=environment_variable, required=True, location="json", action="append"
             )
             parser.add_argument("conversation_variables", type=list, required=False, location="json")
             args = parser.parse_args()

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -508,7 +508,7 @@ class AppDslService:
                 features=workflow_data.get("features", {}),
                 unique_hash=unique_hash,
                 raw_environment_variables=environment_variables,
-                conversation_variables=conversation_variables
+                conversation_variables=conversation_variables,
             )
         elif app_mode in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.COMPLETION}:
             # Initialize model config

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -503,12 +503,12 @@ class AppDslService:
                     ]
             workflow_service.sync_draft_workflow(
                 app_model=app,
-                graph=workflow_data.get("graph", {}),
+                account=account,
+                graph=graph,
                 features=workflow_data.get("features", {}),
                 unique_hash=unique_hash,
-                account=account,
-                environment_variables=environment_variables,
-                conversation_variables=conversation_variables,
+                raw_environment_variables=environment_variables,
+                conversation_variables=conversation_variables
             )
         elif app_mode in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.COMPLETION}:
             # Initialize model config

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -507,7 +507,7 @@ class AppDslService:
                 graph=graph,
                 features=workflow_data.get("features", {}),
                 unique_hash=unique_hash,
-                raw_environment_variables=environment_variables,
+                raw_environment_variables=[var.model_dump() for var in environment_variables],
                 conversation_variables=conversation_variables,
             )
         elif app_mode in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.COMPLETION}:

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -14,6 +14,7 @@ from core.app.apps.workflow.app_config_manager import WorkflowAppConfigManager
 from core.file import File
 from core.repositories import DifyCoreRepositoryFactory
 from core.variables import Variable
+from core.variables.types import SegmentType
 from core.variables.variables import VariableUnion
 from core.workflow.entities.node_entities import NodeRunResult
 from core.workflow.entities.variable_pool import VariablePool
@@ -31,6 +32,7 @@ from core.workflow.system_variable import SystemVariable
 from core.workflow.workflow_entry import WorkflowEntry
 from events.app_event import app_draft_workflow_was_synced, app_published_workflow_was_updated
 from extensions.ext_database import db
+from factories import variable_factory
 from factories.file_factory import build_from_mapping, build_from_mappings
 from libs.datetime_utils import naive_utc_now
 from models.account import Account
@@ -194,6 +196,28 @@ class WorkflowService:
 
         return workflows, has_more
 
+    def _restore_secret_from_version(self, app_model: App, env_var_id: str, from_version: str) -> str:
+        """
+        Restore a secret value from a specific published workflow version.
+        """
+        # Fetch the specific published workflow version
+        published_workflow = db.session.query(Workflow).filter(
+            Workflow.tenant_id == app_model.tenant_id,
+            Workflow.app_id == app_model.id,
+            Workflow.id == from_version
+        ).first()
+
+        if not published_workflow or published_workflow.version == Workflow.VERSION_DRAFT:
+            raise ValueError(f"Published workflow version {from_version} not found.")
+
+        # Find the specific secret environment variable
+        for env_var in published_workflow.environment_variables:
+            if env_var.id == env_var_id and env_var.value_type == SegmentType.SECRET.value:
+                # Return the original encrypted value
+                return env_var.value
+
+        raise ValueError(f"Secret environment variable with id {env_var_id} not found in version {from_version}.")
+
     def sync_draft_workflow(
         self,
         *,
@@ -202,7 +226,7 @@ class WorkflowService:
         features: dict,
         unique_hash: Optional[str],
         account: Account,
-        environment_variables: Sequence[Variable],
+        raw_environment_variables: Sequence[dict],
         conversation_variables: Sequence[Variable],
     ) -> Workflow:
         """
@@ -214,6 +238,29 @@ class WorkflowService:
 
         if workflow and workflow.unique_hash != unique_hash:
             raise WorkflowHashNotEqualError()
+
+        # Process environment variables
+        processed_env_vars = []
+        for var_dict in raw_environment_variables:
+            if var_dict.get('value_type') == SegmentType.SECRET.value and 'from_version' in var_dict:
+                # Restore secret from a previous version
+                try:
+                    restored_value = self._restore_secret_from_version(
+                        app_model=app_model,
+                        env_var_id=var_dict.get('id'),
+                        from_version=var_dict.get('from_version')
+                    )
+                    # Use the restored encrypted value
+                    var_dict['value'] = restored_value
+                except ValueError as e:
+                    # If restoration fails, treat it as a regular variable without a value
+                    # This prevents errors and allows the user to manually set it if needed
+                    var_dict['value'] = ''
+
+            # Build the Variable object after potential restoration
+            processed_env_vars.append(
+                variable_factory.build_environment_variable_from_mapping(var_dict)
+            )
 
         # validate features structure
         self.validate_features_structure(app_model=app_model, features=features)
@@ -228,7 +275,7 @@ class WorkflowService:
                 graph=json.dumps(graph),
                 features=json.dumps(features),
                 created_by=account.id,
-                environment_variables=environment_variables,
+                environment_variables=processed_env_vars,
                 conversation_variables=conversation_variables,
             )
             db.session.add(workflow)
@@ -238,7 +285,7 @@ class WorkflowService:
             workflow.features = json.dumps(features)
             workflow.updated_by = account.id
             workflow.updated_at = naive_utc_now()
-            workflow.environment_variables = environment_variables
+            workflow.environment_variables = processed_env_vars
             workflow.conversation_variables = conversation_variables
 
         # commit db session changes

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -246,25 +246,23 @@ class WorkflowService:
         for var_dict in raw_environment_variables:
             if var_dict.get("value_type") == SegmentType.SECRET.value and "from_version" in var_dict:
                 # Restore secret from a previous version
-                env_var_id = var_dict.get('id')
-                from_version = var_dict.get('from_version')
+                env_var_id = var_dict.get("id")
+                from_version = var_dict.get("from_version")
 
                 if not env_var_id or not from_version:
                     # Skip if essential info is missing
-                    var_dict['value'] = ''
+                    var_dict["value"] = ""
                 else:
                     try:
                         restored_value = self._restore_secret_from_version(
-                            app_model=app_model,
-                            env_var_id=cast(str, env_var_id),
-                            from_version=cast(str, from_version)
+                            app_model=app_model, env_var_id=cast(str, env_var_id), from_version=cast(str, from_version)
                         )
                         # Use the restored encrypted value
-                        var_dict['value'] = restored_value
+                        var_dict["value"] = restored_value
                     except ValueError:
                         # If restoration fails, treat it as a regular variable without a value
                         # This prevents errors and allows the user to manually set it if needed
-                        var_dict['value'] = ''
+                        var_dict["value"] = ""
 
             # Build the Variable object after potential restoration
             processed_env_vars.append(variable_factory.build_environment_variable_from_mapping(var_dict))

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -201,11 +201,13 @@ class WorkflowService:
         Restore a secret value from a specific published workflow version.
         """
         # Fetch the specific published workflow version
-        published_workflow = db.session.query(Workflow).filter(
-            Workflow.tenant_id == app_model.tenant_id,
-            Workflow.app_id == app_model.id,
-            Workflow.id == from_version
-        ).first()
+        published_workflow = (
+            db.session.query(Workflow)
+            .filter(
+                Workflow.tenant_id == app_model.tenant_id, Workflow.app_id == app_model.id, Workflow.id == from_version
+            )
+            .first()
+        )
 
         if not published_workflow or published_workflow.version == Workflow.VERSION_DRAFT:
             raise ValueError(f"Published workflow version {from_version} not found.")
@@ -242,25 +244,21 @@ class WorkflowService:
         # Process environment variables
         processed_env_vars = []
         for var_dict in raw_environment_variables:
-            if var_dict.get('value_type') == SegmentType.SECRET.value and 'from_version' in var_dict:
+            if var_dict.get("value_type") == SegmentType.SECRET.value and "from_version" in var_dict:
                 # Restore secret from a previous version
                 try:
                     restored_value = self._restore_secret_from_version(
-                        app_model=app_model,
-                        env_var_id=var_dict.get('id'),
-                        from_version=var_dict.get('from_version')
+                        app_model=app_model, env_var_id=var_dict.get("id"), from_version=var_dict.get("from_version")
                     )
                     # Use the restored encrypted value
-                    var_dict['value'] = restored_value
+                    var_dict["value"] = restored_value
                 except ValueError as e:
                     # If restoration fails, treat it as a regular variable without a value
                     # This prevents errors and allows the user to manually set it if needed
-                    var_dict['value'] = ''
+                    var_dict["value"] = ""
 
             # Build the Variable object after potential restoration
-            processed_env_vars.append(
-                variable_factory.build_environment_variable_from_mapping(var_dict)
-            )
+            processed_env_vars.append(variable_factory.build_environment_variable_from_mapping(var_dict))
 
         # validate features structure
         self.validate_features_structure(app_model=app_model, features=features)

--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -93,7 +93,7 @@ export const useNodesSyncDraft = () => {
                 name: item.name,
                 value_type: item.value_type,
                 from_version: restoredSecretsInfo[item.id].from_version,
-                // Add missing properties to satisfy the EnvironmentVariable type
+                // value and description are required by type but not used by backend for restored secrets
                 value: '',
                 description: '',
               }

--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation'
 import {
   useWorkflowStore,
 } from '@/app/components/workflow/store'
-import { BlockEnum } from '@/app/components/workflow/types'
+import { BlockEnum, type EnvironmentVariable } from '@/app/components/workflow/types'
 import {
   useNodesReadOnly,
 } from '@/app/components/workflow/hooks/use-workflow'
@@ -22,7 +22,7 @@ export const useNodesSyncDraft = () => {
   const { handleRefreshWorkflowDraft } = useWorkflowRefreshDraft()
   const params = useParams()
 
-  const getPostParams = useCallback(() => {
+  const getPostParams = useCallback((overrideEnv?: EnvironmentVariable[]) => {
     const {
       getNodes,
       edges,
@@ -32,9 +32,12 @@ export const useNodesSyncDraft = () => {
     const {
       appId,
       conversationVariables,
-      environmentVariables,
+      environmentVariables: environmentVariablesFromStore,
       syncWorkflowDraftHash,
+      restoredSecretsInfo,
     } = workflowStore.getState()
+
+    const environmentVariables = overrideEnv || environmentVariablesFromStore
 
     if (appId) {
       const nodes = getNodes()
@@ -82,7 +85,23 @@ export const useNodesSyncDraft = () => {
             sensitive_word_avoidance: features.moderation,
             file_upload: features.file,
           },
-          environment_variables: environmentVariables,
+          environment_variables: environmentVariables.map((item: EnvironmentVariable) => {
+            // If it's a restored secret, send the from_version field
+            if (item.value_type === 'secret' && restoredSecretsInfo[item.id]) {
+              return {
+                id: item.id,
+                name: item.name,
+                value_type: item.value_type,
+                from_version: restoredSecretsInfo[item.id].from_version,
+                // Add missing properties to satisfy the EnvironmentVariable type
+                value: '',
+                description: '',
+              }
+            }
+            // For all other cases, pass the value as is.
+            // For secrets, this will be the plaintext value during the save operation.
+            return item
+          }),
           conversation_variables: conversationVariables,
           hash: syncWorkflowDraftHash,
         },
@@ -110,10 +129,11 @@ export const useNodesSyncDraft = () => {
       onError?: () => void
       onSettled?: () => void
     },
+    overrideEnv?: EnvironmentVariable[],
   ) => {
     if (getNodesReadOnly())
       return
-    const postParams = getPostParams()
+    const postParams = getPostParams(overrideEnv)
 
     if (postParams) {
       const {

--- a/web/app/components/workflow-app/hooks/use-workflow-run.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-run.ts
@@ -341,7 +341,22 @@ export const useWorkflowRun = () => {
     }
 
     featuresStore?.setState({ features: mappedFeatures })
-    workflowStore.getState().setEnvironmentVariables(publishedWorkflow.environment_variables || [])
+
+    // Clear previous restore info before setting new ones
+    workflowStore.getState().setRestoredSecretsInfo({})
+
+    const restoredSecretsInfo: Record<string, { from_version: string }> = {}
+    ;(publishedWorkflow.environment_variables || []).forEach((env) => {
+      if (env.value_type === 'secret')
+        restoredSecretsInfo[env.id] = { from_version: publishedWorkflow.id }
+    })
+    workflowStore.getState().setRestoredSecretsInfo(restoredSecretsInfo)
+
+    workflowStore.getState().setEnvSecrets((publishedWorkflow.environment_variables || []).filter(env => env.value_type === 'secret').reduce((acc, env) => {
+      acc[env.id] = env.value
+      return acc
+    }, {} as Record<string, string>))
+    workflowStore.getState().setEnvironmentVariables(publishedWorkflow.environment_variables?.map(env => env.value_type === 'secret' ? { ...env, value: '[__HIDDEN__]' } : env) || [])
   }, [featuresStore, handleUpdateWorkflowCanvas, workflowStore])
 
   return {

--- a/web/app/components/workflow/hooks-store/store.ts
+++ b/web/app/components/workflow/hooks-store/store.ts
@@ -13,6 +13,7 @@ import type {
   Node,
   ValueSelector,
 } from '@/app/components/workflow/types'
+import type { EnvironmentVariable } from '@/types/workflow'
 
 type CommonHooksFnMap = {
   doSyncWorkflowDraft: (
@@ -21,7 +22,8 @@ type CommonHooksFnMap = {
       onSuccess?: () => void
       onError?: () => void
       onSettled?: () => void
-    }
+    },
+    overrideEnv?: EnvironmentVariable[]
   ) => Promise<void>
   syncWorkflowDraftWhenPageClose: () => void
   handleRefreshWorkflowDraft: () => void

--- a/web/app/components/workflow/store/workflow/env-variable-slice.ts
+++ b/web/app/components/workflow/store/workflow/env-variable-slice.ts
@@ -1,5 +1,7 @@
 import type { StateCreator } from 'zustand'
-import type { EnvironmentVariable } from '@/app/components/workflow/types'
+import type {
+  EnvironmentVariable,
+} from '@/app/components/workflow/types'
 
 export type EnvVariableSliceShape = {
   showEnvPanel: boolean
@@ -8,13 +10,23 @@ export type EnvVariableSliceShape = {
   setEnvironmentVariables: (environmentVariables: EnvironmentVariable[]) => void
   envSecrets: Record<string, string>
   setEnvSecrets: (envSecrets: Record<string, string>) => void
+  restoredSecretsInfo: Record<string, { from_version: string }>
+  setRestoredSecretsInfo: (restoredSecretsInfo: Record<string, { from_version: string }>) => void
+  updateRestoredSecretsInfo: (key: string, value: { from_version: string }) => void
 }
 
-export const createEnvVariableSlice: StateCreator<EnvVariableSliceShape> = set => ({
+export const createEnvVariableSlice: StateCreator<EnvVariableSliceShape> = (set, get) => ({
   showEnvPanel: false,
   setShowEnvPanel: showEnvPanel => set(() => ({ showEnvPanel })),
   environmentVariables: [],
   setEnvironmentVariables: environmentVariables => set(() => ({ environmentVariables })),
   envSecrets: {},
   setEnvSecrets: envSecrets => set(() => ({ envSecrets })),
+  restoredSecretsInfo: {},
+  setRestoredSecretsInfo: restoredSecretsInfo => set(() => ({ restoredSecretsInfo })),
+  updateRestoredSecretsInfo: (key, value) => {
+    const { restoredSecretsInfo } = get()
+    const newRestoredSecretsInfo = { ...restoredSecretsInfo, [key]: value }
+    set(() => ({ restoredSecretsInfo: newRestoredSecretsInfo }))
+  },
 })


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

fix #23975

## Summary

This PR implements a robust and secure mechanism for managing `secret` type environment variables within the workflow, addressing several critical bugs related to version restoration and editing.

**Motivation & Context:**

Previously, handling of secret variables was flawed in two major ways:
1.  **Version Restore Corruption**: When restoring a historical workflow version, the API would provide a masked secret value. The frontend would then attempt to save this masked value back to the draft, leading to a corrupted and unusable secret.
2.  **UI Plaintext Leak**: When a user edited a secret, a UI race condition would cause the new plaintext value to be briefly displayed on the screen before being masked. This was a security concern.

This PR completely overhauls the logic to resolve these issues, ensuring a secure and intuitive user experience.

**Key Changes:**

*   **Backend (`/api`)**:
    *   The `WorkflowDraftApi` has been updated to accept a new `from_version` field for environment variables.
    *   The `WorkflowService` now contains logic to securely retrieve the original encrypted secret from a specified historical version using the `from_version` and `id` references, completely bypassing the need to handle plaintext secrets during restoration.
    *   All related Python linter errors (`E501`) and `NameError`/`AttributeError` bugs discovered during development have been fixed.

*   **Frontend (`/web`)**:
    *   A new state, `restoredSecretsInfo`, has been added to the `workflowStore` to track the origin of restored secrets.
    *   The `useNodesSyncDraft` hook has been refactored. It now constructs a payload with the `from_version` instruction when a restored secret is saved.
    *   The `EnvPanel` component's state management (`handleSave`) has been significantly improved to perform atomic updates, which resolves the plaintext UI leak and correctly handles the data flow for both restored and manually edited secrets.
    *   All related frontend type errors and dependency issues have been resolved.

This comprehensive fix ensures that restoring and editing secret variables is now both secure (no plaintext exposure) and reliable.

## Screenshots

| Before (Buggy Behavior) | After (Successful Restore & Edit) |
|<img width="421" height="626" alt="iShot_2025-08-14_15 21 53" src="https://github.com/user-attachments/assets/24e8bf07-19b0-4f9d-8b21-b6976ddb0589" />|<img width="440" height="693" alt="iShot_2025-08-14_15 19 19" src="https://github.com/user-attachments/assets/63bdb09a-4c34-4968-8746-902fd798b013" />|

https://github.com/user-attachments/assets/57359c7e-fd87-4c74-aaf6-5a1eae7ca565

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [] I've updated the documentation accordingly.
- [] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
