### PR TITLE
fix indexing_technique setting

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -863,6 +863,7 @@ class DatasetService:
                             embedding_model.provider, embedding_model.model
                         )
                         dataset.collection_binding_id = dataset_collection_binding.id
+                        dataset.indexing_technique = knowledge_configuration.indexing_technique
                     except LLMBadRequestError:
                         raise ValueError(
                             "No Embedding Model available. Please configure a valid provider "


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This pull request introduces an update to the dataset settings logic in `api/services/dataset_service.py`, specifically enhancing the configuration of dataset indexing techniques. The main change ensures that the dataset's `indexing_technique` is now set based on the knowledge configuration during the update process.

Enhancement to dataset configuration:

* The `indexing_technique` field of the `dataset` object is now assigned from the `knowledge_configuration`, ensuring that the dataset reflects the correct indexing technique after updates.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
