### PR TITLE
fix(sidebar): eliminate nav link icon jumping and text squashing

### DIFF
--- a/web/app/components/app-sidebar/navLink.tsx
+++ b/web/app/components/app-sidebar/navLink.tsx
@@ -41,6 +41,12 @@ const NavLink = ({
   const isActive = href.toLowerCase().split('/')?.pop() === formattedSegment
   const NavIcon = isActive ? iconMap.selected : iconMap.normal
 
+  const renderIcon = () => (
+    <div className={classNames(mode !== 'expand' && '-ml-1')}>
+      <NavIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+    </div>
+  )
+
   if (disabled) {
     return (
       <button
@@ -54,9 +60,7 @@ const NavLink = ({
         title={mode === 'collapse' ? name : ''}
         aria-disabled
       >
-        <div className={classNames(mode !== 'expand' && '-ml-1')}>
-          <NavIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
-        </div>
+        {renderIcon()}
         <span
           className={classNames(
             'overflow-hidden whitespace-nowrap transition-all duration-200 ease-in-out',
@@ -83,9 +87,7 @@ const NavLink = ({
       )}
       title={mode === 'collapse' ? name : ''}
     >
-      <div className={classNames(mode !== 'expand' && '-ml-1')}>
-        <NavIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
-      </div>
+      {renderIcon()}
       <span
         className={classNames(
           'overflow-hidden whitespace-nowrap transition-all duration-200 ease-in-out',

--- a/web/app/components/app-sidebar/navLink.tsx
+++ b/web/app/components/app-sidebar/navLink.tsx
@@ -49,19 +49,24 @@ const NavLink = ({
         disabled
         className={classNames(
           'system-sm-medium flex h-8 cursor-not-allowed items-center rounded-lg text-components-menu-item-text opacity-30 hover:bg-components-menu-item-bg-hover',
-          mode === 'expand' ? 'pl-3 pr-1' : 'px-1.5',
+          'pl-3 pr-1',
         )}
         title={mode === 'collapse' ? name : ''}
         aria-disabled
       >
-        <NavIcon
+        <div className={classNames(mode !== 'expand' && '-ml-1')}>
+          <NavIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+        </div>
+        <span
           className={classNames(
-            'h-4 w-4 shrink-0',
-            mode === 'expand' ? 'mr-2' : 'mr-0',
+            'overflow-hidden whitespace-nowrap transition-all duration-200 ease-in-out',
+            mode === 'expand'
+              ? 'ml-2 max-w-none opacity-100'
+              : 'ml-0 max-w-0 opacity-0',
           )}
-          aria-hidden='true'
-        />
-        {mode === 'expand' && name}
+        >
+          {name}
+        </span>
       </button>
     )
   }
@@ -74,24 +79,19 @@ const NavLink = ({
         isActive
           ? 'system-sm-semibold border-b-[0.25px] border-l-[0.75px] border-r-[0.25px] border-t-[0.75px] border-effects-highlight-lightmode-off bg-components-menu-item-bg-active text-text-accent-light-mode-only'
           : 'system-sm-medium text-components-menu-item-text hover:bg-components-menu-item-bg-hover hover:text-components-menu-item-text-hover',
-        'flex h-8 items-center rounded-lg',
-        mode === 'expand' ? 'pl-3 pr-1' : 'px-1.5',
+        'flex h-8 items-center rounded-lg pl-3 pr-1',
       )}
       title={mode === 'collapse' ? name : ''}
     >
-      <NavIcon
-        className={classNames(
-          'h-4 w-4 shrink-0',
-          mode === 'expand' ? 'mr-2' : 'mr-0',
-        )}
-        aria-hidden='true'
-      />
+      <div className={classNames(mode !== 'expand' && '-ml-1')}>
+        <NavIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+      </div>
       <span
         className={classNames(
-          'whitespace-nowrap transition-all duration-200 ease-in-out',
+          'overflow-hidden whitespace-nowrap transition-all duration-200 ease-in-out',
           mode === 'expand'
-            ? 'w-auto opacity-100'
-            : 'pointer-events-none w-0 overflow-hidden opacity-0',
+            ? 'ml-2 max-w-none opacity-100'
+            : 'ml-0 max-w-0 opacity-0',
         )}
       >
         {name}


### PR DESCRIPTION
- Unified layout structure using consistent pl-3 pr-1 padding
- Icon micro-adjustment with -ml-1 for better centering in collapsed state
- Text animation uses max-width instead of width to prevent squashing effect
- Maintains smooth transitions without layout jumping

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
