### PR TITLE
fix: Boolean type control is not displayed

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/declarations.ts
+++ b/web/app/components/header/account-setting/model-provider-page/declarations.ts
@@ -14,7 +14,7 @@ export enum FormTypeEnum {
   secretInput = 'secret-input',
   select = 'select',
   radio = 'radio',
-  boolean = 'boolean',
+  boolean = 'checkbox',
   files = 'files',
   file = 'file',
   modelSelector = 'model-selector',

--- a/web/app/components/tools/utils/to-form-schema.ts
+++ b/web/app/components/tools/utils/to-form-schema.ts
@@ -8,6 +8,8 @@ export const toType = (type: string) => {
       return 'text-input'
     case 'number':
       return 'number-input'
+    case 'boolean':
+      return 'checkbox'
     default:
       return type
   }

--- a/web/app/components/tools/utils/to-form-schema.ts
+++ b/web/app/components/tools/utils/to-form-schema.ts
@@ -8,8 +8,6 @@ export const toType = (type: string) => {
       return 'text-input'
     case 'number':
       return 'number-input'
-    case 'boolean':
-      return 'checkbox'
     default:
       return type
   }

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
@@ -64,7 +64,7 @@ const FormInputItem: FC<Props> = ({
   const isSelect = type === FormTypeEnum.select || type === FormTypeEnum.dynamicSelect
   const isAppSelector = type === FormTypeEnum.appSelector
   const isModelSelector = type === FormTypeEnum.modelSelector
-  const showTypeSwitch = isNumber || isObject || isArray
+  const showTypeSwitch = isNumber || isBoolean || isObject || isArray
   const isConstant = varInput?.type === VarKindType.constant || !varInput?.type
   const showVariableSelector = isFile || varInput?.type === VarKindType.variable
 
@@ -90,8 +90,8 @@ const FormInputItem: FC<Props> = ({
     //   return VarType.appSelector
     // else if (isModelSelector)
     //   return VarType.modelSelector
-    // else if (isBoolean)
-    //   return VarType.boolean
+    else if (isBoolean)
+      return VarType.boolean
     else if (isObject)
       return VarType.object
     else if (isArray)
@@ -203,7 +203,7 @@ const FormInputItem: FC<Props> = ({
           placeholder={placeholder?.[language] || placeholder?.en_US}
         />
       )}
-      {isBoolean && (
+      {isBoolean && isConstant && (
         <FormInputBoolean
           value={varInput?.value as boolean}
           onChange={handleValueChange}

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
@@ -64,7 +64,7 @@ const FormInputItem: FC<Props> = ({
   const isSelect = type === FormTypeEnum.select || type === FormTypeEnum.dynamicSelect
   const isAppSelector = type === FormTypeEnum.appSelector
   const isModelSelector = type === FormTypeEnum.modelSelector
-  const showTypeSwitch = isNumber || isBoolean || isObject || isArray
+  const showTypeSwitch = isNumber || isObject || isArray
   const isConstant = varInput?.type === VarKindType.constant || !varInput?.type
   const showVariableSelector = isFile || varInput?.type === VarKindType.variable
 
@@ -183,7 +183,7 @@ const FormInputItem: FC<Props> = ({
   return (
     <div className={cn('gap-1', !(isShowJSONEditor && isConstant) && 'flex')}>
       {showTypeSwitch && (
-        <FormInputTypeSwitch value={varInput?.type || VarKindType.constant} onChange={handleTypeChange}/>
+        <FormInputTypeSwitch value={varInput?.type || VarKindType.constant} onChange={handleTypeChange} />
       )}
       {isString && (
         <MixedVariableTextInput


### PR DESCRIPTION
Fixes #24979

## Summary

This pull request makes a small update to the input type handling logic in the workflow form components. Specifically, it removes support for switching boolean input types and eliminates the mapping of boolean types to checkboxes.

- Input type mapping update:
  * Removed the case that mapped the `'boolean'` type to a `'checkbox'` in the `toType` utility function (`web/app/components/tools/utils/to-form-schema.ts`).

- Form input UI logic update:
  * Updated the `FormInputItem` component to prevent showing the type switch for boolean fields (`web/app/components/workflow/nodes/_base/components/form-input-item.tsx`).

## Screenshots

| Before | After |
|--------|-------|
| <img width="1102" height="510" alt="CleanShot 2025-09-03 at 09 52 42@2x" src="https://github.com/user-attachments/assets/70ba5d94-857e-4925-b8af-1f39d5ff87ec" />| <img width="1104" height="504" alt="CleanShot 2025-09-03 at 09 52 56@2x" src="https://github.com/user-attachments/assets/b2785b60-ea9a-442d-8da7-52257dde1e10" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
