### PR TITLE
fix close button cannot be clicked when the browser page is zoomed out

### DIFF
--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -181,7 +181,7 @@ export default function AccountSetting({
           </div>
         </div>
         <div className='relative flex w-[824px]'>
-          <div className='absolute -right-11 top-6 z-[9999] flex flex-col items-center'>
+          <div className='fixed right-6 top-6 z-[9999] flex flex-col items-center'>
             <Button
               variant='tertiary'
               size='large'


### PR DESCRIPTION

## Summary
fixes: #25574 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| 
<img width="391" height="226" alt="image" src="https://github.com/user-attachments/assets/7683d0ea-bd4b-4e9f-afcc-6a8a127975c8" />
 | 
<img width="701" height="243" alt="image" src="https://github.com/user-attachments/assets/216c1df2-9bcc-416d-b081-dbdc52cd717f" />
|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
