### PR TITLE
refactor: update radio component to handle boolean values instead of numeric

### DIFF
--- a/web/app/components/base/form/components/base/base-field.tsx
+++ b/web/app/components/base/form/components/base/base-field.tsx
@@ -103,12 +103,6 @@ const BaseField = ({
     })
   }, [values, show_on])
 
-  const booleanRadioValue = useMemo(() => {
-    if (value === null || value === undefined)
-      return undefined
-    return value ? 1 : 0
-  }, [value])
-
   if (!show)
     return null
 
@@ -215,11 +209,11 @@ const BaseField = ({
           formSchema.type === FormTypeEnum.boolean && (
             <Radio.Group
               className='flex w-fit items-center'
-              value={booleanRadioValue}
-              onChange={val => field.handleChange(val === 1)}
+              value={value}
+              onChange={v => field.handleChange(v)}
             >
-              <Radio value={1} className='!mr-1'>True</Radio>
-              <Radio value={0}>False</Radio>
+              <Radio value={true} className='!mr-1'>True</Radio>
+              <Radio value={false}>False</Radio>
             </Radio.Group>
           )
         }

--- a/web/app/components/base/radio/component/group/index.tsx
+++ b/web/app/components/base/radio/component/group/index.tsx
@@ -5,7 +5,7 @@ import cn from '@/utils/classnames'
 
 export type TRadioGroupProps = {
   children?: ReactNode | ReactNode[]
-  value?: string | number
+  value?: string | number | boolean
   className?: string
   onChange?: (value: any) => void
 }

--- a/web/app/components/base/radio/component/radio/index.tsx
+++ b/web/app/components/base/radio/component/radio/index.tsx
@@ -10,7 +10,7 @@ export type IRadioProps = {
   labelClassName?: string
   children?: string | ReactNode
   checked?: boolean
-  value?: string | number
+  value?: string | number | boolean
   disabled?: boolean
   onChange?: (e?: IRadioProps['value']) => void
 }

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/Form.tsx
@@ -284,11 +284,11 @@ function Form<
             </div>
             <Radio.Group
               className='flex items-center'
-              value={value[variable] === null ? undefined : (value[variable] ? 1 : 0)}
-              onChange={val => handleFormChange(variable, val === 1)}
+              value={value[variable]}
+              onChange={val => handleFormChange(variable, val)}
             >
-              <Radio value={1} className='!mr-1'>True</Radio>
-              <Radio value={0}>False</Radio>
+              <Radio value={true} className='!mr-1'>True</Radio>
+              <Radio value={false}>False</Radio>
             </Radio.Group>
           </div>
           {fieldMoreInfo?.(formSchema)}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/parameter-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/parameter-item.tsx
@@ -91,8 +91,8 @@ const ParameterItem: FC<ParameterItemProps> = ({
     numberInputRef.current!.value = `${num}`
   }
 
-  const handleRadioChange = (v: number) => {
-    handleInputChange(v === 1)
+  const handleRadioChange = (v: boolean) => {
+    handleInputChange(v)
   }
 
   const handleStringInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -187,11 +187,11 @@ const ParameterItem: FC<ParameterItemProps> = ({
       return (
         <Radio.Group
           className='flex w-[178px] items-center'
-          value={renderValue ? 1 : 0}
+          value={renderValue as boolean}
           onChange={handleRadioChange}
         >
-          <Radio value={1} className='w-[83px]'>True</Radio>
-          <Radio value={0} className='w-[83px]'>False</Radio>
+          <Radio value={true} className='w-[83px]'>True</Radio>
+          <Radio value={false} className='w-[83px]'>False</Radio>
         </Radio.Group>
       )
     }


### PR DESCRIPTION
Fixes https://github.com/langgenius/dify/issues/24964

## Summary

This pull request refactors how boolean values are handled in radio button components across the codebase, improving type safety and consistency. The main change is switching from using `1`/`0` (numbers) to `true`/`false` (booleans) for representing boolean values in radio groups and related handlers.

### Boolean Value Handling Improvements

* Updated all radio button components (`Radio.Group` and `Radio`) to use `true`/`false` instead of `1`/`0` for boolean fields, ensuring consistent and type-safe handling of boolean values in forms. 
* Removed unnecessary conversion logic (such as `booleanRadioValue` and value mapping) that previously mapped boolean values to numbers, simplifying the code. 

### Type Definitions

* Extended the `value` prop type for `Radio.Group` and `Radio` components to include `boolean`, making the components compatible with the new boolean value handling. 

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
