### PR TITLE
Clean up legacy conditions data in if-else nodes to prevent misjudgments

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -1305,10 +1305,7 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
       break
     }
     case BlockEnum.IfElse: {
-      res
-        = (data as IfElseNodeType).conditions?.map((c) => {
-          return c.variable_selector || []
-        }) || []
+      res = []
       res.push(
         ...((data as IfElseNodeType).cases || [])
           .flatMap(c => c.conditions || [])
@@ -1480,9 +1477,8 @@ export const getNodeUsedVarPassToServerKey = (
       break
     }
     case BlockEnum.IfElse: {
-      const targetVar = (data as IfElseNodeType).conditions?.find(
-        c => c.variable_selector?.join('.') === valueSelector.join('.'),
-      )
+      const targetVar = ((data as IfElseNodeType).cases || [])
+        .flatMap(c => c.conditions || []).find(c => c.variable_selector?.join('.') === valueSelector.join('.'))
       if (targetVar) res = `#${valueSelector.join('.')}#`
       break
     }
@@ -1634,13 +1630,6 @@ export const updateNodeVars = (
       }
       case BlockEnum.IfElse: {
         const payload = data as IfElseNodeType
-        if (payload.conditions) {
-          payload.conditions = payload.conditions.map((c) => {
-            if (c.variable_selector?.join('.') === oldVarSelector.join('.'))
-              c.variable_selector = newVarSelector
-            return c
-          })
-        }
         if (payload.cases) {
           payload.cases = payload.cases.map((caseItem) => {
             if (caseItem.conditions) {

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -42,7 +42,7 @@ import type { RAGPipelineVariable } from '@/models/pipeline'
 import type { WebhookTriggerNodeType } from '@/app/components/workflow/nodes/trigger-webhook/types'
 import type { PluginTriggerNodeType } from '@/app/components/workflow/nodes/trigger-plugin/types'
 import PluginTriggerNodeDefault from '@/app/components/workflow/nodes/trigger-plugin/default'
-
+import type { CaseItem, Condition } from '@/app/components/workflow/nodes/if-else/types'
 import {
   AGENT_OUTPUT_STRUCT,
   FILE_STRUCT,

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -1477,8 +1477,22 @@ export const getNodeUsedVarPassToServerKey = (
       break
     }
     case BlockEnum.IfElse: {
-      const targetVar = ((data as IfElseNodeType).cases || [])
-        .flatMap(c => c.conditions || []).find(c => c.variable_selector?.join('.') === valueSelector.join('.'))
+      const findConditionInCases = (cases: CaseItem[]): Condition | undefined => {
+        for (const caseItem of cases) {
+          for (const condition of caseItem.conditions || []) {
+            if (condition.variable_selector?.join('.') === valueSelector.join('.'))
+              return condition
+
+            if (condition.sub_variable_condition) {
+              const found = findConditionInCases([condition.sub_variable_condition])
+              if (found)
+                return found
+            }
+          }
+        }
+        return undefined
+      }
+      const targetVar = findConditionInCases((data as IfElseNodeType).cases || [])
       if (targetVar) res = `#${valueSelector.join('.')}#`
       break
     }

--- a/web/app/components/workflow/nodes/if-else/use-single-run-form-params.ts
+++ b/web/app/components/workflow/nodes/if-else/use-single-run-form-params.ts
@@ -89,15 +89,6 @@ const useSingleRunFormParams = ({
         inputVarsFromValue.push(...getInputVarsFromCase(caseItem))
       })
     }
-
-    if (payload.conditions && payload.conditions.length) {
-      payload.conditions.forEach((condition) => {
-        const conditionVars = getVarSelectorsFromCondition(condition)
-        allInputs.push(...conditionVars)
-        inputVarsFromValue.push(...getInputVarsFromConditionValue(condition))
-      })
-    }
-
     const varInputs = [...varSelectorsToVarInputs(allInputs), ...inputVarsFromValue]
     // remove duplicate inputs
     const existVarsKey: Record<string, boolean> = {}
@@ -146,13 +137,6 @@ const useSingleRunFormParams = ({
       payload.cases.forEach((caseItem) => {
         const caseVars = getVarFromCaseItem(caseItem)
         vars.push(...caseVars)
-      })
-    }
-
-    if (payload.conditions && payload.conditions.length) {
-      payload.conditions.forEach((condition) => {
-        const conditionVars = getVarFromCondition(condition)
-        vars.push(...conditionVars)
       })
     }
     return vars

--- a/web/app/components/workflow/utils/workflow-init.ts
+++ b/web/app/components/workflow/utils/workflow-init.ts
@@ -242,6 +242,11 @@ export const initialNodes = (originNodes: Node[], originEdges: Edge[]) => {
         ...(node.data as IfElseNodeType).cases.map(item => ({ id: item.case_id, name: '' })),
         { id: 'false', name: '' },
       ])
+      // delete conditions and logical_operator if cases is not empty
+      if (nodeData.cases.length > 0 && nodeData.conditions && nodeData.logical_operator) {
+        delete nodeData.conditions
+        delete nodeData.logical_operator
+      }
     }
 
     if (node.data.type === BlockEnum.QuestionClassifier) {


### PR DESCRIPTION
## Summary
fix #28150

This PR cleans up legacy `conditions` data handling in if-else workflow nodes and prevents potential runtime errors from stale data references.

### Changes Made:
- **Remove deprecated conditions processing**: Eliminated all logic that processes the old `conditions` field in if-else nodes throughout the codebase
- **Clean up variable utilities**: Updated `getNodeUsedVars`, `getNodeUsedVarPassToServerKey`, and `updateNodeVars` to only handle the new `cases` data structure
- **Add migration logic**: Implemented automatic data migration in `workflow-init.ts` to handle any legacy conditions during node initialization
- **Prevent misjudgments**: Ensured no code paths accidentally reference non-existent conditions fields

### Problem Solved:
Early if-else nodes used `conditions + logical_operator` fields, but the codebase has migrated to use `cases` structure. This caused "parameter not found" errors when deleting variables that were referenced in stale/unused conditions fields.

### Backward Compatibility:
The migration logic ensures existing workflows continue to work seamlessly without manual intervention.

### Files Changed:
- `app/components/workflow/utils/workflow-init.ts` - Added migration logic
- `app/components/workflow/nodes/_base/components/variable/utils.ts` - Cleaned up variable handling
- `app/components/workflow/nodes/if-else/use-single-run-form-params.ts` - Updated form params logic

### Testing:
- Manually verified no runtime errors when handling legacy data
- Ensured existing workflows remain functional

## Screenshots

No UI changes - this is a data structure and logic cleanup.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods