### PR TITLE
fix: StreamableHTTPTransport got invalid json exception when receive a ping event from mcp server #28111

### DIFF
--- a/api/core/mcp/client/streamable_client.py
+++ b/api/core/mcp/client/streamable_client.py
@@ -138,6 +138,10 @@ class StreamableHTTPTransport:
     ) -> bool:
         """Handle an SSE event, returning True if the response is complete."""
         if sse.event == "message":
+            # ping event send by server will be recognized  as a message event with empty data by httpx-sse's SSEDecoder
+            if not sse.data.strip():
+                return False
+
             try:
                 message = JSONRPCMessage.model_validate_json(sse.data)
                 logger.debug("SSE message: %s", message)


### PR DESCRIPTION
Fixes #28111

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| 
<img width="3002" height="1368" alt="image" src="https://github.com/user-attachments/assets/18759360-2148-4008-a797-e9b1c74f2386" />
 | 
<img width="2770" height="784" alt="image" src="https://github.com/user-attachments/assets/ac733e12-cd1a-45de-ac75-70e63da33d9d" />
 |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
