### PR TITLE
feat: implement TooltipManager for managing tooltip lifecycle

### DIFF
--- a/web/app/components/base/tooltip/TooltipManager.ts
+++ b/web/app/components/base/tooltip/TooltipManager.ts
@@ -4,14 +4,12 @@ class TooltipManager {
   register(closeFn: () => void) {
     if (this.activeCloser)
       this.activeCloser()
-  
     this.activeCloser = closeFn
   }
 
   clear(closeFn: () => void) {
     if (this.activeCloser === closeFn) 
       this.activeCloser = null
-    
   }
 }
 

--- a/web/app/components/base/tooltip/TooltipManager.ts
+++ b/web/app/components/base/tooltip/TooltipManager.ts
@@ -8,7 +8,7 @@ class TooltipManager {
   }
 
   clear(closeFn: () => void) {
-    if (this.activeCloser === closeFn) 
+    if (this.activeCloser === closeFn)
       this.activeCloser = null
   }
 }

--- a/web/app/components/base/tooltip/TooltipManager.ts
+++ b/web/app/components/base/tooltip/TooltipManager.ts
@@ -1,0 +1,18 @@
+class TooltipManager {
+  private activeCloser: (() => void) | null = null;
+
+  register(closeFn: () => void) {
+    if (this.activeCloser) {
+      this.activeCloser();
+    }
+    this.activeCloser = closeFn;
+  }
+
+  clear(closeFn: () => void) {
+    if (this.activeCloser === closeFn) {
+      this.activeCloser = null;
+    }
+  }
+}
+
+export const tooltipManager = new TooltipManager();

--- a/web/app/components/base/tooltip/TooltipManager.ts
+++ b/web/app/components/base/tooltip/TooltipManager.ts
@@ -1,18 +1,18 @@
 class TooltipManager {
-  private activeCloser: (() => void) | null = null;
+  private activeCloser: (() => void) | null = null
 
   register(closeFn: () => void) {
-    if (this.activeCloser) {
-      this.activeCloser();
-    }
-    this.activeCloser = closeFn;
+    if (this.activeCloser)
+      this.activeCloser()
+  
+    this.activeCloser = closeFn
   }
 
   clear(closeFn: () => void) {
-    if (this.activeCloser === closeFn) {
-      this.activeCloser = null;
-    }
+    if (this.activeCloser === closeFn) 
+      this.activeCloser = null
+    
   }
 }
 
-export const tooltipManager = new TooltipManager();
+export const tooltipManager = new TooltipManager()

--- a/web/app/components/base/tooltip/index.tsx
+++ b/web/app/components/base/tooltip/index.tsx
@@ -41,12 +41,12 @@ const Tooltip: FC<TooltipProps> = ({
   const [isHoverPopup, {
     setTrue: setHoverPopup,
     setFalse: setNotHoverPopup,
-   }] = useBoolean(false)
+  }] = useBoolean(false)
 
   const isHoverPopupRef = useRef(isHoverPopup)
-    useEffect(() => {
-      isHoverPopupRef.current = isHoverPopup
-    }, [isHoverPopup])
+  useEffect(() => {
+    isHoverPopupRef.current = isHoverPopup
+  }, [isHoverPopup])
 
   const [isHoverTrigger, {
     setTrue: setHoverTrigger,
@@ -74,7 +74,8 @@ const Tooltip: FC<TooltipProps> = ({
           tooltipManager.clear(close)
         }
       }, 300)
-    } else {
+    }
+    else {
       setOpen(false)
       tooltipManager.clear(close)
     }
@@ -103,18 +104,18 @@ const Tooltip: FC<TooltipProps> = ({
         {children || <div data-testid={triggerTestId} className={triggerClassName || 'h-3.5 w-3.5 shrink-0 p-[1px]'}><RiQuestionLine className='h-full w-full text-text-quaternary hover:text-text-tertiary' /></div>}
       </PortalToFollowElemTrigger>
       <PortalToFollowElemContent
-      className="z-[9999]"
+        className="z-[9999]"
       >
         {popupContent && (<div
-            className={cn(
-              !noDecoration && 'system-xs-regular relative max-w-[300px] break-words rounded-md bg-components-panel-bg px-3 py-2 text-left text-text-tertiary shadow-lg',
-              popupClassName,
-            )}
-            onMouseEnter={() => triggerMethod === 'hover' && setHoverPopup()}
-            onMouseLeave={() => triggerMethod === 'hover' && handleLeave(false)}
-          >
-            {popupContent}
-          </div>)}
+          className={cn(
+            !noDecoration && 'system-xs-regular relative max-w-[300px] break-words rounded-md bg-components-panel-bg px-3 py-2 text-left text-text-tertiary shadow-lg',
+            popupClassName,
+          )}
+          onMouseEnter={() => triggerMethod === 'hover' && setHoverPopup()}
+          onMouseLeave={() => triggerMethod === 'hover' && handleLeave(false)}
+        >
+          {popupContent}
+        </div>)}
       </PortalToFollowElemContent>
     </PortalToFollowElem>
   )

--- a/web/app/components/base/tooltip/index.tsx
+++ b/web/app/components/base/tooltip/index.tsx
@@ -6,7 +6,7 @@ import type { OffsetOptions, Placement } from '@floating-ui/react'
 import { RiQuestionLine } from '@remixicon/react'
 import cn from '@/utils/classnames'
 import { PortalToFollowElem, PortalToFollowElemContent, PortalToFollowElemTrigger } from '@/app/components/base/portal-to-follow-elem'
-import { tooltipManager } from './TooltipManager'  
+import { tooltipManager } from './TooltipManager'
 
 export type TooltipProps = {
   position?: Placement
@@ -42,7 +42,7 @@ const Tooltip: FC<TooltipProps> = ({
     setTrue: setHoverPopup,
     setFalse: setNotHoverPopup,
    }] = useBoolean(false)
-  
+
   const isHoverPopupRef = useRef(isHoverPopup)
     useEffect(() => {
       isHoverPopupRef.current = isHoverPopup
@@ -58,7 +58,7 @@ const Tooltip: FC<TooltipProps> = ({
     isHoverTriggerRef.current = isHoverTrigger
   }, [isHoverTrigger])
 
-  const close = () => setOpen(false)   // function to close this tooltip
+  const close = () => setOpen(false)
 
   const handleLeave = (isTrigger: boolean) => {
     if (isTrigger)
@@ -71,7 +71,7 @@ const Tooltip: FC<TooltipProps> = ({
       setTimeout(() => {
         if (!isHoverPopupRef.current && !isHoverTriggerRef.current) {
           setOpen(false)
-          tooltipManager.clear(close)   // clear from manager
+          tooltipManager.clear(close)
         }
       }, 300)
     } else {
@@ -92,7 +92,7 @@ const Tooltip: FC<TooltipProps> = ({
         onMouseEnter={() => {
           if (triggerMethod === 'hover') {
             setHoverTrigger()
-            tooltipManager.register(close)   // register with manager
+            tooltipManager.register(close)
             setOpen(true)
           }
         }}

--- a/web/app/components/base/tooltip/index.tsx
+++ b/web/app/components/base/tooltip/index.tsx
@@ -6,6 +6,8 @@ import type { OffsetOptions, Placement } from '@floating-ui/react'
 import { RiQuestionLine } from '@remixicon/react'
 import cn from '@/utils/classnames'
 import { PortalToFollowElem, PortalToFollowElemContent, PortalToFollowElemTrigger } from '@/app/components/base/portal-to-follow-elem'
+import { tooltipManager } from './TooltipManager'  
+
 export type TooltipProps = {
   position?: Placement
   triggerMethod?: 'hover' | 'click'
@@ -39,12 +41,12 @@ const Tooltip: FC<TooltipProps> = ({
   const [isHoverPopup, {
     setTrue: setHoverPopup,
     setFalse: setNotHoverPopup,
-  }] = useBoolean(false)
-
+   }] = useBoolean(false)
+  
   const isHoverPopupRef = useRef(isHoverPopup)
-  useEffect(() => {
-    isHoverPopupRef.current = isHoverPopup
-  }, [isHoverPopup])
+    useEffect(() => {
+      isHoverPopupRef.current = isHoverPopup
+    }, [isHoverPopup])
 
   const [isHoverTrigger, {
     setTrue: setHoverTrigger,
@@ -56,22 +58,25 @@ const Tooltip: FC<TooltipProps> = ({
     isHoverTriggerRef.current = isHoverTrigger
   }, [isHoverTrigger])
 
+  const close = () => setOpen(false)   // function to close this tooltip
+
   const handleLeave = (isTrigger: boolean) => {
     if (isTrigger)
       setNotHoverTrigger()
-
     else
       setNotHoverPopup()
 
     // give time to move to the popup
     if (needsDelay) {
       setTimeout(() => {
-        if (!isHoverPopupRef.current && !isHoverTriggerRef.current)
+        if (!isHoverPopupRef.current && !isHoverTriggerRef.current) {
           setOpen(false)
+          tooltipManager.clear(close)   // clear from manager
+        }
       }, 300)
-    }
-    else {
+    } else {
       setOpen(false)
+      tooltipManager.clear(close)
     }
   }
 
@@ -87,6 +92,7 @@ const Tooltip: FC<TooltipProps> = ({
         onMouseEnter={() => {
           if (triggerMethod === 'hover') {
             setHoverTrigger()
+            tooltipManager.register(close)   // register with manager
             setOpen(true)
           }
         }}
@@ -97,18 +103,18 @@ const Tooltip: FC<TooltipProps> = ({
         {children || <div data-testid={triggerTestId} className={triggerClassName || 'h-3.5 w-3.5 shrink-0 p-[1px]'}><RiQuestionLine className='h-full w-full text-text-quaternary hover:text-text-tertiary' /></div>}
       </PortalToFollowElemTrigger>
       <PortalToFollowElemContent
-        className="z-[9999]"
+      className="z-[9999]"
       >
         {popupContent && (<div
-          className={cn(
-            !noDecoration && 'system-xs-regular relative max-w-[300px] break-words rounded-md bg-components-panel-bg px-3 py-2 text-left text-text-tertiary shadow-lg',
-            popupClassName,
-          )}
-          onMouseEnter={() => triggerMethod === 'hover' && setHoverPopup()}
-          onMouseLeave={() => triggerMethod === 'hover' && handleLeave(false)}
-        >
-          {popupContent}
-        </div>)}
+            className={cn(
+              !noDecoration && 'system-xs-regular relative max-w-[300px] break-words rounded-md bg-components-panel-bg px-3 py-2 text-left text-text-tertiary shadow-lg',
+              popupClassName,
+            )}
+            onMouseEnter={() => triggerMethod === 'hover' && setHoverPopup()}
+            onMouseLeave={() => triggerMethod === 'hover' && handleLeave(false)}
+          >
+            {popupContent}
+          </div>)}
       </PortalToFollowElemContent>
     </PortalToFollowElem>
   )


### PR DESCRIPTION
## Summary

This PR introduces a `TooltipManager` to handle tooltip lifecycle globally.  
Previously, multiple tooltips could remain visible at once, leading to a "ghosting" issue.  

With this change:
- Only one tooltip can be open at a time.
- When a new tooltip opens, any previously open tooltip is closed automatically.
- Tooltip hiding still respects the `needsDelay` behavior (300ms default).

Fixes #23837

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
