### PR TITLE
improve opensearch index deletion　#27231 

### DIFF
--- a/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
+++ b/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
@@ -161,12 +161,7 @@ class OpenSearchVector(BaseVector):
                         logger.exception("Error deleting document: %s", error)
 
     def delete(self):
-        index_name = self._collection_name.lower()
-        if not self._client.indices.exists(index=index_name):
-            logger.warning("Index %s does not exist", index_name)
-            return
-
-        self._client.indices.delete(index=index_name)
+        self._client.indices.delete(index=self._collection_name.lower(), ignore_unavailable=True)
 
     def text_exists(self, id: str) -> bool:
         try:

--- a/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
+++ b/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
@@ -161,7 +161,12 @@ class OpenSearchVector(BaseVector):
                         logger.exception("Error deleting document: %s", error)
 
     def delete(self):
-        self._client.indices.delete(index=self._collection_name.lower())
+        index_name = self._collection_name.lower()
+        if not self._client.indices.exists(index=index_name):
+            logger.warning("Index %s does not exist", index_name)
+            return
+
+        self._client.indices.delete(index=index_name)
 
     def text_exists(self, id: str) -> bool:
         try:

--- a/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
+++ b/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
@@ -182,6 +182,34 @@ class TestOpenSearchVector:
         assert len(ids) == 1
         assert ids[0] == "mock_id"
 
+    def test_delete_nonexistent_index(self):
+        """Test deleting a non-existent index."""
+        # Create a vector instance with a non-existent collection name
+        self.vector._client.indices.exists.return_value = False
+
+        # Should not raise an exception
+        self.vector._client.delete()
+
+        # Verify that exists was called but delete was not
+        self.vector._client.indices.exists.assert_called_once_with(
+            index="non_existent_collection"
+        )
+        self.vector._client._client.indices.delete.assert_not_called()
+
+    def test_delete_existing_index(self):
+        """Test deleting an existing index."""
+        self.vector._client.indices.exists.return_value = True
+
+        self.vector.delete()
+
+        # Verify both exists and delete were called
+        self.vector._client.indices.exists.assert_called_once_with(
+            index=self.collection_name.lower()
+        )
+        self.vector._client.indices.delete.assert_called_once_with(
+            index=self.collection_name.lower()
+        )
+
 
 @pytest.mark.usefixtures("setup_mock_redis")
 class TestOpenSearchVectorWithRedis:

--- a/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
+++ b/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
@@ -194,7 +194,7 @@ class TestOpenSearchVector:
         self.vector._client.indices.exists.assert_called_once_with(
             index=self.collection_name.lower()
         )
-        self.vector._client._client.indices.delete.assert_not_called()
+        self.vector._client.indices.delete.assert_not_called()
 
     def test_delete_existing_index(self):
         """Test deleting an existing index."""

--- a/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
+++ b/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
@@ -191,9 +191,7 @@ class TestOpenSearchVector:
         self.vector.delete()
 
         # Verify that exists was called but delete was not
-        self.vector._client.indices.exists.assert_called_once_with(
-            index=self.collection_name.lower()
-        )
+        self.vector._client.indices.exists.assert_called_once_with(index=self.collection_name.lower())
         self.vector._client.indices.delete.assert_not_called()
 
     def test_delete_existing_index(self):
@@ -203,12 +201,8 @@ class TestOpenSearchVector:
         self.vector.delete()
 
         # Verify both exists and delete were called
-        self.vector._client.indices.exists.assert_called_once_with(
-            index=self.collection_name.lower()
-        )
-        self.vector._client.indices.delete.assert_called_once_with(
-            index=self.collection_name.lower()
-        )
+        self.vector._client.indices.exists.assert_called_once_with(index=self.collection_name.lower())
+        self.vector._client.indices.delete.assert_called_once_with(index=self.collection_name.lower())
 
 
 @pytest.mark.usefixtures("setup_mock_redis")

--- a/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
+++ b/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
@@ -86,8 +86,7 @@ class TestOpenSearchVector:
         self.example_doc_id = "example_doc_id"
         self.vector = OpenSearchVector(
             collection_name=self.collection_name,
-            config=OpenSearchConfig(
-                host="localhost", port=9200, secure=False, user="admin", password="password"),
+            config=OpenSearchConfig(host="localhost", port=9200, secure=False, user="admin", password="password"),
         )
         self.vector._client = MagicMock()
 
@@ -117,8 +116,7 @@ class TestOpenSearchVector:
     def test_search_by_full_text(self, search_response, expected_length, expected_doc_id):
         self.vector._client.search.return_value = search_response
 
