### PR TITLE
fix: sync FileUploader context with props to fix inconsistent file parameter state in “View cached variables”.

### DIFF
--- a/web/app/components/base/file-uploader/store.tsx
+++ b/web/app/components/base/file-uploader/store.tsx
@@ -1,8 +1,8 @@
 import {
   createContext,
   useContext,
-  useRef,
   useEffect,
+  useRef,
 } from 'react'
 import {
   create,

--- a/web/app/components/base/file-uploader/store.tsx
+++ b/web/app/components/base/file-uploader/store.tsx
@@ -68,7 +68,7 @@ export const FileContextProvider = ({
   // subscribe to store changes and call latest onChange
   useEffect(() => {
     const store = storeRef.current!
-    const unsubscribe = (store as any).subscribe((state: Shape) => {
+    const unsubscribe = store.subscribe((state: Shape) => {
       if (isSyncingRef.current) return
       onChangeRef.current?.(state.files)
     })
@@ -80,11 +80,8 @@ export const FileContextProvider = ({
     const store = storeRef.current!
     const nextFiles = value ? [...value] : []
     isSyncingRef.current = true
-    ;(store as any).setState({ files: nextFiles })
-    // release the syncing flag in next tick to avoid triggering onChange for external sync
-    setTimeout(() => {
-      isSyncingRef.current = false
-    }, 0)
+    store.setState({ files: nextFiles })
+    isSyncingRef.current = false
   }, [value])
 
   return (


### PR DESCRIPTION
## Summary: Fix inconsistent file parameter state when switching in “View cached variables”

### Changes:
- Remove onChange closure from createFileStore; setFiles updates the store only.
- In FileContextProvider:
  - Track and call the latest onChange via a ref, using a store subscription.
  - Sync external value into the store with setState({ files: [...] }), guarded to avoid firing external onChange.
- Rationale: The store was initialized from props only once and did not update with new props, causing stale state and callback leakage across parameters/nodes.
- Validation: Switching among parameters/nodes and returning to a file-type parameter should show the correct file list;parameters that should not show files remain empty.

Fixed #26198 

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
