### PR TITLE
fix(datasource): load default fileExtensions for file node earlier

### DIFF
--- a/web/app/components/workflow/block-selector/constants.tsx
+++ b/web/app/components/workflow/block-selector/constants.tsx
@@ -7,3 +7,25 @@ export const BLOCK_CLASSIFICATIONS: string[] = [
   BlockClassificationEnum.Transform,
   BlockClassificationEnum.Utilities,
 ]
+
+export const DEFAULT_FILE_EXTENSIONS_IN_LOCAL_FILE_DATA_SOURCE = [
+  'txt',
+  'markdown',
+  'mdx',
+  'pdf',
+  'html',
+  'xlsx',
+  'xls',
+  'vtt',
+  'properties',
+  'doc',
+  'docx',
+  'csv',
+  'eml',
+  'msg',
+  'pptx',
+  'xml',
+  'epub',
+  'ppt',
+  'md',
+]

--- a/web/app/components/workflow/block-selector/data-sources.tsx
+++ b/web/app/components/workflow/block-selector/data-sources.tsx
@@ -10,13 +10,14 @@ import type {
   OnSelectBlock,
   ToolWithProvider,
 } from '../types'
-import type { ToolDefaultValue } from './types'
+import type { DataSourceDefaultValue, ToolDefaultValue } from './types'
 import Tools from './tools'
 import { ViewType } from './view-type-select'
 import cn from '@/utils/classnames'
 import type { ListRef } from '@/app/components/workflow/block-selector/market-place-plugin/list'
 import { getMarketplaceUrl } from '@/utils/var'
 import { useGlobalPublicStore } from '@/context/global-public-context'
+import { DEFAULT_FILE_EXTENSIONS_IN_LOCAL_FILE_DATA_SOURCE } from './constants'
 
 type AllToolsProps = {
   className?: string
@@ -37,14 +38,22 @@ const DataSources = ({
   const pluginRef = useRef<ListRef>(null)
   const wrapElemRef = useRef<HTMLDivElement>(null)
   const handleSelect = useCallback((_: any, toolDefaultValue: ToolDefaultValue) => {
-    onSelect(BlockEnum.DataSource, toolDefaultValue && {
+    let defaultValue: DataSourceDefaultValue = {
       plugin_id: toolDefaultValue?.provider_id,
       provider_type: toolDefaultValue?.provider_type,
       provider_name: toolDefaultValue?.provider_name,
       datasource_name: toolDefaultValue?.tool_name,
       datasource_label: toolDefaultValue?.tool_label,
       title: toolDefaultValue?.title,
-    })
+    }
+    // Update defaultValue with fileExtensions if this is the local file data source
+    if (toolDefaultValue?.provider_id === 'langgenius/file' && toolDefaultValue?.provider_name === 'file') {
+      defaultValue = {
+        ...defaultValue,
+        fileExtensions: DEFAULT_FILE_EXTENSIONS_IN_LOCAL_FILE_DATA_SOURCE,
+      }
+    }
+    onSelect(BlockEnum.DataSource, toolDefaultValue && defaultValue)
   }, [onSelect])
   const { enable_marketplace } = useGlobalPublicStore(s => s.systemFeatures)
 

--- a/web/app/components/workflow/block-selector/types.ts
+++ b/web/app/components/workflow/block-selector/types.ts
@@ -46,6 +46,7 @@ export type DataSourceDefaultValue = {
   datasource_name: string
   datasource_label: string
   title: string
+  fileExtensions?: string[]
 }
 
 export type ToolValue = {

--- a/web/app/components/workflow/nodes/data-source/constants.ts
+++ b/web/app/components/workflow/nodes/data-source/constants.ts
@@ -1,27 +1,5 @@
 import { VarType } from '@/app/components/workflow/types'
 
-export const DEFAULT_FILE_EXTENSIONS_IN_LOCAL_FILE_DATA_SOURCE = [
-  'txt',
-  'markdown',
-  'mdx',
-  'pdf',
-  'html',
-  'xlsx',
-  'xls',
-  'vtt',
-  'properties',
-  'doc',
-  'docx',
-  'csv',
-  'eml',
-  'msg',
-  'pptx',
-  'xml',
-  'epub',
-  'ppt',
-  'md',
-]
-
 export const COMMON_OUTPUT = [
   {
     name: 'datasource_type',

--- a/web/app/components/workflow/nodes/data-source/hooks/use-config.ts
+++ b/web/app/components/workflow/nodes/data-source/hooks/use-config.ts
@@ -9,7 +9,6 @@ import type {
   DataSourceNodeType,
   ToolVarInputs,
 } from '../types'
-import { DEFAULT_FILE_EXTENSIONS_IN_LOCAL_FILE_DATA_SOURCE } from '../constants'
 
 export const useConfig = (id: string, dataSourceList?: any[]) => {
   const store = useStoreApi()
@@ -36,7 +35,6 @@ export const useConfig = (id: string, dataSourceList?: any[]) => {
       handleNodeDataUpdate({
         ...nodeData.data,
         _dataSourceStartToAdd: false,
-        fileExtensions: DEFAULT_FILE_EXTENSIONS_IN_LOCAL_FILE_DATA_SOURCE,
       })
     }
   }, [getNodeData, handleNodeDataUpdate])


### PR DESCRIPTION
## Summary

This is for the ✨ **feat/rag-2** branch.

Closes #25304

### Issues to be solved

With specific steps, the `fileExtensions` option will be null and the `Browse` link will disappear. See the `Before` in `Screenshots` section.

- Create a new pipeline
- Place the File datasource node
- **IMPORTANT: From now on, do not open the panel for this node**
- Connect and configure the extractor, chunker, and vdb
- Ensure there are no validation errors
- Invoke `Test Run`

You will notice that there is no `Browse` link, and if you export the DSL, there is no `fileExtensions` property. You can still try uploading files by drag and drop, but it won't be accepted.

In the current implementation, the default `fileExtensions` are loaded **when the panel for this node is opened**.
This means that if the user never opens the panel until they publish the pipeline, `fileExtensions` has no value and the pipeline cannot accept any file extensions.
This is a possible scenario that can actually occur when the users want to leave all of the file node settings at their default values.

### Changes in this PR

This PR makes the default `fileExtensions` value load **when placing the node**, instead of when opening the panel.
I'm not sure if this is the best solution, but I wanted to let you know about the issue and suggest an idea to solve it.

Of course it's okay to close this if there is an appropriate alternative solution.

F.Y.I. @crazywoola 

## Screenshots

| Before | After |
|--------|-------|
| <img width="913" height="610" alt="Image" src="https://github.com/user-attachments/assets/0e5dac65-b0df-460f-9de6-b5b918fc081a" /> <img width="298" height="476" alt="Image" src="https://github.com/user-attachments/assets/71a29cf0-eda2-43d3-a420-fa57eb1f437e" /> | <img width="910" height="491" alt="Image" src="https://github.com/user-attachments/assets/f57fd0a6-e2b3-4e1a-a4a5-ce948a045350" /> <img width="342" height="846" alt="Image" src="https://github.com/user-attachments/assets/0f74bf97-43c4-4b19-bd28-1e7d626c8dfe" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
