### PR TITLE
fix: API Key Authorization Configuration Model Form render default value

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-auth/hooks/use-model-form-schemas.ts
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/hooks/use-model-form-schemas.ts
@@ -65,7 +65,10 @@ export const useModelFormSchemas = (
   }, [formSchemas, t])
 
   const formValues = useMemo(() => {
-    let result = {}
+    let result: any = {}
+    formSchemas.forEach((schema) => {
+      result[schema.variable] = schema.default
+    })
     if (credential) {
       result = { ...result, __authorization_name__: credential?.credential_name }
       if (credentials)
@@ -74,7 +77,7 @@ export const useModelFormSchemas = (
     if (model)
       result = { ...result, __model_name: model?.model, __model_type: model?.model_type }
     return result
-  }, [credentials, credential, model])
+  }, [credentials, credential, model, formSchemas])
 
   return {
     formSchemas: formSchemasWithAuthorizationName,


### PR DESCRIPTION
Fixes #24960

## Summary

This pull request updates the logic in the `useModelFormSchemas` hook to ensure that form values are initialized from the schema defaults and that memoization properly reflects changes in the schema. These changes improve the reliability and correctness of form initialization for model authentication.

Form initialization improvements:

* Changed the initialization of `result` in the `formValues` calculation to populate default values from each entry in `formSchemas`, ensuring that all schema defaults are included in the form state.

Memoization fix:

* Updated the dependency array of the `useMemo` hook for `formValues` to include `formSchemas`, ensuring that changes to the schemas correctly update the form values.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
