### PR TITLE
fix: inconsistent text color for settings button in webapp cards

### DIFF
--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -311,7 +311,7 @@ function AppCard({
                 >
                   <div className="flex items-center justify-center gap-[1px]">
                     <op.opIcon className="h-3.5 w-3.5" />
-                    <div className={`${runningStatus ? 'text-text-tertiary' : 'text-components-button-ghost-text-disabled'} system-xs-medium px-[3px]`}>{op.opName}</div>
+                    <div className={`${(runningStatus || !disabled) ? 'text-text-tertiary' : 'text-components-button-ghost-text-disabled'} system-xs-medium px-[3px]`}>{op.opName}</div>
                   </div>
                 </Tooltip>
               </Button>


### PR DESCRIPTION
## Summary

Fixes #24753

Fixed inconsistent visual behavior where the settings button text becomes gray when the app is disabled, despite the button remaining functional and clickable. The text color now stays normal (like the icon) when the app is disabled, ensuring visual consistency.

## Screenshots

| Before | After |
|--------|-------|
|<img width="410" height="183" alt="image" src="https://github.com/user-attachments/assets/546f96a6-8dee-4aa7-8214-d68be6235c30" /> |<img width="408" height="173" alt="image" src="https://github.com/user-attachments/assets/a29ada3f-41d9-4a34-860d-fbc5871e0a3c" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods