### PR TITLE
Run import-linter within make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,9 @@ check:
 	@echo "✅ Code check complete"
 
 lint:
-	@echo "🔧 Running ruff format and check with fixes..."
+	@echo "🔧 Running ruff format, check with fixes, and import linter..."
 	@uv run --project api --dev sh -c 'ruff format ./api && ruff check --fix ./api'
+	@uv run --directory api --dev lint-imports
 	@echo "✅ Linting complete"
 
 type-check:


### PR DESCRIPTION
## Summary
- run `uv run --directory api --dev lint-imports` inside the `make lint` target after the ruff fix step
- align contributor workflow with the existing `dev/reformat` script so architectural contracts are enforced locally

Fixes #25932

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
