### PR TITLE
fix: remove unnecessary modal visibility toggle on error in name save

### DIFF
--- a/web/app/account/(commonLayout)/account-page/index.tsx
+++ b/web/app/account/(commonLayout)/account-page/index.tsx
@@ -69,7 +69,6 @@ export default function AccountPage() {
     }
     catch (e) {
       notify({ type: 'error', message: (e as Error).message })
-      setEditNameModalVisible(false)
       setEditing(false)
     }
   }


### PR DESCRIPTION
Fixes #25000 
## Summary
This pull request makes a minor update to the error handling logic in the `AccountPage` component. The change removes the call to `setEditNameModalVisible(false)` from the error handling block, so the edit name modal will no longer be closed automatically when an error occurs during the save operation.

## Screenshots

| Before | After |
|--------|-------|
| ![CleanShot 2025-09-02 at 18 17 59](https://github.com/user-attachments/assets/5283f148-6c2d-4f01-9457-2037a6679a64)| ![CleanShot 2025-09-02 at 18 18 40](https://github.com/user-attachments/assets/fd285778-025f-456b-8f1d-39a4ca54a35e) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