-        hits_by_full_text = self.vector.search_by_full_text(
-            query=get_example_text())
+        hits_by_full_text = self.vector.search_by_full_text(query=get_example_text())
         assert len(hits_by_full_text) == expected_length
         if expected_length > 0:
             assert hits_by_full_text[0].metadata["document_id"] == expected_doc_id
@@ -145,50 +143,42 @@ class TestOpenSearchVector:
 
         print("Hits by vector:", hits_by_vector)
         print("Expected document ID:", self.example_doc_id)
-        print("Actual document ID:",
-              hits_by_vector[0].metadata["document_id"] if hits_by_vector else "No hits")
+        print("Actual document ID:", hits_by_vector[0].metadata["document_id"] if hits_by_vector else "No hits")
 
-        assert len(
-            hits_by_vector) > 0, f"Expected at least one hit, got {len(hits_by_vector)}"
+        assert len(hits_by_vector) > 0, f"Expected at least one hit, got {len(hits_by_vector)}"
         assert hits_by_vector[0].metadata["document_id"] == self.example_doc_id, (
             f"Expected document ID {self.example_doc_id}, got {hits_by_vector[0].metadata['document_id']}"
         )
 
     def test_get_ids_by_metadata_field(self):
-        mock_response = {
-            "hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
+        mock_response = {"hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
         self.vector._client.search.return_value = mock_response
 
-        doc = Document(page_content="Test content", metadata={
-                       "document_id": self.example_doc_id})
+        doc = Document(page_content="Test content", metadata={"document_id": self.example_doc_id})
         embedding = [0.1] * 128
 
         with patch("opensearchpy.helpers.bulk") as mock_bulk:
             mock_bulk.return_value = ([], [])
             self.vector.add_texts([doc], [embedding])
 
-        ids = self.vector.get_ids_by_metadata_field(
-            key="document_id", value=self.example_doc_id)
+        ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
         assert len(ids) == 1
         assert ids[0] == "mock_id"
 
     def test_add_texts(self):
         self.vector._client.index.return_value = {"result": "created"}
 
-        doc = Document(page_content="Test content", metadata={
-                       "document_id": self.example_doc_id})
+        doc = Document(page_content="Test content", metadata={"document_id": self.example_doc_id})
         embedding = [0.1] * 128
 
         with patch("opensearchpy.helpers.bulk") as mock_bulk:
             mock_bulk.return_value = ([], [])
             self.vector.add_texts([doc], [embedding])
 
-        mock_response = {
-            "hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
+        mock_response = {"hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
         self.vector._client.search.return_value = mock_response
 
-        ids = self.vector.get_ids_by_metadata_field(
-            key="document_id", value=self.example_doc_id)
+        ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
         assert len(ids) == 1
         assert ids[0] == "mock_id"
 
@@ -232,15 +222,13 @@ class TestOpenSearchVectorWithRedis:
             "hits": {
                 "total": {"value": 1},
                 "hits": [
-                    {"_source": {"page_content": get_example_text(), "metadata": {
-                        "document_id": "example_doc_id"}}}
+                    {"_source": {"page_content": get_example_text(), "metadata": {"document_id": "example_doc_id"}}}
                 ],
             }
         }
         expected_length = 1
         expected_doc_id = "example_doc_id"
-        self.tester.test_search_by_full_text(
-            search_response, expected_length, expected_doc_id)
+        self.tester.test_search_by_full_text(search_response, expected_length, expected_doc_id)
 
     def test_get_ids_by_metadata_field(self):
         self.tester.setup_method()

--- a/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
+++ b/api/tests/integration_tests/vdb/opensearch/test_opensearch.py
@@ -86,7 +86,8 @@ class TestOpenSearchVector:
         self.example_doc_id = "example_doc_id"
         self.vector = OpenSearchVector(
             collection_name=self.collection_name,
-            config=OpenSearchConfig(host="localhost", port=9200, secure=False, user="admin", password="password"),
+            config=OpenSearchConfig(
+                host="localhost", port=9200, secure=False, user="admin", password="password"),
         )
         self.vector._client = MagicMock()
 
@@ -116,7 +117,8 @@ class TestOpenSearchVector:
     def test_search_by_full_text(self, search_response, expected_length, expected_doc_id):
         self.vector._client.search.return_value = search_response
 
-        hits_by_full_text = self.vector.search_by_full_text(query=get_example_text())
+        hits_by_full_text = self.vector.search_by_full_text(
+            query=get_example_text())
         assert len(hits_by_full_text) == expected_length
         if expected_length > 0:
             assert hits_by_full_text[0].metadata["document_id"] == expected_doc_id
@@ -143,42 +145,50 @@ class TestOpenSearchVector:
 
         print("Hits by vector:", hits_by_vector)
         print("Expected document ID:", self.example_doc_id)
-        print("Actual document ID:", hits_by_vector[0].metadata["document_id"] if hits_by_vector else "No hits")
+        print("Actual document ID:",
+              hits_by_vector[0].metadata["document_id"] if hits_by_vector else "No hits")
 
-        assert len(hits_by_vector) > 0, f"Expected at least one hit, got {len(hits_by_vector)}"
+        assert len(
+            hits_by_vector) > 0, f"Expected at least one hit, got {len(hits_by_vector)}"
         assert hits_by_vector[0].metadata["document_id"] == self.example_doc_id, (
             f"Expected document ID {self.example_doc_id}, got {hits_by_vector[0].metadata['document_id']}"
         )
 
     def test_get_ids_by_metadata_field(self):
-        mock_response = {"hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
+        mock_response = {
+            "hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
         self.vector._client.search.return_value = mock_response
 
-        doc = Document(page_content="Test content", metadata={"document_id": self.example_doc_id})
+        doc = Document(page_content="Test content", metadata={
+                       "document_id": self.example_doc_id})
         embedding = [0.1] * 128
 
         with patch("opensearchpy.helpers.bulk") as mock_bulk:
             mock_bulk.return_value = ([], [])
             self.vector.add_texts([doc], [embedding])
 
-        ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
+        ids = self.vector.get_ids_by_metadata_field(
+            key="document_id", value=self.example_doc_id)
         assert len(ids) == 1
         assert ids[0] == "mock_id"
 
     def test_add_texts(self):
         self.vector._client.index.return_value = {"result": "created"}
 
-        doc = Document(page_content="Test content", metadata={"document_id": self.example_doc_id})
+        doc = Document(page_content="Test content", metadata={
+                       "document_id": self.example_doc_id})
         embedding = [0.1] * 128
 
         with patch("opensearchpy.helpers.bulk") as mock_bulk:
             mock_bulk.return_value = ([], [])
             self.vector.add_texts([doc], [embedding])
 
-        mock_response = {"hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
+        mock_response = {
+            "hits": {"total": {"value": 1}, "hits": [{"_id": "mock_id"}]}}
         self.vector._client.search.return_value = mock_response
 
-        ids = self.vector.get_ids_by_metadata_field(key="document_id", value=self.example_doc_id)
+        ids = self.vector.get_ids_by_metadata_field(
+            key="document_id", value=self.example_doc_id)
         assert len(ids) == 1
         assert ids[0] == "mock_id"
 
@@ -188,11 +198,11 @@ class TestOpenSearchVector:
         self.vector._client.indices.exists.return_value = False
 
         # Should not raise an exception
-        self.vector._client.delete()
+        self.vector.delete()
 
         # Verify that exists was called but delete was not
         self.vector._client.indices.exists.assert_called_once_with(
-            index="non_existent_collection"
+            index=self.collection_name.lower()
         )
         self.vector._client._client.indices.delete.assert_not_called()
 
@@ -222,13 +232,15 @@ class TestOpenSearchVectorWithRedis:
             "hits": {
                 "total": {"value": 1},
                 "hits": [
-                    {"_source": {"page_content": get_example_text(), "metadata": {"document_id": "example_doc_id"}}}
+                    {"_source": {"page_content": get_example_text(), "metadata": {
+                        "document_id": "example_doc_id"}}}
                 ],
             }
         }
         expected_length = 1
         expected_doc_id = "example_doc_id"
-        self.tester.test_search_by_full_text(search_response, expected_length, expected_doc_id)
+        self.tester.test_search_by_full_text(
+            search_response, expected_length, expected_doc_id)
 
     def test_get_ids_by_metadata_field(self):
         self.tester.setup_method()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes an issue where `OpenSearchVector.delete()` would fail with an `index_not_found_exception` when trying to delete a non-existent index. We now check if the index exists before deleting it. If the index is missing, the method returns early without raising an exception, allowing migrations or cleanup tasks to continue smoothly.'

Resolve #27231

## Screenshots

| Before                                 | After                                               |
| -------------------------------------- | --------------------------------------------------- |
| Error raised when index does not exist | Delete completes silently when index does not exist |

## Checklist

* [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
* [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
* [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
* [x] I've updated the documentation accordingly.
* [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
