### PR TITLE
chore: validate param type of application/json when call a webhook

### DIFF
--- a/api/controllers/trigger/webhook.py
+++ b/api/controllers/trigger/webhook.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import jsonify
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import NotFound
 
 from controllers.trigger import bp
 from services.webhook_service import WebhookService
@@ -28,7 +28,7 @@ def handle_webhook(webhook_id: str):
         # Validate request against node configuration
         validation_result = WebhookService.validate_webhook_request(webhook_data, node_config)
         if not validation_result["valid"]:
-            raise BadRequest(validation_result["error"])
+            return jsonify({"error": "Bad Request", "message": validation_result["error"]}), 400
 
         # Process webhook call (send to Celery)
         WebhookService.trigger_workflow_execution(webhook_trigger, webhook_data, workflow)

--- a/api/core/workflow/nodes/trigger_webhook/entities.py
+++ b/api/core/workflow/nodes/trigger_webhook/entities.py
@@ -35,7 +35,17 @@ class WebhookBodyParameter(BaseModel):
     """Body parameter with type information."""
 
     name: str
-    type: Literal["string", "number", "boolean", "object", "array", "file"] = "string"
+    type: Literal[
+        "string",
+        "number",
+        "boolean",
+        "object",
+        "array[string]",
+        "array[number]",
+        "array[boolean]",
+        "array[object]",
+        "file",
+    ] = "string"
     required: bool = False
 
 

--- a/api/services/webhook_service.py
+++ b/api/services/webhook_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from core.file.models import FileTransferMethod
 from core.tools.tool_file_manager import ToolFileManager
+from core.variables.types import SegmentType
 from extensions.ext_database import db
 from factories import file_factory
 from models.account import Account, TenantAccountJoin, TenantAccountRole
@@ -186,7 +187,7 @@ class WebhookService:
                     param_name = param.get("name", "")
                     if param_name not in webhook_data["query_params"]:
                         return {"valid": False, "error": f"Required query parameter missing: {param_name}"}
-            
+
             if configured_content_type == "text/plain":
                 # For text/plain, just validate that we have a body if any body params are configured as required
                 body_params = node_data.get("body", [])
@@ -195,27 +196,136 @@ class WebhookService:
                     raw_content = body_data.get("raw", "")
                     if not raw_content or not isinstance(raw_content, str):
                         return {"valid": False, "error": "Required body content missing for text/plain request"}
+
+            elif configured_content_type == "application/json":
+                # For application/json, validate both existence and types of parameters
+                body_params = node_data.get("body", [])
+                body_data = webhook_data.get("body", {})
+
+                for body_param in body_params:
+                    param_name = body_param.get("name", "")
+                    param_type = body_param.get("type", SegmentType.STRING)
+                    is_required = body_param.get("required", False)
+
+                    # Handle regular JSON parameters
+                    param_exists = param_name in body_data
+
+                    # Check if required parameter exists
+                    if is_required and not param_exists:
+                        return {"valid": False, "error": f"Required body parameter missing: {param_name}"}
+
+                    # Validate parameter type if it exists
+                    if param_exists:
+                        param_value = body_data[param_name]
+                        validation_result = cls._validate_json_parameter_type(param_name, param_value, param_type)
+                        if not validation_result["valid"]:
+                            return validation_result
+
             else:
+                # For other content types (multipart/form-data, application/x-www-form-urlencoded, etc.)
+                # Only validate existence of required parameters, no type validation
                 body_params = node_data.get("body", [])
                 for body_param in body_params:
-                    if body_param.get("required", False):
-                        param_name = body_param.get("name", "")
-                        param_type = body_param.get("type", "string")
+                    param_name = body_param.get("name", "")
+                    param_type = body_param.get("type", SegmentType.STRING)
+                    is_required = body_param.get("required", False)
 
-                        # Check if parameter exists
-                        if param_type == "file":
-                            file_obj = webhook_data.get("files", {}).get(param_name)
-                            if not file_obj:
-                                return {"valid": False, "error": f"Required file parameter missing: {param_name}"}
-                        else:
-                            if param_name not in webhook_data.get("body", {}):
-                                return {"valid": False, "error": f"Required body parameter missing: {param_name}"}
+                    if not is_required:
+                        continue
+
+                    # Check if parameter exists
+                    if param_type == SegmentType.FILE:
+                        file_obj = webhook_data.get("files", {}).get(param_name)
+                        if not file_obj:
+                            return {"valid": False, "error": f"Required file parameter missing: {param_name}"}
+                    else:
+                        body_data = webhook_data.get("body", {})
+                        if param_name not in body_data:
+                            return {"valid": False, "error": f"Required body parameter missing: {param_name}"}
 
             return {"valid": True}
 
         except Exception:
             logger.exception("Validation error")
             return {"valid": False, "error": "Validation failed"}
