### PR TITLE
fix(web): correct title color in option card in dark mode

### DIFF
--- a/web/app/components/datasets/documents/create-from-pipeline/data-source-options/option-card.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source-options/option-card.tsx
@@ -33,7 +33,7 @@ const OptionCard = ({
         <DatasourceIcon iconUrl={iconUrl} />
       </div>
       <div
-        className={cn('system-sm-medium line-clamp-2 grow text-text-secondary', selected && 'text-primary')}
+        className={cn('system-sm-medium line-clamp-2 grow text-text-secondary', selected && 'text-text-primary')}
         title={label}
       >
         {label}

--- a/web/app/components/rag-pipeline/components/panel/test-run/preparation/data-source-options/option-card.tsx
+++ b/web/app/components/rag-pipeline/components/panel/test-run/preparation/data-source-options/option-card.tsx
@@ -43,7 +43,7 @@ const OptionCard = ({
         />
       </div>
       <div
-        className={cn('system-sm-medium line-clamp-2 grow text-text-secondary', selected && 'text-primary')}
+        className={cn('system-sm-medium line-clamp-2 grow text-text-secondary', selected && 'text-text-primary')}
         title={label}
       >
         {label}


### PR DESCRIPTION
## Summary

This is for ✨ **feat/rag-2** branch.

On the pipeline test run screen and the document addition screen, the title of the card where we select a data source was almost unreadable in dark mode.

This PR fixes an incorrect class name so that the card titles are readable in dark mode.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1550" height="580" alt="Image" src="https://github.com/user-attachments/assets/4f2be46d-3beb-4f7d-82b1-fe5528caff81" /><img width="934" height="357" alt="Image" src="https://github.com/user-attachments/assets/587ee113-f29f-4ee9-b895-95b32a931d57" />| <img width="744" height="370" alt="image" src="https://github.com/user-attachments/assets/4de3fb18-9568-4ab8-9803-59522523dcc8" /> <img width="574" height="261" alt="image" src="https://github.com/user-attachments/assets/7a5900f6-c6c9-41f7-9299-85ed14a83f2c" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
