### PR TITLE
doc: add doc for env config when site and backend are in different domains

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -159,7 +159,7 @@ SUPABASE_URL=your-server-url
 # CORS configuration
 WEB_API_CORS_ALLOW_ORIGINS=http://localhost:3000,*
 CONSOLE_CORS_ALLOW_ORIGINS=http://localhost:3000,*
-# When your site uses HTTP, or the frontend and backend run on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`). Leading dots are optional.
+# When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s top-level domain (e.g., `example.com`). Leading dots are optional.
 COOKIE_DOMAIN=
 
 # Vector database configuration

--- a/api/.env.example
+++ b/api/.env.example
@@ -160,7 +160,7 @@ SUPABASE_URL=your-server-url
 WEB_API_CORS_ALLOW_ORIGINS=http://localhost:3000,*
 CONSOLE_CORS_ALLOW_ORIGINS=http://localhost:3000,*
 # Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
-# Provide the registrable domain (e.g. example.com); leading dots are optional.
+# Provide the registrable domain (e.g., example.com); leading dots are optional.
 COOKIE_DOMAIN=
 
 # Vector database configuration

--- a/api/.env.example
+++ b/api/.env.example
@@ -159,7 +159,7 @@ SUPABASE_URL=your-server-url
 # CORS configuration
 WEB_API_CORS_ALLOW_ORIGINS=http://localhost:3000,*
 CONSOLE_CORS_ALLOW_ORIGINS=http://localhost:3000,*
-# Set COOKIE_DOMAIN when the console frontend and API are on different subdomains.
+# Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
 # Provide the registrable domain (e.g. example.com); leading dots are optional.
 COOKIE_DOMAIN=
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -159,8 +159,7 @@ SUPABASE_URL=your-server-url
 # CORS configuration
 WEB_API_CORS_ALLOW_ORIGINS=http://localhost:3000,*
 CONSOLE_CORS_ALLOW_ORIGINS=http://localhost:3000,*
-# Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
-# Provide the registrable domain (e.g., example.com); leading dots are optional.
+# When your site uses HTTP, or the frontend and backend run on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`). Leading dots are optional.
 COOKIE_DOMAIN=
 
 # Vector database configuration

--- a/api/README.md
+++ b/api/README.md
@@ -28,7 +28,7 @@
 
 > [!IMPORTANT]
 >
-> When the site and backend API are on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`) and set `NEXT_PUBLIC_COOKIE_DOMAIN=1` in the [frontend env](../web/.env.example).
+> When your site uses HTTP, or the frontend and backend run on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`).
 
 1. Generate a `SECRET_KEY` in the `.env` file.
 

--- a/api/README.md
+++ b/api/README.md
@@ -26,6 +26,10 @@
    cp .env.example .env
    ```
 
+> [!IMPORTANT]
+>  
+> When the site and backend API are on different domains or subdomains, set COOKIE_DOMAIN to site domain(e.g example.com) and set the [frontend env](../web/.env.example) NEXT_PUBLIC_COOKIE_DOMAIN=1.
+
 1. Generate a `SECRET_KEY` in the `.env` file.
 
    bash for Linux

--- a/api/README.md
+++ b/api/README.md
@@ -27,7 +27,7 @@
    ```
 
 > [!IMPORTANT]
->  
+>
 > When the site and backend API are on different domains or subdomains, set COOKIE_DOMAIN to site domain(e.g example.com) and set the [frontend env](../web/.env.example) NEXT_PUBLIC_COOKIE_DOMAIN=1.
 
 1. Generate a `SECRET_KEY` in the `.env` file.

--- a/api/README.md
+++ b/api/README.md
@@ -28,7 +28,7 @@
 
 > [!IMPORTANT]
 >
-> When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s primary domain (e.g., `example.com`). The frontend and backend must be under the same top-level domain in order to share authentication cookies.
+> When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s top-level domain (e.g., `example.com`). The frontend and backend must be under the same top-level domain in order to share authentication cookies.
 
 1. Generate a `SECRET_KEY` in the `.env` file.
 

--- a/api/README.md
+++ b/api/README.md
@@ -28,7 +28,7 @@
 
 > [!IMPORTANT]
 >
-> When the site and backend API are on different domains or subdomains, set COOKIE_DOMAIN to site domain(e.g example.com) and set the [frontend env](../web/.env.example) NEXT_PUBLIC_COOKIE_DOMAIN=1.
+> When the site and backend API are on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`) and set `NEXT_PUBLIC_COOKIE_DOMAIN=1` in the [frontend env](../web/.env.example).
 
 1. Generate a `SECRET_KEY` in the `.env` file.
 

--- a/api/README.md
+++ b/api/README.md
@@ -28,7 +28,7 @@
 
 > [!IMPORTANT]
 >
-> When your site uses HTTP, or the frontend and backend run on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`).
+> When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s primary domain (e.g., `example.com`). The frontend and backend must be under the same top-level domain in order to share authentication cookies.
 
 1. Generate a `SECRET_KEY` in the `.env` file.
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -367,7 +367,7 @@ WEB_API_CORS_ALLOW_ORIGINS=*
 CONSOLE_CORS_ALLOW_ORIGINS=*
 # When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s top-level domain (e.g., `example.com`). Leading dots are optional.
 COOKIE_DOMAIN=
-# When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
+# When the frontend and backend run on different subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # ------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -365,8 +365,7 @@ WEB_API_CORS_ALLOW_ORIGINS=*
 # Specifies the allowed origins for cross-origin requests to the console API,
 # e.g. https://cloud.dify.ai or * for all origins.
 CONSOLE_CORS_ALLOW_ORIGINS=*
-# Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
-# Provide the registrable domain (e.g., example.com); leading dots are optional.
+# When your site uses HTTP, or the frontend and backend run on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`). Leading dots are optional.
 COOKIE_DOMAIN=
 # When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -368,7 +368,7 @@ CONSOLE_CORS_ALLOW_ORIGINS=*
 # Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
 # Provide the registrable domain (e.g., example.com); leading dots are optional.
 COOKIE_DOMAIN=
-# Set NEXT_PUBLIC_COOKIE_DOMAIN=1 when the console site and API are on different domains or subdomains.
+# Set NEXT_PUBLIC_COOKIE_DOMAIN=1 when the site and API are on different domains or subdomains.
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # ------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -368,7 +368,7 @@ CONSOLE_CORS_ALLOW_ORIGINS=*
 # Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
 # Provide the registrable domain (e.g., example.com); leading dots are optional.
 COOKIE_DOMAIN=
-# Set NEXT_PUBLIC_COOKIE_DOMAIN=1 when the site and API are on different domains or subdomains.
+# When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # ------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -365,10 +365,10 @@ WEB_API_CORS_ALLOW_ORIGINS=*
 # Specifies the allowed origins for cross-origin requests to the console API,
 # e.g. https://cloud.dify.ai or * for all origins.
 CONSOLE_CORS_ALLOW_ORIGINS=*
-# Set COOKIE_DOMAIN when the console frontend and API are on different subdomains.
+# Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
 # Provide the registrable domain (e.g. example.com); leading dots are optional.
 COOKIE_DOMAIN=
-# The frontend reads NEXT_PUBLIC_COOKIE_DOMAIN to align cookie handling with the API.
+# Set NEXT_PUBLIC_COOKIE_DOMAIN=1 when the console site and API are on different domains or subdomains.
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # ------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -366,7 +366,7 @@ WEB_API_CORS_ALLOW_ORIGINS=*
 # e.g. https://cloud.dify.ai or * for all origins.
 CONSOLE_CORS_ALLOW_ORIGINS=*
 # Set COOKIE_DOMAIN when the site and API are on different domains or subdomains.
-# Provide the registrable domain (e.g. example.com); leading dots are optional.
+# Provide the registrable domain (e.g., example.com); leading dots are optional.
 COOKIE_DOMAIN=
 # Set NEXT_PUBLIC_COOKIE_DOMAIN=1 when the console site and API are on different domains or subdomains.
 NEXT_PUBLIC_COOKIE_DOMAIN=

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -365,7 +365,7 @@ WEB_API_CORS_ALLOW_ORIGINS=*
 # Specifies the allowed origins for cross-origin requests to the console API,
 # e.g. https://cloud.dify.ai or * for all origins.
 CONSOLE_CORS_ALLOW_ORIGINS=*
-# When your site uses HTTP, or the frontend and backend run on different domains or subdomains, set `COOKIE_DOMAIN` to the site domain (e.g., `example.com`). Leading dots are optional.
+# When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s top-level domain (e.g., `example.com`). Leading dots are optional.
 COOKIE_DOMAIN=
 # When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,7 +12,7 @@ NEXT_PUBLIC_API_PREFIX=http://localhost:5001/console/api
 # console or api domain.
 # example: http://udify.app/api
 NEXT_PUBLIC_PUBLIC_API_PREFIX=http://localhost:5001/api
-# When the site and API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the backend env COOKIE_DOMAIN to site domain(e.g example.com).
+# When the site and API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the backend env COOKIE_DOMAIN to site domain. (e.g., example.com).
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # The API PREFIX for MARKETPLACE

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,7 +12,7 @@ NEXT_PUBLIC_API_PREFIX=http://localhost:5001/console/api
 # console or api domain.
 # example: http://udify.app/api
 NEXT_PUBLIC_PUBLIC_API_PREFIX=http://localhost:5001/api
-# When the site and API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the backend env COOKIE_DOMAIN to site domain. (e.g., example.com).
+# When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # The API PREFIX for MARKETPLACE

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,6 +12,9 @@ NEXT_PUBLIC_API_PREFIX=http://localhost:5001/console/api
 # console or api domain.
 # example: http://udify.app/api
 NEXT_PUBLIC_PUBLIC_API_PREFIX=http://localhost:5001/api
