### PR TITLE
Add file type validation to paste upload

### DIFF
--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -305,9 +305,23 @@ export const useFile = (fileConfig: FileUpload) => {
     const text = e.clipboardData?.getData('text/plain')
     if (file && !text) {
       e.preventDefault()
+
+      const allowedFileTypes = fileConfig.allowed_file_types || []
+      const fileType = getSupportFileType(file.name, file.type, allowedFileTypes?.includes(SupportUploadFileTypes.custom))
+      const isFileTypeAllowed = allowedFileTypes.includes(fileType)
+
+      // Check if file type is in allowed list
+      if (!isFileTypeAllowed || !fileConfig.enabled) {
+        notify({
+          type: 'error',
+          message: t('common.fileUploader.fileExtensionNotSupport'),
+        })
+        return
+      }
+
       handleLocalFileUpload(file)
     }
-  }, [handleLocalFileUpload])
+  }, [handleLocalFileUpload, fileConfig, notify, t])
 
   const [isDragActive, setIsDragActive] = useState(false)
   const handleDragFileEnter = useCallback((e: React.DragEvent<HTMLElement>) => {


### PR DESCRIPTION
Added checks to ensure pasted files match allowed types and uploader is enabled before proceeding. Displays an error notification if the file type is not supported.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: Fixes #27200 .
## Summary
I fixed a bug that allowed pasting to succeed even when file uploads were disabled. While the original issue only described the problem with images, I found that pasting other file types was also possible. Therefore, I expanded the fix to cover all file types, not just images.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
