### PR TITLE
fix: return empty list instead of raising exception for qdrant search when score_threshold is 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,8 @@ sdks/python-client/dify_client.egg-info
 !.vscode/README.md
 pyrightconfig.json
 api/.vscode
+# vscode Code History Extension
+.history
 
 .idea/
 

--- a/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
+++ b/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
@@ -1,4 +1,5 @@
 from core.rag.datasource.vdb.qdrant.qdrant_vector import QdrantConfig, QdrantVector
+from core.rag.models.document import Document
 from tests.integration_tests.vdb.test_vector_store import (
     AbstractVectorTest,
     setup_mock_redis,
@@ -17,6 +18,14 @@ class QdrantVectorTest(AbstractVectorTest):
                 api_key="difyai123456",
             ),
         )
+
+    def search_by_vector(self):
+        super().search_by_vector()
+        # only tested for qdrant, may not work on other vector stores
+        hits_by_vector: list[Document] = self.vector.search_by_vector(
+            query_vector=self.example_embedding, score_threshold=1
+        )
+        assert len(hits_by_vector) == 0
 
 
 def test_qdrant_vector(setup_mock_redis):

--- a/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
+++ b/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
@@ -21,7 +21,7 @@ class QdrantVectorTest(AbstractVectorTest):
 
     def search_by_vector(self):
         super().search_by_vector()
-        # only tested for qdrant, may not work on other vector stores
+        # only test for qdrant, may not work on other vector stores
         hits_by_vector: list[Document] = self.vector.search_by_vector(
             query_vector=self.example_embedding, score_threshold=1
         )


### PR DESCRIPTION
## Summary

Fixes #24031, I searched the error response, and found the following issue https://github.com/qdrant/fastembed/issues/145, so I think it may be related with qdrant store: 

<img width="1097" height="282" alt="image" src="https://github.com/user-attachments/assets/29f52a19-9618-4a9d-9a33-9920f1ea94c3" />

But I can't reproduce it on my dev environment, which the qdrant store is the newest version: 1.15.3, build: a7d21f16. Even set score_threshold to be 2, the search request to qdrant still doesn't raise exception, so it won't be the precision issue of str to float conversion.

Then I estimate that the qdrant version on cloud.dify.ai may not be the newest, which would report this error, so I fix it by returning empty list to be compatible with old qdrant versions. Please help me check it.

Much thanks.

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
