### PR TITLE
Fix/27468 in dify 192 the iframe embed cannot pass the user id in system variable

### DIFF
--- a/web/__tests__/embedded-user-id-auth.test.tsx
+++ b/web/__tests__/embedded-user-id-auth.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import MailAndPasswordAuth from '@/app/(shareLayout)/webapp-signin/components/mail-and-password-auth'
+import CheckCode from '@/app/(shareLayout)/webapp-signin/check-code/page'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const replaceMock = jest.fn()
+const backMock = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/chatbot/test-app'),
+  useRouter: jest.fn(() => ({
+    replace: replaceMock,
+    back: backMock,
+  })),
+  useSearchParams: jest.fn(),
+}))
+
+const mockStoreState = {
+  embeddedUserId: 'embedded-user-99',
+  shareCode: 'test-app',
+}
+
+const useWebAppStoreMock = jest.fn((selector?: (state: typeof mockStoreState) => any) => {
+  return selector ? selector(mockStoreState) : mockStoreState
+})
+
+jest.mock('@/context/web-app-context', () => ({
+  useWebAppStore: (selector?: (state: typeof mockStoreState) => any) => useWebAppStoreMock(selector),
+}))
+
+const webAppLoginMock = jest.fn()
+const webAppEmailLoginWithCodeMock = jest.fn()
+const sendWebAppEMailLoginCodeMock = jest.fn()
+
+jest.mock('@/service/common', () => ({
+  webAppLogin: (...args: any[]) => webAppLoginMock(...args),
+  webAppEmailLoginWithCode: (...args: any[]) => webAppEmailLoginWithCodeMock(...args),
+  sendWebAppEMailLoginCode: (...args: any[]) => sendWebAppEMailLoginCodeMock(...args),
+}))
+
+const fetchAccessTokenMock = jest.fn()
+
+jest.mock('@/service/share', () => ({
+  fetchAccessToken: (...args: any[]) => fetchAccessTokenMock(...args),
+}))
+
+const setWebAppAccessTokenMock = jest.fn()
+const setWebAppPassportMock = jest.fn()
+
+jest.mock('@/service/webapp-auth', () => ({
+  setWebAppAccessToken: (...args: any[]) => setWebAppAccessTokenMock(...args),
+  setWebAppPassport: (...args: any[]) => setWebAppPassportMock(...args),
+  webAppLogout: jest.fn(),
+}))
+
+jest.mock('@/app/components/signin/countdown', () => () => <div data-testid="countdown" />)
+
+jest.mock('@remixicon/react', () => ({
+  RiMailSendFill: () => <div data-testid="mail-icon" />,
+  RiArrowLeftLine: () => <div data-testid="arrow-icon" />,
+}))
+
+const { useSearchParams } = jest.requireMock('next/navigation') as {
+  useSearchParams: jest.Mock
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('embedded user id propagation in authentication flows', () => {
+  it('passes embedded user id when logging in with email and password', async () => {
+    const params = new URLSearchParams()
+    params.set('redirect_url', encodeURIComponent('/chatbot/test-app'))
+    useSearchParams.mockReturnValue(params)
+
+    webAppLoginMock.mockResolvedValue({ result: 'success', data: { access_token: 'login-token' } })
+    fetchAccessTokenMock.mockResolvedValue({ access_token: 'passport-token' })
+
+    render(<MailAndPasswordAuth isEmailSetup />)
+
+    fireEvent.change(screen.getByLabelText('login.email'), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText(/login\.password/), { target: { value: 'strong-password' } })
+    fireEvent.click(screen.getByRole('button', { name: 'login.signBtn' }))
+
+    await waitFor(() => {
+      expect(fetchAccessTokenMock).toHaveBeenCalledWith({
+        appCode: 'test-app',
+        userId: 'embedded-user-99',
+      })
+    })
+    expect(setWebAppAccessTokenMock).toHaveBeenCalledWith('login-token')
+    expect(setWebAppPassportMock).toHaveBeenCalledWith('test-app', 'passport-token')
+    expect(replaceMock).toHaveBeenCalledWith('/chatbot/test-app')
+  })
+
+  it('passes embedded user id when verifying email code', async () => {
+    const params = new URLSearchParams()
+    params.set('redirect_url', encodeURIComponent('/chatbot/test-app'))
+    params.set('email', encodeURIComponent('user@example.com'))
+    params.set('token', encodeURIComponent('token-abc'))
+    useSearchParams.mockReturnValue(params)
+
+    webAppEmailLoginWithCodeMock.mockResolvedValue({ result: 'success', data: { access_token: 'code-token' } })
+    fetchAccessTokenMock.mockResolvedValue({ access_token: 'passport-token' })
+
+    render(<CheckCode />)
+
+    fireEvent.change(
+      screen.getByPlaceholderText('login.checkCode.verificationCodePlaceholder'),
+      { target: { value: '123456' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'login.checkCode.verify' }))
+
+    await waitFor(() => {
+      expect(fetchAccessTokenMock).toHaveBeenCalledWith({
+        appCode: 'test-app',
+        userId: 'embedded-user-99',
+      })
+    })
+    expect(setWebAppAccessTokenMock).toHaveBeenCalledWith('code-token')
+    expect(setWebAppPassportMock).toHaveBeenCalledWith('test-app', 'passport-token')
+    expect(replaceMock).toHaveBeenCalledWith('/chatbot/test-app')
+  })
+})

--- a/web/__tests__/embedded-user-id-store.test.tsx
+++ b/web/__tests__/embedded-user-id-store.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import WebAppStoreProvider, { useWebAppStore } from '@/context/web-app-context'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/chatbot/sample-app'),
+  useSearchParams: jest.fn(() => {
+    const params = new URLSearchParams()
+    return params
+  }),
+}))
+
+jest.mock('@/service/use-share', () => {
+  const { AccessMode } = jest.requireActual('@/models/access-control')
+  return {
+    useGetWebAppAccessModeByCode: jest.fn(() => ({
+      isLoading: false,
+      data: { accessMode: AccessMode.PUBLIC },
+    })),
+  }
+})
+
+jest.mock('@/app/components/base/chat/utils', () => ({
+  getProcessedSystemVariablesFromUrlParams: jest.fn(),
+}))
+
+const { getProcessedSystemVariablesFromUrlParams: mockGetProcessedSystemVariablesFromUrlParams }
+  = jest.requireMock('@/app/components/base/chat/utils') as {
+    getProcessedSystemVariablesFromUrlParams: jest.Mock
+  }
+
+jest.mock('@/context/global-public-context', () => {
+  const mockGlobalStoreState = {
+    isGlobalPending: false,
+    setIsGlobalPending: jest.fn(),
+    systemFeatures: {},
+    setSystemFeatures: jest.fn(),
+  }
+  const useGlobalPublicStore = Object.assign(
+    (selector?: (state: typeof mockGlobalStoreState) => any) =>
+      selector ? selector(mockGlobalStoreState) : mockGlobalStoreState,
+    {
+      setState: (updater: any) => {
+        if (typeof updater === 'function')
+          Object.assign(mockGlobalStoreState, updater(mockGlobalStoreState) ?? {})
+
+        else
+          Object.assign(mockGlobalStoreState, updater)
+      },
+      __mockState: mockGlobalStoreState,
+    },
+  )
+  return {
+    useGlobalPublicStore,
+  }
+})
+
+const {
+  useGlobalPublicStore: useGlobalPublicStoreMock,
+} = jest.requireMock('@/context/global-public-context') as {
+  useGlobalPublicStore: ((selector?: (state: any) => any) => any) & {
+    setState: (updater: any) => void
+    __mockState: {
+      isGlobalPending: boolean
+      setIsGlobalPending: jest.Mock
+      systemFeatures: Record<string, unknown>
+      setSystemFeatures: jest.Mock
+    }
+  }
+}
+const mockGlobalStoreState = useGlobalPublicStoreMock.__mockState
+
+const TestConsumer = () => {
+  const embeddedUserId = useWebAppStore(state => state.embeddedUserId)
+  return <div data-testid="embedded-user-id">{embeddedUserId ?? 'null'}</div>
+}
+
+const initialWebAppStore = (() => {
+  const snapshot = useWebAppStore.getState()
+  return {
+    shareCode: null as string | null,
+    appInfo: null,
+    appParams: null,
+    webAppAccessMode: snapshot.webAppAccessMode,
+    appMeta: null,
+    userCanAccessApp: false,
+    embeddedUserId: null,
+    updateShareCode: snapshot.updateShareCode,
+    updateAppInfo: snapshot.updateAppInfo,
+    updateAppParams: snapshot.updateAppParams,
+    updateWebAppAccessMode: snapshot.updateWebAppAccessMode,
+    updateWebAppMeta: snapshot.updateWebAppMeta,
+    updateUserCanAccessApp: snapshot.updateUserCanAccessApp,
+    updateEmbeddedUserId: snapshot.updateEmbeddedUserId,
+  }
+})()
+
+beforeEach(() => {
+  mockGlobalStoreState.isGlobalPending = false
+  mockGetProcessedSystemVariablesFromUrlParams.mockReset()
+  useWebAppStore.setState(initialWebAppStore, true)
+})
+
+describe('WebAppStoreProvider embedded user id handling', () => {
+  it('hydrates embedded user id from system variables', async () => {
+    mockGetProcessedSystemVariablesFromUrlParams.mockResolvedValue({ user_id: 'iframe-user-123' })
+
+    render(
+      <WebAppStoreProvider>
+        <TestConsumer />
+      </WebAppStoreProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('embedded-user-id')).toHaveTextContent('iframe-user-123')
+    })
+    expect(useWebAppStore.getState().embeddedUserId).toBe('iframe-user-123')
+  })
+
+  it('clears embedded user id when system variable is absent', async () => {
+    useWebAppStore.setState(state => ({ ...state, embeddedUserId: 'previous-user' }))
+    mockGetProcessedSystemVariablesFromUrlParams.mockResolvedValue({})
+
+    render(
+      <WebAppStoreProvider>
+        <TestConsumer />
+      </WebAppStoreProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('embedded-user-id')).toHaveTextContent('null')
+    })
+    expect(useWebAppStore.getState().embeddedUserId).toBeNull()
+  })
+})

