### PR TITLE
upgrade docker compose milvus version to 2.6.0 to fix installation error

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -576,7 +576,7 @@ services:
 
   milvus-standalone:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v2.5.15
+    image: milvusdb/milvus:v2.6.3
     profiles:
       - milvus
     command: ["milvus", "run", "standalone"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1173,7 +1173,7 @@ services:
 
   milvus-standalone:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v2.6.0
+    image: milvusdb/milvus:v2.6.3
     profiles:
       - milvus
     command: ["milvus", "run", "standalone"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1173,7 +1173,7 @@ services:
 
   milvus-standalone:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v2.5.15
+    image: milvusdb/milvus:v2.6.0
     profiles:
       - milvus
     command: ["milvus", "run", "standalone"]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When try to install dify with milvus using [`docker-compose.yaml`](https://github.com/langgenius/dify/blob/main/docker/docker-compose.yaml), milvus container quited with below error:

```
[2025/09/28 15:56:19.786 +00:00] [WARN] [proxy/listener_manager.go:49] ["Proxy fail to create external grpc listener"] [error="listen tcp :19530: bind: address already in use"] panic: listen tcp :19530: bind: address already in use
```

After checking again and again, there is no other process occupying the 19530 port.  And then upgrade the milvus version from 2.5.15(default version) to 2.6.0([latest is 2.6.2](https://github.com/milvus-io/milvus/releases/tag/v2.6.2)), the error misses and milvus container runs well. Dify install works fine as well.

I looked the error on [milvus github issues list](https://github.com/milvus-io/milvus/issues), [this issue](https://github.com/milvus-io/milvus/issues/30034) is related to the error. Upgrade the milvus version can fix the error. In antoer way, the latest version for milvus is already 2.6.x, the verison in `docker-compose.yaml` is still 2.5.x, upgrade is a good choice.


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
