### PR TITLE
fix(api):safe reset in db pool, avoid rollback in gevent callback

### DIFF
--- a/api/configs/middleware/__init__.py
+++ b/api/configs/middleware/__init__.py
@@ -215,6 +215,7 @@ class DatabaseConfig(BaseSettings):
             "pool_pre_ping": self.SQLALCHEMY_POOL_PRE_PING,
             "connect_args": connect_args,
             "pool_use_lifo": self.SQLALCHEMY_POOL_USE_LIFO,
+            "pool_reset_on_return": None,
         }
 
 

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -24,6 +24,7 @@ def _safe_rollback(connection) -> None:
     except Exception:  # pylint: disable=broad-exception-caught
         logger.exception("Failed to rollback connection")
 
+
 def _setup_gevent_compatibility() -> None:
     global _GEVENT_COMPATIBILITY_SETUP  # pylint: disable=global-statement
 
@@ -47,6 +48,7 @@ def _setup_gevent_compatibility() -> None:
             _safe_rollback(dbapi_connection)
 
     _GEVENT_COMPATIBILITY_SETUP = True
+
 
 def init_app(app: DifyApp):
     db.init_app(app)

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -1,6 +1,53 @@
+import logging
+
+import gevent
+from sqlalchemy import event
+from sqlalchemy.pool import Pool
+
 from dify_app import DifyApp
 from models import db
 
+logger = logging.getLogger(__name__)
+
+# Global flag to avoid duplicate registration of event listener
+_GEVENT_COMPATIBILITY_SETUP: bool = False
+
+
+def _safe_rollback(connection) -> None:
+    """Safely rollback database connection.
+
+    Args:
+        connection: Database connection object
+    """
+    try:
+        connection.rollback()
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Failed to rollback connection")
+
+def _setup_gevent_compatibility() -> None:
+    global _GEVENT_COMPATIBILITY_SETUP  # pylint: disable=global-statement
+
+    # Avoid duplicate registration
+    if _GEVENT_COMPATIBILITY_SETUP:
+        return
+
+    @event.listens_for(Pool, "reset")
+    def _safe_reset(dbapi_connection, connection_record, reset_state) -> None:  # pylint: disable=unused-argument
+        if reset_state.terminate_only:
+            return
+
+        # Safe rollback for connection
+        try:
+            hub = gevent.get_hub()
+            if hasattr(hub, "loop") and getattr(hub.loop, "in_callback", False):
+                gevent.spawn_later(0, lambda: _safe_rollback(dbapi_connection))
+            else:
+                _safe_rollback(dbapi_connection)
+        except (AttributeError, ImportError):
+            _safe_rollback(dbapi_connection)
+
+    _GEVENT_COMPATIBILITY_SETUP = True
 
 def init_app(app: DifyApp):
     db.init_app(app)
+    _setup_gevent_compatibility()

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -90,6 +90,7 @@ def test_flask_configs(monkeypatch):
         "pool_recycle": 3600,
         "pool_size": 30,
         "pool_use_lifo": False,
+        "pool_reset_on_return": None,
     }
 
     assert config["CONSOLE_WEB_URL"] == "https://example.com"


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Related to close #24143 
Fix BlockingSwitchOutError, the fix involves delaying the rollback and only performing the database connection rollback when the hub context is not detected.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
