### PR TITLE
fix: retach user object to session to prevent DetachedInstanceError

### DIFF
--- a/api/core/repositories/sqlalchemy_workflow_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_execution_repository.py
@@ -65,9 +65,8 @@ class SQLAlchemyWorkflowExecutionRepository(WorkflowExecutionRepository):
             raise ValueError(
                 f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
             )
-
         with self._session_factory() as session:
-            user = session.merge(user)
+            session.refresh(user)
             tenant_id = extract_tenant_id(user)
 
         if not tenant_id:

--- a/api/core/repositories/sqlalchemy_workflow_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_execution_repository.py
@@ -66,8 +66,10 @@ class SQLAlchemyWorkflowExecutionRepository(WorkflowExecutionRepository):
                 f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
             )
 
-        # Extract tenant_id from user
-        tenant_id = extract_tenant_id(user)
+        with self._session_factory() as session:
+            user = session.merge(user)
+            tenant_id = extract_tenant_id(user)
+
         if not tenant_id:
             raise ValueError("User must have a tenant_id or current_tenant_id")
         self._tenant_id = tenant_id

--- a/api/core/repositories/sqlalchemy_workflow_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_execution_repository.py
@@ -65,11 +65,11 @@ class SQLAlchemyWorkflowExecutionRepository(WorkflowExecutionRepository):
             raise ValueError(
                 f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
             )
+
         # Extract tenant_id from user
         with self._session_factory() as session:
-            session.refresh(user)
+            user = session.merge(user)
             tenant_id = extract_tenant_id(user)
-
         if not tenant_id:
             raise ValueError("User must have a tenant_id or current_tenant_id")
         self._tenant_id = tenant_id

--- a/api/core/repositories/sqlalchemy_workflow_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_execution_repository.py
@@ -65,6 +65,7 @@ class SQLAlchemyWorkflowExecutionRepository(WorkflowExecutionRepository):
             raise ValueError(
                 f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
             )
+        # Extract tenant_id from user
         with self._session_factory() as session:
             session.refresh(user)
             tenant_id = extract_tenant_id(user)

--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -72,7 +72,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
 
         # Extract tenant_id from user
         with self._session_factory() as session:
-            user = session.merge(user)
+            session.refresh(user)
             tenant_id = extract_tenant_id(user)
         if not tenant_id:
             raise ValueError("User must have a tenant_id or current_tenant_id")

--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -71,7 +71,9 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
             )
 
         # Extract tenant_id from user
-        tenant_id = extract_tenant_id(user)
+        with self._session_factory() as session:
+            user = session.merge(user)
+            tenant_id = extract_tenant_id(user)
         if not tenant_id:
             raise ValueError("User must have a tenant_id or current_tenant_id")
         self._tenant_id = tenant_id

--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -72,7 +72,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
 
         # Extract tenant_id from user
         with self._session_factory() as session:
-            session.refresh(user)
+            user = session.merge(user)
             tenant_id = extract_tenant_id(user)
         if not tenant_id:
             raise ValueError("User must have a tenant_id or current_tenant_id")

--- a/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
+++ b/api/tests/unit_tests/repositories/workflow_node_execution/test_sqlalchemy_repository.py
@@ -46,7 +46,7 @@ def session():
     # Configure the session to be used as a context manager
     session.__enter__ = MagicMock(return_value=session)
     session.__exit__ = MagicMock(return_value=None)
-
+    session.merge.side_effect = lambda x: x
     # Configure the session factory to return the session
     session_factory = MagicMock(spec=sessionmaker)
     session_factory.return_value = session
@@ -104,7 +104,7 @@ def test_save(repository, session):
     repository.to_db_model.assert_called_once_with(execution)
 
     # Assert session.merge was called (now using merge for both save and update)
-    session_obj.merge.assert_called_once_with(execution)
+    session_obj.merge.assert_called_with(execution)
 
 
 def test_save_with_existing_tenant_id(repository, session):
@@ -134,7 +134,7 @@ def test_save_with_existing_tenant_id(repository, session):
     repository.to_db_model.assert_called_once_with(execution)
 
     # Assert session.merge was called with the modified execution (now using merge for both save and update)
-    session_obj.merge.assert_called_once_with(modified_execution)
+    session_obj.merge.assert_called_with(modified_execution)
 
 
 def test_get_by_workflow_run(repository, session, mocker: MockerFixture):


### PR DESCRIPTION
## Summary

tend to fix https://github.com/langgenius/dify/issues/24706.

As https://github.com/langgenius/dify/pull/24290 mentions, the best solution is to pass stabled tenant_id from parent instead of `extract_tenant_id`

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
