### PR TITLE
fix: ensure the modal closed by level

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 import {
   memo,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
 } from 'react'
@@ -187,6 +188,20 @@ const ModelModal: FC<ModelModalProps> = ({
 
     return null
   }, [model, provider])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onCancel()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true)
+    }
+  }, [onCancel])
 
   return (
     <PortalToFollowElem open>


### PR DESCRIPTION
Fixes #24983 

## Summary
This pull request adds an enhancement to the `ModelModal` component to improve user experience. The most notable change is the addition of keyboard support for closing the modal using the Escape key.

**User experience improvements:**

* Added a `useEffect` hook to `ModelModal` that listens for the Escape key and triggers the `onCancel` callback, allowing users to close the modal with the keyboard.
* Imported `useEffect` from React to support the new keyboard event listener logic.

## Screenshots

| Before | After |
|--------|-------|
| ![Image](https://github.com/user-attachments/assets/564706fc-1fc9-49b6-9529-a0b5eebafa49) | ![CleanShot 2025-09-02 at 16 29 38](https://github.com/user-attachments/assets/83c5570c-2a31-4fbf-96ad-526ef032c76f)|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
