### PR TITLE
Sync same logic for datasets.

### DIFF
--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -468,7 +468,6 @@ class DatasetApi(Resource):
         dataset_id_str = str(dataset_id)
         current_user, _ = current_account_with_tenant()
 
-        # The role of the current user in the ta table must be admin, owner, or editor
         if not (current_user.has_edit_permission or current_user.is_dataset_operator):
             raise Forbidden()
 

--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -150,7 +150,6 @@ class ExternalApiTemplateApi(Resource):
         current_user, current_tenant_id = current_account_with_tenant()
         external_knowledge_api_id = str(external_knowledge_api_id)
 
-        # The role of the current user in the ta table must be admin, owner, or editor
         if not (current_user.has_edit_permission or current_user.is_dataset_operator):
             raise Forbidden()
 

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_workflow.py
@@ -937,11 +937,10 @@ class RagPipelineTransformApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    @edit_permission_required
     def post(self, dataset_id: str):
         current_user, _ = current_account_with_tenant()
 
-        if not current_user.is_dataset_operator:
+        if not (current_user.has_edit_permission or current_user.is_dataset_operator):
             raise Forbidden()
 
         dataset_id = str(dataset_id)


### PR DESCRIPTION
Fixes #27055, which introduced at #26077

## Summary

Roles are single-valued (models/account.py:12) and TenantAccountRole.is_editing_role refuses DATASET_OPERATOR (models/account.py:36), while Account.is_dataset_operator only returns True for that same role (models/account.py:228). Because no user can satisfy both conditions, every request ends in a 403 even when logged in.

## Checklist

- [x] This change *not* requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added *no* test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] No need update the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
