### PR TITLE
Force update search method to keyword_search 

### DIFF
--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -340,6 +340,9 @@ class DatasetApi(DatasetApiResource):
         else:
             data["embedding_available"] = True
 
+            # force update search method to keyword_search if indexing_technique is economic
+            data['retrieval_model_dict']['search_method'] = 'keyword_search'
+
         if data.get("permission") == "partial_members":
             part_users_list = DatasetPermissionService.get_dataset_partial_member_list(dataset_id_str)
             data.update({"partial_member_list": part_users_list})

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -341,7 +341,7 @@ class DatasetApi(DatasetApiResource):
             data["embedding_available"] = True
 
             # force update search method to keyword_search if indexing_technique is economic
-            data['retrieval_model_dict']['search_method'] = 'keyword_search'
+            data["retrieval_model_dict"]["search_method"] = "keyword_search"
 
         if data.get("permission") == "partial_members":
             part_users_list = DatasetPermissionService.get_dataset_partial_member_list(dataset_id_str)


### PR DESCRIPTION
fix: #25084

## Summary

Due to the Index Method is set to "economy", the backend expects keyword-based retrieval in Dify.
Force update search method to keyword_search if indexing_technique is economic , When call get dataset detail  service api

## Screenshots

<img width="760" height="460" alt="image" src="https://github.com/user-attachments/assets/dc69850b-79eb-49b9-97e3-66ac412a8540" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
