### PR TITLE
feat: add draft trigger detection to app model and UI

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -108,9 +108,7 @@ class AppListApi(Resource):
                     app.access_mode = res[str(app.id)].access_mode
 
         workflow_capable_app_ids = [
-            str(app.id)
-            for app in app_pagination.items
-            if app.mode in {"workflow", "advanced-chat"}
+            str(app.id) for app in app_pagination.items if app.mode in {"workflow", "advanced-chat"}
         ]
         draft_trigger_app_ids: set[str] = set()
         if workflow_capable_app_ids:

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -15,11 +15,12 @@ from controllers.console.wraps import (
     setup_required,
 )
 from core.ops.ops_trace_manager import OpsTraceManager
+from core.workflow.enums import NodeType
 from extensions.ext_database import db
 from fields.app_fields import app_detail_fields, app_detail_fields_with_site, app_pagination_fields
 from libs.login import current_account_with_tenant, login_required
 from libs.validators import validate_description_length
-from models import App
+from models import App, Workflow
 from services.app_dsl_service import AppDslService, ImportMode
 from services.app_service import AppService
 from services.enterprise.enterprise_service import EnterpriseService
@@ -105,6 +106,37 @@ class AppListApi(Resource):
             for app in app_pagination.items:
                 if str(app.id) in res:
                     app.access_mode = res[str(app.id)].access_mode
+
+        workflow_capable_app_ids = [
+            str(app.id)
+            for app in app_pagination.items
+            if app.mode in {"workflow", "advanced-chat"}
+        ]
+        draft_trigger_app_ids: set[str] = set()
+        if workflow_capable_app_ids:
+            draft_workflows = (
+                db.session.execute(
+                    select(Workflow).where(
+                        Workflow.version == Workflow.VERSION_DRAFT,
+                        Workflow.app_id.in_(workflow_capable_app_ids),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            trigger_node_types = {
+                NodeType.TRIGGER_WEBHOOK,
+                NodeType.TRIGGER_SCHEDULE,
+                NodeType.TRIGGER_PLUGIN,
+            }
+            for workflow in draft_workflows:
+                for _, node_data in workflow.walk_nodes():
+                    if node_data.get("type") in trigger_node_types:
+                        draft_trigger_app_ids.add(str(workflow.app_id))
+                        break
+
+        for app in app_pagination.items:
+            app.has_draft_trigger = str(app.id) in draft_trigger_app_ids
 
         return marshal(app_pagination, app_pagination_fields), 200
 

--- a/api/fields/app_fields.py
+++ b/api/fields/app_fields.py
@@ -116,6 +116,7 @@ app_partial_fields = {
     "access_mode": fields.String,
     "create_user_name": fields.String,
     "author_name": fields.String,
+    "has_draft_trigger": fields.Boolean,
 }
 
 

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -282,21 +282,23 @@ const AppCard = ({ app, onRefresh }: AppCardProps) => {
           </>
         )}
         {
-          (!systemFeatures.webapp_auth.enabled)
-            ? <>
-              <Divider className="my-1" />
-              <button type="button" className='mx-1 flex h-8 cursor-pointer items-center gap-2 rounded-lg px-3 hover:bg-state-base-hover' onClick={onClickInstalledApp}>
-                <span className='system-sm-regular text-text-secondary'>{t('app.openInExplore')}</span>
-              </button>
-            </>
-            : !(isGettingUserCanAccessApp || !userCanAccessApp?.result) && (
-              <>
+          !app.has_draft_trigger && (
+            (!systemFeatures.webapp_auth.enabled)
+              ? <>
                 <Divider className="my-1" />
                 <button type="button" className='mx-1 flex h-8 cursor-pointer items-center gap-2 rounded-lg px-3 hover:bg-state-base-hover' onClick={onClickInstalledApp}>
                   <span className='system-sm-regular text-text-secondary'>{t('app.openInExplore')}</span>
                 </button>
               </>
-            )
+              : !(isGettingUserCanAccessApp || !userCanAccessApp?.result) && (
+                <>
+                  <Divider className="my-1" />
+                  <button type="button" className='mx-1 flex h-8 cursor-pointer items-center gap-2 rounded-lg px-3 hover:bg-state-base-hover' onClick={onClickInstalledApp}>
+                    <span className='system-sm-regular text-text-secondary'>{t('app.openInExplore')}</span>
+                  </button>
+                </>
+              )
+          )
         }
         <Divider className="my-1" />
         {

--- a/web/types/app.ts
+++ b/web/types/app.ts
@@ -379,6 +379,8 @@ export type App = {
   /** access control */
   access_mode: AccessMode
   max_active_requests?: number | null
+  /** whether workflow trigger has un-published draft */
+  has_draft_trigger?: boolean
 }
 
 export type AppSSO = {


### PR DESCRIPTION
The “Open in Explore” button should only be shown in the web app, and it must be hidden if the app has no user input node.

- Introduced `has_draft_trigger` field in the app model to indicate if there are unpublished draft workflows associated with the app.
- Updated the API to populate `has_draft_trigger` based on the presence of draft workflows.
- Modified the app card component to conditionally render UI elements based on the `has_draft_trigger` status.
- Enhanced app type definition to include the new `has_draft_trigger` property.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
