### PR TITLE
feat(stream): added a small tool to clean up LLM stream output

### DIFF
--- a/backend/utils/stream_filter.py
+++ b/backend/utils/stream_filter.py
@@ -1,0 +1,82 @@
+# backend/utils/stream_filter.py
+from typing import Iterator
+
+class StreamingHTMLStripper:
+    """
+    Stream-safe stripper that removes a <details><summary>...</summary></details>
+    wrapper from an async/sync stream of text chunks without buffering the whole stream.
+    """
+
+    def __init__(self, max_buffer: int = 4096):
+        self.buffer = ""
+        self.max_buffer = max_buffer
+
+    def _strip_prefixes_from_buffer(self) -> bool:
+        """
+        If buffer starts with <details ...><summary>... </summary>, remove up to the end of </summary>.
+        Return True if something was removed.
+        """
+        b = self.buffer.lstrip()
+        if not b.startswith("<details"):
+            return False
+
+        # find end of opening <details ...>
+        idx = b.find(">")
+        if idx == -1:
+            return False
+        rest = b[idx+1:].lstrip()
+        if not rest.startswith("<summary"):
+            return False
+        s_idx = rest.find(">")
+        if s_idx == -1:
+            return False
+        after_summary = rest[s_idx+1:]
+        end_summary_idx = after_summary.find("</summary>")
+        if end_summary_idx == -1:
+            return False
+        # remove up to end of </summary>
+        remove_len = (len(b) - len(rest)) + s_idx + 1 + end_summary_idx + len("</summary>")
+        self.buffer = b[remove_len:].lstrip()
+        return True
+
+    def feed(self, chunk: str) -> Iterator[str]:
+        """
+        Feed a chunk and yield cleaned output pieces (synchronous usage).
+        """
+        if not chunk:
+            return
+        self.buffer += chunk
+
+        # keep buffer bounded
+        if len(self.buffer) > self.max_buffer:
+            yield self.buffer
+            self.buffer = ""
+            return
+
+        # attempt to strip wrapper prefix(s)
+        while self._strip_prefixes_from_buffer():
+            pass
+
+        # choose safe cut so we don't emit partial tags
+        last_lt = self.buffer.rfind("<")
+        last_gt = self.buffer.rfind(">")
+        if last_lt == -1:
+            safe_cut = len(self.buffer)
+        elif last_gt > last_lt:
+            safe_cut = len(self.buffer)
+        else:
+            safe_cut = last_lt
+
+        if safe_cut and safe_cut > 0:
+            out = self.buffer[:safe_cut]
+            self.buffer = self.buffer[safe_cut:]
+            if out:
+                yield out
+
+    def finish(self) -> Iterator[str]:
+        """Flush any remaining buffer at stream end."""
+        while self._strip_prefixes_from_buffer():
+            pass
+        if self.buffer:
+            yield self.buffer
+            self.buffer = ""

--- a/backend/utils/stream_filter.py
+++ b/backend/utils/stream_filter.py
@@ -1,5 +1,6 @@
 from typing import Iterator
 
