### PR TITLE
fix: files/support-type JSON serialization error

### DIFF
--- a/api/controllers/console/files.py
+++ b/api/controllers/console/files.py
@@ -108,4 +108,4 @@ class FileSupportTypeApi(Resource):
     @login_required
     @account_initialization_required
     def get(self):
-        return {"allowed_extensions": DOCUMENT_EXTENSIONS}
+        return {"allowed_extensions": list(DOCUMENT_EXTENSIONS)}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

close https://github.com/langgenius/dify/issues/26834

Fix JSON serialization error in /console/api/files/support-type endpoint that was causing 500 Internal Server Error.

error:
```
2025-10-13 11:47:48,18 ERROR [app.py:875] 2aa3e96db4 Exception on /console/api/files/support-type [GET]
Traceback (most recent call last):
  File "/Users/yanhe/project/opensource/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yanhe/project/opensource/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yanhe/project/opensource/dify/api/.venv/lib/python3.12/site-packages/flask_restx/api.py", line 406, in wrapper
    return self.make_response(data, code, headers=headers)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yanhe/project/opensource/dify/api/.venv/lib/python3.12/site-packages/flask_restx/api.py", line 430, in make_response
    resp = self.representations[mediatype](data, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yanhe/project/opensource/dify/api/.venv/lib/python3.12/site-packages/flask_restx/representations.py", line 22, in output_json
    dumped = dumps(data, **settings) + "\n"
             ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: {'vtt', 'MD', 'XLSX', 'TXT', 'MDX', 'mdx', 'PDF', 'txt', 'CSV', 'VTT', 'DOCX', 'XLS', 'md', 'markdown', 'xls', 'docx', 'htm', 'PROPERTIES', 'HTML', 'html', 'MARKDOWN', 'HTM', 'xlsx', 'csv', 'pdf', 'properties'} is not JSON serializable
2025-10-13 11:47:48,19 INFO [_internal.py:97]  127.0.0.1 - - [13/Oct/2025 11:47:48] "GET /console/api/files/support-type HTTP/1.1" 500 -
```


## Screenshots

| Before | After |
|--------|-------|
| <img width="3452" height="1310" alt="image" src="https://github.com/user-attachments/assets/e8d34945-3ce9-439f-9658-88c2e4b1b65a" /> | <img width="3432" height="1480" alt="image" src="https://github.com/user-attachments/assets/51dea372-2330-414c-be96-d03c9fdf7c0b" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
