### PR TITLE
fix(vector): use semantic version comparison for version check

### DIFF
--- a/api/core/rag/datasource/vdb/milvus/milvus_vector.py
+++ b/api/core/rag/datasource/vdb/milvus/milvus_vector.py
@@ -101,7 +101,7 @@ class MilvusVector(BaseVector):
             if "Zilliz Cloud" in milvus_version:
                 return True
             # For standard Milvus installations, check version number
-            return version.parse(milvus_version).base_version >= version.parse("2.5.0").base_version
+            return version.parse(milvus_version) >= version.parse("2.5.0")
         except Exception as e:
             logger.warning("Failed to check Milvus version: %s. Disabling hybrid search.", str(e))
             return False

--- a/api/core/rag/datasource/vdb/oceanbase/oceanbase_vector.py
+++ b/api/core/rag/datasource/vdb/oceanbase/oceanbase_vector.py
@@ -152,7 +152,7 @@ class OceanBaseVector(BaseVector):
             ob_full_version = result.fetchone()[0]
             ob_version = ob_full_version.split()[1]
             logger.debug("Current OceanBase version is %s", ob_version)
-            return version.parse(ob_version).base_version >= version.parse("4.3.5.1").base_version
+            return version.parse(ob_version) >= version.parse("4.3.5.1")
         except Exception as e:
             logger.warning("Failed to check OceanBase version: %s. Disabling hybrid search.", str(e))
             return False


### PR DESCRIPTION

## Summary
Fixes a critical bug in Milvus vector database version comparison that could incorrectly evaluate version requirements for hybrid search functionality.  
  
## Problem  
The current implementation in `MilvusVector._check_hybrid_search_support()` and `OceanBaseVector._check_hybrid_search_support()` uses string comparison of `base_version` attributes:  
 

String comparison fails for multi-digit version numbers. This could disable hybrid search on newer Milvus versions that actually support it.

## Solution
Replace string comparison with proper semantic version comparison using Version objects:

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
