### PR TITLE
chore: align version identifiers with 1.9.2

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.9.1"
+version = "1.9.2"
 requires-python = ">=3.11,<3.13"
 
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1292,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "dify-api"
-version = "1.9.1"
+version = "1.9.2"
 source = { virtual = "." }
 dependencies = [
     { name = "arize-phoenix-otel" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -2,7 +2,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:1.9.1
+    image: langgenius/dify-api:1.9.2
     restart: always
     environment:
       # Use the shared environment variables.
@@ -38,7 +38,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.9.1
+    image: langgenius/dify-api:1.9.2
     restart: always
     environment:
       # Use the shared environment variables.
@@ -72,7 +72,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.9.1
+    image: langgenius/dify-api:1.9.2
     restart: always
     environment:
       # Use the shared environment variables.
@@ -90,7 +90,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.9.1
+    image: langgenius/dify-web:1.9.2
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
@@ -193,7 +193,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.3.0-local
+    image: langgenius/dify-plugin-daemon:0.3.3-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -24,13 +24,6 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-    # TODO: Remove this entrypoint override when weaviate-client 4.17.0 is included in the next Dify release
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        uv pip install --system weaviate-client==4.17.0
-        exec /bin/bash /app/api/docker/entrypoint.sh
     networks:
       - ssrf_proxy_network
       - default
@@ -58,13 +51,6 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-    # TODO: Remove this entrypoint override when weaviate-client 4.17.0 is included in the next Dify release
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        uv pip install --system weaviate-client==4.17.0
-        exec /bin/bash /app/api/docker/entrypoint.sh
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -87,7 +87,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.3.0-local
+    image: langgenius/dify-plugin-daemon:0.3.3-local
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -611,7 +611,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:1.9.1
+    image: langgenius/dify-api:1.9.2
     restart: always
     environment:
       # Use the shared environment variables.
@@ -647,7 +647,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.9.1
+    image: langgenius/dify-api:1.9.2
     restart: always
     environment:
       # Use the shared environment variables.
@@ -681,7 +681,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.9.1
+    image: langgenius/dify-api:1.9.2
     restart: always
     environment:
       # Use the shared environment variables.
@@ -699,7 +699,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.9.1
+    image: langgenius/dify-web:1.9.2
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
@@ -802,7 +802,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.3.0-local
+    image: langgenius/dify-plugin-daemon:0.3.3-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -633,13 +633,6 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-    # TODO: Remove this entrypoint override when weaviate-client 4.17.0 is included in the next Dify release
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        uv pip install --system weaviate-client==4.17.0
-        exec /bin/bash /app/api/docker/entrypoint.sh
     networks:
       - ssrf_proxy_network
       - default
@@ -667,13 +660,6 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
-    # TODO: Remove this entrypoint override when weaviate-client 4.17.0 is included in the next Dify release
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        uv pip install --system weaviate-client==4.17.0
-        exec /bin/bash /app/api/docker/entrypoint.sh
     networks:
       - ssrf_proxy_network
       - default

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the `dify-api` package version metadata to 1.9.2
- update Docker service image tags to 1.9.2 for API, worker, worker_beat, and web
- align the web package.json version field with the 1.9.2 release
- Fixes #27211

## Screenshots

| Before | After |
|--------|-------|
| n/a | n/a |

## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
