### PR TITLE
chore: (trigger)change content type from form to application/octet-stream

### DIFF
--- a/api/core/workflow/nodes/trigger_webhook/entities.py
+++ b/api/core/workflow/nodes/trigger_webhook/entities.py
@@ -21,7 +21,7 @@ class ContentType(StrEnum):
     FORM_DATA = "multipart/form-data"
     FORM_URLENCODED = "application/x-www-form-urlencoded"
     TEXT = "text/plain"
-    RAW = "application/octet-stream"
+    BINARY = "application/octet-stream"
 
 
 class WebhookParameter(BaseModel):

--- a/api/core/workflow/nodes/trigger_webhook/entities.py
+++ b/api/core/workflow/nodes/trigger_webhook/entities.py
@@ -21,7 +21,7 @@ class ContentType(StrEnum):
     FORM_DATA = "multipart/form-data"
     FORM_URLENCODED = "application/x-www-form-urlencoded"
     TEXT = "text/plain"
-    FORM = "form"
+    RAW = "application/octet-stream"
 
 
 class WebhookParameter(BaseModel):

--- a/api/core/workflow/nodes/trigger_webhook/node.py
+++ b/api/core/workflow/nodes/trigger_webhook/node.py
@@ -108,6 +108,9 @@ class TriggerWebhookNode(BaseNode):
                 # For text/plain, the entire body is a single string parameter
                 outputs[param_name] = str(webhook_data.get("body", {}).get("raw", ""))
                 continue
+            elif self._node_data.content_type == ContentType.RAW:
+                outputs[param_name] = webhook_data.get("body", {}).get("raw", b"")
+                continue
 
             if param_type == "file":
                 # Get File object (already processed by webhook controller)

--- a/api/core/workflow/nodes/trigger_webhook/node.py
+++ b/api/core/workflow/nodes/trigger_webhook/node.py
@@ -108,7 +108,7 @@ class TriggerWebhookNode(BaseNode):
                 # For text/plain, the entire body is a single string parameter
                 outputs[param_name] = str(webhook_data.get("body", {}).get("raw", ""))
                 continue
-            elif self._node_data.content_type == ContentType.RAW:
+            elif self._node_data.content_type == ContentType.BINARY:
                 outputs[param_name] = webhook_data.get("body", {}).get("raw", b"")
                 continue
 

--- a/web/app/components/workflow/nodes/trigger-webhook/components/parameter-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/parameter-table.tsx
@@ -78,17 +78,19 @@ const ParameterTable: FC<ParameterTableProps> = ({
 
   const handleDataChange = (data: GenericTableRow[]) => {
     // For text/plain, enforce single text body semantics: keep only first non-empty row and force string type
+    // For application/octet-stream, enforce single file body semantics: keep only first non-empty row and force file type
     const isTextPlain = isRequestBody && (contentType || '').toLowerCase() === 'text/plain'
+    const isOctetStream = isRequestBody && (contentType || '').toLowerCase() === 'application/octet-stream'
 
     const normalized = data
       .filter(row => typeof row.key === 'string' && (row.key as string).trim() !== '')
       .map(row => ({
         name: String(row.key),
-        type: isTextPlain ? VarType.string : normalizeParameterType((row.type as string)),
+        type: isTextPlain ? VarType.string : isOctetStream ? VarType.file : normalizeParameterType((row.type as string)),
         required: Boolean(row.required),
       }))
 
-    const newParams: WebhookParameter[] = isTextPlain
+    const newParams: WebhookParameter[] = (isTextPlain || isOctetStream)
       ? normalized.slice(0, 1)
       : normalized
 

--- a/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
@@ -32,7 +32,7 @@ const CONTENT_TYPES = [
   { name: 'application/json', value: 'application/json' },
   { name: 'application/x-www-form-urlencoded', value: 'application/x-www-form-urlencoded' },
   { name: 'text/plain', value: 'text/plain' },
-  { name: 'forms', value: 'forms' },
+  { name: 'application/octet-stream', value: 'application/octet-stream' },
   { name: 'multipart/form-data', value: 'multipart/form-data' },
 ]
 

--- a/web/app/components/workflow/nodes/trigger-webhook/utils/parameter-type-utils.ts
+++ b/web/app/components/workflow/nodes/trigger-webhook/utils/parameter-type-utils.ts
@@ -42,9 +42,9 @@ const CONTENT_TYPE_CONFIGS = {
     supportedTypes: [VarType.string, VarType.number, VarType.boolean] as const,
     description: 'Form data supports basic types',
   },
-  'forms': {
-    supportedTypes: [VarType.string, VarType.number, VarType.boolean] as const,
-    description: 'Form data supports basic types',
+  'application/octet-stream': {
+    supportedTypes: [VarType.file] as const,
+    description: 'octet-stream supports only binary data',
   },
   'multipart/form-data': {
     supportedTypes: [VarType.string, VarType.number, VarType.boolean, VarType.file] as const,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The content-type `form` is not available; instead, use `application/octet-stream` to align with the HTTP request node body.


<img width="422" height="530" alt="image" src="https://github.com/user-attachments/assets/2a081b8c-73d8-4908-9397-5377821a73b5" />

- form-data: multipart/form-data
- x-www-form-urlencoded: application/x-www-form-urlencoded
- JSON: application/json
- raw: text/plain
- binary:  application/octet-stream




## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
