### PR TITLE
chore: remove pnpm build from dev-setup command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ prepare-web:
 	@echo "🌐 Setting up web environment..."
 	@cp -n web/.env.example web/.env 2>/dev/null || echo "Web .env already exists"
 	@cd web && pnpm install
-	@cd web && pnpm build
 	@echo "✅ Web environment prepared (not started)"
 
 # Step 3: Prepare API environment


### PR DESCRIPTION
## Summary

- remove the Next.js production build step from `make dev-setup`
- rely on development fast compile for initial web builds to keep setup snappy

Fixes #26503

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
