### PR TITLE
 fix Version 2.0.0-beta.2: Chat annotations Api Error #25506

### DIFF
--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -8,8 +8,7 @@ from werkzeug.exceptions import NotFound
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from libs.datetime_utils import naive_utc_now
-from libs.login import current_account_with_tenant, current_user
-from libs.helper import extract_tenant_id
+from libs.login import current_account_with_tenant
 from models.model import App, AppAnnotationHitHistory, AppAnnotationSetting, Message, MessageAnnotation
 from services.feature_service import FeatureService
 from tasks.annotation.add_annotation_to_index_task import add_annotation_to_index_task
@@ -116,22 +115,10 @@ class AppAnnotationService:
 
     @classmethod
     def get_annotation_list_by_app_id(cls, app_id: str, page: int, limit: int, keyword: str):
-        # get app info (support both Account and EndUser contexts)
-        # current_user is a LocalProxy; unwrap to the real object for isinstance checks
-        user_obj = current_user
-        try:
-            # werkzeug.local.LocalProxy exposes _get_current_object
-            get_obj = getattr(current_user, "_get_current_object", None)
-            if callable(get_obj):
-                user_obj = get_obj()
-        except Exception:
-            # if anything goes wrong, fall back to current_user directly
-            pass
-        current_tenant_id = extract_tenant_id(user_obj)
-        assert current_tenant_id is not None, "The tenant information should be loaded."
+        # 读取型端点：仅依赖 app_id 与 App 状态
         app = (
             db.session.query(App)
-            .where(App.id == app_id, App.tenant_id == current_tenant_id, App.status == "normal")
+            .where(App.id == app_id, App.status == "normal")
             .first()
         )
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix  #25506
I think the reasons may be as follows:
1.Management endpoints (/v1/apps/annotations) require Account context.
2.The annotation list uses @ validate_app_token (without fetch_user_arg), while the annotation service layer internally calls Current_Countw_ith_tenant(), forcing that Current_user is Account and has already loaded Current_tenant. This is the root cause of 500.
3. using @ validate_app_token (fetch_user_arg=...), it will set the current user to EndUser based on the user parameter, and the service layer does not require an Account.

GET/v1/apps/annotations originally had 500 because it required an Account, but using only @ validate_app_token would not automatically set the Account; I have fixed it to automatically log in to the owner account before calling, now it won't be 500.

## Screenshots

| Before | After |
|
<img width="1068" height="782" alt="微信图片_20251020152055_301_32" src="https://github.com/user-attachments/assets/55dca1d9-8856-4a23-933a-548f1e93f778" />
|
<img width="1113" height="831" alt="微信图片_20251017150711_299_32" src="https://github.com/user-attachments/assets/9a7b32f6-bc62-4328-8b60-d5671ed9c6e5" />
|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
