### PR TITLE
[Chore/Refactor] Update .gitignore to exclude pyrightconfig.json while preserving api/pyrightconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,8 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+pyrightconfig.json
+!api/pyrightconfig.json
 
 # Pyre type checker
 .pyre/


### PR DESCRIPTION
## Summary
- Update .gitignore to exclude pyrightconfig.json files throughout the repository
- Preserve api/pyrightconfig.json using negation pattern
- Aligns with project's transition from MyPy to Basedpyright for type checking

Fixes #25054