### PR TITLE
Fix array-only filtering in List Operator picker; remove file children fallback and align child types.

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -42,6 +42,7 @@ import type { RAGPipelineVariable } from '@/models/pipeline'
 
 import {
   AGENT_OUTPUT_STRUCT,
+  FILE_STRUCT,
   HTTP_REQUEST_OUTPUT_STRUCT,
   KNOWLEDGE_RETRIEVAL_OUTPUT_STRUCT,
   LLM_OUTPUT_STRUCT,
@@ -138,6 +139,10 @@ export const varTypeToStructType = (type: VarType): Type => {
         [VarType.boolean]: Type.boolean,
         [VarType.object]: Type.object,
         [VarType.array]: Type.array,
+        [VarType.arrayString]: Type.array,
+        [VarType.arrayNumber]: Type.array,
+        [VarType.arrayObject]: Type.array,
+        [VarType.arrayFile]: Type.array,
       } as any
     )[type] || Type.string
   )
@@ -282,15 +287,6 @@ const findExceptVarInObject = (
           children: filteredObj.children,
         }
       })
-
-    if (isFile && Array.isArray(childrenResult)) {
-      if (childrenResult.length === 0) {
-        childrenResult = OUTPUT_FILE_SUB_VARIABLES.map(key => ({
-          variable: key,
-          type: key === 'size' ? VarType.number : VarType.string,
-        }))
-      }
-    }
   }
   else {
     childrenResult = []
@@ -586,17 +582,15 @@ const formatItem = (
             variable: outputKey,
             type:
               output.type === 'array'
-                ? (`Array[${
-                  output.items?.type
-                    ? output.items.type.slice(0, 1).toLocaleUpperCase()
-                        + output.items.type.slice(1)
-                    : 'Unknown'
+                ? (`Array[${output.items?.type
+                  ? output.items.type.slice(0, 1).toLocaleUpperCase()
+                  + output.items.type.slice(1)
+                  : 'Unknown'
                 }]` as VarType)
-                : (`${
-                  output.type
-                    ? output.type.slice(0, 1).toLocaleUpperCase()
-                        + output.type.slice(1)
-                    : 'Unknown'
+                : (`${output.type
+                  ? output.type.slice(0, 1).toLocaleUpperCase()
+                  + output.type.slice(1)
+                  : 'Unknown'
                 }` as VarType),
           })
         },
@@ -690,9 +684,10 @@ const formatItem = (
       const children = (() => {
         if (isFile) {
           return OUTPUT_FILE_SUB_VARIABLES.map((key) => {
+            const def = FILE_STRUCT.find(c => c.variable === key)
             return {
               variable: key,
-              type: key === 'size' ? VarType.number : VarType.string,
+              type: def?.type || VarType.string,
             }
           })
         }
@@ -714,9 +709,10 @@ const formatItem = (
         if (isFile) {
           return {
             children: OUTPUT_FILE_SUB_VARIABLES.map((key) => {
+              const def = FILE_STRUCT.find(c => c.variable === key)
               return {
                 variable: key,
-                type: key === 'size' ? VarType.number : VarType.string,
+                type: def?.type || VarType.string,
               }
             }),
           }

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -18,7 +18,6 @@ import { Type } from '../../../llm/types'
 import PickerStructurePanel from '@/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker'
 import { isSpecialVar, varTypeToStructType } from './utils'
 import type { Field } from '@/app/components/workflow/nodes/llm/types'
-import { FILE_STRUCT } from '@/app/components/workflow/constants'
 import { noop } from 'lodash-es'
 import { CodeAssistant, MagicEdit } from '@/app/components/base/icons/src/vender/line/general'
 import ManageInputField from './manage-input-field'
@@ -106,8 +105,9 @@ const Item: FC<ItemProps> = ({
 
   const objStructuredOutput: StructuredOutput | null = useMemo(() => {
     if (!isObj) return null
-    const properties: Record<string, Field> = {};
-    (isFile ? FILE_STRUCT : (itemData.children as Var[])).forEach((c) => {
+    const properties: Record<string, Field> = {}
+    const childrenVars = (itemData.children as Var[]) || []
+    childrenVars.forEach((c) => {
       properties[c.variable] = {
         type: varTypeToStructType(c.type),
       }
@@ -120,7 +120,7 @@ const Item: FC<ItemProps> = ({
         additionalProperties: false,
       },
     }
-  }, [isFile, isObj, itemData.children])
+  }, [isObj, itemData.children])
 
   const structuredOutput = (() => {
     if (isStructureOutput)
@@ -448,4 +448,5 @@ const VarReferenceVars: FC<Props> = ({
     </>
   )
 }
+
 export default React.memo(VarReferenceVars)

--- a/web/app/components/workflow/nodes/list-operator/panel.tsx
+++ b/web/app/components/workflow/nodes/list-operator/panel.tsx
@@ -55,6 +55,7 @@ const Panel: FC<NodePanelProps<ListFilterNodeType>> = ({
             value={inputs.variable || []}
             onChange={handleVarChanges}
             filterVar={filterVar}
+            isSupportFileVar={false}
             typePlaceHolder='Array'
           />
         </Field>


### PR DESCRIPTION
Fixed #26239 

###  Changes:
    - Remove fallback that repopulates default file children when filtered empty in findExceptVarInObject, so File and its non-matching children do not leak into the picker.
    - Make display phase use filtered children instead of hardcoded FILE_STRUCT when rendering object/file children in VarReferenceVars.
    - Align file sub-variable types between filtering and rendering via FILE_STRUCT as the single source of truth.
    - Add isSupportFileVar={false} to list-operator’s VarReferencePicker to avoid selecting File root; users can still select eligible array children.
    - Map VarType.array* to Type.array in varTypeToStructType to correctly represent arrays in structured panels.
    - Remove stray debug logs.
### Files:
    - app/components/workflow/nodes/_base/components/variable/utils.ts
    - app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
    - app/components/workflow/nodes/list-operator/panel.tsx
### Rationale:
    - Ensures filterVar semantics are respected; only eligible array types remain visible.
    - Eliminates inconsistency between filtering and display phases.
### Risk:
    - Low; affects only variable picker UI. Panels expecting File will continue to show file and its children if their filter allows them.
###  Validation:
    - List Operator shows only arrays; File root and default children no longer appear unless there are array children.