### PR TITLE
fix(metadata_service): ensure database rollback on exceptions during metadata operations

### DIFF
--- a/api/controllers/console/datasets/metadata.py
+++ b/api/controllers/console/datasets/metadata.py
@@ -74,6 +74,8 @@ class DatasetMetadataApi(Resource):
         DatasetService.check_dataset_permission(dataset, current_user)
 
         metadata = MetadataService.update_metadata_name(dataset_id_str, metadata_id_str, name)
+        if metadata is None:
+            raise NotFound("Metadata not found.")
         return metadata, 200
 
     @setup_required
@@ -89,7 +91,9 @@ class DatasetMetadataApi(Resource):
             raise NotFound("Dataset not found.")
         DatasetService.check_dataset_permission(dataset, current_user)
 
-        MetadataService.delete_metadata(dataset_id_str, metadata_id_str)
+        result = MetadataService.delete_metadata(dataset_id_str, metadata_id_str)
+        if result is None:
+            raise NotFound("Metadata not found.")
         return {"result": "success"}, 204
 
 

--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -103,6 +103,8 @@ class DatasetMetadataServiceApi(DatasetApiResource):
         DatasetService.check_dataset_permission(dataset, current_user)
 
         metadata = MetadataService.update_metadata_name(dataset_id_str, metadata_id_str, args["name"])
+        if metadata is None:
+            raise NotFound("Metadata not found.")
         return marshal(metadata, dataset_metadata_fields), 200
 
     @service_api_ns.doc("delete_dataset_metadata")
@@ -125,7 +127,9 @@ class DatasetMetadataServiceApi(DatasetApiResource):
             raise NotFound("Dataset not found.")
         DatasetService.check_dataset_permission(dataset, current_user)
 
-        MetadataService.delete_metadata(dataset_id_str, metadata_id_str)
+        result = MetadataService.delete_metadata(dataset_id_str, metadata_id_str)
+        if result is None:
+            raise NotFound("Metadata not found.")
         return 204
 
 

--- a/api/core/app/apps/pipeline/pipeline_generator.py
+++ b/api/core/app/apps/pipeline/pipeline_generator.py
@@ -34,7 +34,7 @@ from core.datasource.entities.datasource_entities import (
 from core.datasource.online_drive.online_drive_plugin import OnlineDriveDatasourcePlugin
 from core.entities.knowledge_entities import PipelineDataset, PipelineDocument
 from core.model_runtime.errors.invoke import InvokeAuthorizationError
-from core.rag.index_processor.constant.built_in_field import BuiltInField
+from core.rag.index_processor.constant.built_in_field import BuiltInField, get_safe_data_source_value
 from core.repositories.factory import DifyCoreRepositoryFactory
 from core.workflow.repositories.draft_variable_repository import DraftVariableSaverFactory
 from core.workflow.repositories.workflow_execution_repository import WorkflowExecutionRepository
@@ -726,10 +726,10 @@ class PipelineGenerator(BaseAppGenerator):
         if built_in_field_enabled:
             doc_metadata = {
                 BuiltInField.document_name: name,
-                BuiltInField.uploader: account.name,
+                BuiltInField.uploader: account.name or "Unknown",
                 BuiltInField.upload_date: datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S"),
                 BuiltInField.last_update_date: datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S"),
-                BuiltInField.source: datasource_type,
+                BuiltInField.source: get_safe_data_source_value(datasource_type),
             }
         if doc_metadata:
             document.doc_metadata = doc_metadata

--- a/api/core/rag/index_processor/constant/built_in_field.py
+++ b/api/core/rag/index_processor/constant/built_in_field.py
@@ -1,4 +1,7 @@
+import logging
 from enum import StrEnum, auto
+
+logger = logging.getLogger(__name__)
 
 
 class BuiltInField(StrEnum):
@@ -15,3 +18,22 @@ class MetadataDataSource(StrEnum):
     notion_import = "notion"
     local_file = "file_upload"
     online_document = "online_document"
+    online_drive = "online_drive"
+
+
+def get_safe_data_source_value(data_source_type: str) -> str:
+    """
+    Safely get data source value for metadata.
+    Returns the mapped value if exists in enum, otherwise returns the original value.
+
+    Args:
+        data_source_type: The data source type string
+
+    Returns:
+        The mapped enum value if exists, otherwise the original value
+    """
+    try:
+        return MetadataDataSource[data_source_type].value
+    except KeyError:
+        logger.warning("Unknown data source type: %s, using original value", data_source_type)
+        return data_source_type

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -19,7 +19,7 @@ from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.helper.name_generator import generate_incremental_name
 from core.model_manager import ModelManager
 from core.model_runtime.entities.model_entities import ModelType
-from core.rag.index_processor.constant.built_in_field import BuiltInField
+from core.rag.index_processor.constant.built_in_field import BuiltInField, get_safe_data_source_value
 from core.rag.index_processor.constant.index_type import IndexType
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from events.dataset_event import dataset_was_deleted
@@ -2010,10 +2010,10 @@ class DocumentService:
         if dataset.built_in_field_enabled:
             doc_metadata = {
                 BuiltInField.document_name: name,
-                BuiltInField.uploader: account.name,
+                BuiltInField.uploader: account.name or "Unknown",
                 BuiltInField.upload_date: datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S"),
                 BuiltInField.last_update_date: datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S"),
-                BuiltInField.source: data_source_type,
+                BuiltInField.source: get_safe_data_source_value(data_source_type),
             }
         if doc_metadata:
             document.doc_metadata = doc_metadata

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -91,7 +91,9 @@ class MetadataService:
             db.session.commit()
             return metadata
         except Exception:
+            db.session.rollback()
             logger.exception("Update metadata name failed")
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -123,7 +125,9 @@ class MetadataService:
             db.session.commit()
             return metadata
         except Exception:
+            db.session.rollback()
             logger.exception("Delete metadata failed")
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -162,7 +166,9 @@ class MetadataService:
             dataset.built_in_field_enabled = True
             db.session.commit()
         except Exception:
+            db.session.rollback()
             logger.exception("Enable built-in field failed")
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -193,7 +199,9 @@ class MetadataService:
             dataset.built_in_field_enabled = False
             db.session.commit()
         except Exception:
+            db.session.rollback()
             logger.exception("Disable built-in field failed")
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -232,7 +240,9 @@ class MetadataService:
                     db.session.add(dataset_metadata_binding)
                 db.session.commit()
             except Exception:
+                db.session.rollback()
                 logger.exception("Update documents metadata failed")
+                raise
             finally:
                 redis_client.delete(lock_key)
 

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -48,7 +48,7 @@ class MetadataService:
         return metadata
 
     @staticmethod
-    def update_metadata_name(dataset_id: str, metadata_id: str, name: str) -> DatasetMetadata:  # type: ignore
+    def update_metadata_name(dataset_id: str, metadata_id: str, name: str) -> DatasetMetadata | None:
         # check if metadata name is too long
         if len(name) > 255:
             raise ValueError("Metadata name cannot exceed 255 characters.")
@@ -101,7 +101,7 @@ class MetadataService:
             redis_client.delete(lock_key)
 
     @staticmethod
-    def delete_metadata(dataset_id: str, metadata_id: str):
+    def delete_metadata(dataset_id: str, metadata_id: str) -> DatasetMetadata | None:
         lock_key = f"dataset_metadata_lock_{dataset_id}"
         try:
             MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -64,12 +64,12 @@ class MetadataService:
             raise ValueError("Metadata name already exists.")
         for field in BuiltInField:
             if field.value == name:
-                raise ValueError("Metadata name already exists in Built-in fields.")
+                raise ValueError("Metadata name already exists in Built -in fields.")
         try:
             MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)
             metadata = db.session.query(DatasetMetadata).filter_by(id=metadata_id).first()
             if metadata is None:
