### PR TITLE
hotfix: older version of execution_metadata may store agent_log as a JSON string

### DIFF
--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -470,12 +470,12 @@ class LLMGenerator:
                 try:
                     raw_agent_log = json.loads(raw_agent_log)
                 except (json.JSONDecodeError, TypeError) as e:
-                    logging.warning(f"Failed to parse agent_log JSON string: {e}")
+                    logging.warning("Failed to parse agent_log JSON string: %s", e)
                     return []
-            
+
             # Ensure raw_agent_log is a list before iteration
             if not isinstance(raw_agent_log, list):
-                logging.warning(f"agent_log is not a list, got {type(raw_agent_log)}")
+                logging.warning("agent_log is not a list, got %s", type(raw_agent_log))
                 return []
 
             return [

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -465,6 +465,19 @@ class LLMGenerator:
             if not raw_agent_log:
                 return []
 
+            # Handle case where raw_agent_log might be a JSON string from older execution_metadata
+            if isinstance(raw_agent_log, str):
+                try:
+                    raw_agent_log = json.loads(raw_agent_log)
+                except (json.JSONDecodeError, TypeError) as e:
+                    logging.warning(f"Failed to parse agent_log JSON string: {e}")
+                    return []
+            
+            # Ensure raw_agent_log is a list before iteration
+            if not isinstance(raw_agent_log, list):
+                logging.warning(f"agent_log is not a list, got {type(raw_agent_log)}")
+                return []
+
             return [
                 {
                     "status": event["status"],


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

the code assumes raw_agent_log is an iterable list but older execution_metadata may store agent_log as a JSON string, causing per-character iteration and "'str' object is not subscriptable" errors; update the logic to detect if raw_agent_log is a str and attempt json.loads to convert it into a list (catch and log JSONDecodeError and other exceptions), ensure the final value is a list before iterating, and return an empty list (or safe fallback) if parsing fails or the value is not a list.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
