### PR TITLE
bugfix: The randomly generated email by Faker actually corresponded to an existing account in the test database, causing the test to fail.

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -258,7 +258,6 @@ class TestWebAppAuthService:
         non_existent_email = f"nonexistent_{unique_id}_{timestamp}@test-domain-that-never-exists.invalid"
 
         # Double-check this email doesn't exist in the database
-        from models.account import Account
 
         existing_account = db_session_with_containers.query(Account).filter_by(email=non_existent_email).first()
         assert existing_account is None, f"Test email {non_existent_email} already exists in database"

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -249,8 +249,8 @@ class TestWebAppAuthService:
         - Correct exception type and message
         """
         # Arrange: Generate a guaranteed non-existent email
-        import uuid
         import time
+        import uuid
         
         # Use UUID and timestamp to ensure uniqueness
         unique_id = str(uuid.uuid4()).replace('-', '')

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -248,9 +248,19 @@ class TestWebAppAuthService:
         - Proper error handling for non-existent accounts
         - Correct exception type and message
         """
-        # Arrange: Use non-existent email
-        fake = Faker()
-        non_existent_email = fake.email()
+        # Arrange: Generate a guaranteed non-existent email
+        import uuid
+        import time
+        
+        # Use UUID and timestamp to ensure uniqueness
+        unique_id = str(uuid.uuid4()).replace('-', '')
+        timestamp = str(int(time.time() * 1000000))  # microseconds
+        non_existent_email = f"nonexistent_{unique_id}_{timestamp}@test-domain-that-never-exists.invalid"
+        
+        # Double-check this email doesn't exist in the database
+        from models.account import Account
+        existing_account = db_session_with_containers.query(Account).filter_by(email=non_existent_email).first()
+        assert existing_account is None, f"Test email {non_existent_email} already exists in database"
 
         # Act & Assert: Verify proper error handling
         with pytest.raises(AccountNotFoundError):

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -252,7 +252,7 @@ class TestWebAppAuthService:
         """
         # Arrange: Generate a guaranteed non-existent email
         # Use UUID and timestamp to ensure uniqueness
-        unique_id = str(uuid.uuid4()).replace('-', '')
+        unique_id = str(uuid.uuid4()).replace("-", "")
         timestamp = str(int(time.time() * 1000000))  # microseconds
         non_existent_email = f"nonexistent_{unique_id}_{timestamp}@test-domain-that-never-exists.invalid"
 

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -1,3 +1,5 @@
+import time
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -249,16 +251,12 @@ class TestWebAppAuthService:
         - Correct exception type and message
         """
         # Arrange: Generate a guaranteed non-existent email
-        import time
-        import uuid
-        
         # Use UUID and timestamp to ensure uniqueness
         unique_id = str(uuid.uuid4()).replace('-', '')
         timestamp = str(int(time.time() * 1000000))  # microseconds
         non_existent_email = f"nonexistent_{unique_id}_{timestamp}@test-domain-that-never-exists.invalid"
         
         # Double-check this email doesn't exist in the database
-        from models.account import Account
         existing_account = db_session_with_containers.query(Account).filter_by(email=non_existent_email).first()
         assert existing_account is None, f"Test email {non_existent_email} already exists in database"
 

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -251,14 +251,15 @@ class TestWebAppAuthService:
         # Arrange: Generate a guaranteed non-existent email
         import time
         import uuid
-        
+
         # Use UUID and timestamp to ensure uniqueness
-        unique_id = str(uuid.uuid4()).replace('-', '')
+        unique_id = str(uuid.uuid4()).replace("-", "")
         timestamp = str(int(time.time() * 1000000))  # microseconds
         non_existent_email = f"nonexistent_{unique_id}_{timestamp}@test-domain-that-never-exists.invalid"
-        
+
         # Double-check this email doesn't exist in the database
         from models.account import Account
+
         existing_account = db_session_with_containers.query(Account).filter_by(email=non_existent_email).first()
         assert existing_account is None, f"Test email {non_existent_email} already exists in database"
 


### PR DESCRIPTION
Fix the issue where randomly generated emails by faker actually correspond to existing accounts in the test database, causing test failures.

```
WebAppAuthService.authenticate(non_existent_email, "any_password") api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py:257:  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  email = '[adavis@example.org](mailto:adavis@example.org)', password = 'any_password'     @staticmethod    def authenticate(email: str, password: str) -> Account:        """authenticate account with email and password"""        account = db.session.query(Account).filter_by(email=email).first()        if not account:            raise AccountNotFoundError()            if account.status == AccountStatus.BANNED.value:            raise AccountLoginError("Account is banned.")            if account.password is None or not compare_password(password, account.password, account.password_salt): >           raise AccountPasswordError("Invalid email or password.") E           services.errors.account.AccountPasswordError: Invalid email or password.
```

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
