### PR TITLE
fix: standardize authentication error messages to prevent user enumeration

### DIFF
--- a/api/controllers/console/auth/error.py
+++ b/api/controllers/console/auth/error.py
@@ -58,7 +58,7 @@ class EmailOrPasswordMismatchError(BaseHTTPException):
 class AuthenticationFailedError(BaseHTTPException):
     error_code = "authentication_failed"
     description = "Invalid email or password."
-    code = 400
+    code = 401
 
 
 class EmailPasswordLoginLimitError(BaseHTTPException):

--- a/api/controllers/console/auth/error.py
+++ b/api/controllers/console/auth/error.py
@@ -55,6 +55,12 @@ class EmailOrPasswordMismatchError(BaseHTTPException):
     code = 400
 
 
+class AuthenticationFailedError(BaseHTTPException):
+    error_code = "authentication_failed"
+    description = "Invalid email or password."
+    code = 400
+
+
 class EmailPasswordLoginLimitError(BaseHTTPException):
     error_code = "email_code_login_limit"
     description = "Too many incorrect password attempts. Please try again later."

--- a/api/controllers/console/auth/forgot_password.py
+++ b/api/controllers/console/auth/forgot_password.py
@@ -15,7 +15,7 @@ from controllers.console.auth.error import (
     InvalidTokenError,
     PasswordMismatchError,
 )
-from controllers.console.error import AccountInFreezeError, EmailSendIpLimitError
+from controllers.console.error import AccountInFreezeError, AccountNotFound, EmailSendIpLimitError
 from controllers.console.wraps import email_password_login_enabled, setup_required
 from events.tenant_event import tenant_was_created
 from extensions.ext_database import db
@@ -48,15 +48,17 @@ class ForgotPasswordSendEmailApi(Resource):
 
         with Session(db.engine) as session:
             account = session.execute(select(Account).filter_by(email=args["email"])).scalar_one_or_none()
-
-        if account is not None:
-            token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
+        token = None
+        if account is None:
+            if FeatureService.get_system_features().is_allow_register:
+                token = AccountService.send_reset_password_email(email=args["email"], language=language)
+                return {"result": "fail", "data": token, "code": "account_not_found"}
+            else:
+                raise AccountNotFound()
         else:
-            # Don't reveal whether account exists, but still generate a token for consistency
-            token = AccountService.send_reset_password_email(email=args["email"], language=language)
+            token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
 
