### PR TITLE
Fix multiple re-renders in useAppsQueryState caused by searchParams dependency

### DIFF
--- a/web/app/components/apps/hooks/use-apps-query-state.ts
+++ b/web/app/components/apps/hooks/use-apps-query-state.ts
@@ -1,5 +1,5 @@
 import { type ReadonlyURLSearchParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 type AppsQuery = {
   tagIDs?: string[]
@@ -42,16 +42,21 @@ function useAppsQueryState() {
   const router = useRouter()
   const pathname = usePathname()
 
+  const queryRef = useRef(query)
+  useEffect(() => {
+    queryRef.current = query
+  }, [query])
+
   const setQuery = useCallback(
     (updater: (prev: AppsQuery) => AppsQuery) => {
-      const newQuery = updater(query)
+      const newQuery = updater(queryRef.current)
       const params = new URLSearchParams()
       updateSearchParams(newQuery, params)
       const search = params.toString()
       const queryString = search ? `?${search}` : ''
       router.push(`${pathname}${queryString}`, { scroll: false })
     },
-    [query, router, pathname],
+    [router, pathname],
   )
 
   return useMemo(() => ({ query, setQuery }), [query, setQuery])

--- a/web/app/components/apps/hooks/use-apps-query-state.ts
+++ b/web/app/components/apps/hooks/use-apps-query-state.ts
@@ -1,5 +1,5 @@
 import { type ReadonlyURLSearchParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 
 type AppsQuery = {
   tagIDs?: string[]
@@ -42,21 +42,16 @@ function useAppsQueryState() {
   const router = useRouter()
   const pathname = usePathname()
 
-  const queryRef = useRef(query)
-  useEffect(() => {
-    queryRef.current = query
-  }, [query])
-
   const setQuery = useCallback(
     (updater: (prev: AppsQuery) => AppsQuery) => {
-      const newQuery = updater(queryRef.current)
+      const newQuery = updater(query)
       const params = new URLSearchParams()
       updateSearchParams(newQuery, params)
       const search = params.toString()
       const queryString = search ? `?${search}` : ''
       router.push(`${pathname}${queryString}`, { scroll: false })
     },
-    [router, pathname],
+    [query, router, pathname],
   )
 
   return useMemo(() => ({ query, setQuery }), [query, setQuery])

--- a/web/app/components/apps/hooks/use-apps-query-state.ts
+++ b/web/app/components/apps/hooks/use-apps-query-state.ts
@@ -52,7 +52,7 @@ function useAppsQueryState() {
     const params = new URLSearchParams(searchParams)
     updateSearchParams(query, params)
     syncSearchParams(params)
-  }, [query, searchParams, syncSearchParams])
+  }, [query, syncSearchParams])
 
   return useMemo(() => ({ query, setQuery }), [query])
 }

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -75,8 +75,7 @@ const List = () => {
   const [activeTab, setActiveTab] = useTabSearchParams({
     defaultTab: 'all',
   })
-  const { query: { tagIDs = [], keywords = '', isCreatedByMe: queryIsCreatedByMe = false }, setQuery } = useAppsQueryState()
-  const [isCreatedByMe, setIsCreatedByMe] = useState(queryIsCreatedByMe)
+  const { query: { tagIDs = [], keywords = '', isCreatedByMe = false }, setQuery } = useAppsQueryState()
   const [tagFilterValue, setTagFilterValue] = useState<string[]>(tagIDs)
   const [searchKeywords, setSearchKeywords] = useState(keywords)
   const newAppCardRef = useRef<HTMLDivElement>(null)
@@ -171,10 +170,8 @@ const List = () => {
   }
 
   const handleCreatedByMeChange = useCallback(() => {
-    const newValue = !isCreatedByMe
-    setIsCreatedByMe(newValue)
-    setQuery(prev => ({ ...prev, isCreatedByMe: newValue }))
-  }, [isCreatedByMe, setQuery])
+    setQuery(prev => ({ ...prev, isCreatedByMe: !prev.isCreatedByMe }))
+  }, [setQuery])
 
   return (
     <>


### PR DESCRIPTION
## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

try to fix #26000 

When toggling the "Created by me" checkbox on the apps list page, the UI flickers 1–4 times.  It is because the effect in `useAppsQueryState` depends on both `query` and `searchParams`. This PR tries to eliminate multiple flickers when toggling "Created by me".

**before the fix:**
- 1. User toggles the checkbox → setQuery updates query.
- 2. Effect runs → router.push updates the URL.
- 3. URL change updates searchParams → effect runs again.

~~**after the fix:**~~
~~- 1. User toggles the checkbox → query changes → effect runs once.~~
~~- 2. Effect updates the URL with router.push.~~
~~- 3. searchParams updates internally, but no longer retriggers the effect.~~

**after the fix:**
- Refactored `useAppsQueryState` to follow the same pattern as `useDocumentListQueryState`.
- `query` is now always derived from URL search params.
- `setQuery` directly updates the URL; no more local state or useEffect sync.
- Updated `list.tsx` to remove the redundant local `isCreatedByMe` state.


## Screenshots
Before 
<img width="1250" height="965" alt="Screenshot from 2025-09-21 09-58-28" src="https://github.com/user-attachments/assets/343de2ae-c311-43df-bb0f-13c64d9453d8" />
After 
<img width="1247" height="863" alt="Screenshot from 2025-09-21 09-53-04" src="https://github.com/user-attachments/assets/921c2154-4156-42ff-9df1-92ae02dbf834" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