+
+    @classmethod
+    def _validate_json_parameter_type(cls, param_name: str, param_value: Any, param_type: str) -> dict[str, Any]:
+        """Validate JSON parameter type against expected type."""
+        try:
+            if param_type == SegmentType.STRING:
+                if not isinstance(param_value, str):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be a string, got {type(param_value).__name__}",
+                    }
+
+            elif param_type == SegmentType.NUMBER:
+                if not isinstance(param_value, (int, float)):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be a number, got {type(param_value).__name__}",
+                    }
+
+            elif param_type == SegmentType.BOOLEAN:
+                if not isinstance(param_value, bool):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be a boolean, got {type(param_value).__name__}",
+                    }
+
+            elif param_type == SegmentType.OBJECT:
+                if not isinstance(param_value, dict):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be an object, got {type(param_value).__name__}",
+                    }
+
+            elif param_type == SegmentType.ARRAY_STRING:
+                if not isinstance(param_value, list):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be an array, got {type(param_value).__name__}",
+                    }
+                if not all(isinstance(item, str) for item in param_value):
+                    return {"valid": False, "error": f"Parameter '{param_name}' must be an array of strings"}
+
+            elif param_type == SegmentType.ARRAY_NUMBER:
+                if not isinstance(param_value, list):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be an array, got {type(param_value).__name__}",
+                    }
+                if not all(isinstance(item, (int, float)) for item in param_value):
+                    return {"valid": False, "error": f"Parameter '{param_name}' must be an array of numbers"}
+
+            elif param_type == SegmentType.ARRAY_BOOLEAN:
+                if not isinstance(param_value, list):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be an array, got {type(param_value).__name__}",
+                    }
+                if not all(isinstance(item, bool) for item in param_value):
+                    return {"valid": False, "error": f"Parameter '{param_name}' must be an array of booleans"}
+
+            elif param_type == SegmentType.ARRAY_OBJECT:
+                if not isinstance(param_value, list):
+                    return {
+                        "valid": False,
+                        "error": f"Parameter '{param_name}' must be an array, got {type(param_value).__name__}",
+                    }
+                if not all(isinstance(item, dict) for item in param_value):
+                    return {"valid": False, "error": f"Parameter '{param_name}' must be an array of objects"}
+
+            else:
+                # Unknown type, skip validation
+                logger.warning("Unknown parameter type: %s for parameter %s", param_type, param_name)
+
+            return {"valid": True}
+
+        except Exception:
+            logger.exception("Type validation error for parameter %s", param_name)
+            return {"valid": False, "error": f"Type validation failed for parameter '{param_name}'"}
 
     @classmethod
     def trigger_workflow_execution(

--- a/api/tests/unit_tests/services/test_webhook_service.py
+++ b/api/tests/unit_tests/services/test_webhook_service.py
@@ -202,7 +202,7 @@ class TestWebhookServiceUnit:
         result = WebhookService.validate_webhook_request(webhook_data, node_config)
 
         assert result["valid"] is False
-        assert "Required file parameter missing: upload" in result["error"]
+        assert "Required body parameter missing: upload" in result["error"]
 
     def test_validate_webhook_request_text_plain_with_required_body(self):
         """Test webhook validation for text/plain content type with required body content."""
@@ -465,14 +465,14 @@ class TestWebhookServiceUnit:
     def test_validate_json_parameter_type_bool(self):
         """Test JSON parameter type validation for boolean type."""
         # Valid boolean
-        result = WebhookService._validate_json_parameter_type("enabled", True, "bool")
+        result = WebhookService._validate_json_parameter_type("enabled", True, "boolean")
         assert result["valid"] is True
 
-        result = WebhookService._validate_json_parameter_type("enabled", False, "bool")
+        result = WebhookService._validate_json_parameter_type("enabled", False, "boolean")
         assert result["valid"] is True
 
         # Invalid boolean (string)
-        result = WebhookService._validate_json_parameter_type("enabled", "true", "bool")
+        result = WebhookService._validate_json_parameter_type("enabled", "true", "boolean")
         assert result["valid"] is False
         assert "must be a boolean, got str" in result["error"]
 
@@ -517,11 +517,11 @@ class TestWebhookServiceUnit:
     def test_validate_json_parameter_type_array_bool(self):
         """Test JSON parameter type validation for array[bool] type."""
         # Valid array of booleans
-        result = WebhookService._validate_json_parameter_type("flags", [True, False, True], "array[bool]")
+        result = WebhookService._validate_json_parameter_type("flags", [True, False, True], "array[boolean]")
         assert result["valid"] is True
 
         # Invalid - array with non-booleans
-        result = WebhookService._validate_json_parameter_type("flags", [True, "false", True], "array[bool]")
+        result = WebhookService._validate_json_parameter_type("flags", [True, "false", True], "array[boolean]")
         assert result["valid"] is False
         assert "must be an array of booleans" in result["error"]
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<img width="408" height="489" alt="image" src="https://github.com/user-attachments/assets/5ac8b4e3-bc60-4d7c-bb95-7a02dfc3f476" />

the request body data of webhook call must match the node config

<img width="557" height="432" alt="image" src="https://github.com/user-attachments/assets/f836bc44-abf0-40d5-b329-75c002239c83" />


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
