### PR TITLE
Bugfix: When i change the loop variable, 'Loop Termination Condition' wi…

### DIFF
--- a/web/app/components/workflow/nodes/loop/use-config.ts
+++ b/web/app/components/workflow/nodes/loop/use-config.ts
@@ -47,14 +47,14 @@ const useConfig = (id: string, payload: LoopNodeType) => {
   })
 
   const changeErrorResponseMode = useCallback((item: { value: unknown }) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       draft.error_handle_mode = item.value as ErrorHandleMode
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [inputs, handleInputsChange])
 
   const handleAddCondition = useCallback<HandleAddCondition>((valueSelector, varItem) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       if (!draft.break_conditions)
         draft.break_conditions = []
 
@@ -66,34 +66,34 @@ const useConfig = (id: string, payload: LoopNodeType) => {
         value: varItem.type === VarType.boolean ? 'false' : '',
       })
     })
-    setInputs(newInputs)
-  }, [getIsVarFileAttribute, inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [getIsVarFileAttribute, handleInputsChange])
 
   const handleRemoveCondition = useCallback<HandleRemoveCondition>((conditionId) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       draft.break_conditions = draft.break_conditions?.filter(item => item.id !== conditionId)
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleUpdateCondition = useCallback<HandleUpdateCondition>((conditionId, newCondition) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       const targetCondition = draft.break_conditions?.find(item => item.id === conditionId)
       if (targetCondition)
         Object.assign(targetCondition, newCondition)
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleToggleConditionLogicalOperator = useCallback<HandleToggleConditionLogicalOperator>(() => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       draft.logical_operator = draft.logical_operator === LogicalOperator.and ? LogicalOperator.or : LogicalOperator.and
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleAddSubVariableCondition = useCallback<HandleAddSubVariableCondition>((conditionId: string, key?: string) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       const condition = draft.break_conditions?.find(item => item.id === conditionId)
       if (!condition)
         return
@@ -119,11 +119,11 @@ const useConfig = (id: string, payload: LoopNodeType) => {
         })
       }
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleRemoveSubVariableCondition = useCallback((conditionId: string, subConditionId: string) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       const condition = draft.break_conditions?.find(item => item.id === conditionId)
       if (!condition)
         return
@@ -133,11 +133,11 @@ const useConfig = (id: string, payload: LoopNodeType) => {
       if (subVarCondition)
         subVarCondition.conditions = subVarCondition.conditions.filter(item => item.id !== subConditionId)
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleUpdateSubVariableCondition = useCallback<HandleUpdateSubVariableCondition>((conditionId, subConditionId, newSubCondition) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       const targetCondition = draft.break_conditions?.find(item => item.id === conditionId)
       if (targetCondition && targetCondition.sub_variable_condition) {
         const targetSubCondition = targetCondition.sub_variable_condition.conditions.find(item => item.id === subConditionId)
@@ -145,24 +145,24 @@ const useConfig = (id: string, payload: LoopNodeType) => {
           Object.assign(targetSubCondition, newSubCondition)
       }
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleToggleSubVariableConditionLogicalOperator = useCallback<HandleToggleSubVariableConditionLogicalOperator>((conditionId) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       const targetCondition = draft.break_conditions?.find(item => item.id === conditionId)
       if (targetCondition && targetCondition.sub_variable_condition)
         targetCondition.sub_variable_condition.logical_operator = targetCondition.sub_variable_condition.logical_operator === LogicalOperator.and ? LogicalOperator.or : LogicalOperator.and
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleUpdateLoopCount = useCallback((value: number) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputsRef.current, (draft) => {
       draft.loop_count = value
     })
-    setInputs(newInputs)
-  }, [inputs, setInputs])
+    handleInputsChange(newInputs)
+  }, [handleInputsChange])
 
   const handleAddLoopVariable = useCallback(() => {
     const newInputs = produce(inputsRef.current, (draft) => {


### PR DESCRIPTION
fixes #25692

When i change the loop variable, "Loop Termination Condition" will reset back to Previous. 

changes:

- use the 'handleInputsChange' not the 'setInputs' when loop variable change. make sure when inputs change，get the latest inputs.

<img width="3066" height="5047" alt="img_v3_02q5_929af99a-2b16-43bd-b17b-0a6f43f3e5bg" src="https://github.com/user-attachments/assets/2267525a-46a7-44b5-aec2-b139bd3289b1" />


## Summary

To fix #25692

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
