### PR TITLE
chore: enhance basedpyright-check script to support path arguments

### DIFF
--- a/dev/basedpyright-check
+++ b/dev/basedpyright-check
@@ -5,5 +5,12 @@ set -x
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 cd "$SCRIPT_DIR/.."
 
+# Get the path argument if provided
+PATH_TO_CHECK="$1"
+
 # run basedpyright checks
-uv run --directory api --dev basedpyright
+if [ -n "$PATH_TO_CHECK" ]; then
+    uv run --directory api --dev basedpyright "$PATH_TO_CHECK"
+else
+    uv run --directory api --dev basedpyright
+fi


### PR DESCRIPTION
## Summary
- Add support for passing specific file or directory paths to the basedpyright-check script
- Maintain backward compatibility when no arguments are provided
- Enable developers to run targeted type checks for improved workflow efficiency

This enhancement allows developers to check specific files or directories by running:
```bash
./dev/basedpyright-check path/to/file.py
```

While preserving the existing behavior when no arguments are passed:
```bash
./dev/basedpyright-check  # checks entire codebase
```

Fixes #25107