### PR TITLE
fix: `files` parameter in JavaScript sdk incorrectly annotated as the `File` type in WebAPI

### DIFF
--- a/sdks/nodejs-client/index.d.ts
+++ b/sdks/nodejs-client/index.d.ts
@@ -14,6 +14,22 @@ interface HeaderParams {
 interface User {
 }
 
+interface DifyFileBase {
+  type: "image"
+}
+
+export interface DifyRemoteFile extends DifyFileBase {
+  transfer_method: "remote_url"
+  url: string
+}
+
+export interface DifyLocalFile extends DifyFileBase {
+  transfer_method: "local_file"
+  upload_file_id: string
+}
+
+export type DifyFile = DifyRemoteFile | DifyLocalFile;
+
 export declare class DifyClient {
   constructor(apiKey: string, baseUrl?: string);
 
@@ -44,7 +60,7 @@ export declare class CompletionClient extends DifyClient {
     inputs: any,
     user: User,
     stream?: boolean,
-    files?: File[] | null
+    files?: DifyFile[] | null
   ): Promise<any>;
 }
 
@@ -55,7 +71,7 @@ export declare class ChatClient extends DifyClient {
     user: User,
     stream?: boolean,
     conversation_id?: string | null,
-    files?: File[] | null
+    files?: DifyFile[] | null
   ): Promise<any>;
 
   getSuggested(message_id: string, user: User): Promise<any>;


### PR DESCRIPTION


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Created a new type `DifyFile` according to the Dify API documentation, relplacing the incorrect `File` type. Fixes #24640.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
