### PR TITLE
fix: conversation opener feature state persistence and display

### DIFF
--- a/web/app/components/base/features/new-feature-panel/conversation-opener/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/index.tsx
@@ -48,13 +48,21 @@ const ConversationOpener = ({
       },
       onSaveCallback: (newOpening) => {
         const newFeatures = produce(features, (draft) => {
-          draft.opening = newOpening
+          draft.opening = {
+            ...newOpening,
+            enabled: !!(newOpening.opening_statement || (newOpening.suggested_questions && newOpening.suggested_questions.length > 0)),
+          }
         })
         setFeatures(newFeatures)
         if (onChange)
           onChange()
       },
       onCancelCallback: () => {
+        const newFeatures = produce(features, (draft) => {
+          if (draft.opening && !draft.opening.opening_statement && !(draft.opening.suggested_questions && draft.opening.suggested_questions.length > 0))
+            draft.opening.enabled = false
+        })
+        setFeatures(newFeatures)
         if (onChange)
           onChange()
       },
@@ -67,6 +75,11 @@ const ConversationOpener = ({
       setFeatures,
     } = featuresStore!.getState()
 
+    if (enabled && !features.opening?.opening_statement && !(features.opening?.suggested_questions && features.opening.suggested_questions.length > 0)) {
+      handleOpenOpeningModal()
+      return
+    }
+
     const newFeatures = produce(features, (draft) => {
       draft[type] = {
         ...draft[type],
@@ -76,7 +89,7 @@ const ConversationOpener = ({
     setFeatures(newFeatures)
     if (onChange)
       onChange()
-  }, [featuresStore, onChange])
+  }, [featuresStore, onChange, handleOpenOpeningModal])
 
   return (
     <FeatureCard

--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -73,8 +73,8 @@ export const useNodesSyncDraft = () => {
             },
           },
           features: {
-            opening_statement: features.opening?.enabled ? (features.opening?.opening_statement || '') : '',
-            suggested_questions: features.opening?.enabled ? (features.opening?.suggested_questions || []) : [],
+            opening_statement: features.opening?.opening_statement || '',
+            suggested_questions: features.opening?.suggested_questions || [],
             suggested_questions_after_answer: features.suggested,
             text_to_speech: features.text2speech,
             speech_to_text: features.speech2text,

--- a/web/app/components/workflow-app/index.tsx
+++ b/web/app/components/workflow-app/index.tsx
@@ -71,7 +71,7 @@ const WorkflowAppWithAdditionalContext = () => {
       fileUploadConfig: fileUploadConfigResponse,
     },
     opening: {
-      enabled: !!features.opening_statement,
+      enabled: !!features.opening_statement || !!(features.suggested_questions && features.suggested_questions.length > 0),
       opening_statement: features.opening_statement,
       suggested_questions: features.suggested_questions,
     },


### PR DESCRIPTION
## Summary
Fixes #26500 

This PR addresses the issue where the conversation opener feature doesn't preserve its enabled state and doesn't work correctly in Chatflow applications.

### Root Cause
The frontend was determining the feature's enabled state by checking only if `opening_statement` had content (`!!features.opening_statement`). This caused two problems:
1. When a feature was enabled but had no opening statement, it appeared disabled on reload
2. The save logic was clearing content when disabled, making it indistinguishable from "enabled with no content"

### Changes
1. **Updated feature initialization logic** (`workflow-app/index.tsx`): Now checks for both `opening_statement` and `suggested_questions` when determining if the feature is enabled
2. **Simplified save logic** (`use-nodes-sync-draft.ts`): Always sends the actual content instead of conditionally clearing it based on enabled state
3. **Added automatic modal opening** (`conversation-opener/index.tsx`): When user toggles feature on without content, automatically opens the configuration modal
4. **Auto-manage enabled state**: The enabled state is now automatically set based on content presence when saving
5. **Handle modal cancellation**: If user cancels the modal without adding content, the feature is automatically disabled

### Benefits
- ✅ The feature's enabled state correctly persists across page refreshes
- ✅ Users must add content (opening statement or suggested questions) to enable the feature  
- ✅ Better UX: toggling the feature on automatically prompts for configuration
- ✅ Consistent behavior between enabled/disabled states
- ✅ Works with both opening statements and suggested questions

## Test plan
- [x] Run `pnpm lint` - passes with no new errors
- [x] Run type checking - passes with no errors  
- [ ] Manual testing:
  - [ ] Go to Studio → Chatflow → Orchestrate → Features
  - [ ] Enable "Conversation Opener"
  - [ ] Verify modal opens automatically
  - [ ] Add an opening statement and/or suggested questions
  - [ ] Click Save and Publish
  - [ ] Refresh the browser
  - [ ] Go back to Features
  - [ ] Verify "Conversation Opener" is still enabled
  - [ ] Preview or Run App
  - [ ] Verify the conversation opener displays in the chat