### PR TITLE
fix: refresh UI after user profile change

### DIFF
--- a/web/context/app-context.tsx
+++ b/web/context/app-context.tsx
@@ -86,10 +86,9 @@ export const AppContextProvider: FC<AppContextProviderProps> = ({ children }) =>
   const isCurrentWorkspaceEditor = useMemo(() => ['owner', 'admin', 'editor'].includes(currentWorkspace.role), [currentWorkspace.role])
   const isCurrentWorkspaceDatasetOperator = useMemo(() => currentWorkspace.role === 'dataset_operator', [currentWorkspace.role])
   const updateUserProfileAndVersion = useCallback(async () => {
-    if (userProfileResponse) {
+    if (userProfileResponse && !userProfileResponse.bodyUsed) {
       try {
-        const clonedResponse = (userProfileResponse as Response).clone()
-        const result = await clonedResponse.json()
+        const result = await userProfileResponse.json()
         setUserProfile(result)
         const current_version = userProfileResponse.headers.get('x-version')
         const current_env = process.env.NODE_ENV === 'development' ? 'DEVELOPMENT' : userProfileResponse.headers.get('x-env')


### PR DESCRIPTION
Fixes #24997 

## Summary

This pull request makes a small but important improvement to the user profile update logic in the `AppContextProvider` component. The change ensures that the user profile response is only processed if it hasn't already been used, preventing potential runtime errors and unnecessary response cloning.

* Improved robustness of the `updateUserProfileAndVersion` function in `web/context/app-context.tsx` by checking `bodyUsed` before parsing the response and removing unnecessary cloning of the response.
## Screenshots

| Before | After |
|--------|-------|
| ![CleanShot 2025-09-02 at 18 01 58](https://github.com/user-attachments/assets/61874b1c-f161-4cc2-bb0f-1502ffffa18a)| ![CleanShot 2025-09-02 at 18 00 05](https://github.com/user-attachments/assets/ff372991-5887-4f87-9258-3c25989a4ecf) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
