### PR TITLE
fix: docker image version 1.8.1

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -31,7 +31,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.8.0
+    image: langgenius/dify-api:1.8.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -58,7 +58,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.8.0
+    image: langgenius/dify-api:1.8.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -76,7 +76,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.8.0
+    image: langgenius/dify-web:1.8.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -611,7 +611,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.8.0
+    image: langgenius/dify-api:1.8.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -638,7 +638,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.8.0
+    image: langgenius/dify-api:1.8.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -656,7 +656,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.8.0
+    image: langgenius/dify-web:1.8.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}


### PR DESCRIPTION

## Summary
This pull request updates the Docker images used for the worker, worker_beat, and web services in both `docker/docker-compose.yaml` and `docker/docker-compose-template.yaml` files to use the latest available versions. This ensures that the deployment uses the most recent features, bug fixes, and security patches from upstream.

**Docker image version updates:**

* Updated the `worker` and `worker_beat` services to use `langgenius/dify-api:1.8.1` instead of `1.8.0` in both `docker/docker-compose.yaml` and `docker/docker-compose-template.yaml`. [[1]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L614-R614) [[2]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L641-R641) [[3]](diffhunk://#diff-c10b8634ea28f21ad4ecd98ea72cbaaa41a915ddd7cb7d2d32a2359b77b9933aL34-R34) [[4]](diffhunk://#diff-c10b8634ea28f21ad4ecd98ea72cbaaa41a915ddd7cb7d2d32a2359b77b9933aL61-R61)
* Updated the `web` service to use `langgenius/dify-web:1.8.1` instead of `1.8.0` in both `docker/docker-compose.yaml` and `docker/docker-compose-template.yaml`. [[1]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L659-R659) [[2]](diffhunk://#diff-c10b8634ea28f21ad4ecd98ea72cbaaa41a915ddd7cb7d2d32a2359b77b9933aL79-R79)

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
