### PR TITLE
minor fix(rag): return early when pushing empty tasks to avoid Redis DataError

### DIFF
--- a/api/core/rag/pipeline/queue.py
+++ b/api/core/rag/pipeline/queue.py
@@ -54,6 +54,9 @@ class TenantIsolatedTaskQueue:
                 serialized_data = wrapper.serialize()
                 serialized_tasks.append(serialized_data)
 
+        if not serialized_tasks:
+            return
+
         redis_client.lpush(self._queue, *serialized_tasks)
 
     def pull_tasks(self, count: int = 1) -> Sequence[Any]:

--- a/api/tests/unit_tests/core/rag/pipeline/test_queue.py
+++ b/api/tests/unit_tests/core/rag/pipeline/test_queue.py
@@ -179,7 +179,7 @@ class TestTenantIsolatedTaskQueue:
         """Test pushing empty task list."""
         sample_queue.push_tasks([])
 
-        mock_redis.lpush.assert_called_once_with("tenant_self_test-key_task_queue:tenant-123")
+        mock_redis.lpush.assert_not_called()
 
     @patch("core.rag.pipeline.queue.redis_client")
     def test_pull_tasks_default_count(self, mock_redis, sample_queue):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

return early when pushing empty tasks to avoid Redis DataError

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
