### PR TITLE
Add missing import "IO" in client.py

### DIFF
--- a/sdks/python-client/dify_client/client.py
+++ b/sdks/python-client/dify_client/client.py
@@ -1,5 +1,5 @@
 import json
-from typing import Literal, IO
+from typing import IO, Literal
 import requests
 
 

--- a/sdks/python-client/dify_client/client.py
+++ b/sdks/python-client/dify_client/client.py
@@ -1,5 +1,5 @@
 import json
-from typing import Literal
+from typing import Literal, IO
 import requests
 
 


### PR DESCRIPTION
## Summary

- Add missing import "IO" in client.py
- Before: Error "IO" is not defined
- After: It works just fine!

## How did that happen?
This pr is related to https://github.com/langgenius/dify/pull/26317
Gemini Code Assist forgot to mention the import and it got approved.
<img width="880" height="69" alt="{D6E69C2F-0D0D-47A7-A4C6-E1C8FFD0C506}" src="https://github.com/user-attachments/assets/81dfa67d-0bf0-4e01-909b-a409004da940" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
