### PR TITLE
feat: add MCP configuration for Claude Code optimization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+    "permissions": {
+      "allow": []
+    },
+    "env": {
+      "__comment": "Environment variables for MCP servers. Override in .claude/settings.local.json with actual values.",
+      "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    "enabledMcpjsonServers": [
+      "context7",
+      "sequential-thinking",
+      "github",
+      "fetch",
+      "playwright",
+      "ide"
+    ],
+    "enableAllProjectMcpServers": true
+  }

--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,6 +1,7 @@
 {
     "permissions": {
-      "allow": []
+      "allow": [],
+      "deny": []
     },
     "env": {
       "__comment": "Environment variables for MCP servers. Override in .claude/settings.local.json with actual values.",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,40 @@
+{
+    "mcpServers": {
+      "context7": {
+        "type": "http",
+        "url": "https://mcp.context7.com/mcp"
+      },
+      "sequential-thinking": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+        "env": {}
+      },
+      "github": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+        }
+      },
+      "fetch": {
+        "type": "stdio",
+        "command": "uvx",
+        "args": ["mcp-server-fetch"],
+        "env": {}
+      },
+      "playwright": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@playwright/mcp@latest"],
+        "env": {}
+      },
+      "ide": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-ide"],
+        "env": {}
+      }
+    }
+  }

--- a/.mcp.json
+++ b/.mcp.json
@@ -29,12 +29,6 @@
         "command": "npx",
         "args": ["-y", "@playwright/mcp@latest"],
         "env": {}
-      },
-      "ide": {
-        "type": "stdio",
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-ide"],
-        "env": {}
       }
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,4 @@ pnpm test                         # Run Jest tests
 ## Project-Specific Conventions
 
 - All async tasks use Celery with Redis as broker
+- **Internationalization**: Frontend supports multiple languages with English (`web/i18n/en-US/`) as the source. All user-facing text must use i18n keys, no hardcoded strings. Edit corresponding module files in `en-US/` directory for translations.


### PR DESCRIPTION
## Summary

Fixes #24611

This PR adds MCP (Model Context Protocol) configuration files to optimize Claude Code experience when working with the Dify project, plus internationalization guidelines for better development understanding.

### Added Files:
- `.mcp.json`: Configures MCP servers including Context7, Sequential Thinking, GitHub, Fetch, Playwright, and IDE servers
- `.claude/settings.example.json`: Claude Code settings with MCP server configurations and environment variable templates
- `CLAUDE.md`: Added internationalization development guidelines

### Changes:
- **MCP Configuration**: Complete setup for Claude Code with essential servers
- **Settings Template**: Example configuration with placeholder for GitHub tokens
- **I18n Guidelines**: Added frontend internationalization conventions to CLAUDE.md

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods