### PR TITLE
Allow custom app headers in CORS configuration

### DIFF
--- a/api/extensions/ext_blueprints.py
+++ b/api/extensions/ext_blueprints.py
@@ -3,6 +3,23 @@ from constants import HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN, HEADER_NAME_
 from dify_app import DifyApp
 
 
+APP_CREDENTIAL_HEADERS = (HEADER_NAME_APP_CODE, HEADER_NAME_PASSPORT)
+
+
+def _compose_headers(*headers: str) -> list[str]:
+    """
+    Build a header list that keeps insertion order while removing duplicates.
+    """
+    result: list[str] = []
+    seen: set[str] = set()
+    for header in headers:
+        if header in seen:
+            continue
+        result.append(header)
+        seen.add(header)
+    return result
+
+
 def init_app(app: DifyApp):
     # register blueprint routers
 
@@ -17,7 +34,7 @@ def init_app(app: DifyApp):
 
     CORS(
         service_api_bp,
-        allow_headers=["Content-Type", "Authorization", HEADER_NAME_APP_CODE, HEADER_NAME_PASSPORT],
+        allow_headers=_compose_headers("Content-Type", "Authorization", *APP_CREDENTIAL_HEADERS),
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
     )
     app.register_blueprint(service_api_bp)
@@ -26,13 +43,12 @@ def init_app(app: DifyApp):
         web_bp,
         resources={r"/*": {"origins": dify_config.WEB_API_CORS_ALLOW_ORIGINS}},
         supports_credentials=True,
-        allow_headers=[
+        allow_headers=_compose_headers(
             "Content-Type",
             "Authorization",
-            HEADER_NAME_APP_CODE,
+            *APP_CREDENTIAL_HEADERS,
             HEADER_NAME_CSRF_TOKEN,
-            HEADER_NAME_PASSPORT,
-        ],
+        ),
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
         expose_headers=["X-Version", "X-Env"],
     )
@@ -42,13 +58,12 @@ def init_app(app: DifyApp):
         console_app_bp,
         resources={r"/*": {"origins": dify_config.CONSOLE_CORS_ALLOW_ORIGINS}},
         supports_credentials=True,
-        allow_headers=[
+        allow_headers=_compose_headers(
             "Content-Type",
             "Authorization",
-            HEADER_NAME_APP_CODE,
+            *APP_CREDENTIAL_HEADERS,
             HEADER_NAME_CSRF_TOKEN,
-            HEADER_NAME_PASSPORT,
-        ],
+        ),
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
         expose_headers=["X-Version", "X-Env"],
     )
@@ -56,7 +71,7 @@ def init_app(app: DifyApp):
 
     CORS(
         files_bp,
-        allow_headers=["Content-Type", HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN, HEADER_NAME_PASSPORT],
+        allow_headers=_compose_headers("Content-Type", *APP_CREDENTIAL_HEADERS, HEADER_NAME_CSRF_TOKEN),
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
     )
     app.register_blueprint(files_bp)

--- a/api/extensions/ext_blueprints.py
+++ b/api/extensions/ext_blueprints.py
@@ -1,5 +1,5 @@
 from configs import dify_config
-from constants import HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN
+from constants import HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN, HEADER_NAME_PASSPORT
 from dify_app import DifyApp
 
 
@@ -17,7 +17,7 @@ def init_app(app: DifyApp):
 
     CORS(
         service_api_bp,
-        allow_headers=["Content-Type", "Authorization", HEADER_NAME_APP_CODE],
+        allow_headers=["Content-Type", "Authorization", HEADER_NAME_APP_CODE, HEADER_NAME_PASSPORT],
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
     )
     app.register_blueprint(service_api_bp)
@@ -26,7 +26,13 @@ def init_app(app: DifyApp):
         web_bp,
         resources={r"/*": {"origins": dify_config.WEB_API_CORS_ALLOW_ORIGINS}},
         supports_credentials=True,
-        allow_headers=["Content-Type", "Authorization", HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN],
+        allow_headers=[
+            "Content-Type",
+            "Authorization",
+            HEADER_NAME_APP_CODE,
+            HEADER_NAME_CSRF_TOKEN,
+            HEADER_NAME_PASSPORT,
+        ],
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
         expose_headers=["X-Version", "X-Env"],
     )
@@ -36,7 +42,13 @@ def init_app(app: DifyApp):
         console_app_bp,
         resources={r"/*": {"origins": dify_config.CONSOLE_CORS_ALLOW_ORIGINS}},
         supports_credentials=True,
-        allow_headers=["Content-Type", "Authorization", HEADER_NAME_CSRF_TOKEN],
+        allow_headers=[
+            "Content-Type",
+            "Authorization",
+            HEADER_NAME_APP_CODE,
+            HEADER_NAME_CSRF_TOKEN,
+            HEADER_NAME_PASSPORT,
+        ],
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
         expose_headers=["X-Version", "X-Env"],
     )
@@ -44,7 +56,7 @@ def init_app(app: DifyApp):
 
     CORS(
         files_bp,
-        allow_headers=["Content-Type", HEADER_NAME_CSRF_TOKEN],
+        allow_headers=["Content-Type", HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN, HEADER_NAME_PASSPORT],
         methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
     )
     app.register_blueprint(files_bp)

--- a/api/extensions/ext_blueprints.py
+++ b/api/extensions/ext_blueprints.py
@@ -2,7 +2,6 @@ from configs import dify_config
 from constants import HEADER_NAME_APP_CODE, HEADER_NAME_CSRF_TOKEN, HEADER_NAME_PASSPORT
 from dify_app import DifyApp
 
-
 APP_CREDENTIAL_HEADERS = (HEADER_NAME_APP_CODE, HEADER_NAME_PASSPORT)
 
 


### PR DESCRIPTION
## Summary
Fixes #27132

Adds the missing `X-App-Code` and `X-App-Passport` headers to every CORS allow list so that web and service clients using those credentials are not blocked by preflight checks.

## Screenshots

| Before | After |
|--------|-------|
| CORS preflight rejected custom headers | CORS preflight accepts `X-App-Code` and `X-App-Passport` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
