### PR TITLE
Fix variable truncator handling for UpdatedVariable

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -391,7 +391,7 @@ class VariableTruncator:
     def _truncate_json_primitives(self, val: None, target_size: int) -> _PartResult[None]: ...
 
     def _truncate_json_primitives(
-        self, val: str | list | dict | bool | int | float | None, target_size: int
+        self, val: UpdatedVariable | str | list | dict | bool | int | float | None, target_size: int
     ) -> _PartResult[Any]:
         """Truncate a value within an object to fit within budget."""
         if isinstance(val, UpdatedVariable):

--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -17,6 +17,7 @@ from core.variables.segments import (
     StringSegment,
 )
 from core.variables.utils import dumps_with_segments
+from core.workflow.nodes.variable_assigner.common.helpers import UpdatedVariable
 
 _MAX_DEPTH = 100
 
@@ -202,6 +203,9 @@ class VariableTruncator:
         """Recursively calculate JSON size without serialization."""
         if isinstance(value, Segment):
             return VariableTruncator.calculate_json_size(value.value)
+        if isinstance(value, UpdatedVariable):
+            # TODO(Workflow): migrate UpdatedVariable serialization upstream and drop this fallback.
+            return VariableTruncator.calculate_json_size(value.model_dump(), depth=depth + 1)
         if depth > _MAX_DEPTH:
             raise MaxDepthExceededError()
         if isinstance(value, str):
@@ -390,7 +394,10 @@ class VariableTruncator:
         self, val: str | list | dict | bool | int | float | None, target_size: int
     ) -> _PartResult[Any]:
         """Truncate a value within an object to fit within budget."""
-        if isinstance(val, str):
+        if isinstance(val, UpdatedVariable):
+            # TODO(Workflow): push UpdatedVariable normalization closer to its producer.
+            return self._truncate_object(val.model_dump(), target_size)
+        elif isinstance(val, str):
             return self._truncate_string(val, target_size)
         elif isinstance(val, list):
             return self._truncate_array(val, target_size)


### PR DESCRIPTION
## Summary
- Allow `VariableTruncator` to size and truncate `UpdatedVariable` instances emitted by Variable Assigner nodes so streaming stays stable.
- Fixes #27183.

## Screenshots
| Before | After |
|--------|-------|
| n/a | n/a |

## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
