### PR TITLE
fix: avatar is not updated after setted

### DIFF
--- a/web/app/account/(commonLayout)/account-page/AvatarWithEdit.tsx
+++ b/web/app/account/(commonLayout)/account-page/AvatarWithEdit.tsx
@@ -43,9 +43,9 @@ const AvatarWithEdit = ({ onSave, ...props }: AvatarWithEditProps) => {
   const handleSaveAvatar = useCallback(async (uploadedFileId: string) => {
     try {
       await updateUserProfile({ url: 'account/avatar', body: { avatar: uploadedFileId } })
-      notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })
       setIsShowAvatarPicker(false)
       onSave?.()
+      notify({ type: 'success', message: t('common.actionMsg.modifiedSuccessfully') })
     }
     catch (e) {
       notify({ type: 'error', message: (e as Error).message })

--- a/web/app/components/base/avatar/index.tsx
+++ b/web/app/components/base/avatar/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import cn from '@/utils/classnames'
 
 export type AvatarProps = {
@@ -26,6 +26,12 @@ const Avatar = ({
     setImgError(true)
     onError?.(true)
   }
+
+  // after uploaded, api would first return error imgs url: '.../files//file-preview/...'. Then return the right url, Which caused not show the avatar
+  useEffect(() => {
+    if(avatar && imgError)
+      setImgError(false)
+  }, [avatar])
 
   if (avatar && !imgError) {
     return (


### PR DESCRIPTION

## Summary

## Screenshots
After update the avatar
| Before | After |
|--------|-------|
| <img width="250" height="112" alt="image" src="https://github.com/user-attachments/assets/ce118b52-ca20-4032-b561-63bf5e6f00c6" /> | <img width="288" height="104" alt="image" src="https://github.com/user-attachments/assets/99fb9a39-d435-4816-a1ea-1d2614a38241" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
