### PR TITLE
fix: remove redundant z-index from Field component

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/field.tsx
+++ b/web/app/components/workflow/nodes/_base/components/field.tsx
@@ -38,7 +38,7 @@ const Field: FC<Props> = ({
     <div className={cn(className, inline && 'flex w-full items-center justify-between')}>
       <div
         onClick={() => supportFold && toggleFold()}
-        className={cn('sticky top-0 z-10 flex items-center justify-between bg-components-panel-bg', supportFold && 'cursor-pointer')}>
+        className={cn('sticky top-0 flex items-center justify-between bg-components-panel-bg', supportFold && 'cursor-pointer')}>
         <div className='flex h-6 items-center'>
           <div className={cn(isSubTitle ? 'system-xs-medium-uppercase text-text-tertiary' : 'system-sm-semibold-uppercase text-text-secondary')}>
             {title} {required && <span className='text-text-destructive'>*</span>}


### PR DESCRIPTION
Fixes #25033 

## Summary

This pull request makes a minor change to the `Field` component in `field.tsx`. It removes the `z-10` class from the container div, which previously set the stacking order of the element. This change may affect how the component layers with other elements on the page.

## Screenshots

| Before | After |
|--------|-------|
| ![CleanShot 2025-09-03 at 10 26 03](https://github.com/user-attachments/assets/324ad8a0-9898-4bcb-863d-5d40091f6530)| ![CleanShot 2025-09-03 at 10 30 51](https://github.com/user-attachments/assets/4ab0c132-9ac0-4ebd-998f-5a5e3c187df6)|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
