### PR TITLE
fix: resolve stale closure values in LLM node callbacks (#27612)

### DIFF
--- a/web/app/components/workflow/nodes/llm/use-config.ts
+++ b/web/app/components/workflow/nodes/llm/use-config.ts
@@ -27,6 +27,9 @@ const useConfig = (id: string, payload: LLMNodeType) => {
   const [defaultRolePrefix, setDefaultRolePrefix] = useState<{ user: string; assistant: string }>({ user: '', assistant: '' })
   const { inputs, setInputs: doSetInputs } = useNodeCrud<LLMNodeType>(id, payload)
   const inputRef = useRef(inputs)
+  useEffect(() => {
+    inputRef.current = inputs
+  }, [inputs])
 
   const { deleteNodeInspectorVars } = useInspectVarsCrud()
 

--- a/web/app/components/workflow/nodes/llm/use-config.ts
+++ b/web/app/components/workflow/nodes/llm/use-config.ts
@@ -117,7 +117,7 @@ const useConfig = (id: string, payload: LLMNodeType) => {
   } = useConfigVision(model, {
     payload: inputs.vision,
     onChange: (newPayload) => {
-      const newInputs = produce(inputs, (draft) => {
+      const newInputs = produce(inputRef.current, (draft) => {
         draft.vision = newPayload
       })
       setInputs(newInputs)
@@ -148,11 +148,11 @@ const useConfig = (id: string, payload: LLMNodeType) => {
   }, [model.provider, currentProvider, currentModel, handleModelChanged])
 
   const handleCompletionParamsChange = useCallback((newParams: Record<string, any>) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       draft.model.completion_params = newParams
     })
     setInputs(newInputs)
-  }, [inputs, setInputs])
+  }, [setInputs])
 
   // change to vision model to set vision enabled, else disabled
   useEffect(() => {
@@ -238,29 +238,29 @@ const useConfig = (id: string, payload: LLMNodeType) => {
 
   // context
   const handleContextVarChange = useCallback((newVar: ValueSelector | string) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       draft.context.variable_selector = newVar as ValueSelector || []
       draft.context.enabled = !!(newVar && newVar.length > 0)
     })
     setInputs(newInputs)
-  }, [inputs, setInputs])
+  }, [setInputs])
 
   const handlePromptChange = useCallback((newPrompt: PromptItem[] | PromptItem) => {
     const newInputs = produce(inputRef.current, (draft) => {
       draft.prompt_template = newPrompt
     })
     setInputs(newInputs)
-  }, [inputs, setInputs])
+  }, [setInputs])
 
   const handleMemoryChange = useCallback((newMemory?: Memory) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       draft.memory = newMemory
     })
     setInputs(newInputs)
-  }, [inputs, setInputs])
+  }, [setInputs])
 
   const handleSyeQueryChange = useCallback((newQuery: string) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       if (!draft.memory) {
         draft.memory = {
           window: {
@@ -275,7 +275,7 @@ const useConfig = (id: string, payload: LLMNodeType) => {
       }
     })
     setInputs(newInputs)
-  }, [inputs, setInputs])
+  }, [setInputs])
 
   // structure output
   const { data: modelList } = useModelList(ModelTypeEnum.textGeneration)
@@ -286,22 +286,22 @@ const useConfig = (id: string, payload: LLMNodeType) => {
 
   const [structuredOutputCollapsed, setStructuredOutputCollapsed] = useState(true)
   const handleStructureOutputEnableChange = useCallback((enabled: boolean) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       draft.structured_output_enabled = enabled
     })
     setInputs(newInputs)
     if (enabled)
       setStructuredOutputCollapsed(false)
     deleteNodeInspectorVars(id)
-  }, [inputs, setInputs, deleteNodeInspectorVars, id])
+  }, [setInputs, deleteNodeInspectorVars, id])
 
   const handleStructureOutputChange = useCallback((newOutput: StructuredOutput) => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       draft.structured_output = newOutput
     })
     setInputs(newInputs)
     deleteNodeInspectorVars(id)
-  }, [inputs, setInputs, deleteNodeInspectorVars, id])
+  }, [setInputs, deleteNodeInspectorVars, id])
 
   const filterInputVar = useCallback((varPayload: Var) => {
     return [VarType.number, VarType.string, VarType.secret, VarType.arrayString, VarType.arrayNumber, VarType.file, VarType.arrayFile].includes(varPayload.type)
@@ -317,11 +317,11 @@ const useConfig = (id: string, payload: LLMNodeType) => {
 
   // reasoning format
   const handleReasoningFormatChange = useCallback((reasoningFormat: 'tagged' | 'separated') => {
-    const newInputs = produce(inputs, (draft) => {
+    const newInputs = produce(inputRef.current, (draft) => {
       draft.reasoning_format = reasoningFormat
     })
     setInputs(newInputs)
-  }, [inputs, setInputs])
+  }, [setInputs])
 
   const {
     availableVars,


### PR DESCRIPTION
## What does this PR do?
Fixes #27612 

Resolves data loss issue where LLM node prompt changes are lost when calling `/workflows/draft` API.

## Changes
- Updated 8 callback functions in `use-config.ts` to use `inputRef.current` instead of closure-captured `inputs`
- Removed `inputs` from dependency arrays to improve performance
- Made code consistent with other handlers in the same file and other node types

## Root Cause
The callbacks were using stale closure values (`inputs`) instead of the latest ref value (`inputRef.current`), causing updates to be based on outdated data when rapid edits occurred within the 5-second debounce window.

## Testing
- ✅ Tested locally with rapid prompt edits
- ✅ Verified `/workflows/draft` API receives correct data
- ✅ No linter errors
- ✅ No performance regressions observed