### PR TITLE
Fix the bug of automatically appending basepath to image resource.

### DIFF
--- a/web/app/routePrefixHandle.tsx
+++ b/web/app/routePrefixHandle.tsx
@@ -10,7 +10,7 @@ export default function RoutePrefixHandle() {
     const addPrefixToImg = (e: HTMLImageElement) => {
       const url = new URL(e.src)
       const prefix = url.pathname.slice(0, basePath.length)
-      if (prefix !== basePath && !url.href.startsWith('blob:') && !url.href.startsWith('data:')) {
+      if (prefix !== basePath && !url.href.startsWith('blob:') && !url.href.startsWith('data:') && !url.href.startsWith('http')) {
         url.pathname = basePath + url.pathname
         e.src = url.toString()
       }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #24209
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| <img width="2194" height="1204" alt="Image" src="https://github.com/user-attachments/assets/dd901218-7db1-4c60-85ca-9ee20fabe81a" />   | <img width="2266" height="1330" alt="Image" src="https://github.com/user-attachments/assets/141a22f5-8b38-4eb3-944b-b93e0efe9bf4" />  |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
