### PR TITLE
chore(i18n): correct japanese translation

### DIFF
--- a/web/i18n/ja-JP/app-annotation.ts
+++ b/web/i18n/ja-JP/app-annotation.ts
@@ -17,7 +17,7 @@ const translation = {
       bulkImport: '一括インポート',
       bulkExport: '一括エクスポート',
       clearAll: 'すべて削除',
-      clearAllConfirm: 'すべての寸法を削除?',
+      clearAllConfirm: 'すべての注釈を削除しますか？',
     },
   },
   editModal: {

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -565,7 +565,7 @@ const translation = {
     overview: '監視',
     promptEng: 'オーケストレート',
     apiAccess: 'API アクセス',
-    logAndAnn: 'ログ＆アナウンス',
+    logAndAnn: 'ログ＆注釈',
     logs: 'ログ',
   },
   environment: {


### PR DESCRIPTION
## Summary

This PR corrects two obvious translation errors.

- `寸法` (Dimension) -> `注釈` (Annotation)
- `アナウンス` (Announcement) → `注釈` (Annotation)

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
