### PR TITLE
fix: improve TimePicker footer layout and button styling

### DIFF
--- a/web/app/components/base/date-and-time-picker/time-picker/footer.tsx
+++ b/web/app/components/base/date-and-time-picker/time-picker/footer.tsx
@@ -10,26 +10,25 @@ const Footer: FC<TimePickerFooterProps> = ({
   const { t } = useTranslation()
 
   return (
-    <div className='flex items-center justify-end border-t-[0.5px] border-divider-regular p-2'>
-      <div className='flex items-center gap-x-1'>
-        {/* Now */}
-        <button
-          type='button'
-          className='system-xs-medium flex items-center justify-center px-1.5 py-1 text-components-button-secondary-accent-text'
-          onClick={handleSelectCurrentTime}
-        >
-          <span className='px-[3px]'>{t('time.operation.now')}</span>
-        </button>
-        {/* Confirm Button */}
-        <Button
-          variant='primary'
-          size='small'
-          className='w-16 px-1.5 py-1'
-          onClick={handleConfirm.bind(null)}
-        >
-          {t('time.operation.ok')}
-        </Button>
-      </div>
+    <div className='flex items-center justify-between border-t-[0.5px] border-divider-regular p-2'>
+      {/* Now Button */}
+      <Button
+        variant='secondary-accent'
+        size='small'
+        className='mr-1 flex-1'
+        onClick={handleSelectCurrentTime}
+      >
+        {t('time.operation.now')}
+      </Button>
+      {/* Confirm Button */}
+      <Button
+        variant='primary'
+        size='small'
+        className='ml-1 flex-1'
+        onClick={handleConfirm.bind(null)}
+      >
+        {t('time.operation.ok')}
+      </Button>
     </div>
   )
 }


### PR DESCRIPTION
Related #24001 

## Summary

Improved the TimePicker footer component layout and button styling to enhance user experience:

- Changed footer layout from right-aligned to full-width horizontal distribution using `justify-between`
- Replaced plain button element with proper Button component for the "Now" button
- Applied `secondary-accent` variant to maintain blue text color for the "Now" button
- Used `flex-1` classes to make both buttons share equal width
- Maintained proper spacing between buttons with margin classes

The footer now provides a more balanced and consistent visual appearance while preserving the original blue color scheme for the "Now" button.

## Screenshots

| Before | After |
|--------|-------|
|<img width="262" height="310" alt="image" src="https://github.com/user-attachments/assets/2e614e8d-9e7b-4ced-9460-0efc81008700" />|<img width="264" height="306" alt="image" src="https://github.com/user-attachments/assets/2795e27b-6752-4783-8d2b-bd411d508dab" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods