### PR TITLE
fix(makefile): correct uv project path for lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ check:
 
 lint:
 	@echo "🔧 Running ruff format and check with fixes..."
-	@uv run --directory api --dev sh -c 'ruff format ./api && ruff check --fix ./api'
+	@uv run --project api --dev sh -c 'ruff format ./api && ruff check --fix ./api'
 	@echo "✅ Linting complete"
 
 type-check:


### PR DESCRIPTION
## Summary
- update the Makefile lint target to call `uv run --project api --dev` so Ruff executes in the configured API project environment

Fixes #25816

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
