### PR TITLE
Fix json in md when use quesion classifier node

### DIFF
--- a/api/core/workflow/nodes/question_classifier/question_classifier_node.py
+++ b/api/core/workflow/nodes/question_classifier/question_classifier_node.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -194,6 +195,8 @@ class QuestionClassifierNode(Node):
 
             category_name = node_data.classes[0].name
             category_id = node_data.classes[0].id
+            if "<think>" in result_text:
+                result_text = re.sub(r"<think>[\s\S]*?</think>", "", result_text, flags=re.IGNORECASE)
             result_text_json = parse_and_check_json_markdown(result_text, [])
             # result_text_json = json.loads(result_text.strip('```JSON\n'))
             if "category_name" in result_text_json and "category_id" in result_text_json:

--- a/api/core/workflow/nodes/question_classifier/question_classifier_node.py
+++ b/api/core/workflow/nodes/question_classifier/question_classifier_node.py
@@ -196,7 +196,7 @@ class QuestionClassifierNode(Node):
             category_name = node_data.classes[0].name
             category_id = node_data.classes[0].id
             if "<think>" in result_text:
-                result_text = re.sub(r"<think>[\s\S]*?</think>", "", result_text, flags=re.IGNORECASE)
+                result_text = re.sub(r"<think[^>]*>[\s\S]*?</think>", "", result_text, flags=re.IGNORECASE)
             result_text_json = parse_and_check_json_markdown(result_text, [])
             # result_text_json = json.loads(result_text.strip('```JSON\n'))
             if "category_name" in result_text_json and "category_id" in result_text_json:

--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -1,27 +1,29 @@
 import json
+import re
 
 from core.llm_generator.output_parser.errors import OutputParserError
 
 
 def parse_json_markdown(json_string: str):
     # Get json from the backticks/braces
+    json_string = re.sub(r"<think>[\s\S]*?</think>", "", json_string, flags=re.IGNORECASE)
     json_string = json_string.strip()
-    starts = ["```json", "```", "``", "`", "{"]
-    ends = ["```", "``", "`", "}"]
+    starts = ["```json", "```", "``", "`", "{", "["]
+    ends = ["```", "``", "`", "}", "]"]
     end_index = -1
     start_index = 0
     parsed: dict = {}
     for s in starts:
         start_index = json_string.find(s)
         if start_index != -1:
-            if json_string[start_index] != "{":
+            if json_string[start_index] not in ("{", "["):
                 start_index += len(s)
             break
     if start_index != -1:
         for e in ends:
             end_index = json_string.rfind(e, start_index)
             if end_index != -1:
-                if json_string[end_index] == "}":
+                if json_string[end_index] in ("}", "]"):
                     end_index += 1
                 break
     if start_index != -1 and end_index != -1 and start_index < end_index:
@@ -38,6 +40,14 @@ def parse_and_check_json_markdown(text: str, expected_keys: list[str]):
         json_obj = parse_json_markdown(text)
     except json.JSONDecodeError as e:
         raise OutputParserError(f"got invalid json object. error: {e}")
