### PR TITLE
feat: show “View original” in citations and expose document_url in retrieval metadata

### DIFF
--- a/api/core/rag/entities/citation_metadata.py
+++ b/api/core/rag/entities/citation_metadata.py
@@ -21,3 +21,4 @@ class RetrievalSourceMetadata(BaseModel):
     page: int | None = None
     doc_metadata: dict[str, Any] | None = None
     title: str | None = None
+    document_url: str | None = None

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -53,6 +53,10 @@ from core.rag.retrieval.template_prompts import (
     METADATA_FILTER_USER_PROMPT_2,
     METADATA_FILTER_USER_PROMPT_3,
 )
+from core.rag.utils.document_url import (
+    document_url_for_dataset_document,
+    document_url_for_external_metadata,
+)
 from core.tools.utils.dataset_retriever.dataset_retriever_base_tool import DatasetRetrieverBaseTool
 from extensions.ext_database import db
 from libs.json_in_md_parser import parse_and_check_json_markdown
@@ -226,6 +230,7 @@ class DatasetRetrieval:
                 data_source_type="external",
                 retriever_from=invoke_from.to_source(),
                 score=item.metadata.get("score"),
+                document_url=document_url_for_external_metadata(item.metadata),
                 content=item.page_content,
             )
             retrieval_resource_list.append(source)
@@ -270,6 +275,7 @@ class DatasetRetrieval:
                                 retriever_from=invoke_from.to_source(),
                                 score=record.score or 0.0,
                                 doc_metadata=document.doc_metadata,
+                                document_url=document_url_for_dataset_document(document),
                             )
 
                             if invoke_from.to_source() == "dev":

--- a/api/core/rag/utils/document_url.py
+++ b/api/core/rag/utils/document_url.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any
 
 from core.file import helpers as file_helpers
 from models.dataset import Document as DatasetDocument

--- a/api/core/rag/utils/document_url.py
+++ b/api/core/rag/utils/document_url.py
@@ -1,0 +1,50 @@
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from core.file import helpers as file_helpers
+from models.dataset import Document as DatasetDocument
+
+
+def document_url_for_dataset_document(document: DatasetDocument) -> Optional[str]:
+    """
+    Compute a user-accessible URL for the original document referenced by a dataset Document.
+    - upload_file: returns a signed preview URL
+    - website_crawl: returns the crawled page URL if available
+    - notion_import: returns the Notion page link or constructs one from page id
+    - fallback: tries common metadata url-like fields
+    """
+    try:
+        ds_type = document.data_source_type
+        if ds_type == "upload_file":
+            info = document.data_source_info_dict or {}
+            upload_file_id = info.get("upload_file_id")
+            if upload_file_id:
+                return file_helpers.get_signed_file_url(upload_file_id)
+            return None
+        if ds_type == "website_crawl":
+            info = document.data_source_info_dict or {}
+            return info.get("url") or (document.doc_metadata or {}).get("source_url")
+        if ds_type == "notion_import":
+            meta = document.doc_metadata or {}
+            url = meta.get("notion_page_link")
+            if url:
+                return url
+            info = document.data_source_info_dict or {}
+            page_id = info.get("notion_page_id")
+            if page_id:
+                return f"https://www.notion.so/{str(page_id).replace('-', '')}"
+            return None
+
+        # other types: best-effort
+        meta = document.doc_metadata or {}
+        info = document.data_source_info_dict or {}
+        return meta.get("source_url") or meta.get("github_link") or info.get("url")
+    except Exception:
+        return None
+
+
+def document_url_for_external_metadata(metadata: Optional[Mapping[str, Any]]) -> Optional[str]:
+    if not metadata:
+        return None
+    return metadata.get("url") or metadata.get("source_url")  # type: ignore[index]
+

--- a/api/core/rag/utils/document_url.py
+++ b/api/core/rag/utils/document_url.py
@@ -5,7 +5,7 @@ from core.file import helpers as file_helpers
 from models.dataset import Document as DatasetDocument
 
 
