### PR TITLE
fix(web): increase z-index of PortalToFollowElemContent

### DIFF
--- a/web/app/components/app-sidebar/app-operations.tsx
+++ b/web/app/components/app-sidebar/app-operations.tsx
@@ -124,7 +124,7 @@ const AppOperations = ({ operations, gap }: {
               <span className='system-xs-medium text-components-button-secondary-text'>{t('common.operation.more')}</span>
             </Button>
           </PortalToFollowElemTrigger>
-          <PortalToFollowElemContent className='z-[21]'>
+          <PortalToFollowElemContent className='z-[30]'>
             <div className='flex min-w-[264px] flex-col rounded-[12px] border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg backdrop-blur-[5px]'>
               {moreOperations.map(item => <div
                 key={item.id}


### PR DESCRIPTION
## Summary

This PR fixes a visibility issue where the tooltip content rendered by `PortalToFollowElemContent` could be hidden behind other UI layers due to a lower `z-index`.

- **Root cause:** insufficient stacking context in nested layouts
- **Fix:** increased `z-index` for the container
- **Impact:** ensures tooltips or floating content display properly on top of other components
- **Issue:** Fixes #27622

## Screenshots

| Before | After |
|--------|-------|
| <img width="388" height="105" alt="image" src="https://github.com/user-attachments/assets/b1ae1a77-3e65-486d-ba32-3398aa1f3419" /> | <img width="870" height="502" alt="bddc392bdd53215d17fb6514a279b7e5" src="https://github.com/user-attachments/assets/6adf44e5-f1d5-4262-8314-6cdba714d07c" />|