+# When the site and API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the backend env COOKIE_DOMAIN to site domain(e.g example.com).
+NEXT_PUBLIC_COOKIE_DOMAIN=
+
 # The API PREFIX for MARKETPLACE
 NEXT_PUBLIC_MARKETPLACE_API_PREFIX=https://marketplace.dify.ai/api/v1
 # The URL for MARKETPLACE

--- a/web/.env.example
+++ b/web/.env.example
@@ -37,9 +37,6 @@ NEXT_PUBLIC_CSP_WHITELIST=
 # Default is not allow to embed into iframe to prevent Clickjacking: https://owasp.org/www-community/attacks/Clickjacking
 NEXT_PUBLIC_ALLOW_EMBED=
 
-# Shared cookie domain when console UI and API use different subdomains (e.g. example.com)
-NEXT_PUBLIC_COOKIE_DOMAIN=
-
 # Allow rendering unsafe URLs which have "data:" scheme.
 NEXT_PUBLIC_ALLOW_UNSAFE_DATA_SCHEME=false
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,7 +12,7 @@ NEXT_PUBLIC_API_PREFIX=http://localhost:5001/console/api
 # console or api domain.
 # example: http://udify.app/api
 NEXT_PUBLIC_PUBLIC_API_PREFIX=http://localhost:5001/api
-# When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
+# When the frontend and backend run on different subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=
 
 # The API PREFIX for MARKETPLACE

--- a/web/README.md
+++ b/web/README.md
@@ -44,7 +44,7 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 > [!IMPORTANT]
 >
-> 1. When the site and backend API are on different domains or subdomains, set `NEXT_PUBLIC_COOKIE_DOMAIN=1` and set `COOKIE_DOMAIN` in the [backend env](../api/.env.example) to your site's domain (e.g., `example.com`).
+> 1. When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 > 1. It's necessary to set NEXT_PUBLIC_API_PREFIX and NEXT_PUBLIC_PUBLIC_API_PREFIX to the correct backend API URL.
 
 Finally, run the development server:

--- a/web/README.md
+++ b/web/README.md
@@ -43,9 +43,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 ```
 
 > [!IMPORTANT]
->  
+>
 > 1. When the site and backend API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the [backend env](../api/.env.example) COOKIE_DOMAIN to site domain(e.g example.com).
-> 2. It's necessary to set NEXT_PUBLIC_API_PREFIX and NEXT_PUBLIC_PUBLIC_API_PREFIX to the correct backend API URL.
+> 1. It's necessary to set NEXT_PUBLIC_API_PREFIX and NEXT_PUBLIC_PUBLIC_API_PREFIX to the correct backend API URL.
 
 Finally, run the development server:
 

--- a/web/README.md
+++ b/web/README.md
@@ -32,6 +32,7 @@ NEXT_PUBLIC_EDITION=SELF_HOSTED
 # different from api or web app domain.
 # example: http://cloud.dify.ai/console/api
 NEXT_PUBLIC_API_PREFIX=http://localhost:5001/console/api
+NEXT_PUBLIC_COOKIE_DOMAIN=
 # The URL for Web APP, refers to the Web App base URL of WEB service if web app domain is different from
 # console or api domain.
 # example: http://udify.app/api
@@ -40,6 +41,11 @@ NEXT_PUBLIC_PUBLIC_API_PREFIX=http://localhost:5001/api
 # SENTRY
 NEXT_PUBLIC_SENTRY_DSN=
 ```
+
+> [!IMPORTANT]
+>  
+> 1. When the site and backend API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the [backend env](../api/.env.example) COOKIE_DOMAIN to site domain(e.g example.com).
+> 2. It's necessary to set NEXT_PUBLIC_API_PREFIX and NEXT_PUBLIC_PUBLIC_API_PREFIX to the correct backend API URL.
 
 Finally, run the development server:
 

--- a/web/README.md
+++ b/web/README.md
@@ -44,7 +44,7 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 > [!IMPORTANT]
 >
-> 1. When the site and backend API are on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1 and set the [backend env](../api/.env.example) COOKIE_DOMAIN to site domain(e.g example.com).
+> 1. When the site and backend API are on different domains or subdomains, set `NEXT_PUBLIC_COOKIE_DOMAIN=1` and set `COOKIE_DOMAIN` in the [backend env](../api/.env.example) to your site's domain (e.g., `example.com`).
 > 1. It's necessary to set NEXT_PUBLIC_API_PREFIX and NEXT_PUBLIC_PUBLIC_API_PREFIX to the correct backend API URL.
 
 Finally, run the development server:

--- a/web/README.md
+++ b/web/README.md
@@ -44,7 +44,7 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 > [!IMPORTANT]
 >
-> 1. When your site uses HTTPS and the frontend and backend run on different domains or subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
+> 1. When the frontend and backend run on different subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1. The frontend and backend must be under the same top-level domain in order to share authentication cookies.
 > 1. It's necessary to set NEXT_PUBLIC_API_PREFIX and NEXT_PUBLIC_PUBLIC_API_PREFIX to the correct backend API URL.
 
 Finally, run the development server:


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
