### PR TITLE
[Chore/Refactor] use __all__ to specify export member.

### DIFF
--- a/api/controllers/console/__init__.py
+++ b/api/controllers/console/__init__.py
@@ -54,90 +54,90 @@ api.add_resource(AppImportCheckDependenciesApi, "/apps/imports/<string:app_id>/c
 
 # Import other controllers
 from . import (
-    admin,  # pyright: ignore[reportUnusedImport]
-    apikey,  # pyright: ignore[reportUnusedImport]
-    extension,  # pyright: ignore[reportUnusedImport]
-    feature,  # pyright: ignore[reportUnusedImport]
-    init_validate,  # pyright: ignore[reportUnusedImport]
-    ping,  # pyright: ignore[reportUnusedImport]
-    setup,  # pyright: ignore[reportUnusedImport]
-    version,  # pyright: ignore[reportUnusedImport]
+    admin,
+    apikey,
+    extension,
+    feature,
+    init_validate,
+    ping,
+    setup,
+    version,
 )
 
 # Import app controllers
 from .app import (
-    advanced_prompt_template,  # pyright: ignore[reportUnusedImport]
-    agent,  # pyright: ignore[reportUnusedImport]
-    annotation,  # pyright: ignore[reportUnusedImport]
-    app,  # pyright: ignore[reportUnusedImport]
-    audio,  # pyright: ignore[reportUnusedImport]
-    completion,  # pyright: ignore[reportUnusedImport]
-    conversation,  # pyright: ignore[reportUnusedImport]
-    conversation_variables,  # pyright: ignore[reportUnusedImport]
-    generator,  # pyright: ignore[reportUnusedImport]
-    mcp_server,  # pyright: ignore[reportUnusedImport]
-    message,  # pyright: ignore[reportUnusedImport]
-    model_config,  # pyright: ignore[reportUnusedImport]
-    ops_trace,  # pyright: ignore[reportUnusedImport]
-    site,  # pyright: ignore[reportUnusedImport]
-    statistic,  # pyright: ignore[reportUnusedImport]
-    workflow,  # pyright: ignore[reportUnusedImport]
-    workflow_app_log,  # pyright: ignore[reportUnusedImport]
-    workflow_draft_variable,  # pyright: ignore[reportUnusedImport]
-    workflow_run,  # pyright: ignore[reportUnusedImport]
-    workflow_statistic,  # pyright: ignore[reportUnusedImport]
+    advanced_prompt_template,
+    agent,
+    annotation,
+    app,
+    audio,
+    completion,
+    conversation,
+    conversation_variables,
+    generator,
+    mcp_server,
+    message,
+    model_config,
+    ops_trace,
+    site,
+    statistic,
+    workflow,
+    workflow_app_log,
+    workflow_draft_variable,
+    workflow_run,
+    workflow_statistic,
 )
 
 # Import auth controllers
 from .auth import (
-    activate,  # pyright: ignore[reportUnusedImport]
-    data_source_bearer_auth,  # pyright: ignore[reportUnusedImport]
-    data_source_oauth,  # pyright: ignore[reportUnusedImport]
-    email_register,  # pyright: ignore[reportUnusedImport]
-    forgot_password,  # pyright: ignore[reportUnusedImport]
-    login,  # pyright: ignore[reportUnusedImport]
-    oauth,  # pyright: ignore[reportUnusedImport]
-    oauth_server,  # pyright: ignore[reportUnusedImport]
+    activate,
+    data_source_bearer_auth,
+    data_source_oauth,
+    email_register,
+    forgot_password,
+    login,
+    oauth,
+    oauth_server,
 )
 
 # Import billing controllers
-from .billing import billing, compliance  # pyright: ignore[reportUnusedImport]
+from .billing import billing, compliance
 
 # Import datasets controllers
 from .datasets import (
-    data_source,  # pyright: ignore[reportUnusedImport]
-    datasets,  # pyright: ignore[reportUnusedImport]
-    datasets_document,  # pyright: ignore[reportUnusedImport]
-    datasets_segments,  # pyright: ignore[reportUnusedImport]
-    external,  # pyright: ignore[reportUnusedImport]
-    hit_testing,  # pyright: ignore[reportUnusedImport]
-    metadata,  # pyright: ignore[reportUnusedImport]
-    website,  # pyright: ignore[reportUnusedImport]
+    data_source,
+    datasets,
+    datasets_document,
+    datasets_segments,
+    external,
+    hit_testing,
+    metadata,
+    website,
 )
 
 # Import explore controllers
 from .explore import (
-    installed_app,  # pyright: ignore[reportUnusedImport]
-    parameter,  # pyright: ignore[reportUnusedImport]
-    recommended_app,  # pyright: ignore[reportUnusedImport]
-    saved_message,  # pyright: ignore[reportUnusedImport]
+    installed_app,
+    parameter,
+    recommended_app,
+    saved_message,
 )
 
 # Import tag controllers
-from .tag import tags  # pyright: ignore[reportUnusedImport]
+from .tag import tags
 
 # Import workspace controllers
 from .workspace import (
-    account,  # pyright: ignore[reportUnusedImport]
-    agent_providers,  # pyright: ignore[reportUnusedImport]
-    endpoint,  # pyright: ignore[reportUnusedImport]
-    load_balancing_config,  # pyright: ignore[reportUnusedImport]
-    members,  # pyright: ignore[reportUnusedImport]
-    model_providers,  # pyright: ignore[reportUnusedImport]
-    models,  # pyright: ignore[reportUnusedImport]
-    plugin,  # pyright: ignore[reportUnusedImport]
-    tool_providers,  # pyright: ignore[reportUnusedImport]
-    workspace,  # pyright: ignore[reportUnusedImport]
+    account,
+    agent_providers,
+    endpoint,
+    load_balancing_config,
+    members,
+    model_providers,
+    models,
+    plugin,
+    tool_providers,
+    workspace,
 )
 
 # Explore Audio
@@ -212,3 +212,72 @@ api.add_resource(
 )
 
 api.add_namespace(console_ns)
+
+__all__ = [
+    "account",
+    "activate",
+    # Imported modules for side-effects (Flask route registration)
+    "admin",
+    "advanced_prompt_template",
+    "agent",
+    "agent_providers",
+    "annotation",
+    "api",
+    "apikey",
+    "app",
+    "audio",
+    "billing",
+    # Core components
+    "bp",
+    "completion",
+    "compliance",
+    "console_ns",
+    "conversation",
+    "conversation_variables",
+    "data_source",
+    "data_source_bearer_auth",
+    "data_source_oauth",
+    "datasets",
+    "datasets_document",
+    "datasets_segments",
+    "email_register",
+    "endpoint",
+    "extension",
+    "external",
+    "feature",
+    "forgot_password",
+    "generator",
+    "hit_testing",
+    "init_validate",
+    "installed_app",
+    "load_balancing_config",
+    "login",
+    "mcp_server",
+    "members",
+    "message",
+    "metadata",
+    "model_config",
+    "model_providers",
+    "models",
+    "oauth",
+    "oauth_server",
+    "ops_trace",
+    "parameter",
+    "ping",
+    "plugin",
+    "recommended_app",
+    "saved_message",
+    "setup",
+    "site",
+    "statistic",
+    "tags",
+    "tool_providers",
+    "version",
+    "website",
+    "workflow",
+    "workflow_app_log",
+    "workflow_draft_variable",
+    "workflow_run",
+    "workflow_statistic",
+    "workspace",
+]

--- a/api/controllers/console/__init__.py
+++ b/api/controllers/console/__init__.py
@@ -216,7 +216,6 @@ api.add_namespace(console_ns)
 __all__ = [
     "account",
     "activate",
-    # Imported modules for side-effects (Flask route registration)
     "admin",
     "advanced_prompt_template",
     "agent",
@@ -227,7 +226,6 @@ __all__ = [
     "app",
     "audio",
     "billing",
-    # Core components
     "bp",
     "completion",
     "compliance",

--- a/api/controllers/files/__init__.py
+++ b/api/controllers/files/__init__.py
@@ -20,10 +20,8 @@ api.add_namespace(files_ns)
 
 __all__ = [
     "api",
-    # Core components
     "bp",
     "files_ns",
-    # Imported modules for side-effects (Flask route registration)
     "image_preview",
     "tool_files",
     "upload",

--- a/api/controllers/files/__init__.py
+++ b/api/controllers/files/__init__.py
@@ -14,6 +14,17 @@ api = ExternalApi(
 
 files_ns = Namespace("files", description="File operations", path="/")
 
-from . import image_preview, tool_files, upload  # pyright: ignore[reportUnusedImport]
+from . import image_preview, tool_files, upload
 
 api.add_namespace(files_ns)
+
+__all__ = [
+    "api",
+    # Core components
+    "bp",
+    "files_ns",
+    # Imported modules for side-effects (Flask route registration)
+    "image_preview",
+    "tool_files",
+    "upload",
+]

--- a/api/controllers/inner_api/__init__.py
+++ b/api/controllers/inner_api/__init__.py
@@ -22,12 +22,10 @@ from .workspace import workspace as _workspace
 api.add_namespace(inner_api_ns)
 
 __all__ = [
-    # Imported modules for side-effects (Flask route registration)
     "_mail",
     "_plugin",
     "_workspace",
     "api",
-    # Core components
     "bp",
     "inner_api_ns",
 ]

--- a/api/controllers/inner_api/__init__.py
+++ b/api/controllers/inner_api/__init__.py
@@ -15,8 +15,19 @@ api = ExternalApi(
 # Create namespace
 inner_api_ns = Namespace("inner_api", description="Internal API operations", path="/")
 
-from . import mail as _mail  # pyright: ignore[reportUnusedImport]
-from .plugin import plugin as _plugin  # pyright: ignore[reportUnusedImport]
-from .workspace import workspace as _workspace  # pyright: ignore[reportUnusedImport]
+from . import mail as _mail
+from .plugin import plugin as _plugin
+from .workspace import workspace as _workspace
 
 api.add_namespace(inner_api_ns)
+
+__all__ = [
+    # Imported modules for side-effects (Flask route registration)
+    "_mail",
+    "_plugin",
+    "_workspace",
+    "api",
+    # Core components
+    "bp",
+    "inner_api_ns",
+]

--- a/api/controllers/mcp/__init__.py
+++ b/api/controllers/mcp/__init__.py
@@ -14,6 +14,15 @@ api = ExternalApi(
 
 mcp_ns = Namespace("mcp", description="MCP operations", path="/")
 
-from . import mcp  # pyright: ignore[reportUnusedImport]
+from . import mcp
 
 api.add_namespace(mcp_ns)
+
+__all__ = [
+    "api",
+    # Core components
+    "bp",
+    # Imported modules for side-effects (Flask route registration)
+    "mcp",
+    "mcp_ns",
+]

--- a/api/controllers/mcp/__init__.py
+++ b/api/controllers/mcp/__init__.py
@@ -20,9 +20,7 @@ api.add_namespace(mcp_ns)
 
 __all__ = [
     "api",
-    # Core components
     "bp",
-    # Imported modules for side-effects (Flask route registration)
     "mcp",
     "mcp_ns",
 ]

--- a/api/controllers/web/__init__.py
+++ b/api/controllers/web/__init__.py
@@ -36,10 +36,8 @@ api.add_namespace(web_ns)
 
 __all__ = [
     "api",
-    # Imported modules for side-effects (Flask route registration)
     "app",
     "audio",
-    # Core components
     "bp",
     "completion",
     "conversation",

--- a/api/controllers/web/__init__.py
+++ b/api/controllers/web/__init__.py
@@ -16,20 +16,42 @@ api = ExternalApi(
 web_ns = Namespace("web", description="Web application API operations", path="/")
 
 from . import (
-    app,  # pyright: ignore[reportUnusedImport]
-    audio,  # pyright: ignore[reportUnusedImport]
-    completion,  # pyright: ignore[reportUnusedImport]
-    conversation,  # pyright: ignore[reportUnusedImport]
-    feature,  # pyright: ignore[reportUnusedImport]
-    files,  # pyright: ignore[reportUnusedImport]
-    forgot_password,  # pyright: ignore[reportUnusedImport]
-    login,  # pyright: ignore[reportUnusedImport]
-    message,  # pyright: ignore[reportUnusedImport]
-    passport,  # pyright: ignore[reportUnusedImport]
-    remote_files,  # pyright: ignore[reportUnusedImport]
-    saved_message,  # pyright: ignore[reportUnusedImport]
-    site,  # pyright: ignore[reportUnusedImport]
-    workflow,  # pyright: ignore[reportUnusedImport]
+    app,
+    audio,
+    completion,
+    conversation,
+    feature,
+    files,
+    forgot_password,
+    login,
+    message,
+    passport,
+    remote_files,
+    saved_message,
+    site,
+    workflow,
 )
 
 api.add_namespace(web_ns)
+
+__all__ = [
+    "api",
+    # Imported modules for side-effects (Flask route registration)
+    "app",
+    "audio",
+    # Core components
+    "bp",
+    "completion",
+    "conversation",
+    "feature",
+    "files",
+    "forgot_password",
+    "login",
+    "message",
+    "passport",
+    "remote_files",
+    "saved_message",
+    "site",
+    "web_ns",
+    "workflow",
+]

--- a/api/core/rag/extractor/unstructured/unstructured_doc_extractor.py
+++ b/api/core/rag/extractor/unstructured/unstructured_doc_extractor.py
@@ -23,7 +23,7 @@ class UnstructuredWordExtractor(BaseExtractor):
         unstructured_version = tuple(int(x) for x in __unstructured_version__.split("."))
         # check the file extension
         try:
-            import magic  # noqa: F401  # pyright: ignore[reportUnusedImport]
+            import magic  # noqa: F401
 
             is_doc = detect_filetype(self._file_path) == FileType.DOC
         except ImportError:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR replaces all `pyright: ignore[reportUnusedImport]` comments with proper `__all__` declarations to explicitly specify module exports. 

**Files modified:**
- `api/controllers/console/__init__.py` 
- `api/controllers/web/__init__.py` 
- `api/controllers/inner_api/__init__.py` 
- `api/controllers/mcp/__init__.py` 
- `api/controllers/files/__init__.py` 
- `api/core/rag/extractor/unstructured/unstructured_doc_extractor.py` 

Fixes #25665

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
