### PR TITLE
fix: TypeSelector component style

### DIFF
--- a/web/app/components/app/configuration/config-var/config-modal/type-select.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/type-select.tsx
@@ -54,7 +54,7 @@ const TypeSelector: FC<Props> = ({
             <InputVarTypeIcon type={selectedItem?.value as InputVarType} className='size-4 shrink-0 text-text-secondary' />
             <span
               className={`
-              ml-1.5 ${!selectedItem?.name && 'text-components-input-text-placeholder'}
+              ml-1.5 text-components-input-text-filled ${!selectedItem?.name && 'text-components-input-text-placeholder'}
             `}
             >
               {selectedItem?.name}


### PR DESCRIPTION
Fixes #25123

## Summary
This pull request makes a minor UI update to the `TypeSelector` component in the `type-select.tsx` file. The change improves the visual styling of the selected item's text by ensuring it uses the correct filled text color class.

* Updated the `span` element in `TypeSelector` to always include the `text-components-input-text-filled` class, ensuring consistent styling for filled input text.

## Screenshots

| Before | After |
|--------|-------|
| <img width="482" height="584" alt="image" src="https://github.com/user-attachments/assets/1b8174e5-8375-415e-a27e-79d484b4bb6f" />| <img width="499" height="594" alt="image" src="https://github.com/user-attachments/assets/b06ad8e9-631c-4cce-bb38-d6c90c6c7bd3" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
