### PR TITLE
fix: https://github.com/langgenius/dify/issues/27063

### DIFF
--- a/web/app/components/app/annotation/edit-annotation-modal/edit-item/index.tsx
+++ b/web/app/components/app/annotation/edit-annotation-modal/edit-item/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { FC } from 'react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RiDeleteBinLine, RiEditFill, RiEditLine } from '@remixicon/react'
 import { Robot, User } from '@/app/components/base/icons/src/public/avatar'
@@ -16,7 +16,7 @@ type Props = {
   type: EditItemType
   content: string
   readonly?: boolean
-  onSave: (content: string) => void
+  onSave: (content: string) => Promise<void>
 }
 
 export const EditTitle: FC<{ className?: string; title: string }> = ({ className, title }) => (
@@ -46,8 +46,13 @@ const EditItem: FC<Props> = ({
   const placeholder = type === EditItemType.Query ? t('appAnnotation.editModal.queryPlaceholder') : t('appAnnotation.editModal.answerPlaceholder')
   const [isEdit, setIsEdit] = useState(false)
 
-  const handleSave = () => {
-    onSave(newContent)
+  // Reset newContent when content prop changes
+  useEffect(() => {
+    setNewContent('')
+  }, [content])
+
+  const handleSave = async () => {
+    await onSave(newContent)
     setIsEdit(false)
   }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #27063

1. State initialization problem: Local state (newQuestion, newAnswer) was initialized
only once when the component mounted
2. No prop change handling: When the modal reopened with updated data from the server,
the local state didn't update with the new prop values
3. Async save handling: The component updated local state immediately, even if the
save operation failed

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
