### PR TITLE
Bump release references to 1.9.1

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.9.0"
+version = "1.9.1"
 requires-python = ">=3.11,<3.13"
 
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1276,7 +1276,7 @@ wheels = [
 
 [[package]]
 name = "dify-api"
-version = "1.9.0"
+version = "1.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "arize-phoenix-otel" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -2,7 +2,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:1.9.0
+    image: langgenius/dify-api:1.9.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -31,7 +31,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.9.0
+    image: langgenius/dify-api:1.9.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -58,7 +58,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.9.0
+    image: langgenius/dify-api:1.9.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -76,7 +76,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.9.0
+    image: langgenius/dify-web:1.9.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -599,7 +599,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:1.9.0
+    image: langgenius/dify-api:1.9.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -628,7 +628,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.9.0
+    image: langgenius/dify-api:1.9.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -655,7 +655,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.9.0
+    image: langgenius/dify-api:1.9.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -673,7 +673,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.9.0
+    image: langgenius/dify-web:1.9.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "packageManager": "pnpm@10.16.0",
   "engines": {


### PR DESCRIPTION
## Summary
- Fixes #26452
- Bump the API package metadata to version 1.9.1.
- Update Docker compose images to the 1.9.1 tags for API, worker, worker_beat, and web.
- Align the web package manifest with version 1.9.1.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
