### PR TITLE
fix: preserve share code headers after login redirect

### DIFF
--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -40,7 +40,7 @@ class PassportResource(Resource):
             raise Unauthorized("X-App-Code header is missing.")
         if system_features.webapp_auth.enabled:
             enterprise_user_decoded = decode_enterprise_webapp_user_id(access_token)
-            app_auth_type = WebAppAuthService.get_app_auth_type(app_code = app_code)
+            app_auth_type = WebAppAuthService.get_app_auth_type(app_code=app_code)
             if app_auth_type != WebAppAuthType.PUBLIC:
                 if not enterprise_user_decoded:
                     raise WebAppAuthRequiredError()

--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -38,19 +38,14 @@ class PassportResource(Resource):
         app_code = request.headers.get(HEADER_NAME_APP_CODE)
         user_id = request.args.get("user_id")
         access_token = extract_access_token(request)
-
         if app_code is None:
             raise Unauthorized("X-App-Code header is missing.")
-        app_id = AppService.get_app_id_by_code(app_code)
-
         if system_features.webapp_auth.enabled:
-            app_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=app_id)
-            if not app_settings or app_settings.access_mode != "public":
-                enterprise_user_decoded = decode_enterprise_webapp_user_id(access_token)
-                if enterprise_user_decoded:
-                    return exchange_token_for_existing_web_user(
-                        app_code=app_code, enterprise_user_decoded=enterprise_user_decoded
-                    )
+            enterprise_user_decoded = decode_enterprise_webapp_user_id(access_token)
+            if enterprise_user_decoded:
+                return exchange_token_for_existing_web_user(
+                    app_code=app_code, enterprise_user_decoded=enterprise_user_decoded
+                )
 
         # get site from db and check if it is normal
         site = db.session.scalar(select(Site).where(Site.code == app_code, Site.status == "normal"))

--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -14,8 +14,6 @@ from extensions.ext_database import db
 from libs.passport import PassportService
 from libs.token import extract_access_token
 from models.model import App, EndUser, Site
-from services.app_service import AppService
-from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
 from services.webapp_auth_service import WebAppAuthService, WebAppAuthType
 

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -291,7 +291,9 @@ export const textToAudioStream = (url: string, isPublicAPI: boolean, header: { c
 export const fetchAccessToken = async ({ userId, appCode }: { userId?: string, appCode: string }) => {
   const headers = new Headers()
   headers.append(WEB_APP_SHARE_CODE_HEADER_NAME, appCode)
-  headers.append('Authorization', `Bearer ${getWebAppAccessToken()}`)
+  const accessToken = getWebAppAccessToken()
+  if (accessToken)
+    headers.append('Authorization', `Bearer ${accessToken}`)
   const params = new URLSearchParams()
   userId && params.append('user_id', userId)
   const url = `/passport?${params.toString()}`


### PR DESCRIPTION
## Summary
- keep shared app requests associated with the original share code even when the user passes through `/webapp-signin`, `/check-code`, or `/login`
- avoid attaching an empty bearer token when the webapp access token is absent
- Fixes #27224

## Screenshots
| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
