### PR TITLE
Add translations for trigger node tooltip

### DIFF
--- a/web/i18n/de-DE/app-overview.ts
+++ b/web/i18n/de-DE/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Deaktivieren',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Die Funktion {{feature}} wird im Trigger-Knoten-Modus nicht unterstützt.',
+    },
   },
   analysis: {
     title: 'Analyse',

--- a/web/i18n/es-ES/app-overview.ts
+++ b/web/i18n/es-ES/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Deshabilitar',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'La función {{feature}} no es compatible en el modo Nodo de disparo.',
+    },
   },
   analysis: {
     title: 'Análisis',

--- a/web/i18n/fa-IR/app-overview.ts
+++ b/web/i18n/fa-IR/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'غیرفعال',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'ویژگی {{feature}} در حالت گره تریگر پشتیبانی نمی‌شود.',
+    },
   },
   analysis: {
     title: 'تحلیل',

--- a/web/i18n/fr-FR/app-overview.ts
+++ b/web/i18n/fr-FR/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Désactiver',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'La fonctionnalité {{feature}} n\'est pas prise en charge en mode Nœud Déclencheur.',
+    },
   },
   analysis: {
     title: 'Analyse',

--- a/web/i18n/hi-IN/app-overview.ts
+++ b/web/i18n/hi-IN/app-overview.ts
@@ -138,7 +138,9 @@ const translation = {
       disable: 'अक्षम करें',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'ट्रिगर नोड मोड में {{feature}} फ़ीचर समर्थित नहीं है।',
+    },
   },
   analysis: {
     title: 'विश्लेषण',

--- a/web/i18n/id-ID/app-overview.ts
+++ b/web/i18n/id-ID/app-overview.ts
@@ -125,7 +125,9 @@ const translation = {
     },
     title: 'Ikhtisar',
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Fitur {{feature}} tidak didukung dalam mode Node Pemicu.',
+    },
   },
   analysis: {
     totalMessages: {

--- a/web/i18n/it-IT/app-overview.ts
+++ b/web/i18n/it-IT/app-overview.ts
@@ -140,7 +140,9 @@ const translation = {
       disable: 'Disabilita',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'La funzionalità {{feature}} non è supportata in modalità Nodo Trigger.',
+    },
   },
   analysis: {
     title: 'Analisi',

--- a/web/i18n/ko-KR/app-overview.ts
+++ b/web/i18n/ko-KR/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: '비활성',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: '트리거 노드 모드에서는 {{feature}} 기능이 지원되지 않습니다.',
+    },
   },
   analysis: {
     title: '분석',

--- a/web/i18n/pl-PL/app-overview.ts
+++ b/web/i18n/pl-PL/app-overview.ts
@@ -138,7 +138,9 @@ const translation = {
       disable: 'Wyłącz',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Funkcja {{feature}} nie jest obsługiwana w trybie węzła wyzwalającego.',
+    },
   },
   analysis: {
     title: 'Analiza',

--- a/web/i18n/pt-BR/app-overview.ts
+++ b/web/i18n/pt-BR/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Desabilitar',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'O recurso {{feature}} não é compatível no modo Nó de Gatilho.',
+    },
   },
   analysis: {
     title: 'Análise',

--- a/web/i18n/ro-RO/app-overview.ts
+++ b/web/i18n/ro-RO/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Dezactivat',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Funcționalitatea {{feature}} nu este suportată în modul Nod Trigger.',
+    },
   },
   analysis: {
     title: 'Analiză',

--- a/web/i18n/ru-RU/app-overview.ts
+++ b/web/i18n/ru-RU/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Отключено',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Функция {{feature}} не поддерживается в режиме узла триггера.',
+    },
   },
   analysis: {
     title: 'Анализ',

--- a/web/i18n/sl-SI/app-overview.ts
+++ b/web/i18n/sl-SI/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Onemogočeno',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Funkcija {{feature}} ni podprta v načinu vozlišča sprožilca.',
+    },
   },
   analysis: {
     title: 'Analiza',

--- a/web/i18n/th-TH/app-overview.ts
+++ b/web/i18n/th-TH/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'พิการ',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'โหมดโหนดทริกเกอร์ไม่รองรับฟีเจอร์ {{feature}}.',
+    },
   },
   analysis: {
     title: 'การวิเคราะห์',

--- a/web/i18n/tr-TR/app-overview.ts
+++ b/web/i18n/tr-TR/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Devre Dışı',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Trigger Düğümü modunda {{feature}} özelliği desteklenmiyor.',
+    },
   },
   analysis: {
     title: 'Analiz',

--- a/web/i18n/uk-UA/app-overview.ts
+++ b/web/i18n/uk-UA/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Вимкнути',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Функція {{feature}} не підтримується в режимі вузла тригера.',
+    },
   },
   analysis: {
     title: 'Аналіз',

--- a/web/i18n/vi-VN/app-overview.ts
+++ b/web/i18n/vi-VN/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: 'Đã tắt',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: 'Tính năng {{feature}} không được hỗ trợ trong chế độ Nút Kích hoạt.',
+    },
   },
   analysis: {
     title: 'Phân tích',

--- a/web/i18n/zh-Hant/app-overview.ts
+++ b/web/i18n/zh-Hant/app-overview.ts
@@ -127,7 +127,9 @@ const translation = {
       disable: '已停用',
     },
     triggerInfo: {},
-    disableTooltip: {},
+    disableTooltip: {
+      triggerMode: '觸發節點模式不支援 {{feature}} 功能。',
+    },
   },
   analysis: {
     title: '分析',


### PR DESCRIPTION
## Summary
- add localized trigger-mode disable tooltip strings across the app overview translations

## Testing
- tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c48a8de108331be0f96f39a1b7002)