### PR TITLE
feat: close tooltip on scroll in model selector Popup component

### DIFF
--- a/web/app/components/base/tooltip/TooltipManager.ts
+++ b/web/app/components/base/tooltip/TooltipManager.ts
@@ -11,6 +11,13 @@ class TooltipManager {
     if (this.activeCloser === closeFn)
       this.activeCloser = null
   }
+
+  closeAll() {
+    if (this.activeCloser) {
+      this.activeCloser()
+      this.activeCloser = null
+    }
+  }
 }
 
 export const tooltipManager = new TooltipManager()

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   RiArrowRightUpLine,
@@ -16,6 +16,7 @@ import PopupItem from './popup-item'
 import { XCircle } from '@/app/components/base/icons/src/vender/solid/general'
 import { useModalContext } from '@/context/modal-context'
 import { supportFunctionCall } from '@/utils/tool-call'
+import { tooltipManager } from '@/app/components/base/tooltip/TooltipManager'
 
 type PopupProps = {
   defaultModel?: DefaultModel
@@ -35,6 +36,20 @@ const Popup: FC<PopupProps> = ({
   const language = useLanguage()
   const [searchText, setSearchText] = useState('')
   const { setShowAccountSettingModal } = useModalContext()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Close all tooltips when scrolling
+  useEffect(() => {
+    const handleScroll = () => {
+      tooltipManager.closeAll()
+    }
+
+    const scrollContainer = scrollRef.current
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', handleScroll)
+      return () => scrollContainer.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
 
   const filteredModelList = useMemo(() => {
     return modelList.map((model) => {
@@ -60,7 +75,10 @@ const Popup: FC<PopupProps> = ({
   }, [language, modelList, scopeFeatures, searchText])
 
   return (
-    <div className='max-h-[480px] w-[320px] overflow-y-auto rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg'>
+    <div
+      ref={scrollRef}
+      className='max-h-[480px] w-[320px] overflow-y-auto rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg'
+    >
       <div className='sticky top-0 z-10 bg-components-panel-bg pb-1 pl-3 pr-2 pt-3'>
         <div className={`
           flex h-8 items-center rounded-lg border pl-[9px] pr-[10px]


### PR DESCRIPTION
Fixes https://github.com/langgenius/dify/issues/24490

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
close the tooltip when list scroll

## Screenshots

| Before | After |
|--------|-------|
|  ![CleanShot 2025-08-26 at 14 50 46](https://github.com/user-attachments/assets/aef2430b-e4c8-4322-9fac-c2863ce1b56e) | ![CleanShot 2025-08-26 at 14 52 55](https://github.com/user-attachments/assets/ff99223a-f28b-4c15-9992-b56ff6e23e7f) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
