### PR TITLE
Fix flask response: 200 -> {}, 200

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -249,7 +249,7 @@ class DataSourceNotionDatasetSyncApi(Resource):
         documents = DocumentService.get_document_by_dataset_id(dataset_id_str)
         for document in documents:
             document_indexing_sync_task.delay(dataset_id_str, document.id)
-        return 200
+        return {"result": "success"}, 200
 
 
 class DataSourceNotionDocumentSyncApi(Resource):
@@ -267,7 +267,7 @@ class DataSourceNotionDocumentSyncApi(Resource):
         if document is None:
             raise NotFound("Document not found.")
         document_indexing_sync_task.delay(dataset_id_str, document_id_str)
-        return 200
+        return {"result": "success"}, 200
 
 
 api.add_resource(DataSourceApi, "/data-source/integrates", "/data-source/integrates/<uuid:binding_id>/<string:action>")

--- a/api/controllers/console/datasets/metadata.py
+++ b/api/controllers/console/datasets/metadata.py
@@ -113,7 +113,7 @@ class DatasetMetadataBuiltInFieldActionApi(Resource):
             MetadataService.enable_built_in_field(dataset)
         elif action == "disable":
             MetadataService.disable_built_in_field(dataset)
-        return 200
+        return {"result": "success"}, 200
 
 
 class DocumentMetadataEditApi(Resource):
@@ -135,7 +135,7 @@ class DocumentMetadataEditApi(Resource):
 
         MetadataService.update_documents_metadata(dataset, metadata_args)
 
-        return 200
+        return {"result": "success"}, 200
 
 
 api.add_resource(DatasetMetadataCreateApi, "/datasets/<uuid:dataset_id>/metadata")

--- a/api/controllers/console/tag/tags.py
+++ b/api/controllers/console/tag/tags.py
@@ -111,7 +111,7 @@ class TagBindingCreateApi(Resource):
         args = parser.parse_args()
         TagService.save_tag_binding(args)
 
-        return 200
+        return {"result": "success"}, 200
 
 
 class TagBindingDeleteApi(Resource):
@@ -132,7 +132,7 @@ class TagBindingDeleteApi(Resource):
         args = parser.parse_args()
         TagService.delete_tag_binding(args)
 
-        return 200
+        return {"result": "success"}, 200
 
 
 api.add_resource(TagListApi, "/tags")

--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -174,7 +174,7 @@ class DatasetMetadataBuiltInFieldActionServiceApi(DatasetApiResource):
             MetadataService.enable_built_in_field(dataset)
         elif action == "disable":
             MetadataService.disable_built_in_field(dataset)
-        return 200
+        return {"result": "success"}, 200
 
 
 @service_api_ns.route("/datasets/<uuid:dataset_id>/documents/metadata")
@@ -204,4 +204,4 @@ class DocumentMetadataEditServiceApi(DatasetApiResource):
 
         MetadataService.update_documents_metadata(dataset, metadata_args)
 
-        return 200
+        return {"result": "success"}, 200


### PR DESCRIPTION
Fixes #25406 

The original code return 200 actually returns `Response("200", status=200)`, where "200" is the response body and the status code is also 200. After the fix, `return {"result": "success"}, 200` will return a JSON response with `{"result": "success"}` as the body and 200 as the status code.
To keep the API responses consistent, we change it to the latter form.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
