### PR TITLE
fix(i18n): align zh-Hant indexMethodEconomyTip with zh-Hans

### DIFF
--- a/web/i18n/zh-Hant/dataset-settings.ts
+++ b/web/i18n/zh-Hant/dataset-settings.ts
@@ -16,7 +16,7 @@ const translation = {
     indexMethodHighQuality: '高質量',
     indexMethodHighQualityTip: '使用 Embedding 模型進行處理，以在使用者查詢時提供更高的準確度。',
     indexMethodEconomy: '經濟',
-    indexMethodEconomyTip: '使用離線的向量引擎、關鍵詞索引等方式，降低了準確度但無需花費 Token',
+    indexMethodEconomyTip: '每個區塊使用 10 個關鍵字進行檢索，不會消耗 tokens，但可能會降低檢索的準確度。',
     embeddingModel: 'Embedding 模型',
     embeddingModelTip: '修改 Embedding 模型，請去',
     embeddingModelTipLink: '設定',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #24931

This PR updates the Traditional Chinese (zh-Hant) translation for indexMethodEconomyTip in the i18n files to improve accuracy and consistency with the Simplified Chinese (zh-Hans) version.

The current zh-Hant text reads:

`使用離線的向量引擎、關鍵詞索引等方式，降低了準確度但無需花費 Token`

This is misleading because in this context the project does not use a vector engine, and the translation does not match the zh-Hans description. It could confuse users.

### Changes
The zh-Hant text has been updated to:

`每個區塊使用 10 個關鍵字進行檢索，不會消耗 tokens，但可能會降低檢索的準確度。`

## Screenshots

| Before | After |
|--------|-------|
| <img width="836" height="460" alt="截屏2025-09-02 09 34 38" src="https://github.com/user-attachments/assets/eee35847-8976-49dc-87bb-50052b0b636f" /> | <img width="835" height="460" alt="截屏2025-09-02 09 48 07" src="https://github.com/user-attachments/assets/3e8549bf-494a-45ca-a004-54d71e7a9cdf" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
