### PR TITLE
feat: add HTTPX client instrumentation for OpenTelemetry

### DIFF
--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -136,6 +136,7 @@ def init_app(app: DifyApp):
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as HTTPSpanExporter
     from opentelemetry.instrumentation.celery import CeleryInstrumentor
     from opentelemetry.instrumentation.flask import FlaskInstrumentor
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
     from opentelemetry.instrumentation.redis import RedisInstrumentor
     from opentelemetry.instrumentation.requests import RequestsInstrumentor
     from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -238,6 +239,7 @@ def init_app(app: DifyApp):
     init_sqlalchemy_instrumentor(app)
     RedisInstrumentor().instrument()
     RequestsInstrumentor().instrument()
+    HTTPXClientInstrumentor().instrument()
     atexit.register(shutdown_tracer)
 
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "opentelemetry-instrumentation==0.48b0",
     "opentelemetry-instrumentation-celery==0.48b0",
     "opentelemetry-instrumentation-flask==0.48b0",
+    "opentelemetry-instrumentation-httpx==0.48b0",
     "opentelemetry-instrumentation-redis==0.48b0",
     "opentelemetry-instrumentation-requests==0.48b0",
     "opentelemetry-instrumentation-sqlalchemy==0.48b0",

--- a/api/pyrightconfig.json
+++ b/api/pyrightconfig.json
@@ -12,6 +12,7 @@
     "flask_login",
     "opentelemetry.instrumentation.celery",
     "opentelemetry.instrumentation.flask",
+    "opentelemetry.instrumentation.httpx",
     "opentelemetry.instrumentation.requests",
     "opentelemetry.instrumentation.sqlalchemy",
     "opentelemetry.instrumentation.redis"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1323,6 +1323,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-celery" },
     { name = "opentelemetry-instrumentation-flask" },
+    { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
@@ -1513,6 +1514,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", specifier = "==0.48b0" },
     { name = "opentelemetry-instrumentation-celery", specifier = "==0.48b0" },
     { name = "opentelemetry-instrumentation-flask", specifier = "==0.48b0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = "==0.48b0" },
     { name = "opentelemetry-instrumentation-redis", specifier = "==0.48b0" },
     { name = "opentelemetry-instrumentation-requests", specifier = "==0.48b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = "==0.48b0" },
@@ -3876,6 +3878,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/2f/5c3af780a69f9ba78445fe0e5035c41f67281a31b08f3c3e7ec460bda726/opentelemetry_instrumentation_flask-0.48b0.tar.gz", hash = "sha256:e03a34428071aebf4864ea6c6a564acef64f88c13eb3818e64ea90da61266c3d", size = 19196, upload-time = "2024-08-28T21:28:01.986Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/3d/fcde4f8f0bf9fa1ee73a12304fa538076fb83fe0a2ae966ab0f0b7da5109/opentelemetry_instrumentation_flask-0.48b0-py3-none-any.whl", hash = "sha256:26b045420b9d76e85493b1c23fcf27517972423480dc6cf78fd6924248ba5808", size = 14588, upload-time = "2024-08-28T21:26:58.504Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.48b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/d9/c65d818607c16d1b7ea8d2de6111c6cecadf8d2fd38c1885a72733a7c6d3/opentelemetry_instrumentation_httpx-0.48b0.tar.gz", hash = "sha256:ee977479e10398931921fb995ac27ccdeea2e14e392cb27ef012fc549089b60a", size = 16931, upload-time = "2024-08-28T21:28:03.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/fe/f2daa9d6d988c093b8c7b1d35df675761a8ece0b600b035dc04982746c9d/opentelemetry_instrumentation_httpx-0.48b0-py3-none-any.whl", hash = "sha256:d94f9d612c82d09fe22944d1904a30a464c19bea2ba76be656c99a28ad8be8e5", size = 13900, upload-time = "2024-08-28T21:27:01.566Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #26598
This PR adds HTTPX client instrumentation support to the OpenTelemetry configuration, enabling distributed tracing for HTTPX client requests.

### Changes:
- Add `opentelemetry-instrumentation-httpx==0.48b0` dependency to `pyproject.toml`
- Import and initialize `HTTPXClientInstrumentor` in the OpenTelemetry extension
- Enable automatic instrumentation of HTTPX client requests for better observability

### Benefits:
- **Enhanced Observability**: HTTPX client requests are now automatically traced
- **Distributed Tracing**: Better visibility into outbound HTTP calls across services
- **Performance Monitoring**: Track HTTP request latency and error rates
- **Debugging Support**: Easier troubleshooting of API integrations

## Screenshots

| Before | After |
|--------|-------|
| No HTTPX tracing | HTTPX requests now traced in distributed tracing |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods