### PR TITLE
feat: LLM prompt Jinja2 template now support more variables

### DIFF
--- a/web/app/components/workflow/nodes/llm/panel.tsx
+++ b/web/app/components/workflow/nodes/llm/panel.tsx
@@ -140,7 +140,7 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({
           <ConfigPrompt
             readOnly={readOnly}
             nodeId={id}
-            filterVar={filterInputVar}
+            filterVar={isShowVars ? filterJinja2InputVar : filterInputVar}
             isChatModel={isChatModel}
             isChatApp={isChatMode}
             isShowContext

--- a/web/app/components/workflow/nodes/llm/use-config.ts
+++ b/web/app/components/workflow/nodes/llm/use-config.ts
@@ -308,7 +308,7 @@ const useConfig = (id: string, payload: LLMNodeType) => {
   }, [])
 
   const filterJinja2InputVar = useCallback((varPayload: Var) => {
-    return [VarType.number, VarType.string, VarType.secret, VarType.arrayString, VarType.arrayNumber].includes(varPayload.type)
+    return [VarType.number, VarType.string, VarType.secret, VarType.arrayString, VarType.arrayNumber, VarType.arrayBoolean, VarType.arrayObject, VarType.object, VarType.array, VarType.boolean].includes(varPayload.type)
   }, [])
 
   const filterMemoryPromptVar = useCallback((varPayload: Var) => {


### PR DESCRIPTION
Fixes #24945
## Summary

This pull request updates the logic for filtering input variables in the LLM node configuration panel to support a wider range of variable types and improves how variable filtering is applied based on UI state.

**Improvements to variable filtering:**

* Expanded the `filterJinja2InputVar` function in `use-config.ts` to include additional variable types such as `arrayBoolean`, `arrayObject`, `object`, `array`, and `boolean`, allowing for more flexible prompt configuration.

**UI logic enhancement:**

* Updated the `Panel` component in `panel.tsx` to conditionally use `filterJinja2InputVar` or `filterInputVar` for filtering variables, depending on the `isShowVars` state, ensuring that the correct filtering logic is applied in different UI scenarios.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
