### PR TITLE
feat: enhance Makefile with code quality commands and default help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,7 @@ check:
 
 lint:
 	@echo "🔧 Running ruff format and check with fixes..."
-	@uv run --project api --dev ruff format ./api
-	@uv run --project api --dev ruff check --fix ./api
+	@uv run --directory api --dev sh -c 'ruff format ./api && ruff check --fix ./api'
 	@echo "✅ Linting complete"
 
 type-check:

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ WEB_IMAGE=$(DOCKER_REGISTRY)/dify-web
 API_IMAGE=$(DOCKER_REGISTRY)/dify-api
 VERSION=latest
 
+# Default target - show help
+.DEFAULT_GOAL := help
+
 # Backend Development Environment Setup
 .PHONY: dev-setup prepare-docker prepare-web prepare-api
 
-# Default dev setup target
+# Dev setup target
 dev-setup: prepare-docker prepare-web prepare-api
 	@echo "✅ Backend development environment setup complete!"
 
@@ -45,6 +48,28 @@ dev-clean:
 	@rm -rf docker/volumes/weaviate
 	@rm -rf api/storage
 	@echo "✅ Cleanup complete"
+
+# Backend Code Quality Commands
+format:
+	@echo "🎨 Running ruff format..."
+	@uv run --project api --dev ruff format ./api
+	@echo "✅ Code formatting complete"
+
+check:
+	@echo "🔍 Running ruff check..."
+	@uv run --project api --dev ruff check ./api
+	@echo "✅ Code check complete"
+
+lint:
+	@echo "🔧 Running ruff format and check with fixes..."
+	@uv run --project api --dev ruff format ./api
+	@uv run --project api --dev ruff check --fix ./api
+	@echo "✅ Linting complete"
+
+type-check:
+	@echo "📝 Running type check with basedpyright..."
+	@uv run --directory api --dev basedpyright
+	@echo "✅ Type check complete"
 
 # Build Docker images
 build-web:
@@ -90,6 +115,12 @@ help:
 	@echo "  make prepare-api    - Set up API environment"
 	@echo "  make dev-clean      - Stop Docker middleware containers"
 	@echo ""
+	@echo "Backend Code Quality:"
+	@echo "  make format         - Format code with ruff"
+	@echo "  make check          - Check code with ruff"
+	@echo "  make lint           - Format and fix code with ruff"
+	@echo "  make type-check     - Run type checking with basedpyright"
+	@echo ""
 	@echo "Docker Build Targets:"
 	@echo "  make build-web      - Build web Docker image"
 	@echo "  make build-api      - Build API Docker image"
@@ -98,4 +129,4 @@ help:
 	@echo "  make build-push-all - Build and push all Docker images"
 
 # Phony targets
-.PHONY: build-web build-api push-web push-api build-all push-all build-push-all dev-setup prepare-docker prepare-web prepare-api dev-clean help
+.PHONY: build-web build-api push-web push-api build-all push-all build-push-all dev-setup prepare-docker prepare-web prepare-api dev-clean help format check lint type-check


### PR DESCRIPTION
## Summary
- Set help as default target when running `make` without arguments for better discoverability
- Add convenient make targets for backend code quality tools (format, check, lint, type-check)
- Include `--dev` flag for automatic dependency installation when running code quality commands

This enhancement improves developer experience by providing shorter, more memorable commands for common code quality tasks and making the Makefile more discoverable.

Fixes #25654