### PR TITLE
chore: hide delete action when avatar is none

### DIFF
--- a/web/app/account/account-page/AvatarWithEdit.tsx
+++ b/web/app/account/account-page/AvatarWithEdit.tsx
@@ -30,6 +30,8 @@ const AvatarWithEdit = ({ onSave, ...props }: AvatarWithEditProps) => {
   const [isShowDeleteConfirm, setIsShowDeleteConfirm] = useState(false)
   const [hoverArea, setHoverArea] = useState<string>('left')
 
+  const [onAvatarError, setOnAvatarError] = useState(false)
+
   const handleImageInput: OnImageInput = useCallback(async (isCropped: boolean, fileOrTempUrl: string | File, croppedAreaPixels?: Area, fileName?: string) => {
     setInputImageInfo(
       isCropped
@@ -98,10 +100,15 @@ const AvatarWithEdit = ({ onSave, ...props }: AvatarWithEditProps) => {
     <>
       <div>
         <div className="group relative">
-          <Avatar {...props} />
+          <Avatar {...props} onError={(x: boolean) => setOnAvatarError(x)} />
           <div
             className="absolute inset-0 flex cursor-pointer items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
-            onClick={() => hoverArea === 'right' ? setIsShowDeleteConfirm(true) : setIsShowAvatarPicker(true)}
+            onClick={() => {
+              if (hoverArea === 'right' && !onAvatarError)
+                setIsShowDeleteConfirm(true)
+               else
+                setIsShowAvatarPicker(true)
+            }}
             onMouseMove={(e) => {
               const rect = e.currentTarget.getBoundingClientRect()
               const x = e.clientX - rect.left
@@ -109,12 +116,15 @@ const AvatarWithEdit = ({ onSave, ...props }: AvatarWithEditProps) => {
               setHoverArea(isRight ? 'right' : 'left')
             }}
           >
-            {hoverArea === 'right' ? <span className="text-xs text-white">
-              <RiDeleteBin5Line />
-            </span> : <span className="text-xs text-white">
-              <RiPencilLine />
-            </span>}
-
+            {hoverArea === 'right' && !onAvatarError ? (
+              <span className="text-xs text-white">
+                <RiDeleteBin5Line />
+              </span>
+            ) : (
+              <span className="text-xs text-white">
+                <RiPencilLine />
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/web/app/components/base/avatar/index.tsx
+++ b/web/app/components/base/avatar/index.tsx
@@ -8,6 +8,7 @@ export type AvatarProps = {
   size?: number
   className?: string
   textClassName?: string
+  onError?: (x: boolean) => void
 }
 const Avatar = ({
   name,
@@ -15,6 +16,7 @@ const Avatar = ({
   size = 30,
   className,
   textClassName,
+  onError,
 }: AvatarProps) => {
   const avatarClassName = 'shrink-0 flex items-center rounded-full bg-primary-600'
   const style = { width: `${size}px`, height: `${size}px`, fontSize: `${size}px`, lineHeight: `${size}px` }
@@ -22,6 +24,7 @@ const Avatar = ({
 
   const handleError = () => {
     setImgError(true)
+    onError?.(true)
   }
 
   if (avatar && !imgError) {
@@ -32,6 +35,7 @@ const Avatar = ({
         alt={name}
         src={avatar}
         onError={handleError}
+        onLoad={() => onError?.(false)}
       />
     )
   }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request improves the user experience when editing or deleting an avatar by handling avatar image loading errors more gracefully. The changes ensure that the delete option is only available when the avatar image loads successfully, and introduce error state management between the `Avatar` and `AvatarWithEdit` components.

**Avatar error handling improvements:**

* Added an `onError` callback prop to the `Avatar` component, allowing parent components to be notified when the avatar image fails to load or loads successfully. (`web/app/components/base/avatar/index.tsx`) [[1]](diffhunk://#diff-ca55b878c67493af3bb13674e21832da3d7d402840a6c40459a1bc640efe5909R11-R27) [[2]](diffhunk://#diff-ca55b878c67493af3bb13674e21832da3d7d402840a6c40459a1bc640efe5909R38)
* Updated the `AvatarWithEdit` component to track avatar image error state and disable the delete option if the image failed to load. (`web/app/account/account-page/AvatarWithEdit.tsx`) [[1]](diffhunk://#diff-2b0786d736de3c95d4ac20ff58d1d217be0eac25b7f26cccd09c432395498a20R33-R34) [[2]](diffhunk://#diff-2b0786d736de3c95d4ac20ff58d1d217be0eac25b7f26cccd09c432395498a20L101-R127)

**UI logic improvements:**

* Modified the click logic and icon rendering in `AvatarWithEdit` so that the delete option is only shown and enabled when the avatar image loads without error. (`web/app/account/account-page/AvatarWithEdit.tsx`)

## Screenshots

| Before | After |
|--------|-------|
| <img width="604" height="350" alt="image" src="https://github.com/user-attachments/assets/e67a5133-2696-4919-b7ab-6dda893498a4" /> | <img width="562" height="346" alt="image" src="https://github.com/user-attachments/assets/4b507984-3df4-46d1-b6b4-b9a3f0febb6f" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
