### PR TITLE
fix: validate checklist before publishing workflow

### DIFF
--- a/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
@@ -3,7 +3,7 @@ import {
   useCallback,
   useMemo,
 } from 'react'
-import { useStore as useReactflowStore } from 'reactflow'
+import { useEdges, useNodes, useStore as useReactflowStore } from 'reactflow'
 import { RiApps2AddLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -11,6 +11,7 @@ import {
   useWorkflowStore,
 } from '@/app/components/workflow/store'
 import {
+  useChecklist,
   useChecklistBeforePublish,
   useNodesReadOnly,
   useNodesSyncDraft,
@@ -18,6 +19,10 @@ import {
 import Button from '@/app/components/base/button'
 import AppPublisher from '@/app/components/app/app-publisher'
 import { useFeatures } from '@/app/components/base/features/hooks'
+import type {
+  CommonEdgeType,
+  CommonNodeType,
+} from '@/app/components/workflow/types'
 import {
   BlockEnum,
   InputVarType,
@@ -92,8 +97,19 @@ const FeaturesTrigger = () => {
     }
   }, [appID, setAppDetail])
   const { mutateAsync: publishWorkflow } = usePublishWorkflow(appID!)
+  const nodes = useNodes<CommonNodeType>()
+  const edges = useEdges<CommonEdgeType>()
+  const needWarningNodes = useChecklist(nodes, edges)
+
   const updatePublishedWorkflow = useInvalidateAppWorkflow()
   const onPublish = useCallback(async (params?: PublishWorkflowParams) => {
+    // First check if there are any items in the checklist
+    if (needWarningNodes.length > 0) {
+      notify({ type: 'error', message: t('workflow.panel.checklistTip') })
+      throw new Error('Checklist has unresolved items')
+    }
+
+    // Then perform the detailed validation
     if (await handleCheckBeforePublish()) {
       const res = await publishWorkflow({
         title: params?.title || '',
@@ -111,7 +127,7 @@ const FeaturesTrigger = () => {
     else {
       throw new Error('Checklist failed')
     }
-  }, [handleCheckBeforePublish, publishWorkflow, notify, t, updatePublishedWorkflow, appID, updateAppDetail, workflowStore, resetWorkflowVersionHistory])
+  }, [needWarningNodes, handleCheckBeforePublish, publishWorkflow, notify, t, updatePublishedWorkflow, appID, updateAppDetail, workflowStore, resetWorkflowVersionHistory])
 
   const onPublisherToggle = useCallback((state: boolean) => {
     if (state)


### PR DESCRIPTION
## Summary
This PR adds validation for checklist items before publishing a workflow, ensuring that workflows with unresolved configuration issues cannot be published.

<img width="460" height="270" alt="image" src="https://github.com/user-attachments/assets/5d0c4010-0ca0-4f7d-a2e8-219676141a05" />

## Changes
- Added checklist validation as the first step in the workflow publish process
- Import necessary hooks (`useNodes`, `useEdges`, `useChecklist`) to check checklist status
- Display error notification when attempting to publish with unresolved checklist items
- Prevent workflow publication until all checklist issues are resolved

## Problem
Previously, the workflow publish process would perform detailed validation but didn't check the checklist status first. This could lead to confusing situations where workflows with configuration issues might proceed further in the publish process than intended.

## Solution
The solution checks for unresolved checklist items at the beginning of the `onPublish` callback. If any items are found, it:
1. Shows an error notification with the existing translation key `workflow.panel.checklistTip`
2. Throws an error to prevent the publish process from continuing
3. Only proceeds to detailed validation if the checklist is clear

Fixes #24103