### PR TITLE
fix(web): fix unit promotion in formatNumberAbbreviated

### DIFF
--- a/web/utils/format.spec.ts
+++ b/web/utils/format.spec.ts
@@ -121,7 +121,7 @@ describe('formatNumberAbbreviated', () => {
     expect(formatNumberAbbreviated(1000000)).toBe('1M')
     expect(formatNumberAbbreviated(1500000)).toBe('1.5M')
     expect(formatNumberAbbreviated(2300000)).toBe('2.3M')
-    expect(formatNumberAbbreviated(999999999)).toBe('1000M')
+    expect(formatNumberAbbreviated(999999999)).toBe('1B')
   })
 
   it('should format billions with B suffix', () => {
@@ -145,7 +145,7 @@ describe('formatNumberAbbreviated', () => {
   it('should handle edge cases', () => {
     expect(formatNumberAbbreviated(950)).toBe('950')
     expect(formatNumberAbbreviated(1001)).toBe('1k')
-    expect(formatNumberAbbreviated(999999)).toBe('1000k')
+    expect(formatNumberAbbreviated(999999)).toBe('1M')
   })
 })
 

--- a/web/utils/format.ts
+++ b/web/utils/format.ts
@@ -83,10 +83,20 @@ export const formatNumberAbbreviated = (num: number) => {
 
   for (let i = 0; i < units.length; i++) {
     if (num >= units[i].value) {
-      const formatted = (num / units[i].value).toFixed(1)
+      const value = num / units[i].value
+      let rounded = Math.round(value * 10) / 10
+      let unitIndex = i
+
+      // If rounded value >= 1000, promote to next unit
+      if (rounded >= 1000 && i > 0) {
+        rounded = rounded / 1000
+        unitIndex = i - 1
+      }
+
+      const formatted = rounded.toFixed(1)
       return formatted.endsWith('.0')
-        ? `${Number.parseInt(formatted)}${units[i].symbol}`
-        : `${formatted}${units[i].symbol}`
+        ? `${Number.parseInt(formatted)}${units[unitIndex].symbol}`
+        : `${formatted}${units[unitIndex].symbol}`
     }
   }
 }


### PR DESCRIPTION


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Perform rounding before unit selection and promote to next unit when rounded value >= 1000. This fixes edge cases like 999999999 -> '1B' instead of '1000M' and 999999 -> '1M' instead of '1000k'.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
