### PR TITLE
fix: Render variables in Question Classifier class names

### DIFF
--- a/api/core/workflow/nodes/question_classifier/question_classifier_node.py
+++ b/api/core/workflow/nodes/question_classifier/question_classifier_node.py
@@ -193,6 +193,9 @@ class QuestionClassifierNode(Node):
                     finish_reason = event.finish_reason
                     break
 
+            for class_ in node_data.classes:
+                class_.name = variable_pool.convert_template(class_.name).text
+
             category_name = node_data.classes[0].name
             category_id = node_data.classes[0].id
             if "<think>" in result_text:

--- a/api/core/workflow/nodes/question_classifier/question_classifier_node.py
+++ b/api/core/workflow/nodes/question_classifier/question_classifier_node.py
@@ -193,18 +193,19 @@ class QuestionClassifierNode(Node):
                     finish_reason = event.finish_reason
                     break
 
-            for class_ in node_data.classes:
-                class_.name = variable_pool.convert_template(class_.name).text
+            rendered_classes = [
+                c.model_copy(update={"name": variable_pool.convert_template(c.name).text}) for c in node_data.classes
+            ]
 
-            category_name = node_data.classes[0].name
-            category_id = node_data.classes[0].id
+            category_name = rendered_classes[0].name
+            category_id = rendered_classes[0].id
             if "<think>" in result_text:
                 result_text = re.sub(r"<think[^>]*>[\s\S]*?</think>", "", result_text, flags=re.IGNORECASE)
             result_text_json = parse_and_check_json_markdown(result_text, [])
             # result_text_json = json.loads(result_text.strip('```JSON\n'))
             if "category_name" in result_text_json and "category_id" in result_text_json:
                 category_id_result = result_text_json["category_id"]
-                classes = node_data.classes
+                classes = rendered_classes
                 classes_map = {class_.id: class_.name for class_ in classes}
                 category_ids = [_class.id for _class in classes]
                 if category_id_result in category_ids:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixed #27355
- Issue: When a class name contains variables, the Question Classifier returns the raw variable placeholder in the result
- Fix: Render each class name via the variable pool before producing outputs


## Screenshots

| Before | After |
|--------|-------|
|  <img width="366" height="210" alt="before" src="https://github.com/user-attachments/assets/0b565724-2cca-4d15-82e7-f0f2a8f76122" /> |  <img width="366" height="210" alt="after" src="https://github.com/user-attachments/assets/49365eb1-681e-4946-a502-2e9418d4ca86" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
