### PR TITLE
fix: installation_id is missing when in tools page

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/detail-header.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/detail-header.tsx
@@ -73,7 +73,7 @@ const DetailHeader = ({
   const { enable_marketplace } = useGlobalPublicStore(s => s.systemFeatures)
 
   const {
-    installation_id,
+    id,
     source,
     tenant_id,
     version,
@@ -197,7 +197,7 @@ const DetailHeader = ({
 
   const handleDelete = useCallback(async () => {
     showDeleting()
-    const res = await uninstallPlugin(installation_id)
+    const res = await uninstallPlugin(id)
     hideDeleting()
     if (res.success) {
       hideDeleteConfirm()
@@ -207,7 +207,7 @@ const DetailHeader = ({
       if (PluginType.tool.includes(category))
         invalidateAllToolProviders()
     }
-  }, [showDeleting, installation_id, hideDeleting, hideDeleteConfirm, onUpdate, category, refreshModelProviders, invalidateAllToolProviders])
+  }, [showDeleting, id, hideDeleting, hideDeleteConfirm, onUpdate, category, refreshModelProviders, invalidateAllToolProviders])
 
   return (
     <div className={cn('shrink-0 border-b border-divider-subtle bg-components-panel-bg p-4 pb-3')}>
@@ -351,7 +351,6 @@ const DetailHeader = ({
           content={
             <div>
               {t(`${i18nPrefix}.deleteContentLeft`)}<span className='system-md-semibold'>{label[locale]}</span>{t(`${i18nPrefix}.deleteContentRight`)}<br />
-              {/* {usedInApps > 0 && t(`${i18nPrefix}.usedInApps`, { num: usedInApps })} */}
             </div>
           }
           onCancel={hideDeleteConfirm}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request refactors the plugin uninstallation logic in the `DetailHeader` component to use the `id` property instead of `installation_id`. This change ensures consistency in how plugins are identified and simplifies the code by updating all relevant references. Additionally, a commented-out line related to usage information display has been removed for cleaner code.

**Refactor plugin identification:**

* Replaced usage of `installation_id` with `id` throughout the `DetailHeader` component, including in function parameters and dependency arrays. [[1]](diffhunk://#diff-5c430ddd34d22fd011768194667a128dc0b87019fc0596db568fd7934c8e935dL76-R76) [[2]](diffhunk://#diff-5c430ddd34d22fd011768194667a128dc0b87019fc0596db568fd7934c8e935dL200-R200) [[3]](diffhunk://#diff-5c430ddd34d22fd011768194667a128dc0b87019fc0596db568fd7934c8e935dL210-R210)

**Code cleanup:**

* Removed a commented-out line that referenced displaying the number of apps using the plugin in the delete confirmation dialog.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
