### PR TITLE
chore: remove duplicate Python style checks handled by autofix CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -44,20 +44,9 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: uv sync --project api --dev
 
-      - name: Ruff check
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
-          uv run --directory api ruff --version
-          uv run --directory api ruff check ./
-          uv run --directory api ruff format --check ./
-
       - name: Dotenv check
         if: steps.changed-files.outputs.any_changed == 'true'
         run: uv run --project api dotenv-linter ./api/.env.example ./web/.env.example
-
-      - name: Lint hints
-        if: failure()
-        run: echo "Please run 'dev/reformat' to fix the fixable linting errors."
 
   web-style:
     name: Web Style


### PR DESCRIPTION
## Summary

This PR removes redundant Python style check steps from the CI workflow that are already handled by the autofix.yml workflow.

### Changes:
- Removed `ruff check` and `ruff format --check` steps from `.github/workflows/style.yml`
- Removed the "Lint hints" message that suggested running `dev/reformat`
- Kept `dotenv-linter` check as it's not covered by autofix

The autofix.yml workflow already runs these same ruff commands with `--fix-only` flag on every PR, making the manual checks redundant.

Fixes #24832

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods