### PR TITLE
fix: fix numeric type conversion issue in if-else condition comparison

### DIFF
--- a/api/core/workflow/utils/condition/processor.py
+++ b/api/core/workflow/utils/condition/processor.py
@@ -268,20 +268,20 @@ def _assert_not_empty(*, value: object) -> bool:
 def _normalize_numeric_values(value: int | float, expected: object) -> tuple[int | float, int | float]:
     """
     Normalize value and expected to compatible numeric types for comparison.
-    
+
     Args:
         value: The actual numeric value (int or float)
         expected: The expected value (int, float, or str)
-    
+
     Returns:
         A tuple of (normalized_value, normalized_expected) with compatible types
-    
+
     Raises:
         ValueError: If expected cannot be converted to a number
     """
     if not isinstance(expected, (int, float, str)):
         raise ValueError(f"Cannot convert {type(expected)} to number")
-    
+
     # Convert expected to appropriate numeric type
     if isinstance(expected, str):
         # Try to convert to float first to handle decimal strings
@@ -289,7 +289,7 @@ def _normalize_numeric_values(value: int | float, expected: object) -> tuple[int
             expected_float = float(expected)
         except ValueError as e:
             raise ValueError(f"Cannot convert '{expected}' to number") from e
-        
+
         # If value is int and expected is a whole number, keep as int comparison
         if isinstance(value, int) and expected_float.is_integer():
             return value, int(expected_float)

--- a/api/core/workflow/utils/condition/processor.py
+++ b/api/core/workflow/utils/condition/processor.py
@@ -265,6 +265,45 @@ def _assert_not_empty(*, value: object) -> bool:
     return False
 
 
+def _normalize_numeric_values(value: int | float, expected: object) -> tuple[int | float, int | float]:
+    """
+    Normalize value and expected to compatible numeric types for comparison.
+    
+    Args:
+        value: The actual numeric value (int or float)
+        expected: The expected value (int, float, or str)
+    
+    Returns:
+        A tuple of (normalized_value, normalized_expected) with compatible types
+    
+    Raises:
+        ValueError: If expected cannot be converted to a number
+    """
+    if not isinstance(expected, (int, float, str)):
+        raise ValueError(f"Cannot convert {type(expected)} to number")
+    
+    # Convert expected to appropriate numeric type
+    if isinstance(expected, str):
+        # Try to convert to float first to handle decimal strings
+        try:
+            expected_float = float(expected)
+        except ValueError as e:
+            raise ValueError(f"Cannot convert '{expected}' to number") from e
+        
+        # If value is int and expected is a whole number, keep as int comparison
+        if isinstance(value, int) and expected_float.is_integer():
+            return value, int(expected_float)
+        else:
+            # Otherwise convert value to float for comparison
+            return float(value) if isinstance(value, int) else value, expected_float
+    elif isinstance(expected, float):
+        # If expected is already float, convert int value to float
+        return float(value) if isinstance(value, int) else value, expected
+    else:
+        # expected is int
+        return value, expected
+
+
 def _assert_equal(*, value: object, expected: object) -> bool:
     if value is None:
         return False
@@ -324,18 +363,8 @@ def _assert_greater_than(*, value: object, expected: object) -> bool:
     if not isinstance(value, (int, float)):
         raise ValueError("Invalid actual value type: number")
 
-    if isinstance(value, int):
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to int")
-        expected = int(expected)
-    else:
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to float")
-        expected = float(expected)
-
-    if value <= expected:
-        return False
-    return True
+    value, expected = _normalize_numeric_values(value, expected)
+    return value > expected
 
 
 def _assert_less_than(*, value: object, expected: object) -> bool:
@@ -345,18 +374,8 @@ def _assert_less_than(*, value: object, expected: object) -> bool:
     if not isinstance(value, (int, float)):
         raise ValueError("Invalid actual value type: number")
 
-    if isinstance(value, int):
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to int")
-        expected = int(expected)
-    else:
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to float")
-        expected = float(expected)
-
-    if value >= expected:
-        return False
-    return True
+    value, expected = _normalize_numeric_values(value, expected)
+    return value < expected
 
 
 def _assert_greater_than_or_equal(*, value: object, expected: object) -> bool:
@@ -366,18 +385,8 @@ def _assert_greater_than_or_equal(*, value: object, expected: object) -> bool:
     if not isinstance(value, (int, float)):
         raise ValueError("Invalid actual value type: number")
 
-    if isinstance(value, int):
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to int")
-        expected = int(expected)
-    else:
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to float")
-        expected = float(expected)
-
-    if value < expected:
-        return False
-    return True
+    value, expected = _normalize_numeric_values(value, expected)
+    return value >= expected
 
 
 def _assert_less_than_or_equal(*, value: object, expected: object) -> bool:
@@ -387,18 +396,8 @@ def _assert_less_than_or_equal(*, value: object, expected: object) -> bool:
     if not isinstance(value, (int, float)):
         raise ValueError("Invalid actual value type: number")
 
-    if isinstance(value, int):
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to int")
-        expected = int(expected)
-    else:
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to float")
-        expected = float(expected)
-
-    if value > expected:
-        return False
-    return True
+    value, expected = _normalize_numeric_values(value, expected)
+    return value <= expected
 
 
 def _assert_null(*, value: object) -> bool:

--- a/api/tests/unit_tests/core/workflow/utils/test_condition.py
+++ b/api/tests/unit_tests/core/workflow/utils/test_condition.py
@@ -10,45 +10,43 @@ def test_number_formatting():
     variable_pool.add(["test_node_id", "one"], 1)
     variable_pool.add(["test_node_id", "one_one"], 1.1)
     # 0 <= 0.95
-    assert condition_processor.process_conditions(
-        variable_pool=variable_pool,
-        conditions=[Condition(
-            variable_selector=["test_node_id", "zone"],
-            comparison_operator="≤",
-            value="0.95"
-        )],
-        operator="or",
-    ).final_result == True
+    assert (
+        condition_processor.process_conditions(
+            variable_pool=variable_pool,
+            conditions=[Condition(variable_selector=["test_node_id", "zone"], comparison_operator="≤", value="0.95")],
+            operator="or",
+        ).final_result
+        == True
+    )
 
     # 1 >= 0.95
-    assert condition_processor.process_conditions(
-        variable_pool=variable_pool,
-        conditions=[Condition(
-            variable_selector=["test_node_id", "one"],
-            comparison_operator="≥",
-            value="0.95"
-        )],
-        operator="or",
-    ).final_result == True
+    assert (
+        condition_processor.process_conditions(
+            variable_pool=variable_pool,
+            conditions=[Condition(variable_selector=["test_node_id", "one"], comparison_operator="≥", value="0.95")],
+            operator="or",
+        ).final_result
+        == True
+    )
 
     # 1.1 >= 0.95
-    assert condition_processor.process_conditions(
-        variable_pool=variable_pool,
-        conditions=[Condition(
-            variable_selector=["test_node_id", "one_one"],
-            comparison_operator="≥",
-            value="0.95"
-        )],
-        operator="or",
-    ).final_result == True
+    assert (
+        condition_processor.process_conditions(
+            variable_pool=variable_pool,
+            conditions=[
+                Condition(variable_selector=["test_node_id", "one_one"], comparison_operator="≥", value="0.95")
+            ],
+            operator="or",
+        ).final_result
+        == True
+    )
 
     # 1.1 > 0
-    assert condition_processor.process_conditions(
-        variable_pool=variable_pool,
-        conditions=[Condition(
-            variable_selector=["test_node_id", "one_one"],
-            comparison_operator=">",
-            value="0"
-        )],
-        operator="or",
-    ).final_result == True
+    assert (
+        condition_processor.process_conditions(
+            variable_pool=variable_pool,
+            conditions=[Condition(variable_selector=["test_node_id", "one_one"], comparison_operator=">", value="0")],
+            operator="or",
+        ).final_result
+        == True
+    )

--- a/api/tests/unit_tests/core/workflow/utils/test_condition.py
+++ b/api/tests/unit_tests/core/workflow/utils/test_condition.py
@@ -1,0 +1,54 @@
+from core.workflow.runtime import VariablePool
+from core.workflow.utils.condition.entities import Condition
+from core.workflow.utils.condition.processor import ConditionProcessor
+
+
+def test_number_formatting():
+    condition_processor = ConditionProcessor()
+    variable_pool = VariablePool()
+    variable_pool.add(["test_node_id", "zone"], 0)
+    variable_pool.add(["test_node_id", "one"], 1)
+    variable_pool.add(["test_node_id", "one_one"], 1.1)
+    # 0 <= 0.95
+    assert condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[Condition(
+            variable_selector=["test_node_id", "zone"],
+            comparison_operator="≤",
+            value="0.95"
+        )],
+        operator="or",
+    ).final_result == True
+
+    # 1 >= 0.95
+    assert condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[Condition(
+            variable_selector=["test_node_id", "one"],
+            comparison_operator="≥",
+            value="0.95"
+        )],
+        operator="or",
+    ).final_result == True
+
+    # 1.1 >= 0.95
+    assert condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[Condition(
+            variable_selector=["test_node_id", "one_one"],
+            comparison_operator="≥",
+            value="0.95"
+        )],
+        operator="or",
+    ).final_result == True
+
+    # 1.1 > 0
+    assert condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[Condition(
+            variable_selector=["test_node_id", "one_one"],
+            comparison_operator=">",
+            value="0"
+        )],
+        operator="or",
+    ).final_result == True


