### PR TITLE
Chore: thanks to bump-pydantic

### DIFF
--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -95,7 +95,7 @@ class AppGenerateEntity(BaseModel):
     task_id: str
 
     # app config
-    app_config: Any
+    app_config: Any = None
     file_upload_config: Optional[FileUploadConfig] = None
 
     inputs: Mapping[str, Any]

--- a/api/core/app/entities/queue_entities.py
+++ b/api/core/app/entities/queue_entities.py
@@ -432,8 +432,8 @@ class QueueAgentLogEvent(AppQueueEvent):
     id: str
     label: str
     node_execution_id: str
-    parent_id: str | None
-    error: str | None
+    parent_id: str | None = None
+    error: str | None = None
     status: str
     data: Mapping[str, Any]
     metadata: Optional[Mapping[str, Any]] = None

--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -828,8 +828,8 @@ class AgentLogStreamResponse(StreamResponse):
         node_execution_id: str
         id: str
         label: str
-        parent_id: str | None
-        error: str | None
+        parent_id: str | None = None
+        error: str | None = None
         status: str
         data: Mapping[str, Any]
         metadata: Optional[Mapping[str, Any]] = None

--- a/api/core/entities/provider_entities.py
+++ b/api/core/entities/provider_entities.py
@@ -107,7 +107,7 @@ class CustomModelConfiguration(BaseModel):
 
     model: str
     model_type: ModelType
-    credentials: dict | None
+    credentials: dict | None = None
     current_credential_id: Optional[str] = None
     current_credential_name: Optional[str] = None
     available_model_credentials: list[CredentialConfiguration] = []

--- a/api/core/mcp/types.py
+++ b/api/core/mcp/types.py
@@ -809,7 +809,7 @@ class LoggingMessageNotificationParams(NotificationParams):
     """The severity of this log message."""
     logger: str | None = None
     """An optional name of the logger issuing this message."""
-    data: Any
+    data: Any = None
     """
     The data to be logged, such as a string message or an object. Any JSON serializable
     type is allowed here.

--- a/api/core/ops/entities/trace_entity.py
+++ b/api/core/ops/entities/trace_entity.py
@@ -35,7 +35,7 @@ class BaseTraceInfo(BaseModel):
 
 
 class WorkflowTraceInfo(BaseTraceInfo):
-    workflow_data: Any
+    workflow_data: Any = None
     conversation_id: Optional[str] = None
     workflow_app_log_id: Optional[str] = None
     workflow_id: str
@@ -89,7 +89,7 @@ class SuggestedQuestionTraceInfo(BaseTraceInfo):
 
 
 class DatasetRetrievalTraceInfo(BaseTraceInfo):
-    documents: Any
+    documents: Any = None
 
 
 class ToolTraceInfo(BaseTraceInfo):
@@ -97,12 +97,12 @@ class ToolTraceInfo(BaseTraceInfo):
     tool_inputs: dict[str, Any]
     tool_outputs: str
     metadata: dict[str, Any]
-    message_file_data: Any
+    message_file_data: Any = None
     error: Optional[str] = None
     tool_config: dict[str, Any]
     time_cost: Union[int, float]
     tool_parameters: dict[str, Any]
-    file_url: Union[str, None, list]
+    file_url: Union[str, None, list] = None
 
 
 class GenerateNameTraceInfo(BaseTraceInfo):
@@ -113,7 +113,7 @@ class GenerateNameTraceInfo(BaseTraceInfo):
 class TaskData(BaseModel):
     app_id: str
     trace_info_type: str
-    trace_info: Any
+    trace_info: Any = None
 
 
 trace_info_info_map = {

--- a/api/core/plugin/entities/plugin_daemon.py
+++ b/api/core/plugin/entities/plugin_daemon.py
@@ -24,7 +24,7 @@ class PluginDaemonBasicResponse(BaseModel, Generic[T]):
 
     code: int
     message: str
-    data: Optional[T]
+    data: Optional[T] = None
 
 
 class InstallPluginMessage(BaseModel):

--- a/api/core/rag/datasource/vdb/huawei/huawei_cloud_vector.py
+++ b/api/core/rag/datasource/vdb/huawei/huawei_cloud_vector.py
@@ -28,8 +28,8 @@ def create_ssl_context() -> ssl.SSLContext:
 
 class HuaweiCloudVectorConfig(BaseModel):
     hosts: str
-    username: str | None
-    password: str | None
+    username: str | None = None
+    password: str | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/api/core/rag/datasource/vdb/tencent/tencent_vector.py
+++ b/api/core/rag/datasource/vdb/tencent/tencent_vector.py
@@ -24,10 +24,10 @@ logger = logging.getLogger(__name__)
 
 class TencentConfig(BaseModel):
     url: str
-    api_key: Optional[str]
+    api_key: Optional[str] = None
     timeout: float = 30
-    username: Optional[str]
-    database: Optional[str]
+    username: Optional[str] = None
+    database: Optional[str] = None
     index_type: str = "HNSW"
     metric_type: str = "IP"
     shard: int = 1

--- a/api/core/variables/segments.py
+++ b/api/core/variables/segments.py
@@ -19,7 +19,7 @@ class Segment(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     value_type: SegmentType
-    value: Any
+    value: Any = None
 
     @field_validator("value_type")
     @classmethod

--- a/api/core/workflow/nodes/base/entities.py
+++ b/api/core/workflow/nodes/base/entities.py
@@ -23,7 +23,7 @@ NumberType = Union[int, float]
 
 
 class DefaultValue(BaseModel):
-    value: Any
+    value: Any = None
     type: DefaultValueType
     key: str
 

--- a/api/core/workflow/nodes/variable_assigner/common/helpers.py
+++ b/api/core/workflow/nodes/variable_assigner/common/helpers.py
@@ -16,7 +16,7 @@ class UpdatedVariable(BaseModel):
     name: str
     selector: Sequence[str]
     value_type: SegmentType
-    new_value: Any
+    new_value: Any = None
 
 
 _T = TypeVar("_T", bound=MutableMapping[str, Any])

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -99,17 +99,17 @@ def _check_version_compatibility(imported_version: str) -> ImportStatus:
 class PendingData(BaseModel):
     import_mode: str
     yaml_content: str
-    name: str | None
-    description: str | None
-    icon_type: str | None
-    icon: str | None
-    icon_background: str | None
-    app_id: str | None
+    name: str | None = None
+    description: str | None = None
+    icon_type: str | None = None
+    icon: str | None = None
+    icon_background: str | None = None
+    app_id: str | None = None
 
 
 class CheckDependenciesPendingData(BaseModel):
     dependencies: list[PluginDependency]
-    app_id: str | None
+    app_id: str | None = None
 
 
 class AppDslService:


### PR DESCRIPTION
Fixes #25436 

This PR updates all optional fields of the form `str | None` to `str | None = None` in accordance with Pydantic V2 best practices by **bump-pydantic**.
- Ensures explicit default values for optional fields, avoiding unexpected validation errors.
- Improves clarity: it’s clear which fields are optional and what their default value is.
- Aligns with Pydantic V2, where optional fields without defaults can trigger warnings or require explicit defaults.

BTW, this tool really takes a lot of time to run.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
