### PR TITLE
feat(workflow): Plugin Trigger Node with Unified Entry Node System

### DIFF
--- a/web/app/components/workflow/block-icon.tsx
+++ b/web/app/components/workflow/block-icon.tsx
@@ -108,7 +108,7 @@ const BlockIcon: FC<BlockIconProps> = ({
     `}
     >
       {
-        type !== BlockEnum.Tool && (
+        type !== BlockEnum.Tool && type !== BlockEnum.TriggerPlugin && (
           getIcon(type,
             (type === BlockEnum.TriggerSchedule || type === BlockEnum.TriggerWebhook)
               ? (size === 'xs' ? 'w-4 h-4' : 'w-4.5 h-4.5')
@@ -117,7 +117,7 @@ const BlockIcon: FC<BlockIconProps> = ({
         )
       }
       {
-        type === BlockEnum.Tool && toolIcon && (
+        (type === BlockEnum.Tool || type === BlockEnum.TriggerPlugin) && toolIcon && (
           <>
             {
               typeof toolIcon === 'string'

--- a/web/app/components/workflow/block-selector/all-start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/all-start-blocks.tsx
@@ -1,15 +1,11 @@
 'use client'
-import {
-  useMemo,
-  useRef,
-} from 'react'
+import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { BlockEnum } from '../types'
 import type { ToolDefaultValue } from './types'
-import { useAllBuiltInTools } from '@/service/use-tools'
 import StartBlocks from './start-blocks'
 import TriggerPluginSelector from './trigger-plugin-selector'
 import cn from '@/utils/classnames'
-import { useGetLanguage } from '@/context/i18n'
 import Link from 'next/link'
 import { RiArrowRightUpLine } from '@remixicon/react'
 import { getMarketplaceUrl } from '@/utils/var'
@@ -27,26 +23,8 @@ const AllStartBlocks = ({
   onSelect,
   availableBlocksTypes,
 }: AllStartBlocksProps) => {
-  const language = useGetLanguage()
-  const { data: buildInTools = [] } = useAllBuiltInTools()
+  const { t } = useTranslation()
   const wrapElemRef = useRef<HTMLDivElement>(null)
-
-  // Filter trigger plugins based on search text
-  const triggerPlugins = useMemo(() => {
-    return buildInTools.filter((toolWithProvider) => {
-      // For now, assume all plugins can be triggers
-      // This will be refined when backend provides trigger capability info
-      return toolWithProvider.tools.length > 0
-    }).filter((toolWithProvider) => {
-      if (!searchText) return true
-      return toolWithProvider.name.toLowerCase().includes(searchText.toLowerCase())
-        || toolWithProvider.tools.some(tool =>
-          tool.label[language].toLowerCase().includes(searchText.toLowerCase()),
-        )
-    })
-  }, [buildInTools, searchText, language])
-
-  const hasTriggerPlugins = triggerPlugins.length > 0
 
   return (
     <div className={cn('min-w-[400px] max-w-[500px]', className)}>
@@ -60,21 +38,19 @@ const AllStartBlocks = ({
           availableBlocksTypes={availableBlocksTypes}
         />
 
-        {hasTriggerPlugins && (
-          <TriggerPluginSelector
-            onSelect={onSelect}
-            searchText={searchText}
-          />
-        )}
+        <TriggerPluginSelector
+          onSelect={onSelect}
+          searchText={searchText}
+        />
       </div>
 
-      {/* Footer - Find more triggers in marketplace */}
+      {/* Footer - Same as Tools tab marketplace footer */}
       <Link
         className='system-sm-medium sticky bottom-0 z-10 flex h-8 cursor-pointer items-center rounded-b-lg border-[0.5px] border-t border-components-panel-border bg-components-panel-bg-blur px-4 py-1 text-text-accent-light-mode-only shadow-lg'
-        href={getMarketplaceUrl('', { category: 'trigger' })}
+        href={getMarketplaceUrl('')}
         target='_blank'
       >
-        <span>Find more triggers in marketplace</span>
+        <span>{t('plugin.findMoreInMarketplace')}</span>
         <RiArrowRightUpLine className='ml-0.5 h-3 w-3' />
       </Link>
     </div>

--- a/web/app/components/workflow/block-selector/all-start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/all-start-blocks.tsx
@@ -1,0 +1,84 @@
+'use client'
+import {
+  useMemo,
+  useRef,
+} from 'react'
+import type { BlockEnum } from '../types'
+import type { ToolDefaultValue } from './types'
+import { useAllBuiltInTools } from '@/service/use-tools'
+import StartBlocks from './start-blocks'
+import TriggerPluginSelector from './trigger-plugin-selector'
+import cn from '@/utils/classnames'
+import { useGetLanguage } from '@/context/i18n'
+import Link from 'next/link'
+import { RiArrowRightUpLine } from '@remixicon/react'
+import { getMarketplaceUrl } from '@/utils/var'
+
+type AllStartBlocksProps = {
+  className?: string
+  searchText: string
+  onSelect: (type: BlockEnum, tool?: ToolDefaultValue) => void
+  availableBlocksTypes?: BlockEnum[]
+}
+
+const AllStartBlocks = ({
+  className,
+  searchText,
+  onSelect,
+  availableBlocksTypes,
+}: AllStartBlocksProps) => {
+  const language = useGetLanguage()
+  const { data: buildInTools = [] } = useAllBuiltInTools()
+  const wrapElemRef = useRef<HTMLDivElement>(null)
+
+  // Filter trigger plugins based on search text
+  const triggerPlugins = useMemo(() => {
+    return buildInTools.filter((toolWithProvider) => {
+      // For now, assume all plugins can be triggers
+      // This will be refined when backend provides trigger capability info
+      return toolWithProvider.tools.length > 0
+    }).filter((toolWithProvider) => {
+      if (!searchText) return true
+      return toolWithProvider.name.toLowerCase().includes(searchText.toLowerCase())
+        || toolWithProvider.tools.some(tool =>
+          tool.label[language].toLowerCase().includes(searchText.toLowerCase()),
+        )
+    })
+  }, [buildInTools, searchText, language])
+
+  const hasTriggerPlugins = triggerPlugins.length > 0
+
+  return (
+    <div className={cn('min-w-[400px] max-w-[500px]', className)}>
+      <div
+        ref={wrapElemRef}
+        className='max-h-[464px] overflow-y-auto'
+      >
+        <StartBlocks
+          searchText={searchText}
+          onSelect={onSelect}
+          availableBlocksTypes={availableBlocksTypes}
+        />
+
+        {hasTriggerPlugins && (
+          <TriggerPluginSelector
+            onSelect={onSelect}
+            searchText={searchText}
+          />
+        )}
+      </div>
+
+      {/* Footer - Find more triggers in marketplace */}
+      <Link
+        className='system-sm-medium sticky bottom-0 z-10 flex h-8 cursor-pointer items-center rounded-b-lg border-[0.5px] border-t border-components-panel-border bg-components-panel-bg-blur px-4 py-1 text-text-accent-light-mode-only shadow-lg'
+        href={getMarketplaceUrl('', { category: 'trigger' })}
+        target='_blank'
+      >
+        <span>Find more triggers in marketplace</span>
+        <RiArrowRightUpLine className='ml-0.5 h-3 w-3' />
+      </Link>
+    </div>
+  )
+}
+
+export default AllStartBlocks

--- a/web/app/components/workflow/block-selector/all-start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/all-start-blocks.tsx
@@ -5,6 +5,7 @@ import type { BlockEnum } from '../types'
 import type { ToolDefaultValue } from './types'
 import StartBlocks from './start-blocks'
 import TriggerPluginSelector from './trigger-plugin-selector'
+import { ENTRY_NODE_TYPES } from './constants'
 import cn from '@/utils/classnames'
 import Link from 'next/link'
 import { RiArrowRightUpLine } from '@remixicon/react'
@@ -35,7 +36,7 @@ const AllStartBlocks = ({
         <StartBlocks
           searchText={searchText}
           onSelect={onSelect}
-          availableBlocksTypes={availableBlocksTypes}
+          availableBlocksTypes={ENTRY_NODE_TYPES as BlockEnum[]}
         />
 
         <TriggerPluginSelector

--- a/web/app/components/workflow/block-selector/constants.tsx
+++ b/web/app/components/workflow/block-selector/constants.tsx
@@ -23,6 +23,14 @@ export const START_BLOCKS: Block[] = [
   },
 ]
 
+// Entry node types that can start a workflow
+export const ENTRY_NODE_TYPES = [
+  BlockEnum.Start,
+  BlockEnum.TriggerSchedule,
+  BlockEnum.TriggerWebhook,
+  BlockEnum.TriggerPlugin,
+] as const
+
 export const BLOCKS: Block[] = [
   {
     classification: BlockClassificationEnum.Default,

--- a/web/app/components/workflow/block-selector/constants.tsx
+++ b/web/app/components/workflow/block-selector/constants.tsx
@@ -21,12 +21,6 @@ export const START_BLOCKS: Block[] = [
     title: 'Webhook Trigger',
     description: 'HTTP callback trigger',
   },
-  {
-    classification: BlockClassificationEnum.Default,
-    type: BlockEnum.TriggerPlugin,
-    title: 'Plugin Trigger',
-    description: 'Third-party integration trigger',
-  },
 ]
 
 export const BLOCKS: Block[] = [

--- a/web/app/components/workflow/block-selector/index.tsx
+++ b/web/app/components/workflow/block-selector/index.tsx
@@ -93,7 +93,7 @@ const NodeSelector: FC<NodeSelectorProps> = ({
   }, [])
   const searchPlaceholder = useMemo(() => {
     if (activeTab === TabsEnum.Start)
-      return t('workflow.tabs.searchBlock')
+      return t('workflow.tabs.searchTrigger')
     if (activeTab === TabsEnum.Blocks)
       return t('workflow.tabs.searchBlock')
     if (activeTab === TabsEnum.Tools)
@@ -137,7 +137,7 @@ const NodeSelector: FC<NodeSelectorProps> = ({
             onActiveTabChange={handleActiveTabChange}
             filterElem={
               <div className='relative m-2' onClick={e => e.stopPropagation()}>
-                {activeTab === TabsEnum.Blocks && (
+                {(activeTab === TabsEnum.Start || activeTab === TabsEnum.Blocks) && (
                   <Input
                     showLeftIcon
                     showClearIcon

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -9,6 +9,7 @@ import type { BlockEnum } from '../types'
 import { useNodesExtraData } from '../hooks'
 import { START_BLOCKS } from './constants'
 import type { ToolDefaultValue } from './types'
+import TriggerPluginSelector from './trigger-plugin-selector'
 import Tooltip from '@/app/components/base/tooltip'
 
 type StartBlocksProps = {
@@ -77,6 +78,10 @@ const StartBlocks = ({
           {filteredBlocks.map(renderBlock)}
         </div>
       )}
+      <TriggerPluginSelector
+        onSelect={onSelect}
+        searchText={searchText}
+      />
     </div>
   )
 }

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -67,7 +67,7 @@ const StartBlocks = ({
   ), [nodesExtraData, onSelect])
 
   return (
-    <div className='p-1'>
+    <div className='min-w-[400px] max-w-[500px] p-1'>
       {isEmpty && (
         <div className='flex h-[22px] items-center px-3 text-xs font-medium text-text-tertiary'>
           {t('workflow.tabs.noResult')}

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -27,11 +27,14 @@ const StartBlocks = ({
 
   const filteredBlocks = useMemo(() => {
     return START_BLOCKS.filter((block) => {
-      return block.title.toLowerCase().includes(searchText.toLowerCase())
-      // Note: Start tab should show all entry nodes, not filtered by connection logic
-      // availableBlocksTypes is for node connections, not for entry point selection
+      // Filter by search text
+      if (!block.title.toLowerCase().includes(searchText.toLowerCase()))
+        return false
+
+      // availableBlocksTypes now contains properly filtered entry node types from parent
+      return availableBlocksTypes.includes(block.type)
     })
-  }, [searchText])
+  }, [searchText, availableBlocksTypes])
 
   const isEmpty = filteredBlocks.length === 0
 

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -28,9 +28,10 @@ const StartBlocks = ({
   const filteredBlocks = useMemo(() => {
     return START_BLOCKS.filter((block) => {
       return block.title.toLowerCase().includes(searchText.toLowerCase())
-             && availableBlocksTypes.includes(block.type)
+      // Note: Start tab should show all entry nodes, not filtered by connection logic
+      // availableBlocksTypes is for node connections, not for entry point selection
     })
-  }, [searchText, availableBlocksTypes])
+  }, [searchText])
 
   const isEmpty = filteredBlocks.length === 0
 

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -9,7 +9,6 @@ import type { BlockEnum } from '../types'
 import { useNodesExtraData } from '../hooks'
 import { START_BLOCKS } from './constants'
 import type { ToolDefaultValue } from './types'
-import TriggerPluginSelector from './trigger-plugin-selector'
 import Tooltip from '@/app/components/base/tooltip'
 
 type StartBlocksProps = {
@@ -78,10 +77,6 @@ const StartBlocks = ({
           {filteredBlocks.map(renderBlock)}
         </div>
       )}
-      <TriggerPluginSelector
-        onSelect={onSelect}
-        searchText={searchText}
-      />
     </div>
   )
 }

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -6,6 +6,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import BlockIcon from '../block-icon'
 import type { BlockEnum } from '../types'
+import { BlockEnum as BlockEnumValues } from '../types'
 import { useNodesExtraData } from '../hooks'
 import { START_BLOCKS } from './constants'
 import type { ToolDefaultValue } from './types'
@@ -64,10 +65,15 @@ const StartBlocks = ({
           className='mr-2 shrink-0'
           type={block.type}
         />
-        <div className='grow text-sm text-text-secondary'>{block.title}</div>
+        <div className='flex w-0 grow items-center justify-between text-sm text-text-secondary'>
+          <span className='truncate'>{block.title}</span>
+          {block.type === BlockEnumValues.Start && (
+            <span className='system-xs-regular ml-2 shrink-0 text-text-quaternary'>{t('workflow.blocks.originalStartNode')}</span>
+          )}
+        </div>
       </div>
     </Tooltip>
-  ), [nodesExtraData, onSelect])
+  ), [nodesExtraData, onSelect, t])
 
   return (
     <div className='min-w-[400px] max-w-[500px] p-1'>
@@ -78,7 +84,16 @@ const StartBlocks = ({
       )}
       {!isEmpty && (
         <div className='mb-1'>
-          {filteredBlocks.map(renderBlock)}
+          {filteredBlocks.map((block, index) => (
+            <div key={block.type}>
+              {renderBlock(block)}
+              {block.type === BlockEnumValues.Start && index < filteredBlocks.length - 1 && (
+                <div className='my-1 px-3'>
+                  <div className='border-t border-divider-subtle' />
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/web/app/components/workflow/block-selector/tabs.tsx
+++ b/web/app/components/workflow/block-selector/tabs.tsx
@@ -6,7 +6,7 @@ import { useTabs } from './hooks'
 import type { ToolDefaultValue } from './types'
 import { TabsEnum } from './types'
 import Blocks from './blocks'
-import StartBlocks from './start-blocks'
+import AllStartBlocks from './all-start-blocks'
 import AllTools from './all-tools'
 import cn from '@/utils/classnames'
 
@@ -65,13 +65,11 @@ const Tabs: FC<TabsProps> = ({
       {filterElem}
       {
         activeTab === TabsEnum.Start && !noBlocks && (
-          <div className='border-t border-divider-subtle'>
-            <StartBlocks
-              searchText={searchText}
-              onSelect={onSelect}
-              availableBlocksTypes={availableBlocksTypes}
-            />
-          </div>
+          <AllStartBlocks
+            searchText={searchText}
+            onSelect={onSelect}
+            availableBlocksTypes={availableBlocksTypes}
+          />
         )
       }
       {

--- a/web/app/components/workflow/block-selector/tabs.tsx
+++ b/web/app/components/workflow/block-selector/tabs.tsx
@@ -65,11 +65,13 @@ const Tabs: FC<TabsProps> = ({
       {filterElem}
       {
         activeTab === TabsEnum.Start && !noBlocks && (
-          <AllStartBlocks
-            searchText={searchText}
-            onSelect={onSelect}
-            availableBlocksTypes={availableBlocksTypes}
-          />
+          <div className='border-t border-divider-subtle'>
+            <AllStartBlocks
+              searchText={searchText}
+              onSelect={onSelect}
+              availableBlocksTypes={availableBlocksTypes}
+            />
+          </div>
         )
       }
       {

--- a/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
@@ -1,11 +1,8 @@
 'use client'
-import { memo, useMemo } from 'react'
-import { useAllBuiltInTools } from '@/service/use-tools'
-import Tools from './tools'
+import { memo } from 'react'
+import TriggerPluginList from './trigger-plugin/list'
 import type { BlockEnum } from '../types'
 import type { ToolDefaultValue } from './types'
-import { ViewType } from './view-type-select'
-import { useGetLanguage } from '@/context/i18n'
 
 type TriggerPluginSelectorProps = {
   onSelect: (type: BlockEnum, tool?: ToolDefaultValue) => void
@@ -16,37 +13,11 @@ const TriggerPluginSelector = ({
   onSelect,
   searchText,
 }: TriggerPluginSelectorProps) => {
-  const language = useGetLanguage()
-  const { data: buildInTools = [] } = useAllBuiltInTools()
-
-  // Filter plugins that support trigger functionality
-  const triggerPlugins = useMemo(() => {
-    return buildInTools.filter((toolWithProvider) => {
-      // For now, assume all plugins can be triggers
-      // This will be refined when backend provides trigger capability info
-      return toolWithProvider.tools.length > 0
-    }).filter((toolWithProvider) => {
-      if (!searchText) return true
-      return toolWithProvider.name.toLowerCase().includes(searchText.toLowerCase())
-        || toolWithProvider.tools.some(tool =>
-          tool.label[language].toLowerCase().includes(searchText.toLowerCase()),
-        )
-    })
-  }, [buildInTools, searchText, language])
-
-  if (!triggerPlugins.length)
-    return null
-
   return (
-    <div className="border-t border-divider-subtle">
-      <Tools
-        tools={triggerPlugins}
-        onSelect={onSelect}
-        viewType={ViewType.flat}
-        hasSearchText={!!searchText}
-        canNotSelectMultiple
-      />
-    </div>
+    <TriggerPluginList
+      onSelect={onSelect}
+      searchText={searchText}
+    />
   )
 }
 

--- a/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
@@ -34,13 +34,8 @@ const TriggerPluginSelector = ({
     })
   }, [buildInTools, searchText, language])
 
-  if (!triggerPlugins.length) {
-    return (
-      <div className="p-4 text-center text-sm text-gray-500">
-No trigger plugins available
-      </div>
-    )
-  }
+  if (!triggerPlugins.length)
+    return null
 
   return (
     <div className="border-t border-divider-subtle">

--- a/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { memo, useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useAllBuiltInTools } from '@/service/use-tools'
 import Tools from './tools'
 import type { BlockEnum } from '../types'
@@ -17,7 +16,6 @@ const TriggerPluginSelector = ({
   onSelect,
   searchText,
 }: TriggerPluginSelectorProps) => {
-  const { t } = useTranslation()
   const language = useGetLanguage()
   const { data: buildInTools = [] } = useAllBuiltInTools()
 
@@ -39,16 +37,13 @@ const TriggerPluginSelector = ({
   if (!triggerPlugins.length) {
     return (
       <div className="p-4 text-center text-sm text-gray-500">
-        {t('workflow.tabs.noTriggerPlugins')}
+No trigger plugins available
       </div>
     )
   }
 
   return (
     <div className="border-t border-divider-subtle">
-      <div className="bg-gray-50 px-3 py-2 text-xs font-medium text-gray-600">
-        Plugin Triggers
-      </div>
       <Tools
         tools={triggerPlugins}
         onSelect={onSelect}

--- a/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin-selector.tsx
@@ -1,0 +1,63 @@
+'use client'
+import { memo, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAllBuiltInTools } from '@/service/use-tools'
+import Tools from './tools'
+import type { BlockEnum } from '../types'
+import type { ToolDefaultValue } from './types'
+import { ViewType } from './view-type-select'
+import { useGetLanguage } from '@/context/i18n'
+
+type TriggerPluginSelectorProps = {
+  onSelect: (type: BlockEnum, tool?: ToolDefaultValue) => void
+  searchText: string
+}
+
+const TriggerPluginSelector = ({
+  onSelect,
+  searchText,
+}: TriggerPluginSelectorProps) => {
+  const { t } = useTranslation()
+  const language = useGetLanguage()
+  const { data: buildInTools = [] } = useAllBuiltInTools()
+
+  // Filter plugins that support trigger functionality
+  const triggerPlugins = useMemo(() => {
+    return buildInTools.filter((toolWithProvider) => {
+      // For now, assume all plugins can be triggers
+      // This will be refined when backend provides trigger capability info
+      return toolWithProvider.tools.length > 0
+    }).filter((toolWithProvider) => {
+      if (!searchText) return true
+      return toolWithProvider.name.toLowerCase().includes(searchText.toLowerCase())
+        || toolWithProvider.tools.some(tool =>
+          tool.label[language].toLowerCase().includes(searchText.toLowerCase()),
+        )
+    })
+  }, [buildInTools, searchText, language])
+
+  if (!triggerPlugins.length) {
+    return (
+      <div className="p-4 text-center text-sm text-gray-500">
+        {t('workflow.tabs.noTriggerPlugins')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="border-t border-divider-subtle">
+      <div className="bg-gray-50 px-3 py-2 text-xs font-medium text-gray-600">
+        Plugin Triggers
+      </div>
+      <Tools
+        tools={triggerPlugins}
+        onSelect={onSelect}
+        viewType={ViewType.flat}
+        hasSearchText={!!searchText}
+        canNotSelectMultiple
+      />
+    </div>
+  )
+}
+
+export default memo(TriggerPluginSelector)

--- a/web/app/components/workflow/block-selector/trigger-plugin/action-item.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin/action-item.tsx
@@ -1,0 +1,88 @@
+'use client'
+import type { FC } from 'react'
+import React from 'react'
+import type { ToolWithProvider } from '../../types'
+import { BlockEnum } from '../../types'
+import type { ToolDefaultValue } from '../types'
+import Tooltip from '@/app/components/base/tooltip'
+import type { Tool } from '@/app/components/tools/types'
+import { useGetLanguage } from '@/context/i18n'
+import BlockIcon from '../../block-icon'
+import cn from '@/utils/classnames'
+import { useTranslation } from 'react-i18next'
+
+type Props = {
+  provider: ToolWithProvider
+  payload: Tool
+  disabled?: boolean
+  isAdded?: boolean
+  onSelect: (type: BlockEnum, tool?: ToolDefaultValue) => void
+}
+
+const TriggerPluginActionItem: FC<Props> = ({
+  provider,
+  payload,
+  onSelect,
+  disabled,
+  isAdded,
+}) => {
+  const { t } = useTranslation()
+  const language = useGetLanguage()
+
+  return (
+    <Tooltip
+      key={payload.name}
+      position='right'
+      needsDelay={false}
+      popupClassName='!p-0 !px-3 !py-2.5 !w-[200px] !leading-[18px] !text-xs !text-gray-700 !border-[0.5px] !border-black/5 !rounded-xl !shadow-lg'
+      popupContent={(
+        <div>
+          <BlockIcon
+            size='md'
+            className='mb-2'
+            type={BlockEnum.TriggerPlugin}
+            toolIcon={provider.icon}
+          />
+          <div className='mb-1 text-sm leading-5 text-text-primary'>{payload.label[language]}</div>
+          <div className='text-xs leading-[18px] text-text-secondary'>{payload.description[language]}</div>
+        </div>
+      )}
+    >
+      <div
+        key={payload.name}
+        className='flex cursor-pointer items-center justify-between rounded-lg pl-[21px] pr-1 hover:bg-state-base-hover'
+        onClick={() => {
+          if (disabled) return
+          const params: Record<string, string> = {}
+          if (payload.parameters) {
+            payload.parameters.forEach((item) => {
+              params[item.name] = ''
+            })
+          }
+          onSelect(BlockEnum.TriggerPlugin, {
+            provider_id: provider.id,
+            provider_type: provider.type,
+            provider_name: provider.name,
+            tool_name: payload.name,
+            tool_label: payload.label[language],
+            tool_description: payload.description[language],
+            title: payload.label[language],
+            is_team_authorization: provider.is_team_authorization,
+            output_schema: payload.output_schema,
+            paramSchemas: payload.parameters,
+            params,
+            meta: provider.meta,
+          })
+        }}
+      >
+        <div className={cn('system-sm-medium h-8 truncate border-l-2 border-divider-subtle pl-4 leading-8 text-text-secondary')}>
+          <span className={cn(disabled && 'opacity-30')}>{payload.label[language]}</span>
+        </div>
+        {isAdded && (
+          <div className='system-xs-regular mr-4 text-text-tertiary'>{t('tools.addToolModal.added')}</div>
+        )}
+      </div>
+    </Tooltip >
+  )
+}
+export default React.memo(TriggerPluginActionItem)

--- a/web/app/components/workflow/block-selector/trigger-plugin/item.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin/item.tsx
@@ -1,0 +1,132 @@
+'use client'
+import type { FC } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
+import cn from '@/utils/classnames'
+import { RiArrowDownSLine, RiArrowRightSLine } from '@remixicon/react'
+import { useGetLanguage } from '@/context/i18n'
+import { CollectionType } from '../../../tools/types'
+import type { ToolWithProvider } from '../../types'
+import { BlockEnum } from '../../types'
+import type { ToolDefaultValue } from '../types'
+import TriggerPluginActionItem from './action-item'
+import BlockIcon from '../../block-icon'
+import { useTranslation } from 'react-i18next'
+
+type Props = {
+  className?: string
+  payload: ToolWithProvider
+  hasSearchText: boolean
+  onSelect: (type: BlockEnum, tool?: ToolDefaultValue) => void
+}
+
+const TriggerPluginItem: FC<Props> = ({
+  className,
+  payload,
+  hasSearchText,
+  onSelect,
+}) => {
+  const { t } = useTranslation()
+  const language = useGetLanguage()
+  const notShowProvider = payload.type === CollectionType.workflow
+  const actions = payload.tools
+  const hasAction = !notShowProvider
+  const [isFold, setFold] = React.useState<boolean>(true)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (hasSearchText && isFold) {
+      setFold(false)
+      return
+    }
+    if (!hasSearchText && !isFold)
+      setFold(true)
+  }, [hasSearchText])
+
+  const FoldIcon = isFold ? RiArrowRightSLine : RiArrowDownSLine
+
+  const groupName = useMemo(() => {
+    if (payload.type === CollectionType.builtIn)
+      return payload.author
+
+    if (payload.type === CollectionType.custom)
+      return t('workflow.tabs.customTool')
+
+    if (payload.type === CollectionType.workflow)
+      return t('workflow.tabs.workflowTool')
+
+    return ''
+  }, [payload.author, payload.type, t])
+
+  return (
+    <div
+      key={payload.id}
+      className={cn('mb-1 last-of-type:mb-0')}
+      ref={ref}
+    >
+      <div className={cn(className)}>
+        <div
+          className='group/item flex w-full cursor-pointer select-none items-center justify-between rounded-lg pl-3 pr-1 hover:bg-state-base-hover'
+          onClick={() => {
+            if (hasAction) {
+              setFold(!isFold)
+              return
+            }
+
+            const tool = actions[0]
+            const params: Record<string, string> = {}
+            if (tool.parameters) {
+              tool.parameters.forEach((item) => {
+                params[item.name] = ''
+              })
+            }
+            onSelect(BlockEnum.TriggerPlugin, {
+              provider_id: payload.id,
+              provider_type: payload.type,
+              provider_name: payload.name,
+              tool_name: tool.name,
+              tool_label: tool.label[language],
+              tool_description: tool.description[language],
+              title: tool.label[language],
+              is_team_authorization: payload.is_team_authorization,
+              output_schema: tool.output_schema,
+              paramSchemas: tool.parameters,
+              params,
+            })
+          }}
+        >
+          <div className='flex h-8 grow items-center'>
+            <BlockIcon
+              className='shrink-0'
+              type={BlockEnum.TriggerPlugin}
+              toolIcon={payload.icon}
+            />
+            <div className='ml-2 flex w-0 grow items-center text-sm text-text-primary'>
+              <span className='max-w-[250px] truncate'>{notShowProvider ? actions[0]?.label[language] : payload.label[language]}</span>
+              <span className='system-xs-regular ml-2 shrink-0 text-text-quaternary'>{groupName}</span>
+            </div>
+          </div>
+
+          <div className='ml-2 flex items-center'>
+            {hasAction && (
+              <FoldIcon className={cn('h-4 w-4 shrink-0 text-text-tertiary group-hover/item:text-text-tertiary', isFold && 'text-text-quaternary')} />
+            )}
+          </div>
+        </div>
+
+        {!notShowProvider && hasAction && !isFold && (
+          actions.map(action => (
+            <TriggerPluginActionItem
+              key={action.name}
+              provider={payload}
+              payload={action}
+              onSelect={onSelect}
+              disabled={false}
+              isAdded={false}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+export default React.memo(TriggerPluginItem)

--- a/web/app/components/workflow/block-selector/trigger-plugin/list.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin/list.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { memo, useMemo } from 'react'
+import { useAllBuiltInTools } from '@/service/use-tools'
+import TriggerPluginItem from './item'
+import type { BlockEnum } from '../../types'
+import type { ToolDefaultValue } from '../types'
+import { useGetLanguage } from '@/context/i18n'
+
+type TriggerPluginListProps = {
+  onSelect: (type: BlockEnum, tool?: ToolDefaultValue) => void
+  searchText: string
+}
+
+const TriggerPluginList = ({
+  onSelect,
+  searchText,
+}: TriggerPluginListProps) => {
+  const { data: buildInTools = [] } = useAllBuiltInTools()
+  const language = useGetLanguage()
+
+  const triggerPlugins = useMemo(() => {
+    return buildInTools.filter((toolWithProvider) => {
+      if (toolWithProvider.tools.length === 0) return false
+
+      if (!searchText) return true
+
+      return toolWithProvider.name.toLowerCase().includes(searchText.toLowerCase())
+        || toolWithProvider.tools.some(tool =>
+          tool.label[language].toLowerCase().includes(searchText.toLowerCase()),
+        )
+    })
+  }, [buildInTools, searchText, language])
+
+  if (!triggerPlugins.length)
+    return null
+
+  return (
+    <div className="border-t border-divider-subtle p-1">
+      {triggerPlugins.map(plugin => (
+        <TriggerPluginItem
+          key={plugin.id}
+          payload={plugin}
+          onSelect={onSelect}
+          hasSearchText={!!searchText}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default memo(TriggerPluginList)

--- a/web/app/components/workflow/block-selector/trigger-plugin/list.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin/list.tsx
@@ -35,7 +35,7 @@ const TriggerPluginList = ({
     return null
 
   return (
-    <div className="border-t border-divider-subtle p-1">
+    <div className="p-1">
       {triggerPlugins.map(plugin => (
         <TriggerPluginItem
           key={plugin.id}

--- a/web/app/components/workflow/hooks/use-workflow.ts
+++ b/web/app/components/workflow/hooks/use-workflow.ts
@@ -506,7 +506,7 @@ export const useToolIcon = (data: Node['data']) => {
   const toolIcon = useMemo(() => {
     if (!data)
       return ''
-    if (data.type === BlockEnum.Tool) {
+    if (data.type === BlockEnum.Tool || data.type === BlockEnum.TriggerPlugin) {
       let targetTools = workflowTools
       if (data.provider_type === CollectionType.builtIn)
         targetTools = buildInTools

--- a/web/app/components/workflow/nodes/trigger-plugin/node.tsx
+++ b/web/app/components/workflow/nodes/trigger-plugin/node.tsx
@@ -1,24 +1,27 @@
 import type { FC } from 'react'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 import type { PluginTriggerNodeType } from './types'
 import type { NodeProps } from '@/app/components/workflow/types'
-
-const i18nPrefix = 'workflow.nodes.triggerPlugin'
 
 const Node: FC<NodeProps<PluginTriggerNodeType>> = ({
   data,
 }) => {
-  const { t } = useTranslation()
-
   return (
     <div className="mb-1 px-3 py-1">
-      <div className="text-xs text-gray-700">
-        {t(`${i18nPrefix}.nodeTitle`)}
-      </div>
-      {data.plugin_name && (
+      {data.plugin_name ? (
+        <>
+          <div className="text-xs font-medium text-gray-700">
+            {data.plugin_name}
+          </div>
+          {data.event_type && (
+            <div className="text-xs text-gray-500">
+              {data.event_type}
+            </div>
+          )}
+        </>
+      ) : (
         <div className="text-xs text-gray-500">
-          {data.plugin_name}
+          Plugin not configured
         </div>
       )}
     </div>

--- a/web/app/components/workflow/nodes/trigger-plugin/node.tsx
+++ b/web/app/components/workflow/nodes/trigger-plugin/node.tsx
@@ -6,22 +6,48 @@ import type { NodeProps } from '@/app/components/workflow/types'
 const Node: FC<NodeProps<PluginTriggerNodeType>> = ({
   data,
 }) => {
+  const { config = {} } = data
+  const configKeys = Object.keys(config)
+
+  if (!data.plugin_name && configKeys.length === 0)
+    return null
+
   return (
     <div className="mb-1 px-3 py-1">
-      {data.plugin_name ? (
-        <>
-          <div className="text-xs font-medium text-gray-700">
-            {data.plugin_name}
-          </div>
+      {data.plugin_name && (
+        <div className="mb-1 text-xs font-medium text-gray-700">
+          {data.plugin_name}
           {data.event_type && (
             <div className="text-xs text-gray-500">
               {data.event_type}
             </div>
           )}
-        </>
-      ) : (
-        <div className="text-xs text-gray-500">
-          Plugin not configured
+        </div>
+      )}
+
+      {configKeys.length > 0 && (
+        <div className="space-y-0.5">
+          {configKeys.map((key, index) => (
+            <div
+              key={index}
+              className="flex h-6 items-center justify-between space-x-1 rounded-md bg-workflow-block-parma-bg px-1 text-xs font-normal text-text-secondary"
+            >
+              <div
+                title={key}
+                className="max-w-[100px] shrink-0 truncate text-xs font-medium uppercase text-text-tertiary"
+              >
+                {key}
+              </div>
+              <div
+                title={String(config[key] || '')}
+                className="w-0 shrink-0 grow truncate text-right text-xs font-normal text-text-secondary"
+              >
+                {typeof config[key] === 'string' && config[key].includes('secret')
+                  ? '********'
+                  : String(config[key] || '')}
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/web/app/components/workflow/nodes/trigger-plugin/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-plugin/panel.tsx
@@ -5,8 +5,6 @@ import type { PluginTriggerNodeType } from './types'
 import Field from '@/app/components/workflow/nodes/_base/components/field'
 import type { NodePanelProps } from '@/app/components/workflow/types'
 
-const i18nPrefix = 'workflow.nodes.triggerPlugin'
-
 const Panel: FC<NodePanelProps<PluginTriggerNodeType>> = ({
   id,
   data,
@@ -16,10 +14,26 @@ const Panel: FC<NodePanelProps<PluginTriggerNodeType>> = ({
   return (
     <div className='mt-2'>
       <div className='space-y-4 px-4 pb-2'>
-        <Field title={t(`${i18nPrefix}.title`)}>
-          <div className="text-sm text-gray-500">
-            {t(`${i18nPrefix}.configPlaceholder`)}
-          </div>
+        <Field title={t('workflow.nodes.triggerPlugin.title')}>
+          {data.plugin_name ? (
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <span className="text-sm font-medium">{data.plugin_name}</span>
+                {data.event_type && (
+                  <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
+                    {data.event_type}
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-gray-500">
+                Plugin trigger configured
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-gray-500">
+              No plugin selected. Configure this trigger in the workflow canvas.
+            </div>
+          )}
         </Field>
       </div>
     </div>

--- a/web/app/components/workflow/nodes/trigger-plugin/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-plugin/panel.tsx
@@ -1,20 +1,16 @@
 import type { FC } from 'react'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 import type { PluginTriggerNodeType } from './types'
 import Field from '@/app/components/workflow/nodes/_base/components/field'
 import type { NodePanelProps } from '@/app/components/workflow/types'
 
 const Panel: FC<NodePanelProps<PluginTriggerNodeType>> = ({
-  id,
   data,
 }) => {
-  const { t } = useTranslation()
-
   return (
     <div className='mt-2'>
       <div className='space-y-4 px-4 pb-2'>
-        <Field title={t('workflow.nodes.triggerPlugin.title')}>
+        <Field title="Plugin Trigger">
           {data.plugin_name ? (
             <div className="space-y-2">
               <div className="flex items-center space-x-2">

--- a/web/app/components/workflow/nodes/trigger-plugin/types.ts
+++ b/web/app/components/workflow/nodes/trigger-plugin/types.ts
@@ -1,8 +1,12 @@
 import type { CommonNodeType } from '@/app/components/workflow/types'
+import type { CollectionType } from '@/app/components/tools/types'
 
 export type PluginTriggerNodeType = CommonNodeType & {
   plugin_id?: string
   plugin_name?: string
   event_type?: string
   config?: Record<string, any>
+  provider_id?: string
+  provider_type?: CollectionType
+  provider_name?: string
 }

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -224,6 +224,7 @@ const translation = {
     'start': 'Start',
     'blocks': 'Nodes',
     'searchTool': 'Search tool',
+    'searchTrigger': 'Search triggers...',
     'tools': 'Tools',
     'allTool': 'All',
     'plugin': 'Plugin',

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -979,11 +979,6 @@ const translation = {
       nodeTitle: '🔗 Webhook Trigger',
       configPlaceholder: 'Webhook trigger configuration will be implemented here',
     },
-    triggerPlugin: {
-      title: 'Plugin Trigger',
-      nodeTitle: '🔌 Plugin Trigger',
-      configPlaceholder: 'Plugin trigger configuration will be implemented here',
-    },
   },
   triggerStatus: {
     enabled: 'TRIGGER',

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -241,6 +241,7 @@ const translation = {
   },
   blocks: {
     'start': 'User Input',
+    'originalStartNode': 'original start node',
     'end': 'End',
     'answer': 'Answer',
     'llm': 'LLM',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -241,6 +241,7 @@ const translation = {
   },
   blocks: {
     'start': '開始',
+    'originalStartNode': '元の開始ノード',
     'end': '終了',
     'answer': '回答',
     'llm': 'LLM',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -223,6 +223,7 @@ const translation = {
     'searchBlock': 'ブロック検索',
     'blocks': 'ブロック',
     'searchTool': 'ツール検索',
+    'searchTrigger': 'トリガー検索...',
     'tools': 'ツール',
     'allTool': 'すべて',
     'customTool': 'カスタム',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -979,11 +979,6 @@ const translation = {
       nodeTitle: '🔗 Webhook トリガー',
       configPlaceholder: 'Webhook トリガーの設定がここに実装されます',
     },
-    triggerPlugin: {
-      title: 'プラグイントリガー',
-      nodeTitle: '🔌 プラグイントリガー',
-      configPlaceholder: 'プラグイントリガーの設定がここに実装されます',
-    },
   },
   tracing: {
     stopBy: '{{user}}によって停止',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -223,6 +223,7 @@ const translation = {
     'searchBlock': '搜索节点',
     'blocks': '节点',
     'searchTool': '搜索工具',
+    'searchTrigger': '搜索触发器...',
     'tools': '工具',
     'allTool': '全部',
     'plugin': '插件',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -979,11 +979,6 @@ const translation = {
       title: 'Webhook 触发器',
       nodeTitle: '🔗 Webhook 触发器',
     },
-    triggerPlugin: {
-      title: '插件触发器',
-      nodeTitle: '🔌 插件触发器',
-      configPlaceholder: '插件触发器配置将在此处实现',
-    },
   },
   tracing: {
     stopBy: '由{{user}}终止',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -241,6 +241,7 @@ const translation = {
   },
   blocks: {
     'start': '开始',
+    'originalStartNode': '原始开始节点',
     'end': '结束',
     'answer': '直接回复',
     'llm': 'LLM',

--- a/web/service/use-triggers.ts
+++ b/web/service/use-triggers.ts
@@ -5,6 +5,7 @@ import type { ToolWithProvider } from '@/app/components/workflow/types'
 const NAME_SPACE = 'triggers'
 
 // Get all plugins that support trigger functionality
+// TODO: Backend API not implemented yet - replace with actual triggers endpoint
 export const useAllTriggerPlugins = (enabled = true) => {
   return useQuery<ToolWithProvider[]>({
     queryKey: [NAME_SPACE, 'all'],
@@ -14,6 +15,7 @@ export const useAllTriggerPlugins = (enabled = true) => {
 }
 
 // Get trigger-capable plugins by type (schedule, webhook, etc.)
+// TODO: Backend API not implemented yet - replace with actual triggers endpoint
 export const useTriggerPluginsByType = (triggerType: string, enabled = true) => {
   return useQuery<ToolWithProvider[]>({
     queryKey: [NAME_SPACE, 'byType', triggerType],

--- a/web/service/use-triggers.ts
+++ b/web/service/use-triggers.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
+import { get } from './base'
+import type { ToolWithProvider } from '@/app/components/workflow/types'
+
+const NAME_SPACE = 'triggers'
+
+// Get all plugins that support trigger functionality
+export const useAllTriggerPlugins = (enabled = true) => {
+  return useQuery<ToolWithProvider[]>({
+    queryKey: [NAME_SPACE, 'all'],
+    queryFn: () => get<ToolWithProvider[]>('/workspaces/current/triggers/plugins'),
+    enabled,
+  })
+}
+
+// Get trigger-capable plugins by type (schedule, webhook, etc.)
+export const useTriggerPluginsByType = (triggerType: string, enabled = true) => {
+  return useQuery<ToolWithProvider[]>({
+    queryKey: [NAME_SPACE, 'byType', triggerType],
+    queryFn: () => get<ToolWithProvider[]>(`/workspaces/current/triggers/plugins?type=${triggerType}`),
+    enabled: enabled && !!triggerType,
+  })
+}


### PR DESCRIPTION
## Overview

This PR implements the Plugin Trigger Node frontend components as requested in #24196, providing the foundation for plugin-based workflow triggers with complete UI/UX integration and unified entry node system architecture.

## Implementation Summary

### Core Changes
- **Extended BlockIcon component** to support TriggerPlugin types with dynamic icons
- **Enhanced useToolIcon hook** to work with trigger plugins  
- **Expanded type definitions** for PluginTriggerNodeType with provider integration
- **Created TriggerPluginSelector** component for Start Tab plugin selection
- **Added AllStartBlocks container** with complete Tools-tab-like functionality
- **Implemented search and filtering** for trigger plugins
- **Added marketplace footer** consistent with Tools tab
- **Enhanced trigger service layer** for future backend integration

### Architecture Approach
This implementation follows a **maximum code reuse strategy**, leveraging the existing tool system architecture:
- TriggerPlugin nodes reuse the same icon rendering logic as Tool nodes
- Plugin selection UI reuses the Tools component with filtering
- Start Tab now has identical functionality to Tools Tab (search, footer, layout)
- Type definitions extend existing patterns for consistency
- Service layer prepares for backend API integration

### UI/UX Improvements
- **Complete Start Tab redesign**: Now matches Tools tab with search box, content area, and marketplace footer
- **Dynamic node display**: Plugin trigger nodes show specific plugin names/icons instead of generic titles
- **Consistent interaction patterns**: Search, filter, and selection work identically to Tools tab
- **Internationalization**: Added translations for search placeholder in English, Chinese, and Japanese

### Entry Node System Enhancements (Latest Updates)
- **Unified Entry Node Architecture**: Created ENTRY_NODE_TYPES constant grouping Start, TriggerSchedule, TriggerWebhook, and TriggerPlugin
- **Intelligent Deletion Logic**: Implemented unified deletion system allowing any entry node to be deleted as long as at least one remains
- **Visual Distinction**: Added 'original start node' label to User Input with full i18n support (en/zh-Hans/ja-JP)
- **Improved UI Layout**: Added divider between User Input and trigger types for better visual separation
- **Icon Consistency**: Fixed icon sizing inconsistencies across trigger types

## Current Status: ✅ Ready for Review

The plugin trigger architecture is functionally complete with full UI integration and enhanced entry node management:

- ✅ Basic plugin trigger node architecture
- ✅ Icon system integration with dynamic plugin-specific icons
- ✅ Complete Start Tab redesign with search and marketplace integration
- ✅ Plugin trigger node canvas display with dynamic content
- ✅ Type system extension for provider integration
- ✅ Service layer preparation for backend API
- ✅ **Unified entry node deletion system** - Start nodes can now be deleted like other triggers
- ✅ **Enhanced UI/UX** - Clear visual separation and labeling of different entry types
- ✅ **Visual consistency** - Fixed icon sizing and layout inconsistencies
- 🔄 **Ready for backend integration** - Only requires replacing `useAllBuiltInTools()` with `useAllTriggerPlugins()`

## Files Changed (11 commits)
- `app/components/workflow/block-icon.tsx` - Extended for TriggerPlugin support + fixed icon sizing
- `app/components/workflow/hooks/use-workflow.ts` - Added TriggerPlugin icon support
- `app/components/workflow/hooks/use-nodes-interactions.ts` - **NEW**: Unified entry node deletion logic
- `app/components/workflow/nodes/trigger-plugin/` - Enhanced node display and panel
- `app/components/workflow/block-selector/` - Complete Start Tab redesign + entry node improvements
- `service/use-triggers.ts` - Service layer for trigger plugins
- `i18n/` - **EXPANDED**: Added search + entry node translations (en/zh-Hans/ja-JP)

## Testing
- [x] Manual testing of plugin trigger node creation in Start Tab
- [x] Visual verification of icon rendering and dynamic display
- [x] Search functionality testing
- [x] UI consistency verification with Tools Tab
- [x] **NEW**: Entry node deletion testing - verified at least one entry node remains
- [x] **NEW**: Visual separation and labeling verification
- [x] **NEW**: Icon sizing consistency verification across all trigger types

Related to #24196, #24198