### PR TITLE
feat: add circular scrolling to GotoAnything command menu

### DIFF
--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -284,6 +284,7 @@ const GotoAnything: FC<Props> = ({
             value={cmdVal}
             onValueChange={setCmdVal}
             disablePointerSelection
+            loop
           >
             <div className='flex items-center gap-3 border-b border-divider-subtle bg-components-panel-bg-blur px-4 py-3'>
               <RiSearchLine className='h-4 w-4 text-text-quaternary' />


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #25661

This PR adds circular scrolling (loop navigation) to the GotoAnything command menu. When users reach the end of the list and press the down arrow key, it now jumps to the first item. Similarly, pressing the up arrow at the first item jumps to the last item.

The implementation leverages cmdk's native `loop` prop, which is a minimal one-line change that significantly improves keyboard navigation UX.

## Screenshots

| Before | After |
|--------|-------|
| Navigation stops at first/last item | Navigation loops from last to first item and vice versa |

## Benefits

- ✅ Improved navigation efficiency  
- ✅ Consistent with other command palettes (VS Code, Raycast, etc.)
- ✅ Better user experience for keyboard-heavy users
- ✅ No performance impact

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods