### PR TITLE
fix: Fix database connection leak in EasyUIBasedGenerateTaskPipeline

### DIFF
--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -472,7 +472,7 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
         :param event: agent thought event
         :return:
         """
-        with Session(db.engine) as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             agent_thought: Optional[MessageAgentThought] = (
                 session.query(MessageAgentThought).where(MessageAgentThought.id == event.agent_thought_id).first()
             )

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -472,9 +472,10 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
         :param event: agent thought event
         :return:
         """
-        agent_thought: Optional[MessageAgentThought] = (
-            db.session.query(MessageAgentThought).where(MessageAgentThought.id == event.agent_thought_id).first()
-        )
+        with Session(db.engine) as session:
+            agent_thought: Optional[MessageAgentThought] = (
+                session.query(MessageAgentThought).where(MessageAgentThought.id == event.agent_thought_id).first()
+            )
 
         if agent_thought:
             return AgentThoughtStreamResponse(


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes a database connection leak issue in the `EasyUIBasedGenerateTaskPipeline` class.

### Problem
The `_agent_thought_to_stream_response` method was using the global `db.session` for database queries, while other methods in the same file use `with Session(db.engine) as session:` context managers. The `db.session` approach doesn't automatically close database connections, leading to connection leaks.

### Solution
Replace the `db.session.query()` call with an explicit `Session(db.engine)` context manager to ensure database connections are properly closed after use.

### Changes
- Modified the database query approach in `_agent_thought_to_stream_response` method
- Changed from `db.session.query()` to `with Session(db.engine) as session:`
- Ensured database connections are automatically closed after use to prevent leaks

### Impact
This fix resolves potential database connection leaks, improves application stability in high-concurrency scenarios, and reduces pressure on the database connection pool.
## Screenshots

| Before | After |
|--------|-------|
| 
<img width="5018" height="544" alt="image" src="https://github.com/user-attachments/assets/0cdcd74e-9aca-4d4b-a6ad-9291ccb1de88" />
 | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
