### PR TITLE
chore(workflows): remove redundant eslint command from style workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -102,7 +102,6 @@ jobs:
         working-directory: ./web
         run: |
           pnpm run lint
-          pnpm run eslint
 
   docker-compose-template:
     name: Docker Compose Template


### PR DESCRIPTION
## Summary
- Removed duplicate 'pnpm run eslint' command from GitHub style workflow
- 'pnpm run lint' already includes ESLint checking, making the separate command redundant

## Changes
- Simplified .github/workflows/style.yml by removing unnecessary eslint step

## Benefits
- Reduces CI execution time by eliminating redundant linting
- Streamlines workflow configuration
- Maintains same linting coverage since 'pnpm run lint' includes ESLint