### PR DESCRIPTION
## Summary

fix #28154

This PR fixes a numeric type conversion issue in if-else condition comparison functions. When comparing integer values with float strings (e.g., `0 <= "0.95"`), the code was incorrectly converting float strings to integers, causing precision loss and incorrect evaluation results.

### Changes

- Add `_normalize_numeric_values` function to handle numeric type normalization uniformly
- Refactor numeric comparison functions (greater than, less than, greater than or equal, less than or equal) to use unified type conversion logic
- Fix comparison issues between integers, floats, and string numeric values
- Add unit tests to verify numeric formatting and comparison functionality

### Root Cause

The comparison functions (`_assert_greater_than`, `_assert_less_than`, `_assert_greater_than_or_equal`, `_assert_less_than_or_equal`) in `core/workflow/utils/condition/processor.py` had inconsistent type conversion logic. When comparing `int` values with float strings, the code would convert the string to `int`, losing precision (e.g., `"0.95"` becomes `0`).

### Solution

Introduced a unified `_normalize_numeric_values` function that:
- Converts string numeric values to appropriate numeric types (int or float)
- Preserves precision when comparing integers with float strings
- Handles edge cases properly (e.g., whole number floats converted to ints when comparing with ints)

### Testing

Added comprehensive unit tests in `tests/unit_tests/core/workflow/utils/test_condition.py` covering:
- Integer vs float string comparisons (`0 <= "0.95"`, `1 >= "0.95"`)
- Float vs float string comparisons (`1.1 >= "0.95"`)
- Float vs integer string comparisons (`1.1 > "0"`)

## Screenshots

| Before | After |
|--------|-------|
| `0 <= "0.95"` evaluates to `False` (incorrect) | `0 <= "0.95"` evaluates to `True` (correct) |
| `1 >= "0.95"` evaluates to `False` (incorrect) | `1 >= "0.95"` evaluates to `True` (correct) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
