### PR TITLE
fix: invalid data source list in plugin refresh hook

### DIFF
--- a/web/app/components/plugins/install-plugin/hooks/use-refresh-plugin-list.tsx
+++ b/web/app/components/plugins/install-plugin/hooks/use-refresh-plugin-list.tsx
@@ -7,6 +7,7 @@ import { useInvalidateStrategyProviders } from '@/service/use-strategy'
 import type { Plugin, PluginDeclaration, PluginManifestInMarket } from '../../types'
 import { PluginType } from '../../types'
 import { useInvalidDataSourceList } from '@/service/use-pipeline'
+import { useInvalidDataSourceListAuth } from '@/service/use-datasource'
 
 const useRefreshPluginList = () => {
   const invalidateInstalledPluginList = useInvalidateInstalledPluginList()
@@ -18,6 +19,8 @@ const useRefreshPluginList = () => {
   const invalidateAllToolProviders = useInvalidateAllToolProviders()
   const invalidateAllBuiltInTools = useInvalidateAllBuiltInTools()
   const invalidateAllDataSources = useInvalidDataSourceList()
+
+  const invalidateDataSourceListAuth = useInvalidDataSourceListAuth()
 
   const invalidateStrategyProviders = useInvalidateStrategyProviders()
   return {
@@ -32,8 +35,10 @@ const useRefreshPluginList = () => {
         // TODO: update suggested tools. It's a function in hook useMarketplacePlugins,handleUpdatePlugins
       }
 
-      if ((manifest && PluginType.datasource.includes(manifest.category)) || refreshAllType)
+      if ((manifest && PluginType.datasource.includes(manifest.category)) || refreshAllType) {
         invalidateAllDataSources()
+        invalidateDataSourceListAuth()
+      }
 
       // model select
       if ((manifest && PluginType.model.includes(manifest.category)) || refreshAllType) {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
|![20251013111152_rec_](https://github.com/user-attachments/assets/56694cc7-806b-4291-a951-ec6dfab33866)|![20251013111252_rec_](https://github.com/user-attachments/assets/538327a3-c002-4bdd-958c-5a889b9b5f0b)|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
