### PR TITLE
docs: mention backend lint gate in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The codebase is split into:
 ## Backend Workflow
 
 - Run backend CLI commands through `uv run --project api <command>`.
+- All backend modifications must pass `make lint` and `make type-check` locally before submission.
 
 - Backend QA gate requires passing `make lint`, `make type-check`, and `uv run --project api --dev dev/pytest/pytest_unit_tests.sh` before review.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The codebase is split into:
 ## Backend Workflow
 
 - Run backend CLI commands through `uv run --project api <command>`.
+
 - All backend modifications must pass `make lint` and `make type-check` locally before submission.
 
 - Backend QA gate requires passing `make lint`, `make type-check`, and `uv run --project api --dev dev/pytest/pytest_unit_tests.sh` before review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,7 @@ The codebase is split into:
 
 - Run backend CLI commands through `uv run --project api <command>`.
 
-- All backend modifications must pass `make lint` and `make type-check` locally before submission.
-
-- Backend QA gate requires passing `make lint`, `make type-check`, and `uv run --project api --dev dev/pytest/pytest_unit_tests.sh` before review.
+- Before submission, all backend modifications must pass local checks: `make lint`, `make type-check`, and `uv run --project api --dev dev/pytest/pytest_unit_tests.sh`.
 
 - Use Makefile targets for linting and formatting; `make lint` and `make type-check` cover the required checks.
 


### PR DESCRIPTION
## Summary

- Document that backend contributions must run `make lint` and `make type-check` before submission in the contributor guide.
- Aligns backend workflow guidance with the QA gate to reduce avoidable review cycles.

Fixes #27101

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
