### PR TITLE
Remove unused after_request hooks from console API keys

### DIFF
--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -1,5 +1,4 @@
 import flask_restx
-from flask import Response
 from flask_restx import Resource, fields, marshal_with
 from flask_restx._http import HTTPStatus
 from sqlalchemy import select
@@ -156,11 +155,6 @@ class AppApiKeyListResource(BaseApiKeyListResource):
         """Create a new API key for an app"""
         return super().post(resource_id)
 
-    def after_request(self, resp: Response):
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Credentials"] = "true"
-        return resp
-
     resource_type = "app"
     resource_model = App
     resource_id_field = "app_id"
@@ -176,11 +170,6 @@ class AppApiKeyResource(BaseApiKeyResource):
     def delete(self, resource_id, api_key_id):
         """Delete an API key for an app"""
         return super().delete(resource_id, api_key_id)
-
-    def after_request(self, resp):
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Credentials"] = "true"
-        return resp
 
     resource_type = "app"
     resource_model = App
@@ -206,11 +195,6 @@ class DatasetApiKeyListResource(BaseApiKeyListResource):
         """Create a new API key for a dataset"""
         return super().post(resource_id)
 
-    def after_request(self, resp: Response):
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Credentials"] = "true"
-        return resp
-
     resource_type = "dataset"
     resource_model = Dataset
     resource_id_field = "dataset_id"
@@ -226,11 +210,6 @@ class DatasetApiKeyResource(BaseApiKeyResource):
     def delete(self, resource_id, api_key_id):
         """Delete an API key for a dataset"""
         return super().delete(resource_id, api_key_id)
-
-    def after_request(self, resp: Response):
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Credentials"] = "true"
-        return resp
 
     resource_type = "dataset"
     resource_model = Dataset


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
- remove the unused `after_request` overrides from the console API key resources so CORS handling stays in the global middleware
- tidy the module imports after dropping the dead hooks

Fixes #26895

## Screenshots

| Before | After |
|--------|-------|
| n/a | n/a |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
