### PR TITLE
feat: When deploying and running "ubuntu/squid" on "x86_64 GNU/Linux", "ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted" appears

### DIFF
--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -180,6 +180,10 @@ services:
     networks:
       - ssrf_proxy_network
       - default
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   # The Weaviate vector store.
   weaviate:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -872,6 +872,10 @@ services:
     networks:
       - ssrf_proxy_network
       - default
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   # Certbot service
   # use `docker-compose --profile certbot up` to start the certbot service.


### PR DESCRIPTION
When running docker compose up -d on Linux, we encountered an issue where the "ubuntu/squid" container consistently failed to start. Checking the logs revealed the corresponding error, and we resolved the problem by modifying the ulimits configuration. It is important to note that before our modification, the container ran normally on both macOS and Ubuntu systems.
```sh
sh docker-entrypoint.sh
[ENTRYPOINT] re-create snakeoil self-signed certificate removed in the build process
[ENTRYPOINT] replacing environment variables in the template
2025/10/22 09:41:57| Creating missing swap directories
2025/10/22 09:41:57| No cache_dir stores are configured.
2025/10/22 09:41:57| Removing PID file (/run/squid.pid)
2025/10/22 09:41:57| Processing Configuration File: /etc/squid/squid.conf (depth 0)
2025/10/22 09:41:57| Processing Configuration File: /etc/squid/conf.d/debian.conf (depth 1)
2025/10/22 09:41:57| Processing Configuration File: /etc/squid/conf.d/rock.conf (depth 1)
2025/10/22 09:41:57| Created PID file (/run/squid.pid)
2025/10/22 09:41:57| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:41:57| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:41:57| Set Current Directory to /var/spool/squid
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/squid.conf (depth 0)
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/conf.d/debian.conf (depth 1)
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/conf.d/rock.conf (depth 1)
2025/10/22 09:46:24| Created PID file (/run/squid.pid)
2025/10/22 09:46:24| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:46:24| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/squid.conf (depth 0)
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/conf.d/debian.conf (depth 1)
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/conf.d/rock.conf (depth 1)
2025/10/22 09:46:24| Created PID file (/run/squid.pid)
2025/10/22 09:46:24| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:46:24| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:46:24| Set Current Directory to /var/spool/squid
2025/10/22 09:46:24| Set Current Directory to /var/spool/squid
2025/10/22 09:46:24| Creating missing swap directories
2025/10/22 09:46:24| No cache_dir stores are configured.
2025/10/22 09:46:24| Removing PID file (/run/squid.pid)
2025/10/22 09:46:24| Creating missing swap directories
2025/10/22 09:46:24| No cache_dir stores are configured.
2025/10/22 09:46:24| Removing PID file (/run/squid.pid)
[ENTRYPOINT] starting squid
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/squid.conf (depth 0)
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/conf.d/debian.conf (depth 1)
2025/10/22 09:46:24| Processing Configuration File: /etc/squid/conf.d/rock.conf (depth 1)
2025/10/22 09:46:24| Created PID file (/run/squid.pid)
2025/10/22 09:46:24| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:46:24| ERROR: setrlimit: RLIMIT_NOFILE: (1) Operation not permitted
2025/10/22 09:46:24| Set Current Directory to /var/spool/squid
Killed
```