### PR TITLE
optimize close action on about page

### DIFF
--- a/web/app/components/header/account-about/index.tsx
+++ b/web/app/components/header/account-about/index.tsx
@@ -8,7 +8,7 @@ import Button from '@/app/components/base/button'
 import type { LangGeniusVersionResponse } from '@/models/common'
 import { IS_CE_EDITION } from '@/config'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
-import { noop } from 'lodash-es'
+
 import { useGlobalPublicStore } from '@/context/global-public-context'
 
 type IAccountSettingProps = {
@@ -27,12 +27,12 @@ export default function AccountAbout({
   return (
     <Modal
       isShow
-      onClose={noop}
+      onClose={onCancel}
       className='!w-[480px] !max-w-[480px] !px-6 !py-4'
     >
-      <div>
-        <div className='absolute right-4 top-4 flex h-8 w-8 cursor-pointer items-center justify-center' onClick={onCancel}>
-          <RiCloseLine className='h-4 w-4 text-text-tertiary' />
+      <div className='relative'>
+        <div className='absolute right-0 top-0 flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-divider-subtle transition-colors hover:border-divider-regular hover:bg-state-base-hover' onClick={onCancel}>
+          <RiCloseLine className='h-4 w-4 text-text-secondary hover:text-text-primary' />
         </div>
         <div className='flex flex-col items-center gap-4 py-8'>
           {systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo

--- a/web/app/components/header/account-about/index.tsx
+++ b/web/app/components/header/account-about/index.tsx
@@ -31,8 +31,8 @@ export default function AccountAbout({
       className='!w-[480px] !max-w-[480px] !px-6 !py-4'
     >
       <div className='relative'>
-        <div className='absolute right-0 top-0 flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-divider-subtle transition-colors hover:border-divider-regular hover:bg-state-base-hover' onClick={onCancel}>
-          <RiCloseLine className='h-4 w-4 text-text-secondary hover:text-text-primary' />
+        <div className='absolute right-0 top-0 flex h-8 w-8 cursor-pointer items-center justify-center' onClick={onCancel}>
+          <RiCloseLine className='h-4 w-4 text-text-tertiary' />
         </div>
         <div className='flex flex-col items-center gap-4 py-8'>
           {systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo


### PR DESCRIPTION
optimize about page: close action improvements and close button style

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR improves the **About Page modal** behavior and user experience:
- Close action has been optimized to allow clicking outside of the modal panel to close it.
- Enhanced the style of the close button (improved hover state, alignment, and accessibility).
- Minor refactoring to simplify event handling and reduce redundant code.

Fixes #24334 

## Screenshots

| Before | After |
|--------|-------|
| about panel does not close when clicking outside | panel now closes on outside click |
| Close button style less visible <img width="1433" height="749" alt="rpH7s9WnxQ" src="https://github.com/user-attachments/assets/7b67b4f7-7587-41ed-8873-1d589a3cce9b" /> | Close button has clearer hover/focus styles  <img width="1253" height="726" alt="截屏2025-08-22 17 11 42" src="https://github.com/user-attachments/assets/2eaee668-3975-4852-a91f-8b75d939fe93" />
|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

