### PR TITLE
fix(graph_engine): block response nodes during streaming

### DIFF
--- a/api/core/workflow/graph_engine/response_coordinator/coordinator.py
+++ b/api/core/workflow/graph_engine/response_coordinator/coordinator.py
@@ -216,6 +216,7 @@ class ResponseStreamCoordinator:
                 if source_node.execution_type in {
                     NodeExecutionType.BRANCH,
                     NodeExecutionType.CONTAINER,
+                    NodeExecutionType.RESPONSE,
                 } or source_node.blocks_variable_output(variable_selectors):
                     blocking_edges.append(edge_id)
 

--- a/api/core/workflow/graph_engine/response_coordinator/coordinator.py
+++ b/api/core/workflow/graph_engine/response_coordinator/coordinator.py
@@ -212,7 +212,7 @@ class ResponseStreamCoordinator:
                 edge = self._graph.edges[edge_id]
                 source_node = self._graph.nodes[edge.tail]
 
-                # Check if node is a branch/container (original behavior)
+                # Check if node is a branch, container, or response node
                 if source_node.execution_type in {
                     NodeExecutionType.BRANCH,
                     NodeExecutionType.CONTAINER,


### PR DESCRIPTION
## Summary

- treat Response nodes as blocking sources in the streaming coordinator so dependent edges wait for final output
- prevent partial or duplicated replies when a Response node is still emitting tokens

Fixes #26363.

## Screenshots

| Before | After |
|--------|-------|
| n/a | n/a |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
