### PR TITLE
feat: add validation to prevent saving empty opening statement in conversation opener modal

### DIFF
--- a/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
@@ -46,6 +46,10 @@ const OpeningSettingModal = ({
   const [notIncludeKeys, setNotIncludeKeys] = useState<string[]>([])
 
   const handleSave = useCallback((ignoreVariablesCheck?: boolean) => {
+    // Prevent saving if opening statement is empty
+    if (!tempValue.trim())
+      return
+
     if (!ignoreVariablesCheck) {
       const keys = getInputKeys(tempValue)
       const promptKeys = promptVariables.map(item => item.key)
@@ -217,6 +221,7 @@ const OpeningSettingModal = ({
         <Button
           variant='primary'
           onClick={() => handleSave()}
+          disabled={!tempValue.trim()}
         >
           {t('common.operation.save')}
         </Button>

--- a/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useBoolean } from 'ahooks'
 import { produce } from 'immer'
@@ -45,9 +45,11 @@ const OpeningSettingModal = ({
   const [isShowConfirmAddVar, { setTrue: showConfirmAddVar, setFalse: hideConfirmAddVar }] = useBoolean(false)
   const [notIncludeKeys, setNotIncludeKeys] = useState<string[]>([])
 
+  const isSaveDisabled = useMemo(() => !tempValue.trim(), [tempValue])
+
   const handleSave = useCallback((ignoreVariablesCheck?: boolean) => {
     // Prevent saving if opening statement is empty
-    if (!tempValue.trim())
+    if (isSaveDisabled)
       return
 
     if (!ignoreVariablesCheck) {
@@ -79,7 +81,7 @@ const OpeningSettingModal = ({
       }
     })
     onSave(newOpening)
-  }, [data, onSave, promptVariables, workflowVariables, showConfirmAddVar, tempSuggestedQuestions, tempValue])
+  }, [data, onSave, promptVariables, workflowVariables, showConfirmAddVar, tempSuggestedQuestions, tempValue, isSaveDisabled])
 
   const cancelAutoAddVar = useCallback(() => {
     hideConfirmAddVar()
@@ -221,7 +223,7 @@ const OpeningSettingModal = ({
         <Button
           variant='primary'
           onClick={() => handleSave()}
-          disabled={!tempValue.trim()}
+          disabled={isSaveDisabled}
         >
           {t('common.operation.save')}
         </Button>


### PR DESCRIPTION
## Summary

Fixes #27842 
Added validation to the conversation opener modal to prevent saving empty opening statements. The save button is now disabled when the content is empty, and an early return check in the save function ensures empty content cannot be persisted.

## Screenshots

| Before | After |
|--------|-------|
| <img width="633" height="312" alt="image" src="https://github.com/user-attachments/assets/019647cc-e379-4624-9860-5b37e42e6df0" />| <img width="633" height="314" alt="image" src="https://github.com/user-attachments/assets/38496e73-ca53-4c5d-8ea2-9e42651500d5" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
