### PR TITLE
feat: improve trigger plugin UI layout and responsiveness

### DIFF
--- a/web/app/components/workflow/block-selector/trigger-plugin/item.tsx
+++ b/web/app/components/workflow/block-selector/trigger-plugin/item.tsx
@@ -100,9 +100,9 @@ const TriggerPluginItem: FC<Props> = ({
               type={BlockEnum.TriggerPlugin}
               toolIcon={payload.icon}
             />
-            <div className='ml-2 flex w-0 grow items-center text-sm text-text-primary'>
-              <span className='max-w-[250px] truncate'>{notShowProvider ? actions[0]?.label[language] : payload.label[language]}</span>
-              <span className='system-xs-regular ml-2 shrink-0 text-text-quaternary'>{groupName}</span>
+            <div className='ml-2 flex min-w-0 flex-1 items-center text-sm text-text-primary'>
+              <span className='max-w-[200px] truncate'>{notShowProvider ? actions[0]?.label[language] : payload.label[language]}</span>
+              <span className='system-xs-regular ml-2 truncate text-text-quaternary'>{groupName}</span>
             </div>
           </div>
 

--- a/web/app/components/workflow/nodes/_base/components/entry-node-container.tsx
+++ b/web/app/components/workflow/nodes/_base/components/entry-node-container.tsx
@@ -33,7 +33,7 @@ const EntryNodeContainer: FC<EntryNodeContainerProps> = ({
   }, [status, customLabel, nodeType, t])
 
   return (
-    <div className="w-[242px] rounded-2xl bg-workflow-block-wrapper-bg-1 px-0 pb-0 pt-0.5">
+    <div className="w-fit min-w-[242px] rounded-2xl bg-workflow-block-wrapper-bg-1 px-0 pb-0 pt-0.5">
       <div className="mb-0.5 flex items-center px-1.5 pt-0.5">
         {showIndicator && (
           <div className={cn('ml-0.5 mr-0.5 h-1.5 w-1.5 rounded-sm border border-black/15', statusConfig.dotColor)} />


### PR DESCRIPTION
## Summary

Improved trigger plugin UI layout and responsiveness for better user experience. Enhanced the visual consistency of trigger plugin items and entry node containers with better spacing and alignment.

**Changes made:**
- Enhanced trigger plugin item layout with improved spacing and responsive design
- Fixed UI consistency issues in trigger block selector items
- Optimized entry node container layout for better visual alignment

## Screenshots

| Before | After |
|--------|-------|
| <img width="303" height="163" alt="image" src="https://github.com/user-attachments/assets/df7260fd-a65c-42c1-8f85-829689feabd5" />| <img width="283" height="169" alt="image" src="https://github.com/user-attachments/assets/f0966d50-8886-46e5-af4c-baedca8a788f" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods