### PR TITLE
fix: basepath did not read from the environment variable

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,4 +1,3 @@
-const { basePath, assetPrefix } = require('./utils/var-basePath')
 const { codeInspectorPlugin } = require('code-inspector-plugin')
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
@@ -24,8 +23,7 @@ const remoteImageURLs = [hasSetWebPrefix ? new URL(`${process.env.NEXT_PUBLIC_WE
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  basePath,
-  assetPrefix,
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   webpack: (config, { dev, isServer }) => {
     if (dev) {
       config.plugins.push(codeInspectorPlugin({ bundler: 'webpack' }))

--- a/web/utils/var-basePath.js
+++ b/web/utils/var-basePath.js
@@ -1,6 +1,0 @@
-// export basePath to next.config.js
-// same as the one exported from var.ts
-module.exports = {
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
-  assetPrefix: '',
-}

--- a/web/utils/var.ts
+++ b/web/utils/var.ts
@@ -118,7 +118,7 @@ export const getVars = (value: string) => {
 
 // Set the value of basePath
 // example: /dify
-export const basePath = ''
+export const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
 
 export function getMarketplaceUrl(path: string, params?: Record<string, string | undefined>) {
   const searchParams = new URLSearchParams({ source: encodeURIComponent(window.location.origin) })


### PR DESCRIPTION
Fixes:  #24871 
## Summary

This pull request refactors how the `basePath` configuration is handled in the Next.js app. The main change is to remove the separate `var-basePath.js` file and directly use environment variables for `basePath` in both `next.config.js` and utility files. This simplifies the configuration and reduces duplication.

Configuration refactoring:

* Removed the `web/utils/var-basePath.js` file and its exports, eliminating duplication of the `basePath` logic.
* Updated `web/next.config.js` to set `basePath` directly from the `NEXT_PUBLIC_BASE_PATH` environment variable, instead of importing it from `var-basePath.js`. 
* Changed the default export of `basePath` in `web/utils/var.ts` to use the environment variable, aligning it with the new configuration approach.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
