### PR TITLE
Fix: Use --fix flag instead of --fix-only in autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,7 +20,7 @@ jobs:
           cd api
           uv sync --dev
           # Fix lint errors
-          uv run ruff check --fix-only .
+          uv run ruff check --fix .
           # Format code
           uv run ruff format .
       - name: ast-grep


### PR DESCRIPTION
## Summary

This PR fixes the autofix workflow to use `ruff check --fix` instead of `ruff check --fix-only`. The `--fix-only` flag was silently ignoring ruff errors that cannot be auto-fixed, which could allow problematic code to pass through the workflow without notification.

## Changes

- Updated `.github/workflows/autofix.yml` to use `--fix` flag for ruff check

## Why this change is needed

The previous configuration with `--fix-only` would only apply safe fixes and ignore any errors that couldn't be automatically fixed. This meant that code quality issues requiring manual intervention would go unnoticed. Using `--fix` ensures all errors are reported, even those that need manual fixes.

Fixes #25424