### PR TITLE
fix: missing key for translation path

### DIFF
--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -68,7 +68,7 @@ const StartBlocks = ({
             className='mb-2'
             type={block.type}
           />
-          <div className='system-md-medium mb-1 text-text-primary'>{block.title}</div>
+          <div className='system-md-medium mb-1 text-text-primary'>{t(`workflow.blockSelector.${block.type}`)}</div>
           <div className='system-xs-regular text-text-secondary'>{nodesExtraData[block.type].about}</div>
           {(block.type === BlockEnumValues.TriggerWebhook || block.type === BlockEnumValues.TriggerSchedule) && (
             <div className='system-xs-regular mb-1 mt-1 text-text-tertiary'>
@@ -87,7 +87,7 @@ const StartBlocks = ({
           type={block.type}
         />
         <div className='flex w-0 grow items-center justify-between text-sm text-text-secondary'>
-          <span className='truncate'>{block.title}</span>
+          <span className='truncate'>{t(`workflow.blockSelector.${block.type}`)}</span>
           {block.type === BlockEnumValues.Start && (
             <span className='system-xs-regular ml-2 shrink-0 text-text-quaternary'>{t('workflow.blocks.originalStartNode')}</span>
           )}

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -68,7 +68,12 @@ const StartBlocks = ({
             className='mb-2'
             type={block.type}
           />
-          <div className='system-md-medium mb-1 text-text-primary'>{t(`workflow.blockSelector.${block.type}`)}</div>
+          <div className='system-md-medium mb-1 text-text-primary'>
+            {block.type === BlockEnumValues.TriggerWebhook
+              ? t('workflow.customWebhook')
+              : t(`workflow.blocks.${block.type}`)
+            }
+          </div>
           <div className='system-xs-regular text-text-secondary'>{nodesExtraData[block.type].about}</div>
           {(block.type === BlockEnumValues.TriggerWebhook || block.type === BlockEnumValues.TriggerSchedule) && (
             <div className='system-xs-regular mb-1 mt-1 text-text-tertiary'>

--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -87,7 +87,7 @@ const StartBlocks = ({
           type={block.type}
         />
         <div className='flex w-0 grow items-center justify-between text-sm text-text-secondary'>
-          <span className='truncate'>{t(`workflow.blockSelector.${block.type}`)}</span>
+          <span className='truncate'>{t(`workflow.blocks.${block.type}`)}</span>
           {block.type === BlockEnumValues.Start && (
             <span className='system-xs-regular ml-2 shrink-0 text-text-quaternary'>{t('workflow.blocks.originalStartNode')}</span>
           )}

--- a/web/app/components/workflow/nodes/trigger-schedule/constants.ts
+++ b/web/app/components/workflow/nodes/trigger-schedule/constants.ts
@@ -1,6 +1,5 @@
 import type { ScheduleTriggerNodeType } from './types'
 
-// Unified default values for trigger schedule
 export const getDefaultScheduleConfig = (): Partial<ScheduleTriggerNodeType> => ({
   mode: 'visual',
   frequency: 'weekly',

--- a/web/app/components/workflow/nodes/trigger-schedule/types.ts
+++ b/web/app/components/workflow/nodes/trigger-schedule/types.ts
@@ -5,16 +5,16 @@ export type ScheduleMode = 'visual' | 'cron'
 export type ScheduleFrequency = 'hourly' | 'daily' | 'weekly' | 'monthly'
 
 export type VisualConfig = {
-  time?: string // User timezone time format: "2:30 PM"
-  weekdays?: string[] // ['mon', 'tue', 'wed'] for weekly frequency
-  on_minute?: number // 0-59 for hourly frequency
-  monthly_days?: (number | 'last')[] // [1, 15, 'last'] for monthly frequency
+  time?: string
+  weekdays?: string[]
+  on_minute?: number
+  monthly_days?: (number | 'last')[]
 }
 
 export type ScheduleTriggerNodeType = CommonNodeType & {
-  mode: ScheduleMode // 'visual' or 'cron' configuration mode
-  frequency: ScheduleFrequency // 'hourly' | 'daily' | 'weekly' | 'monthly'
-  cron_expression?: string // Cron expression when mode is 'cron'
-  visual_config?: VisualConfig // User-friendly configuration when mode is 'visual'
-  timezone: string // User profile timezone (e.g., 'Asia/Shanghai', 'America/New_York')
+  mode: ScheduleMode
+  frequency: ScheduleFrequency
+  cron_expression?: string
+  visual_config?: VisualConfig
+  timezone: string
 }

--- a/web/app/components/workflow/nodes/trigger-webhook/default.ts
+++ b/web/app/components/workflow/nodes/trigger-webhook/default.ts
@@ -30,7 +30,7 @@ const nodeDefault: NodeDefault<WebhookTriggerNodeType> = {
     if (!payload.webhook_url) {
       return {
         isValid: false,
-        errorMessage: t('workflow.nodes.webhook.validation.webhookUrlRequired'),
+        errorMessage: t('workflow.nodes.triggerWebhook.validation.webhookUrlRequired'),
       }
     }
 
@@ -45,7 +45,7 @@ const nodeDefault: NodeDefault<WebhookTriggerNodeType> = {
       if (!isValidParameterType(param.type)) {
         return {
           isValid: false,
-          errorMessage: t('workflow.nodes.webhook.validation.invalidParameterType', {
+          errorMessage: t('workflow.nodes.triggerWebhook.validation.invalidParameterType', {
             name: param.name,
             type: param.type,
           }),

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -280,12 +280,7 @@ const translation = {
     'trigger-webhook': 'Webhook Trigger',
     'trigger-plugin': 'Plugin Trigger',
   },
-  blockSelector: {
-    'start': 'User Input',
-    'trigger-schedule': 'Schedule Trigger',
-    'trigger-webhook': 'Custom Webhook',
-    'trigger-plugin': 'Plugin Trigger',
-  },
+  customWebhook: 'Custom Webhook',
   blocksAbout: {
     'start': 'Define the initial parameters for launching a workflow',
     'end': 'Define the end and result type of a workflow',

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -1028,6 +1028,10 @@ const translation = {
       responseBody: 'Response Body',
       responseBodyPlaceholder: 'Write your response body here',
       headers: 'Headers',
+      validation: {
+        webhookUrlRequired: 'Webhook URL is required',
+        invalidParameterType: 'Invalid parameter type "{{type}}" for parameter "{{name}}"',
+      },
     },
   },
   triggerStatus: {

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -280,6 +280,12 @@ const translation = {
     'trigger-webhook': 'Webhook Trigger',
     'trigger-plugin': 'Plugin Trigger',
   },
+  blockSelector: {
+    'start': 'User Input',
+    'trigger-schedule': 'Schedule Trigger',
+    'trigger-webhook': 'Custom Webhook',
+    'trigger-plugin': 'Plugin Trigger',
+  },
   blocksAbout: {
     'start': 'Define the initial parameters for launching a workflow',
     'end': 'Define the end and result type of a workflow',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -280,12 +280,7 @@ const translation = {
     'trigger-webhook': 'Webhook トリガー',
     'trigger-schedule': 'スケジュールトリガー',
   },
-  blockSelector: {
-    'start': 'ユーザー入力',
-    'trigger-schedule': 'スケジュールトリガー',
-    'trigger-webhook': 'カスタムWebhook',
-    'trigger-plugin': 'プラグイントリガー',
-  },
+  customWebhook: 'カスタムWebhook',
   blocksAbout: {
     'start': 'ワークフロー開始時の初期パラメータを定義します。',
     'end': 'ワークフローの終了条件と結果のタイプを定義します。',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -1028,6 +1028,10 @@ const translation = {
       responseBody: 'レスポンスボディ',
       responseBodyPlaceholder: 'ここにレスポンスボディを入力してください',
       headers: 'ヘッダー',
+      validation: {
+        webhookUrlRequired: 'Webhook URLが必要です',
+        invalidParameterType: 'パラメータ"{{name}}"の無効なパラメータタイプ"{{type}}"です',
+      },
     },
   },
   tracing: {

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -253,7 +253,7 @@ const translation = {
     'start': '始める',
   },
   blocks: {
-    'start': '開始',
+    'start': 'ユーザー入力',
     'originalStartNode': '元の開始ノード',
     'end': '終了',
     'answer': '回答',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -280,6 +280,12 @@ const translation = {
     'trigger-webhook': 'Webhook トリガー',
     'trigger-schedule': 'スケジュールトリガー',
   },
+  blockSelector: {
+    'start': 'ユーザー入力',
+    'trigger-schedule': 'スケジュールトリガー',
+    'trigger-webhook': 'カスタムWebhook',
+    'trigger-plugin': 'プラグイントリガー',
+  },
   blocksAbout: {
     'start': 'ワークフロー開始時の初期パラメータを定義します。',
     'end': 'ワークフローの終了条件と結果のタイプを定義します。',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -1028,6 +1028,10 @@ const translation = {
       responseBody: '响应体',
       responseBodyPlaceholder: '在此输入您的响应体',
       headers: 'Headers',
+      validation: {
+        webhookUrlRequired: '需要提供Webhook URL',
+        invalidParameterType: '参数"{{name}}"的参数类型"{{type}}"无效',
+      },
     },
   },
   tracing: {

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -253,7 +253,7 @@ const translation = {
     'start': '开始',
   },
   blocks: {
-    'start': '开始',
+    'start': '用户输入',
     'originalStartNode': '原始开始节点',
     'end': '结束',
     'answer': '直接回复',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -280,12 +280,7 @@ const translation = {
     'trigger-schedule': '定时触发器',
     'trigger-plugin': '插件触发器',
   },
-  blockSelector: {
-    'start': '用户输入',
-    'trigger-schedule': '定时触发器',
-    'trigger-webhook': '自定义 Webhook',
-    'trigger-plugin': '插件触发器',
-  },
+  customWebhook: '自定义 Webhook',
   blocksAbout: {
     'start': '定义一个 workflow 流程启动的初始参数',
     'end': '定义一个 workflow 流程的结束和结果类型',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -280,6 +280,12 @@ const translation = {
     'trigger-schedule': '定时触发器',
     'trigger-plugin': '插件触发器',
   },
+  blockSelector: {
+    'start': '用户输入',
+    'trigger-schedule': '定时触发器',
+    'trigger-webhook': '自定义 Webhook',
+    'trigger-plugin': '插件触发器',
+  },
   blocksAbout: {
     'start': '定义一个 workflow 流程启动的初始参数',
     'end': '定义一个 workflow 流程的结束和结果类型',


### PR DESCRIPTION
## Summary

This PR addresses several translation and internationalization issues in the workflow trigger system:

**Key Fixes:**
1. **Missing validation translations** - Added missing webhookUrlRequired and invalidParameterType translation keys that were causing display issues
2. **Incorrect translation paths** - Fixed wrong translation key paths from workflow.nodes.webhook to workflow.nodes.triggerWebhook 
3. **Block selector improvements** - Enhanced tooltip display for webhook trigger to show 'Custom Webhook' while maintaining 'Webhook Trigger' in selection list
4. **Translation consistency** - Unified start block translations across languages to properly reflect 'User Input' meaning

**Technical Approach:**
- Used minimal code changes with conditional logic instead of creating redundant translation structures
- Maintained existing architecture (TriggerPlugin continues using dedicated selector)
- Applied consistent translation patterns across EN/ZH/JP languages

The changes ensure proper internationalization of workflow trigger validation messages and improve user experience with clearer, consistent naming.

## Screenshots

| Before | After |
|--------|-------|
|<img width="429" height="183" alt="image" src="https://github.com/user-attachments/assets/f60a52c0-49c1-43f4-a3de-ca326d44e330" />|<img width="425" height="159" alt="image" src="https://github.com/user-attachments/assets/072a855e-d14e-458a-81ed-c7966eac286c" />|
| |<img width="239" height="159" alt="image" src="https://github.com/user-attachments/assets/097086a8-e360-424b-b87d-b2671e05ac89" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran dev/reformat(backend) and cd web && npx lint-staged(frontend) to appease the lint gods