### PR TITLE
fix(api): add session_id validation for webapp JWT authentication

### DIFF
--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -81,6 +81,7 @@ class LoginStatusApi(Resource):
     )
     def get(self):
         app_code = request.args.get("app_code")
+        user_id = request.args.get("user_id")
         token = extract_webapp_access_token(request)
         if not app_code:
             return {
@@ -103,7 +104,7 @@ class LoginStatusApi(Resource):
                 user_logged_in = False
 
         try:
-            _ = decode_jwt_token(app_code=app_code)
+            _ = decode_jwt_token(app_code=app_code, user_id=user_id)
             app_logged_in = True
         except Exception:
             app_logged_in = False

--- a/api/controllers/web/wraps.py
+++ b/api/controllers/web/wraps.py
@@ -62,7 +62,7 @@ def decode_jwt_token(app_code: str | None = None, user_id: str | None = None):
             end_user = session.scalar(select(EndUser).where(EndUser.id == end_user_id))
             if not end_user:
                 raise NotFound()
-            
+
             # Validate user_id against end_user's session_id if provided
             if user_id is not None and end_user.session_id != user_id:
                 raise Unauthorized("Authentication has expired.")

--- a/api/controllers/web/wraps.py
+++ b/api/controllers/web/wraps.py
@@ -38,7 +38,7 @@ def validate_jwt_token(view: Callable[Concatenate[App, EndUser, P], R] | None = 
     return decorator
 
 
-def decode_jwt_token(app_code: str | None = None):
+def decode_jwt_token(app_code: str | None = None, user_id: str | None = None):
     system_features = FeatureService.get_system_features()
     if not app_code:
         app_code = str(request.headers.get(HEADER_NAME_APP_CODE))
@@ -62,6 +62,10 @@ def decode_jwt_token(app_code: str | None = None):
             end_user = session.scalar(select(EndUser).where(EndUser.id == end_user_id))
             if not end_user:
                 raise NotFound()
+            
+            # Validate user_id against end_user's session_id if provided
+            if user_id is not None and end_user.session_id != user_id:
+                raise Unauthorized("Authentication has expired.")
 
         # for enterprise webapp auth
         app_web_auth_enabled = False

--- a/web/app/(shareLayout)/components/splash.tsx
+++ b/web/app/(shareLayout)/components/splash.tsx
@@ -58,7 +58,7 @@ const Splash: FC<PropsWithChildren> = ({ children }) => {
 
     (async () => {
       // if access mode is public, user login is always true, but the app login(passport) may be expired
-      const { userLoggedIn, appLoggedIn } = await webAppLoginStatus(shareCode!)
+      const { userLoggedIn, appLoggedIn } = await webAppLoginStatus(shareCode!, embeddedUserId || undefined)
       if (userLoggedIn && appLoggedIn) {
         redirectOrFinish()
       }

--- a/web/service/webapp-auth.ts
+++ b/web/service/webapp-auth.ts
@@ -30,10 +30,13 @@ type isWebAppLogin = {
   app_logged_in: boolean
 }
 
-export async function webAppLoginStatus(shareCode: string) {
+export async function webAppLoginStatus(shareCode: string, userId?: string) {
   // always need to check login to prevent passport from being outdated
   // check remotely, the access token could be in cookie (enterprise SSO redirected with https)
-  const { logged_in, app_logged_in } = await getPublic<isWebAppLogin>(`/login/status?app_code=${shareCode}`)
+  const params = new URLSearchParams({ app_code: shareCode })
+  if (userId)
+    params.append('user_id', userId)
+  const { logged_in, app_logged_in } = await getPublic<isWebAppLogin>(`/login/status?${params.toString()}`)
   return {
     userLoggedIn: logged_in,
     appLoggedIn: app_logged_in,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #28224

- Add optional `user_id` parameter to `decode_jwt_token()` for session validation
- Validate JWT end_user session_id against provided user_id parameter
- Update backend `LoginStatusApi` to accept and pass through user_id
- Update frontend `webAppLoginStatus()` to support userId parameter
- Pass embeddedUserId to login status checks in splash component

When user_id is provided, JWT authentication will fail if the session ID doesn't match, enabling detection of expired sessions. Therefore, we can dynamically update user_id.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
