### PR TITLE
chore: simplify getting rag transform yaml file in RagPipelineTransformService

### DIFF
--- a/api/services/rag_pipeline/rag_pipeline_transform_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_transform_service.py
@@ -126,9 +126,11 @@ class RagPipelineTransformService:
                     raise ValueError(f"Unsupported doc form {doc_form}")
             if not file_name:
                 raise ValueError(f"Unsupported doc form {doc_form} with {datasource_type}")
-        except KeyError:
+        except KeyError as e:
+            missing_key = e.args[0] if e.args else "unknown"
             raise ValueError(
-                f"Unsupported datasource type {datasource_type} or indexing technique {indexing_technique or ''}"
+                f"Missing key '{missing_key}' in yaml_map. "
+                f"doc_form: {doc_form}, datasource_type: {datasource_type}, indexing_technique: {indexing_technique or ''}"
             )
         file_path = Path(__file__).parent / f"transform/{file_name}"
         with open(file_path) as f:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- simplify getting rag transform yaml file in RagPipelineTransformService, by adding unified map and prefer using enum for index type and data source type

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
