### PR TITLE
Fix typo in docker/.env.example: 'defualt' -> 'default'

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -316,7 +316,7 @@ REDIS_CLUSTERS_PASSWORD=
 # Celery Configuration
 # ------------------------------
 
-# Use standalone redis as the broker, and redis db 1 for celery broker. (redis_username is usually set by defualt as empty)
+# Use standalone redis as the broker, and redis db 1 for celery broker. (redis_username is usually set by default as empty)
 # Format as follows: `redis://<redis_username>:<redis_password>@<redis_host>:<redis_port>/<redis_database>`.
 # Example: redis://:difyai123456@redis:6379/1
 # If use Redis Sentinel, format as follows: `sentinel://<redis_username>:<redis_password>@<sentinel_host1>:<sentinel_port>/<redis_database>`


### PR DESCRIPTION
Fixed a small typo in [.env.example] by changing “defualt” to “default” in the Celery broker comment; this is a documentation-only correction to improve clarity and correct spelling, it does not change any runtime behavior, and the fix has been pushed to the branch.