### PR TITLE
feat: add icon support for trigger plugin workflow nodes

### DIFF
--- a/web/app/components/workflow/hooks/use-workflow.ts
+++ b/web/app/components/workflow/hooks/use-workflow.ts
@@ -46,6 +46,7 @@ import {
   fetchAllMCPTools,
   fetchAllWorkflowTools,
 } from '@/service/tools'
+import { useAllTriggerPlugins } from '@/service/use-triggers'
 import { CollectionType } from '@/app/components/tools/types'
 import { CUSTOM_ITERATION_START_NODE } from '@/app/components/workflow/nodes/iteration-start/constants'
 import { CUSTOM_LOOP_START_NODE } from '@/app/components/workflow/nodes/loop-start/constants'
@@ -502,22 +503,29 @@ export const useToolIcon = (data: Node['data']) => {
   const customTools = useStore(s => s.customTools)
   const workflowTools = useStore(s => s.workflowTools)
   const mcpTools = useStore(s => s.mcpTools)
+  const { data: triggerPlugins } = useAllTriggerPlugins()
 
   const toolIcon = useMemo(() => {
     if (!data)
       return ''
     if (data.type === BlockEnum.Tool || data.type === BlockEnum.TriggerPlugin) {
       let targetTools = workflowTools
-      if (data.provider_type === CollectionType.builtIn)
-        targetTools = buildInTools
-      else if (data.provider_type === CollectionType.custom)
-        targetTools = customTools
-      else if (data.provider_type === CollectionType.mcp)
-        targetTools = mcpTools
+
+      if (data.type === BlockEnum.TriggerPlugin) {
+        targetTools = triggerPlugins || []
+      }
+      else {
+        if (data.provider_type === CollectionType.builtIn)
+          targetTools = buildInTools
+        else if (data.provider_type === CollectionType.custom)
+          targetTools = customTools
+        else if (data.provider_type === CollectionType.mcp)
+          targetTools = mcpTools
+      }
 
       return targetTools.find(toolWithProvider => canFindTool(toolWithProvider.id, data.provider_id))?.icon
     }
-  }, [data, buildInTools, customTools, mcpTools, workflowTools])
+  }, [data, buildInTools, customTools, mcpTools, triggerPlugins, workflowTools])
 
   return toolIcon
 }

--- a/web/app/components/workflow/hooks/use-workflow.ts
+++ b/web/app/components/workflow/hooks/use-workflow.ts
@@ -508,20 +508,20 @@ export const useToolIcon = (data: Node['data']) => {
   const toolIcon = useMemo(() => {
     if (!data)
       return ''
-    if (data.type === BlockEnum.Tool || data.type === BlockEnum.TriggerPlugin) {
-      let targetTools = workflowTools
 
-      if (data.type === BlockEnum.TriggerPlugin) {
-        targetTools = triggerPlugins || []
-      }
-      else {
-        if (data.provider_type === CollectionType.builtIn)
-          targetTools = buildInTools
-        else if (data.provider_type === CollectionType.custom)
-          targetTools = customTools
-        else if (data.provider_type === CollectionType.mcp)
-          targetTools = mcpTools
-      }
+    if (data.type === BlockEnum.TriggerPlugin) {
+      const targetTools = triggerPlugins || []
+      return targetTools.find(toolWithProvider => canFindTool(toolWithProvider.id, data.provider_id))?.icon
+    }
+
+    if (data.type === BlockEnum.Tool) {
+      let targetTools = workflowTools
+      if (data.provider_type === CollectionType.builtIn)
+        targetTools = buildInTools
+      else if (data.provider_type === CollectionType.custom)
+        targetTools = customTools
+      else if (data.provider_type === CollectionType.mcp)
+        targetTools = mcpTools
 
       return targetTools.find(toolWithProvider => canFindTool(toolWithProvider.id, data.provider_id))?.icon
     }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Enable trigger plugin nodes to display icons in workflow editor by integrating with existing useAllTriggerPlugins hook.
  This change reuses established data patterns and leverages React Query caching for optimal performance.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
