### PR TITLE
Fix auth error handling

### DIFF
--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import request
 from flask_restx import Resource, marshal_with, reqparse
 from werkzeug.exceptions import Unauthorized
@@ -87,8 +89,11 @@ class AppWebAuthPermission(Resource):
 
             decoded = PassportService().verify(tk)
             user_id = decoded.get("user_id", "visitor")
-        except Exception as e:
-            pass
+        except Unauthorized:
+            raise
+        except Exception:
+            logging.exception("Unexpected error during auth verification")
+            raise
 
         features = FeatureService.get_system_features()
         if not features.webapp_auth.enabled:


### PR DESCRIPTION
Fixes #24337 

`Unauthorized` is a subclass of `HTTPException -> Exception`, so the old code silently swallowed it, causing 401 responses to never reach the client.

Now,
- Replace `except Exception: pass` with explicit handling:
- `except Unauthorized: raise` → let 401 bubble up correctly
- `except Exception:` → log and re-raise unexpected errors

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
