### PR TITLE
refactor: Update shareCode in useEffect to avoid setState during render

### DIFF
--- a/web/context/web-app-context.tsx
+++ b/web/context/web-app-context.tsx
@@ -64,7 +64,9 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
 
   // Compute shareCode directly
   const shareCode = getShareCodeFromRedirectUrl(redirectUrlParam) || getShareCodeFromPathname(pathname)
-  updateShareCode(shareCode)
+  useEffect(() => {
+    updateShareCode(shareCode)
+  }, [shareCode, updateShareCode])
 
   const { isFetching, data: accessModeResult } = useGetWebAppAccessModeByCode(shareCode)
   const [isFetchingAccessToken, setIsFetchingAccessToken] = useState(false)


### PR DESCRIPTION
## Summary

Fix next.js warning:

Cannot update a component (`Splash`) while rendering a different component (`WebAppStoreProvider`). To locate the bad setState() call inside `WebAppStoreProvider`, follow the stack trace as described in https://react.dev/link/setstate-in-render

```web/context/web-app-context.tsx:32
updateShareCode: (shareCode: string | null) => set(() => ({ shareCode })),
```


## Checklist

- [x] This change *not* requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I not add test for this PR, but I tried as much as possible to make a single atomic change.
- [x] I've *not* updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
