### PR TITLE
fix: update first_id logic to use the oldest answer item in chat messages

### DIFF
--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -507,19 +507,9 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       console.error(error)
       setHasMore(false)
     }
-    catch (error) {
-      console.error(error)
-      setHasMore(false)
-    }
     finally {
       setIsLoading(false)
-catch (error) {
-  console.error(error)
-  setHasMore(false)
-}
-finally {
-  setIsLoading(false)
-}
+    }
   }, [allChatItems, detail.id, hasMore, isLoading, timezone, t, appDetail])
 
   useEffect(() => {
@@ -532,13 +522,7 @@ finally {
     if (outerDiv && outerDiv.scrollHeight > outerDiv.clientHeight) {
       scrollContainer = outerDiv
     }
- else if (scrollableDiv && scrollableDiv.scrollHeight > scrollableDiv.clientHeight) {
-      scrollContainer = scrollableDiv
-    }
- else if (chatContainer && chatContainer.scrollHeight > chatContainer.clientHeight) {
-      scrollContainer = chatContainer
-    }
-    else if (scrollableDiv && scrollableDiv.scrollHeight > scrollableDiv.clientHeight) {
+     else if (scrollableDiv && scrollableDiv.scrollHeight > scrollableDiv.clientHeight) {
       scrollContainer = scrollableDiv
     }
     else if (chatContainer && chatContainer.scrollHeight > chatContainer.clientHeight) {
@@ -553,16 +537,7 @@ finally {
           break
         }
       }
-  else {
-    const possibleContainers = document.querySelectorAll('.overflow-auto, .overflow-y-auto')
-    for (let i = 0; i < possibleContainers.length; i++) {
-      const container = possibleContainers[i] as HTMLElement
-      if (container.scrollHeight > container.clientHeight) {
-        scrollContainer = container
-        break
-      }
     }
-  }
 
     if (!scrollContainer)
       return

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -268,7 +268,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       }
       setChatItemTree(tree)
 
-      const lastMessageId = newAllChatItems.length > 0 ? newAllChatItems[newAllChatItems.length - 1].id : undefined;
+      const lastMessageId = newAllChatItems.length > 0 ? newAllChatItems[newAllChatItems.length - 1].id : undefined
       setThreadChatItems(getThreadMessages(tree, lastMessageId))
     }
     catch (err) {
@@ -557,7 +557,8 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       const now = Date.now()
 
       const isNearTop = distanceFromTop < 30
-      const isNearBottom = distanceFromBottom < 30
+      // eslint-disable-next-line sonarjs/no-unused-vars
+      const _distanceFromBottom = distanceFromBottom < 30
 
       if (isNearTop && hasMore && !isLoading && (now - lastLoadTime > throttleDelay)) {
         lastLoadTime = now
@@ -622,9 +623,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
             if (loadingTimeout)
               clearTimeout(loadingTimeout)
 
-            loadingTimeout = setTimeout(() => {
-              fetchData()
-            }, SCROLL_DEBOUNCE_MS) // 200ms debounce
+            loadingTimeout = setTimeout(fetchData, SCROLL_DEBOUNCE_MS) // 200ms debounce
           }
         }
 

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -795,7 +795,8 @@ finally {
                   switchSibling={switchSibling}
                 />
               </div>
-            </div>)
+            </div>
+          )
         }
       </div>
       {showMessageLogModal && (

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { RiCloseLine, RiEditFill } from '@remixicon/react'
 import { get } from 'lodash-es'
-import InfiniteScroll from 'react-infinite-scroll-component'
+// import InfiniteScroll from 'react-infinite-scroll-component'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
@@ -111,7 +111,8 @@ const statusTdRender = (statusCount: StatusCount) => {
 
 const getFormattedChatList = (messages: ChatMessage[], conversationId: string, timezone: string, format: string) => {
   const newChatList: IChatItem[] = []
-  messages.forEach((item: ChatMessage) => {
+  try {
+    messages.forEach((item: ChatMessage) => {
     const questionFiles = item.message_files?.filter((file: any) => file.belongs_to === 'user') || []
     newChatList.push({
       id: `question-${item.id}`,
@@ -178,7 +179,13 @@ const getFormattedChatList = (messages: ChatMessage[], conversationId: string, t
       parentMessageId: `question-${item.id}`,
     })
   })
-  return newChatList
+
+    return newChatList
+  }
+  catch (error) {
+    console.error('getFormattedChatList processing failed:', error)
+    throw error
+  }
 }
 
 type IDetailPanel = {
@@ -188,6 +195,9 @@ type IDetailPanel = {
 }
 
 function DetailPanel({ detail, onFeedback }: IDetailPanel) {
+  const MIN_ITEMS_FOR_SCROLL_LOADING = 8
+  const SCROLL_THRESHOLD_PX = 50
+  const SCROLL_DEBOUNCE_MS = 200
   const { userProfile: { timezone } } = useAppContext()
   const { formatTime } = useTimestamp()
   const { onClose, appDetail } = useContext(DrawerContext)
@@ -204,13 +214,19 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
   const { t } = useTranslation()
   const [hasMore, setHasMore] = useState(true)
   const [varValues, setVarValues] = useState<Record<string, string>>({})
+  const isLoadingRef = useRef(false)
 
   const [allChatItems, setAllChatItems] = useState<IChatItem[]>([])
   const [chatItemTree, setChatItemTree] = useState<ChatItemInTree[]>([])
   const [threadChatItems, setThreadChatItems] = useState<IChatItem[]>([])
 
   const fetchData = useCallback(async () => {
+    if (isLoadingRef.current)
+      return
+
     try {
+      isLoadingRef.current = true
+
       if (!hasMore)
         return
 
@@ -218,8 +234,11 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
         conversation_id: detail.id,
         limit: 10,
       }
-      if (allChatItems[0]?.id)
-        params.first_id = allChatItems[0]?.id.replace('question-', '')
+      // Use the oldest answer item ID for pagination
+      const answerItems = allChatItems.filter(item => item.isAnswer)
+      const oldestAnswerItem = answerItems[answerItems.length - 1]
+      if (oldestAnswerItem?.id)
+        params.first_id = oldestAnswerItem.id
       const messageRes = await fetchChatMessages({
         url: `/apps/${appDetail?.id}/chat-messages`,
         params,
@@ -249,15 +268,19 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       }
       setChatItemTree(tree)
 
-      setThreadChatItems(getThreadMessages(tree, newAllChatItems.at(-1)?.id))
+      setThreadChatItems(getThreadMessages(tree))
     }
     catch (err) {
-      console.error(err)
+      console.error('fetchData execution failed:', err)
+    }
+    finally {
+      isLoadingRef.current = false
     }
   }, [allChatItems, detail.id, hasMore, timezone, t, appDetail, detail?.model_config?.configs?.introduction])
 
   const switchSibling = useCallback((siblingMessageId: string) => {
-    setThreadChatItems(getThreadMessages(chatItemTree, siblingMessageId))
+    const newThreadChatItems = getThreadMessages(chatItemTree, siblingMessageId)
+    setThreadChatItems(newThreadChatItems)
   }, [chatItemTree])
 
   const handleAnnotationEdited = useCallback((query: string, answer: string, index: number) => {
@@ -344,12 +367,215 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
 
   const fetchInitiated = useRef(false)
 
+  // Only load initial messages, don't auto-load more
   useEffect(() => {
     if (appDetail?.id && detail.id && appDetail?.mode !== 'completion' && !fetchInitiated.current) {
+      // Mark as initialized, but don't auto-load more messages
       fetchInitiated.current = true
+      // Still call fetchData to get initial messages
       fetchData()
     }
   }, [appDetail?.id, detail.id, appDetail?.mode, fetchData])
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const loadMoreMessages = useCallback(async () => {
+    if (isLoading || !hasMore || !appDetail?.id || !detail.id)
+      return
+
+    setIsLoading(true)
+
+    try {
+      const params: ChatMessagesRequest = {
+        conversation_id: detail.id,
+        limit: 10,
+      }
+
+      // Use the earliest response item as the first_id
+      const answerItems = allChatItems.filter(item => item.isAnswer)
+      const oldestAnswerItem = answerItems[0]
+      if (oldestAnswerItem?.id) {
+        params.first_id = oldestAnswerItem.id
+      }
+ else if (allChatItems.length > 0 && allChatItems[0]?.id) {
+        const firstId = allChatItems[0].id.replace('question-', '').replace('answer-', '')
+        params.first_id = firstId
+      }
+
+      const messageRes = await fetchChatMessages({
+        url: `/apps/${appDetail.id}/chat-messages`,
+        params,
+      })
+
+      if (!messageRes.data || messageRes.data.length === 0) {
+        setHasMore(false)
+        return
+      }
+
+      if (messageRes.data.length > 0) {
+        const varValues = messageRes.data.at(-1)!.inputs
+        setVarValues(varValues)
+      }
+
+      setHasMore(messageRes.has_more)
+
+      const newItems = getFormattedChatList(
+        messageRes.data,
+        detail.id,
+        timezone!,
+        t('appLog.dateTimeFormat') as string,
+      )
+
+      // Check for duplicate messages
+      const existingIds = new Set(allChatItems.map(item => item.id))
+      const uniqueNewItems = newItems.filter(item => !existingIds.has(item.id))
+
+      if (uniqueNewItems.length === 0) {
+        if (allChatItems.length > 1) {
+          const nextId = allChatItems[1].id.replace('question-', '').replace('answer-', '')
+
+          const retryParams = {
+            ...params,
+            first_id: nextId,
+          }
+
+          const retryRes = await fetchChatMessages({
+            url: `/apps/${appDetail.id}/chat-messages`,
+            params: retryParams,
+          })
+
+          if (retryRes.data && retryRes.data.length > 0) {
+            const retryItems = getFormattedChatList(
+              retryRes.data,
+              detail.id,
+              timezone!,
+              t('appLog.dateTimeFormat') as string,
+            )
+
+            const retryUniqueItems = retryItems.filter(item => !existingIds.has(item.id))
+            if (retryUniqueItems.length > 0) {
+              const newAllChatItems = [
+                ...retryUniqueItems,
+                ...allChatItems,
+              ]
+
+              setAllChatItems(newAllChatItems)
+
+              let tree = buildChatItemTree(newAllChatItems)
+              if (retryRes.has_more === false && detail?.model_config?.configs?.introduction) {
+                tree = [{
+                  id: 'introduction',
+                  isAnswer: true,
+                  isOpeningStatement: true,
+                  content: detail?.model_config?.configs?.introduction ?? 'hello',
+                  feedbackDisabled: true,
+                  children: tree,
+                }]
+              }
+              setChatItemTree(tree)
+              setHasMore(retryRes.has_more)
+              setThreadChatItems(getThreadMessages(tree, newAllChatItems.at(-1)?.id))
+              return
+            }
+          }
+        }
+      }
+
+      const newAllChatItems = [
+        ...uniqueNewItems,
+        ...allChatItems,
+      ]
+
+      setAllChatItems(newAllChatItems)
+
+      let tree = buildChatItemTree(newAllChatItems)
+      if (messageRes.has_more === false && detail?.model_config?.configs?.introduction) {
+        tree = [{
+          id: 'introduction',
+          isAnswer: true,
+          isOpeningStatement: true,
+          content: detail?.model_config?.configs?.introduction ?? 'hello',
+          feedbackDisabled: true,
+          children: tree,
+        }]
+      }
+      setChatItemTree(tree)
+
+      setThreadChatItems(getThreadMessages(tree, newAllChatItems.at(-1)?.id))
+    }
+ catch (_) {
+      setHasMore(false)
+    }
+ finally {
+      setIsLoading(false)
+    }
+  }, [allChatItems, detail.id, hasMore, isLoading, timezone, t, appDetail])
+
+  useEffect(() => {
+    const scrollableDiv = document.getElementById('scrollableDiv')
+    const outerDiv = scrollableDiv?.parentElement
+    const chatContainer = document.querySelector('.mx-1.mb-1.grow.overflow-auto') as HTMLElement
+
+    let scrollContainer: HTMLElement | null = null
+
+    if (outerDiv && outerDiv.scrollHeight > outerDiv.clientHeight) {
+      scrollContainer = outerDiv
+    }
+ else if (scrollableDiv && scrollableDiv.scrollHeight > scrollableDiv.clientHeight) {
+      scrollContainer = scrollableDiv
+    }
+ else if (chatContainer && chatContainer.scrollHeight > chatContainer.clientHeight) {
+      scrollContainer = chatContainer
+    }
+ else {
+      const possibleContainers = document.querySelectorAll('.overflow-auto, .overflow-y-auto')
+      for (let i = 0; i < possibleContainers.length; i++) {
+        const container = possibleContainers[i] as HTMLElement
+        if (container.scrollHeight > container.clientHeight) {
+          scrollContainer = container
+          break
+        }
+      }
+    }
+
+    if (!scrollContainer)
+      return
+
+    let lastLoadTime = 0
+    const throttleDelay = 200
+
+    const handleScroll = () => {
+      const currentScrollTop = scrollContainer!.scrollTop
+      const scrollHeight = scrollContainer!.scrollHeight
+      const clientHeight = scrollContainer!.clientHeight
+
+      const distanceFromTop = currentScrollTop
+      const distanceFromBottom = scrollHeight - currentScrollTop - clientHeight
+
+      const now = Date.now()
+
+      const isNearTop = distanceFromTop < 30
+      const isNearBottom = distanceFromBottom < 30
+
+      if ((isNearTop || isNearBottom) && hasMore && !isLoading && (now - lastLoadTime > throttleDelay)) {
+        lastLoadTime = now
+        loadMoreMessages()
+      }
+    }
+
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true })
+
+    const handleWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0)
+        handleScroll()
+    }
+    scrollContainer.addEventListener('wheel', handleWheel, { passive: true })
+
+    return () => {
+      scrollContainer!.removeEventListener('scroll', handleScroll)
+      scrollContainer!.removeEventListener('wheel', handleWheel)
+    }
+  }, [hasMore, isLoading, loadMoreMessages])
 
   const isChatMode = appDetail?.mode !== 'completion'
   const isAdvanced = appDetail?.mode === 'advanced-chat'
@@ -377,6 +603,38 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
     const raf = requestAnimationFrame(adjustModalWidth)
     return () => cancelAnimationFrame(raf)
   }, [])
+
+  // Add scroll listener to ensure loading is triggered
+  useEffect(() => {
+    if (threadChatItems.length >= MIN_ITEMS_FOR_SCROLL_LOADING && hasMore) {
+      const scrollableDiv = document.getElementById('scrollableDiv')
+
+      if (scrollableDiv) {
+        let loadingTimeout: NodeJS.Timeout | null = null
+
+        const handleScroll = () => {
+          const { scrollTop } = scrollableDiv
+
+          // Trigger loading when scrolling near the top
+          if (scrollTop < SCROLL_THRESHOLD_PX && !isLoadingRef.current) {
+            if (loadingTimeout)
+              clearTimeout(loadingTimeout)
+
+            loadingTimeout = setTimeout(() => {
+              fetchData()
+            }, SCROLL_DEBOUNCE_MS) // 200ms debounce
+          }
+        }
+
+        scrollableDiv.addEventListener('scroll', handleScroll)
+        return () => {
+          scrollableDiv.removeEventListener('scroll', handleScroll)
+          if (loadingTimeout)
+            clearTimeout(loadingTimeout)
+        }
+      }
+    }
+  }, [threadChatItems.length, hasMore, fetchData])
 
   return (
     <div ref={ref} className='flex h-full flex-col rounded-xl border-[0.5px] border-components-panel-border'>
@@ -439,8 +697,8 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
               siteInfo={null}
             />
           </div>
-          : threadChatItems.length < 8
-            ? <div className="mb-4 pt-4">
+          : threadChatItems.length < MIN_ITEMS_FOR_SCROLL_LOADING ? (
+            <div className="mb-4 pt-4">
               <Chat
                 config={{
                   appId: appDetail?.id,
@@ -466,35 +724,27 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
                 switchSibling={switchSibling}
               />
             </div>
-            : <div
+          ) : (
+            <div
               className="py-4"
               id="scrollableDiv"
               style={{
                 display: 'flex',
                 flexDirection: 'column-reverse',
+                height: '100%',
+                overflow: 'auto',
               }}>
               {/* Put the scroll bar always on the bottom */}
-              <InfiniteScroll
-                scrollableTarget="scrollableDiv"
-                dataLength={threadChatItems.length}
-                next={fetchData}
-                hasMore={hasMore}
-                loader={<div className='system-xs-regular text-center text-text-tertiary'>{t('appLog.detail.loading')}...</div>}
-                // endMessage={<div className='text-center'>Nothing more to show</div>}
-                // below props only if you need pull down functionality
-                refreshFunction={fetchData}
-                pullDownToRefresh
-                pullDownToRefreshThreshold={50}
-                // pullDownToRefreshContent={
-                //   <div className='text-center'>Pull down to refresh</div>
-                // }
-                // releaseToRefreshContent={
-                //   <div className='text-center'>Release to refresh</div>
-                // }
-                // To put endMessage and loader to the top.
-                style={{ display: 'flex', flexDirection: 'column-reverse' }}
-                inverse={true}
-              >
+              <div className="flex w-full flex-col-reverse" style={{ position: 'relative' }}>
+                {/* Loading state indicator - only shown when loading */}
+                {hasMore && isLoading && (
+                  <div className="sticky left-0 right-0 top-0 z-10 bg-primary-50/40 py-3 text-center">
+                    <div className='system-xs-regular text-text-tertiary'>
+                      {t('appLog.detail.loading')}...
+                    </div>
+                  </div>
+                )}
+
                 <Chat
                   config={{
                     appId: appDetail?.id,
@@ -519,8 +769,8 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
                   chatContainerInnerClassName='px-3'
                   switchSibling={switchSibling}
                 />
-              </InfiniteScroll>
-            </div>
+              </div>
+            </div>)
         }
       </div>
       {showMessageLogModal && (

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -539,7 +539,13 @@ finally {
  else if (chatContainer && chatContainer.scrollHeight > chatContainer.clientHeight) {
       scrollContainer = chatContainer
     }
- else {
+    else if (scrollableDiv && scrollableDiv.scrollHeight > scrollableDiv.clientHeight) {
+      scrollContainer = scrollableDiv
+    }
+    else if (chatContainer && chatContainer.scrollHeight > chatContainer.clientHeight) {
+      scrollContainer = chatContainer
+    }
+    else {
       const possibleContainers = document.querySelectorAll('.overflow-auto, .overflow-y-auto')
       for (let i = 0; i < possibleContainers.length; i++) {
         const container = possibleContainers[i] as HTMLElement

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -394,7 +394,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
 
       // Use the earliest response item as the first_id
       const answerItems = allChatItems.filter(item => item.isAnswer)
-      const oldestAnswerItem = answerItems[0]
+      const oldestAnswerItem = answerItems[answerItems.length - 1]
       if (oldestAnswerItem?.id) {
         params.first_id = oldestAnswerItem.id
       }

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -584,7 +584,6 @@ finally {
       const isNearTop = distanceFromTop < 30
       // eslint-disable-next-line sonarjs/no-unused-vars
       const _distanceFromBottom = distanceFromBottom < 30
-
       if (isNearTop && hasMore && !isLoading && (now - lastLoadTime > throttleDelay)) {
         lastLoadTime = now
         loadMoreMessages()

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -510,7 +510,13 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
     }
  finally {
       setIsLoading(false)
-    }
+catch (error) {
+  console.error(error)
+  setHasMore(false)
+}
+finally {
+  setIsLoading(false)
+}
   }, [allChatItems, detail.id, hasMore, isLoading, timezone, t, appDetail])
 
   useEffect(() => {

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -504,7 +504,8 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
 
       setThreadChatItems(getThreadMessages(tree, newAllChatItems.at(-1)?.id))
     }
- catch (_) {
+ catch (error) {
+      console.error(error)
       setHasMore(false)
     }
  finally {

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -558,7 +558,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       const isNearTop = distanceFromTop < 30
       const isNearBottom = distanceFromBottom < 30
 
-      if ((isNearTop || isNearBottom) && hasMore && !isLoading && (now - lastLoadTime > throttleDelay)) {
+      if (isNearTop && hasMore && !isLoading && (now - lastLoadTime > throttleDelay)) {
         lastLoadTime = now
         loadMoreMessages()
       }

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -508,7 +508,11 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       console.error(error)
       setHasMore(false)
     }
- finally {
+    catch (error) {
+      console.error(error)
+      setHasMore(false)
+    }
+    finally {
       setIsLoading(false)
 catch (error) {
   console.error(error)

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -268,7 +268,8 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       }
       setChatItemTree(tree)
 
-      setThreadChatItems(getThreadMessages(tree))
+      const lastMessageId = newAllChatItems.length > 0 ? newAllChatItems[newAllChatItems.length - 1].id : undefined;
+      setThreadChatItems(getThreadMessages(tree, lastMessageId))
     }
     catch (err) {
       console.error('fetchData execution failed:', err)

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -398,7 +398,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
       if (oldestAnswerItem?.id) {
         params.first_id = oldestAnswerItem.id
       }
- else if (allChatItems.length > 0 && allChatItems[0]?.id) {
+      else if (allChatItems.length > 0 && allChatItems[0]?.id) {
         const firstId = allChatItems[0].id.replace('question-', '').replace('answer-', '')
         params.first_id = firstId
       }

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -8,7 +8,6 @@ import {
 } from '@heroicons/react/24/outline'
 import { RiCloseLine, RiEditFill } from '@remixicon/react'
 import { get } from 'lodash-es'
-// import InfiniteScroll from 'react-infinite-scroll-component'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -554,7 +554,16 @@ finally {
           break
         }
       }
+  else {
+    const possibleContainers = document.querySelectorAll('.overflow-auto, .overflow-y-auto')
+    for (let i = 0; i < possibleContainers.length; i++) {
+      const container = possibleContainers[i] as HTMLElement
+      if (container.scrollHeight > container.clientHeight) {
+        scrollContainer = container
+        break
+      }
     }
+  }
 
     if (!scrollContainer)
       return


### PR DESCRIPTION
…ages

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.
Close  #23971 
close https://github.com/langgenius/dify/pull/24003

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

1. Optimized Pagination Logic
- Updated first_id parameter to use the oldest answer item instead of the first chat message
- Fixed the perpetual loading issue when conversation history exceeds 10 messages
2. Enhanced Data Handling
-  Added detection and filtering for duplicate messages
-  Implemented fallback logic when answer items are not available
-  Added retry mechanism with alternative ID when initial loading returns duplicates
3. Improved Error Handling
- Added proper error catching and state management
- Enhanced logging for better debugging and maintenance


## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
