### PR TITLE
chore: improve the user experience of not login into apps

### DIFF
--- a/web/app/(commonLayout)/layout.tsx
+++ b/web/app/(commonLayout)/layout.tsx
@@ -15,25 +15,23 @@ import Splash from '../components/splash'
 const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <Splash>
-      <>
-        <GA gaType={GaType.admin} />
-        <SwrInitializer>
-          <AppContextProvider>
-            <EventEmitterContextProvider>
-              <ProviderContextProvider>
-                <ModalContextProvider>
-                  <HeaderWrapper>
-                    <Header />
-                  </HeaderWrapper>
-                  {children}
-                  <GotoAnything />
-                </ModalContextProvider>
-              </ProviderContextProvider>
-            </EventEmitterContextProvider>
-          </AppContextProvider>
-          <Zendesk />
-        </SwrInitializer>
-      </>
+      <GA gaType={GaType.admin} />
+      <SwrInitializer>
+        <AppContextProvider>
+          <EventEmitterContextProvider>
+            <ProviderContextProvider>
+              <ModalContextProvider>
+                <HeaderWrapper>
+                  <Header />
+                </HeaderWrapper>
+                {children}
+                <GotoAnything />
+              </ModalContextProvider>
+            </ProviderContextProvider>
+          </EventEmitterContextProvider>
+        </AppContextProvider>
+        <Zendesk />
+      </SwrInitializer>
     </Splash>
   )
 }

--- a/web/app/(commonLayout)/layout.tsx
+++ b/web/app/(commonLayout)/layout.tsx
@@ -10,28 +10,31 @@ import { ProviderContextProvider } from '@/context/provider-context'
 import { ModalContextProvider } from '@/context/modal-context'
 import GotoAnything from '@/app/components/goto-anything'
 import Zendesk from '@/app/components/base/zendesk'
+import Splash from '../components/splash'
 
 const Layout = ({ children }: { children: ReactNode }) => {
   return (
-    <>
-      <GA gaType={GaType.admin} />
-      <SwrInitializer>
-        <AppContextProvider>
-          <EventEmitterContextProvider>
-            <ProviderContextProvider>
-              <ModalContextProvider>
-                <HeaderWrapper>
-                  <Header />
-                </HeaderWrapper>
-                {children}
-                <GotoAnything />
-              </ModalContextProvider>
-            </ProviderContextProvider>
-          </EventEmitterContextProvider>
-        </AppContextProvider>
-        <Zendesk />
-      </SwrInitializer>
-    </>
+    <Splash>
+      <>
+        <GA gaType={GaType.admin} />
+        <SwrInitializer>
+          <AppContextProvider>
+            <EventEmitterContextProvider>
+              <ProviderContextProvider>
+                <ModalContextProvider>
+                  <HeaderWrapper>
+                    <Header />
+                  </HeaderWrapper>
+                  {children}
+                  <GotoAnything />
+                </ModalContextProvider>
+              </ProviderContextProvider>
+            </EventEmitterContextProvider>
+          </AppContextProvider>
+          <Zendesk />
+        </SwrInitializer>
+      </>
+    </Splash>
   )
 }
 export default Layout

--- a/web/app/(commonLayout)/layout.tsx
+++ b/web/app/(commonLayout)/layout.tsx
@@ -14,7 +14,7 @@ import Splash from '../components/splash'
 
 const Layout = ({ children }: { children: ReactNode }) => {
   return (
-    <Splash>
+    <>
       <GA gaType={GaType.admin} />
       <SwrInitializer>
         <AppContextProvider>
@@ -26,13 +26,14 @@ const Layout = ({ children }: { children: ReactNode }) => {
                 </HeaderWrapper>
                 {children}
                 <GotoAnything />
+                <Splash />
               </ModalContextProvider>
             </ProviderContextProvider>
           </EventEmitterContextProvider>
         </AppContextProvider>
         <Zendesk />
       </SwrInitializer>
-    </Splash>
+    </>
   )
 }
 export default Layout

--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -4,23 +4,20 @@ import React from 'react'
 import { useIsLogin } from '@/service/use-common'
 import Loading from './base/loading'
 
-const Splash: FC<PropsWithChildren> = ({
-  children,
-}) => {
+const Splash: FC<PropsWithChildren> = () => {
   // would auto redirect to signin page if not logged in
   const { isLoading, data: loginData } = useIsLogin()
   const isLoggedIn = loginData?.logged_in
 
   if (isLoading || !isLoggedIn) {
     return (
-      <div className='flex h-full items-center justify-center'>
+      <div className='fixed inset-0 z-[9999999] flex h-full items-center justify-center bg-background-body'>
         <Loading />
       </div>
     )
   }
   return (
     <>
-      {children}
     </>
   )
 }

--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -1,0 +1,27 @@
+'use client'
+import type { FC, PropsWithChildren } from 'react'
+import React from 'react'
+import { useIsLogin } from '@/service/use-common'
+import Loading from './base/loading'
+
+const Splash: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  // would auto redirect to signin page if not logged in
+  const { isLoading, data: loginData } = useIsLogin()
+  const isLoggedIn = loginData?.logged_in
+
+  if (isLoading || !isLoggedIn) {
+    return (
+      <div className='flex h-full items-center justify-center'>
+        <Loading />
+      </div>
+    )
+  }
+  return (
+    <>
+      {children}
+    </>
+  )
+}
+export default React.memo(Splash)

--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -16,9 +16,6 @@ const Splash: FC<PropsWithChildren> = () => {
       </div>
     )
   }
-  return (
-    <>
-    </>
-  )
+  return null
 }
 export default React.memo(Splash)


### PR DESCRIPTION
In before logic, if  someone has not login, but he visits a need login page. He would stay in that page before one api call, then redirect to login page. Now,  the user would see the loading status, then show the target page(if has login) or redirect to login  page. 

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
