### PR TITLE
fix: Allow textarea to expand vertically

### DIFF
--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -120,7 +120,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                   )}
                   {item.type === 'paragraph' && (
                     <Textarea
-                      className='h-[104px] sm:text-xs'
+                      className='min-h-[104px] max-h-[500px] resize-y sm:text-xs'
                       placeholder={`${item.name}${!item.required ? `(${t('appDebug.variableTable.optional')})` : ''}`}
                       value={inputs[item.key]}
                       onChange={(e: ChangeEvent<HTMLTextAreaElement>) => { handleInputsChange({ ...inputsRef.current, [item.key]: e.target.value }) }}


### PR DESCRIPTION
This commit addresses issue #23566.

The `Textarea` component in `web/app/components/share/text-generation/run-once/index.tsx` had a fixed height, which prevented it from expanding when the user entered a large amount of text.

This change replaces the fixed-height utility class with classes that allow vertical resizing, and sets a minimum and maximum height for the textarea. This improves the user experience by allowing the input field to accommodate more content without scrolling.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
