### PR TITLE
chore(ci): enforce typed String mapped columns

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -53,6 +53,8 @@ jobs:
           # Fix forward references that were incorrectly converted (Python doesn't support "Type" | None syntax)
           find . -name "*.py" -type f -exec sed -i.bak -E 's/"([^"]+)" \| None/Optional["\1"]/g; s/'"'"'([^'"'"']+)'"'"' \| None/Optional['"'"'\1'"'"']/g' {} \;
           find . -name "*.py.bak" -type f -delete
+          # Rewrite SQLAlchemy with Type Annotations
+          uvx --from ast-grep-cli sg scan -r dev/ast-grep/rules/remove-nullable-arg.yaml api/models -U
 
       - name: mdformat
         run: |

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1778,7 +1778,7 @@ class MessageAgentThought(Base):
     answer_price_unit = mapped_column(sa.Numeric(10, 7), nullable=False, server_default=sa.text("0.001"))
     tokens: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)
     total_price = mapped_column(sa.Numeric, nullable=True)
-    currency = mapped_column(String, nullable=True)
+    currency: Mapped[str | None] = mapped_column()
     latency: Mapped[float | None] = mapped_column(sa.Float, nullable=True)
     created_by_role = mapped_column(String, nullable=False)
     created_by = mapped_column(StringUUID, nullable=False)

--- a/dev/ast-grep/rules/remove-nullable-arg.yaml
+++ b/dev/ast-grep/rules/remove-nullable-arg.yaml
@@ -3,8 +3,8 @@ language: python
 rule:
   pattern: $X = mapped_column($$$ARGS)
   any:
-    - pattern: $X = mapped_column($$$BEFORE, String, $$$MID, nullable=True, $$$AFTER)
-    - pattern: $X = mapped_column($$$BEFORE, String, $$$MID, nullable=True)
+    - pattern: $X = mapped_column($$$BEFORE, sa.String, $$$MID, nullable=True, $$$AFTER)
+    - pattern: $X = mapped_column($$$BEFORE, sa.String, $$$MID, nullable=True)
 rewriters:
 - id: filter-string-nullable
   rule:

--- a/dev/ast-grep/rules/remove-nullable-arg.yaml
+++ b/dev/ast-grep/rules/remove-nullable-arg.yaml
@@ -1,0 +1,30 @@
+id: remove-nullable-arg
+language: python
+rule:
+  pattern: $X = mapped_column($$$ARGS)
+  any:
+    - pattern: $X = mapped_column($$$BEFORE, String, $$$MID, nullable=True, $$$AFTER)
+    - pattern: $X = mapped_column($$$BEFORE, String, $$$MID, nullable=True)
+rewriters:
+- id: filter-string-nullable
+  rule:
+    pattern: $ARG
+    inside:
+      kind: argument_list
+    all:
+    - not:
+        pattern: String
+    - not:
+        pattern:
+          context: a(nullable=True)
+          selector: keyword_argument
+  fix: $ARG
+
+transform:
+  NEWARGS:
+    rewrite:
+      rewriters: [filter-string-nullable]
+      source: $$$ARGS
+      joinBy: ', '
+fix: |-
+  $X: Mapped[str | None] = mapped_column($NEWARGS)


### PR DESCRIPTION
## Summary

Fixes #27746

- ensure `MessageAgentThought.currency` declares a typed `Mapped[str | None]` column instead of relying on a bare `String`
- add an ast-grep rewrite that upgrades `mapped_column(String, nullable=True)` definitions to typed mapped columns across the API models
- wire the new rewrite into the autofix workflow so future runs keep SQLAlchemy models aligned with the migration

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
