### PR TITLE
fix(api): fix `VariablePool.get` adding unexpected keys to variable_dictionary

### DIFF
--- a/api/core/workflow/runtime/variable_pool.py
+++ b/api/core/workflow/runtime/variable_pool.py
@@ -153,7 +153,11 @@ class VariablePool(BaseModel):
             return None
 
         node_id, name = self._selector_to_keys(selector)
-        segment: Segment | None = self.variable_dictionary[node_id].get(name)
+        node_map = self.variable_dictionary.get(node_id)
+        if node_map is None:
+            return None
+
+        segment: Segment | None = node_map.get(name)
 
         if segment is None:
             return None

--- a/api/tests/unit_tests/core/workflow/entities/test_variable_pool.py
+++ b/api/tests/unit_tests/core/workflow/entities/test_variable_pool.py
@@ -111,3 +111,26 @@ class TestVariablePoolGetAndNestedAttribute:
         assert segment_false is not None
         assert isinstance(segment_false, BooleanSegment)
         assert segment_false.value is False
+
+
+class TestVariablePoolGetNotModifyVairableDictionary:
+    _NODE_ID = "start"
+    _VAR_NAME = "name"
+
+    def test_convert_to_template_should_not_introduce_extra_keys(self):
+        pool = VariablePool.empty()
+        pool.add([self._NODE_ID, self._VAR_NAME], 0)
+        pool.convert_template("The start.name is {{#start.name#}}")
+        assert "The start" not in pool.variable_dictionary
+
+    def test_get_should_not_modify_variable_dictionary(self):
+        pool = VariablePool.empty()
+        pool.get([self._NODE_ID, self._VAR_NAME])
+        assert len(pool.variable_dictionary) == 1  # only contains `sys` node id
+        assert "start" not in pool.variable_dictionary
+
+        pool = VariablePool.empty()
+        pool.add([self._NODE_ID, self._VAR_NAME], "Joe")
+        pool.get([self._NODE_ID, "count"])
+        start_subdict = pool.variable_dictionary[self._NODE_ID]
+        assert "count" not in start_subdict

--- a/api/tests/unit_tests/core/workflow/entities/test_variable_pool.py
+++ b/api/tests/unit_tests/core/workflow/entities/test_variable_pool.py
@@ -113,7 +113,7 @@ class TestVariablePoolGetAndNestedAttribute:
         assert segment_false.value is False
 
 
-class TestVariablePoolGetNotModifyVairableDictionary:
+class TestVariablePoolGetNotModifyVariableDictionary:
     _NODE_ID = "start"
     _VAR_NAME = "name"
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix #26765.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
