### PR TITLE
Fix jsonschema compliance: use number instead of float

### DIFF
--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -258,5 +258,5 @@ def convert_input_form_to_parameters(
             parameters[item.variable]["type"] = "string"
             parameters[item.variable]["enum"] = item.options
         elif item.type == VariableEntityType.NUMBER:
-            parameters[item.variable]["type"] = "float"
+            parameters[item.variable]["type"] = "number"
     return parameters, required

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -1,7 +1,7 @@
 import json
-import jsonschema
 from unittest.mock import Mock, patch
 
+import jsonschema
 import pytest
 
 from core.app.app_config.entities import VariableEntity, VariableEntityType


### PR DESCRIPTION
Fixes #25048 

This PR fixes a schema bug where numeric parameters were incorrectly assigned type `float`. According to the JSON Schema specification (draft 2020-12), `float` is not a valid type. The correct type for both integers and floating-point values is `number`.

Ref: https://json-schema.org/understanding-json-schema/reference/numeric

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
