### PR TITLE
fix: correct typos in parameter extractor node prompts

### DIFF
--- a/api/core/workflow/nodes/parameter_extractor/prompts.py
+++ b/api/core/workflow/nodes/parameter_extractor/prompts.py
@@ -19,7 +19,7 @@ Steps:
 1. Review the chat history provided within the <histories> tags.
 2. Extract the relevant information based on the criteria given, output multiple values if there is multiple relevant information that match the criteria in the given text.
 3. Generate a well-formatted output using the defined functions and arguments.
-4. Use the `extract_parameter` function to create structured outputs with appropriate parameters.
+4. Use the `extract_parameters` function to create structured outputs with appropriate parameters.
 5. Do not include any XML tags in your output.
 ### Example
 To illustrate, if the task involves extracting a user's name and their request, your function call might look like this: Ensure your output follows a similar structure to examples.
@@ -179,6 +179,6 @@ CHAT_EXAMPLE = [
                 "required": ["food"],
             },
         },
-        "assistant": {"text": "I need to output a valid JSON object.", "json": {"result": "apple pie"}},
+        "assistant": {"text": "I need to output a valid JSON object.", "json": {"food": "apple pie"}},
     },
 ]


### PR DESCRIPTION
- Fix 'extract_parameter' to 'extract_parameters' for consistency
- Fix incorrect property name 'result' to 'food' in CHAT_EXAMPLE

Fixes #25586

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
