### PR TITLE
refactor: relocate China npm registry config to base image

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,6 +5,9 @@ LABEL maintainer="takatost@gmail.com"
 # if you located in China, you can use aliyun mirror to speed up
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 
+# if you located in China, you can use taobao registry to speed up
+# RUN npm config set registry https://registry.npmmirror.com
+
 RUN apk add --no-cache tzdata
 RUN corepack enable
 ENV PNPM_HOME="/pnpm"
@@ -21,9 +24,6 @@ COPY pnpm-lock.yaml .
 
 # Use packageManager from package.json
 RUN corepack install
-
-# if you located in China, you can use taobao registry to speed up
-# RUN pnpm install --frozen-lockfile --registry https://registry.npmmirror.com/
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

This pull request updates the `web/Dockerfile` to improve support for developers located in China by providing instructions for using faster package registries. The main changes involve adding commented lines to help speed up dependency installation by switching to local mirrors.

Improvements for developers in China:

* Added a commented instruction to use the Taobao npm registry for faster npm installs (`npm config set registry https://registry.npmmirror.com`).
* Removed the commented instruction for using the Taobao pnpm registry during installation, streamlining the Dockerfile and avoiding redundancy.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
