### PR TITLE
feat(workflow): Allow paste node into nested block

### DIFF
--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -39,6 +39,7 @@ import {
 import {
   genNewNodeTitleFromOld,
   generateNewNode,
+  getNestedNodePosition,
   getNodeCustomTypeByNodeDataType,
   getNodesConnectedSourceOrTargetHandleIdsMap,
   getTopLeftNodePosition,
@@ -1354,11 +1355,23 @@ export const useNodesInteractions = () => {
               newNode.data.isInIteration = true
               newNode.data.iteration_id = selectedNode.data.iteration_id
               newNode.parentId = selectedNode.id
+              newNode.positionAbsolute = {
+                x: newNode.position.x,
+                y: newNode.position.y,
+              }
+              // set position base on parent node
+              newNode.position = getNestedNodePosition(newNode, selectedNode)
             }
             else if (selectedNode.data.type === BlockEnum.Loop) {
               newNode.data.isInLoop = true
               newNode.data.loop_id = selectedNode.data.loop_id
               newNode.parentId = selectedNode.id
+              newNode.positionAbsolute = {
+                x: newNode.position.x,
+                y: newNode.position.y,
+              }
+              // set position base on parent node
+              newNode.position = getNestedNodePosition(newNode, selectedNode)
             }
           }
         }

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -1326,8 +1326,7 @@ export const useNodesInteractions = () => {
           })
           newChildren.push(newIterationStartNode!)
         }
-
-        if (nodeToPaste.data.type === BlockEnum.Loop) {
+        else if (nodeToPaste.data.type === BlockEnum.Loop) {
           newLoopStartNode!.parentId = newNode.id;
           (newNode.data as LoopNodeType).start_node_id = newLoopStartNode!.id
 
@@ -1337,6 +1336,32 @@ export const useNodesInteractions = () => {
           })
           newChildren.push(newLoopStartNode!)
         }
+        else {
+          // single node paste
+          const selectedNode = nodes.find(node => node.selected)
+          if (selectedNode) {
+            const commonNestedDisallowPasteNodes = [
+              // end node only can be placed outermost layer
+              BlockEnum.End,
+            ]
+
+            // handle disallow paste node
+            if (commonNestedDisallowPasteNodes.includes(nodeToPaste.data.type))
+              return
+
+            // handle paste to nested block
+            if (selectedNode.data.type === BlockEnum.Iteration) {
+              newNode.data.isInIteration = true
+              newNode.data.iteration_id = selectedNode.data.iteration_id
+              newNode.parentId = selectedNode.id
+            }
+            else if (selectedNode.data.type === BlockEnum.Loop) {
+              newNode.data.isInLoop = true
+              newNode.data.loop_id = selectedNode.data.loop_id
+              newNode.parentId = selectedNode.id
+            }
+          }
+        }
 
         nodesToPaste.push(newNode)
 
@@ -1344,6 +1369,7 @@ export const useNodesInteractions = () => {
           nodesToPaste.push(...newChildren)
       })
 
+      // only handle edge when paste nested block
       edges.forEach((edge) => {
         const sourceId = idMapping[edge.source]
         const targetId = idMapping[edge.target]

--- a/web/app/components/workflow/utils/node.ts
+++ b/web/app/components/workflow/utils/node.ts
@@ -135,6 +135,13 @@ export const getTopLeftNodePosition = (nodes: Node[]) => {
   }
 }
 
+export const getNestedNodePosition = (node: Node, parentNode: Node) => {
+  return {
+    x: node.position.x - parentNode.position.x,
+    y: node.position.y - parentNode.position.y,
+  }
+}
+
 export const hasRetryNode = (nodeType?: BlockEnum) => {
   return nodeType === BlockEnum.LLM || nodeType === BlockEnum.Tool || nodeType === BlockEnum.HttpRequest || nodeType === BlockEnum.Code
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/24232

Add feature about allow paste node into nested block, and can calculate correct position base on nested block.

## Screenshots

copy single node into nested block

![copy single node into nested block](https://github.com/user-attachments/assets/7d9a3a3e-cc19-48cf-8899-315dc3dc357c)

copy multi node into nested block

![copy multi node into nested block](https://github.com/user-attachments/assets/b148d5ae-8379-40e8-ad8f-27fb88841de7)

cannot copy end node into nested block, when multi node include end node, it will not be pasted

![cannot copy end node into nested block](https://github.com/user-attachments/assets/cbb9cf4f-24ef-41f8-8487-45d9225bbaa2)


| Before | After |
|--------|-------|
| Can not paste node into nested block | Allow paste node into nested block |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
