### PR TITLE
fix: lazy init audioplayer to fix no tts message also switch audio source bug

### DIFF
--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -29,6 +29,7 @@ import type { Annotation } from '@/models/log'
 import { WorkflowRunningStatus } from '@/app/components/workflow/types'
 import useTimestamp from '@/hooks/use-timestamp'
 import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import {
   getProcessedFiles,
@@ -308,7 +309,15 @@ export const useChat = (
       else
         ttsUrl = `/apps/${params.appId}/text-to-audio`
     }
-    const player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', noop)
+    // Lazy initialization: Only create AudioPlayer when TTS is actually needed
+    // This prevents opening audio channel unnecessarily
+    let player: AudioPlayer | null = null
+    const getOrCreatePlayer = () => {
+      if (!player)
+        player = AudioPlayerManager.getInstance().getAudioPlayer(ttsUrl, ttsIsPublic, uuidV4(), 'none', 'none', noop)
+
+      return player
+    }
     ssePost(
       url,
       {
@@ -582,11 +591,16 @@ export const useChat = (
         onTTSChunk: (messageId: string, audio: string) => {
           if (!audio || audio === '')
             return
-          player.playAudioWithAudio(audio, true)
-          AudioPlayerManager.getInstance().resetMsgId(messageId)
+          const audioPlayer = getOrCreatePlayer()
+          if (audioPlayer) {
+            audioPlayer.playAudioWithAudio(audio, true)
+            AudioPlayerManager.getInstance().resetMsgId(messageId)
+          }
         },
         onTTSEnd: (messageId: string, audio: string) => {
-          player.playAudioWithAudio(audio, false)
+          const audioPlayer = getOrCreatePlayer()
+          if (audioPlayer)
+            audioPlayer.playAudioWithAudio(audio, false)
         },
         onLoopStart: ({ data: loopStartedData }) => {
           responseItem.workflowProcess!.tracing!.push({


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes https://github.com/langgenius/dify/issues/28431

Lazy initialization: Only create AudioPlayer when TTS is actually needed.
This prevents opening audio channel unnecessarily.

## Screenshots

### Before

In chatflow preview, without TTS will auto switch audio source

https://github.com/user-attachments/assets/7b7309b1-6881-4c56-88dc-bef3155fd31e

In embed chatbot, without TTS will auto switch audio source

https://github.com/user-attachments/assets/a4eb8960-1067-46f3-830d-f112dd614be8

### After

In chatflow preview, without TTS will not switch audio source, if open TTS and autoplay, it will switch audio source

https://github.com/user-attachments/assets/5dfe6f9b-82af-4548-ac1b-90bad8a2cf1f

https://github.com/user-attachments/assets/1aca126b-aeb5-4f32-b753-e48bc19e9145


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
