### PR TITLE
Add timeout so any plugin daemon call (including the SSE path) that legitimately takes longer than 5s would right.

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -189,6 +189,11 @@ class PluginConfig(BaseSettings):
         default="plugin-api-key",
     )
 
+    PLUGIN_DAEMON_TIMEOUT: PositiveFloat | None = Field(
+        description="Timeout in seconds for requests to the plugin daemon (set to None to disable)",
+        default=300.0,
+    )
+
     INNER_API_KEY_FOR_PLUGIN: str = Field(description="Inner api key for plugin", default="inner-api-key")
 
     PLUGIN_REMOTE_INSTALL_HOST: str = Field(

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -2,7 +2,7 @@ import inspect
 import json
 import logging
 from collections.abc import Callable, Generator
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 import httpx
 from pydantic import BaseModel
@@ -31,6 +31,17 @@ from core.plugin.impl.exc import (
 )
 
 plugin_daemon_inner_api_baseurl = URL(str(dify_config.PLUGIN_DAEMON_URL))
+_plugin_daemon_timeout_config = cast(
+    float | httpx.Timeout | None,
+    getattr(dify_config, "PLUGIN_DAEMON_TIMEOUT", 300.0),
+)
+plugin_daemon_request_timeout: httpx.Timeout | None
+if _plugin_daemon_timeout_config is None:
+    plugin_daemon_request_timeout = None
+elif isinstance(_plugin_daemon_timeout_config, httpx.Timeout):
+    plugin_daemon_request_timeout = _plugin_daemon_timeout_config
+else:
+    plugin_daemon_request_timeout = httpx.Timeout(_plugin_daemon_timeout_config)
 
 T = TypeVar("T", bound=(BaseModel | dict | list | bool | str))
 
@@ -58,6 +69,7 @@ class BasePluginClient:
             "headers": headers,
             "params": params,
             "files": files,
+            "timeout": plugin_daemon_request_timeout,
         }
         if isinstance(prepared_data, dict):
             request_kwargs["data"] = prepared_data
@@ -116,6 +128,7 @@ class BasePluginClient:
             "headers": headers,
             "params": params,
             "files": files,
+            "timeout": plugin_daemon_request_timeout,
         }
         if isinstance(prepared_data, dict):
             stream_kwargs["data"] = prepared_data


### PR DESCRIPTION
## Summary

fix after #26119 in Nano banana case

## Screenshots

<img width="832" height="609" alt="image" src="https://github.com/user-attachments/assets/68a51df7-2a9a-4189-8bd9-0fc84205c17d" />

## Checklist

- [x] This change *not* requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've *not* added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] No need to updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
