### PR TITLE
fix(tests): resolve order dependency in disable_segments_from_index_task tests

### DIFF
--- a/api/tests/test_containers_integration_tests/tasks/test_disable_segments_from_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_disable_segments_from_index_task.py
@@ -290,9 +290,9 @@ class TestDisableSegmentsFromIndexTask:
                 # Verify the call arguments (checking by attributes rather than object identity)
                 call_args = mock_processor.clean.call_args
                 assert call_args[0][0].id == dataset.id  # First argument should be the dataset
-                assert call_args[0][1] == [
-                    segment.index_node_id for segment in segments
-                ]  # Second argument should be node IDs
+                assert sorted(call_args[0][1]) == sorted(
+                    [segment.index_node_id for segment in segments]
+                )  # Compare sorted lists to handle any order while preserving duplicates
                 assert call_args[1]["with_keywords"] is True
                 assert call_args[1]["delete_child_chunks"] is False
 
@@ -719,7 +719,9 @@ class TestDisableSegmentsFromIndexTask:
                 # Verify the call arguments
                 call_args = mock_processor.clean.call_args
                 assert call_args[0][0].id == dataset.id  # First argument should be the dataset
-                assert call_args[0][1] == expected_node_ids  # Second argument should be node IDs
+                assert sorted(call_args[0][1]) == sorted(
+                    expected_node_ids
+                )  # Compare sorted lists to handle any order while preserving duplicates
                 assert call_args[1]["with_keywords"] is True
                 assert call_args[1]["delete_child_chunks"] is False
 


### PR DESCRIPTION
## Summary

This PR fixes a test instability issue in the `disable_segments_from_index_task` integration tests by removing order dependency from assertions.

## Changes

- Updated test assertions to compare segment node IDs as sets instead of ordered lists
- Affected tests:
  - `test_disable_segments_success`
  - `test_disable_segments_mixed_valid_invalid_ids`

## Why This Fix Is Needed

The database query in `disable_segments_from_index_task.py` doesn't specify an `ORDER BY` clause when fetching segments, meaning results can be returned in any order depending on database internals. The tests were comparing node IDs as ordered lists, which could cause intermittent failures. Since the order doesn't affect the correctness of the `clean()` operation, comparing as sets ensures stable test results.

Fixes #25736