### PR TITLE
Remove redundant from_variable_selector null-check

### DIFF
--- a/api/core/workflow/nodes/answer/answer_stream_processor.py
+++ b/api/core/workflow/nodes/answer/answer_stream_processor.py
@@ -149,9 +149,6 @@ class AnswerStreamProcessor(StreamProcessor):
             return []
 
         stream_output_value_selector = event.from_variable_selector
-        if not stream_output_value_selector:
-            return []
-
         stream_out_answer_node_ids = []
         for answer_node_id, route_position in self.route_position.items():
             if answer_node_id not in self.rest_node_ids:

--- a/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
+++ b/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
@@ -18,7 +18,7 @@ import s from './style.module.css'
 import Modal from '@/app/components/base/modal'
 import Button from '@/app/components/base/button'
 import Toast from '@/app/components/base/toast'
-import { generateBasicAppFistTimeRule, generateRule } from '@/service/debug'
+import { generateBasicAppFirstTimeRule, generateRule } from '@/service/debug'
 import type { CompletionParams, Model } from '@/types/app'
 import type { AppType } from '@/types/app'
 import Loading from '@/app/components/base/loading'
@@ -226,7 +226,7 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
       let apiRes: GenRes
       let hasError = false
       if (isBasicMode || !currentPrompt) {
-        const { error, ...res } = await generateBasicAppFistTimeRule({
+        const { error, ...res } = await generateBasicAppFirstTimeRule({
           instruction,
           model_config: model,
           no_variable: false,

--- a/web/service/debug.ts
+++ b/web/service/debug.ts
@@ -80,7 +80,7 @@ export const fetchConversationMessages = (appId: string, conversation_id: string
   })
 }
 
-export const generateBasicAppFistTimeRule = (body: Record<string, any>) => {
+export const generateBasicAppFirstTimeRule = (body: Record<string, any>) => {
   return post<BasicAppFirstRes>('/rule-generate', {
     body,
   })


### PR DESCRIPTION
Fixes #24841 

This PR simplifies _get_stream_out_answer_node_ids in AnswerStreamProcessor by removing a duplicate null-check on from_variable_selector.


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
