### PR TITLE
chore: simplify the workflow details logic 

### DIFF
--- a/web/app/components/base/chat/chat/answer/index.tsx
+++ b/web/app/components/base/chat/chat/answer/index.tsx
@@ -137,24 +137,14 @@ const Answer: FC<AnswerProps> = ({
                 />
               )
             }
-            {/** Render the normal steps */}
+            {/** Render workflow process */}
             {
-              workflowProcess && !hideProcessDetail && (
+              workflowProcess && (
                 <WorkflowProcessItem
                   data={workflowProcess}
                   item={item}
                   hideProcessDetail={hideProcessDetail}
-                />
-              )
-            }
-            {/** Hide workflow steps by it's settings in siteInfo */}
-            {
-              workflowProcess && hideProcessDetail && appData && (
-                <WorkflowProcessItem
-                  data={workflowProcess}
-                  item={item}
-                  hideProcessDetail={hideProcessDetail}
-                  readonly={!appData.site.show_workflow_steps}
+                  readonly={hideProcessDetail && appData ? !appData.site.show_workflow_steps : undefined}
                 />
               )
             }

--- a/web/app/components/base/chat/chat/answer/workflow-process.tsx
+++ b/web/app/components/base/chat/chat/answer/workflow-process.tsx
@@ -39,6 +39,8 @@ const WorkflowProcessItem = ({
     setCollapse(!expand)
   }, [expand])
 
+  if (readonly) return null
+
   return (
     <div
       className={cn(
@@ -51,8 +53,8 @@ const WorkflowProcessItem = ({
       )}
     >
       <div
-        className={cn('flex cursor-pointer items-center', !collapse && 'px-1.5', readonly && 'cursor-default')}
-        onClick={() => !readonly && setCollapse(!collapse)}
+        className={cn('flex cursor-pointer items-center', !collapse && 'px-1.5')}
+        onClick={() => setCollapse(!collapse)}
       >
         {
           running && (
@@ -72,10 +74,10 @@ const WorkflowProcessItem = ({
         <div className={cn('system-xs-medium text-text-secondary', !collapse && 'grow')}>
           {t('workflow.common.workflowProcess')}
         </div>
-        {!readonly && <RiArrowRightSLine className={cn('ml-1 h-4 w-4 text-text-tertiary', !collapse && 'rotate-90')} />}
+        <RiArrowRightSLine className={cn('ml-1 h-4 w-4 text-text-tertiary', !collapse && 'rotate-90')} />
       </div>
       {
-        !collapse && !readonly && (
+        !collapse && (
           <div className='mt-1.5'>
             {
               <TracingPanel


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

close https://github.com/langgenius/dify/issues/23612

This pull request refactors the workflow process rendering logic in the chat answer component, simplifying how workflow steps are displayed and controlled. The main change is to always hide the workflow process UI when it is marked as readonly, rather than conditionally rendering parts of it. This makes the code easier to follow and ensures consistent behavior.

**Workflow process rendering logic:**

* The `WorkflowProcessItem` component now returns `null` when `readonly` is true, fully hiding the workflow process UI in readonly mode.
* The workflow process arrow icon and collapse/expand behavior are no longer conditional on `readonly`, simplifying user interaction and visual cues. [[1]](diffhunk://#diff-27f7eff85cb13745439f0f1216281620009f22d04cbedc088931387aec785c99L54-R57) [[2]](diffhunk://#diff-27f7eff85cb13745439f0f1216281620009f22d04cbedc088931387aec785c99L75-R80)

**Component usage and prop handling:**

* The logic for rendering the workflow process in the `Answer` component is simplified: it now always renders the workflow process if present, and sets the `readonly` prop based on `hideProcessDetail` and the site settings.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
