### PR TITLE
fix: variable assigner can't assign float number

### DIFF
--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -808,7 +808,11 @@ class DraftVariableSaver:
             # We only save conversation variable here.
             if selector[0] != CONVERSATION_VARIABLE_NODE_ID:
                 continue
-            segment = WorkflowDraftVariable.build_segment_with_type(segment_type=item.value_type, value=item.new_value)
+            # Conversation variables are exposed as NUMBER in the UI even if their
+            # persisted type is INTEGER. Allow float updates by loosening the type
+            # to NUMBER here so downstream storage infers the precise subtype.
+            segment_type = SegmentType.NUMBER if item.value_type == SegmentType.INTEGER else item.value_type
+            segment = WorkflowDraftVariable.build_segment_with_type(segment_type=segment_type, value=item.new_value)
             draft_vars.append(
                 WorkflowDraftVariable.new_conversation_variable(
                     app_id=self._app_id,


### PR DESCRIPTION


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/28030

error log:

```
2025-11-11 01:07:06,630 INFO [debug_logging.py:164]  ✅ Node succeeded: 1762822713123
Debugging middleware caught exception in streamed response at a point where response headers were already sent.
Traceback (most recent call last):
  File "/root/dify/api/.venv/lib/python3.12/site-packages/werkzeug/wsgi.py", line 256, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/root/dify/api/.venv/lib/python3.12/site-packages/werkzeug/wrappers/response.py", line 32, in _iter_encoded
    for item in iterable:
  File "/root/dify/api/.venv/lib/python3.12/site-packages/flask/helpers.py", line 132, in generator
    yield from gen
  File "/root/dify/api/libs/helper.py", line 209, in generate
    yield from response
  File "/root/dify/api/core/app/features/rate_limiting/rate_limit.py", line 120, in __next__
    return next(self.generator)
           ^^^^^^^^^^^^^^^^^^^^
  File "/root/dify/api/core/app/apps/base_app_generator.py", line 176, in gen
    for message in generator:
  File "/root/dify/api/core/app/apps/base_app_generate_response_converter.py", line 27, in _generate_full_response
    yield from cls.convert_stream_full_response(response)
  File "/root/dify/api/core/app/apps/advanced_chat/generate_response_converter.py", line 66, in convert_stream_full_response
    for chunk in stream_response:
  File "/root/dify/api/core/app/apps/advanced_chat/generate_task_pipeline.py", line 202, in _to_stream_response
    for stream_response in generator:
  File "/root/dify/api/core/app/apps/advanced_chat/generate_task_pipeline.py", line 235, in _wrapper_process_stream_response
    for response in self._process_stream_response(tts_publisher=tts_publisher, trace_manager=trace_manager):
  File "/root/dify/api/core/app/apps/advanced_chat/generate_task_pipeline.py", line 757, in _process_stream_response
    if responses := list(
                    ^^^^^
  File "/root/dify/api/core/app/apps/advanced_chat/generate_task_pipeline.py", line 699, in _dispatch_event
    yield from handler(
  File "/root/dify/api/core/app/apps/advanced_chat/generate_task_pipeline.py", line 356, in _handle_node_succeeded_event
    self._save_output_for_event(event, event.node_execution_id)
  File "/root/dify/api/core/app/apps/advanced_chat/generate_task_pipeline.py", line 891, in _save_output_for_event
    saver.save(event.process_data, event.outputs)
  File "/root/dify/api/services/workflow_draft_variable_service.py", line 1028, in save
    draft_vars = self._build_from_variable_assigner_mapping(process_data=process_data)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/dify/api/services/workflow_draft_variable_service.py", line 811, in _build_from_variable_assigner_mapping
    segment = WorkflowDraftVariable.build_segment_with_type(segment_type=item.value_type, value=item.new_value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/dify/api/models/workflow.py", line 1376, in build_segment_with_type
    return build_segment_with_type(segment_type=segment_type, value=value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/dify/api/factories/variable_factory.py", line 278, in build_segment_with_type
    raise TypeMismatchError(f"Type mismatch: expected {segment_type}, but got {inferred_type}, value={value}")
factories.variable_factory.TypeMismatchError: Type mismatch: expected integer, but got float, value=111.1
```

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
