### PR TITLE
fix(workflow): Remove frontend upper limit on HTTP node timeout values

### DIFF
--- a/web/app/components/workflow/nodes/http/components/timeout/index.tsx
+++ b/web/app/components/workflow/nodes/http/components/timeout/index.tsx
@@ -43,7 +43,7 @@ const InputField: FC<{
           else {
             const parsedValue = Number.parseInt(inputValue, 10)
             if (!Number.isNaN(parsedValue)) {
-              const value = Math.max(min, Math.min(max, parsedValue))
+              const value = Math.max(min, parsedValue)
               onChange(value)
             }
           }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #26319

Remove frontend upper limit restriction on HTTP node timeout values to allow users to configure longer timeouts as needed for slow external services.

## Problem

Users reported that the HTTP node times out after 10 minutes even when they need longer timeouts for slow-processing services (like document processing, knowledge base operations, etc.).

The issue was that the frontend enforced a hard limit on timeout values:
- Connect timeout: capped at 300s (5 minutes)
- Read/Write timeout: capped at 600s (10 minutes)

Even though backend supports configuring higher limits via `.env` variables:
```bash
HTTP_REQUEST_MAX_CONNECT_TIMEOUT=<custom_value>
HTTP_REQUEST_MAX_READ_TIMEOUT=<custom_value>
HTTP_REQUEST_MAX_WRITE_TIMEOUT=<custom_value>
```

The frontend validation prevented users from entering values higher than the default caps, making these environment variables ineffective.

## Solution

Changed the validation logic in the timeout input field from:
```typescript
const value = Math.max(min, Math.min(max, parsedValue))
```
to:
```typescript
const value = Math.max(min, parsedValue)
```

**Now the frontend:**
- ✅ Enforces minimum value (1 second) to prevent invalid inputs
- ✅ Allows users to configure timeout values beyond default suggestions
- ✅ Respects backend `.env` configuration as the final authority on max limits
- ✅ Properly separates concerns: frontend for UX validation, backend for security boundaries

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
