### PR TITLE
✨fix: has_more logic in ChatMessageListApi to ensure correct on behavior when no more messages are available.

### DIFF
--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -95,18 +95,22 @@ class ChatMessageListApi(Resource):
                 .all()
             )
 
+        # Initialize has_more based on whether we have a full page
         if len(history_messages) == args["limit"]:
             current_page_first_message = history_messages[-1]
-
-        has_more = db.session.scalar(
-            select(
-                exists().where(
-                    Message.conversation_id == conversation.id,
-                    Message.created_at < current_page_first_message.created_at,
-                    Message.id != current_page_first_message.id,
+            # Check if there are more messages before the current page
+            has_more = db.session.scalar(
+                select(
+                    exists().where(
+                        Message.conversation_id == conversation.id,
+                        Message.created_at < current_page_first_message.created_at,
+                        Message.id != current_page_first_message.id,
+                    )
                 )
             )
-        )
+        else:
+            # If we don't have a full page, there are no more messages
+            has_more = False
 
         history_messages = list(reversed(history_messages))
 


### PR DESCRIPTION
## Summary

Fix #24583 introduced current_page_first_message is used before initialize by GPT 5 high
Fixes https://github.com/langgenius/dify/issues/24686
Fixes https://github.com/langgenius/dify/issues/24684

## Checklist

- [x] This change *not* requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] No need add test, and I tried as much as possible to make a single atomic change.
- [x] No need update the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
