### PR TITLE
fix bug 26613: get wrong credentials with multiple authorizations plugin

### DIFF
--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -349,14 +349,10 @@ class BuiltinToolManageService:
             provider_controller = ToolManager.get_builtin_provider(default_provider.provider, tenant_id)
 
             credentials: list[ToolProviderCredentialApiEntity] = []
-            encrypters = {}
             for provider in providers:
-                credential_type = provider.credential_type
-                if credential_type not in encrypters:
-                    encrypters[credential_type] = BuiltinToolManageService.create_tool_encrypter(
-                        tenant_id, provider, provider.provider, provider_controller
-                    )[0]
-                encrypter = encrypters[credential_type]
+                encrypter, _ = BuiltinToolManageService.create_tool_encrypter(
+                    tenant_id, provider, provider.provider, provider_controller
+                )
                 decrypt_credential = encrypter.mask_tool_credentials(encrypter.decrypt(provider.credentials))
                 credential_entity = ToolTransformService.convert_builtin_provider_to_credential_entity(
                     provider=provider,


### PR DESCRIPTION
## Summary

The plugins configured multiple authorizations can only retrieve the first configuration from API. The root cause is reusing encrypters per credential_type causes decrypted credentials to be identical across provider entries because the encrypter's cache is keyed by provider identity, not credential_type. 

fix #26613 

## Screenshots

| Before | After |
|--------|-------|
| <img width="1076" height="615" alt="image" src="https://github.com/user-attachments/assets/62c90ad8-702d-4e43-9fdb-a8ef3f0d0fb9" /> | <img width="1141" height="592" alt="image" src="https://github.com/user-attachments/assets/d1d2954d-a975-4e8b-83c2-279c3bfd58fc" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