+
+    if isinstance(json_obj, list):
+        if len(json_obj) == 1 and isinstance(json_obj[0], dict):
+            json_obj = json_obj[0]
+        else:
+            raise OutputParserError(
+                "got invalid return object. obj:{json_obj}"
+            )
     for key in expected_keys:
         if key not in json_obj:
             raise OutputParserError(

--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -43,7 +43,7 @@ def parse_and_check_json_markdown(text: str, expected_keys: list[str]):
         if len(json_obj) == 1 and isinstance(json_obj[0], dict):
             json_obj = json_obj[0]
         else:
-            raise OutputParserError("got invalid return object. obj:{json_obj}")
+            raise OutputParserError(f"got invalid return object. obj:{json_obj}")
     for key in expected_keys:
         if key not in json_obj:
             raise OutputParserError(

--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -1,12 +1,10 @@
 import json
-import re
 
 from core.llm_generator.output_parser.errors import OutputParserError
 
 
 def parse_json_markdown(json_string: str):
     # Get json from the backticks/braces
-    json_string = re.sub(r"<think>[\s\S]*?</think>", "", json_string, flags=re.IGNORECASE)
     json_string = json_string.strip()
     starts = ["```json", "```", "``", "`", "{", "["]
     ends = ["```", "``", "`", "}", "]"]
@@ -45,9 +43,7 @@ def parse_and_check_json_markdown(text: str, expected_keys: list[str]):
         if len(json_obj) == 1 and isinstance(json_obj[0], dict):
             json_obj = json_obj[0]
         else:
-            raise OutputParserError(
-                "got invalid return object. obj:{json_obj}"
-            )
+            raise OutputParserError("got invalid return object. obj:{json_obj}")
     for key in expected_keys:
         if key not in json_obj:
             raise OutputParserError(

--- a/api/tests/unit_tests/libs/test_json_in_md_parser.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser.py
@@ -87,6 +87,7 @@ def test_parse_and_check_json_markdown_multiple_blocks_fails():
     with pytest.raises(OutputParserError):
         parse_and_check_json_markdown(src, [])
 
+
 def test_parse_and_check_json_markdown_handles_think_fenced_and_raw_variants():
     expected = {"keywords": ["2"], "category_id": "2", "category_name": "2"}
     cases = [

--- a/api/tests/unit_tests/libs/test_json_in_md_parser.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser.py
@@ -86,3 +86,23 @@ def test_parse_and_check_json_markdown_multiple_blocks_fails():
     # opening fence to the last closing fence, causing JSON decode failure.
     with pytest.raises(OutputParserError):
         parse_and_check_json_markdown(src, [])
+
+def test_parse_and_check_json_markdown_handles_think_fenced_and_raw_variants():
+    expected = {"keywords": ["2"], "category_id": "2", "category_name": "2"}
+    cases = [
+        """
+        <think> xxx </think> ```json
+        [{"keywords": ["2"], "category_id": "2", "category_name": "2"}]
+        ```, error: Expecting value: line 1 column 1 (char 0)
+        """,
+        """
+        <think> xxx </think> ```json
+        {"keywords": ["2"], "category_id": "2", "category_name": "2"}
+        ```, error: Extra data: line 2 column 5 (char 66)
+        """,
+        '{"keywords": ["2"], "category_id": "2", "category_name": "2"}',
+        '[{"keywords": ["2"], "category_id": "2", "category_name": "2"}]',
+    ]
+    for src in cases:
+        obj = parse_and_check_json_markdown(src, ["keywords", "category_id", "category_name"])
+        assert obj == expected

--- a/api/tests/unit_tests/libs/test_json_in_md_parser.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser.py
@@ -91,12 +91,12 @@ def test_parse_and_check_json_markdown_handles_think_fenced_and_raw_variants():
     expected = {"keywords": ["2"], "category_id": "2", "category_name": "2"}
     cases = [
         """
-        <think> xxx </think> ```json
+        ```json
         [{"keywords": ["2"], "category_id": "2", "category_name": "2"}]
         ```, error: Expecting value: line 1 column 1 (char 0)
         """,
         """
-        <think> xxx </think> ```json
+        ```json
         {"keywords": ["2"], "category_id": "2", "category_name": "2"}
         ```, error: Extra data: line 2 column 5 (char 66)
         """,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #26976

## Error Description
When using glm 4.6,  llm may returns the following data format in the quesion classifier node
1. case 1：
` <think> some content </think> ```json [{"keywords": ["2"], "category_id": "2", "category_name": "2"}] ```
 `

this will cause error: Expecting value: line 1 column 1 (char 0)

2. case 2:
` <think>some content。 the final JSON will be： ```json {"keywords": ["2"], "category_id": "2", "category_name": "2"} ``` some content 。 </think> ```json {"keywords": ["2"], "category_id": "2", "category_name": "2"} ``` `

this will cause error: Extra data: line 2 column 5 (char 66)

The current JSON parsing is greedy matching, and it will report an error when `json format`  appears in the ` <think> </think>` content and the final answer at the same time.

In order to fix the above two errors for minimal changes:
1. Remove the think tag in the quesion classifier node
2. Make the JSON parsing utility class compatible with both {} and []
3. Add new unit tests

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
