### PR TITLE
fix: prevent workflow canvas clearing due to race condition and viewport errors

### DIFF
--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -44,7 +44,6 @@ export const useNodesSyncDraft = () => {
       // 2. Empty edges array along with empty nodes
       if (nodes.length === 0 && edges.length === 0 && x === 0 && y === 0 && zoom === 1) {
         // This appears to be an uninitialized React Flow state, skip sync to prevent data loss
-        console.warn('Skipping sync: React Flow appears uninitialized (empty nodes/edges with default viewport)')
         return null
       }
 

--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -37,7 +37,16 @@ export const useNodesSyncDraft = () => {
 
     if (appId) {
       const nodes = getNodes()
-      // Allow empty workflows - sync restrictions removed to support empty workflow editing
+
+      // Prevent syncing empty workflow if React Flow isn't properly initialized
+      // Check multiple indicators of uninitialized state:
+      // 1. Empty nodes with default viewport (x=0, y=0, zoom=1)
+      // 2. Empty edges array along with empty nodes
+      if (nodes.length === 0 && edges.length === 0 && x === 0 && y === 0 && zoom === 1) {
+        // This appears to be an uninitialized React Flow state, skip sync to prevent data loss
+        console.warn('Skipping sync: React Flow appears uninitialized (empty nodes/edges with default viewport)')
+        return null
+      }
 
       const features = featuresStore!.getState().features
       const producedNodes = produce(nodes, (draft) => {

--- a/web/app/components/workflow-app/hooks/use-workflow-refresh-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-refresh-draft.ts
@@ -19,7 +19,13 @@ export const useWorkflowRefreshDraft = () => {
     } = workflowStore.getState()
     setIsSyncingWorkflowDraft(true)
     fetchWorkflowDraft(`/apps/${appId}/workflows/draft`).then((response) => {
-      handleUpdateWorkflowCanvas(response.graph as WorkflowDataUpdater)
+      // Ensure we have a valid workflow structure with viewport
+      const workflowData: WorkflowDataUpdater = {
+        nodes: response.graph?.nodes || [],
+        edges: response.graph?.edges || [],
+        viewport: response.graph?.viewport || { x: 0, y: 0, zoom: 1 },
+      }
+      handleUpdateWorkflowCanvas(workflowData)
       setSyncWorkflowDraftHash(response.hash)
       setEnvSecrets((response.environment_variables || []).filter(env => env.value_type === 'secret').reduce((acc, env) => {
         acc[env.id] = env.value

--- a/web/app/components/workflow/hooks/use-workflow-interactions.ts
+++ b/web/app/components/workflow/hooks/use-workflow-interactions.ts
@@ -329,7 +329,10 @@ export const useWorkflowUpdate = () => {
         edges: initialEdges(edges, nodes),
       },
     } as any)
-    setViewport(viewport)
+
+    // Only set viewport if it exists and is valid
+    if (viewport && typeof viewport.x === 'number' && typeof viewport.y === 'number' && typeof viewport.zoom === 'number')
+      setViewport(viewport)
   }, [eventEmitter, reactflow])
 
   return {

--- a/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
@@ -177,7 +177,7 @@ const GenericTable: FC<GenericTableProps> = ({
               'h-6 rounded-none bg-transparent px-0 text-text-secondary',
               'hover:bg-transparent focus-visible:bg-transparent group-hover/simple-select:bg-transparent',
             )}
-            optionWrapClassName="w-26 min-w-26 z-[5] -ml-3"
+            optionWrapClassName="w-26 min-w-26 z-[60] -ml-3"
             notClearable
           />
         )


### PR DESCRIPTION
## Changes

Fixed race condition issues that caused workflow canvas to clear after publishing and refreshing:

### Modified Files:
1. **use-nodes-sync-draft.ts**: Added initialization state detection to prevent syncing empty workflow data
2. **use-workflow-interactions.ts**: Added viewport validation to prevent undefined property access errors  
3. **use-workflow-refresh-draft.ts**: Ensured complete data structure with default viewport values

### Problem Solved:
- Prevents canvas clearing after publish + refresh
- Fixes 'Cannot read properties of undefined (reading x)' viewport errors
- Reduces 400 HTTP errors from invalid sync requests

All changes are backward compatible with defensive programming approach.