### PR TITLE
chore(devcontainer): update Python base image from bullseye to bookworm in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.12-bullseye
+FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install libgmp-dev libmpfr-dev libmpc-dev


### PR DESCRIPTION
Fixes #26518

error: GMPY2 requires MPC 1.2.1 or later

## Summary

Debian 11 (bullseye) has MPC version 1.1.0, which is too old for gmpy2 2.2.1
Debian 12 (bookworm) has MPC version 1.3.1, which meets the requirement
This now matches the api Dockerfile configuration (which already uses bookworm)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
