### PR TITLE
fix: initialize recur fields when switching to hourly frequency

### DIFF
--- a/web/app/components/workflow/nodes/trigger-schedule/use-config.ts
+++ b/web/app/components/workflow/nodes/trigger-schedule/use-config.ts
@@ -38,6 +38,10 @@ const useConfig = (id: string, payload: ScheduleTriggerNodeType) => {
         ...(frequency === 'hourly' || frequency === 'once') && !inputs.visual_config?.datetime && {
           datetime: new Date().toISOString(),
         },
+        ...(frequency === 'hourly') && {
+          recur_every: inputs.visual_config?.recur_every || 1,
+          recur_unit: inputs.visual_config?.recur_unit || 'hours',
+        },
         ...(frequency !== 'hourly' && frequency !== 'once') && {
           datetime: undefined,
         },


### PR DESCRIPTION
## Problem

When switching from daily/weekly/monthly/once frequency to hourly frequency, the `recur_every` and `recur_unit` fields are not initialized in the visual config, causing validation to fail with "Invalid recur unit" error. 

**Root Cause**: The `handleFrequencyChange` function only initializes the `datetime` field for hourly mode but ignores the required `recur_every` and `recur_unit` fields.

**User Impact**: Users cannot modify date/time after switching to hourly frequency until they manually click the minutes/hours toggle to initialize the missing field.

## Solution

Initialize `recur_every` and `recur_unit` fields with safe defaults when switching to hourly frequency:

- `recur_every`: Default to `1` (matches RecurConfig component default)
- `recur_unit`: Default to `'hours'` (matches RecurConfig component default)

**Implementation**:
```typescript
...(frequency === 'hourly') && {
  recur_every: inputs.visual_config?.recur_every || 1,
  recur_unit: inputs.visual_config?.recur_unit || 'hours',
},
```

## Backward Compatibility

- Preserves existing values if already set (`|| 1` and `|| 'hours'` fallback)
- Uses same defaults as UI components (RecurConfig)
- Only affects hourly frequency mode
- No impact on other frequency modes

## Testing

- Verified daily → hourly switch works correctly
- Verified existing hourly configurations unchanged
- Validated against existing validation rules (1-999 range, hours/minutes units)