### PR TITLE
feat: auto-login after admin account setup

### DIFF
--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -74,11 +74,11 @@ const InstallForm = () => {
     if (loginRes.result === 'success') {
       localStorage.setItem('console_token', loginRes.data.access_token)
       localStorage.setItem('refresh_token', loginRes.data.refresh_token)
-      router.push('/apps')
+      router.replace('/apps')
     }
  else {
       // Fallback to signin page if auto-login fails
-      router.push('/signin')
+      router.replace('/signin')
     }
   }
 

--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -14,7 +14,7 @@ import Loading from '../components/base/loading'
 import classNames from '@/utils/classnames'
 import Button from '@/app/components/base/button'
 
-import { fetchInitValidateStatus, fetchSetupStatus, setup } from '@/service/common'
+import { fetchInitValidateStatus, fetchSetupStatus, login, setup } from '@/service/common'
 import type { InitValidateStatusResponse, SetupStatusResponse } from '@/models/common'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { useDocLink } from '@/context/i18n'
@@ -54,12 +54,32 @@ const InstallForm = () => {
   })
 
   const onSubmit: SubmitHandler<AccountFormValues> = async (data) => {
+    // First, setup the admin account
     await setup({
       body: {
         ...data,
       },
     })
-    router.push('/signin')
+
+    // Then, automatically login with the same credentials
+    const loginRes = await login({
+      url: '/login',
+      body: {
+        email: data.email,
+        password: data.password,
+      },
+    })
+
+    // Store tokens and redirect to apps if login successful
+    if (loginRes.result === 'success') {
+      localStorage.setItem('console_token', loginRes.data.access_token)
+      localStorage.setItem('refresh_token', loginRes.data.refresh_token)
+      router.push('/apps')
+    }
+ else {
+      // Fallback to signin page if auto-login fails
+      router.push('/signin')
+    }
   }
 
   const handleSetting = async () => {


### PR DESCRIPTION
## Summary
- Implemented automatic login after admin account creation during initial setup
- Users are now directly redirected to the apps page after setup completion
- Eliminates the need to manually login with the same credentials just created

## Related Issue
Fixes #24394

https://github.com/user-attachments/assets/a45322b9-51e6-4692-87a6-610f78e73bdf

## Implementation Details
The solution is implemented entirely in the frontend by:
1. After successful admin account setup, automatically calling the login API with the same credentials
2. Storing the returned access_token and refresh_token in localStorage
3. Redirecting to /apps instead of /signin
4. Includes fallback behavior to redirect to signin if auto-login fails