### PR TITLE
refactor: remove duplicate pull_request triggers from workflow files

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -2,13 +2,6 @@ name: Run Pytest
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - api/**
-      - docker/**
-      - .github/workflows/api-tests.yml
 
 concurrency:
   group: api-tests-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,10 +1,6 @@
 name: autofix.ci
 on:
   workflow_call:
-  pull_request:
-    branches: [ "main" ]
-  push:
-    branches: [ "main" ]
 permissions:
   contents: read
 

--- a/.github/workflows/db-migration-test.yml
+++ b/.github/workflows/db-migration-test.yml
@@ -2,13 +2,6 @@ name: DB Migration Test
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - main
-      - plugins/beta
-    paths:
-      - api/migrations/**
-      - .github/workflows/db-migration-test.yml
 
 concurrency:
   group: db-migration-test-${{ github.ref }}

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -3,6 +3,8 @@ name: Main CI Pipeline
 on:
   pull_request:
     branches: [ "main" ]
+  push:
+    branches: [ "main" ]
 
 permissions:
   contents: write

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,9 +2,6 @@ name: Style check
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: style-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -2,15 +2,6 @@ name: Run VDB Tests
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - api/core/rag/datasource/**
-      - docker/**
-      - .github/workflows/vdb-tests.yml
-      - api/uv.lock
-      - api/pyproject.toml
 
 concurrency:
   group: vdb-tests-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -2,11 +2,6 @@ name: Web Tests
 
 on:
   workflow_call:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - web/**
 
 concurrency:
   group: web-tests-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary
- Removes direct pull_request triggers from individual workflow files to prevent duplicate runs
- Ensures workflows only run via workflow_call from the main-ci pipeline
- Eliminates redundant CI resource usage

## Related Issue
Fixes #24813
