### PR TITLE
fix: adjust padding in AgentNode and NodeComponent for consistent layout

### DIFF
--- a/web/app/components/workflow/nodes/agent/node.tsx
+++ b/web/app/components/workflow/nodes/agent/node.tsx
@@ -65,7 +65,7 @@ const AgentNode: FC<NodeProps<AgentNodeType>> = (props) => {
     })
     return tools
   }, [currentStrategy?.parameters, inputs.agent_parameters])
-  return <div className='mb-1 space-y-1 px-3 py-1'>
+  return <div className='mb-1 space-y-1 px-3'>
     {inputs.agent_strategy_name
       ? <SettingItem
         label={t('workflow.nodes.agent.strategy.shortLabel')}

--- a/web/app/components/workflow/nodes/document-extractor/node.tsx
+++ b/web/app/components/workflow/nodes/document-extractor/node.tsx
@@ -25,7 +25,7 @@ const NodeComponent: FC<NodeProps<DocExtractorNodeType>> = ({
   const isSystem = isSystemVar(variable)
   const node = isSystem ? nodes.find(node => node.data.type === BlockEnum.Start) : nodes.find(node => node.id === variable[0])
   return (
-    <div className='relative px-3'>
+    <div className='relative mb-1 px-3 py-1'>
       <div className='system-2xs-medium-uppercase mb-1 text-text-tertiary'>{t(`${i18nPrefix}.inputVar`)}</div>
       <VariableLabelInNode
         variables={variable}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #28174

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
|<img width="630" height="826" alt="CleanShot 2025-11-13 at 18 56 59" src="https://github.com/user-attachments/assets/9679e77e-b41f-446c-98c8-2dff958ea2d3" />| <img width="535" height="748" alt="CleanShot 2025-11-13 at 18 38 58" src="https://github.com/user-attachments/assets/07b2cb75-c311-48e0-8bf6-1687d8630931" /> |


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
