### PR TITLE
fix: Variable Aggregator cannot select conversation variables

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/add-variable-popup-with-position.tsx
+++ b/web/app/components/workflow/nodes/_base/components/add-variable-popup-with-position.tsx
@@ -64,7 +64,7 @@ const AddVariablePopupWithPosition = ({
         } as any,
       ],
       hideEnv: true,
-      hideChatVar: true,
+      hideChatVar: !isChatMode,
       isChatMode,
       filterVar: filterVar(outputType as VarType),
     })


### PR DESCRIPTION
Fixes #24787
## Summary

This pull request makes a small change to the `AddVariablePopupWithPosition` component to improve its behavior in chat mode. The change ensures that the `hideChatVar` property is dynamically set based on the current chat mode, rather than always being hidden.

* The `hideChatVar` property is now set to `!isChatMode`, so chat variables are only hidden when not in chat mode.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
