### PR TITLE
Update knowledge_retrieval_node.py

### DIFF
--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -391,10 +391,10 @@ class KnowledgeRetrievalNode(BaseNode):
                                 "score": record.score or 0.0,
                                 "child_chunks": [
                                     {
-                                        "id": str(getattr(chunk, 'id', '')),
-                                        "content": str(getattr(chunk, 'content', '')),
-                                        "position": int(getattr(chunk, 'position', 0)),
-                                        "score": float(getattr(chunk, 'score', 0.0))
+                                        "id": str(getattr(chunk, "id", "")),
+                                        "content": str(getattr(chunk, "content", "")),
+                                        "position": int(getattr(chunk, "position", 0)),
+                                        "score": float(getattr(chunk, "score", 0.0)),
                                     }
                                     for chunk in (record.child_chunks or [])
                                 ],

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -389,6 +389,15 @@ class KnowledgeRetrievalNode(BaseNode):
                                 "segment_id": segment.id,
                                 "retriever_from": "workflow",
                                 "score": record.score or 0.0,
+                                "child_chunks": [
+                                    {
+                                        "id": str(getattr(chunk, 'id', '')),
+                                        "content": str(getattr(chunk, 'content', '')),
+                                        "position": int(getattr(chunk, 'position', 0)),
+                                        "score": float(getattr(chunk, 'score', 0.0))
+                                    }
+                                    for chunk in (record.child_chunks or [])
+                                ],
                                 "segment_hit_count": segment.hit_count,
                                 "segment_word_count": segment.word_count,
                                 "segment_position": segment.position,


### PR DESCRIPTION
Update the workflow knowledge base node to align with the `/datasets/<uuid:dataset_id>/hit-testing` node and return the results of `child_chunks`.

<img width="2464" height="1508" alt="image" src="https://github.com/user-attachments/assets/750e7428-06d1-4d71-8a0d-48b46c1fbe91" />


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
