### PR TITLE
fix: flask_restx  namespace path wrong

### DIFF
--- a/api/controllers/files/__init__.py
+++ b/api/controllers/files/__init__.py
@@ -13,7 +13,7 @@ api = ExternalApi(
     doc="/docs",  # Enable Swagger UI at /files/docs
 )
 
-files_ns = Namespace("files", description="File operations")
+files_ns = Namespace("files", description="File operations", path="/")
 
 from . import image_preview, tool_files, upload
 

--- a/api/controllers/mcp/__init__.py
+++ b/api/controllers/mcp/__init__.py
@@ -13,7 +13,7 @@ api = ExternalApi(
     doc="/docs",  # Enable Swagger UI at /mcp/docs
 )
 
-mcp_ns = Namespace("mcp", description="MCP operations")
+mcp_ns = Namespace("mcp", description="MCP operations", path="/")
 
 from . import mcp
 

--- a/api/controllers/service_api/__init__.py
+++ b/api/controllers/service_api/__init__.py
@@ -13,7 +13,7 @@ api = ExternalApi(
     doc="/docs",  # Enable Swagger UI at /v1/docs
 )
 
-service_api_ns = Namespace("service_api", description="Service operations")
+service_api_ns = Namespace("service_api", description="Service operations", path="/")
 
 from . import index
 from .app import annotation, app, audio, completion, conversation, file, file_preview, message, site, workflow


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fixes #24455

ref #24423  #24424 #24425

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

<img width="1042" height="839" alt="image" src="https://github.com/user-attachments/assets/5e7778c2-397b-431b-8379-0198c6398d72" />


| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
