### PR TITLE
fix: loop exit condition accepts variables from nodes inside the loop  #24183:

### DIFF
--- a/api/core/workflow/nodes/loop/loop_node.py
+++ b/api/core/workflow/nodes/loop/loop_node.py
@@ -313,29 +313,30 @@ class LoopNode(BaseNode):
                 and event.node_type == NodeType.LOOP_END
                 and not isinstance(event, NodeRunStreamChunkEvent)
             ):
-                check_break_result = True
+                # Check if variables in break conditions exist and process conditions
+                # Allow loop internal variables to be used in break conditions
+                available_conditions = []
+                for condition in break_conditions:
+                    variable = self.graph_runtime_state.variable_pool.get(condition.variable_selector)
+                    if variable:
+                        available_conditions.append(condition)
+                
+                # Process conditions if at least one variable is available
+                if available_conditions:
+                    input_conditions, group_result, check_break_result = condition_processor.process_conditions(
+                        variable_pool=self.graph_runtime_state.variable_pool,
+                        conditions=available_conditions,
+                        operator=logical_operator,
+                    )
+                    if check_break_result:
+                        break
+                else:
+                    check_break_result = True
                 yield self._handle_event_metadata(event=event, iter_run_index=current_index)
                 break
 
             if isinstance(event, NodeRunSucceededEvent):
                 yield self._handle_event_metadata(event=event, iter_run_index=current_index)
-
-                # Check if all variables in break conditions exist
-                exists_variable = False
-                for condition in break_conditions:
-                    if not self.graph_runtime_state.variable_pool.get(condition.variable_selector):
-                        exists_variable = False
-                        break
-                    else:
-                        exists_variable = True
-                if exists_variable:
-                    input_conditions, group_result, check_break_result = condition_processor.process_conditions(
-                        variable_pool=self.graph_runtime_state.variable_pool,
-                        conditions=break_conditions,
-                        operator=logical_operator,
-                    )
-                    if check_break_result:
-                        break
 
             elif isinstance(event, BaseGraphEvent):
                 if isinstance(event, GraphRunFailedEvent):

--- a/api/core/workflow/nodes/loop/loop_node.py
+++ b/api/core/workflow/nodes/loop/loop_node.py
@@ -320,7 +320,7 @@ class LoopNode(BaseNode):
                     variable = self.graph_runtime_state.variable_pool.get(condition.variable_selector)
                     if variable:
                         available_conditions.append(condition)
-                
+
                 # Process conditions if at least one variable is available
                 if available_conditions:
                     input_conditions, group_result, check_break_result = condition_processor.process_conditions(


### PR DESCRIPTION
- Modified loop node to check break conditions only at LOOP_END event
- Changed variable existence check to process available conditions only
- Ensures Variable Assigner and other internal nodes execute before condition check
- Fixes #24183: Loop termination condition now accepts variables from internal nodes

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
