### PR TITLE
Fix: add 'api_key' alias for backward compatibility

### DIFF
--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -108,10 +108,18 @@ class ApiProviderAuthType(Enum):
         :param value: mode value
         :return: mode
         """
+        # 'api_key' deprecated in PR #21656
+        # normalize & tiny alias for backward compatibility
+        v = (value or "").strip().lower()
+        if v == "api_key":
+            v = cls.API_KEY_HEADER.value
+
         for mode in cls:
-            if mode.value == value:
+            if mode.value == v:
                 return mode
-        raise ValueError(f"invalid mode value {value}")
+
+        valid = ", ".join(m.value for m in cls)
+        raise ValueError(f"invalid mode value '{value}', expected one of: {valid}")
 
 
 class ToolInvokeMessage(BaseModel):


### PR DESCRIPTION
Fixes #24005 

In PR #21656, the 'api_key' auth mode was deprecated in favor of 'api_key_header' and 'api_key_query'.
This change adds a tiny alias in `ApiProviderAuthType.value_of` to map legacy 'api_key' to 'api_key_header',
preventing breaking existing configurations that still use the old value.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
