### PR TITLE
fix: Ensure the order of execution steps are correct when logging with Weave by W&B

### DIFF
--- a/api/core/ops/weave_trace/weave_trace.py
+++ b/api/core/ops/weave_trace/weave_trace.py
@@ -120,7 +120,7 @@ class WeaveDataTrace(BaseTraceInstance):
         workflow_attributes["trace_id"] = trace_id
         workflow_attributes["start_time"] = trace_info.start_time
         workflow_attributes["end_time"] = trace_info.end_time
-        workflow_attributes["tags"] = ["workflow"]
+        workflow_attributes["tags"] = ["dify_workflow"]
 
         workflow_run = WeaveTraceModel(
             file_list=trace_info.file_list,
@@ -155,6 +155,9 @@ class WeaveDataTrace(BaseTraceInstance):
         workflow_node_executions = workflow_node_execution_repository.get_by_workflow_run(
             workflow_run_id=trace_info.workflow_run_id
         )
+
+        # rearrange workflow_node_executions by starting time
+        workflow_node_executions = sorted(workflow_node_executions, key=lambda x: x.created_at)
 
         for node_execution in workflow_node_executions:
             node_execution_id = node_execution.id


### PR DESCRIPTION
fixes #25182

## Summary

This very short PR fixes the issue of workflow steps showing up out of order on Weave by W&B dashboard. Also, updates the default tag passed with the traces.

## Screenshots

| Before | After |
|--------|-------|
| <img width="auto" height="400" alt="Screenshot 2025-09-04 at 23 21 19" src="https://github.com/user-attachments/assets/f0e9b658-34d9-4ce4-8f3a-63d9fb695dc3" /> | <img width="auto" height="400" alt="image" src="https://github.com/user-attachments/assets/49a3075a-02b6-47b9-8d06-dc3517763e4c" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
