### PR TITLE
Fix tooltip visibility issues during scroll in model selector popup

### DIFF
--- a/web/app/components/base/tooltip/TooltipManager.ts
+++ b/web/app/components/base/tooltip/TooltipManager.ts
@@ -11,6 +11,17 @@ class TooltipManager {
     if (this.activeCloser === closeFn)
       this.activeCloser = null
   }
+
+  /**
+   * Closes the currently active tooltip by calling its closer function
+   * and clearing the reference to it
+   */
+  closeActiveTooltip() {
+    if (this.activeCloser) {
+      this.activeCloser()
+      this.activeCloser = null
+    }
+  }
 }
 
 export const tooltipManager = new TooltipManager()

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   RiArrowRightUpLine,
@@ -16,6 +16,7 @@ import PopupItem from './popup-item'
 import { XCircle } from '@/app/components/base/icons/src/vender/solid/general'
 import { useModalContext } from '@/context/modal-context'
 import { supportFunctionCall } from '@/utils/tool-call'
+import { tooltipManager } from '@/app/components/base/tooltip/TooltipManager'
 
 type PopupProps = {
   defaultModel?: DefaultModel
@@ -35,6 +36,25 @@ const Popup: FC<PopupProps> = ({
   const language = useLanguage()
   const [searchText, setSearchText] = useState('')
   const { setShowAccountSettingModal } = useModalContext()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Close any open tooltips when the user scrolls to prevent them from appearing
+  // in incorrect positions or becoming detached from their trigger elements
+  useEffect(() => {
+    const handleTooltipCloseOnScroll = () => {
+      tooltipManager.closeActiveTooltip()
+    }
+
+    const scrollContainer = scrollRef.current
+    if (!scrollContainer) return
+
+    // Use passive listener for better performance since we don't prevent default
+    scrollContainer.addEventListener('scroll', handleTooltipCloseOnScroll, { passive: true })
+
+    return () => {
+      scrollContainer.removeEventListener('scroll', handleTooltipCloseOnScroll)
+    }
+  }, [])
 
   const filteredModelList = useMemo(() => {
     return modelList.map((model) => {
@@ -60,7 +80,7 @@ const Popup: FC<PopupProps> = ({
   }, [language, modelList, scopeFeatures, searchText])
 
   return (
-    <div className='max-h-[480px] w-[320px] overflow-y-auto rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg'>
+    <div ref={scrollRef} className='max-h-[480px] w-[320px] overflow-y-auto rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg'>
       <div className='sticky top-0 z-10 bg-components-panel-bg pb-1 pl-3 pr-2 pt-3'>
         <div className={`
           flex h-8 items-center rounded-lg border pl-[9px] pr-[10px]


### PR DESCRIPTION

Fixes #24490 - Tooltip remains visible when anchor origin is not

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### The Problem
The tooltip system in your codebase only manages tooltip visibility through hover and click events. When a user scrolls, the tooltip doesn't automatically detect that its anchor element has moved out of view, so it stays visible even when it should be hidden.

### The Result
Now when users scroll in the model selector popup, any open tooltips automatically close, preventing them from appearing in wrong positions or becoming detached from their trigger elements. This creates a much better user experience without the complexity of tracking individual tooltip visibility states.

## Screenshots

| Before | After |
|--------|-------|
|![before](https://github.com/user-attachments/assets/80065785-3c4b-4dfa-8058-dadb538a7c17) | ![Adobe Express - after](https://github.com/user-attachments/assets/cf3a27d6-bff8-4716-93a5-3520774257b3) |




## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
