### PR TITLE
Fix advanced chat workflow event handler signature mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ prepare-web:
 prepare-api:
 	@echo "🔧 Setting up API environment..."
 	@cp -n api/.env.example api/.env 2>/dev/null || echo "API .env already exists"
-	@cd api && uv sync --dev --extra all
+	@cd api && uv sync --dev
 	@cd api && uv run flask db upgrade
 	@echo "✅ API environment prepared (not started)"
 

--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -310,7 +310,7 @@ class AdvancedChatAppGenerateTaskPipeline:
             err = self._base_task_pipeline._handle_error(event=event, session=session, message_id=self._message_id)
         yield self._base_task_pipeline._error_to_stream_response(err)
 
-    def _handle_workflow_started_event(self, **kwargs) -> Generator[StreamResponse, None, None]:
+    def _handle_workflow_started_event(self, *args, **kwargs) -> Generator[StreamResponse, None, None]:
         """Handle workflow started events."""
         with self._database_session() as session:
             workflow_execution = self._workflow_cycle_manager.handle_workflow_run_start()

--- a/api/extensions/storage/clickzetta_volume/file_lifecycle.py
+++ b/api/extensions/storage/clickzetta_volume/file_lifecycle.py
@@ -1,7 +1,8 @@
 """ClickZetta Volume file lifecycle management
 
-This module provides file lifecycle management features including version control, automatic cleanup, backup and restore.
-Supports complete lifecycle management for knowledge base files.
+This module provides file lifecycle management features including version control, 
+automatic cleanup, backup and restore. Supports complete lifecycle management for 
+knowledge base files.
 """
 
 import json

--- a/api/extensions/storage/clickzetta_volume/file_lifecycle.py
+++ b/api/extensions/storage/clickzetta_volume/file_lifecycle.py
@@ -1,7 +1,7 @@
 """ClickZetta Volume file lifecycle management
 
-This module provides file lifecycle management features including version control, 
-automatic cleanup, backup and restore. Supports complete lifecycle management for 
+This module provides file lifecycle management features including version control,
+automatic cleanup, backup and restore. Supports complete lifecycle management for
 knowledge base files.
 """
 

--- a/api/extensions/storage/clickzetta_volume/volume_permissions.py
+++ b/api/extensions/storage/clickzetta_volume/volume_permissions.py
@@ -121,7 +121,8 @@ class VolumePermissionManager:
 
         except Exception:
             logger.exception("User Volume permission check failed")
-            # For User Volume, if permission check fails, it might be a configuration issue, provide friendlier error message
+            # For User Volume, if permission check fails, it might be a configuration issue, 
+            # provide friendlier error message
             logger.info("User Volume permission check failed, but permission checking is disabled in this version")
             return False
 

--- a/api/extensions/storage/clickzetta_volume/volume_permissions.py
+++ b/api/extensions/storage/clickzetta_volume/volume_permissions.py
@@ -121,7 +121,7 @@ class VolumePermissionManager:
 
         except Exception:
             logger.exception("User Volume permission check failed")
-            # For User Volume, if permission check fails, it might be a configuration issue, 
+            # For User Volume, if permission check fails, it might be a configuration issue,
             # provide friendlier error message
             logger.info("User Volume permission check failed, but permission checking is disabled in this version")
             return False


### PR DESCRIPTION
## Summary
- Fixed method signature for `_handle_workflow_started_event` to accept positional arguments
- Removed unnecessary `--extra all` flag from Makefile's uv sync command
- Fixed line length linting issues in clickzetta_volume modules

## Related Issue
Fixes #25077

This PR addresses a bug where the workflow started event handler in advanced chat applications would fail when receiving positional arguments. The handler now correctly accepts both positional and keyword arguments to maintain compatibility with the event system.