### PR TITLE
feat: add select input support to the conversation opener

### DIFF
--- a/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
@@ -8,6 +8,7 @@ import Modal from '@/app/components/base/modal'
 import Button from '@/app/components/base/button'
 import Divider from '@/app/components/base/divider'
 import ConfirmAddVar from '@/app/components/app/configuration/config-prompt/confirm-add-var'
+import PromptEditor from '@/app/components/base/prompt-editor'
 import type { OpeningStatement } from '@/app/components/base/features/types'
 import { getInputKeys } from '@/app/components/base/block-input'
 import type { PromptVariable } from '@/models/debug'
@@ -101,7 +102,7 @@ const OpeningSettingModal = ({
             <div>·</div>
             <div>{tempSuggestedQuestions.length}/{MAX_QUESTION_NUM}</div>
           </div>
-          <Divider bgStyle='gradient' className='ml-3 h-px w-0 grow'/>
+          <Divider bgStyle='gradient' className='ml-3 h-px w-0 grow' />
         </div>
         <ReactSortable
           className="space-y-1"
@@ -178,19 +179,32 @@ const OpeningSettingModal = ({
     >
       <div className='mb-6 flex items-center justify-between'>
         <div className='title-2xl-semi-bold text-text-primary'>{t('appDebug.feature.conversationOpener.title')}</div>
-        <div className='cursor-pointer p-1' onClick={onCancel}><RiCloseLine className='h-4 w-4 text-text-tertiary'/></div>
+        <div className='cursor-pointer p-1' onClick={onCancel}><RiCloseLine className='h-4 w-4 text-text-tertiary' /></div>
       </div>
       <div className='mb-8 flex gap-2'>
         <div className='mt-1.5 h-8 w-8 shrink-0 rounded-lg border-components-panel-border bg-util-colors-orange-dark-orange-dark-500 p-1.5'>
           <RiAsterisk className='h-5 w-5 text-text-primary-on-surface' />
         </div>
         <div className='grow rounded-2xl border-t border-divider-subtle bg-chat-bubble-bg p-3 shadow-xs'>
-          <textarea
+          <PromptEditor
             value={tempValue}
-            rows={3}
-            onChange={e => setTempValue(e.target.value)}
-            className="system-md-regular w-full border-0 bg-transparent  px-0 text-text-secondary focus:outline-none"
+            onChange={setTempValue}
             placeholder={t('appDebug.openingStatement.placeholder') as string}
+            variableBlock={{
+              show: true,
+              variables: [
+                // Prompt variables
+                ...promptVariables.map(item => ({
+                  name: item.name || item.key,
+                  value: item.key,
+                })),
+                // Workflow variables
+                ...workflowVariables.map(item => ({
+                  name: item.variable,
+                  value: item.variable,
+                })),
+              ],
+            }}
           />
           {renderQuestions()}
         </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

Fixes #23428 

## Summary

This PR changes the current UI component for the conversation opener message field from using a textarea to a PromptEditor. Using PromptEditor allows users to use / or { to select an existing variable or create a new one.

## Screenshots

| Before | After |
|--------|-------|
| <img width="799" height="414" alt="image" src="https://github.com/user-attachments/assets/6451353e-9f7d-4a3d-a398-9913e092d7e7" /> | <img width="803" height="370" alt="image" src="https://github.com/user-attachments/assets/fc0712da-dc0d-4074-b047-ffcb9d01ef76" /> |
| <img width="805" height="419" alt="image" src="https://github.com/user-attachments/assets/3a0f1c24-cfee-43f0-997a-ff934100c9ae" /> | <img width="800" height="371" alt="image" src="https://github.com/user-attachments/assets/bf26f534-aa81-46b0-bca4-0693a7138be4" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
