### PR TITLE
fix agent putout the output of workflow-tool twice (#26835) 

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -230,12 +230,10 @@ class ToolEngine:
         """
         parts: list[str] = []
         json_parts: list[str] = []
-        saw_text = False
 
         for response in tool_response:
             if response.type == ToolInvokeMessage.MessageType.TEXT:
                 parts.append(cast(ToolInvokeMessage.TextMessage, response.message).text)
-                saw_text = True
             elif response.type == ToolInvokeMessage.MessageType.LINK:
                 parts.append(
                     f"result link: {cast(ToolInvokeMessage.TextMessage, response.message).text}."
@@ -256,7 +254,7 @@ class ToolEngine:
             else:
                 parts.append(str(response.message))
 
-          # Add JSON parts, avoiding duplicates from text parts.
+        # Add JSON parts, avoiding duplicates from text parts.
         if json_parts:
             existing_parts = set(parts)
             parts.extend(p for p in json_parts if p not in existing_parts)

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -256,9 +256,10 @@ class ToolEngine:
             else:
                 parts.append(str(response.message))
 
-         # If no TEXT message is present, append JSON parts to avoid duplication.
-        if not saw_text and json_parts:
-            parts.extend(json_parts)
+          # Add JSON parts, avoiding duplicates from text parts.
+        if json_parts:
+            existing_parts = set(parts)
+            parts.extend(p for p in json_parts if p not in existing_parts)
 
         return "".join(parts)
 

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -228,29 +228,39 @@ class ToolEngine:
         """
         Handle tool response
         """
-        result = ""
+        parts: list[str] = []
+        json_parts: list[str] = []
+        saw_text = False
+
         for response in tool_response:
             if response.type == ToolInvokeMessage.MessageType.TEXT:
-                result += cast(ToolInvokeMessage.TextMessage, response.message).text
+                parts.append(cast(ToolInvokeMessage.TextMessage, response.message).text)
+                saw_text = True
             elif response.type == ToolInvokeMessage.MessageType.LINK:
-                result += (
+                parts.append(
                     f"result link: {cast(ToolInvokeMessage.TextMessage, response.message).text}."
                     + " please tell user to check it."
                 )
             elif response.type in {ToolInvokeMessage.MessageType.IMAGE_LINK, ToolInvokeMessage.MessageType.IMAGE}:
-                result += (
+                parts.append(
                     "image has been created and sent to user already, "
                     + "you do not need to create it, just tell the user to check it now."
                 )
             elif response.type == ToolInvokeMessage.MessageType.JSON:
-                result += json.dumps(
-                    safe_json_value(cast(ToolInvokeMessage.JsonMessage, response.message).json_object),
-                    ensure_ascii=False,
+                json_parts.append(
+                    json.dumps(
+                        safe_json_value(cast(ToolInvokeMessage.JsonMessage, response.message).json_object),
+                        ensure_ascii=False,
+                    )
                 )
             else:
-                result += str(response.message)
+                parts.append(str(response.message))
 
-        return result
+         # If no TEXT message is present, append JSON parts to avoid duplication.
+        if not saw_text and json_parts:
+            parts.extend(json_parts)
+
+        return "".join(parts)
 
     @staticmethod
     def _extract_tool_response_binary_and_text(


### PR DESCRIPTION
Refactor tool response handling to use lists for parts and JSON messages. Ensure proper concatenation and avoid duplication of messages.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Previously, there would be repeated output text. Now, regardless of whether the tool's response is in plain text, pure JSON format, or text+JSON format, it can output as expected.

close #26835

**I noticed a discussion and code improvement regarding this issue in # 27087. This code may serve as a reference for code improvement.**

## Screenshots

| Before | After |
|--------|
<img width="849" height="264" alt="微信图片_20251031185112_337_32" src="https://github.com/user-attachments/assets/8680403e-8286-4171-975b-8997e4b84cc7" />
|
| ... | 
<img width="864" height="201" alt="微信图片_20251031185205_338_32" src="https://github.com/user-attachments/assets/3f4b2472-17c0-4a93-9ead-88ae2a0f8ba2" />
|
| ... | 
<img width="854" height="309" alt="微信图片_20251031185421_339_32" src="https://github.com/user-attachments/assets/4eb1684b-0ea0-4335-970f-31e8821886e5" />
|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

