### PR TITLE
replace the secret field from obfuscated to full-masked value

### DIFF
--- a/api/core/helper/encrypter.py
+++ b/api/core/helper/encrypter.py
@@ -11,6 +11,10 @@ def obfuscated_token(token: str):
     return token[:6] + "*" * 12 + token[-2:]
 
 
+def full_mask_token(token_length=20):
+    return "*" * token_length
+
+
 def encrypt_token(tenant_id: str, token: str):
     from models.account import Tenant
     from models.engine import db

--- a/api/fields/workflow_fields.py
+++ b/api/fields/workflow_fields.py
@@ -17,7 +17,7 @@ class EnvironmentVariableField(fields.Raw):
             return {
                 "id": value.id,
                 "name": value.name,
-                "value": encrypter.obfuscated_token(value.value),
+                "value": "*" * 20,
                 "value_type": value.value_type.value,
                 "description": value.description,
             }

--- a/api/fields/workflow_fields.py
+++ b/api/fields/workflow_fields.py
@@ -1,5 +1,6 @@
 from flask_restx import fields
 
+from core.helper import encrypter
 from core.variables import SecretVariable, SegmentType, Variable
 from fields.member_fields import simple_account_fields
 from libs.helper import TimestampField

--- a/api/fields/workflow_fields.py
+++ b/api/fields/workflow_fields.py
@@ -17,7 +17,7 @@ class EnvironmentVariableField(fields.Raw):
             return {
                 "id": value.id,
                 "name": value.name,
-                "value": "*" * 20,
+                "value": encrypter.full_mask_token(),
                 "value_type": value.value_type.value,
                 "description": value.description,
             }

--- a/api/fields/workflow_fields.py
+++ b/api/fields/workflow_fields.py
@@ -1,6 +1,5 @@
 from flask_restx import fields
 
-from core.helper import encrypter
 from core.variables import SecretVariable, SegmentType, Variable
 from fields.member_fields import simple_account_fields
 from libs.helper import TimestampField


### PR DESCRIPTION
## Summary


Fixes #24660
I believe that secret variables should replace all characters with asterisks, rather than showing part of them.  obfuscation can be use to mask the user name but it's not good idea for handle the password. the uncovered characters may reveal patterns in the password.

## Screenshots

| Before | After |
|--------|-------|
| <img width="410" height="275" alt="image" src="https://github.com/user-attachments/assets/9f6509ac-9d90-4e1f-ba66-4b24429b2256" /> | <img width="411" height="276" alt="image" src="https://github.com/user-attachments/assets/136f2211-32bc-45cd-b85d-59105b5c503c" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
