### PR TITLE
fix: resolve UUID parsing error for default user session lookup

### DIFF
--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -32,11 +32,19 @@ def get_user(tenant_id: str, user_id: str | None) -> EndUser:
 
             if is_anonymous:
                 user_id = DefaultEndUserSessionID.DEFAULT_SESSION_ID.value
-            else:
                 user_model = (
                     session.query(EndUser)
                     .where(
                         EndUser.session_id == user_id,
+                        EndUser.tenant_id == tenant_id,
+                    )
+                    .first()
+                )
+            else:
+                user_model = (
+                    session.query(EndUser)
+                    .where(
+                        EndUser.id == user_id,
                         EndUser.tenant_id == tenant_id,
                     )
                     .first()

--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -24,20 +24,15 @@ def get_user(tenant_id: str, user_id: str | None) -> EndUser:
     NOTE: user_id is not trusted, it could be maliciously set to any value.
     As a result, it could only be considered as an end user id.
     """
+
+    is_anonymous = not user_id
     try:
         with Session(db.engine) as session:
-            if not user_id:
-                user_id = DefaultEndUserSessionID.DEFAULT_SESSION_ID.value
+            user_model = None
 
-            user_model = (
-                session.query(EndUser)
-                .where(
-                    EndUser.id == user_id,
-                    EndUser.tenant_id == tenant_id,
-                )
-                .first()
-            )
-            if not user_model:
+            if is_anonymous:
+                user_id = DefaultEndUserSessionID.DEFAULT_SESSION_ID.value
+            else:
                 user_model = (
                     session.query(EndUser)
                     .where(
@@ -46,11 +41,12 @@ def get_user(tenant_id: str, user_id: str | None) -> EndUser:
                     )
                     .first()
                 )
+
             if not user_model:
                 user_model = EndUser(
                     tenant_id=tenant_id,
                     type="service_api",
-                    is_anonymous=user_id == DefaultEndUserSessionID.DEFAULT_SESSION_ID.value,
+                    is_anonymous=is_anonymous,
                     session_id=user_id,
                 )
                 session.add(user_model)
@@ -68,6 +64,7 @@ def get_user_tenant(view: Callable[P, R] | None = None):
         @wraps(view_func)
         def decorated_view(*args: P.args, **kwargs: P.kwargs):
             # fetch json body
+
             parser = reqparse.RequestParser()
             parser.add_argument("tenant_id", type=str, required=True, location="json")
             parser.add_argument("user_id", type=str, required=True, location="json")

--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -72,7 +72,6 @@ def get_user_tenant(view: Callable[P, R] | None = None):
         @wraps(view_func)
         def decorated_view(*args: P.args, **kwargs: P.kwargs):
             # fetch json body
-
             parser = reqparse.RequestParser()
             parser.add_argument("tenant_id", type=str, required=True, location="json")
             parser.add_argument("user_id", type=str, required=True, location="json")

--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -24,14 +24,14 @@ def get_user(tenant_id: str, user_id: str | None) -> EndUser:
     NOTE: user_id is not trusted, it could be maliciously set to any value.
     As a result, it could only be considered as an end user id.
     """
-
-    is_anonymous = not user_id
+    if not user_id:
+        user_id = DefaultEndUserSessionID.DEFAULT_SESSION_ID.value
+    is_anonymous = user_id == DefaultEndUserSessionID.DEFAULT_SESSION_ID.value
     try:
         with Session(db.engine) as session:
             user_model = None
 
             if is_anonymous:
-                user_id = DefaultEndUserSessionID.DEFAULT_SESSION_ID.value
                 user_model = (
                     session.query(EndUser)
                     .where(


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced by PR #25416 that caused PostgreSQL UUID parsing errors when handling default user sessions in plugin API endpoints.

**Problem**: After the refactoring in PR #25416, the constant `DEFAULT-USER` (a string) was incorrectly used to query the `EndUser.id` field (UUID type), causing PostgreSQL to throw `invalid input syntax for type uuid: "DEFAULT-USER"` errors.

**Root Cause**: The refactoring moved `DEFAULT_SERVICE_API_USER_ID` to `DefaultEndUserSessionID` enum but didn't account for the fact that `"DEFAULT-USER"` is a session identifier, not a UUID, and should only be used to query the `session_id` field.

**Solution**: 
- Pre-calculate `is_anonymous` flag based on whether `user_id` is provided
- For anonymous users, set `user_id` to default value and query by `session_id` field only
- For non-anonymous users, query by `session_id` field (since user_id in plugin context represents session_id)
- Simplify the logic by removing unnecessary UUID vs session_id detection

**Impact**: This fix resolves the 400 errors occurring in plugin encryption endpoints (`/inner/api/invoke/encrypt`) and ensures proper user session handling for plugin APIs.

## Screenshots

This is a backend bug fix with no visual changes - the error was occurring in API responses:

| Before | After |
|--------|-------|
| `HTTP 400 - user not found` | `HTTP 200 - successful encryption/decryption` |
| <img width="412" height="332" alt="image" src="https://github.com/user-attachments/assets/45c8d2a7-2968-43e3-bb15-f0797fbc59fd" /> | <img width="442" height="357" alt="image" src="https://github.com/user-attachments/assets/22e67aaa-3148-4a2c-940e-b892f4ab6371" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods