### PR TITLE
fix: Remove invalid key from firecrawl request payload.

### DIFF
--- a/api/core/rag/extractor/firecrawl/firecrawl_app.py
+++ b/api/core/rag/extractor/firecrawl/firecrawl_app.py
@@ -22,7 +22,6 @@ class FirecrawlApp:
             "formats": ["markdown"],
             "onlyMainContent": True,
             "timeout": 30000,
-            "integration": "dify",
         }
         if params:
             json_data.update(params)
@@ -40,7 +39,7 @@ class FirecrawlApp:
     def crawl_url(self, url, params=None) -> str:
         # Documentation: https://docs.firecrawl.dev/api-reference/endpoint/crawl-post
         headers = self._prepare_headers()
-        json_data = {"url": url, "integration": "dify"}
+        json_data = {"url": url}
         if params:
             json_data.update(params)
         response = self._post_request(f"{self.base_url}/v1/crawl", json_data, headers)
@@ -138,7 +137,6 @@ class FirecrawlApp:
             "timeout": 60000,
             "ignoreInvalidURLs": False,
             "scrapeOptions": {},
-            "integration": "dify",
         }
         if params:
             json_data.update(params)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #23762 

Removed invalid key `integration` from firecrawl request payload to fix error `Bad Request` on self-hosted firecrawl environment.

API Reference:
- [crawl](https://docs.firecrawl.dev/api-reference/v1-endpoint/crawl-post)
- [scrape](https://docs.firecrawl.dev/api-reference/v1-endpoint/scrape)
- [search](https://docs.firecrawl.dev/api-reference/v1-endpoint/search)



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
