### PR TITLE
FEAT: Tencent Vector optimize BM25 initialization to reduce loading time

### DIFF
--- a/api/core/rag/datasource/vdb/tencent/tencent_vector.py
+++ b/api/core/rag/datasource/vdb/tencent/tencent_vector.py
@@ -39,6 +39,9 @@ class TencentConfig(BaseModel):
         return {"url": self.url, "username": self.username, "key": self.api_key, "timeout": self.timeout}
 
 
+bm25 = BM25Encoder.default("zh")
+
+
 class TencentVector(BaseVector):
     field_id: str = "id"
     field_vector: str = "vector"
@@ -53,7 +56,6 @@ class TencentVector(BaseVector):
         self._dimension = 1024
         self._init_database()
         self._load_collection()
-        self._bm25 = BM25Encoder.default("zh")
 
     def _load_collection(self):
         """
@@ -186,7 +188,7 @@ class TencentVector(BaseVector):
                     metadata=metadata,
                 )
                 if self._enable_hybrid_search:
-                    doc.__dict__["sparse_vector"] = self._bm25.encode_texts(texts[i])
+                    doc.__dict__["sparse_vector"] = bm25.encode_texts(texts[i])
                 docs.append(doc)
             self._client.upsert(
                 database_name=self._client_config.database,
@@ -264,7 +266,7 @@ class TencentVector(BaseVector):
             match=[
                 KeywordSearch(
                     field_name="sparse_vector",
-                    data=self._bm25.encode_queries(query),
+                    data=bm25.encode_queries(query),
                 ),
             ],
             rerank=WeightedRerank(


### PR DESCRIPTION
# Summary

Tencent Vector search supports backward compatibility with the previous score calculation approach.

> [!Tip]
Resolves https://github.com/langgenius/dify/issues/24914

# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

