### PR TITLE
GPT-5-high fix #24310 bug.

### DIFF
--- a/api/libs/external_api.py
+++ b/api/libs/external_api.py
@@ -78,9 +78,11 @@ class ExternalApi(Api):
         data = getattr(e, "data", default_data)
 
         error_cls_name = type(e).__name__
-        if error_cls_name in self.errors:
-            custom_data = self.errors.get(error_cls_name, {})
-            custom_data = custom_data.copy()
+        # Flask-RESTX Api does not define `errors` like Flask-RESTful.
+        # Safely access a potential mapping if present (for backward compatibility).
+        errors_mapping = getattr(self, "errors", None)
+        if isinstance(errors_mapping, dict) and error_cls_name in errors_mapping:
+            custom_data = errors_mapping.get(error_cls_name, {}).copy()
             status_code = custom_data.get("status", 500)
 
             if "message" in custom_data:

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -57,7 +57,7 @@ def run(script):
 
 
 class AppIconUrlField(fields.Raw):
-    def output(self, key, obj):
+    def output(self, key, obj, ordered: bool = False):
         if obj is None:
             return None
 
@@ -72,7 +72,7 @@ class AppIconUrlField(fields.Raw):
 
 
 class AvatarUrlField(fields.Raw):
-    def output(self, key, obj):
+    def output(self, key, obj, ordered: bool = False):
         if obj is None:
             return None
 

--- a/api/tests/test_containers_integration_tests/services/test_annotation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_annotation_service.py
@@ -410,7 +410,7 @@ class TestAnnotationService:
         app, account = self._create_test_app_and_account(db_session_with_containers, mock_external_service_dependencies)
 
         # Create annotations with specific keywords
-        unique_keyword = fake.word()
+        unique_keyword = f"kw_{fake.uuid4()}"
         annotation_args = {
             "question": f"Question with {unique_keyword} keyword",
             "answer": f"Answer with {unique_keyword} keyword",


### PR DESCRIPTION
## Summary

Another pure GPT-5-high and cursor auto fix.

ExternalApi.handle_error no longer accesses self.errors directly (Flask-RESTX lacks that attribute). It now checks for an errors dict via getattr before using it.

it’s related to “try flask_restful -> flask_restx (#24310)”. Flask-RESTful Api exposes errors; Flask-RESTX does not. Your error handler assumed it existed and raised AttributeError.

Also fixed Flask-RESTX marshalling crashes by updating custom fields:

* AppIconUrlField.output(self, key, obj, ordered: bool = False)
* AvatarUrlField.output(self, key, obj, ordered: bool = False)