### PR TITLE
fix: resolve devalue prototype pollution vulnerability

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -244,11 +244,12 @@
   "pnpm": {
     "overrides": {
       "@eslint/plugin-kit@<0.3.4": "0.3.4",
+      "brace-expansion@<2.0.2": "2.0.2",
+      "devalue@<5.3.2": "5.3.2",
       "esbuild@<0.25.0": "0.25.0",
       "pbkdf2@<3.1.3": "3.1.3",
-      "vite@<6.2.7": "6.2.7",
       "prismjs@<1.30.0": "1.30.0",
-      "brace-expansion@<2.0.2": "2.0.2",
+      "vite@<6.2.7": "6.2.7",
       "array-includes": "npm:@nolyfill/array-includes@^1",
       "array.prototype.findlast": "npm:@nolyfill/array.prototype.findlast@^1",
       "array.prototype.findlastindex": "npm:@nolyfill/array.prototype.findlastindex@^1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -43,6 +43,7 @@ overrides:
   string.prototype.trimend: npm:@nolyfill/string.prototype.trimend@^1
   typed-array-buffer: npm:@nolyfill/typed-array-buffer@^1
   which-typed-array: npm:@nolyfill/which-typed-array@^1
+  devalue@<5.3.2: 5.3.2
 
 importers:
 
@@ -4825,8 +4826,8 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -11981,7 +11982,7 @@ snapshots:
       '@tanstack/form-core': 1.14.0
       '@tanstack/react-store': 0.7.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       decode-formdata: 0.9.0
-      devalue: 5.1.1
+      devalue: 5.3.2
       react: 19.1.1
     transitivePeerDependencies:
       - react-dom
@@ -13842,7 +13843,7 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  devalue@5.1.1: {}
+  devalue@5.3.2: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
This PR fixes a security vulnerability in the `devalue` package by forcing it to use the patched version 5.3.2.

## Related Issue
Fixes #25708

## Changes
- Added `devalue@<5.3.2: 5.3.2` to pnpm overrides in `web/package.json`
- This ensures the vulnerable version (5.1.1) is replaced with the patched version (5.3.2)

## Security Impact
This resolves the prototype pollution vulnerability identified by Dependabot in the devalue package, which was being pulled in as a transitive dependency through @tanstack/react-form.