+
 class StreamingHTMLStripper:
     """
     Stream-safe stripper that removes a <details><summary>...</summary></details>
@@ -23,13 +24,13 @@ class StreamingHTMLStripper:
         idx = b.find(">")
         if idx == -1:
             return False
-        rest = b[idx+1:].lstrip()
+        rest = b[idx + 1 :].lstrip()
         if not rest.startswith("<summary"):
             return False
         s_idx = rest.find(">")
         if s_idx == -1:
             return False
-        after_summary = rest[s_idx+1:]
+        after_summary = rest[s_idx + 1 :]
         end_summary_idx = after_summary.find("</summary>")
         if end_summary_idx == -1:
             return False
@@ -80,7 +81,6 @@ class StreamingHTMLStripper:
             self.buffer = self.buffer[safe_cut:]
             if out:
                 yield out
-
 
     def finish(self) -> Iterator[str]:
         """Flush any remaining buffer at stream end."""

--- a/tests/test_stream_filter.py
+++ b/tests/test_stream_filter.py
@@ -1,4 +1,3 @@
-# tests/test_stream_filter.py
 from backend.utils.stream_filter import StreamingHTMLStripper
 
 def collect_outputs(stripper, chunks):

--- a/tests/test_stream_filter.py
+++ b/tests/test_stream_filter.py
@@ -1,0 +1,26 @@
+# tests/test_stream_filter.py
+from backend.utils.stream_filter import StreamingHTMLStripper
+
+def collect_outputs(stripper, chunks):
+    outs = []
+    for c in chunks:
+        for o in stripper.feed(c):
+            outs.append(o)
+    for o in stripper.finish():
+        outs.append(o)
+    return "".join(outs)
+
+def test_prefix_in_one_chunk():
+    s = StreamingHTMLStripper()
+    chunks = ["<details><summary>Thinking...</summary>Hello world"]
+    assert collect_outputs(s, chunks).strip() == "Hello world"
+
+def test_prefix_split_across_chunks():
+    s = StreamingHTMLStripper()
+    chunks = ["<deta", "ils><summary>Think", "ing...</summary>Hi"]
+    assert collect_outputs(s, chunks).strip() == "Hi"
+
+def test_no_prefix_pass_through():
+    s = StreamingHTMLStripper()
+    chunks = ["Hello ", "there ", "friend"]
+    assert collect_outputs(s, chunks) == "Hello there friend"

--- a/tests/test_stream_filter.py
+++ b/tests/test_stream_filter.py
@@ -1,5 +1,6 @@
 from backend.utils.stream_filter import StreamingHTMLStripper
 
+
 def collect_outputs(stripper, chunks):
     outs = []
     for c in chunks:
@@ -9,15 +10,18 @@ def collect_outputs(stripper, chunks):
         outs.append(o)
     return "".join(outs)
 
+
 def test_prefix_in_one_chunk():
     s = StreamingHTMLStripper()
     chunks = ["<details><summary>Thinking...</summary>Hello world"]
     assert collect_outputs(s, chunks).strip() == "Hello world"
 
+
 def test_prefix_split_across_chunks():
     s = StreamingHTMLStripper()
     chunks = ["<deta", "ils><summary>Think", "ing...</summary>Hi"]
     assert collect_outputs(s, chunks).strip() == "Hi"
+
 
 def test_no_prefix_pass_through():
     s = StreamingHTMLStripper()

--- a/tools/stream_filter_demo.py
+++ b/tools/stream_filter_demo.py
@@ -1,4 +1,3 @@
-# tools/stream_filter_demo.py
 import asyncio
 from backend.utils.stream_filter import StreamingHTMLStripper
 

--- a/tools/stream_filter_demo.py
+++ b/tools/stream_filter_demo.py
@@ -1,0 +1,25 @@
+# tools/stream_filter_demo.py
+import asyncio
+from backend.utils.stream_filter import StreamingHTMLStripper
+
+async def fake_llm_stream():
+    chunks = [
+        "<details><summary>Thinking...</summary>",
+        "Hello ",
+        "world! This is streamed ",
+        "and the </details> trailing part"
+    ]
+    for c in chunks:
+        await asyncio.sleep(0.05)
+        yield c
+
+async def main():
+    s = StreamingHTMLStripper()
+    async for c in fake_llm_stream():
+        for out in s.feed(c):
+            print("OUT:", repr(out))
+    for out in s.finish():
+        print("FINAL:", repr(out))
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tools/stream_filter_demo.py
+++ b/tools/stream_filter_demo.py
@@ -1,16 +1,18 @@
 import asyncio
 from backend.utils.stream_filter import StreamingHTMLStripper
 
+
 async def fake_llm_stream():
     chunks = [
         "<details><summary>Thinking...</summary>",
         "Hello ",
         "world! This is streamed ",
-        "and the </details> trailing part"
+        "and the </details> trailing part",
     ]
     for c in chunks:
         await asyncio.sleep(0.05)
         yield c
+
 
 async def main():
     s = StreamingHTMLStripper()
@@ -20,5 +22,6 @@ async def main():
     for out in s.finish():
         print("FINAL:", repr(out))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Hey there 👋

I added a small Python class called `StreamingHTMLStripper` that cleans up streamed LLM responses by removing extra tags like 

```html
<details><summary>Thinking...</summary>
```

. It works even when those tags are split across chunks in the stream.

This helps keep the output clean and readable while the stream is still going. I also added a quick demo script and a few tests to make sure it works as expected.

How to test:
- Run `python tools/stream_filter_demo.py` to see how it behaves
- Or run `pytest tests/test_stream_filter.py` to check the tests

Happy to adjust anything if needed 🙂