### PR TITLE
fix: update iteration node to use correct variable segment types

### DIFF
--- a/api/core/workflow/nodes/iteration/iteration_node.py
+++ b/api/core/workflow/nodes/iteration/iteration_node.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 from flask import Flask, current_app
 
 from configs import dify_config
-from core.variables import ArrayVariable, IntegerVariable, NoneVariable
+from core.variables import IntegerVariable, NoneSegment
 from core.variables.segments import ArrayAnySegment, ArraySegment
 from core.workflow.entities.node_entities import (
     NodeRunResult,
@@ -112,10 +112,10 @@ class IterationNode(BaseNode):
         if not variable:
             raise IteratorVariableNotFoundError(f"iterator variable {self._node_data.iterator_selector} not found")
 
-        if not isinstance(variable, ArrayVariable) and not isinstance(variable, NoneVariable):
+        if not isinstance(variable, ArraySegment) and not isinstance(variable, NoneSegment):
             raise InvalidIteratorValueError(f"invalid iterator value: {variable}, please provide a list.")
 
-        if isinstance(variable, NoneVariable) or len(variable.value) == 0:
+        if isinstance(variable, NoneSegment) or len(variable.value) == 0:
             # Try our best to preserve the type informat.
             if isinstance(variable, ArraySegment):
                 output = variable.model_copy(update={"value": []})


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR updates the type checking in the iteration node to use the correct variable segment types (`ArraySegment` and `NoneSegment`) instead of the deprecated variable types (`ArrayVariable` and `NoneVariable`). This ensures consistency with the current codebase architecture and prevents potential type-related issues.

Fixes #25314

## Screenshots

N/A - This is an internal refactoring change with no visual impact.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods