### PR TITLE
fix:  EndUser not bound to Session when plugin invokes callback

### DIFF
--- a/api/core/plugin/backwards_invocation/app.py
+++ b/api/core/plugin/backwards_invocation/app.py
@@ -2,6 +2,7 @@ from collections.abc import Generator, Mapping
 from typing import Optional, Union
 
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from controllers.service_api.wraps import create_or_update_end_user_for_user_id
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
@@ -194,11 +195,12 @@ class PluginAppBackwardsInvocation(BaseBackwardsInvocation):
         """
         get the user by user id
         """
-        stmt = select(EndUser).where(EndUser.id == user_id)
-        user = db.session.scalar(stmt)
-        if not user:
-            stmt = select(Account).where(Account.id == user_id)
-            user = db.session.scalar(stmt)
+        with Session(db.engine, expire_on_commit=False) as session:
+            stmt = select(EndUser).where(EndUser.id == user_id)
+            user = session.scalar(stmt)
+            if not user:
+                stmt = select(Account).where(Account.id == user_id)
+                user = session.scalar(stmt)
 
         if not user:
             raise ValueError("user not found")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #25131 
this is another part of #24907 for fixing plugin invoking callback issue

I hope this is the last time we have to fix this kind of problem.  :-)

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
