### PR TITLE
optimize _merge_splits function by using enumerate instead of manual index tracking

### DIFF
--- a/api/core/rag/splitter/text_splitter.py
+++ b/api/core/rag/splitter/text_splitter.py
@@ -110,8 +110,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         docs = []
         current_doc: list[str] = []
         total = 0
-        for i,d in enumerate(splits):
-            _len = lengths[i]
+        for d, _len in zip(splits, lengths):
             if total + _len + (separator_len if len(current_doc) > 0 else 0) > self._chunk_size:
                 if total > self._chunk_size:
                     logger.warning(

--- a/api/core/rag/splitter/text_splitter.py
+++ b/api/core/rag/splitter/text_splitter.py
@@ -110,9 +110,8 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         docs = []
         current_doc: list[str] = []
         total = 0
-        index = 0
-        for d in splits:
-            _len = lengths[index]
+        for i,d in enumerate(splits):
+            _len = lengths[i]
             if total + _len + (separator_len if len(current_doc) > 0 else 0) > self._chunk_size:
                 if total > self._chunk_size:
                     logger.warning(
@@ -134,7 +133,6 @@ class TextSplitter(BaseDocumentTransformer, ABC):
                         current_doc = current_doc[1:]
             current_doc.append(d)
             total += _len + (separator_len if len(current_doc) > 1 else 0)
-            index += 1
         doc = self._join_docs(current_doc, separator)
         if doc is not None:
             docs.append(doc)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixed #25679 This issue proposes a code refactoring improvement to the _merge_splits function in api/core/rag/splitter/text_splitter.py. The change replaces manual index variable management with Python's built-in enumerate() function for cleaner and more Pythonic code.

## Screenshots

**Before**:
```
index = 0
for d in splits:
    _len = lengths[index]
    # ... rest of the logic
    index += 1
```
**After**:
```
for i, d in enumerate(splits):
    _len = lengths[i]
    # ... rest of the logic
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
