### PR TITLE
fix: Fix login error handling by raising exception instead of returning

### DIFF
--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -221,7 +221,7 @@ class EmailCodeLoginApi(Resource):
                     email=user_email, name=user_email, interface_language=languages[0]
                 )
             except WorkSpaceNotAllowedCreateError:
-                return NotAllowedCreateWorkspace()
+                raise NotAllowedCreateWorkspace()
             except AccountRegisterError as are:
                 raise AccountInFreezeError()
             except WorkspacesLimitExceededError:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes the login error handling issue where `NotAllowedCreateWorkspace` was being returned instead of raised in the `EmailCodeLoginApi` endpoint. Additionally, it updates all Flask-RESTX error handlers to follow the documented pattern of returning tuples instead of using `api.make_response()`.

### Changes:
- Changed `return NotAllowedCreateWorkspace()` to `raise NotAllowedCreateWorkspace()` in `api/controllers/console/auth/login.py`
- Updated all error handlers in `api/libs/external_api.py` to return tuples `(data, status_code)` or `(data, status_code, headers)` as per [Flask-RESTX documentation](https://flask-restx.readthedocs.io/en/latest/errors.html)
- Removed unnecessary `api.make_response()` calls and `werkzeug.datastructures.Headers` import

Fixes #24449
close https://github.com/langgenius/dify/pull/24446

## Screenshots

Not applicable - backend error handling fix

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods