### PR TITLE
feat: show the start time with seconds of the app logs

### DIFF
--- a/web/app/components/app/workflow-log/list.tsx
+++ b/web/app/components/app/workflow-log/list.tsx
@@ -112,7 +112,7 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
                   </div>
                 )}
               </td>
-              <td className='w-[160px] p-3 pr-2'>{formatTime(log.created_at, t('appLog.dateTimeFormat') as string)}</td>
+              <td className='w-[180px] p-3 pr-2'>{formatTime(log.created_at, t('appLog.dateTimeFormat') as string)}</td>
               <td className='p-3 pr-2'>{statusTdRender(log.workflow_run.status)}</td>
               <td className='p-3 pr-2'>
                 <div className={cn(

--- a/web/i18n/de-DE/app-log.ts
+++ b/web/i18n/de-DE/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Protokolle',
   description: 'Die Protokolle zeichnen den Betriebsstatus der Anwendung auf, einschließlich Benutzereingaben und KI-Antworten.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   dateFormat: 'MM/DD/YYYY',
   table: {
     header: {

--- a/web/i18n/en-US/app-log.ts
+++ b/web/i18n/en-US/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Logs',
   description: 'The logs record the running status of the application, including user inputs and AI replies.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   dateFormat: 'MM/DD/YYYY',
   table: {
     header: {

--- a/web/i18n/es-ES/app-log.ts
+++ b/web/i18n/es-ES/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Registros',
   description: 'Los registros registran el estado de ejecución de la aplicación, incluyendo las entradas de usuario y las respuestas de la IA.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Hora actualizada',

--- a/web/i18n/fa-IR/app-log.ts
+++ b/web/i18n/fa-IR/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'لاگ‌ها',
   description: 'لاگ‌ها وضعیت اجرایی برنامه را ثبت می‌کنند، شامل ورودی‌های کاربر و پاسخ‌های هوش مصنوعی.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'زمان به‌روزرسانی',

--- a/web/i18n/fr-FR/app-log.ts
+++ b/web/i18n/fr-FR/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Journaux',
   description: 'Les journaux enregistrent l\'état d\'exécution de l\'application, y compris les entrées utilisateur et les réponses de l\'IA.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Heure de mise à jour',

--- a/web/i18n/hi-IN/app-log.ts
+++ b/web/i18n/hi-IN/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'लॉग्स',
   description: 'लॉग्स एप्लिकेशन के रनिंग स्टेटस को रिकॉर्ड करते हैं, जिसमें यूजर इनपुट और एआई रिप्लाईज़ शामिल हैं।',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'अपडेट का समय',

--- a/web/i18n/it-IT/app-log.ts
+++ b/web/i18n/it-IT/app-log.ts
@@ -2,7 +2,7 @@ const translation = {
   title: 'Registri',
   description:
     'I registri registrano lo stato di esecuzione dell\'applicazione, inclusi input degli utenti e risposte AI.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Ora di aggiornamento',

--- a/web/i18n/ja-JP/app-log.ts
+++ b/web/i18n/ja-JP/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'ログ',
   description: 'ログは、アプリケーションの実行状態を記録します。ユーザーの入力や AI の応答などが含まれます。',
-  dateTimeFormat: 'YYYY/MM/DD hh:mm A',
+  dateTimeFormat: 'YYYY/MM/DD hh:mm:ss A',
   dateFormat: 'YYYY/MM/DD',
   table: {
     header: {

--- a/web/i18n/ko-KR/app-log.ts
+++ b/web/i18n/ko-KR/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: '로그',
   description: '로그는 애플리케이션 실행 상태를 기록합니다. 사용자 입력 및 AI 응답이 포함됩니다.',
-  dateTimeFormat: 'YYYY/MM/DD HH:mm',
+  dateTimeFormat: 'YYYY/MM/DD HH:mm:ss',
   table: {
     header: {
       updatedTime: '업데이트 시간',

--- a/web/i18n/pl-PL/app-log.ts
+++ b/web/i18n/pl-PL/app-log.ts
@@ -2,7 +2,7 @@ const translation = {
   title: 'Dzienniki',
   description:
     'Dzienniki rejestrują stan działania aplikacji, w tym dane wejściowe użytkowników i odpowiedzi AI.',
-  dateTimeFormat: 'DD/MM/YYYY HH:mm',
+  dateTimeFormat: 'DD/MM/YYYY HH:mm:ss',
   table: {
     header: {
       updatedTime: 'Czas aktualizacji',

--- a/web/i18n/pt-BR/app-log.ts
+++ b/web/i18n/pt-BR/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Registros',
   description: 'Os registros registram o status de execução do aplicativo, incluindo entradas do usuário e respostas do AI.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Hora de atualização',

--- a/web/i18n/ro-RO/app-log.ts
+++ b/web/i18n/ro-RO/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Jurnale',
   description: 'Jurnalele înregistrează starea de funcționare a aplicației, inclusiv intrările utilizatorilor și răspunsurile AI.',
-  dateTimeFormat: 'DD/MM/YYYY hh:mm A',
+  dateTimeFormat: 'DD/MM/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Timp actualizare',

--- a/web/i18n/ru-RU/app-log.ts
+++ b/web/i18n/ru-RU/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Логирование',
   description: 'В логах записывается состояние работы приложения, включая пользовательский ввод и ответы ИИ.',
-  dateTimeFormat: 'DD.MM.YYYY HH:mm',
+  dateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
   table: {
     header: {
       updatedTime: 'Время обновления',

--- a/web/i18n/sl-SI/app-log.ts
+++ b/web/i18n/sl-SI/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Dnevniki',
   description: 'Dnevniki beležijo stanje delovanja aplikacije, vključno z vnosi uporabnikov in odgovori umetne inteligence.',
-  dateTimeFormat: 'DD.MM.YYYY hh:mm A',
+  dateTimeFormat: 'DD.MM.YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Čas posodobitve',

--- a/web/i18n/th-TH/app-log.ts
+++ b/web/i18n/th-TH/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'บันทึก',
   description: 'บันทึกบันทึกสถานะการทํางานของแอปพลิเคชัน รวมถึงการป้อนข้อมูลของผู้ใช้และการตอบกลับ AI',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'อัพเดทเวลา',

--- a/web/i18n/uk-UA/app-log.ts
+++ b/web/i18n/uk-UA/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Журнали',
   description: 'Журнали фіксують робочий статус додатка, включаючи введення користувачів та відповіді штучного інтелекту.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Час оновлення',

--- a/web/i18n/vi-VN/app-log.ts
+++ b/web/i18n/vi-VN/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: 'Nhật ký',
   description: 'Nhật ký ghi lại trạng thái hoạt động của ứng dụng, bao gồm đầu vào của người dùng và phản hồi của trí tuệ nhân tạo.',
-  dateTimeFormat: 'MM/DD/YYYY hh:mm A',
+  dateTimeFormat: 'MM/DD/YYYY hh:mm:ss A',
   table: {
     header: {
       updatedTime: 'Thời gian cập nhật',

--- a/web/i18n/zh-Hans/app-log.ts
+++ b/web/i18n/zh-Hans/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: '日志',
   description: '日志记录了应用的运行情况，包括用户的输入和 AI 的回复。',
-  dateTimeFormat: 'YYYY-MM-DD HH:mm',
+  dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
   dateFormat: 'YYYY-MM-DD',
   table: {
     header: {

--- a/web/i18n/zh-Hant/app-log.ts
+++ b/web/i18n/zh-Hant/app-log.ts
@@ -1,7 +1,7 @@
 const translation = {
   title: '日誌',
   description: '日誌記錄了應用的執行情況，包括使用者的輸入和 AI 的回覆。',
-  dateTimeFormat: 'YYYY-MM-DD HH:mm',
+  dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
   table: {
     header: {
       updatedTime: '更新時間',


### PR DESCRIPTION
## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Current the start time of the app log was showed with minutes, we'd like to show with seconds.

Fixes #24266. 

## Screenshots

| Before | After |
|--------|-------|
|<img width="1918" height="638" alt="Screenshot 2025-08-20 030434" src="https://github.com/user-attachments/assets/25d322e8-1088-4c79-afd7-57a5ebc168bf" />|<img width="1920" height="1032" alt="Screenshot 2025-08-20 201520" src="https://github.com/user-attachments/assets/608f7d16-7eb0-43f8-9ab8-b30aa1f8027c" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
