### PR TITLE
Fix plugin detail panel  not show when installed plugins more than 100

### DIFF
--- a/web/app/components/tools/provider-list.tsx
+++ b/web/app/components/tools/provider-list.tsx
@@ -17,11 +17,10 @@ import CardMoreInfo from '@/app/components/plugins/card/card-more-info'
 import PluginDetailPanel from '@/app/components/plugins/plugin-detail-panel'
 import MCPList from './mcp'
 import { useAllToolProviders } from '@/service/use-tools'
-import { useInvalidateInstalledPluginList, usePluginDeclarationFromMarketPlace } from '@/service/use-plugins'
+import { useCheckInstalled, useInvalidateInstalledPluginList } from '@/service/use-plugins'
 import { useGlobalPublicStore } from '@/context/global-public-context'
 import { ToolTypeEnum } from '../workflow/block-selector/types'
 import { useMarketplace } from './marketplace/hooks'
-import type { PluginDetail } from '@/app/components/plugins/types'
 
 const getToolType = (type: string) => {
   switch (type) {
@@ -78,18 +77,14 @@ const ProviderList = () => {
   const currentProvider = useMemo<Collection | undefined>(() => {
     return filteredCollectionList.find(collection => collection.id === currentProviderId)
   }, [currentProviderId, filteredCollectionList])
-  const { data: pluginDetail } = usePluginDeclarationFromMarketPlace(currentProvider?.plugin_unique_identifier || '')
+  const { data: checkedInstalledData } = useCheckInstalled({
+    pluginIds: currentProvider?.plugin_id ? [currentProvider.plugin_id] : [],
+    enabled: !!currentProvider?.plugin_id,
+  })
   const invalidateInstalledPluginList = useInvalidateInstalledPluginList()
   const currentPluginDetail = useMemo(() => {
-    if (!pluginDetail) return
-    const detail = {
-      plugin_id: currentProvider?.plugin_id,
-      plugin_unique_identifier: currentProvider?.plugin_unique_identifier,
-      declaration: pluginDetail?.manifest,
-      tenant_id: currentProvider?.tenant_id,
-    }
-    return detail as PluginDetail
-  }, [currentProvider, pluginDetail])
+    return checkedInstalledData?.plugins?.[0]
+  }, [checkedInstalledData])
 
   const toolListTailRef = useRef<HTMLDivElement>(null)
   const showMarketplacePanel = useCallback(() => {

--- a/web/app/components/tools/provider-list.tsx
+++ b/web/app/components/tools/provider-list.tsx
@@ -17,10 +17,11 @@ import CardMoreInfo from '@/app/components/plugins/card/card-more-info'
 import PluginDetailPanel from '@/app/components/plugins/plugin-detail-panel'
 import MCPList from './mcp'
 import { useAllToolProviders } from '@/service/use-tools'
-import { useInstalledPluginList, useInvalidateInstalledPluginList } from '@/service/use-plugins'
+import { useInvalidateInstalledPluginList, usePluginDeclarationFromMarketPlace } from '@/service/use-plugins'
 import { useGlobalPublicStore } from '@/context/global-public-context'
 import { ToolTypeEnum } from '../workflow/block-selector/types'
 import { useMarketplace } from './marketplace/hooks'
+import type { PluginDetail } from '@/app/components/plugins/types'
 
 const getToolType = (type: string) => {
   switch (type) {
@@ -77,12 +78,18 @@ const ProviderList = () => {
   const currentProvider = useMemo<Collection | undefined>(() => {
     return filteredCollectionList.find(collection => collection.id === currentProviderId)
   }, [currentProviderId, filteredCollectionList])
-  const { data: pluginList } = useInstalledPluginList()
+  const { data: pluginDetail } = usePluginDeclarationFromMarketPlace(currentProvider?.plugin_unique_identifier || '')
   const invalidateInstalledPluginList = useInvalidateInstalledPluginList()
   const currentPluginDetail = useMemo(() => {
-    const detail = pluginList?.plugins.find(plugin => plugin.plugin_id === currentProvider?.plugin_id)
-    return detail
-  }, [currentProvider?.plugin_id, pluginList?.plugins])
+    if (!pluginDetail) return
+    const detail = {
+      plugin_id: currentProvider?.plugin_id,
+      plugin_unique_identifier: currentProvider?.plugin_unique_identifier,
+      declaration: pluginDetail?.manifest,
+      tenant_id: currentProvider?.tenant_id,
+    }
+    return detail as PluginDetail
+  }, [currentProvider, pluginDetail])
 
   const toolListTailRef = useRef<HTMLDivElement>(null)
   const showMarketplacePanel = useCallback(() => {

--- a/web/app/components/tools/types.ts
+++ b/web/app/components/tools/types.ts
@@ -53,8 +53,6 @@ export type Collection = {
   allow_delete: boolean
   labels: string[]
   plugin_id?: string
-  plugin_unique_identifier?: string
-  tenant_id?: string
   letter?: string
   // MCP Server
   server_url?: string

--- a/web/app/components/tools/types.ts
+++ b/web/app/components/tools/types.ts
@@ -53,6 +53,8 @@ export type Collection = {
   allow_delete: boolean
   labels: string[]
   plugin_id?: string
+  plugin_unique_identifier?: string
+  tenant_id?: string
   letter?: string
   // MCP Server
   server_url?: string


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix #26420

## Screenshots

<img width="1606" height="1760" alt="image" src="https://github.com/user-attachments/assets/77f36f80-7a37-40b5-9976-723b7be70e14" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
