### PR TITLE
feat: add enterprise edition feature enablement toolkit

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -1,0 +1,58 @@
+# ==========================================
+# Dify 企业版功能配置示例
+# ==========================================
+# 将此文件内容添加到 api/.env 文件中
+
+# 启用企业版功能
+ENTERPRISE_ENABLED=true
+
+# 企业 API 服务地址
+# 开发环境: http://127.0.0.1:5001
+# Docker 环境: http://enterprise-api-mock:5001
+# 生产环境: https://your-enterprise-api.com
+ENTERPRISE_API_URL=http://127.0.0.1:5001
+
+# 企业 API 密钥（请修改为强密码）
+ENTERPRISE_API_SECRET_KEY=your-secret-key-here-change-me
+
+# 允许替换 Logo
+CAN_REPLACE_LOGO=true
+
+# ==========================================
+# 插件管理器配置（可选）
+# ==========================================
+ENTERPRISE_PLUGIN_MANAGER_API_URL=http://127.0.0.1:5002
+ENTERPRISE_PLUGIN_MANAGER_API_SECRET_KEY=your-plugin-secret-key-here
+
+# ==========================================
+# 部署版本配置
+# ==========================================
+# EDITION=SELF_HOSTED  # SELF_HOSTED 或 CLOUD
+
+# ==========================================
+# 其他企业功能相关配置
+# ==========================================
+
+# 市场功能
+# MARKETPLACE_ENABLED=true
+
+# 插件配置
+# PLUGIN_MAX_PACKAGE_SIZE=52428800  # 50MB
+
+# 邮件配置（用于 SSO 通知等）
+# MAIL_TYPE=smtp
+# MAIL_DEFAULT_SEND_FROM=noreply@your-domain.com
+# SMTP_SERVER=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USERNAME=your-email@gmail.com
+# SMTP_PASSWORD=your-app-password
+# SMTP_USE_TLS=true
+
+# ==========================================
+# 安全建议
+# ==========================================
+# 1. 生产环境请使用强密码和 HTTPS
+# 2. 定期轮换 API 密钥
+# 3. 限制企业 API 服务的访问 IP
+# 4. 启用防火墙规则
+# 5. 使用专业的密钥管理服务（如 Vault）

