### PR TITLE
Support node reference multiple structured_output variables in single-step run

### DIFF
--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -423,7 +423,7 @@ class WorkflowEntry:
 
                     # Support for a single node to reference multiple structured_output variables
                     current_variable = variable_pool.get([variable_node_id] + variable_key_list)
-                    if current_variable and current_variable.value:
+                    if current_variable and isinstance(current_variable.value, dict):
                         input_value = current_variable.value | input_value
 
                 variable_pool.add([variable_node_id] + variable_key_list, input_value)

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -420,4 +420,10 @@ class WorkflowEntry:
                 if len(variable_key_list) == 2 and variable_key_list[0] == "structured_output":
                     input_value = {variable_key_list[1]: input_value}
                     variable_key_list = variable_key_list[0:1]
+
+                    # Support for a single node to reference multiple structured_output variables
+                    current_variable = variable_pool.get([variable_node_id] + variable_key_list)
+                    if current_variable and current_variable.value:
+                        input_value = current_variable.value | input_value
+
                 variable_pool.add([variable_node_id] + variable_key_list, input_value)


### PR DESCRIPTION
…-step run

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
close #26660 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
