### PR TITLE
chore: Updated pnpm version to 10.15.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "dify-web",
   "version": "1.8.0",
   "private": true,
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@10.15.1",
   "engines": {
     "node": ">=v22.11.0"
   },


### PR DESCRIPTION
## Summary

This pull request includes a minor update to the `web/package.json` file, bumping the `pnpm` package manager version from 10.15.0 to 10.15.1. This ensures compatibility with the latest bug fixes and improvements in `pnpm`.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