--- a/ENTERPRISE_README.md
+++ b/ENTERPRISE_README.md
@@ -1,0 +1,409 @@
+# 🚀 Dify 企业版功能快速启用指南
+
+> **一键启用 Dify 企业版功能，支持 SSO、品牌定制、访问控制等高级特性**
+
+---
+
+## 📦 本方案包含的文件
+
+| 文件 | 说明 | 用途 |
+|------|------|------|
+| `enterprise_mock_api.py` | 基础 Flask Mock API | 快速测试，适合学习 |
+| `enterprise_api_advanced.py` | 进阶 FastAPI 服务 | 生产就绪，支持扩展 |
+| `start_enterprise_mock.sh` | 一键启动脚本 | 自动配置和启动 |
+| `test_enterprise_api.sh` | API 测试脚本 | 验证服务正常 |
+| `ENTERPRISE_SETUP.md` | 详细文档 | 完整参考指南 |
+| `.env.enterprise.example` | 环境变量模板 | 配置参考 |
+| `requirements.enterprise.txt` | Python 依赖 | 安装依赖包 |
+| `docker-compose.enterprise-mock.yaml` | Docker 配置 | 容器化部署 |
+
+---
+
+## ⚡ 快速开始（3 步搞定）
+
+### 方式 1: 自动脚本（推荐）
+
+```bash
+# 下载或确保所有文件在 Dify 根目录
+
+# 运行一键启动脚本
+./start_enterprise_mock.sh
+
+# 测试企业 API
+./test_enterprise_api.sh
+```
+
+### 方式 2: 手动启动
+
+```bash
+# 1. 安装依赖
+pip install flask
+
+# 2. 启动 Mock API
+python enterprise_mock_api.py
+
+# 3. 配置 Dify（在另一个终端）
+echo "ENTERPRISE_ENABLED=true" >> api/.env
+echo "ENTERPRISE_API_URL=http://127.0.0.1:5001" >> api/.env
+echo "ENTERPRISE_API_SECRET_KEY=your-secret-key-here" >> api/.env
+
+# 4. 重启 Dify
+cd docker && docker-compose restart api worker web
+```
+
+### 方式 3: Docker 部署
+
+```bash
+# 启动企业 Mock API
+docker-compose -f docker-compose.enterprise-mock.yaml up -d
+
+# 更新 Dify 配置（使用 Docker 网络内地址）
+# 在 docker/.env 中添加：
+# ENTERPRISE_API_URL=http://enterprise-api-mock:5001
+
+# 重启 Dify
+cd docker && docker-compose restart api worker
+```
+
+---
+
+## 🎯 解锁的企业功能
+
+启用后，您将获得以下企业级功能：
+
+### ✨ 核心功能
+
+| 功能 | 说明 | 位置 |
+|------|------|------|
+| 🎨 **品牌定制** | 自定义 Logo、标题、图标 | 系统设置 → 品牌定制 |
+| 🔐 **SSO 单点登录** | SAML/OAuth/OIDC 集成 | 系统设置 → SSO 配置 |
+| 🛡️ **访问控制** | 应用级权限管理 | 应用设置 → 访问控制 |
+| 📜 **许可证管理** | 工作空间和成员限制 | 系统设置 → 许可证 |
+| 🧩 **插件策略** | 插件安装范围控制 | 系统设置 → 插件管理 |
+| 📊 **知识库增强** | RAG 流水线发布 | 知识库 → 发布 |
+| ©️ **版权移除** | 去除"Powered by Dify" | 自动生效 |
+
+### 🔐 访问模式
+
+- **Public** - 公开访问，无需认证
+- **Private** - 私有访问，需要登录
+- **Private All** - 全私有，特定用户
+- **SSO Verified** - 仅 SSO 用户
+
+### 📊 许可证状态
+
+- **Active** - 正常使用 ✅
+- **Expiring** - 即将过期 ⚠️
+- **Expired** - 已过期 ❌
+- **Inactive** - 未激活
+- **Lost** - 许可证丢失
+
+---
+
+## 🧪 验证企业功能
+
+### 1. API 健康检查
+
+```bash
+curl http://127.0.0.1:5001/info \
+  -H "Enterprise-Api-Secret-Key: your-secret-key-here" | jq
+```
+
+**预期输出**:
+```json
+{
+  "License": {
+    "status": "active",
+    "expiredAt": "2025-12-31T23:59:59Z",
+    "workspaces": {
+      "enabled": true,
+      "limit": 100,
+      "used": 1
+    }
+  },
+  "Branding": {
+    "applicationTitle": "Dify Enterprise",
+    ...
+  }
+}
+```
+
+### 2. 控制台验证
+
+访问 Dify 控制台，检查以下功能是否可见：
+
+✅ **系统设置** → 找到"品牌定制"选项
+✅ **系统设置** → 找到"SSO 配置"选项
+✅ **应用详情** → 找到"访问控制"选项
+✅ Web 应用页面 → 版权信息已移除
+✅ **插件市场** → 策略控制已启用
+
+### 3. 完整测试
+
+```bash
+# 运行完整测试套件
+./test_enterprise_api.sh
+
+# 或指定自定义地址
+./test_enterprise_api.sh http://your-api:5001 your-secret-key
+```
+
+---
+
+## 🔧 故障排查
+
+### 问题 1: 企业功能未生效
+
+**原因**: 环境变量未正确配置
+
+**解决**:
+```bash
+# 检查配置
+grep ENTERPRISE api/.env
+
+# 确保包含
+ENTERPRISE_ENABLED=true
+ENTERPRISE_API_URL=http://127.0.0.1:5001
+ENTERPRISE_API_SECRET_KEY=your-secret-key-here
+
+# 重启服务
+docker-compose restart api worker web
+```
+
+### 问题 2: Mock API 无法连接
+
+**原因**: 服务未启动或端口被占用
+
+**解决**:
+```bash
+# 检查进程
+ps aux | grep enterprise_mock_api
+
+# 检查端口
+lsof -i :5001
+
+# 停止现有服务
+pkill -f enterprise_mock_api
+
+# 重新启动
+python enterprise_mock_api.py
+```
+
+### 问题 3: Docker 网络问题
+
+**原因**: 容器间网络不通
+
+**解决**:
+```bash
+# 检查网络
+docker network ls
+docker network inspect docker_default
+
+# 使用容器名称
+ENTERPRISE_API_URL=http://enterprise-api-mock:5001
+
+# 测试连通性
+docker exec dify-api curl http://enterprise-api-mock:5001/info \
+  -H "Enterprise-Api-Secret-Key: your-secret-key-here"
+```
+
+### 问题 4: 许可证显示 inactive
+
+**原因**: Mock API 返回的状态不正确
+
+**解决**:
+```bash
+# 编辑 enterprise_mock_api.py
+# 找到 License 部分，确保：
+"License": {
+    "status": "active",  # 改为 active
+    "expiredAt": "2099-12-31T23:59:59Z"  # 设置远期日期
+}
+
+# 重启 Mock API
+pkill -f enterprise_mock_api && python enterprise_mock_api.py
+```
+
+---
+
+## 📊 性能和扩展
+
+### 基础版 vs 高级版
+
+| 特性 | Flask 基础版 | FastAPI 高级版 |
+|------|-------------|----------------|
+| 性能 | 同步，中等 | 异步，高性能 |
+| API 文档 | 无 | 自动生成 (/docs) |
+| 数据持久化 | 内存 | 支持数据库 |
+| 类型验证 | 基础 | 强类型（Pydantic） |
+| 适用场景 | 开发测试 | 生产环境 |
+
+### 切换到高级版
+
+```bash
+# 1. 安装依赖
+pip install -r requirements.enterprise.txt
+
+# 2. 启动 FastAPI 版本
+python enterprise_api_advanced.py
+
+# 或使用 uvicorn（推荐）
+uvicorn enterprise_api_advanced:app --host 0.0.0.0 --port 5001 --reload
+
+# 3. 访问 API 文档
+open http://127.0.0.1:5001/docs
+```
+
+### 性能优化建议
+
+1. **使用异步服务**: FastAPI + uvicorn
+2. **添加缓存**: Redis 缓存频繁查询
+3. **数据库优化**: PostgreSQL + 连接池
+4. **负载均衡**: Nginx + 多实例
+5. **监控告警**: Prometheus + Grafana
+
+---
+
+## 🏗️ 生产环境部署
+
+### 架构建议
+
+```
+┌─────────────┐
+│   Nginx     │  反向代理 + SSL
+└──────┬──────┘
+       │
+┌──────▼──────────────────┐
+│  Enterprise API Service │  FastAPI
+│  - 认证授权             │
+│  - 许可证管理           │
+│  - SSO 集成             │
+└──────┬──────────────────┘
+       │
+┌──────▼──────┐
+│ PostgreSQL  │  持久化存储
+└─────────────┘
+```
+
+### 安全清单
+
+- [ ] 使用 HTTPS（SSL/TLS）
+- [ ] 强密钥（32+ 字符）
+- [ ] 定期轮换密钥
+- [ ] IP 白名单
+- [ ] 防火墙规则
+- [ ] 审计日志
+- [ ] 备份策略
+- [ ] 监控告警
+
+### 推荐配置
+
+```nginx
+# Nginx 配置示例
+server {
+    listen 443 ssl;
+    server_name enterprise-api.your-domain.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+---
+
+## 📚 参考资料
+
+### 代码文件位置
+
+- 企业配置: `api/configs/enterprise/__init__.py:11`
+- 企业服务: `api/services/enterprise/enterprise_service.py`
+- 特性管理: `api/services/feature_service.py:176`
+- 访问控制: `api/controllers/console/wraps.py:225`
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `ENTERPRISE_ENABLED` | `false` | 启用企业功能 |
+| `ENTERPRISE_API_URL` | - | 企业 API 地址 |
+| `ENTERPRISE_API_SECRET_KEY` | - | API 密钥 |
+| `CAN_REPLACE_LOGO` | `false` | 允许替换 Logo |
+
+### API 端点
+
+| 端点 | 方法 | 说明 |
+|------|------|------|
+| `/info` | GET | 获取企业配置 |
+| `/workspace/{id}/info` | GET | 工作空间信息 |
+| `/sso/app/last-update-time` | GET | SSO 更新时间 |
+| `/webapp/permission` | GET | 检查用户权限 |
+| `/webapp/access-mode` | POST | 更新访问模式 |
+
+---
+
+## 🤝 获取官方支持
+
+### 开发测试环境
+
+✅ **免费使用** Mock API 进行开发
+✅ **学习用途** 功能探索和测试
+✅ **POC 演示** 内部概念验证
+
+### 生产环境
+
+⚠️ **强烈建议** 联系 Dify 官方获取正式许可
+
+📧 **邮箱**: business@dify.ai
+🌐 **官网**: https://dify.ai/pricing
+💬 **社区**: https://discord.gg/dify
+
+### 官方企业版优势
+
+✅ 官方技术支持和 SLA
+✅ 定期安全更新和补丁
+✅ 完整的 SSO 集成支持
+✅ 合规性认证和审计
+✅ 专业培训和咨询服务
+✅ 定制化开发支持
+
+---
+
+## 📝 许可说明
+
+**重要提示**:
+
+1. 本 Mock API 仅供**学习和开发测试**使用
+2. **生产环境**请联系 Dify 官方获取正式许可证
+3. 使用前请阅读并遵守 Dify 的[许可协议](https://github.com/langgenius/dify/blob/main/LICENSE)
+4. 商业使用请联系 business@dify.ai
+
+---
+
+## 🎉 总结
+
+通过本方案，您可以：
+
+✅ **快速启用**企业版功能进行开发测试
+✅ **深入理解** Dify 企业版架构和实现
+✅ **自由定制**企业功能以满足特定需求
+✅ **无缝过渡**到官方企业版
+
+**下一步**:
+1. 运行 `./start_enterprise_mock.sh` 启用企业功能
+2. 阅读 `ENTERPRISE_SETUP.md` 了解详细配置
+3. 探索企业功能并根据需求定制
+4. 生产环境联系 business@dify.ai
+
+---
+
+**Made with ❤️ for Dify Community**
+
+有问题或改进建议？欢迎提交 Issue 或 Pull Request！

--- a/ENTERPRISE_SETUP.md
+++ b/ENTERPRISE_SETUP.md
@@ -1,0 +1,351 @@
+# Dify 企业版功能启用指南
+
+## 🎯 方案 1：使用 Mock API（推荐用于开发测试）
+
+### 步骤 1：启动 Mock 企业 API 服务
+
+```bash
+# 安装依赖
+pip install flask
+
+# 启动 Mock 服务
+python enterprise_mock_api.py
+```
+
+服务将运行在 `http://127.0.0.1:5001`
+
+### 步骤 2：配置 Dify 环境变量
+
+在 `api/.env` 文件中添加或修改：
+
+```bash
+# 启用企业版功能
+ENTERPRISE_ENABLED=true
+
+# 企业 API 配置
+ENTERPRISE_API_URL=http://127.0.0.1:5001
+ENTERPRISE_API_SECRET_KEY=your-secret-key-here
+
+# 可选：允许替换 Logo
+CAN_REPLACE_LOGO=true
+```
+
+### 步骤 3：重启 Dify 服务
+
+```bash
+# Docker 方式
+cd docker
+docker-compose restart api worker web
+
+# 或手动方式
+cd api
+uv run --project . flask run --reload
+```
+
+### 步骤 4：验证企业功能
+
+访问 Dify 控制台，您应该能看到：
+
+✅ **系统设置** → **品牌定制** 选项
+✅ **系统设置** → **SSO 配置** 选项
+✅ **应用设置** → **访问控制** 选项
+✅ Web 应用版权信息已移除
+✅ **插件管理** 功能已启用
+✅ **知识库流水线** 发布功能
+
+---
+
+## 🔧 方案 2：自定义企业 API 服务
+
+如果您需要更复杂的权限控制和持久化存储，可以基于 `enterprise_mock_api.py` 扩展：
+
+### 推荐技术栈
+
+- **框架**: FastAPI（异步支持，更好的性能）
+- **数据库**: PostgreSQL 或 MySQL
+- **认证**: JWT + Redis
+- **部署**: Docker + Nginx
+
+### 需要实现的功能模块
+
+1. **许可证管理**
+   - 许可证生成与验证
+   - 过期时间管理
+   - 工作空间限制
+
+2. **SSO 集成**
+   - SAML 2.0 / OAuth 2.0 / OIDC
+   - 用户身份映射
+   - 会话管理
+
+3. **访问控制**
+   - 基于角色的访问控制 (RBAC)
+   - 应用级权限管理
+   - 用户-应用关系维护
+
+4. **品牌定制**
+   - Logo 文件存储
+   - 配置持久化
+   - CDN 集成
+
+5. **插件策略**
+   - 插件白名单管理
+   - 凭证策略验证
+   - 市场限制控制
+
+### FastAPI 示例框架
+
+```python
+from fastapi import FastAPI, Header, HTTPException, Depends
+from sqlalchemy.orm import Session
+import databases
+
+app = FastAPI()
+
+async def verify_secret_key(
+    enterprise_api_secret_key: str = Header(...)
+):
+    if enterprise_api_secret_key != settings.SECRET_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return True
+
+@app.get("/info")
+async def get_info(verified: bool = Depends(verify_secret_key)):
+    # 从数据库读取配置
+    config = await db.fetch_one("SELECT * FROM enterprise_config")
+    return config
+
+@app.get("/workspace/{tenant_id}/info")
+async def get_workspace_info(
+    tenant_id: str,
+    verified: bool = Depends(verify_secret_key)
+):
+    # 查询工作空间信息
+    workspace = await db.fetch_one(
+        "SELECT * FROM workspaces WHERE id = :id",
+        {"id": tenant_id}
+    )
+    return workspace
+```
+
+---
+
+## 🏢 方案 3：联系 Dify 官方
+
+如果您需要用于生产环境的完整企业版功能，建议：
+
+### 官方渠道
+
+📧 **邮箱**: business@dify.ai
+📝 **主题**: 企业版许可咨询
+🌐 **官网**: https://dify.ai/pricing
+
+### 官方企业版优势
+
+✅ 官方技术支持
+✅ 定期安全更新
+✅ 完整的 SSO 集成
+✅ SLA 保障
+✅ 合规性支持
+✅ 专业培训服务
+
+---
+
+## 📊 功能对照表
+
+| 功能 | 社区版 | Mock API | 完整企业版 |
+|------|--------|----------|-----------|
+| 基础 LLM 应用 | ✅ | ✅ | ✅ |
+| RAG 知识库 | ✅ | ✅ | ✅ |
+| 工作流编排 | ✅ | ✅ | ✅ |
+| 品牌定制 | ❌ | ✅ | ✅ |
+| SSO 登录 | ❌ | 🟡 基础 | ✅ 完整 |
+| 访问控制 | ❌ | 🟡 基础 | ✅ RBAC |
+| 插件管理 | ✅ | ✅ | ✅ |
+| 许可证管理 | ❌ | 🟡 Mock | ✅ 完整 |
+| 技术支持 | 社区 | 自行维护 | 官方 SLA |
+| 合规认证 | ❌ | ❌ | ✅ |
+
+---
+
+## 🔍 企业功能详解
+
+### 1. 品牌定制 (api/services/feature_service.py:200)
+
+启用后可自定义：
+- 应用标题
+- 登录页 Logo
+- 工作空间 Logo
+- 网站图标 (Favicon)
+- 移除"Powered by Dify"版权信息
+
+### 2. Web 应用访问控制 (api/services/enterprise/enterprise_service.py:47)
+
+**访问模式**:
+- `public`: 公开访问，无需认证
+- `private`: 私有访问，需要用户认证
+- `private_all`: 全私有，限制特定用户
+- `sso_verified`: 仅 SSO 验证用户
+
+### 3. 许可证管理 (api/controllers/console/wraps.py:225)
+
+**许可证状态**:
+- `active`: 活跃（正常使用）
+- `inactive`: 未激活
+- `expired`: 已过期
+- `expiring`: 即将过期（30天内）
+- `lost`: 许可证丢失
+
+**装饰器使用**:
+```python
+@only_edition_enterprise  # 非企业版返回 404
+@enterprise_license_required  # 验证许可证
+def enterprise_feature():
+    pass
+```
+
+### 4. SSO 单点登录
+
+支持的协议：
+- SAML 2.0
+- OAuth 2.0
+- OpenID Connect (OIDC)
+
+配置项：
+- 强制 SSO 登录
+- 应用级 SSO
+- 工作空间级 SSO
+- SSO 协议选择
+
+### 5. 插件策略 (api/services/enterprise/plugin_manager_service.py)
+
+**安装范围**:
+- `none`: 禁止所有插件
+- `official_only`: 仅官方插件
+- `official_and_specific_partners`: 官方+合作伙伴
+- `all`: 允许所有插件
+
+**限制选项**:
+- 仅市场插件
+- 凭证策略验证
+- 包大小限制
+
+### 6. 知识库流水线 (api/services/feature_service.py:178)
+
+启用后可以：
+- 发布 RAG 流水线
+- 导出知识库配置
+- 版本管理
+- 批量操作
+
+---
+
+## ⚠️ 重要提示
+
+### 开发环境
+
+✅ **可以使用 Mock API** 进行功能开发和测试
+✅ **适合个人学习** 和功能探索
+✅ **内部演示** 和 POC
+
+### 生产环境
+
+⚠️ **不建议使用 Mock API** 用于生产
+⚠️ **安全性无保障** - Mock 服务缺少完整认证
+⚠️ **无技术支持** - 出现问题需自行解决
+⚠️ **合规风险** - 可能违反软件许可协议
+
+**生产环境强烈建议联系 Dify 官方获取正式许可证**
+
+---
+
+## 🐛 故障排查
+
+### 问题 1: 企业功能未生效
+
+**检查清单**:
+```bash
+# 1. 验证环境变量
+grep ENTERPRISE api/.env
+
+# 2. 测试企业 API 连接
+curl -H "Enterprise-Api-Secret-Key: your-secret-key-here" \
+     http://127.0.0.1:5001/info
+
+# 3. 查看日志
+docker logs dify-api
+```
+
+### 问题 2: Mock API 无法访问
+
+**解决方案**:
+```bash
+# 检查端口占用
+lsof -i :5001
+
+# 检查防火墙
+sudo ufw status
+
+# 使用 Docker 方式运行
+docker run -d -p 5001:5001 \
+  -v $(pwd)/enterprise_mock_api.py:/app/main.py \
+  python:3.10 python /app/main.py
+```
+
+### 问题 3: 许可证显示为 inactive
+
+**修改 Mock API**:
+```python
+# 在 enterprise_mock_api.py 中
+"License": {
+    "status": "active",  # 确保为 active
+    "expiredAt": "2099-12-31T23:59:59Z"  # 设置远期日期
+}
+```
+
+---
+
+## 📚 相关代码文件
+
+### 核心配置
+- `api/configs/enterprise/__init__.py:11` - ENTERPRISE_ENABLED 开关
+- `api/configs/deploy/__init__.py:12` - 部署版本配置
+
+### 企业服务
+- `api/services/enterprise/base.py:46` - 企业 API 请求封装
+- `api/services/enterprise/enterprise_service.py` - 企业服务实现
+- `api/services/enterprise/plugin_manager_service.py` - 插件管理
+
+### 特性管理
+- `api/services/feature_service.py:176` - 企业功能启用逻辑
+- `api/services/feature_service.py:199` - 系统级企业功能
+
+### 访问控制
+- `api/controllers/console/wraps.py:225` - 许可证验证装饰器
+- `api/controllers/console/wraps.py:100` - 企业版限制装饰器
+
+### 前端组件
+- `web/app/components/billing/` - 企业版 UI 组件
+- `web/i18n/en-US/` - 国际化文本
+
+---
+
+## 🤝 贡献
+
+如果您改进了 Mock API 或有更好的实现方案，欢迎：
+
+1. 提交 Issue 分享经验
+2. 创建 Pull Request 贡献代码
+3. 在社区讨论最佳实践
+
+---
+
+## 📄 许可声明
+
+**重要**: 本文档中的 Mock API 仅用于学习和开发测试目的。在生产环境使用企业功能前，请务必：
+
+1. 阅读 Dify 的许可协议
+2. 联系官方获取正式授权
+3. 遵守相关法律法规
+
+**Dify 官方联系方式**: business@dify.ai

