### PR TITLE
fix: dataset metadata counts when documents are deleted

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -37,7 +37,6 @@ from models.dataset import (
     Dataset,
     DatasetAutoDisableLog,
     DatasetCollectionBinding,
-    DatasetMetadataBinding,
     DatasetPermission,
     DatasetPermissionEnum,
     DatasetProcessRule,
@@ -1269,10 +1268,6 @@ class DocumentService:
                 data_source_info = document.data_source_info_dict
                 if data_source_info and "upload_file_id" in data_source_info:
                     file_id = data_source_info["upload_file_id"]
-        db.session.query(DatasetMetadataBinding).where(
-            DatasetMetadataBinding.dataset_id == document.dataset_id,
-            DatasetMetadataBinding.document_id == document.id,
-        ).delete(synchronize_session=False)
         document_was_deleted.send(
             document.id, dataset_id=document.dataset_id, doc_form=document.doc_form, file_id=file_id
         )
@@ -1291,10 +1286,6 @@ class DocumentService:
             for document in documents
             if document.data_source_type == "upload_file" and document.data_source_info_dict
         ]
-        db.session.query(DatasetMetadataBinding).where(
-            DatasetMetadataBinding.dataset_id == dataset.id,
-            DatasetMetadataBinding.document_id.in_(document_ids),
-        ).delete(synchronize_session=False)
         if dataset.doc_form is not None:
             batch_clean_document_task.delay(document_ids, dataset.id, dataset.doc_form, file_ids)
 

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -37,6 +37,7 @@ from models.dataset import (
     Dataset,
     DatasetAutoDisableLog,
     DatasetCollectionBinding,
+    DatasetMetadataBinding,
     DatasetPermission,
     DatasetPermissionEnum,
     DatasetProcessRule,
@@ -1268,6 +1269,10 @@ class DocumentService:
                 data_source_info = document.data_source_info_dict
                 if data_source_info and "upload_file_id" in data_source_info:
                     file_id = data_source_info["upload_file_id"]
+        db.session.query(DatasetMetadataBinding).where(
+            DatasetMetadataBinding.dataset_id == document.dataset_id,
+            DatasetMetadataBinding.document_id == document.id,
+        ).delete(synchronize_session=False)
         document_was_deleted.send(
             document.id, dataset_id=document.dataset_id, doc_form=document.doc_form, file_id=file_id
         )
@@ -1286,6 +1291,10 @@ class DocumentService:
             for document in documents
             if document.data_source_type == "upload_file" and document.data_source_info_dict
         ]
+        db.session.query(DatasetMetadataBinding).where(
+            DatasetMetadataBinding.dataset_id == dataset.id,
+            DatasetMetadataBinding.document_id.in_(document_ids),
+        ).delete(synchronize_session=False)
         if dataset.doc_form is not None:
             batch_clean_document_task.delay(document_ids, dataset.id, dataset.doc_form, file_ids)
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #28253
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
