### PR TITLE
Fix: handle 204 No Content response in MCP client

### DIFF
--- a/api/core/mcp/client/streamable_client.py
+++ b/api/core/mcp/client/streamable_client.py
@@ -245,11 +245,11 @@ class StreamableHTTPTransport:
             if response.status_code == 202:
                 logger.debug("Received 202 Accepted")
                 return
-                
+
             if response.status_code == 204:
                 logger.debug("Received 204 No Content")
                 return
-                
+
             if response.status_code == 404:
                 if isinstance(message.root, JSONRPCRequest):
                     self._send_session_terminated_error(

--- a/api/core/mcp/client/streamable_client.py
+++ b/api/core/mcp/client/streamable_client.py
@@ -245,7 +245,11 @@ class StreamableHTTPTransport:
             if response.status_code == 202:
                 logger.debug("Received 202 Accepted")
                 return
-
+                
+            if response.status_code == 204:
+                logger.debug("Received 204 No Content")
+                return
+                
             if response.status_code == 404:
                 if isinstance(message.root, JSONRPCRequest):
                     self._send_session_terminated_error(


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR fixes an issue in the MCP client where HTTP 204 No Content responses are incorrectly processed as if they contained a body. According to the HTTP spec, 204 responses must not include a response body and typically omit the Content-Type header. 

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Changes
- Added an explicit check for `response.status_code == 204` in 
  `StreamableHTTPTransport._handle_post_request`.
- Return early to prevent attempts to read Content-Type or parse a body.

## Related Issue
Fixes #24962 

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
