### PR TITLE
feat: make secretInput type field prevent browser auto-fill

### DIFF
--- a/web/app/components/base/form/components/base/base-field.tsx
+++ b/web/app/components/base/form/components/base/base-field.tsx
@@ -149,6 +149,7 @@ const BaseField = ({
               onBlur={field.handleBlur}
               disabled={disabled}
               placeholder={memorizedPlaceholder}
+              autoComplete={'new-password'}
             />
           )
         }


### PR DESCRIPTION
Fixes #24968

## Summary
This pull request introduces improvements to form handling in the model provider authentication flow and enhances input security in the base field component. The main changes focus on initializing form values for model schemas and updating input field properties for better user experience and security.

**Form value initialization and hook improvements:**

* Updated the logic in the `useModelFormSchemas` hook to initialize form values using the default values from each schema in `formSchemas`, ensuring that fields are properly pre-filled.
* Extended the dependency array for the memoization of form values to include `formSchemas`, so that changes to schemas correctly trigger updates to the computed form values.

**Input field security and user experience:**

* Added `autoComplete={'new-password'}` to the input field in `BaseField`, improving security by preventing browsers from autofilling sensitive fields with existing credentials.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
