### PR TITLE
fix(http_request): set response.text if there is no file

### DIFF
--- a/api/core/workflow/nodes/http_request/node.py
+++ b/api/core/workflow/nodes/http_request/node.py
@@ -104,7 +104,7 @@ class HttpRequestNode(Node):
                     status=WorkflowNodeExecutionStatus.FAILED,
                     outputs={
                         "status_code": response.status_code,
-                        "body": response.text if not files else "",
+                        "body": response.text if not files.value else "",
                         "headers": response.headers,
                         "files": files,
                     },


### PR DESCRIPTION
## Summary

This PR ensures that, in the HTTP Request node, when an HTTP request fails, the response body is correctly set in `body`.
This makes troubleshooting easier.

Closes #27609.

## Screenshots

| Before | After |
|--------|-------|
| <img width="766" height="859" alt="image" src="https://github.com/user-attachments/assets/b3dc0e58-d2c2-4cfa-9a3a-89e438ff0ab7" /> | <img width="759" height="792" alt="image" src="https://github.com/user-attachments/assets/d0b6ba14-e125-447f-908a-df75a6e8ac82" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