--- a/web/app/(shareLayout)/components/splash.tsx
+++ b/web/app/(shareLayout)/components/splash.tsx
@@ -15,6 +15,7 @@ const Splash: FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation()
   const shareCode = useWebAppStore(s => s.shareCode)
   const webAppAccessMode = useWebAppStore(s => s.webAppAccessMode)
+  const embeddedUserId = useWebAppStore(s => s.embeddedUserId)
   const searchParams = useSearchParams()
   const router = useRouter()
   const redirectUrl = searchParams.get('redirect_url')
@@ -69,7 +70,10 @@ const Splash: FC<PropsWithChildren> = ({ children }) => {
       }
       else if (userLoggedIn && !appLoggedIn) {
         try {
-          const { access_token } = await fetchAccessToken({ appCode: shareCode! })
+          const { access_token } = await fetchAccessToken({
+            appCode: shareCode!,
+            userId: embeddedUserId || undefined,
+          })
           setWebAppPassport(shareCode!, access_token)
           redirectOrFinish()
         }
@@ -85,7 +89,8 @@ const Splash: FC<PropsWithChildren> = ({ children }) => {
     router,
     message,
     webAppAccessMode,
-    tokenFromUrl])
+    tokenFromUrl,
+    embeddedUserId])
 
   if (message) {
     return <div className='flex h-full flex-col items-center justify-center gap-y-4'>

--- a/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
@@ -12,6 +12,7 @@ import { sendWebAppEMailLoginCode, webAppEmailLoginWithCode } from '@/service/co
 import I18NContext from '@/context/i18n'
 import { setWebAppAccessToken, setWebAppPassport } from '@/service/webapp-auth'
 import { fetchAccessToken } from '@/service/share'
+import { useWebAppStore } from '@/context/web-app-context'
 
 export default function CheckCode() {
   const { t } = useTranslation()
@@ -23,6 +24,7 @@ export default function CheckCode() {
   const [loading, setIsLoading] = useState(false)
   const { locale } = useContext(I18NContext)
   const redirectUrl = searchParams.get('redirect_url')
+  const embeddedUserId = useWebAppStore(s => s.embeddedUserId)
 
   const getAppCodeFromRedirectUrl = useCallback(() => {
     if (!redirectUrl)
@@ -63,7 +65,10 @@ export default function CheckCode() {
       const ret = await webAppEmailLoginWithCode({ email, code, token })
       if (ret.result === 'success') {
         setWebAppAccessToken(ret.data.access_token)
-        const { access_token } = await fetchAccessToken({ appCode: appCode! })
+        const { access_token } = await fetchAccessToken({
+          appCode: appCode!,
+          userId: embeddedUserId || undefined,
+        })
         setWebAppPassport(appCode!, access_token)
         router.replace(decodeURIComponent(redirectUrl))
       }

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
@@ -10,6 +10,7 @@ import { emailRegex } from '@/config'
 import { webAppLogin } from '@/service/common'
 import Input from '@/app/components/base/input'
 import I18NContext from '@/context/i18n'
+import { useWebAppStore } from '@/context/web-app-context'
 import { noop } from 'lodash-es'
 import { fetchAccessToken } from '@/service/share'
 import { setWebAppAccessToken, setWebAppPassport } from '@/service/webapp-auth'
@@ -30,6 +31,7 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
 
   const [isLoading, setIsLoading] = useState(false)
   const redirectUrl = searchParams.get('redirect_url')
+  const embeddedUserId = useWebAppStore(s => s.embeddedUserId)
 
   const getAppCodeFromRedirectUrl = useCallback(() => {
     if (!redirectUrl)
@@ -82,7 +84,10 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
       if (res.result === 'success') {
         setWebAppAccessToken(res.data.access_token)
 
-        const { access_token } = await fetchAccessToken({ appCode: appCode! })
+        const { access_token } = await fetchAccessToken({
+          appCode: appCode!,
+          userId: embeddedUserId || undefined,
+        })
         setWebAppPassport(appCode!, access_token)
         router.replace(decodeURIComponent(redirectUrl))
       }

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -66,16 +66,23 @@ export const useEmbeddedChatbot = () => {
   const appInfo = useWebAppStore(s => s.appInfo)
   const appMeta = useWebAppStore(s => s.appMeta)
   const appParams = useWebAppStore(s => s.appParams)
+  const embeddedConversationId = useWebAppStore(s => s.embeddedConversationId)
+  const embeddedUserId = useWebAppStore(s => s.embeddedUserId)
   const appId = useMemo(() => appInfo?.app_id, [appInfo])
 
   const [userId, setUserId] = useState<string>()
   const [conversationId, setConversationId] = useState<string>()
+
   useEffect(() => {
-    getProcessedSystemVariablesFromUrlParams().then(({ user_id, conversation_id }) => {
-      setUserId(user_id)
-      setConversationId(conversation_id)
-    })
-  }, [])
+    setUserId(embeddedUserId || undefined)
+  }, [embeddedUserId])
+
+  useEffect(() => {
+    if (embeddedConversationId !== undefined && embeddedConversationId !== null)
+      setConversationId(embeddedConversationId)
+    else
+      setConversationId(undefined)
+  }, [embeddedConversationId])
 
   useEffect(() => {
     const setLanguageFromParams = async () => {

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -78,10 +78,7 @@ export const useEmbeddedChatbot = () => {
   }, [embeddedUserId])
 
   useEffect(() => {
-    if (embeddedConversationId !== undefined && embeddedConversationId !== null)
-      setConversationId(embeddedConversationId)
-    else
-      setConversationId(undefined)
+    setConversationId(embeddedConversationId || undefined)
   }, [embeddedConversationId])
 
   useEffect(() => {

--- a/web/context/web-app-context.tsx
+++ b/web/context/web-app-context.tsx
@@ -27,6 +27,8 @@ type WebAppStore = {
   updateUserCanAccessApp: (canAccess: boolean) => void
   embeddedUserId: string | null
   updateEmbeddedUserId: (userId: string | null) => void
+  embeddedConversationId: string | null
+  updateEmbeddedConversationId: (conversationId: string | null) => void
 }
 
 export const useWebAppStore = create<WebAppStore>(set => ({
@@ -44,6 +46,9 @@ export const useWebAppStore = create<WebAppStore>(set => ({
   updateUserCanAccessApp: (canAccess: boolean) => set(() => ({ userCanAccessApp: canAccess })),
   embeddedUserId: null,
   updateEmbeddedUserId: (userId: string | null) => set(() => ({ embeddedUserId: userId })),
+  embeddedConversationId: null,
+  updateEmbeddedConversationId: (conversationId: string | null) =>
+    set(() => ({ embeddedConversationId: conversationId })),
 }))
 
 const getShareCodeFromRedirectUrl = (redirectUrl: string | null): string | null => {
@@ -64,6 +69,7 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
   const updateWebAppAccessMode = useWebAppStore(state => state.updateWebAppAccessMode)
   const updateShareCode = useWebAppStore(state => state.updateShareCode)
   const updateEmbeddedUserId = useWebAppStore(state => state.updateEmbeddedUserId)
+  const updateEmbeddedConversationId = useWebAppStore(state => state.updateEmbeddedConversationId)
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const redirectUrlParam = searchParams.get('redirect_url')
@@ -79,20 +85,24 @@ const WebAppStoreProvider: FC<PropsWithChildren> = ({ children }) => {
     let cancelled = false
     const syncEmbeddedUserId = async () => {
       try {
-        const { user_id } = await getProcessedSystemVariablesFromUrlParams()
-        if (!cancelled)
+        const { user_id, conversation_id } = await getProcessedSystemVariablesFromUrlParams()
+        if (!cancelled) {
           updateEmbeddedUserId(user_id || null)
+          updateEmbeddedConversationId(conversation_id || null)
+        }
       }
       catch {
-        if (!cancelled)
+        if (!cancelled) {
           updateEmbeddedUserId(null)
+          updateEmbeddedConversationId(null)
+        }
       }
     }
     syncEmbeddedUserId()
     return () => {
       cancelled = true
     }
-  }, [searchParamsString, updateEmbeddedUserId])
+  }, [searchParamsString, updateEmbeddedUserId, updateEmbeddedConversationId])
 
   const { isLoading, data: accessModeResult } = useGetWebAppAccessModeByCode(shareCode)
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request introduces and propagates support for "embedded user ID" and "embedded conversation ID" throughout the authentication and chatbot flows in the web application. The changes ensure that these IDs, when present (such as in embedded/iframe contexts), are hydrated from system variables and correctly passed to backend API calls for access token retrieval and session management. Comprehensive tests are also added to verify the correct handling of these IDs in both store hydration and authentication scenarios.

**Support for embedded user/conversation IDs:**

* The `WebAppStore` now includes `embeddedUserId` and `embeddedConversationId` fields, along with corresponding update methods. These are hydrated from system variables using the `getProcessedSystemVariablesFromUrlParams` utility in the `WebAppStoreProvider`, and are cleared if not present. [[1]](diffhunk://#diff-3a86cc2e5e7499e0b60ee3c0c330efd5d5949d7f4429b5d0ea232ed0d78c3426R28-R31) [[2]](diffhunk://#diff-3a86cc2e5e7499e0b60ee3c0c330efd5d5949d7f4429b5d0ea232ed0d78c3426R47-R51) [[3]](diffhunk://#diff-3a86cc2e5e7499e0b60ee3c0c330efd5d5949d7f4429b5d0ea232ed0d78c3426R71-R106)
* The `useEmbeddedChatbot` hook now uses `embeddedUserId` and `embeddedConversationId` from the store instead of fetching system variables directly, ensuring consistent propagation across the app.

**Authentication flow updates:**

* Both the email/password (`MailAndPasswordAuth`) and email code (`CheckCode`) authentication components now pass `embeddedUserId` (when available) to the `fetchAccessToken` API call, ensuring the correct user context is used during login. [[1]](diffhunk://#diff-6ae95b0cc410c57b043506c524431a6155cbe9215b700b3c05fb40ea7c3fd3ccR13) [[2]](diffhunk://#diff-6ae95b0cc410c57b043506c524431a6155cbe9215b700b3c05fb40ea7c3fd3ccR34) [[3]](diffhunk://#diff-6ae95b0cc410c57b043506c524431a6155cbe9215b700b3c05fb40ea7c3fd3ccL85-R90) [[4]](diffhunk://#diff-822a5b7386cd0bdba3059432879e10bce4ab84dee4fce88c66460eb3f9dc6327R15) [[5]](diffhunk://#diff-822a5b7386cd0bdba3059432879e10bce4ab84dee4fce88c66460eb3f9dc6327R27) [[6]](diffhunk://#diff-822a5b7386cd0bdba3059432879e10bce4ab84dee4fce88c66460eb3f9dc6327L66-R71)
* The `Splash` component also passes `embeddedUserId` to `fetchAccessToken` during session restoration, and now listens for changes to `embeddedUserId` to trigger effect updates. [[1]](diffhunk://#diff-78ba539f75b26c22e705fa4182ad27dbadc3c90ea038734c32f8971c0498c9ddR18) [[2]](diffhunk://#diff-78ba539f75b26c22e705fa4182ad27dbadc3c90ea038734c32f8971c0498c9ddL72-R76) [[3]](diffhunk://#diff-78ba539f75b26c22e705fa4182ad27dbadc3c90ea038734c32f8971c0498c9ddL88-R93)

**Testing enhancements:**

* New tests verify that the store hydrates and clears `embeddedUserId` and `embeddedConversationId` based on system variable presence.
* Additional tests ensure that authentication flows correctly propagate `embeddedUserId` to API calls and session setup logic.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
