### PR TITLE
Fix never hit `(!code || code.length === 0)`

### DIFF
--- a/web/service/use-share.ts
+++ b/web/service/use-share.ts
@@ -6,12 +6,7 @@ const NAME_SPACE = 'webapp'
 export const useGetWebAppAccessModeByCode = (code: string | null) => {
   return useQuery({
     queryKey: [NAME_SPACE, 'appAccessMode', code],
-    queryFn: () => {
-      if (!code || code.length === 0)
-        return Promise.reject(new Error('App code is required to get access mode'))
-
-      return getAppAccessModeByAppCode(code)
-    },
+    queryFn: () => getAppAccessModeByAppCode(code!),
     enabled: !!code,
   })
 }


### PR DESCRIPTION
Fixes #24861 

Removed the redundant `if (!code || code.length === 0)` guard inside `queryFn` of 
`useGetWebAppAccessModeByCode`. The `enabled: !!code` option in React Query already 
prevents `queryFn` from running when `code` is null or empty.



> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
