### PR TITLE
fix: xxx is not bound to a Session

### DIFF
--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -453,7 +453,7 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
         # release database connection, because the following new thread operations may take a long time
         db.session.refresh(workflow)
         db.session.refresh(message)
-        db.session.refresh(user)
+        # db.session.refresh(user)
         db.session.close()
 
         # return response or stream generator

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -145,7 +145,10 @@ class AccountService:
         if naive_utc_now() - account.last_active_at > timedelta(minutes=10):
             account.last_active_at = naive_utc_now()
             db.session.commit()
-
+        # NOTE: make sure account is accessible outside of a db session
+        # This ensures that it will work correctly after upgrading to Flask version 3.1.2
+        db.session.refresh(account)
+        db.session.close()
         return account
 
     @staticmethod


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #24702
Fixes #24598
Fixes #24896 

Remarks：I have first tried to use `with Session(db.engine, expire_on_commit=False) as session:` to solve related issues, but it broken all AccountService-related test cases. 

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
