### PR TITLE
Fix UpdatedVariable truncation crash

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -283,7 +283,7 @@ class VariableTruncator:
                 break
 
             remaining_budget = target_size - used_size
-            if item is None or isinstance(item, (str, list, dict, bool, int, float)):
+            if item is None or isinstance(item, (str, list, dict, bool, int, float, UpdatedVariable)):
                 part_result = self._truncate_json_primitives(item, remaining_budget)
             else:
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
@@ -372,6 +372,11 @@ class VariableTruncator:
                 truncated = True
 
         return _PartResult(truncated_obj, used_size, truncated)
+
+    @overload
+    def _truncate_json_primitives(
+        self, val: UpdatedVariable, target_size: int
+    ) -> _PartResult[Mapping[str, object]]: ...
 
     @overload
     def _truncate_json_primitives(self, val: str, target_size: int) -> _PartResult[str]: ...


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Fixes #27343 by allowing `VariableTruncator` to normalize `UpdatedVariable` instances that appear inside array payloads (`api/services/variable_truncator.py:255`).
- Adds an explicit overload documenting `_truncate_json_primitives` support for `UpdatedVariable` inputs (`api/services/variable_truncator.py:378`).
- Verified the truncator suite with `uv run --project api --dev pytest api/tests/unit_tests/services/test_variable_truncator.py -q`.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
