### PR TITLE
refactor: update pyrightconfig.json to use ignore field for better type checking configuration

### DIFF
--- a/api/pyrightconfig.json
+++ b/api/pyrightconfig.json
@@ -1,11 +1,7 @@
 {
-  "include": [
-    "."
-  ],
-  "exclude": [
-    "tests/",
-    "migrations/",
-    ".venv/",
+  "include": ["models", "configs"],
+  "exclude": [".venv", "tests/", "migrations/"],
+  "ignore": [
     "core/",
     "controllers/",
     "tasks/",


### PR DESCRIPTION
## Summary
This PR updates the pyrightconfig.json configuration to use the "ignore" field instead of expanding the "exclude" field for directories that should not be type-checked.

## Related Issue
Closes #25372

## Changes Made
- Moved directories from `exclude` to `ignore` field for clearer semantics
- Narrowed `include` field to focus on `models` and `configs` directories  
- Kept essential exclusions (`.venv`, `tests/`, `migrations/`) in `exclude` field

## Rationale
Using the `ignore` field for directories that should not be type-checked provides clearer semantics:
- `exclude` is for files that shouldn't be processed at all
- `ignore` is for files that are processed but not type-checked

This distinction helps maintainers understand the intent better and aligns with Pyright's recommended configuration patterns.