### PR TITLE
Normalize null metadata handling in tool entities

### DIFF
--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -189,6 +189,11 @@ class ToolInvokeMessage(BaseModel):
         data: Mapping[str, Any] = Field(..., description="Detailed log data")
         metadata: Mapping[str, Any] = Field(default_factory=dict, description="The metadata of the log")
 
+        @field_validator("metadata", mode="before")
+        @classmethod
+        def _normalize_metadata(cls, value: Mapping[str, Any] | None) -> Mapping[str, Any]:
+            return value or {}
+
     class RetrieverResourceMessage(BaseModel):
         retriever_resources: list[RetrievalSourceMetadata] = Field(..., description="retriever resources")
         context: str = Field(..., description="context")
@@ -375,6 +380,11 @@ class ToolEntity(BaseModel):
     @classmethod
     def set_parameters(cls, v, validation_info: ValidationInfo) -> list[ToolParameter]:
         return v or []
+
+    @field_validator("output_schema", mode="before")
+    @classmethod
+    def _normalize_output_schema(cls, value: Mapping[str, object] | None) -> Mapping[str, object]:
+        return value or {}
 
 
 class OAuthSchema(BaseModel):

--- a/api/tests/unit_tests/core/tools/test_tool_entities.py
+++ b/api/tests/unit_tests/core/tools/test_tool_entities.py
@@ -1,0 +1,29 @@
+from core.tools.entities.common_entities import I18nObject
+from core.tools.entities.tool_entities import ToolEntity, ToolIdentity, ToolInvokeMessage
+
+
+def _make_identity() -> ToolIdentity:
+    return ToolIdentity(
+        author="author",
+        name="tool",
+        label=I18nObject(en_US="Label"),
+        provider="builtin",
+    )
+
+
+def test_log_message_metadata_none_defaults_to_empty_dict():
+    log_message = ToolInvokeMessage.LogMessage(
+        id="log-1",
+        label="Log entry",
+        status=ToolInvokeMessage.LogMessage.LogStatus.START,
+        data={},
+        metadata=None,
+    )
+
+    assert log_message.metadata == {}
+
+
+def test_tool_entity_output_schema_none_defaults_to_empty_dict():
+    entity = ToolEntity(identity=_make_identity(), output_schema=None)
+
+    assert entity.output_schema == {}


### PR DESCRIPTION
## Summary

Fixes #26889

- normalize `ToolInvokeMessage.LogMessage.metadata` so explicit `null` inputs become empty mappings
- treat `ToolEntity.output_schema` the same to preserve behavior for existing tool definitions
- add regression coverage for both normalization paths

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
