### PR TITLE
fix: Optimize scrolling experience on plugin page (#24314)

### DIFF
--- a/web/app/components/plugins/plugin-page/plugins-panel.tsx
+++ b/web/app/components/plugins/plugin-page/plugins-panel.tsx
@@ -73,7 +73,7 @@ const PluginsPanel = () => {
       {!isPluginListLoading && (
         <>
           {(filteredList?.length ?? 0) > 0 ? (
-            <div className='flex grow flex-wrap content-start items-start justify-center gap-2 self-stretch px-12'>
+            <div className='flex grow flex-wrap content-start items-start justify-center gap-2 self-stretch overflow-y-auto px-12'>
               <div className='w-full'>
                 <List pluginList={filteredList || []} />
               </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add vertical scroll bar to plugin list container
- Fix abnormal occlusion issue during overflow scrolling

Fixes #24314

## Screenshots

| Before | After |
|--------|-------|
| <img width="2476" height="1312" alt="68b457149f96a4debb5893f018d60a52" src="https://github.com/user-attachments/assets/db2b5bbc-445d-4934-90c9-2993c7532b48" /> | <img width="2520" height="1240" alt="df795360fdf1a16484a3149ba76e432a" src="https://github.com/user-attachments/assets/eb48a3fb-5281-4541-9415-0e8b941528f1" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