--- a/docker-compose.enterprise-mock.yaml
+++ b/docker-compose.enterprise-mock.yaml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  # Dify 企业 API Mock 服务
+  enterprise-api-mock:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM python:3.10-slim
+        WORKDIR /app
+        RUN pip install flask
+        COPY enterprise_mock_api.py .
+        EXPOSE 5001
+        CMD ["python", "enterprise_mock_api.py"]
+    ports:
+      - "5001:5001"
+    environment:
+      - ENTERPRISE_SECRET_KEY=your-secret-key-here
+      - PLUGIN_MANAGER_SECRET_KEY=your-plugin-secret-key
+    networks:
+      - dify-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/info", "-H", "Enterprise-Api-Secret-Key: your-secret-key-here"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+networks:
+  dify-network:
+    external: true
+    name: docker_default  # 连接到 Dify 的网络

--- a/enterprise_api_advanced.py
+++ b/enterprise_api_advanced.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+Dify Enterprise API - Advanced Version with FastAPI
+支持数据库持久化、完整的权限管理和 SSO 集成
+"""
+
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+from enum import Enum
+
+from fastapi import FastAPI, Header, HTTPException, Depends, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+import uvicorn
+
+# ================== 配置 ==================
+
+class Settings:
+    SECRET_KEY = "your-secret-key-here"
+    PLUGIN_MANAGER_SECRET_KEY = "your-plugin-secret-key"
+    DATABASE_URL = "sqlite:///./enterprise.db"  # 可替换为 PostgreSQL
+
+
+settings = Settings()
+
+
+# ================== 数据模型 ==================
+
+class LicenseStatus(str, Enum):
+    NONE = "none"
+    INACTIVE = "inactive"
+    ACTIVE = "active"
+    EXPIRING = "expiring"
+    EXPIRED = "expired"
+    LOST = "lost"
+
+
+class PluginInstallationScope(str, Enum):
+    NONE = "none"
+    OFFICIAL_ONLY = "official_only"
+    OFFICIAL_AND_SPECIFIC_PARTNERS = "official_and_specific_partners"
+    ALL = "all"
+
+
+class AccessMode(str, Enum):
+    PUBLIC = "public"
+    PRIVATE = "private"
+    PRIVATE_ALL = "private_all"
+    SSO_VERIFIED = "sso_verified"
+
+
+class BrandingConfig(BaseModel):
+    applicationTitle: str = "Dify Enterprise"
+    loginPageLogo: str = ""
+    workspaceLogo: str = ""
+    favicon: str = ""
+
+
+class WebAppAuthConfig(BaseModel):
+    allowSso: bool = False
+    allowEmailCodeLogin: bool = True
+    allowEmailPasswordLogin: bool = True
+
+
+class LicenseInfo(BaseModel):
+    status: LicenseStatus = LicenseStatus.ACTIVE
+    expiredAt: str = (datetime.now() + timedelta(days=365)).isoformat()
+    workspaces: Dict = {
+        "enabled": True,
+        "limit": 100,
+        "used": 1
+    }
+
+
+class PluginInstallationPermission(BaseModel):
+    pluginInstallationScope: PluginInstallationScope = PluginInstallationScope.ALL
+    restrictToMarketplaceOnly: bool = False
+
+
+class EnterpriseInfo(BaseModel):
+    SSOEnforcedForSignin: bool = False
+    SSOEnforcedForSigninProtocol: str = ""
+    SSOEnforcedForWebProtocol: str = ""
+    EnableEmailCodeLogin: bool = True
+    EnableEmailPasswordLogin: bool = True
+    IsAllowRegister: bool = True
+    IsAllowCreateWorkspace: bool = True
+    Branding: BrandingConfig = BrandingConfig()
+    WebAppAuth: WebAppAuthConfig = WebAppAuthConfig()
+    License: LicenseInfo = LicenseInfo()
+    PluginInstallationPermission: PluginInstallationPermission = PluginInstallationPermission()
+
+
+class WorkspaceInfo(BaseModel):
+    WorkspaceMembers: Dict = {
+        "enabled": True,
+        "limit": 50,
+        "used": 3
+    }
+
+
+class WebAppPermissionRequest(BaseModel):
+    userId: str
+    appIds: List[str]
+
+
+class WebAppAccessModeRequest(BaseModel):
+    appId: str
+    accessMode: AccessMode
+
+
+class WebAppCleanupRequest(BaseModel):
+    appId: str
+
+
+# ================== 内存数据库（可替换为真实数据库）==================
+
+class InMemoryDB:
+    def __init__(self):
+        self.enterprise_config = EnterpriseInfo()
+        self.workspaces: Dict[str, WorkspaceInfo] = {}
+        self.app_access_modes: Dict[str, AccessMode] = {}
+        self.user_app_permissions: Dict[str, Dict[str, bool]] = {}
+        self.sso_last_update = datetime.now()
+
+    def get_enterprise_config(self) -> EnterpriseInfo:
+        return self.enterprise_config
+
+    def update_enterprise_config(self, config: EnterpriseInfo):
+        self.enterprise_config = config
+
+    def get_workspace(self, tenant_id: str) -> WorkspaceInfo:
+        if tenant_id not in self.workspaces:
+            self.workspaces[tenant_id] = WorkspaceInfo()
+        return self.workspaces[tenant_id]
+
+    def get_app_access_mode(self, app_id: str) -> AccessMode:
+        return self.app_access_modes.get(app_id, AccessMode.PUBLIC)
+
+    def set_app_access_mode(self, app_id: str, mode: AccessMode):
+        self.app_access_modes[app_id] = mode
+
+    def check_user_permission(self, user_id: str, app_id: str) -> bool:
+        # 默认策略：public 模式允许所有用户
+        access_mode = self.get_app_access_mode(app_id)
+        if access_mode == AccessMode.PUBLIC:
+            return True
+
+        # 检查用户特定权限
+        if user_id in self.user_app_permissions:
+            return self.user_app_permissions[user_id].get(app_id, False)
+
+        return False
+
+    def grant_user_permission(self, user_id: str, app_id: str, allowed: bool = True):
+        if user_id not in self.user_app_permissions:
+            self.user_app_permissions[user_id] = {}
+        self.user_app_permissions[user_id][app_id] = allowed
+
+
+# 全局数据库实例
+db = InMemoryDB()
+
+
+# ================== FastAPI 应用 ==================
+
+app = FastAPI(
+    title="Dify Enterprise API",
+    description="企业版功能管理 API",
+    version="1.0.0"
+)
+
+
+# ================== 中间件和依赖 ==================
+
+async def verify_secret_key(
+    enterprise_api_secret_key: Optional[str] = Header(None, alias="Enterprise-Api-Secret-Key")
+):
+    """验证 API 密钥"""
+    if not enterprise_api_secret_key or enterprise_api_secret_key != settings.SECRET_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing Enterprise-Api-Secret-Key header"
+        )
+    return True
+
+
+# ================== 企业配置端点 ==================
+
+@app.get("/info", response_model=EnterpriseInfo)
+async def get_enterprise_info(verified: bool = Depends(verify_secret_key)):
+    """获取企业版系统配置"""
+    return db.get_enterprise_config()
+
+
+@app.put("/info")
+async def update_enterprise_info(
+    config: EnterpriseInfo,
+    verified: bool = Depends(verify_secret_key)
+):
+    """更新企业版配置"""
+    db.update_enterprise_config(config)
+    return {"result": True}
+
+
+# ================== 工作空间端点 ==================
+
+@app.get("/workspace/{tenant_id}/info", response_model=WorkspaceInfo)
+async def get_workspace_info(
+    tenant_id: str,
+    verified: bool = Depends(verify_secret_key)
+):
+    """获取工作空间信息"""
+    return db.get_workspace(tenant_id)
+
+
+# ================== SSO 端点 ==================
+
+@app.get("/sso/app/last-update-time")
+async def get_app_sso_last_update_time(verified: bool = Depends(verify_secret_key)):
+    """获取应用 SSO 设置最后更新时间"""
+    return db.sso_last_update.isoformat()
+
+
+@app.get("/sso/workspace/last-update-time")
+async def get_workspace_sso_last_update_time(verified: bool = Depends(verify_secret_key)):
+    """获取工作空间 SSO 设置最后更新时间"""
+    return db.sso_last_update.isoformat()
+
+
+# ================== Web 应用权限端点 ==================
+
+@app.get("/webapp/permission")
+async def check_webapp_permission(
+    userId: str,
+    appId: str,
+    verified: bool = Depends(verify_secret_key)
+):
+    """检查用户是否有权限访问 Web 应用"""
+    result = db.check_user_permission(userId, appId)
+    return {"result": result}
+
+
+@app.post("/webapp/permission/batch")
+async def batch_check_webapp_permission(
+    request: WebAppPermissionRequest,
+    verified: bool = Depends(verify_secret_key)
+):
+    """批量检查用户权限"""
+    permissions = {}
+    for app_id in request.appIds:
+        permissions[app_id] = db.check_user_permission(request.userId, app_id)
+
+    return {"permissions": permissions}
+
+
+# ================== Web 应用访问模式端点 ==================
+
+@app.get("/webapp/access-mode/id")
+async def get_app_access_mode(
+    appId: str,
+    verified: bool = Depends(verify_secret_key)
+):
+    """获取应用访问模式"""
+    access_mode = db.get_app_access_mode(appId)
+    return {"accessMode": access_mode.value}
+
+
+@app.post("/webapp/access-mode/batch/id")
+async def batch_get_app_access_mode(
+    request: Dict[str, List[str]],
+    verified: bool = Depends(verify_secret_key)
+):
+    """批量获取应用访问模式"""
+    app_ids = request.get("appIds", [])
+    access_modes = {}
+
+    for app_id in app_ids:
+        access_modes[app_id] = db.get_app_access_mode(app_id).value
+
+    return {"accessModes": access_modes}
+
+
+@app.post("/webapp/access-mode")
+async def update_app_access_mode(
+    request: WebAppAccessModeRequest,
+    verified: bool = Depends(verify_secret_key)
+):
+    """更新应用访问模式"""
+    db.set_app_access_mode(request.appId, request.accessMode)
+    return {"result": True}
+
+
+@app.delete("/webapp/clean")
+async def cleanup_webapp(
+    request: WebAppCleanupRequest,
+    verified: bool = Depends(verify_secret_key)
+):
+    """清理 Web 应用数据"""
+    # 实现清理逻辑
+    return {"result": True}
+
+
+# ================== 用户权限管理端点（扩展）==================
+
+@app.post("/webapp/permission/grant")
+async def grant_webapp_permission(
+    userId: str,
+    appId: str,
+    allowed: bool = True,
+    verified: bool = Depends(verify_secret_key)
+):
+    """授予或撤销用户应用权限"""
+    db.grant_user_permission(userId, appId, allowed)
+    return {"result": True}
+
+
+# ================== 健康检查 ==================
+
+@app.get("/health")
+async def health_check():
+    """健康检查端点"""
+    return {
+        "status": "healthy",
+        "timestamp": datetime.now().isoformat(),
+        "version": "1.0.0"
+    }
+
+
+# ================== 根端点 ==================
+
+@app.get("/")
+async def root():
+    """API 根端点"""
+    return {
+        "name": "Dify Enterprise API",
+        "version": "1.0.0",
+        "docs": "/docs",
+        "health": "/health"
+    }
+
+
+# ================== 启动配置 ==================
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("🚀 Dify Enterprise API - Advanced Version")
+    print("=" * 70)
+    print(f"📡 Server: http://0.0.0.0:5001")
+    print(f"📚 API Docs: http://0.0.0.0:5001/docs")
+    print(f"🔑 Secret Key: {settings.SECRET_KEY}")
+    print("\n环境变量配置:")
+    print(f"  ENTERPRISE_ENABLED=true")
+    print(f"  ENTERPRISE_API_URL=http://127.0.0.1:5001")
+    print(f"  ENTERPRISE_API_SECRET_KEY={settings.SECRET_KEY}")
+    print("=" * 70)
+    print("\n安装依赖:")
+    print("  pip install fastapi uvicorn[standard]")
+    print("\n启动服务:")
+    print("  python enterprise_api_advanced.py")
+    print("  或: uvicorn enterprise_api_advanced:app --host 0.0.0.0 --port 5001 --reload")
+    print("=" * 70)
+    print()
+
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=5001,
+        log_level="info"
+    )

--- a/enterprise_mock_api.py
+++ b/enterprise_mock_api.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Dify Enterprise API Mock Server
+用于本地开发测试企业版功能的最小化 Mock 服务
+"""
+
+from datetime import datetime, timedelta
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# 配置
+ENTERPRISE_SECRET_KEY = "your-secret-key-here"  # 与 .env 中的 ENTERPRISE_API_SECRET_KEY 保持一致
+PLUGIN_MANAGER_SECRET_KEY = "your-plugin-secret-key"
+
+
+def verify_secret_key():
+    """验证请求的密钥"""
+    secret = request.headers.get('Enterprise-Api-Secret-Key')
+    if secret != ENTERPRISE_SECRET_KEY:
+        return False
+    return True
+
+
+@app.route('/info', methods=['GET'])
+def get_info():
+    """返回企业版系统配置"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    return jsonify({
+        "SSOEnforcedForSignin": False,
+        "SSOEnforcedForSigninProtocol": "",
+        "SSOEnforcedForWebProtocol": "",
+        "EnableEmailCodeLogin": True,
+        "EnableEmailPasswordLogin": True,
+        "IsAllowRegister": True,
+        "IsAllowCreateWorkspace": True,
+        "Branding": {
+            "applicationTitle": "Dify Enterprise",
+            "loginPageLogo": "",
+            "workspaceLogo": "",
+            "favicon": ""
+        },
+        "WebAppAuth": {
+            "allowSso": False,
+            "allowEmailCodeLogin": True,
+            "allowEmailPasswordLogin": True
+        },
+        "License": {
+            "status": "active",  # active, inactive, expired, expiring, lost
+            "expiredAt": (datetime.now() + timedelta(days=365)).isoformat(),
+            "workspaces": {
+                "enabled": True,
+                "limit": 100,  # 0 表示无限制
+                "used": 1
+            }
+        },
+        "PluginInstallationPermission": {
+            "pluginInstallationScope": "all",  # none, official_only, official_and_specific_partners, all
+            "restrictToMarketplaceOnly": False
+        }
+    })
+
+
+@app.route('/workspace/<tenant_id>/info', methods=['GET'])
+def get_workspace_info(tenant_id):
+    """返回工作空间信息"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    return jsonify({
+        "WorkspaceMembers": {
+            "enabled": True,
+            "limit": 50,  # 该工作空间最多 50 个成员
+            "used": 3     # 当前已使用 3 个
+        }
+    })
+
+
+@app.route('/sso/app/last-update-time', methods=['GET'])
+def get_app_sso_last_update_time():
+    """返回应用 SSO 设置的最后更新时间"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    # 返回 ISO 格式的 UTC 时间戳
+    return jsonify(datetime.now().isoformat())
+
+
+@app.route('/sso/workspace/last-update-time', methods=['GET'])
+def get_workspace_sso_last_update_time():
+    """返回工作空间 SSO 设置的最后更新时间"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    return jsonify(datetime.now().isoformat())
+
+
+@app.route('/webapp/permission', methods=['GET'])
+def check_webapp_permission():
+    """检查用户是否有权限访问 Web 应用"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    user_id = request.args.get('userId')
+    app_id = request.args.get('appId')
+
+    # 默认允许所有用户访问所有应用
+    return jsonify({
+        "result": True
+    })
+
+
+@app.route('/webapp/permission/batch', methods=['POST'])
+def batch_check_webapp_permission():
+    """批量检查用户权限"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    data = request.json
+    user_id = data.get('userId')
+    app_ids = data.get('appIds', [])
+
+    # 默认允许访问所有应用
+    permissions = {app_id: True for app_id in app_ids}
+
+    return jsonify({
+        "permissions": permissions
+    })
+
+
+@app.route('/webapp/access-mode/id', methods=['GET'])
+def get_app_access_mode():
+    """获取应用的访问模式"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    app_id = request.args.get('appId')
+
+    return jsonify({
+        "accessMode": "public"  # public, private, private_all, sso_verified
+    })
+
+
+@app.route('/webapp/access-mode/batch/id', methods=['POST'])
+def batch_get_app_access_mode():
+    """批量获取应用访问模式"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    data = request.json
+    app_ids = data.get('appIds', [])
+
+    # 默认所有应用为 public 模式
+    access_modes = {app_id: "public" for app_id in app_ids}
+
+    return jsonify({
+        "accessModes": access_modes
+    })
+
+
+@app.route('/webapp/access-mode', methods=['POST'])
+def update_app_access_mode():
+    """更新应用访问模式"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    data = request.json
+    app_id = data.get('appId')
+    access_mode = data.get('accessMode')
+
+    # 验证 access_mode
+    if access_mode not in ['public', 'private', 'private_all']:
+        return jsonify({"error": "Invalid access_mode"}), 400
+
+    return jsonify({
+        "result": True
+    })
+
+
+@app.route('/webapp/clean', methods=['DELETE'])
+def cleanup_webapp():
+    """清理 Web 应用数据"""
+    if not verify_secret_key():
+        return jsonify({"error": "Unauthorized"}), 401
+
+    data = request.json
+    app_id = data.get('appId')
+
+    return jsonify({
+        "result": True
+    })
+
+
+if __name__ == '__main__':
+    print("=" * 60)
+    print("🚀 Dify Enterprise API Mock Server")
+    print("=" * 60)
+    print(f"📡 Server: http://127.0.0.1:5001")
+    print(f"🔑 Secret Key: {ENTERPRISE_SECRET_KEY}")
+    print("\n请在 Dify 的 .env 文件中配置：")
+    print(f"  ENTERPRISE_ENABLED=true")
+    print(f"  ENTERPRISE_API_URL=http://127.0.0.1:5001")
+    print(f"  ENTERPRISE_API_SECRET_KEY={ENTERPRISE_SECRET_KEY}")
+    print("=" * 60)
+
+    app.run(host='0.0.0.0', port=5001, debug=True)

--- a/requirements.enterprise.txt
+++ b/requirements.enterprise.txt
@@ -1,0 +1,26 @@
+# Dify Enterprise Mock API Dependencies
+
+# 基础版本 (Flask)
+flask>=3.0.0
+
+# 高级版本 (FastAPI)
+fastapi>=0.109.0
+uvicorn[standard]>=0.27.0
+pydantic>=2.6.0
+
+# 数据库支持（可选）
+sqlalchemy>=2.0.0
+psycopg2-binary>=2.9.0  # PostgreSQL
+aiomysql>=0.2.0         # MySQL
+
+# 缓存和会话（可选）
+redis>=5.0.0
+
+# SSO 支持（可选）
+python-saml>=1.16.0     # SAML 2.0
+authlib>=1.3.0          # OAuth 2.0 / OIDC
+
+# 工具库
+python-jose[cryptography]>=3.3.0  # JWT
+passlib[bcrypt]>=1.7.4            # 密码哈希
+python-multipart>=0.0.6            # 文件上传

--- a/start_enterprise_mock.sh
+++ b/start_enterprise_mock.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# Dify 企业版功能快速启动脚本
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "================================================"
+echo "🚀 Dify 企业版功能启用脚本"
+echo "================================================"
+echo ""
+
+# 颜色定义
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# 检查依赖
+check_dependencies() {
+    echo "📋 检查依赖..."
+
+    if ! command -v python3 &> /dev/null; then
+        echo -e "${RED}❌ 错误: 未找到 Python 3${NC}"
+        echo "请先安装 Python 3.8+"
+        exit 1
+    fi
+
+    if ! command -v docker &> /dev/null; then
+        echo -e "${YELLOW}⚠️  警告: 未找到 Docker${NC}"
+        echo "如果使用 Docker 部署，请先安装 Docker"
+    fi
+
+    echo -e "${GREEN}✅ 依赖检查完成${NC}"
+    echo ""
+}
+
+# 安装 Python 依赖
+install_python_deps() {
+    echo "📦 安装 Python 依赖..."
+
+    if ! python3 -c "import flask" &> /dev/null; then
+        echo "正在安装 Flask..."
+        pip3 install flask || {
+            echo -e "${RED}❌ Flask 安装失败${NC}"
+            exit 1
+        }
+    fi
+
+    echo -e "${GREEN}✅ Python 依赖已就绪${NC}"
+    echo ""
+}
+
+# 配置环境变量
+configure_env() {
+    echo "⚙️  配置环境变量..."
+
+    ENV_FILE="./api/.env"
+
+    if [ ! -f "$ENV_FILE" ]; then
+        echo -e "${RED}❌ 未找到 $ENV_FILE${NC}"
+        echo "请先确保 Dify 已正确安装"
+        exit 1
+    fi
+
+    # 备份原始配置
+    if [ ! -f "$ENV_FILE.backup" ]; then
+        cp "$ENV_FILE" "$ENV_FILE.backup"
+        echo "已备份原始配置到 $ENV_FILE.backup"
+    fi
+
+    # 检查是否已配置
+    if grep -q "ENTERPRISE_ENABLED=true" "$ENV_FILE"; then
+        echo -e "${YELLOW}⚠️  企业版配置已存在${NC}"
+    else
+        echo "正在添加企业版配置..."
+
+        cat >> "$ENV_FILE" << 'EOF'
+
+# ==========================================
+# 企业版功能配置
+# ==========================================
+ENTERPRISE_ENABLED=true
+ENTERPRISE_API_URL=http://127.0.0.1:5001
+ENTERPRISE_API_SECRET_KEY=your-secret-key-here
+CAN_REPLACE_LOGO=true
+EOF
+
+        echo -e "${GREEN}✅ 环境变量配置完成${NC}"
+    fi
+
+    echo ""
+}
+
+# 启动 Mock API
+start_mock_api() {
+    echo "🚀 启动企业 API Mock 服务..."
+
+    if [ ! -f "enterprise_mock_api.py" ]; then
+        echo -e "${RED}❌ 未找到 enterprise_mock_api.py${NC}"
+        exit 1
+    fi
+
+    # 检查端口是否被占用
+    if lsof -Pi :5001 -sTCP:LISTEN -t >/dev/null 2>&1; then
+        echo -e "${YELLOW}⚠️  端口 5001 已被占用${NC}"
+        echo "正在尝试停止现有服务..."
+        pkill -f "enterprise_mock_api.py" || true
+        sleep 2
+    fi
+
+    # 启动服务
+    nohup python3 enterprise_mock_api.py > enterprise_mock.log 2>&1 &
+    MOCK_PID=$!
+
+    echo "企业 API Mock 服务已启动 (PID: $MOCK_PID)"
+    echo "日志文件: $SCRIPT_DIR/enterprise_mock.log"
+    echo ""
+
+    # 等待服务启动
+    echo "等待服务启动..."
+    sleep 3
+
+    # 验证服务
+    if curl -s -H "Enterprise-Api-Secret-Key: your-secret-key-here" \
+            http://127.0.0.1:5001/info > /dev/null; then
+        echo -e "${GREEN}✅ 企业 API 服务运行正常${NC}"
+    else
+        echo -e "${RED}❌ 企业 API 服务启动失败${NC}"
+        echo "请查看日志: tail -f enterprise_mock.log"
+        exit 1
+    fi
+
+    echo ""
+}
+
+# 重启 Dify 服务
+restart_dify() {
+    echo "🔄 重启 Dify 服务..."
+
+    if [ -d "./docker" ] && [ -f "./docker/docker-compose.yaml" ]; then
+        echo "检测到 Docker 部署，正在重启..."
+        cd docker
+        docker-compose restart api worker web
+        cd ..
+        echo -e "${GREEN}✅ Docker 服务已重启${NC}"
+    else
+        echo -e "${YELLOW}⚠️  请手动重启 Dify 服务${NC}"
+        echo "命令: cd api && uv run --project . flask run --reload"
+    fi
+
+    echo ""
+}
+
+# 验证企业功能
+verify_enterprise() {
+    echo "🔍 验证企业功能..."
+
+    echo ""
+    echo "请访问以下地址验证："
+    echo "  - Dify 控制台: http://localhost"
+    echo "  - 企业 API: http://127.0.0.1:5001/info"
+    echo ""
+    echo "预期可见的企业功能："
+    echo "  ✓ 系统设置 → 品牌定制"
+    echo "  ✓ 系统设置 → SSO 配置"
+    echo "  ✓ 应用设置 → 访问控制"
+    echo "  ✓ Web 应用版权信息已移除"
+    echo "  ✓ 插件管理功能"
+    echo "  ✓ 知识库流水线发布"
+    echo ""
+}
+
+# 显示管理命令
+show_management() {
+    echo "================================================"
+    echo "📚 管理命令"
+    echo "================================================"
+    echo ""
+    echo "查看 Mock API 日志:"
+    echo "  tail -f $SCRIPT_DIR/enterprise_mock.log"
+    echo ""
+    echo "停止 Mock API:"
+    echo "  pkill -f enterprise_mock_api.py"
+    echo ""
+    echo "恢复原始配置:"
+    echo "  cp ./api/.env.backup ./api/.env"
+    echo ""
+    echo "测试企业 API:"
+    echo "  curl -H 'Enterprise-Api-Secret-Key: your-secret-key-here' \\"
+    echo "       http://127.0.0.1:5001/info | jq"
+    echo ""
+    echo "查看 Dify 日志 (Docker):"
+    echo "  docker logs -f dify-api"
+    echo ""
+    echo "================================================"
+    echo ""
+}
+
+# 主流程
+main() {
+    check_dependencies
+    install_python_deps
+    configure_env
+    start_mock_api
+    restart_dify
+    verify_enterprise
+    show_management
+
+    echo -e "${GREEN}✨ 企业版功能启用完成！${NC}"
+    echo ""
+    echo "📖 详细文档请参考: ENTERPRISE_SETUP.md"
+    echo ""
+}
+
+# 执行主流程
+main

--- a/test_enterprise_api.sh
+++ b/test_enterprise_api.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Dify 企业 API 测试脚本
+
+API_URL="${1:-http://127.0.0.1:5001}"
+SECRET_KEY="${2:-your-secret-key-here}"
+
+echo "================================================"
+echo "🧪 Dify 企业 API 测试"
+echo "================================================"
+echo "API URL: $API_URL"
+echo "Secret Key: ${SECRET_KEY:0:20}..."
+echo "================================================"
+echo ""
+
+# 颜色定义
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# 测试计数
+PASSED=0
+FAILED=0
+
+# 测试函数
+test_endpoint() {
+    local name=$1
+    local method=$2
+    local endpoint=$3
+    local data=$4
+
+    echo -n "测试: $name ... "
+
+    if [ "$method" == "GET" ]; then
+        response=$(curl -s -w "\n%{http_code}" \
+            -H "Enterprise-Api-Secret-Key: $SECRET_KEY" \
+            "$API_URL$endpoint")
+    else
+        response=$(curl -s -w "\n%{http_code}" \
+            -X "$method" \
+            -H "Enterprise-Api-Secret-Key: $SECRET_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$data" \
+            "$API_URL$endpoint")
+    fi
+
+    http_code=$(echo "$response" | tail -n 1)
+    body=$(echo "$response" | head -n -1)
+
+    if [ "$http_code" -eq 200 ]; then
+        echo -e "${GREEN}✅ PASS${NC}"
+        PASSED=$((PASSED + 1))
+        if command -v jq &> /dev/null; then
+            echo "$body" | jq '.' 2>/dev/null | head -n 10
+        else
+            echo "$body" | head -c 200
+        fi
+    else
+        echo -e "${RED}❌ FAIL (HTTP $http_code)${NC}"
+        FAILED=$((FAILED + 1))
+        echo "$body"
+    fi
+    echo ""
+}
+
+# 执行测试
+echo "开始测试..."
+echo ""
+
+# 1. 系统配置
+test_endpoint "获取企业配置" "GET" "/info"
+
+# 2. 工作空间信息
+test_endpoint "获取工作空间信息" "GET" "/workspace/test-tenant-123/info"
+
+# 3. SSO 更新时间
+test_endpoint "获取应用 SSO 更新时间" "GET" "/sso/app/last-update-time"
+test_endpoint "获取工作空间 SSO 更新时间" "GET" "/sso/workspace/last-update-time"
+
+# 4. Web 应用权限
+test_endpoint "检查用户权限" "GET" "/webapp/permission?userId=user123&appId=app456"
+
+test_endpoint "批量检查权限" "POST" "/webapp/permission/batch" \
+    '{"userId":"user123","appIds":["app1","app2","app3"]}'
+
+# 5. 访问模式
+test_endpoint "获取应用访问模式" "GET" "/webapp/access-mode/id?appId=app123"
+
+test_endpoint "批量获取访问模式" "POST" "/webapp/access-mode/batch/id" \
+    '{"appIds":["app1","app2"]}'
+
+test_endpoint "更新访问模式" "POST" "/webapp/access-mode" \
+    '{"appId":"app123","accessMode":"private"}'
+
+# 6. 清理操作
+test_endpoint "清理 Web 应用" "DELETE" "/webapp/clean" \
+    '{"appId":"app123"}'
+
+# 测试总结
+echo "================================================"
+echo "📊 测试总结"
+echo "================================================"
+TOTAL=$((PASSED + FAILED))
+echo "总测试数: $TOTAL"
+echo -e "通过: ${GREEN}$PASSED${NC}"
+echo -e "失败: ${RED}$FAILED${NC}"
+
+if [ $FAILED -eq 0 ]; then
+    echo -e "\n${GREEN}✨ 所有测试通过！${NC}"
+    exit 0
+else
+    echo -e "\n${RED}⚠️  部分测试失败${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Add comprehensive toolkit to enable Dify enterprise features including:
- Mock Enterprise API server (Flask and FastAPI versions)
- One-click startup script with automatic configuration
- Complete documentation and setup guides
- API testing utilities
- Docker deployment configuration
- Environment variable templates

This enables enterprise features such as SSO, branding customization, access control, plugin management, and knowledge pipeline publishing for development and testing environments.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
