### PR TITLE
fix(workflow): doc extractor node now correctly extracts mdx files

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -171,6 +171,7 @@ def _extract_text_by_file_extension(*, file_content: bytes, file_extension: str)
             ".txt"
             | ".markdown"
             | ".md"
+            | ".mdx"
             | ".html"
             | ".htm"
             | ".xml"


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #27569

- doc extractor node now correctly extracts mdx files
<img width="1439" height="682" alt="Image" src="https://github.com/user-attachments/assets/8e7fc6e0-7cb9-4473-8fc5-e9f60fc50959" />

## Screenshots

| Before | After |
|--------|-------|
| <img width="1439" height="682" alt="修复前" src="https://github.com/user-attachments/assets/0c6e5663-eec1-4057-bee5-13f7c75f90de" /> | <img width="1439" height="682" alt="修复后" src="https://github.com/user-attachments/assets/e73e5435-64ba-49ba-998f-dba54184c088" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
