### PR TITLE
fix(trigger-webhook): remove redundant WebhookParam type and simplify parameter handling

### DIFF
--- a/web/app/components/workflow/nodes/trigger-webhook/components/parameter-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/parameter-table.tsx
@@ -4,12 +4,25 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import GenericTable from './generic-table'
 import type { ColumnConfig, GenericTableRow } from './generic-table'
-import type { WebhookParam } from '../types'
+import type { ParameterType, WebhookParameter } from '../types'
+
+const normalizeParamType = (type: string): ParameterType => {
+  switch (type) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'array':
+    case 'object':
+      return type
+    default:
+      return 'string'
+  }
+}
 
 type ParameterTableProps = {
   title: string
-  parameters: WebhookParam[]
-  onChange: (params: WebhookParam[]) => void
+  parameters: WebhookParameter[]
+  onChange: (params: WebhookParameter[]) => void
   readonly?: boolean
   placeholder?: string
   showType?: boolean
@@ -70,22 +83,19 @@ const ParameterTable: FC<ParameterTableProps> = ({
     required: false,
   }
 
-  // Convert WebhookParam[] to GenericTableRow[]
   const tableData: GenericTableRow[] = parameters.map(param => ({
-    key: param.key,
+    key: param.name,
     type: param.type,
     required: param.required,
-    value: param.value,
   }))
 
   const handleDataChange = (data: GenericTableRow[]) => {
-    const newParams: WebhookParam[] = data
+    const newParams: WebhookParameter[] = data
       .filter(row => typeof row.key === 'string' && (row.key as string).trim() !== '')
       .map(row => ({
-        key: String(row.key),
-        type: (row.type as string) || 'string',
+        name: String(row.key),
+        type: normalizeParamType((row.type as string) || 'string'),
         required: Boolean(row.required),
-        value: (row.value as string) || '',
       }))
     onChange(newParams)
   }

--- a/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { HttpMethod, WebhookParam, WebhookParameter, WebhookTriggerNodeType } from './types'
+import type { HttpMethod, WebhookTriggerNodeType } from './types'
 import useConfig from './use-config'
 import ParameterTable from './components/parameter-table'
 import HeaderTable from './components/header-table'
@@ -114,8 +114,8 @@ const Panel: FC<NodePanelProps<WebhookTriggerNodeType>> = ({
         <ParameterTable
           readonly={readOnly}
           title="Query Parameters"
-          parameters={inputs.params as unknown as WebhookParam[]}
-          onChange={params => handleParamsChange(params as unknown as WebhookParameter[])}
+          parameters={inputs.params}
+          onChange={handleParamsChange}
           placeholder={t(`${i18nPrefix}.noQueryParameters`)}
           showType={false}
         />
@@ -135,8 +135,8 @@ const Panel: FC<NodePanelProps<WebhookTriggerNodeType>> = ({
         <ParameterTable
           readonly={readOnly}
           title="Request Body Parameters"
-          parameters={inputs.body as unknown as WebhookParam[]}
-          onChange={params => handleBodyChange(params as unknown as WebhookParameter[])}
+          parameters={inputs.body}
+          onChange={handleBodyChange}
           placeholder={t(`${i18nPrefix}.noBodyParameters`)}
           showType={true}
           isRequestBody={true}

--- a/web/app/components/workflow/nodes/trigger-webhook/types.ts
+++ b/web/app/components/workflow/nodes/trigger-webhook/types.ts
@@ -12,13 +12,6 @@ export type WebhookParameter = {
   required: boolean
 }
 
-export type WebhookParam = {
-  key: string
-  type: string
-  value: string
-  required: boolean
-}
-
 export type WebhookHeader = {
   name: string
   required: boolean


### PR DESCRIPTION
…plify parameter handling

Remove duplicate WebhookParam type and use WebhookParameter consistently. Simplify parameter table logic by removing unnecessary type conversions and adding type normalization.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes https://github.com/langgenius/dify/issues/23981 https://github.com/langgenius/dify/issues/24020

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
