### PR TITLE
fix(api): Fix variable truncation for `list[File]` value in output mapping

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -262,6 +262,14 @@ class VariableTruncator:
         target_length = self._array_element_limit
 
         for i, item in enumerate(value):
+            # Dirty fix:
+            # The output of `Start` node may contain list of `File` elements,
+            # causing `AssertionError` while invoking `_truncate_json_primitives`.
+            #
+            # This check ensures that `list[File]` are handled separately
+            if isinstance(item, File):
+                truncated_value.append(item)
+                continue
             if i >= target_length:
                 return _PartResult(truncated_value, used_size, True)
             if i > 0:

--- a/api/tests/unit_tests/services/test_variable_truncator.py
+++ b/api/tests/unit_tests/services/test_variable_truncator.py
@@ -588,3 +588,11 @@ class TestIntegrationScenarios:
             if isinstance(result.result, ObjectSegment):
                 result_size = truncator.calculate_json_size(result.result.value)
                 assert result_size <= original_size
+
+    def test_file_and_array_file_variable_mapping(self, file):
+        truncator = VariableTruncator(string_length_limit=30, array_element_limit=3, max_size_bytes=300)
+
+        mapping = {"array_file": [file]}
+        truncated_mapping, truncated = truncator.truncate_variable_mapping(mapping)
+        assert truncated is False
+        assert truncated_mapping == mapping


### PR DESCRIPTION
## Summary

Fixes #26097
Fix the issue that variable truncation does not handle `list[File]` properly. 
The output of `Start` node may contain output variable of `list[File]`, causing `AssertionError` while truncating 
node outputs.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1001" height="400" alt="image" src="https://github.com/user-attachments/assets/c5c06032-c5a7-4b01-b3d1-746a534f4558" />  <img width="432" height="404" alt="image" src="https://github.com/user-attachments/assets/6f13737a-f522-4ea5-a449-b6633a8b2410" /> | <img width="480" height="355" alt="image" src="https://github.com/user-attachments/assets/b544e18d-0a0c-40d6-b273-54884c001333" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
