### PR TITLE
Fix: avoid mutating node props

### DIFF
--- a/web/app/components/workflow/nodes/iteration/node.tsx
+++ b/web/app/components/workflow/nodes/iteration/node.tsx
@@ -41,7 +41,7 @@ const Node: FC<NodeProps<IterationNodeType>> = ({
       })
       setShowTips(false)
     }
-  }, [nodesInitialized, id, handleNodeIterationRerender, data, showTips, t])
+  }, [nodesInitialized, id, handleNodeIterationRerender, data.is_parallel, showTips, t])
 
   return (
     <div className={cn(

--- a/web/app/components/workflow/nodes/iteration/node.tsx
+++ b/web/app/components/workflow/nodes/iteration/node.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 import {
   memo,
   useEffect,
+  useState,
 } from 'react'
 import {
   Background,
@@ -27,19 +28,20 @@ const Node: FC<NodeProps<IterationNodeType>> = ({
   const nodesInitialized = useNodesInitialized()
   const { handleNodeIterationRerender } = useNodeIterationInteractions()
   const { t } = useTranslation()
+  const [showTips, setShowTips] = useState(data._isShowTips)
 
   useEffect(() => {
     if (nodesInitialized)
       handleNodeIterationRerender(id)
-    if (data.is_parallel && data._isShowTips) {
+    if (data.is_parallel && showTips) {
       Toast.notify({
         type: 'warning',
         message: t(`${i18nPrefix}.answerNodeWarningDesc`),
         duration: 5000,
       })
-      data._isShowTips = false
+      setShowTips(false)
     }
-  }, [nodesInitialized, id, handleNodeIterationRerender, data, t])
+  }, [nodesInitialized, id, handleNodeIterationRerender, data, showTips, t])
 
   return (
     <div className={cn(


### PR DESCRIPTION
Fixes #26267 

This PR fixes a React anti-pattern where `data._isShowTips` was mutated directly inside `Node` component.
- Replace `data._isShowTips = false` with local `useState` (`showTips`)
- Preserve initial value from props to keep behavior unchanged
- Prevents potential inconsistencies between parent props and child rendering

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
