### PR TITLE
i18n(ja-JP): Use 「公開」 for App Overview “Launch” action label

### DIFF
--- a/web/i18n/ja-JP/app-overview.ts
+++ b/web/i18n/ja-JP/app-overview.ts
@@ -113,7 +113,7 @@ const translation = {
           operation: 'ドキュメント',
         },
       },
-      launch: '発射',
+      launch: '公開',
     },
     apiInfo: {
       title: 'バックエンドサービス API',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

https://github.com/langgenius/dify/issues/27679

## Summary
This PR updates the Japanese translation for the App Overview “Launch” action:
File: web/i18n/ja-JP/app-overview.ts
Key: overview.appInfo.launch
Change: 「発射」 → 「公開」

「発射」 commonly means “to fire/launch a projectile” and is confusing in this context.
「公開」 is the natural term for releasing/publishing an app and aligns with the English “Launch”.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

Before
<img width="407" height="167" alt="スクリーンショット_2025-10-31_10_35_43" src="https://github.com/user-attachments/assets/48470395-b98f-4a96-8ad6-68709eae99aa" />

After
<img width="406" height="166" alt="スクリーンショット_2025-10-31_10_36_13" src="https://github.com/user-attachments/assets/a9622c47-d928-442f-b3bf-c3f2b63ea450" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
