### PR TITLE
chore: limit webhook status code 200~399

### DIFF
--- a/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
@@ -51,6 +51,7 @@ const Panel: FC<NodePanelProps<WebhookTriggerNodeType>> = ({
     handleParamsChange,
     handleBodyChange,
     handleStatusCodeChange,
+    handleStatusCodeBlur,
     handleResponseBodyChange,
     generateWebhookUrl,
   } = useConfig(id, data)
@@ -189,6 +190,7 @@ const Panel: FC<NodePanelProps<WebhookTriggerNodeType>> = ({
                 type="number"
                 value={inputs.status_code}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleStatusCodeChange(Number(e.target.value))}
+                onBlur={(e: React.FocusEvent<HTMLInputElement>) => handleStatusCodeBlur(Number(e.target.value))}
                 disabled={readOnly}
                 wrapperClassName="w-[120px]"
                 className="h-8"

--- a/web/app/components/workflow/nodes/trigger-webhook/use-config.ts
+++ b/web/app/components/workflow/nodes/trigger-webhook/use-config.ts
@@ -136,6 +136,15 @@ const useConfig = (id: string, payload: WebhookTriggerNodeType) => {
     }))
   }, [inputs, setInputs])
 
+  const handleStatusCodeBlur = useCallback((statusCode: number) => {
+    // Only clamp when user finishes editing (on blur)
+    const clampedStatusCode = Math.min(Math.max(statusCode, 200), 399)
+
+    setInputs(produce(inputs, (draft) => {
+      draft.status_code = clampedStatusCode
+    }))
+  }, [inputs, setInputs])
+
   const handleResponseBodyChange = useCallback((responseBody: string) => {
     setInputs(produce(inputs, (draft) => {
       draft.response_body = responseBody
@@ -182,6 +191,7 @@ const useConfig = (id: string, payload: WebhookTriggerNodeType) => {
     handleBodyChange,
     handleAsyncModeChange,
     handleStatusCodeChange,
+    handleStatusCodeBlur,
     handleResponseBodyChange,
     generateWebhookUrl,
   }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

the reponse code of webhook node should limit to 200~399

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
