### PR TITLE
Fix ChatClient.audio_to_text files keyword to make it work

### DIFF
--- a/sdks/python-client/dify_client/client.py
+++ b/sdks/python-client/dify_client/client.py
@@ -139,7 +139,7 @@ class ChatClient(DifyClient):
         data = {"user": user}
         return self._send_request("DELETE", f"/conversations/{conversation_id}", data)
 
-    def audio_to_text(self, audio_file: tuple, user: str):
+    def audio_to_text(self, audio_file: IO[bytes] | tuple, user: str):
         data = {"user": user}
         files = {"file": audio_file}
         return self._send_request_with_files("POST", "/audio-to-text", data, files)

--- a/sdks/python-client/dify_client/client.py
+++ b/sdks/python-client/dify_client/client.py
@@ -139,7 +139,7 @@ class ChatClient(DifyClient):
         data = {"user": user}
         return self._send_request("DELETE", f"/conversations/{conversation_id}", data)
 
-    def audio_to_text(self, audio_file: dict, user: str):
+    def audio_to_text(self, audio_file: tuple, user: str):
         data = {"user": user}
         files = {"file": audio_file}
         return self._send_request_with_files("POST", "/audio-to-text", data, files)

--- a/sdks/python-client/dify_client/client.py
+++ b/sdks/python-client/dify_client/client.py
@@ -141,7 +141,7 @@ class ChatClient(DifyClient):
 
     def audio_to_text(self, audio_file: dict, user: str):
         data = {"user": user}
-        files = {"audio_file": audio_file}
+        files = {"file": audio_file}
         return self._send_request_with_files("POST", "/audio-to-text", data, files)
 
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The python sdk is wrong about the needed keyword.
The python backend actually expects a file named `file` in the files variabe instead of `audio_file`

Then you can use the api as follows:
```python
from config import DIFY_API_KEY, DIFY_API_ENDPOINT
from dify_client import ChatClient

chat_client = ChatClient(DIFY_API_KEY)
chat_client.base_url = DIFY_API_ENDPOINT

audio_file = ("audio.wav", open("audio.wav", "rb"), "audio/wav")
response = chat_client.audio_to_text(
    audio_file=audio_file,
    user="default"
)
print(response.json())
```

Refer to this issue:
https://github.com/langgenius/dify/issues/20313

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
