### PR TITLE
refactor: improve TypeScript types for NodeCardProps and debug configuration context

### DIFF
--- a/web/app/components/workflow/workflow-preview/components/nodes/base.tsx
+++ b/web/app/components/workflow/workflow-preview/components/nodes/base.tsx
@@ -23,8 +23,10 @@ import {
 } from '../node-handle'
 import ErrorHandleOnNode from '../error-handle-on-node'
 
+type NodeChildElement = ReactElement<Partial<NodeProps>>
+
 type NodeCardProps = NodeProps & {
-  children?: ReactElement
+  children?: NodeChildElement
 }
 
 const BaseCard = ({

--- a/web/context/debug-configuration.ts
+++ b/web/context/debug-configuration.ts
@@ -242,7 +242,7 @@ const DebugConfigurationContext = createContext<IDebugConfiguration>({
   },
   datasetConfigsRef: {
     current: null,
-  },
+  } as unknown as RefObject<DatasetConfigs>,
   setDatasetConfigs: noop,
   hasSetContextVar: false,
   isShowVisionConfig: false,

--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -324,7 +324,7 @@ const baseFetch = base
 
 type UploadOptions = {
   xhr: XMLHttpRequest
-  method: string
+  method?: string
   url?: string
   headers?: Record<string, string>
   data: FormData


### PR DESCRIPTION

- Updated `children` prop type in `NodeCardProps` to use a more specific `NodeChildElement` type.
- Cast `datasetConfigsRef` in `DebugConfigurationContext` to `RefObject<DatasetConfigs>` for better type safety.
- Made `method` in `UploadOptions` optional to enhance flexibility in API requests.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #27000 27000

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
