### PR TITLE
fix(pipeline): make kb node deletable

### DIFF
--- a/web/app/components/rag-pipeline/hooks/use-available-nodes-meta-data.ts
+++ b/web/app/components/rag-pipeline/hooks/use-available-nodes-meta-data.ts
@@ -30,7 +30,6 @@ export const useAvailableNodesMetaData = () => {
       metaData: {
         ...knowledgeBaseDefault.metaData,
         isRequired: true,
-        isUndeletable: true,
       },
     },
     {


### PR DESCRIPTION
## Summary

This is for the ✨ **feat/rag-2** branch.

In the current implementation, the `Knowledge Base` node is duplicatable, but undeleatable.
This causes making the pipeline unusable by duplicated KB nodes, by selecting `Duplicate` or by pressing `Ctrl + C` + `Ctrl + V` (see `Before` image).

This PR removes `isUndeletable: true` flag from the KB node to make KB node deletable. The KB node still has `isRequired` flag, so it is guaranteed that published pipeline has at least one KB node.

This is the same behavior as `End` node of the app workflow.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1093" height="652" alt="image" src="https://github.com/user-attachments/assets/0e123aee-afc2-4571-907e-d15b97ebac5d" /> | <img width="1112" height="615" alt="image" src="https://github.com/user-attachments/assets/79227b0f-007f-44d8-b8c9-44eb29189b8c" /> <img width="942" height="621" alt="image" src="https://github.com/user-attachments/assets/0a7db7f8-49a8-4105-82b6-1a0fa46e3093" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
