### PR TITLE
fix: #24292 HTTP Request Node Unable to Access File from Start Node When Using Remote URL in Workflow API Call

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -230,7 +230,7 @@ class Executor:
                     for key, files_in_segment in files_list:
                         for file in files_in_segment:
                             if file.related_id is not None or (
-                                file.transfer_method == FileTransferMethod.remote_url
+                                file.transfer_method == FileTransferMethod.REMOTE_URL
                                 and file.remote_url is not None
                             ):
                                 file_tuple = (

--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -230,8 +230,7 @@ class Executor:
                     for key, files_in_segment in files_list:
                         for file in files_in_segment:
                             if file.related_id is not None or (
-                                file.transfer_method == FileTransferMethod.remote_url
-                                and file.remote_url is not None
+                                file.transfer_method == FileTransferMethod.remote_url and file.remote_url is not None
                             ):
                                 file_tuple = (
                                     file.filename,

--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -12,6 +12,7 @@ from json_repair import repair_json
 
 from configs import dify_config
 from core.file import file_manager
+from core.file.enums import FileTransferMethod
 from core.helper import ssrf_proxy
 from core.variables.segments import ArrayFileSegment, FileSegment
 from core.workflow.entities.variable_pool import VariablePool
@@ -228,7 +229,10 @@ class Executor:
                     files: dict[str, list[tuple[str | None, bytes, str]]] = {}
                     for key, files_in_segment in files_list:
                         for file in files_in_segment:
-                            if file.related_id is not None:
+                            if file.related_id is not None or (
+                                file.transfer_method == FileTransferMethod.remote_url
+                                and file.remote_url is not None
+                            ):
                                 file_tuple = (
                                     file.filename,
                                     file_manager.download(file),


### PR DESCRIPTION
…hen Using Remote URL in Workflow API Call

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #24292 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
