### PR TITLE
test(graph_engine): block response nodes during streaming

### DIFF
--- a/api/tests/fixtures/workflow/test-answer-order.yml
+++ b/api/tests/fixtures/workflow/test-answer-order.yml
@@ -1,0 +1,222 @@
+app:
+  description: 'this is a chatflow with 2 answer nodes.
+
+
+    it''s outouts should like:
+
+
+    ```
+
+    --- answer 1 ---
+
+
+    foo
+
+    --- answer 2 ---
+
+
+    <llm''s outputs>
+
+    ```'
+  icon: 🤖
+  icon_background: '#FFEAD5'
+  mode: advanced-chat
+  name: test-answer-order
+  use_icon_as_answer_icon: false
+dependencies:
+- current_identifier: null
+  type: marketplace
+  value:
+    marketplace_plugin_unique_identifier: langgenius/openai:0.2.6@e2665624a156f52160927bceac9e169bd7e5ae6b936ae82575e14c90af390e6e
+    version: null
+kind: app
+version: 0.4.0
+workflow:
+  conversation_variables: []
+  environment_variables: []
+  features:
+    file_upload:
+      allowed_file_extensions:
+      - .JPG
+      - .JPEG
+      - .PNG
+      - .GIF
+      - .WEBP
+      - .SVG
+      allowed_file_types:
+      - image
+      allowed_file_upload_methods:
+      - local_file
+      - remote_url
+      enabled: false
+      fileUploadConfig:
+        audio_file_size_limit: 50
+        batch_count_limit: 5
+        file_size_limit: 15
+        image_file_size_limit: 10
+        video_file_size_limit: 100
+        workflow_file_upload_limit: 10
+      image:
+        enabled: false
+        number_limits: 3
+        transfer_methods:
+        - local_file
+        - remote_url
+      number_limits: 3
+    opening_statement: ''
+    retriever_resource:
+      enabled: true
+    sensitive_word_avoidance:
+      enabled: false
+    speech_to_text:
+      enabled: false
+    suggested_questions: []
+    suggested_questions_after_answer:
+      enabled: false
+    text_to_speech:
+      enabled: false
+      language: ''
+      voice: ''
+  graph:
+    edges:
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: answer
+        targetType: answer
+      id: 1759052466526-source-1759052469368-target
+      source: '1759052466526'
+      sourceHandle: source
+      target: '1759052469368'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: start
+        targetType: llm
+      id: 1759052439553-source-1759052580454-target
+      source: '1759052439553'
+      sourceHandle: source
+      target: '1759052580454'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: llm
+        targetType: answer
+      id: 1759052580454-source-1759052466526-target
+      source: '1759052580454'
+      sourceHandle: source
+      target: '1759052466526'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    nodes:
+    - data:
+        selected: false
+        title: Start
+        type: start
+        variables: []
+      height: 52
+      id: '1759052439553'
+      position:
+        x: 30
+        y: 242
+      positionAbsolute:
+        x: 30
+        y: 242
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 242
+    - data:
+        answer: '--- answer 1 ---
+
+
+          foo
+
+          '
+        selected: false
+        title: Answer
+        type: answer
+        variables: []
+      height: 100
+      id: '1759052466526'
+      position:
+        x: 632
+        y: 242
+      positionAbsolute:
+        x: 632
+        y: 242
+      selected: true
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 242
+    - data:
+        answer: '--- answer 2 ---
+
+
+          {{#1759052580454.text#}}
+
+          '
+        selected: false
+        title: Answer 2
+        type: answer
+        variables: []
+      height: 103
+      id: '1759052469368'
+      position:
+        x: 934
+        y: 242
+      positionAbsolute:
+        x: 934
+        y: 242
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 242
+    - data:
+        context:
+          enabled: false
+          variable_selector: []
+        model:
+          completion_params:
+            temperature: 0.7
+          mode: chat
+          name: gpt-4o
+          provider: langgenius/openai/openai
+        prompt_template:
+        - id: 5c1d873b-06b2-4dce-939e-672882bbd7c0
+          role: system
+          text: ''
+        - role: user
+          text: '{{#sys.query#}}'
+        selected: false
+        title: LLM
+        type: llm
+        vision:
+          enabled: false
+      height: 88
+      id: '1759052580454'
+      position:
+        x: 332
+        y: 242
+      positionAbsolute:
+        x: 332
+        y: 242
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 242
+    viewport:
+      x: 126.2797574512839
+      y: 289.55932160537446
+      zoom: 1.0743222672006216
+  rag_pipeline_variables: []

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_answer_order_workflow.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_answer_order_workflow.py
@@ -1,7 +1,6 @@
 from .test_mock_config import MockConfigBuilder
 from .test_table_runner import TableTestRunner, WorkflowTestCase
 
-
 LLM_NODE_ID = "1759052580454"
 
 
@@ -13,14 +12,7 @@ def test_answer_nodes_emit_in_order() -> None:
         .build()
     )
 
-    expected_answer = (
-        "--- answer 1 ---\n"
-        "\n"
-        "foo\n"
-        "--- answer 2 ---\n"
-        "\n"
-        "mocked llm text\n"
-    )
+    expected_answer = "--- answer 1 ---\n\nfoo\n--- answer 2 ---\n\nmocked llm text\n"
 
     case = WorkflowTestCase(
         fixture_path="test-answer-order",

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_answer_order_workflow.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_answer_order_workflow.py
@@ -1,0 +1,36 @@
+from .test_mock_config import MockConfigBuilder
+from .test_table_runner import TableTestRunner, WorkflowTestCase
+
+
+LLM_NODE_ID = "1759052580454"
+
+
+def test_answer_nodes_emit_in_order() -> None:
+    mock_config = (
+        MockConfigBuilder()
+        .with_llm_response("unused default")
+        .with_node_output(LLM_NODE_ID, {"text": "mocked llm text"})
+        .build()
+    )
+
+    expected_answer = (
+        "--- answer 1 ---\n"
+        "\n"
+        "foo\n"
+        "--- answer 2 ---\n"
+        "\n"
+        "mocked llm text\n"
+    )
+
+    case = WorkflowTestCase(
+        fixture_path="test-answer-order",
+        query="",
+        expected_outputs={"answer": expected_answer},
+        use_auto_mock=True,
+        mock_config=mock_config,
+    )
+
+    runner = TableTestRunner()
+    result = runner.run_test_case(case)
+
+    assert result.success, result.error


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
follow-up #26364
## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
