### PR TITLE
Fix 500 in dataset page.

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -2738,11 +2738,7 @@ class DatasetPermissionService:
             ).where(DatasetPermission.dataset_id == dataset_id)
         ).all()
 
-        user_list = []
-        for user in user_list_query:
-            user_list.append(user.account_id)
-
-        return user_list
+        return user_list_query
 
     @classmethod
     def update_partial_member_list(cls, tenant_id, dataset_id, user_list):


### PR DESCRIPTION
## Summary

Fix #25476

```
2025-09-10 07:02:10,362 ERROR [app.py:875] e034a12187 Exception on /console/api/datasets [GET]
Traceback (most recent call last):
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask_restx/api.py", line 402, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/.venv/lib/python3.12/site-packages/flask_restx/resource.py", line 41, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/controllers/console/wraps.py", line 215, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/libs/login.py", line 62, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/controllers/console/wraps.py", line 37, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/controllers/console/wraps.py", line 227, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/controllers/console/datasets/datasets.py", line 95, in get
    part_users_list = DatasetPermissionService.get_dataset_partial_member_list(item["id"])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dify/dify/api/services/dataset_service.py", line 2743, in get_dataset_partial_member_list
    user_list.append(user.account_id)
                     ^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'account_id'
```

```
curl 'http://dify-api.thape.com.cn:5001/console/api/datasets?page=1&ids=33ef76a4-e1be-4a62-b0d7-3e62442d7cef' \
-X 'GET' \
-H 'Content-Type: application/json' \
-H 'Accept: */*' \
-H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMzA0N2EwYTAtNjQyYS00NzBkLWExYjItZThkMGRlZTU0NmZkIiwiZXhwIjoxNzU3NDg3ODgzLCJpc3MiOiJTRUxGX0hPU1RFRCIsInN1YiI6IkNvbnNvbGUgQVBJIFBhc3Nwb3J0In0.QcN13T6k5JGysQd4rVo6GuQiAQIZzlE7QUIoiBWEbo4' \
-H 'Sec-Fetch-Site: same-site' \
-H 'Accept-Language: en-US,en;q=0.9' \
-H 'Sec-Fetch-Mode: cors' \
-H 'Origin: https://dify.thape.com.cn' \
-H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15' \
-H 'Referer: https://dify.thape.com.cn/' \
-H 'Sec-Fetch-Dest: empty' \
-H 'Priority: u=3, i'
```

## Checklist

- [x] This change not requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] No test need, and I tried as much as possible to make a single atomic change.
- [x] No documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
