### PR TITLE
Fix: replace stdout prints with debug logging

### DIFF
--- a/api/celery_entrypoint.py
+++ b/api/celery_entrypoint.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _log(message: str):
-    print(message, flush=True)
+    _logger.debug(message)
 
 
 # grpc gevent

--- a/api/commands.py
+++ b/api/commands.py
@@ -1544,7 +1544,7 @@ def transform_datasource_credentials():
                 if jina_plugin_id not in installed_plugins_ids:
                     if jina_plugin_unique_identifier:
                         # install jina plugin
-                        print(jina_plugin_unique_identifier)
+                        logger.debug("Installing Jina plugin %s", jina_plugin_unique_identifier)
                         PluginService.install_from_marketplace_pkg(tenant_id, [jina_plugin_unique_identifier])
 
                 auth_count = 0

--- a/api/core/schemas/registry.py
+++ b/api/core/schemas/registry.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import threading
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
@@ -7,6 +8,8 @@ from typing import Any, ClassVar, Optional
 
 class SchemaRegistry:
     """Schema registry manages JSON schemas with version support"""
+
+    logger: ClassVar[logging.Logger] = logging.getLogger(__name__)
 
     _default_instance: ClassVar[Optional["SchemaRegistry"]] = None
     _lock: ClassVar[threading.Lock] = threading.Lock()
@@ -83,7 +86,7 @@ class SchemaRegistry:
             self.metadata[uri] = metadata
 
         except (OSError, json.JSONDecodeError) as e:
-            print(f"Warning: failed to load schema {version}/{schema_name}: {e}")
+            self.logger.debug("Failed to load schema %s/%s: %s", version, schema_name, e)
 
     def get_schema(self, uri: str) -> Any | None:
         """Retrieves a schema by URI with version support"""

--- a/api/core/schemas/registry.py
+++ b/api/core/schemas/registry.py
@@ -86,7 +86,7 @@ class SchemaRegistry:
             self.metadata[uri] = metadata
 
         except (OSError, json.JSONDecodeError) as e:
-            self.logger.debug("Failed to load schema %s/%s: %s", version, schema_name, e)
+            self.logger.warning("Failed to load schema %s/%s: %s", version, schema_name, e)
 
     def get_schema(self, uri: str) -> Any | None:
         """Retrieves a schema by URI with version support"""

--- a/api/services/rag_pipeline/rag_pipeline_transform_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_transform_service.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -16,6 +17,8 @@ from models.workflow import Workflow, WorkflowType
 from services.entities.knowledge_entities.rag_pipeline_entities import KnowledgeConfiguration, RetrievalSetting
 from services.plugin.plugin_migration import PluginMigration
 from services.plugin.plugin_service import PluginService
+
+logger = logging.getLogger(__name__)
 
 
 class RagPipelineTransformService:
@@ -257,7 +260,7 @@ class RagPipelineTransformService:
                     if plugin_unique_identifier:
                         need_install_plugin_unique_identifiers.append(plugin_unique_identifier)
         if need_install_plugin_unique_identifiers:
-            print(need_install_plugin_unique_identifiers)
+            logger.debug("Installing missing pipeline plugins %s", need_install_plugin_unique_identifiers)
             PluginService.install_from_marketplace_pkg(tenant_id, need_install_plugin_unique_identifiers)
 
     def _transfrom_to_empty_pipeline(self, dataset: Dataset):


### PR DESCRIPTION
## Summary

- route backend initialization and migration messages through module loggers instead of stdout prints
- avoid T201 lint warnings by logging plugin installation identifiers at debug level

Fixes #25930.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
