### PR TITLE
feat: change feedback to forum

### DIFF
--- a/web/app/components/goto-anything/actions/commands/forum.tsx
+++ b/web/app/components/goto-anything/actions/commands/forum.tsx
@@ -4,26 +4,26 @@ import { RiFeedbackLine } from '@remixicon/react'
 import i18n from '@/i18n-config/i18next-config'
 import { registerCommands, unregisterCommands } from './command-bus'
 
-// Feedback command dependency types
-type FeedbackDeps = Record<string, never>
+// Forum command dependency types
+type ForumDeps = Record<string, never>
 
 /**
- * Feedback command - Opens GitHub feedback discussions
+ * Forum command - Opens Dify community forum
  */
-export const feedbackCommand: SlashCommandHandler<FeedbackDeps> = {
-  name: 'feedback',
-  description: 'Open feedback discussions',
+export const forumCommand: SlashCommandHandler<ForumDeps> = {
+  name: 'forum',
+  description: 'Open Dify community forum',
   mode: 'direct',
 
   // Direct execution function
   execute: () => {
-    const url = 'https://github.com/langgenius/dify/discussions/categories/feedbacks'
+    const url = 'https://forum.dify.ai'
     window.open(url, '_blank', 'noopener,noreferrer')
   },
 
   async search(args: string, locale: string = 'en') {
     return [{
-      id: 'feedback',
+      id: 'forum',
       title: i18n.t('common.userProfile.communityFeedback', { lng: locale }),
       description: i18n.t('app.gotoAnything.actions.feedbackDesc', { lng: locale }) || 'Open community feedback discussions',
       type: 'command' as const,
@@ -32,20 +32,20 @@ export const feedbackCommand: SlashCommandHandler<FeedbackDeps> = {
           <RiFeedbackLine className='h-4 w-4 text-text-tertiary' />
         </div>
       ),
-      data: { command: 'navigation.feedback', args: { url: 'https://github.com/langgenius/dify/discussions/categories/feedbacks' } },
+      data: { command: 'navigation.forum', args: { url: 'https://forum.dify.ai' } },
     }]
   },
 
-  register(_deps: FeedbackDeps) {
+  register(_deps: ForumDeps) {
     registerCommands({
-      'navigation.feedback': async (args) => {
-        const url = args?.url || 'https://github.com/langgenius/dify/discussions/categories/feedbacks'
+      'navigation.forum': async (args) => {
+        const url = args?.url || 'https://forum.dify.ai'
         window.open(url, '_blank', 'noopener,noreferrer')
       },
     })
   },
 
   unregister() {
-    unregisterCommands(['navigation.feedback'])
+    unregisterCommands(['navigation.forum'])
   },
 }

--- a/web/app/components/goto-anything/actions/commands/forum.tsx
+++ b/web/app/components/goto-anything/actions/commands/forum.tsx
@@ -24,7 +24,7 @@ export const forumCommand: SlashCommandHandler<ForumDeps> = {
   async search(args: string, locale: string = 'en') {
     return [{
       id: 'forum',
-      title: i18n.t('common.userProfile.communityFeedback', { lng: locale }),
+      title: i18n.t('common.userProfile.forum', { lng: locale }),
       description: i18n.t('app.gotoAnything.actions.feedbackDesc', { lng: locale }) || 'Open community feedback discussions',
       type: 'command' as const,
       icon: (

--- a/web/app/components/goto-anything/actions/commands/slash.tsx
+++ b/web/app/components/goto-anything/actions/commands/slash.tsx
@@ -7,7 +7,7 @@ import { useTheme } from 'next-themes'
 import { setLocaleOnClient } from '@/i18n-config'
 import { themeCommand } from './theme'
 import { languageCommand } from './language'
-import { feedbackCommand } from './feedback'
+import { forumCommand } from './forum'
 import { docsCommand } from './docs'
 import { communityCommand } from './community'
 import { accountCommand } from './account'
@@ -34,7 +34,7 @@ export const registerSlashCommands = (deps: Record<string, any>) => {
   // Register command handlers to the registry system with their respective dependencies
   slashCommandRegistry.register(themeCommand, { setTheme: deps.setTheme })
   slashCommandRegistry.register(languageCommand, { setLocale: deps.setLocale })
-  slashCommandRegistry.register(feedbackCommand, {})
+  slashCommandRegistry.register(forumCommand, {})
   slashCommandRegistry.register(docsCommand, {})
   slashCommandRegistry.register(communityCommand, {})
   slashCommandRegistry.register(accountCommand, {})
@@ -44,7 +44,7 @@ export const unregisterSlashCommands = () => {
   // Remove command handlers from registry system (automatically calls each command's unregister method)
   slashCommandRegistry.unregister('theme')
   slashCommandRegistry.unregister('language')
-  slashCommandRegistry.unregister('feedback')
+  slashCommandRegistry.unregister('forum')
   slashCommandRegistry.unregister('docs')
   slashCommandRegistry.unregister('community')
   slashCommandRegistry.unregister('account')

--- a/web/app/components/header/account-dropdown/support.tsx
+++ b/web/app/components/header/account-dropdown/support.tsx
@@ -1,5 +1,5 @@
 import { Menu, MenuButton, MenuItem, MenuItems, Transition } from '@headlessui/react'
-import { RiArrowRightSLine, RiArrowRightUpLine, RiChatSmile2Line, RiDiscordLine, RiFeedbackLine, RiMailSendLine, RiQuestionLine } from '@remixicon/react'
+import { RiArrowRightSLine, RiArrowRightUpLine, RiChatSmile2Line, RiDiscordLine, RiDiscussLine, RiMailSendLine, RiQuestionLine } from '@remixicon/react'
 import { Fragment } from 'react'
 import Link from 'next/link'
 import { useTranslation } from 'react-i18next'
@@ -88,7 +88,7 @@ export default function Support({ closeAccountDropdown }: SupportProps) {
                     )}
                     href='https://forum.dify.ai/'
                     target='_blank' rel='noopener noreferrer'>
-                    <RiFeedbackLine className='size-4 shrink-0 text-text-tertiary' />
+                    <RiDiscussLine className='size-4 shrink-0 text-text-tertiary' />
                     <div className='system-md-regular grow px-1 text-text-secondary'>{t('common.userProfile.forum')}</div>
                     <RiArrowRightUpLine className='size-[14px] shrink-0 text-text-tertiary' />
                   </Link>

--- a/web/app/components/header/account-dropdown/support.tsx
+++ b/web/app/components/header/account-dropdown/support.tsx
@@ -86,10 +86,10 @@ export default function Support({ closeAccountDropdown }: SupportProps) {
                     className={cn(itemClassName, 'group justify-between',
                       'data-[active]:bg-state-base-hover',
                     )}
-                    href='https://github.com/langgenius/dify/discussions/categories/feedbacks'
+                    href='https://forum.dify.ai/'
                     target='_blank' rel='noopener noreferrer'>
                     <RiFeedbackLine className='size-4 shrink-0 text-text-tertiary' />
-                    <div className='system-md-regular grow px-1 text-text-secondary'>{t('common.userProfile.communityFeedback')}</div>
+                    <div className='system-md-regular grow px-1 text-text-secondary'>{t('common.userProfile.forum')}</div>
                     <RiArrowRightUpLine className='size-[14px] shrink-0 text-text-tertiary' />
                   </Link>
                 </MenuItem>

--- a/web/i18n/de-DE/common.ts
+++ b/web/i18n/de-DE/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: 'Arbeitsbereich',
     createWorkspace: 'Arbeitsbereich erstellen',
     helpCenter: 'Hilfe',
-    communityFeedback: 'Rückmeldung',
     roadmap: 'Fahrplan',
     community: 'Gemeinschaft',
     about: 'Über',

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -177,7 +177,6 @@ const translation = {
     helpCenter: 'Docs',
     support: 'Support',
     compliance: 'Compliance',
-    communityFeedback: 'Feedback',
     forum: 'Forum',
     roadmap: 'Roadmap',
     github: 'GitHub',

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -178,6 +178,7 @@ const translation = {
     support: 'Support',
     compliance: 'Compliance',
     communityFeedback: 'Feedback',
+    forum: 'Forum',
     roadmap: 'Roadmap',
     github: 'GitHub',
     community: 'Community',

--- a/web/i18n/es-ES/common.ts
+++ b/web/i18n/es-ES/common.ts
@@ -165,7 +165,6 @@ const translation = {
     workspace: 'Espacio de trabajo',
     createWorkspace: 'Crear espacio de trabajo',
     helpCenter: 'Ayuda',
-    communityFeedback: 'Comentarios',
     roadmap: 'Hoja de ruta',
     community: 'Comunidad',
     about: 'Acerca de',

--- a/web/i18n/fa-IR/common.ts
+++ b/web/i18n/fa-IR/common.ts
@@ -165,7 +165,6 @@ const translation = {
     workspace: 'فضای کاری',
     createWorkspace: 'ایجاد فضای کاری',
     helpCenter: 'راهنما',
-    communityFeedback: 'بازخورد',
     roadmap: 'نقشه راه',
     community: 'انجمن',
     about: 'درباره',

--- a/web/i18n/fr-FR/common.ts
+++ b/web/i18n/fr-FR/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: 'Espace de travail',
     createWorkspace: 'Créer un Espace de Travail',
     helpCenter: 'Aide',
-    communityFeedback: 'Retour d\'information',
     roadmap: 'Feuille de route',
     community: 'Communauté',
     about: 'À propos',

--- a/web/i18n/hi-IN/common.ts
+++ b/web/i18n/hi-IN/common.ts
@@ -170,7 +170,6 @@ const translation = {
     workspace: 'वर्कस्पेस',
     createWorkspace: 'वर्कस्पेस बनाएं',
     helpCenter: 'सहायता',
-    communityFeedback: 'प्रतिक्रिया',
     roadmap: 'रोडमैप',
     community: 'समुदाय',
     about: 'के बारे में',

--- a/web/i18n/id-ID/common.ts
+++ b/web/i18n/id-ID/common.ts
@@ -163,7 +163,6 @@ const translation = {
     helpCenter: 'Docs',
     compliance: 'Kepatuhan',
     community: 'Masyarakat',
-    communityFeedback: 'Umpan balik',
     roadmap: 'Peta jalan',
     logout: 'Keluar',
     settings: 'Pengaturan',

--- a/web/i18n/it-IT/common.ts
+++ b/web/i18n/it-IT/common.ts
@@ -170,7 +170,6 @@ const translation = {
     workspace: 'Workspace',
     createWorkspace: 'Crea Workspace',
     helpCenter: 'Aiuto',
-    communityFeedback: 'Feedback',
     roadmap: 'Tabella di marcia',
     community: 'Comunità',
     about: 'Informazioni',

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -173,7 +173,6 @@ const translation = {
     helpCenter: 'ヘルプ',
     support: 'サポート',
     compliance: 'コンプライアンス',
-    communityFeedback: 'フィードバック',
     roadmap: 'ロードマップ',
     community: 'コミュニティ',
     about: 'Dify について',

--- a/web/i18n/ko-KR/common.ts
+++ b/web/i18n/ko-KR/common.ts
@@ -157,7 +157,6 @@ const translation = {
     workspace: '작업 공간',
     createWorkspace: '작업 공간 만들기',
     helpCenter: '도움말 센터',
-    communityFeedback: '로드맵 및 피드백',
     roadmap: '로드맵',
     community: '커뮤니티',
     about: 'Dify 소개',

--- a/web/i18n/pl-PL/common.ts
+++ b/web/i18n/pl-PL/common.ts
@@ -166,7 +166,6 @@ const translation = {
     workspace: 'Przestrzeń robocza',
     createWorkspace: 'Utwórz przestrzeń roboczą',
     helpCenter: 'Pomoc',
-    communityFeedback: 'Opinie',
     roadmap: 'Plan działania',
     community: 'Społeczność',
     about: 'O',

--- a/web/i18n/pt-BR/common.ts
+++ b/web/i18n/pt-BR/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: 'Espaço de trabalho',
     createWorkspace: 'Criar Espaço de Trabalho',
     helpCenter: 'Ajuda',
-    communityFeedback: 'Feedback',
     roadmap: 'Roteiro',
     community: 'Comunidade',
     about: 'Sobre',

--- a/web/i18n/ro-RO/common.ts
+++ b/web/i18n/ro-RO/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: 'Spațiu de lucru',
     createWorkspace: 'Creează Spațiu de lucru',
     helpCenter: 'Ajutor',
-    communityFeedback: 'Feedback',
     roadmap: 'Plan de acțiune',
     community: 'Comunitate',
     about: 'Despre',

--- a/web/i18n/ru-RU/common.ts
+++ b/web/i18n/ru-RU/common.ts
@@ -165,7 +165,6 @@ const translation = {
     workspace: 'Рабочее пространство',
     createWorkspace: 'Создать рабочее пространство',
     helpCenter: 'Помощь',
-    communityFeedback: 'Обратная связь',
     roadmap: 'План развития',
     community: 'Сообщество',
     about: 'О нас',

--- a/web/i18n/sl-SI/common.ts
+++ b/web/i18n/sl-SI/common.ts
@@ -165,7 +165,6 @@ const translation = {
     workspace: 'Delovni prostor',
     createWorkspace: 'Ustvari delovni prostor',
     helpCenter: 'Pomoč',
-    communityFeedback: 'Povratne informacije',
     roadmap: 'Načrt razvoja',
     community: 'Skupnost',
     about: 'O nas',

--- a/web/i18n/th-TH/common.ts
+++ b/web/i18n/th-TH/common.ts
@@ -160,7 +160,6 @@ const translation = {
     workspace: 'พื้นที่',
     createWorkspace: 'สร้างพื้นที่ทํางาน',
     helpCenter: 'วิธีใช้',
-    communityFeedback: 'การตอบสนอง',
     roadmap: 'แผนงาน',
     community: 'ชุมชน',
     about: 'ประมาณ',

--- a/web/i18n/tr-TR/common.ts
+++ b/web/i18n/tr-TR/common.ts
@@ -165,7 +165,6 @@ const translation = {
     workspace: 'Çalışma Alanı',
     createWorkspace: 'Çalışma Alanı Oluştur',
     helpCenter: 'Yardım',
-    communityFeedback: 'Geri Bildirim',
     roadmap: 'Yol haritası',
     community: 'Topluluk',
     about: 'Hakkında',

--- a/web/i18n/uk-UA/common.ts
+++ b/web/i18n/uk-UA/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: 'Робочий простір',
     createWorkspace: 'Створити робочий простір',
     helpCenter: 'Довідковий центр',
-    communityFeedback: 'відгуки',
     roadmap: 'Дорожня карта',
     community: 'Спільнота',
     about: 'Про нас',

--- a/web/i18n/vi-VN/common.ts
+++ b/web/i18n/vi-VN/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: 'Không gian làm việc',
     createWorkspace: 'Tạo Không gian làm việc',
     helpCenter: 'Trung tâm trợ giúp',
-    communityFeedback: 'Phản hồi',
     roadmap: 'Lộ trình',
     community: 'Cộng đồng',
     about: 'Về chúng tôi',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -177,6 +177,7 @@ const translation = {
     support: '支持',
     compliance: '合规',
     communityFeedback: '用户反馈',
+    forum: '论坛',
     roadmap: '路线图',
     github: 'GitHub',
     community: '社区',

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -176,7 +176,6 @@ const translation = {
     helpCenter: '帮助文档',
     support: '支持',
     compliance: '合规',
-    communityFeedback: '用户反馈',
     forum: '论坛',
     roadmap: '路线图',
     github: 'GitHub',

--- a/web/i18n/zh-Hant/common.ts
+++ b/web/i18n/zh-Hant/common.ts
@@ -161,7 +161,6 @@ const translation = {
     workspace: '工作空間',
     createWorkspace: '建立工作空間',
     helpCenter: '幫助文件',
-    communityFeedback: '使用者反饋',
     roadmap: '路線圖',
     community: '社群',
     about: '關於',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
This pull request updates the "Community Feedback" link in the account dropdown to point to the new Dify forum, and adjusts the label for clarity in both English and Chinese. The most important changes are:

**UI Update:**

* Changed the community feedback link in the account dropdown (`support.tsx`) from the GitHub Discussions page to the new Dify forum, and updated the label from "Feedback" to "Forum".

**Internationalization:**

* Added the new "Forum" label to the English translations in `common.ts`.
* Added the new "论坛" label to the Chinese translations in `common.ts`.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