-def document_url_for_dataset_document(document: DatasetDocument) -> Optional[str]:
+def document_url_for_dataset_document(document: DatasetDocument) -> str | None:
     """
     Compute a user-accessible URL for the original document referenced by a dataset Document.
     - upload_file: returns a signed preview URL
@@ -43,8 +43,7 @@ def document_url_for_dataset_document(document: DatasetDocument) -> Optional[str
         return None
 
 
-def document_url_for_external_metadata(metadata: Optional[Mapping[str, Any]]) -> Optional[str]:
+def document_url_for_external_metadata(metadata: Mapping[str, Any] | None) -> str | None:
     if not metadata:
         return None
     return metadata.get("url") or metadata.get("source_url")  # type: ignore[index]
-

--- a/api/core/tools/utils/dataset_retriever/dataset_multi_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_multi_retriever_tool.py
@@ -13,6 +13,7 @@ from core.rag.entities.citation_metadata import RetrievalSourceMetadata
 from core.rag.models.document import Document as RagDocument
 from core.rag.rerank.rerank_model import RerankModelRunner
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
+from core.rag.utils.document_url import document_url_for_dataset_document
 from core.tools.utils.dataset_retriever.dataset_retriever_base_tool import DatasetRetrieverBaseTool
 from extensions.ext_database import db
 from models.dataset import Dataset, Document, DocumentSegment
@@ -128,6 +129,7 @@ class DatasetMultiRetrieverTool(DatasetRetrieverBaseTool):
                             retriever_from=self.retriever_from,
                             score=document_score_list.get(segment.index_node_id),
                             doc_metadata=document.doc_metadata,
+                            document_url=document_url_for_dataset_document(document),
                         )
 
                         if self.retriever_from == "dev":

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -10,6 +10,10 @@ from core.rag.entities.context_entities import DocumentContext
 from core.rag.models.document import Document as RetrievalDocument
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
+from core.rag.utils.document_url import (
+    document_url_for_dataset_document,
+    document_url_for_external_metadata,
+)
 from core.tools.utils.dataset_retriever.dataset_retriever_base_tool import DatasetRetrieverBaseTool
 from extensions.ext_database import db
 from models.dataset import Dataset
@@ -113,6 +117,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                         data_source_type="external",
                         retriever_from=self.retriever_from,
                         score=item.metadata.get("score"),
+                        document_url=document_url_for_external_metadata(item.metadata),
                         title=item.metadata.get("title"),
                         content=item.page_content,
                     )
@@ -205,6 +210,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                                     retriever_from=self.retriever_from,
                                     score=record.score or 0.0,
                                     doc_metadata=document.doc_metadata,
+                                    document_url=document_url_for_dataset_document(document),
                                 )
 
                                 if self.retriever_from == "dev":

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -724,6 +724,7 @@ class LLMNode(Node):
                 content=context_dict.get("content"),
                 page=metadata.get("page"),
                 doc_metadata=metadata.get("doc_metadata"),
+                document_url=metadata.get("document_url"),
             )
 
             return source

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -43,6 +43,7 @@ retriever_resource_fields = {
     "dataset_name": fields.String,
     "document_id": fields.String,
     "document_name": fields.String,
+    "document_url": fields.String,
     "data_source_type": fields.String,
     "segment_id": fields.String,
     "score": fields.Float,

--- a/web/app/components/base/chat/chat/citation/popup.tsx
+++ b/web/app/components/base/chat/chat/citation/popup.tsx
@@ -73,16 +73,26 @@ const Popup: FC<PopupProps> = ({
                             {source.segment_position || index + 1}
                           </div>
                         </div>
-                        {
-                          showHitInfo && (
+                        <div className='hidden items-center gap-3 group-hover:flex'>
+                          {source.document_url && (
+                            <Link
+                              href={source.document_url}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              className='flex h-[18px] items-center text-xs text-text-accent'>
+                              {t('common.chat.citation.viewOriginal')}
+                              <ArrowUpRight className='ml-1 h-3 w-3' />
+                            </Link>
+                          )}
+                          {showHitInfo && (
                             <Link
                               href={`/datasets/${source.dataset_id}/documents/${source.document_id}`}
-                              className='hidden h-[18px] items-center text-xs text-text-accent group-hover:flex'>
+                              className='flex h-[18px] items-center text-xs text-text-accent'>
                               {t('common.chat.citation.linkToDataset')}
                               <ArrowUpRight className='ml-1 h-3 w-3' />
                             </Link>
-                          )
-                        }
+                          )}
+                        </div>
                       </div>
                       <div className='break-words text-[13px] text-text-secondary'>{source.content}</div>
                       {

--- a/web/app/components/base/chat/chat/type.ts
+++ b/web/app/components/base/chat/chat/type.ts
@@ -55,6 +55,7 @@ export type CitationItem = {
   dataset_id: string
   document_id: string
   document_name: string
+  document_url?: string
   hit_count: number
   index_node_hash: string
   segment_id: string

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -658,6 +658,7 @@ const translation = {
     citation: {
       title: 'CITATIONS',
       linkToDataset: 'Link to Knowledge',
+      viewOriginal: 'View Original',
       characters: 'Characters:',
       hitCount: 'Retrieval count:',
       vectorHash: 'Vector hash:',

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -649,6 +649,7 @@ const translation = {
     citation: {
       title: '引用',
       linkToDataset: 'ナレッジへのリンク',
+      viewOriginal: 'ソース',
       characters: '文字数：',
       hitCount: '検索回数：',
       vectorHash: 'ベクトルハッシュ：',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -652,6 +652,7 @@ const translation = {
     citation: {
       title: '引用',
       linkToDataset: '跳转至知识库',
+      viewOriginal: '源文件',
       characters: '字符：',
       hitCount: '召回次数：',
       vectorHash: '向量哈希：',


### PR DESCRIPTION
## Summary

Fixes #27596

Motivation: Enterprise users want to view the original file/web page for any recalled chunk from both internal and external knowledge bases, and API consumers need a document URL in responses for auditability and deep linking. Scope includes Chatflow and Chatbot apps.

What’s included:
- API: Add `document_url` to retrieval metadata so clients can open the source document.
  - Internal KBs: For dataset documents, generate a user-accessible URL based on source type:
    - Uploads: signed preview URL
    - Website crawl: original page URL
    - Notion import: Notion page link (or derived from page id)
    - Fallback: best-effort from `source_url`-like metadata
  - External KBs: Use `url`/`source_url` metadata when available.
- UI: In the chat "Citation and Attributions" view, add an action to open the original source ("View original"). Applies to Chatflow and Chatbot.

Notable changes:
- Backend
  - `api/core/rag/utils/document_url.py`: New helpers to derive document URLs for internal and external sources.
  - `api/core/rag/entities/citation_metadata.py`: Extend `RetrievalSourceMetadata` with `document_url`.
  - `api/core/rag/retrieval/dataset_retrieval.py`: Populate `document_url` for internal and external retrieval sources.
  - `api/controllers/service_api/app/message.py`: Rebuild `retriever_resources` on read to include fresh `document_url` for each resource.
- Frontend
  - `web/app/components/base/chat/chat/citation/popup.tsx`: Add UI affordance to open the original document from citations/attributions.
  - `web/app/components/base/chat/chat/type.ts`: Type updates to include `document_url`.
  - `web/i18n/*/common.ts`: i18n strings for the new UI text.

Behavioral notes:
- No breaking changes; `document_url` is additive on existing retrieval metadata.
- Works for app modes Chatflow and Chatbot, in both draft mode and published mode.
- Signed URLs for uploads respect existing file helper security and expiration behavior.

Example API shape (trimmed):

```json
{
  "data": [
    {
      "retriever_resources": [
        {
          "dataset_id": "...",
          "document_id": "...",
          "score": 0.87,
          "content": "...",
          "document_url": "https://..."  
        }
      ]
    }
  ]
}
```

## Screenshots
### Chatflow
- the kb node now returns document_url field
- a 'view original' button displays on the citation area if document_url field exists, click it to either view the file content(if browser supports it or download the file)
<img width="1666" height="733" alt="image" src="https://github.com/user-attachments/assets/d8cebfd1-58db-41c0-a470-e5894ea1821a" />


also works for published chatflow:
<img width="900" height="865" alt="image" src="https://github.com/user-attachments/assets/aa367c63-4fc2-46da-b5d5-fd6eee5ab3ca" />


also works for api call:
<img width="1475" height="587" alt="image" src="https://github.com/user-attachments/assets/49eb44b3-7be8-4b40-9c34-be5307c42b45" />

### Chatbot
in draft mode:
<img width="1649" height="685" alt="image" src="https://github.com/user-attachments/assets/cdcdd046-c44d-4ee2-9920-07edc3870310" />

in published mode:
<img width="836" height="766" alt="image" src="https://github.com/user-attachments/assets/e34432e6-ea16-4b96-b582-b0b5ea0fdb92" />

api:
<img width="744" height="357" alt="image" src="https://github.com/user-attachments/assets/495f96b7-cf80-40e4-afbc-2b6f2d9fbf49" />




## Checklist

- [ ] This change requires a documentation update, included: Dify Document (docs to describe `document_url` in API responses and the new UI action)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

