### PR TITLE
Chore: remove unused class-level variables in DatasourceManager

### DIFF
--- a/api/core/datasource/datasource_manager.py
+++ b/api/core/datasource/datasource_manager.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class DatasourceManager:
-
     @classmethod
     def get_datasource_plugin_provider(
         cls, provider_id: str, tenant_id: str, datasource_type: DatasourceProviderType

--- a/api/core/datasource/datasource_manager.py
+++ b/api/core/datasource/datasource_manager.py
@@ -1,11 +1,9 @@
 import logging
 from threading import Lock
-from typing import Union
 
 import contexts
 from core.datasource.__base.datasource_plugin import DatasourcePlugin
 from core.datasource.__base.datasource_provider import DatasourcePluginProviderController
-from core.datasource.entities.common_entities import I18nObject
 from core.datasource.entities.datasource_entities import DatasourceProviderType
 from core.datasource.errors import DatasourceProviderNotFoundError
 from core.datasource.local_file.local_file_provider import LocalFileDatasourcePluginProviderController
@@ -18,10 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class DatasourceManager:
-    _builtin_provider_lock = Lock()
-    _hardcoded_providers: dict[str, DatasourcePluginProviderController] = {}
-    _builtin_providers_loaded = False
-    _builtin_tools_labels: dict[str, Union[I18nObject, None]] = {}
 
     @classmethod
     def get_datasource_plugin_provider(


### PR DESCRIPTION
Fixes #27012

The following unused variables were removed from `DatasourceManager`:

- `_builtin_provider_lock`
- `_hardcoded_providers`
- `_builtin_providers_loaded`
- `_builtin_tools_labels`

These fields were copied from `ToolManager` but are not referenced anywhere in the current datasource logic.
They serve no functional purpose and can be safely deleted to reduce confusion and maintain code clarity.


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
