### PR TITLE
chore: remove ty type checker from reformat script and pre-commit hooks

### DIFF
--- a/dev/reformat
+++ b/dev/reformat
@@ -14,8 +14,5 @@ uv run --directory api --dev ruff format ./
 # run dotenv-linter linter
 uv run --project api --dev dotenv-linter ./api/.env.example ./web/.env.example
 
-# run ty check
-dev/ty-check
-
 # run mypy check
 dev/mypy-check

--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -41,15 +41,6 @@ if $api_modified; then
       echo "Please run 'dev/reformat' to fix the fixable linting errors."
       exit 1
     fi
-
-    # run ty checks
-    uv run --directory api --dev ty check || status=$?
-    status=${status:-0}
-    if [ $status -ne 0 ]; then
-      echo "ty type checker on api module error, exit code: $status"
-      echo "Please run 'dev/ty-check' to check the type errors."
-      exit 1
-    fi
 fi
 
 if $web_modified; then


### PR DESCRIPTION
## Summary
- Remove ty type checker from `dev/reformat` script
- Remove ty type checker from `web/.husky/pre-commit` hook
- Keep mypy for critical type safety checks

## Motivation
The ty type checker is currently blocking developers from committing code in the early stages of this project. Since the project is not yet production-ready and may contain code that isn't fully covered by type annotations, enforcing strict type checking at the pre-commit stage creates a poor developer experience.

By removing ty from the automated checks while keeping mypy, we maintain type safety where it matters most while allowing more flexibility during the development phase.

Fixes #25020