### PR TITLE
use autospec=True in mock

### DIFF
--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
@@ -250,7 +250,7 @@ class TestAdvancedChatAppRunnerConversationVariables:
 
         # Patch the necessary components
         with (
-            patch("core.app.apps.advanced_chat.app_runner.Session") as mock_session_class,
+            patch("core.app.apps.advanced_chat.app_runner.Session", autospec=True) as mock_session_class,
             patch("core.app.apps.advanced_chat.app_runner.select") as mock_select,
             patch("core.app.apps.advanced_chat.app_runner.db") as mock_db,
             patch.object(runner, "_init_graph") as mock_init_graph,

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
@@ -250,15 +250,15 @@ class TestAdvancedChatAppRunnerConversationVariables:
 
         # Patch the necessary components
         with (
-            patch("core.app.apps.advanced_chat.app_runner.Session", autospec=True) as mock_session_class,
-            patch("core.app.apps.advanced_chat.app_runner.select", autospec=True) as mock_select,
-            patch("core.app.apps.advanced_chat.app_runner.db", autospec=True) as mock_db,
-            patch.object(runner, "_init_graph", autospec=True) as mock_init_graph,
+            patch("core.app.apps.advanced_chat.app_runner.Session") as mock_session_class,
+            patch("core.app.apps.advanced_chat.app_runner.select") as mock_select,
+            patch("core.app.apps.advanced_chat.app_runner.db") as mock_db,
+            patch.object(runner, "_init_graph") as mock_init_graph,
             patch.object(runner, "handle_input_moderation", return_value=False),
             patch.object(runner, "handle_annotation_reply", return_value=False),
-            patch("core.app.apps.advanced_chat.app_runner.WorkflowEntry", autospec=True) as mock_workflow_entry_class,
-            patch("core.app.apps.advanced_chat.app_runner.VariablePool", autospec=True) as mock_variable_pool_class,
-            patch("core.app.apps.advanced_chat.app_runner.ConversationVariable", autospec=True) as mock_conv_var_class,
+            patch("core.app.apps.advanced_chat.app_runner.WorkflowEntry") as mock_workflow_entry_class,
+            patch("core.app.apps.advanced_chat.app_runner.VariablePool") as mock_variable_pool_class,
+            patch("core.app.apps.advanced_chat.app_runner.ConversationVariable") as mock_conv_var_class,
         ):
             # Setup mocks
             mock_session_class.return_value.__enter__.return_value = mock_session

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
@@ -251,14 +251,14 @@ class TestAdvancedChatAppRunnerConversationVariables:
         # Patch the necessary components
         with (
             patch("core.app.apps.advanced_chat.app_runner.Session", autospec=True) as mock_session_class,
-            patch("core.app.apps.advanced_chat.app_runner.select") as mock_select,
-            patch("core.app.apps.advanced_chat.app_runner.db") as mock_db,
-            patch.object(runner, "_init_graph") as mock_init_graph,
+            patch("core.app.apps.advanced_chat.app_runner.select", autospec=True) as mock_select,
+            patch("core.app.apps.advanced_chat.app_runner.db", autospec=True) as mock_db,
+            patch.object(runner, "_init_graph", autospec=True) as mock_init_graph,
             patch.object(runner, "handle_input_moderation", return_value=False),
             patch.object(runner, "handle_annotation_reply", return_value=False),
-            patch("core.app.apps.advanced_chat.app_runner.WorkflowEntry") as mock_workflow_entry_class,
-            patch("core.app.apps.advanced_chat.app_runner.VariablePool") as mock_variable_pool_class,
-            patch("core.app.apps.advanced_chat.app_runner.ConversationVariable") as mock_conv_var_class,
+            patch("core.app.apps.advanced_chat.app_runner.WorkflowEntry", autospec=True) as mock_workflow_entry_class,
+            patch("core.app.apps.advanced_chat.app_runner.VariablePool", autospec=True) as mock_variable_pool_class,
+            patch("core.app.apps.advanced_chat.app_runner.ConversationVariable", autospec=True) as mock_conv_var_class,
         ):
             # Setup mocks
             mock_session_class.return_value.__enter__.return_value = mock_session

--- a/api/tests/unit_tests/extensions/storage/test_supabase_storage.py
+++ b/api/tests/unit_tests/extensions/storage/test_supabase_storage.py
@@ -11,12 +11,12 @@ class TestSupabaseStorage:
 
     def test_init_success_with_all_config(self):
         """Test successful initialization when all required config is provided."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 
@@ -31,7 +31,7 @@ class TestSupabaseStorage:
 
     def test_init_raises_error_when_url_missing(self):
         """Test initialization raises ValueError when SUPABASE_URL is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = None
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
@@ -41,7 +41,7 @@ class TestSupabaseStorage:
 
     def test_init_raises_error_when_api_key_missing(self):
         """Test initialization raises ValueError when SUPABASE_API_KEY is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = None
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
@@ -51,7 +51,7 @@ class TestSupabaseStorage:
 
     def test_init_raises_error_when_bucket_name_missing(self):
         """Test initialization raises ValueError when SUPABASE_BUCKET_NAME is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = None
@@ -61,12 +61,12 @@ class TestSupabaseStorage:
 
     def test_create_bucket_when_not_exists(self):
         """Test create_bucket creates bucket when it doesn't exist."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 
@@ -77,12 +77,12 @@ class TestSupabaseStorage:
 
     def test_create_bucket_when_exists(self):
         """Test create_bucket does not create bucket when it already exists."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 
@@ -94,12 +94,12 @@ class TestSupabaseStorage:
     @pytest.fixture
     def storage_with_mock_client(self):
         """Fixture providing SupabaseStorage with mocked client."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 
@@ -251,12 +251,12 @@ class TestSupabaseStorage:
 
     def test_bucket_exists_returns_true_when_bucket_found(self):
         """Test bucket_exists returns True when bucket is found in list."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 
@@ -271,12 +271,12 @@ class TestSupabaseStorage:
 
     def test_bucket_exists_returns_false_when_bucket_not_found(self):
         """Test bucket_exists returns False when bucket is not found in list."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 
@@ -294,12 +294,12 @@ class TestSupabaseStorage:
 
     def test_bucket_exists_returns_false_when_no_buckets(self):
         """Test bucket_exists returns False when no buckets exist."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
+        with patch("extensions.storage.supabase_storage.dify_config", autospec=True) as mock_config:
             mock_config.SUPABASE_URL = "https://test.supabase.co"
             mock_config.SUPABASE_API_KEY = "test-api-key"
             mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
 
-            with patch("extensions.storage.supabase_storage.Client") as mock_client_class:
+            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
                 mock_client = Mock()
                 mock_client_class.return_value = mock_client
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

part of #24650

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

> [Mock](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock) is a very powerful and flexible object, but it suffers from a flaw which is general to mocking. If you refactor some of your code, rename members and so on, any tests for code that is still using the old api but uses mocks instead of the real objects will still pass. This means your tests can all pass even though your code is broken.

ref https://docs.python.org/3/library/unittest.mock.html#autospeccing



## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
