### PR TITLE
chore: disable workflow logs auto-cleanup by default

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -527,7 +527,7 @@ API_WORKFLOW_NODE_EXECUTION_REPOSITORY=repositories.sqlalchemy_api_workflow_node
 API_WORKFLOW_RUN_REPOSITORY=repositories.sqlalchemy_api_workflow_run_repository.DifyAPISQLAlchemyWorkflowRunRepository
 # Workflow log cleanup configuration
 # Enable automatic cleanup of workflow run logs to manage database size
-WORKFLOW_LOG_CLEANUP_ENABLED=true
+WORKFLOW_LOG_CLEANUP_ENABLED=false
 # Number of days to retain workflow run logs (default: 30 days)
 WORKFLOW_LOG_RETENTION_DAYS=30
 # Batch size for workflow log cleanup operations (default: 100)

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1190,7 +1190,7 @@ class AccountConfig(BaseSettings):
 
 
 class WorkflowLogConfig(BaseSettings):
-    WORKFLOW_LOG_CLEANUP_ENABLED: bool = Field(default=True, description="Enable workflow run log cleanup")
+    WORKFLOW_LOG_CLEANUP_ENABLED: bool = Field(default=False, description="Enable workflow run log cleanup")
     WORKFLOW_LOG_RETENTION_DAYS: int = Field(default=30, description="Retention days for workflow run logs")
     WORKFLOW_LOG_CLEANUP_BATCH_SIZE: int = Field(
         default=100, description="Batch size for workflow run log cleanup operations"


### PR DESCRIPTION
## Summary

This PR changes the default value of `WORKFLOW_LOG_CLEANUP_ENABLED` from `true` to `false` across all configuration files.

## Changes

- **api/configs/feature/__init__.py**: Changed `WorkflowLogConfig.WORKFLOW_LOG_CLEANUP_ENABLED` default from `True` to `False`
- **api/.env.example**: Changed `WORKFLOW_LOG_CLEANUP_ENABLED` from `true` to `false`

Note: `docker/.env.example` and `docker/docker-compose.yaml` already had the correct default value of `false`.

## Motivation

Setting the default to `false` provides safer default behavior by:
- Preventing unintended data loss for new installations
- Giving users explicit control over when to enable log cleanup
- Following the opt-in principle for data deletion features

Users who need automatic cleanup can enable it by setting `WORKFLOW_LOG_CLEANUP_ENABLED=true` in their configuration.

Fixes #28135