### PR TITLE
fix: remove duplicate weekdays keys in i18n workflow files

### DIFF
--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -959,7 +959,6 @@ const translation = {
       visualConfig: 'Visual Configuration',
       monthlyDay: 'Monthly Day',
       executionTime: 'Execution Time',
-      weekdays: 'Weekdays',
       invalidTimezone: 'Invalid timezone',
       invalidCronExpression: 'Invalid cron expression',
       noValidExecutionTime: 'No valid execution time can be calculated',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -959,7 +959,6 @@ const translation = {
       visualConfig: 'ビジュアル設定',
       monthlyDay: '月の日',
       executionTime: '実行時間',
-      weekdays: '曜日',
       invalidTimezone: '無効なタイムゾーン',
       invalidCronExpression: '無効なCron式',
       noValidExecutionTime: '有効な実行時間を計算できません',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -959,7 +959,6 @@ const translation = {
       visualConfig: '可视化配置',
       monthlyDay: '月份日期',
       executionTime: '执行时间',
-      weekdays: '工作日',
       invalidTimezone: '无效的时区',
       invalidCronExpression: '无效的 Cron 表达式',
       noValidExecutionTime: '无法计算有效的执行时间',


### PR DESCRIPTION
Fix duplicate weekdays keys in workflow translation files