### PR TITLE
chore(api): adjust monkey patching in gunicorn.conf.py

### DIFF
--- a/api/celery_entrypoint.py
+++ b/api/celery_entrypoint.py
@@ -1,20 +1,11 @@
-import logging
-
 import psycogreen.gevent as pscycogreen_gevent  # type: ignore
 from grpc.experimental import gevent as grpc_gevent  # type: ignore
 
-_logger = logging.getLogger(__name__)
-
-
-def _log(message: str):
-    _logger.debug(message)
-
-
 # grpc gevent
 grpc_gevent.init_gevent()
-_log("gRPC  patched with gevent.")
+print("gRPC patched with gevent.", flush=True)  # noqa: T201
 pscycogreen_gevent.patch_psycopg()
-_log("psycopg2 patched with gevent.")
+print("psycopg2 patched with gevent.", flush=True)  # noqa: T201
 
 
 from app import app, celery

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -1,10 +1,32 @@
 import psycogreen.gevent as pscycogreen_gevent  # type: ignore
+from gevent import events as gevent_events
 from grpc.experimental import gevent as grpc_gevent  # type: ignore
 
+# NOTE(QuantumGhost): here we cannot use post_fork to patch gRPC, as
+# grpc_gevent.init_gevent must be called after patching stdlib.
+# Gunicorn calls `post_init` before applying monkey patch.
+# Use `post_init` to setup gRPC gevent support would cause deadlock and
+# some other weird issues.
+#
+# ref:
+# - https://github.com/grpc/grpc/blob/62533ea13879d6ee95c6fda11ec0826ca822c9dd/src/python/grpcio/grpc/experimental/gevent.py
+# - https://github.com/gevent/gevent/issues/2060#issuecomment-3016768668
+# - https://github.com/benoitc/gunicorn/blob/master/gunicorn/arbiter.py#L607-L613
 
-def post_fork(server, worker):
+
+def post_patch(event):
+    # this function is only called for gevent worker.
+    # from gevent docs (https://www.gevent.org/api/gevent.monkey.html):
+    # You can also subscribe to the events to provide additional patching beyond what gevent distributes, either for
+    # additional standard library modules, or for third-party packages. The suggested time to do this patching is in
+    # the subscriber for gevent.events.GeventDidPatchBuiltinModulesEvent.
+    if not isinstance(event, gevent_events.GeventDidPatchBuiltinModulesEvent):
+        return
     # grpc gevent
     grpc_gevent.init_gevent()
-    server.log.info("gRPC  patched with gevent.")
+    print("gRPC patched with gevent.", flush=True)  # noqa: T201
     pscycogreen_gevent.patch_psycopg()
-    server.log.info("psycopg2 patched with gevent.")
+    print("psycopg2 patched with gevent.", flush=True)  # noqa: T201
+
+
+gevent_events.subscribers.append(post_patch)


### PR DESCRIPTION
## Summary

The `grpc_gevent.init_gevent` function must be called after stdlib has been patched. 
However, the `post_fork` hook is called before monkey patching is applied. 
These timing mismatch cauing `grpc_gevent` patching failed to work properly, and result in deadlock while using `ThreadPoolExecutor`.

Special thanks to @rouxiaomin for providing a reproducible example.

Closes #25823.

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
