### PR TITLE
refactor(types): remove `any` usages and strengthen typings across web and base

### DIFF
--- a/web/app/components/share/text-generation/result/index.tsx
+++ b/web/app/components/share/text-generation/result/index.tsx
@@ -78,15 +78,15 @@ const Result: FC<IResultProps> = ({
       setRespondingFalse()
   }, [controlStopResponding])
 
-  const [completionRes, doSetCompletionRes] = useState<any>('')
-  const completionResRef = useRef<any>()
-  const setCompletionRes = (res: any) => {
+  const [completionRes, doSetCompletionRes] = useState<string>('')
+  const completionResRef = useRef<string>('')
+  const setCompletionRes = (res: string) => {
     completionResRef.current = res
     doSetCompletionRes(res)
   }
   const getCompletionRes = () => completionResRef.current
   const [workflowProcessData, doSetWorkflowProcessData] = useState<WorkflowProcess>()
-  const workflowProcessDataRef = useRef<WorkflowProcess>()
+  const workflowProcessDataRef = useRef<WorkflowProcess | undefined>(undefined)
   const setWorkflowProcessData = (data: WorkflowProcess) => {
     workflowProcessDataRef.current = data
     doSetWorkflowProcessData(data)

--- a/web/app/components/workflow/hooks/use-workflow-history.ts
+++ b/web/app/components/workflow/hooks/use-workflow-history.ts
@@ -41,33 +41,27 @@ export const useWorkflowHistory = () => {
   const { store: workflowHistoryStore } = useWorkflowHistoryStore()
   const { t } = useTranslation()
 
-  const [undoCallbacks, setUndoCallbacks] = useState<unknown[]>([])
-  const [redoCallbacks, setRedoCallbacks] = useState<unknown[]>([])
+  const [undoCallbacks, setUndoCallbacks] = useState<(() => void)[]>([])
+  const [redoCallbacks, setRedoCallbacks] = useState<(() => void)[]>([])
 
-  const onUndo = useCallback((callback: unknown) => {
-    setUndoCallbacks((prev: unknown[]) => [...prev, callback])
+  const onUndo = useCallback((callback: () => void) => {
+    setUndoCallbacks(prev => [...prev, callback])
     return () => setUndoCallbacks(prev => prev.filter(cb => cb !== callback))
   }, [])
 
-  const onRedo = useCallback((callback: unknown) => {
-    setRedoCallbacks((prev: unknown[]) => [...prev, callback])
+  const onRedo = useCallback((callback: () => void) => {
+    setRedoCallbacks(prev => [...prev, callback])
     return () => setRedoCallbacks(prev => prev.filter(cb => cb !== callback))
   }, [])
 
   const undo = useCallback(() => {
     workflowHistoryStore.temporal.getState().undo()
-    undoCallbacks.forEach((callback) => {
-      if (typeof callback === 'function')
-        callback()
-    })
+    undoCallbacks.forEach(callback => callback())
   }, [undoCallbacks, workflowHistoryStore.temporal])
 
   const redo = useCallback(() => {
     workflowHistoryStore.temporal.getState().redo()
-    redoCallbacks.forEach((callback) => {
-      if (typeof callback === 'function')
-        callback()
-    })
+    redoCallbacks.forEach(callback => callback())
   }, [redoCallbacks, workflowHistoryStore.temporal])
 
   // Some events may be triggered multiple times in a short period of time.

--- a/web/app/components/workflow/hooks/use-workflow-history.ts
+++ b/web/app/components/workflow/hooks/use-workflow-history.ts
@@ -41,27 +41,33 @@ export const useWorkflowHistory = () => {
   const { store: workflowHistoryStore } = useWorkflowHistoryStore()
   const { t } = useTranslation()
 
-  const [undoCallbacks, setUndoCallbacks] = useState<any[]>([])
-  const [redoCallbacks, setRedoCallbacks] = useState<any[]>([])
+  const [undoCallbacks, setUndoCallbacks] = useState<unknown[]>([])
+  const [redoCallbacks, setRedoCallbacks] = useState<unknown[]>([])
 
   const onUndo = useCallback((callback: unknown) => {
-    setUndoCallbacks((prev: any) => [...prev, callback])
+    setUndoCallbacks((prev: unknown[]) => [...prev, callback])
     return () => setUndoCallbacks(prev => prev.filter(cb => cb !== callback))
   }, [])
 
   const onRedo = useCallback((callback: unknown) => {
-    setRedoCallbacks((prev: any) => [...prev, callback])
+    setRedoCallbacks((prev: unknown[]) => [...prev, callback])
     return () => setRedoCallbacks(prev => prev.filter(cb => cb !== callback))
   }, [])
 
   const undo = useCallback(() => {
     workflowHistoryStore.temporal.getState().undo()
-    undoCallbacks.forEach(callback => callback())
+    undoCallbacks.forEach((callback) => {
+      if (typeof callback === 'function')
+        callback()
+    })
   }, [undoCallbacks, workflowHistoryStore.temporal])
 
   const redo = useCallback(() => {
     workflowHistoryStore.temporal.getState().redo()
-    redoCallbacks.forEach(callback => callback())
+    redoCallbacks.forEach((callback) => {
+      if (typeof callback === 'function')
+        callback()
+    })
   }, [redoCallbacks, workflowHistoryStore.temporal])
 
   // Some events may be triggered multiple times in a short period of time.

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
@@ -127,7 +127,7 @@ const VarReferencePicker: FC<Props> = ({
 
   const reactflow = useReactFlow()
 
-  const startNode = availableNodes.find((node: any) => {
+  const startNode = availableNodes.find((node: Node) => {
     return node.data.type === BlockEnum.Start
   })
 

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-config.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-config.tsx
@@ -120,7 +120,7 @@ const JsonSchemaConfig: FC<JsonSchemaConfigProps> = ({
       setJson(JSON.stringify(schema, null, 2))
   }, [currentTab])
 
-  const handleSubmit = useCallback((schema: any) => {
+  const handleSubmit = useCallback((schema: Record<string, unknown>) => {
     const jsonSchema = jsonToSchema(schema) as SchemaRoot
     if (currentTab === SchemaView.VisualEditor)
       setJsonSchema(jsonSchema)

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/index.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/index.tsx
@@ -152,14 +152,16 @@ const EditCard: FC<EditCardProps> = ({
   }, [isAdvancedEditing, emitPropertyOptionsChange, currentFields])
 
   const handleAdvancedOptionsChange = useCallback((options: AdvancedOptionsType) => {
-    let enumValue: any = options.enum
-    if (enumValue === '') {
+    let enumValue: SchemaEnumType | undefined
+    if (options.enum === '') {
       enumValue = undefined
     }
     else {
-      enumValue = options.enum.replace(/\s/g, '').split(',')
+      const stringArray = options.enum.replace(/\s/g, '').split(',')
       if (currentFields.type === Type.number)
-        enumValue = (enumValue as SchemaEnumType).map(value => Number(value)).filter(num => !Number.isNaN(num))
+        enumValue = stringArray.map(value => Number(value)).filter(num => !Number.isNaN(num))
+      else
+        enumValue = stringArray
     }
     setCurrentFields(prev => ({ ...prev, enum: enumValue }))
     if (isAdvancedEditing) return


### PR DESCRIPTION

- Share/Text Generation Result:
  - Replace `any` state/refs with `string` and `WorkflowProcess | undefined`.
- Workflow History:
  - Type undo/redo callback arrays as `unknown[]` and guard invocation with function checks.
- Var Reference Picker:
  - Use `Node` in `availableNodes.find` to eliminate `any`.
- LLM JSON Schema Config:
  - Type `handleSubmit` parameter as `Record<string, unknown>`.
- Visual Editor (Edit Card):
  - Use `SchemaEnumType` for enum handling; parse string input into `string[]` or `number[]` based on field type.
- Base service:
  - Type SSE reader result as `ReadableStreamReadResult<Uint8Array>`.
  - Introduce `UploadOptions`/`UploadResponse` types and refactor upload option merging with explicit header typings.
  - Type `res.json()` response for 401 handling as `{ code?: string; message?: string }`.

Rationale:
- Improves type safety, readability, and maintainability under strict TS settings.
- Reduces risk of runtime errors from untyped values.

Impact:
- No functional changes expected; UI and runtime behavior remain the same.
- Safer typings for internal APIs and components.

Testing:
- Compiles under strict typing; linting passes locally.

BREAKING CHANGE: none

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #26670

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
