### PR TITLE
fix(app-cards): restrict toggle enable to Start nodes only

### DIFF
--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -41,7 +41,7 @@ import AccessControl from '../app-access-control'
 import { useAppWhiteListSubjects } from '@/service/access-control'
 import { useAppWorkflow } from '@/service/use-workflow'
 import { useGlobalPublicStore } from '@/context/global-public-context'
-import { getWorkflowEntryNode } from '@/app/components/workflow/utils/workflow-entry'
+import { BlockEnum } from '@/app/components/workflow/types'
 import { useDocLink } from '@/context/i18n'
 
 export type IAppCardProps = {
@@ -107,12 +107,12 @@ function AppCard({
     : t('appOverview.overview.apiInfo.title')
   const isWorkflowApp = appInfo.mode === 'workflow'
   const appUnpublished = isWorkflowApp && !currentWorkflow?.graph
-  const hasEntryNode = getWorkflowEntryNode(currentWorkflow?.graph?.nodes || [])
-  const missingEntryNode = isWorkflowApp && !hasEntryNode
+  const hasStartNode = currentWorkflow?.graph?.nodes?.some(node => node.data.type === BlockEnum.Start)
+  const missingStartNode = isWorkflowApp && !hasStartNode
   const hasInsufficientPermissions = isApp ? !isCurrentWorkspaceEditor : !isCurrentWorkspaceManager
-  const toggleDisabled = hasInsufficientPermissions || appUnpublished || missingEntryNode
-  const runningStatus = (appUnpublished || missingEntryNode) ? false : (isApp ? appInfo.enable_site : appInfo.enable_api)
-  const isMinimalState = appUnpublished || missingEntryNode
+  const toggleDisabled = hasInsufficientPermissions || appUnpublished || missingStartNode
+  const runningStatus = (appUnpublished || missingStartNode) ? false : (isApp ? appInfo.enable_site : appInfo.enable_api)
+  const isMinimalState = appUnpublished || missingStartNode
   const { app_base_url, access_token } = appInfo.site ?? {}
   const appMode = (appInfo.mode !== 'completion' && appInfo.mode !== 'workflow') ? 'chat' : appInfo.mode
   const appUrl = `${app_base_url}${basePath}/${appMode}/${access_token}`
@@ -214,7 +214,7 @@ function AppCard({
             {isApp ? (
               <Tooltip
                 popupContent={
-                  toggleDisabled && (appUnpublished || missingEntryNode) ? (
+                  toggleDisabled && (appUnpublished || missingStartNode) ? (
                     <>
                       <div className="mb-1 text-xs font-normal text-text-secondary">
                         {t('appOverview.overview.appInfo.enableTooltip.description')}

--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -211,34 +211,30 @@ function AppCard({
                   : t('appOverview.overview.status.disable')}
               </div>
             </div>
-            {isApp ? (
-              <Tooltip
-                popupContent={
-                  toggleDisabled && (appUnpublished || missingStartNode) ? (
-                    <>
-                      <div className="mb-1 text-xs font-normal text-text-secondary">
-                        {t('appOverview.overview.appInfo.enableTooltip.description')}
-                      </div>
-                      <div
-                        className="cursor-pointer text-xs font-normal text-text-accent hover:underline"
-                        onClick={() => window.open(docLink('/guides/workflow/node/start'), '_blank')}
-                      >
-                        {t('appOverview.overview.appInfo.enableTooltip.learnMore')}
-                      </div>
-                    </>
-                  ) : ''
-                }
-                position="right"
-                popupClassName="w-58 max-w-60 rounded-xl border-[0.5px] p-3.5 shadow-lg backdrop-blur-[10px]"
-                offset={24}
-              >
-                <div>
-                  <Switch defaultValue={runningStatus} onChange={onChangeStatus} disabled={toggleDisabled} />
-                </div>
-              </Tooltip>
-            ) : (
-              <Switch defaultValue={runningStatus} onChange={onChangeStatus} disabled={toggleDisabled} />
-            )}
+            <Tooltip
+              popupContent={
+                toggleDisabled && (appUnpublished || missingStartNode) ? (
+                  <>
+                    <div className="mb-1 text-xs font-normal text-text-secondary">
+                      {t('appOverview.overview.appInfo.enableTooltip.description')}
+                    </div>
+                    <div
+                      className="cursor-pointer text-xs font-normal text-text-accent hover:underline"
+                      onClick={() => window.open(docLink('/guides/workflow/node/start'), '_blank')}
+                    >
+                      {t('appOverview.overview.appInfo.enableTooltip.learnMore')}
+                    </div>
+                  </>
+                ) : ''
+              }
+              position="right"
+              popupClassName="w-58 max-w-60 rounded-xl border-[0.5px] p-3.5 shadow-lg backdrop-blur-[10px]"
+              offset={24}
+            >
+              <div>
+                <Switch defaultValue={runningStatus} onChange={onChangeStatus} disabled={toggleDisabled} />
+              </div>
+            </Tooltip>
           </div>
           {!isMinimalState && (
             <div className='flex flex-col items-start justify-center self-stretch'>

--- a/web/app/components/tools/mcp/mcp-service-card.tsx
+++ b/web/app/components/tools/mcp/mcp-service-card.tsx
@@ -24,7 +24,6 @@ import {
   useUpdateMCPServer,
 } from '@/service/use-tools'
 import { BlockEnum } from '@/app/components/workflow/types'
-import { getWorkflowEntryNode } from '@/app/components/workflow/utils/workflow-entry'
 import cn from '@/utils/classnames'
 import { fetchAppDetail } from '@/service/apps'
 
@@ -75,11 +74,11 @@ function MCPServiceCard({
   const serverPublished = !!id
   const serverActivated = status === 'active'
   const serverURL = serverPublished ? `${appInfo.api_base_url.replace('/v1', '')}/mcp/server/${server_code}/mcp` : '***********'
-  const hasEntryNode = getWorkflowEntryNode(currentWorkflow?.graph?.nodes || [])
-  const missingEntryNode = isWorkflowApp && !hasEntryNode
+  const hasStartNode = currentWorkflow?.graph?.nodes?.some(node => node.data.type === BlockEnum.Start)
+  const missingStartNode = isWorkflowApp && !hasStartNode
   const hasInsufficientPermissions = !isCurrentWorkspaceEditor
-  const toggleDisabled = hasInsufficientPermissions || appUnpublished || missingEntryNode
-  const isMinimalState = appUnpublished || missingEntryNode
+  const toggleDisabled = hasInsufficientPermissions || appUnpublished || missingStartNode
+  const isMinimalState = appUnpublished || missingStartNode
 
   const [activated, setActivated] = useState(serverActivated)
 

--- a/web/app/components/tools/mcp/mcp-service-card.tsx
+++ b/web/app/components/tools/mcp/mcp-service-card.tsx
@@ -26,6 +26,7 @@ import {
 import { BlockEnum } from '@/app/components/workflow/types'
 import cn from '@/utils/classnames'
 import { fetchAppDetail } from '@/service/apps'
+import { useDocLink } from '@/context/i18n'
 
 export type IAppCardProps = {
   appInfo: AppDetailResponse & Partial<AppSSO>
@@ -35,6 +36,7 @@ function MCPServiceCard({
   appInfo,
 }: IAppCardProps) {
   const { t } = useTranslation()
+  const docLink = useDocLink()
   const appId = appInfo.id
   const { mutateAsync: updateMCPServer } = useUpdateMCPServer()
   const { mutateAsync: refreshMCPServerCode, isPending: genLoading } = useRefreshMCPServerCode()
@@ -164,7 +166,28 @@ function MCPServiceCard({
                 </div>
               </div>
               <Tooltip
-                popupContent={appUnpublished ? t('tools.mcp.server.publishTip') : ''}
+                popupContent={
+                  toggleDisabled ? (
+                    appUnpublished ? (
+                      t('tools.mcp.server.publishTip')
+                    ) : missingStartNode ? (
+                      <>
+                        <div className="mb-1 text-xs font-normal text-text-secondary">
+                          {t('appOverview.overview.appInfo.enableTooltip.description')}
+                        </div>
+                        <div
+                          className="cursor-pointer text-xs font-normal text-text-accent hover:underline"
+                          onClick={() => window.open(docLink('/guides/workflow/node/start'), '_blank')}
+                        >
+                          {t('appOverview.overview.appInfo.enableTooltip.learnMore')}
+                        </div>
+                      </>
+                    ) : ''
+                  ) : ''
+                }
+                position="right"
+                popupClassName="w-58 max-w-60 rounded-xl border-[0.5px] p-3.5 shadow-lg backdrop-blur-[10px]"
+                offset={24}
               >
                 <div>
                   <Switch defaultValue={activated} onChange={onChangeStatus} disabled={toggleDisabled} />


### PR DESCRIPTION
## Summary

Fix the app card toggle enable logic to only allow workflows with Start nodes (user input) to be enabled, excluding trigger nodes (webhook, schedule, plugin).

### Changes
- Replace `getWorkflowEntryNode` logic with direct `BlockEnum.Start` check
- Update both `app-card.tsx` and `mcp-service-card.tsx` consistently  
- Remove unused `getWorkflowEntryNode` imports
- Rename variables from `hasEntryNode/missingEntryNode` to `hasStartNode/missingStartNode`

### Problem Fixed
Previously, workflows with only trigger nodes (webhook/schedule/plugin) could be enabled, but according to business logic, only workflows with actual user input (Start nodes) should be toggleable.

### Affected Components
- `web/app/components/app/overview/app-card.tsx` 
- `web/app/components/tools/mcp/mcp-service-card.tsx`

## Screenshots

| Before | After |
|--------|-------|
| Trigger nodes allowed toggle enable | Only Start nodes allow toggle enable |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods