### PR TITLE
fix: debounce ref

### DIFF
--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -159,10 +159,16 @@ const Chat: FC<ChatProps> = ({
     }
   })
 
+  const debouncedResizeRef = useRef(debounce(handleWindowResize, 200))
+
   useEffect(() => {
-    window.addEventListener('resize', debounce(handleWindowResize))
-    return () => window.removeEventListener('resize', handleWindowResize)
+    debouncedResizeRef.current = debounce(handleWindowResize, 200)
   }, [handleWindowResize])
+
+  useEffect(() => {
+    window.addEventListener('resize', debouncedResizeRef.current)
+    return () => window.removeEventListener('resize', debouncedResizeRef.current)
+  }, [])
 
   useEffect(() => {
     if (chatFooterRef.current && chatContainerRef.current) {

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -159,16 +159,15 @@ const Chat: FC<ChatProps> = ({
     }
   })
 
-  const debouncedResizeRef = useRef(debounce(handleWindowResize, 200))
-
   useEffect(() => {
-    debouncedResizeRef.current = debounce(handleWindowResize, 200)
+    const debouncedHandler = debounce(handleWindowResize, 200)
+    window.addEventListener('resize', debouncedHandler)
+
+    return () => {
+      window.removeEventListener('resize', debouncedHandler)
+      debouncedHandler.cancel()
+    }
   }, [handleWindowResize])
-
-  useEffect(() => {
-    window.addEventListener('resize', debouncedResizeRef.current)
-    return () => window.removeEventListener('resize', debouncedResizeRef.current)
-  }, [])
 
   useEffect(() => {
     if (chatFooterRef.current && chatContainerRef.current) {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request improves how window resize events are handled in the `Chat` component to prevent performance issues and ensure proper cleanup. The main change is to debounce the resize event listener using a ref, which avoids creating a new debounced function on every render and ensures the correct function is removed during cleanup.

**Improvements to event handling and performance:**

* Refactored the window resize event listener in `chat/index.tsx` to use a debounced function stored in a ref, ensuring consistent handler registration and cleanup, and reducing unnecessary re-renders.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
