### PR TITLE
Fix: ensure InstalledApp deletion uses model instances instead of Row

### DIFF
--- a/api/controllers/console/admin.py
+++ b/api/controllers/console/admin.py
@@ -130,12 +130,16 @@ class InsertExploreAppApi(Resource):
             app.is_public = False
 
         with Session(db.engine) as session:
-            installed_apps = session.execute(
-                select(InstalledApp).where(
-                    InstalledApp.app_id == recommended_app.app_id,
-                    InstalledApp.tenant_id != InstalledApp.app_owner_tenant_id,
+            installed_apps = (
+                session.execute(
+                    select(InstalledApp).where(
+                        InstalledApp.app_id == recommended_app.app_id,
+                        InstalledApp.tenant_id != InstalledApp.app_owner_tenant_id,
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
 
             for installed_app in installed_apps:
                 session.delete(installed_app)

--- a/api/controllers/console/admin.py
+++ b/api/controllers/console/admin.py
@@ -135,10 +135,10 @@ class InsertExploreAppApi(Resource):
                     InstalledApp.app_id == recommended_app.app_id,
                     InstalledApp.tenant_id != InstalledApp.app_owner_tenant_id,
                 )
-            ).all()
+            ).scalars().all()
 
-        for installed_app in installed_apps:
-            db.session.delete(installed_app)
+            for installed_app in installed_apps:
+                session.delete(installed_app)
 
         db.session.delete(recommended_app)
         db.session.commit()

--- a/web/app/components/tools/setting/build-in/config-credentials.tsx
+++ b/web/app/components/tools/setting/build-in/config-credentials.tsx
@@ -111,7 +111,7 @@ const ConfigCredential: FC<Props> = ({
                       <Button onClick={onRemove}>{t('common.operation.remove')}</Button>
                     )
                   }
-                  < div className='flex space-x-2'>
+                  <div className='flex space-x-2'>
                     <Button onClick={onCancel}>{t('common.operation.cancel')}</Button>
                     <Button loading={isLoading || isSaving} disabled={isLoading || isSaving} variant='primary' onClick={handleSave}>{t('common.operation.save')}</Button>
                   </div>


### PR DESCRIPTION
Fixes #24943 
The delete API used `.all()`, which returns Row objects instead of model instances.
This caused `session.delete(installed_app)` to fail. Changed to `.scalars().all()` so it correctly returns InstalledApp instances and deletion works as expected.

This is a common pitfall when mixing SQLAlchemy 1.x and 2.0 styles.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
