### PR TITLE
add icon for forum

### DIFF
--- a/web/app/components/apps/footer.tsx
+++ b/web/app/components/apps/footer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { RiDiscordFill, RiGithubFill } from '@remixicon/react'
+import { RiDiscordFill, RiDiscussLine, RiGithubFill } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 
 type CustomLinkProps = {
@@ -37,6 +37,9 @@ const Footer = () => {
         </CustomLink>
         <CustomLink href='https://discord.gg/FngNHpbcY7'>
           <RiDiscordFill className='h-5 w-5 text-text-tertiary' />
+        </CustomLink>
+        <CustomLink href='https://forum.dify.ai'>
+          <RiDiscussLine className='h-5 w-5 text-text-tertiary' />
         </CustomLink>
       </div>
     </footer>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request makes a small update to the footer component by adding a new link to the Dify.ai forum and importing the corresponding icon.

Most important changes:

**Footer links update:**

* Added a new forum link (`https://forum.dify.ai`) to the footer using the `RiDiscussLine` icon.
* Imported the `RiDiscussLine` icon from `@remixicon/react` in `footer.tsx` to support the new forum link.

Fix https://github.com/langgenius/dify/issues/28165

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
