### PR TITLE
fix(api): remove 250-character limit for knowledge base retrieval api

### DIFF
--- a/api/controllers/service_api/dataset/hit_testing.py
+++ b/api/controllers/service_api/dataset/hit_testing.py
@@ -25,6 +25,5 @@ class HitTestingApi(DatasetApiResource, DatasetsHitTestingBase):
 
         dataset = self.get_and_validate_dataset(dataset_id_str)
         args = self.parse_args()
-        self.hit_testing_args_check(args)
 
         return self.perform_hit_testing(dataset, args)


### PR DESCRIPTION
Fixes #21156