### PR TITLE
Fixes#26332 Remove FILES_URL in default .yaml settings 

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -45,7 +45,7 @@ APP_WEB_URL=
 #   Recommendation: use a dedicated domain (e.g., https://upload.example.com).
 #   Alternatively, use http://<your-ip>:5001 or http://api:5001,
 #   ensuring port 5001 is externally accessible (see docker-compose.yaml).
-FILES_URL=http://api:5001
+FILES_URL=
 
 # INTERNAL_FILES_URL is used for plugin daemon communication within Docker network.
 # Set this to the internal Docker service URL for proper plugin file access.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,7 +10,7 @@ x-shared-env: &shared-api-worker-env
   SERVICE_API_URL: ${SERVICE_API_URL:-}
   APP_API_URL: ${APP_API_URL:-}
   APP_WEB_URL: ${APP_WEB_URL:-}
-  FILES_URL: ${FILES_URL:-http://api:5001}
+  FILES_URL: ${FILES_URL:-}
   INTERNAL_FILES_URL: ${INTERNAL_FILES_URL:-}
   LANG: ${LANG:-en_US.UTF-8}
   LC_ALL: ${LC_ALL:-en_US.UTF-8}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
I encountered the same issue, then found that it was caused by the default setting of FILES_URL in the original yaml file as api:5001. No need to change the .env file.
<img width="908" height="423" alt="屏幕截图 2025-09-29 105908" src="https://github.com/user-attachments/assets/8ed80b75-483e-4997-9755-c732b3ab7ba9" />

close https://github.com/langgenius/dify/issues/26332

## Screenshots

| Before | After |
|--------|-------|
| <img width="908" height="423" alt="屏幕截图 2025-09-29 105908" src="https://github.com/user-attachments/assets/8ed80b75-483e-4997-9755-c732b3ab7ba9" /> |<img width="1026" height="233" alt="image" src="https://github.com/user-attachments/assets/c555caca-0b84-4434-a5b4-08b4819fac0e" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
