### PR TITLE
feat: datasets hit-testing retrieve chunking detail answer when docum…

### DIFF
--- a/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
+++ b/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
@@ -27,10 +27,11 @@ const ChunkDetailModal: FC<Props> = ({
 }) => {
   const { t } = useTranslation()
   const { segment, score, child_chunks } = payload
-  const { position, content, sign_content, keywords, document } = segment
+  const { position, content, sign_content, keywords, document, answer } = segment
   const isParentChildRetrieval = !!(child_chunks && child_chunks.length > 0)
   const extension = document.name.split('.').slice(-1)[0] as FileAppearanceTypeEnum
   const heighClassName = isParentChildRetrieval ? 'h-[min(627px,_80vh)] overflow-y-auto' : 'h-[min(539px,_80vh)] overflow-y-auto'
+  const labelPrefix = isParentChildRetrieval ? t('datasetDocuments.segment.parentChunk') : t('datasetDocuments.segment.chunk')
   return (
     <Modal
       title={t(`${i18nPrefix}.chunkDetail`)}
@@ -45,7 +46,7 @@ const ChunkDetailModal: FC<Props> = ({
           <div className='flex items-center justify-between'>
             <div className='flex grow items-center space-x-2'>
               <SegmentIndexTag
-                labelPrefix={`${isParentChildRetrieval ? 'Parent-' : ''}Chunk`}
+                labelPrefix={labelPrefix}
                 positionId={position}
                 className={cn('w-fit group-hover:opacity-100')}
               />
@@ -57,17 +58,40 @@ const ChunkDetailModal: FC<Props> = ({
             </div>
             <Score value={score} />
           </div>
-          <Markdown
-            className={cn('!mt-2 !text-text-secondary', heighClassName)}
-            content={sign_content || content}
-            customDisallowedElements={['input']}
-          />
+          {!answer && (
+            <Markdown
+              className={cn('!mt-2 !text-text-secondary', heighClassName)}
+              content={sign_content || content}
+              customDisallowedElements={['input']}
+            />
+          )}
+          {answer && (
+            <div>
+              <div className='flex gap-x-1'>
+                <div className='w-4 shrink-0 text-[13px] font-medium leading-[20px] text-text-tertiary'>Q</div>
+                <div
+                  className={cn('body-md-regular text-text-secondary',
+                    'line-clamp-20',
+                  )}>
+                  {content}
+                </div>
+              </div>
+              <div className='flex gap-x-1'>
+                <div className='w-4 shrink-0 text-[13px] font-medium leading-[20px] text-text-tertiary'>A</div>
+                <div className={cn('body-md-regular text-text-secondary',
+                  'line-clamp-20',
+                )}>
+                  {answer}
+                </div>
+              </div>
+            </div>
+          )}
           {!isParentChildRetrieval && keywords && keywords.length > 0 && (
             <div className='mt-6'>
               <div className='text-xs font-medium uppercase text-text-tertiary'>{t(`${i18nPrefix}.keyword`)}</div>
               <div className='mt-1 flex flex-wrap'>
                 {keywords.map(keyword => (
-                  <Tag key={keyword} text={keyword} className='mr-2' />
+                  <Tag key={keyword} text={keyword} className='mr-2'/>
                 ))}
               </div>
             </div>
@@ -76,7 +100,8 @@ const ChunkDetailModal: FC<Props> = ({
 
         {isParentChildRetrieval && (
           <div className='flex-1 pb-6 pl-6'>
-            <div className='system-xs-semibold-uppercase text-text-secondary'>{t(`${i18nPrefix}.hitChunks`, { num: child_chunks.length })}</div>
+            <div
+              className='system-xs-semibold-uppercase text-text-secondary'>{t(`${i18nPrefix}.hitChunks`, {num: child_chunks.length})}</div>
             <div className={cn('mt-1 space-y-2', heighClassName)}>
               {child_chunks.map(item => (
                 <ChildChunksItem key={item.id} payload={item} isShowAll />

--- a/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
+++ b/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
@@ -69,18 +69,13 @@ const ChunkDetailModal: FC<Props> = ({
             <div>
               <div className='flex gap-x-1'>
                 <div className='w-4 shrink-0 text-[13px] font-medium leading-[20px] text-text-tertiary'>Q</div>
-                <div
-                  className={cn('body-md-regular text-text-secondary',
-                    'line-clamp-20',
-                  )}>
+                <div className={cn('body-md-regular text-text-secondary line-clamp-20')}>
                   {content}
                 </div>
               </div>
               <div className='flex gap-x-1'>
                 <div className='w-4 shrink-0 text-[13px] font-medium leading-[20px] text-text-tertiary'>A</div>
-                <div className={cn('body-md-regular text-text-secondary',
-                  'line-clamp-20',
-                )}>
+                <div className={cn('body-md-regular text-text-secondary line-clamp-20')}>
                   {answer}
                 </div>
               </div>
@@ -91,7 +86,7 @@ const ChunkDetailModal: FC<Props> = ({
               <div className='text-xs font-medium uppercase text-text-tertiary'>{t(`${i18nPrefix}.keyword`)}</div>
               <div className='mt-1 flex flex-wrap'>
                 {keywords.map(keyword => (
-                  <Tag key={keyword} text={keyword} className='mr-2'/>
+                  <Tag key={keyword} text={keyword} className='mr-2' />
                 ))}
               </div>
             </div>
@@ -100,8 +95,7 @@ const ChunkDetailModal: FC<Props> = ({
 
         {isParentChildRetrieval && (
           <div className='flex-1 pb-6 pl-6'>
-            <div
-              className='system-xs-semibold-uppercase text-text-secondary'>{t(`${i18nPrefix}.hitChunks`, {num: child_chunks.length})}</div>
+            <div className='system-xs-semibold-uppercase text-text-secondary'>{t(`${i18nPrefix}.hitChunks`, { num: child_chunks.length })}</div>
             <div className={cn('mt-1 space-y-2', heighClassName)}>
               {child_chunks.map(item => (
                 <ChildChunksItem key={item.id} payload={item} isShowAll />

--- a/web/models/datasets.ts
+++ b/web/models/datasets.ts
@@ -545,6 +545,7 @@ export type Segment = {
   keywords: string[]
   hit_count: number
   index_node_hash: string
+  answer: string
 }
 
 export type Document = {


### PR DESCRIPTION
Fixes https://github.com/langgenius/dify/issues/24523

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
This PR adds answer data for retrieve chunks in the dataset base hit testing when the dataset document is in QA mode

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
Before
<img width="1217" height="736" alt="image" src="https://github.com/user-attachments/assets/e4d7951f-6078-429e-8972-099ba1cce4a8" />

After
<img width="847" height="167" alt="image" src="https://github.com/user-attachments/assets/a5b6c193-1425-4c49-97a7-61ddb5756783" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
