### PR TITLE
fix: update input field width for retry configuration in RetryOnPanel

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
+++ b/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
@@ -76,7 +76,7 @@ const RetryOnPanel = ({
                 />
                 <Input
                   type='number'
-                  wrapperClassName='w-[80px]'
+                  wrapperClassName='w-[100px]'
                   value={retry_config?.max_retries || 3}
                   onChange={e => handleMaxRetriesChange(e.target.value as any)}
                   min={1}
@@ -96,7 +96,7 @@ const RetryOnPanel = ({
                 />
                 <Input
                   type='number'
-                  wrapperClassName='w-[80px]'
+                  wrapperClassName='w-[100px]'
                   value={retry_config?.retry_interval || 1000}
                   onChange={e => handleRetryIntervalChange(e.target.value as any)}
                   min={100}

--- a/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
+++ b/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
@@ -78,7 +78,9 @@ const RetryOnPanel = ({
                   type='number'
                   wrapperClassName='w-[100px]'
                   value={retry_config?.max_retries || 3}
-                  onChange={e => handleMaxRetriesChange(e.target.value as any)}
+                  onChange={e =>
+                    handleMaxRetriesChange(Number.parseInt(e.currentTarget.value, 10) || 3)
+                  }
                   min={1}
                   max={10}
                   unit={t('workflow.nodes.common.retry.times') || ''}
@@ -98,7 +100,9 @@ const RetryOnPanel = ({
                   type='number'
                   wrapperClassName='w-[100px]'
                   value={retry_config?.retry_interval || 1000}
-                  onChange={e => handleRetryIntervalChange(e.target.value as any)}
+                  onChange={e =>
+                    handleRetryIntervalChange(Number.parseInt(e.currentTarget.value, 10) || 1000)
+                  }
                   min={100}
                   max={5000}
                   unit={t('workflow.nodes.common.retry.ms') || ''}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

FIxes: #28141 

## Summary
In the UI for entering re-execution intervals (e.g., LLM blocks), the unit label is “ミリ秒” (milliseconds) in the Japanese locale. When the input field is narrow and the value grows to four digits (e.g., 1000), the unit overlaps the number, reducing readability. We’d like to widen the input field to eliminate this overlap.


## Screenshots

Before
<img width="639" height="121" alt="スクリーンショット 2025-11-13 0 21 04" src="https://github.com/user-attachments/assets/897daf03-e02a-49ee-9eef-5068cfb10475" />


After
<img width="596" height="142" alt="スクリーンショット 2025-11-13 0 17 49" src="https://github.com/user-attachments/assets/ff47425b-0333-4d53-91a2-49c6960e798a" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
