### PR TITLE
chore: remove UP042 ruff rule as it requires preview mode

### DIFF
--- a/api/.ruff.toml
+++ b/api/.ruff.toml
@@ -45,7 +45,6 @@ select = [
     "G001", # don't use str format to logging messages
     "G003", # don't use + in logging messages
     "G004", # don't use f-strings to format logging messages
-    "UP042", # use StrEnum
 ]
 
 ignore = [


### PR DESCRIPTION
## Summary
- Removed UP042 rule from ruff configuration as it is a preview rule that requires preview mode to be enabled

## Related Issue
Closes #25738

## Changes
Removed the UP042 rule ("use StrEnum") from `api/.ruff.toml` since it's a preview rule and our configuration has `preview = false`, meaning this rule was not actually being applied.