### PR TITLE
fix(workflow): resolve note node copy/duplicate errors

### DIFF
--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -1445,6 +1445,7 @@ export const useNodesInteractions = () => {
         // If no nodeId is provided, fall back to the current behavior
         const bundledNodes = nodes.filter((node) => {
           if (!node.data._isBundled) return false
+          if (node.type === CUSTOM_NOTE_NODE) return true
           const { metaData } = nodesMetaDataMap![node.data.type as BlockEnum]
           if (metaData.isSingleton) return false
           return !node.data.isInIteration && !node.data.isInLoop
@@ -1457,6 +1458,7 @@ export const useNodesInteractions = () => {
 
         const selectedNode = nodes.find((node) => {
           if (!node.data.selected) return false
+          if (node.type === CUSTOM_NOTE_NODE) return true
           const { metaData } = nodesMetaDataMap![node.data.type as BlockEnum]
           return !metaData.isSingleton
         })
@@ -1495,7 +1497,7 @@ export const useNodesInteractions = () => {
           = generateNewNode({
             type: nodeToPaste.type,
             data: {
-              ...nodesMetaDataMap![nodeType].defaultValue,
+              ...(nodeToPaste.type !== CUSTOM_NOTE_NODE && nodesMetaDataMap![nodeType].defaultValue),
               ...nodeToPaste.data,
               selected: false,
               _isBundled: false,

--- a/web/app/components/workflow/note-node/index.tsx
+++ b/web/app/components/workflow/note-node/index.tsx
@@ -1,6 +1,5 @@
 import {
   memo,
-  useCallback,
   useRef,
 } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -51,10 +50,6 @@ const NoteNode = ({
   } = useNodesInteractions()
   const { handleNodeDataUpdateWithSyncDraft } = useNodeDataUpdate()
 
-  const handleDeleteNode = useCallback(() => {
-    handleNodeDelete(id)
-  }, [id, handleNodeDelete])
-
   useClickAway(() => {
     handleNodeDataUpdateWithSyncDraft({ id, data: { selected: false } })
   }, ref)
@@ -102,9 +97,9 @@ const NoteNode = ({
                 <NoteEditorToolbar
                   theme={theme}
                   onThemeChange={handleThemeChange}
-                  onCopy={handleNodesCopy}
-                  onDuplicate={handleNodesDuplicate}
-                  onDelete={handleDeleteNode}
+                  onCopy={() => handleNodesCopy(id)}
+                  onDuplicate={() => handleNodesDuplicate(id)}
+                  onDelete={() => handleNodeDelete(id)}
                   showAuthor={data.showAuthor}
                   onShowAuthorChange={handleShowAuthorChange}
                 />


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #27527

  - resolve note node copy/duplicate errors, ensuring that nodes can be copied/duplicated correctly whether using the toolbar operation button or the shortcut key.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1439" height="682" alt="修复前报错" src="https://github.com/user-attachments/assets/9ffba5d4-5f18-4280-845a-24a0fa9fb9ec" /> | |

https://github.com/user-attachments/assets/2bfa7069-ec9e-4bef-bc7a-88e16da6ecd0

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
