### PR TITLE
fix: add missing particle in Japanese trigger events translation

### DIFF
--- a/web/i18n/ja-JP/billing.ts
+++ b/web/i18n/ja-JP/billing.ts
@@ -81,8 +81,8 @@ const translation = {
       'top-priority': '最優先',
     },
     triggerEvents: {
-      sandbox: '{{count,number}} トリガーイベント数',
-      professional: '{{count,number}} トリガーイベント数/月',
+      sandbox: '{{count,number}}のトリガーイベント数',
+      professional: '{{count,number}}のトリガーイベント数/月',
       unlimited: '無制限のトリガーイベント数',
       tooltip: 'プラグイントリガー、タイマートリガー、または Webhook トリガーによって自動的にワークフローを起動するイベントの回数です。',
     },


### PR DESCRIPTION
## Summary

Fixed Japanese translation by adding missing "の" particle to trigger events count text.

**Changes:**
- `3,000 トリガーイベント数` → `3,000のトリガーイベント数`
- `20,000 トリガーイベント数/月` → `20,000のトリガーイベント数/月`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods