### PR TITLE
fix: add missing statuses permission to main CI workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: write
+  statuses: write
 
 concurrency:
   group: main-ci-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary
This PR fixes a CI workflow permission error that prevents the style checks from running correctly.

## Problem
The main-ci.yml workflow was failing with:
```
The workflow is requesting 'statuses: write', but is only allowed 'statuses: none'.
```

## Solution
Added the missing `statuses: write` permission to the main-ci.yml workflow's permissions section. This allows the reusable style.yml workflow to update commit statuses as required.

## Changes
- Added `statuses: write` to the permissions in `.github/workflows/main-ci.yml`

Fixes #24808