### PR TITLE
fix: determine cpu cores determination in baseedpyright-check script on macos 

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,7 +1,7 @@
 import sys
 
 
-def is_db_command():
+def is_db_command() -> bool:
     if len(sys.argv) > 1 and sys.argv[0].endswith("flask") and sys.argv[1] == "db":
         return True
     return False

--- a/dev/basedpyright-check
+++ b/dev/basedpyright-check
@@ -8,9 +8,14 @@ cd "$SCRIPT_DIR/.."
 # Get the path argument if provided
 PATH_TO_CHECK="$1"
 
-# run basedpyright checks
-if [ -n "$PATH_TO_CHECK" ]; then
-    uv run --directory api --dev -- basedpyright --threads $(nproc) "$PATH_TO_CHECK"
-else
-    uv run --directory api --dev -- basedpyright --threads $(nproc)
-fi
+# Determine CPU core count based on OS
+CPU_CORES=$(
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    sysctl -n hw.ncpu 2>/dev/null
+  else
+      nproc
+  fi
+)
+
+# Run basedpyright checks
+uv run --directory api --dev -- basedpyright --threads "$CPU_CORES" $PATH_TO_CHECK

--- a/dev/basedpyright-check
+++ b/dev/basedpyright-check
@@ -13,7 +13,7 @@ CPU_CORES=$(
   if [[ "$(uname -s)" == "Darwin" ]]; then
     sysctl -n hw.ncpu 2>/dev/null
   else
-      nproc
+    nproc
   fi
 )
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- to fix #28057

## Screenshots

Before:
```
% dev/basedpyright-check 
+++ realpath dev/basedpyright-check
++ dirname /Users/bw/dev/dify/dev/basedpyright-check
+ SCRIPT_DIR=/Users/bw/dev/dify/dev
+ cd /Users/bw/dev/dify/dev/..
+ PATH_TO_CHECK=
+ '[' -n '' ']'
++ nproc
dev/basedpyright-check: line 15: nproc: command not found
+ uv run --directory api --dev -- basedpyright --threads
0 errors, 0 warnings, 0 notes
```

After:
```
% dev/basedpyright-check 
+++ realpath dev/basedpyright-check
++ dirname /Users/bw/dev/dify/dev/basedpyright-check
+ SCRIPT_DIR=/Users/bw/dev/dify/dev
+ cd /Users/bw/dev/dify/dev/..
+ PATH_TO_CHECK=
+++ uname -s
++ [[ Darwin == \D\a\r\w\i\n ]]
++ sysctl -n hw.ncpu
+ CPU_CORES=16
+ uv run --directory api --dev -- basedpyright --threads 16
0 errors, 0 warnings, 0 notes
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
