### PR TITLE
fix:knowledge base reference information is overwritten when using mu…

### DIFF
--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -140,13 +140,8 @@ class MessageCycleManager:
         if not self._application_generate_entity.app_config.additional_features:
             raise ValueError("Additional features not found")
         if self._application_generate_entity.app_config.additional_features.show_retrieve_source:
-
             merged_resources = [r for r in self._task_state.metadata.retriever_resources or [] if r]
-            existing_ids = {
-                (r.dataset_id, r.document_id)
-                for r in merged_resources
-                if r.dataset_id and r.document_id
-            }
+            existing_ids = {(r.dataset_id, r.document_id) for r in merged_resources if r.dataset_id and r.document_id}
 
             # Add new unique resources from the event
             for resource in event.retriever_resources or []:
@@ -154,9 +149,9 @@ class MessageCycleManager:
                     continue
 
                 is_duplicate = (
-                    resource.dataset_id and
-                    resource.document_id and
-                    (resource.dataset_id, resource.document_id) in existing_ids
+                    resource.dataset_id
+                    and resource.document_id
+                    and (resource.dataset_id, resource.document_id) in existing_ids
                 )
 
                 if not is_duplicate:

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -140,7 +140,32 @@ class MessageCycleManager:
         if not self._application_generate_entity.app_config.additional_features:
             raise ValueError("Additional features not found")
         if self._application_generate_entity.app_config.additional_features.show_retrieve_source:
-            self._task_state.metadata.retriever_resources = event.retriever_resources
+
+            merged_resources = [r for r in self._task_state.metadata.retriever_resources or [] if r]
+            existing_ids = {
+                (r.dataset_id, r.document_id)
+                for r in merged_resources
+                if r.dataset_id and r.document_id
+            }
+
+            # Add new unique resources from the event
+            for resource in event.retriever_resources or []:
+                if not resource:
+                    continue
+
+                is_duplicate = (
+                    resource.dataset_id and
+                    resource.document_id and
+                    (resource.dataset_id, resource.document_id) in existing_ids
+                )
+
+                if not is_duplicate:
+                    merged_resources.append(resource)
+
+            for i, resource in enumerate(merged_resources, 1):
+                resource.position = i
+
+            self._task_state.metadata.retriever_resources = merged_resources
 
     def message_file_to_stream_response(self, event: QueueMessageFileEvent) -> MessageFileStreamResponse | None:
         """


### PR DESCRIPTION
…ltiple large model nodes

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #27806 (https://github.com/langgenius/dify/issues/27806)

## Summary

- Problem : When using multiple large model nodes, the knowledge base reference information is overwritten by the application information from the last large model node, rather than incorporating all knowledge base reference information.

- KeyChange：MessageCycleManager line143-166

## Screenshots

| Before | After |
|--------|-------|
| <img width="1552" height="263" alt="image" src="https://github.com/user-attachments/assets/c80be937-c600-4cbf-844a-29158f8805b6" /> <img width="756" height="711" alt="image" src="https://github.com/user-attachments/assets/b719efbd-739e-4efb-9e0e-162a5df48b11" /> | <img width="678" height="818" alt="image" src="https://github.com/user-attachments/assets/74b1281d-2a66-4c92-9c66-7c8e0fe43c76" />  |
 <img width="1186" height="288" alt="image" src="https://github.com/user-attachments/assets/bdad47eb-3a0c-4178-ba99-c4e57a030680" /><img width="819" height="821" alt="image" src="https://github.com/user-attachments/assets/c202fe3c-9312-49fc-b169-0263df1ac14f" /> | <img width="962" height="852" alt="image" src="https://github.com/user-attachments/assets/6ca6abc0-2076-4af2-8f9a-ea1b1c58915b" /> |


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