-                raise ValueError("Metadata not found.")
+                return None
             old_name = metadata.name
             metadata.name = name
             metadata.updated_by = current_user.id
@@ -107,7 +107,7 @@ class MetadataService:
             MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)
             metadata = db.session.query(DatasetMetadata).filter_by(id=metadata_id).first()
             if metadata is None:
-                raise ValueError("Metadata not found.")
+                return None
             db.session.delete(metadata)
 
             # deal related documents
@@ -216,7 +216,8 @@ class MetadataService:
                 MetadataService.knowledge_base_metadata_lock_check(None, operation.document_id)
                 document = DocumentService.get_document(dataset.id, operation.document_id)
                 if document is None:
-                    raise ValueError("Document not found.")
+                    logger.warning("Document not found: %s", operation.document_id)
+                    continue
                 doc_metadata = {}
                 for metadata_value in operation.metadata_list:
                     doc_metadata[metadata_value.name] = metadata_value.value

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -1,7 +1,10 @@
 import copy
 import logging
 
-from core.rag.index_processor.constant.built_in_field import BuiltInField, MetadataDataSource
+from core.rag.index_processor.constant.built_in_field import (
+    BuiltInField,
+    get_safe_data_source_value,
+)
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from libs.datetime_utils import naive_utc_now
@@ -157,10 +160,10 @@ class MetadataService:
                     else:
                         doc_metadata = copy.deepcopy(document.doc_metadata)
                     doc_metadata[BuiltInField.document_name] = document.name
-                    doc_metadata[BuiltInField.uploader] = document.uploader
+                    doc_metadata[BuiltInField.uploader] = document.uploader or "Unknown"
                     doc_metadata[BuiltInField.upload_date] = document.upload_date.timestamp()
                     doc_metadata[BuiltInField.last_update_date] = document.last_update_date.timestamp()
-                    doc_metadata[BuiltInField.source] = MetadataDataSource[document.data_source_type]
+                    doc_metadata[BuiltInField.source] = get_safe_data_source_value(document.data_source_type)
                     document.doc_metadata = doc_metadata
                     db.session.add(document)
             dataset.built_in_field_enabled = True
@@ -219,10 +222,10 @@ class MetadataService:
                     doc_metadata[metadata_value.name] = metadata_value.value
                 if dataset.built_in_field_enabled:
                     doc_metadata[BuiltInField.document_name] = document.name
-                    doc_metadata[BuiltInField.uploader] = document.uploader
+                    doc_metadata[BuiltInField.uploader] = document.uploader or "Unknown"
                     doc_metadata[BuiltInField.upload_date] = document.upload_date.timestamp()
                     doc_metadata[BuiltInField.last_update_date] = document.last_update_date.timestamp()
-                    doc_metadata[BuiltInField.source] = MetadataDataSource[document.data_source_type]
+                    doc_metadata[BuiltInField.source] = get_safe_data_source_value(document.data_source_type)
                 document.doc_metadata = doc_metadata
                 db.session.add(document)
                 db.session.commit()


### PR DESCRIPTION

Related to #27427

1. Fix the MetadataDataSource enumeration by adding the missing data source types.
2. Use safe dictionary access methods to prevent KeyError.
3. Handle the case where the uploader might be None.


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