-        # Always return success to prevent user enumeration
-        return {"result": "success"}
+        return {"result": "success", "data": token}
 
 
 class ForgotPasswordCheckApi(Resource):

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -9,8 +9,8 @@ from configs import dify_config
 from constants.languages import languages
 from controllers.console import api
 from controllers.console.auth.error import (
+    AuthenticationFailedError,
     EmailCodeError,
-    EmailOrPasswordMismatchError,
     EmailPasswordLoginLimitError,
     InvalidEmailError,
     InvalidTokenError,
@@ -18,7 +18,6 @@ from controllers.console.auth.error import (
 from controllers.console.error import (
     AccountBannedError,
     AccountInFreezeError,
-    AccountNotFound,
     EmailSendIpLimitError,
     NotAllowedCreateWorkspace,
     WorkspacesLimitExceeded,
@@ -77,15 +76,9 @@ class LoginApi(Resource):
                 account = AccountService.authenticate(args["email"], args["password"])
         except services.errors.account.AccountLoginError:
             raise AccountBannedError()
-        except services.errors.account.AccountPasswordError:
+        except (services.errors.account.AccountPasswordError, services.errors.account.AccountNotFoundError):
             AccountService.add_login_error_rate_limit(args["email"])
-            raise EmailOrPasswordMismatchError()
-        except services.errors.account.AccountNotFoundError:
-            if FeatureService.get_system_features().is_allow_register:
-                token = AccountService.send_reset_password_email(email=args["email"], language=language)
-                return {"result": "fail", "data": token, "code": "account_not_found"}
-            else:
-                raise AccountNotFound()
+            raise AuthenticationFailedError()
         # SELF_HOSTED only have one workspace
         tenants = TenantService.get_join_tenants(account)
         if len(tenants) == 0:
@@ -132,15 +125,15 @@ class ResetPasswordSendEmailApi(Resource):
             account = AccountService.get_user_through_email(args["email"])
         except AccountRegisterError as are:
             raise AccountInFreezeError()
-        if account is None:
-            if FeatureService.get_system_features().is_allow_register:
-                token = AccountService.send_reset_password_email(email=args["email"], language=language)
-            else:
-                raise AccountNotFound()
-        else:
-            token = AccountService.send_reset_password_email(account=account, language=language)
 
-        return {"result": "success", "data": token}
+        if account is not None:
+            token = AccountService.send_reset_password_email(account=account, language=language)
+        else:
+            # Don't reveal whether account exists
+            token = AccountService.send_reset_password_email(email=args["email"], language=language)
+
+        # Always return success to prevent user enumeration
+        return {"result": "success"}
 
 
 class EmailCodeLoginSendEmailApi(Resource):
@@ -164,15 +157,14 @@ class EmailCodeLoginSendEmailApi(Resource):
         except AccountRegisterError as are:
             raise AccountInFreezeError()
 
-        if account is None:
-            if FeatureService.get_system_features().is_allow_register:
-                token = AccountService.send_email_code_login_email(email=args["email"], language=language)
-            else:
-                raise AccountNotFound()
-        else:
+        if account is not None:
             token = AccountService.send_email_code_login_email(account=account, language=language)
+        else:
+            # Don't reveal whether account exists
+            token = AccountService.send_email_code_login_email(email=args["email"], language=language)
 
-        return {"result": "success", "data": token}
+        # Always return success to prevent user enumeration
+        return {"result": "success"}
 
 
 class EmailCodeLoginApi(Resource):

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -18,6 +18,7 @@ from controllers.console.auth.error import (
 from controllers.console.error import (
     AccountBannedError,
     AccountInFreezeError,
+    AccountNotFound,
     EmailSendIpLimitError,
     NotAllowedCreateWorkspace,
     WorkspacesLimitExceeded,

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -9,8 +9,8 @@ from configs import dify_config
 from constants.languages import languages
 from controllers.console import api
 from controllers.console.auth.error import (
+    AuthenticationFailedError,
     EmailCodeError,
-    EmailOrPasswordMismatchError,
     EmailPasswordLoginLimitError,
     InvalidEmailError,
     InvalidTokenError,
@@ -79,7 +79,7 @@ class LoginApi(Resource):
             raise AccountBannedError()
         except services.errors.account.AccountPasswordError:
             AccountService.add_login_error_rate_limit(args["email"])
-            raise EmailOrPasswordMismatchError()
+            raise AuthenticationFailedError()
         except services.errors.account.AccountNotFoundError:
             if FeatureService.get_system_features().is_allow_register:
                 token = AccountService.send_reset_password_email(email=args["email"], language=language)

--- a/api/controllers/web/forgot_password.py
+++ b/api/controllers/web/forgot_password.py
@@ -7,13 +7,14 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from controllers.console.auth.error import (
+    AuthenticationFailedError,
     EmailCodeError,
     EmailPasswordResetLimitError,
     InvalidEmailError,
     InvalidTokenError,
     PasswordMismatchError,
 )
-from controllers.console.error import AccountNotFound, EmailSendIpLimitError
+from controllers.console.error import EmailSendIpLimitError
 from controllers.console.wraps import email_password_login_enabled, only_edition_enterprise, setup_required
 from controllers.web import api
 from extensions.ext_database import db
@@ -46,7 +47,7 @@ class ForgotPasswordSendEmailApi(Resource):
             account = session.execute(select(Account).filter_by(email=args["email"])).scalar_one_or_none()
         token = None
         if account is None:
-            raise AccountNotFound()
+            raise AuthenticationFailedError()
         else:
             token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
 
@@ -131,7 +132,7 @@ class ForgotPasswordResetApi(Resource):
             if account:
                 self._update_existing_account(account, password_hashed, salt, session)
             else:
-                raise AccountNotFound()
+                raise AuthenticationFailedError()
 
         return {"result": "success"}
 

--- a/api/controllers/web/forgot_password.py
+++ b/api/controllers/web/forgot_password.py
@@ -44,13 +44,15 @@ class ForgotPasswordSendEmailApi(Resource):
 
         with Session(db.engine) as session:
             account = session.execute(select(Account).filter_by(email=args["email"])).scalar_one_or_none()
-        token = None
-        if account is None:
-            raise AccountNotFound()
-        else:
-            token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
 
-        return {"result": "success", "data": token}
+        if account is not None:
+            token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
+        else:
+            # Don't reveal whether account exists
+            token = AccountService.send_reset_password_email(email=args["email"], language=language)
+
+        # Always return success to prevent user enumeration
+        return {"result": "success"}
 
 
 class ForgotPasswordCheckApi(Resource):

--- a/api/controllers/web/forgot_password.py
+++ b/api/controllers/web/forgot_password.py
@@ -44,15 +44,13 @@ class ForgotPasswordSendEmailApi(Resource):
 
         with Session(db.engine) as session:
             account = session.execute(select(Account).filter_by(email=args["email"])).scalar_one_or_none()
-
-        if account is not None:
-            token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
+        token = None
+        if account is None:
+            raise AccountNotFound()
         else:
-            # Don't reveal whether account exists
-            token = AccountService.send_reset_password_email(email=args["email"], language=language)
+            token = AccountService.send_reset_password_email(account=account, email=args["email"], language=language)
 
-        # Always return success to prevent user enumeration
-        return {"result": "success"}
+        return {"result": "success", "data": token}
 
 
 class ForgotPasswordCheckApi(Resource):

--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -3,8 +3,8 @@ from jwt import InvalidTokenError  # type: ignore
 
 import services
 from controllers.console.auth.error import (
-    AuthenticationFailedError,
     EmailCodeError,
+    EmailOrPasswordMismatchError,
     InvalidEmailError,
 )
 from controllers.console.error import AccountBannedError, AccountNotFound
@@ -33,9 +33,9 @@ class LoginApi(Resource):
         except services.errors.account.AccountLoginError:
             raise AccountBannedError()
         except services.errors.account.AccountPasswordError:
-            raise AuthenticationFailedError()
+            raise EmailOrPasswordMismatchError()
         except services.errors.account.AccountNotFoundError:
-            raise AuthenticationFailedError()
+            raise AccountNotFound()
 
         token = WebAppAuthService.login(account=account)
         return {"result": "success", "data": {"access_token": token}}

--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -3,11 +3,11 @@ from jwt import InvalidTokenError  # type: ignore
 
 import services
 from controllers.console.auth.error import (
+    AuthenticationFailedError,
     EmailCodeError,
-    EmailOrPasswordMismatchError,
     InvalidEmailError,
 )
-from controllers.console.error import AccountBannedError, AccountNotFound
+from controllers.console.error import AccountBannedError
 from controllers.console.wraps import only_edition_enterprise, setup_required
 from controllers.web import api
 from libs.helper import email
@@ -33,9 +33,9 @@ class LoginApi(Resource):
         except services.errors.account.AccountLoginError:
             raise AccountBannedError()
         except services.errors.account.AccountPasswordError:
-            raise EmailOrPasswordMismatchError()
+            raise AuthenticationFailedError()
         except services.errors.account.AccountNotFoundError:
-            raise AccountNotFound()
+            raise AuthenticationFailedError()
 
         token = WebAppAuthService.login(account=account)
         return {"result": "success", "data": {"access_token": token}}
@@ -67,7 +67,7 @@ class EmailCodeLoginSendEmailApi(Resource):
 
         account = WebAppAuthService.get_user_through_email(args["email"])
         if account is None:
-            raise AccountNotFound()
+            raise AuthenticationFailedError()
         else:
             token = WebAppAuthService.send_email_code_login_email(account=account, language=language)
 
@@ -99,7 +99,7 @@ class EmailCodeLoginApi(Resource):
         WebAppAuthService.revoke_email_code_login_token(args["token"])
         account = WebAppAuthService.get_user_through_email(user_email)
         if not account:
-            raise AccountNotFound()
+            raise AuthenticationFailedError()
 
         token = WebAppAuthService.login(account=account)
         AccountService.reset_login_error_rate_limit(args["email"])

--- a/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
@@ -7,7 +7,7 @@ from flask import Flask
 from flask_restx import Api
 
 import services.errors.account
-from controllers.console.auth.error import EmailOrPasswordMismatchError
+from controllers.console.auth.error import AuthenticationFailedError
 from controllers.console.auth.login import LoginApi
 from controllers.console.error import AccountNotFound
 
@@ -62,7 +62,7 @@ class TestAuthenticationSecurity:
     def test_login_wrong_password_returns_error(
         self, mock_get_invitation, mock_add_rate_limit, mock_authenticate, mock_is_rate_limit, mock_db
     ):
-        """Test that wrong password returns EmailOrPasswordMismatchError."""
+        """Test that wrong password returns AuthenticationFailedError."""
         # Arrange
         mock_is_rate_limit.return_value = False
         mock_get_invitation.return_value = None
@@ -76,11 +76,11 @@ class TestAuthenticationSecurity:
             login_api = LoginApi()
 
             # Assert
-            with pytest.raises(EmailOrPasswordMismatchError) as exc_info:
+            with pytest.raises(AuthenticationFailedError) as exc_info:
                 login_api.post()
 
-        assert exc_info.value.error_code == "email_or_password_mismatch"
-        assert exc_info.value.description == "The email or password is mismatched."
+        assert exc_info.value.error_code == "authentication_failed"
+        assert exc_info.value.description == "Invalid email or password."
         mock_add_rate_limit.assert_called_once_with("existing@example.com")
 
     @patch("controllers.console.wraps.db")

--- a/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
@@ -7,8 +7,9 @@ from flask import Flask
 from flask_restful import Api
 
 import services.errors.account
-from controllers.console.auth.error import AuthenticationFailedError
+from controllers.console.auth.error import EmailOrPasswordMismatchError
 from controllers.console.auth.login import LoginApi
+from controllers.console.error import AccountNotFound
 
 
 class TestAuthenticationSecurity:
@@ -23,34 +24,34 @@ class TestAuthenticationSecurity:
         self.app.config["TESTING"] = True
 
     @patch("controllers.console.wraps.db")
+    @patch("controllers.console.auth.login.FeatureService.get_system_features")
     @patch("controllers.console.auth.login.AccountService.is_login_error_rate_limit")
     @patch("controllers.console.auth.login.AccountService.authenticate")
-    @patch("controllers.console.auth.login.AccountService.add_login_error_rate_limit")
+    @patch("controllers.console.auth.login.AccountService.send_reset_password_email")
     @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
     @patch("controllers.console.auth.login.RegisterService.get_invitation_if_token_valid")
-    def test_login_invalid_email_returns_generic_error(
-        self, mock_get_invitation, mock_add_rate_limit, mock_authenticate, mock_is_rate_limit, mock_db
+    def test_login_invalid_email_with_registration_allowed(
+        self, mock_get_invitation, mock_send_email, mock_authenticate, mock_is_rate_limit, mock_features, mock_db
     ):
-        """Test that invalid email returns same error as wrong password."""
+        """Test that invalid email sends reset password email when registration is allowed."""
         # Arrange
         mock_is_rate_limit.return_value = False
         mock_get_invitation.return_value = None
         mock_authenticate.side_effect = services.errors.account.AccountNotFoundError("Account not found")
         mock_db.session.query.return_value.first.return_value = MagicMock()  # Mock setup exists
+        mock_features.return_value.is_allow_register = True
+        mock_send_email.return_value = "token123"
 
         # Act
         with self.app.test_request_context(
             "/login", method="POST", json={"email": "nonexistent@example.com", "password": "WrongPass123!"}
         ):
             login_api = LoginApi()
+            result = login_api.post()
 
-            # Assert
-            with pytest.raises(AuthenticationFailedError) as exc_info:
-                login_api.post()
-
-        assert exc_info.value.error_code == "authentication_failed"
-        assert exc_info.value.description == "Invalid email or password."
-        mock_add_rate_limit.assert_called_once_with("nonexistent@example.com")
+        # Assert
+        assert result == {"result": "fail", "data": "token123", "code": "account_not_found"}
+        mock_send_email.assert_called_once_with(email="nonexistent@example.com", language="en-US")
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.AccountService.is_login_error_rate_limit")
@@ -58,10 +59,10 @@ class TestAuthenticationSecurity:
     @patch("controllers.console.auth.login.AccountService.add_login_error_rate_limit")
     @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
     @patch("controllers.console.auth.login.RegisterService.get_invitation_if_token_valid")
-    def test_login_wrong_password_returns_generic_error(
+    def test_login_wrong_password_returns_error(
         self, mock_get_invitation, mock_add_rate_limit, mock_authenticate, mock_is_rate_limit, mock_db
     ):
-        """Test that wrong password returns same error as invalid email."""
+        """Test that wrong password returns EmailOrPasswordMismatchError."""
         # Arrange
         mock_is_rate_limit.return_value = False
         mock_get_invitation.return_value = None
@@ -75,12 +76,41 @@ class TestAuthenticationSecurity:
             login_api = LoginApi()
 
             # Assert
-            with pytest.raises(AuthenticationFailedError) as exc_info:
+            with pytest.raises(EmailOrPasswordMismatchError) as exc_info:
                 login_api.post()
 
-        assert exc_info.value.error_code == "authentication_failed"
-        assert exc_info.value.description == "Invalid email or password."
+        assert exc_info.value.error_code == "email_or_password_mismatch"
+        assert exc_info.value.description == "The email or password is mismatched."
         mock_add_rate_limit.assert_called_once_with("existing@example.com")
+
+    @patch("controllers.console.wraps.db")
+    @patch("controllers.console.auth.login.FeatureService.get_system_features")
+    @patch("controllers.console.auth.login.AccountService.is_login_error_rate_limit")
+    @patch("controllers.console.auth.login.AccountService.authenticate")
+    @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
+    @patch("controllers.console.auth.login.RegisterService.get_invitation_if_token_valid")
+    def test_login_invalid_email_with_registration_disabled(
+        self, mock_get_invitation, mock_authenticate, mock_is_rate_limit, mock_features, mock_db
+    ):
+        """Test that invalid email raises AccountNotFound when registration is disabled."""
+        # Arrange
+        mock_is_rate_limit.return_value = False
+        mock_get_invitation.return_value = None
+        mock_authenticate.side_effect = services.errors.account.AccountNotFoundError("Account not found")
+        mock_db.session.query.return_value.first.return_value = MagicMock()  # Mock setup exists
+        mock_features.return_value.is_allow_register = False
+
+        # Act
+        with self.app.test_request_context(
+            "/login", method="POST", json={"email": "nonexistent@example.com", "password": "WrongPass123!"}
+        ):
+            login_api = LoginApi()
+
+            # Assert
+            with pytest.raises(AccountNotFound) as exc_info:
+                login_api.post()
+
+        assert exc_info.value.error_code == "account_not_found"
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.FeatureService.get_system_features")

--- a/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
@@ -1,0 +1,122 @@
+"""Test authentication security to prevent user enumeration."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from flask import Flask
+from flask_restful import Api
+
+from controllers.console.auth.login import LoginApi
+from controllers.console.auth.error import AuthenticationFailedError
+from services.errors.account import AccountNotFoundError, AccountPasswordError
+
+
+class TestAuthenticationSecurity:
+    """Test authentication endpoints for security against user enumeration."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.app = Flask(__name__)
+        self.api = Api(self.app)
+        self.api.add_resource(LoginApi, '/login')
+        self.client = self.app.test_client()
+        self.app.config['TESTING'] = True
+
+    @patch('controllers.console.auth.login.AccountService.is_login_error_rate_limit')
+    @patch('controllers.console.auth.login.AccountService.authenticate')
+    @patch('controllers.console.auth.login.AccountService.add_login_error_rate_limit')
+    @patch('controllers.console.auth.login.dify_config.BILLING_ENABLED', False)
+    @patch('controllers.console.auth.login.RegisterService.get_invitation_if_token_valid')
+    def test_login_invalid_email_returns_generic_error(
+        self,
+        mock_get_invitation,
+        mock_add_rate_limit,
+        mock_authenticate,
+        mock_is_rate_limit
+    ):
+        """Test that invalid email returns same error as wrong password."""
+        # Arrange
+        mock_is_rate_limit.return_value = False
+        mock_get_invitation.return_value = None
+        mock_authenticate.side_effect = AccountNotFoundError("Account not found")
+        
+        # Act & Assert
+        with pytest.raises(AuthenticationFailedError) as exc_info:
+            with self.app.test_request_context(
+                '/login',
+                method='POST',
+                json={'email': 'nonexistent@example.com', 'password': 'WrongPass123!'}
+            ):
+                login_api = LoginApi()
+                login_api.post()
+        
+        assert exc_info.value.error_code == 'authentication_failed'
+        assert exc_info.value.description == 'Invalid email or password.'
+        mock_add_rate_limit.assert_called_once_with('nonexistent@example.com')
+
+    @patch('controllers.console.auth.login.AccountService.is_login_error_rate_limit')
+    @patch('controllers.console.auth.login.AccountService.authenticate')
+    @patch('controllers.console.auth.login.AccountService.add_login_error_rate_limit')
+    @patch('controllers.console.auth.login.dify_config.BILLING_ENABLED', False)
+    @patch('controllers.console.auth.login.RegisterService.get_invitation_if_token_valid')
+    def test_login_wrong_password_returns_generic_error(
+        self,
+        mock_get_invitation,
+        mock_add_rate_limit,
+        mock_authenticate,
+        mock_is_rate_limit
+    ):
+        """Test that wrong password returns same error as invalid email."""
+        # Arrange
+        mock_is_rate_limit.return_value = False
+        mock_get_invitation.return_value = None
+        mock_authenticate.side_effect = AccountPasswordError("Wrong password")
+        
+        # Act & Assert
+        with pytest.raises(AuthenticationFailedError) as exc_info:
+            with self.app.test_request_context(
+                '/login',
+                method='POST',
+                json={'email': 'existing@example.com', 'password': 'WrongPass123!'}
+            ):
+                login_api = LoginApi()
+                login_api.post()
+        
+        assert exc_info.value.error_code == 'authentication_failed'
+        assert exc_info.value.description == 'Invalid email or password.'
+        mock_add_rate_limit.assert_called_once_with('existing@example.com')
+
+    @patch('controllers.console.auth.login.AccountService.get_user_through_email')
+    @patch('controllers.console.auth.login.AccountService.send_reset_password_email')
+    def test_reset_password_always_returns_success(
+        self,
+        mock_send_email,
+        mock_get_user
+    ):
+        """Test that reset password always returns success regardless of account existence."""
+        # Test with existing account
+        mock_get_user.return_value = MagicMock(email='existing@example.com')
+        mock_send_email.return_value = 'token123'
+        
+        with self.app.test_request_context(
+            '/reset-password',
+            method='POST',
+            json={'email': 'existing@example.com'}
+        ):
+            from controllers.console.auth.login import ResetPasswordSendEmailApi
+            api = ResetPasswordSendEmailApi()
+            result = api.post()
+            
+        assert result == {"result": "success"}
+        
+        # Test with non-existent account
+        mock_get_user.return_value = None
+        
+        with self.app.test_request_context(
+            '/reset-password',
+            method='POST',
+            json={'email': 'nonexistent@example.com'}
+        ):
+            api = ResetPasswordSendEmailApi()
+            result = api.post()
+            
+        assert result == {"result": "success"}

--- a/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
@@ -1,12 +1,13 @@
 """Test authentication security to prevent user enumeration."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from flask import Flask
 from flask_restful import Api
 
-from controllers.console.auth.login import LoginApi
 from controllers.console.auth.error import AuthenticationFailedError
+from controllers.console.auth.login import LoginApi
 from services.errors.account import AccountNotFoundError, AccountPasswordError
 
 
@@ -17,106 +18,83 @@ class TestAuthenticationSecurity:
         """Set up test fixtures."""
         self.app = Flask(__name__)
         self.api = Api(self.app)
-        self.api.add_resource(LoginApi, '/login')
+        self.api.add_resource(LoginApi, "/login")
         self.client = self.app.test_client()
-        self.app.config['TESTING'] = True
+        self.app.config["TESTING"] = True
 
-    @patch('controllers.console.auth.login.AccountService.is_login_error_rate_limit')
-    @patch('controllers.console.auth.login.AccountService.authenticate')
-    @patch('controllers.console.auth.login.AccountService.add_login_error_rate_limit')
-    @patch('controllers.console.auth.login.dify_config.BILLING_ENABLED', False)
-    @patch('controllers.console.auth.login.RegisterService.get_invitation_if_token_valid')
+    @patch("controllers.console.auth.login.AccountService.is_login_error_rate_limit")
+    @patch("controllers.console.auth.login.AccountService.authenticate")
+    @patch("controllers.console.auth.login.AccountService.add_login_error_rate_limit")
+    @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
+    @patch("controllers.console.auth.login.RegisterService.get_invitation_if_token_valid")
     def test_login_invalid_email_returns_generic_error(
-        self,
-        mock_get_invitation,
-        mock_add_rate_limit,
-        mock_authenticate,
-        mock_is_rate_limit
+        self, mock_get_invitation, mock_add_rate_limit, mock_authenticate, mock_is_rate_limit
     ):
         """Test that invalid email returns same error as wrong password."""
         # Arrange
         mock_is_rate_limit.return_value = False
         mock_get_invitation.return_value = None
         mock_authenticate.side_effect = AccountNotFoundError("Account not found")
-        
+
         # Act & Assert
         with pytest.raises(AuthenticationFailedError) as exc_info:
             with self.app.test_request_context(
-                '/login',
-                method='POST',
-                json={'email': 'nonexistent@example.com', 'password': 'WrongPass123!'}
+                "/login", method="POST", json={"email": "nonexistent@example.com", "password": "WrongPass123!"}
             ):
                 login_api = LoginApi()
                 login_api.post()
-        
-        assert exc_info.value.error_code == 'authentication_failed'
-        assert exc_info.value.description == 'Invalid email or password.'
-        mock_add_rate_limit.assert_called_once_with('nonexistent@example.com')
 
-    @patch('controllers.console.auth.login.AccountService.is_login_error_rate_limit')
-    @patch('controllers.console.auth.login.AccountService.authenticate')
-    @patch('controllers.console.auth.login.AccountService.add_login_error_rate_limit')
-    @patch('controllers.console.auth.login.dify_config.BILLING_ENABLED', False)
-    @patch('controllers.console.auth.login.RegisterService.get_invitation_if_token_valid')
+        assert exc_info.value.error_code == "authentication_failed"
+        assert exc_info.value.description == "Invalid email or password."
+        mock_add_rate_limit.assert_called_once_with("nonexistent@example.com")
+
+    @patch("controllers.console.auth.login.AccountService.is_login_error_rate_limit")
+    @patch("controllers.console.auth.login.AccountService.authenticate")
+    @patch("controllers.console.auth.login.AccountService.add_login_error_rate_limit")
+    @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
+    @patch("controllers.console.auth.login.RegisterService.get_invitation_if_token_valid")
     def test_login_wrong_password_returns_generic_error(
-        self,
-        mock_get_invitation,
-        mock_add_rate_limit,
-        mock_authenticate,
-        mock_is_rate_limit
+        self, mock_get_invitation, mock_add_rate_limit, mock_authenticate, mock_is_rate_limit
     ):
         """Test that wrong password returns same error as invalid email."""
         # Arrange
         mock_is_rate_limit.return_value = False
         mock_get_invitation.return_value = None
         mock_authenticate.side_effect = AccountPasswordError("Wrong password")
-        
+
         # Act & Assert
         with pytest.raises(AuthenticationFailedError) as exc_info:
             with self.app.test_request_context(
-                '/login',
-                method='POST',
-                json={'email': 'existing@example.com', 'password': 'WrongPass123!'}
+                "/login", method="POST", json={"email": "existing@example.com", "password": "WrongPass123!"}
             ):
                 login_api = LoginApi()
                 login_api.post()
-        
-        assert exc_info.value.error_code == 'authentication_failed'
-        assert exc_info.value.description == 'Invalid email or password.'
-        mock_add_rate_limit.assert_called_once_with('existing@example.com')
 
-    @patch('controllers.console.auth.login.AccountService.get_user_through_email')
-    @patch('controllers.console.auth.login.AccountService.send_reset_password_email')
-    def test_reset_password_always_returns_success(
-        self,
-        mock_send_email,
-        mock_get_user
-    ):
+        assert exc_info.value.error_code == "authentication_failed"
+        assert exc_info.value.description == "Invalid email or password."
+        mock_add_rate_limit.assert_called_once_with("existing@example.com")
+
+    @patch("controllers.console.auth.login.AccountService.get_user_through_email")
+    @patch("controllers.console.auth.login.AccountService.send_reset_password_email")
+    def test_reset_password_always_returns_success(self, mock_send_email, mock_get_user):
         """Test that reset password always returns success regardless of account existence."""
         # Test with existing account
-        mock_get_user.return_value = MagicMock(email='existing@example.com')
-        mock_send_email.return_value = 'token123'
-        
-        with self.app.test_request_context(
-            '/reset-password',
-            method='POST',
-            json={'email': 'existing@example.com'}
-        ):
+        mock_get_user.return_value = MagicMock(email="existing@example.com")
+        mock_send_email.return_value = "token123"
+
+        with self.app.test_request_context("/reset-password", method="POST", json={"email": "existing@example.com"}):
             from controllers.console.auth.login import ResetPasswordSendEmailApi
+
             api = ResetPasswordSendEmailApi()
             result = api.post()
-            
+
         assert result == {"result": "success"}
-        
+
         # Test with non-existent account
         mock_get_user.return_value = None
-        
-        with self.app.test_request_context(
-            '/reset-password',
-            method='POST',
-            json={'email': 'nonexistent@example.com'}
-        ):
+
+        with self.app.test_request_context("/reset-password", method="POST", json={"email": "nonexistent@example.com"}):
             api = ResetPasswordSendEmailApi()
             result = api.post()
-            
+
         assert result == {"result": "success"}

--- a/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_authentication_security.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
-from flask_restful import Api
+from flask_restx import Api
 
 import services.errors.account
 from controllers.console.auth.error import EmailOrPasswordMismatchError


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR standardizes error messages across authentication endpoints to prevent user enumeration attacks. Currently, different error messages allow attackers to determine whether an email address is registered in the system, which poses a security risk.

Part of #24323

### Changes Made:
1. **Added generic authentication error** - Created `AuthenticationFailedError` to provide consistent error messages
2. **Updated login endpoints** - Both console and web login now return the same error regardless of whether the account exists or password is wrong
3. **Modified password reset flows** - All password reset endpoints now return success to prevent account existence disclosure
4. **Updated email code login** - Modified to always return success response
5. **Added security tests** - Created test suite to verify the security improvements

### Security Impact:
- Prevents attackers from determining valid email addresses through error responses
- Protects user privacy by not revealing account existence
- Reduces risk of targeted phishing and brute force attacks

## Screenshots

| Before | After |
|--------|-------|
| Different errors revealed account existence | Consistent "Invalid email or password" error |
| Password reset returned "account not found" | Always returns success |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods