### PR TITLE
fix: treat -1 as unlimited for API rate limit and trigger events

### DIFF
--- a/web/app/components/billing/utils/index.ts
+++ b/web/app/components/billing/utils/index.ts
@@ -9,6 +9,13 @@ const parseLimit = (limit: number) => {
   return limit
 }
 
+const parseRateLimit = (limit: number) => {
+  if (limit === 0 || limit === -1)
+    return NUM_INFINITE
+
+  return limit
+}
+
 const normalizeResetDate = (resetDate?: number | null) => {
   if (typeof resetDate !== 'number' || resetDate <= 0)
     return null
@@ -46,9 +53,9 @@ const getResetInDaysFromDate = (resetDate?: number | null) => {
 export const parseCurrentPlan = (data: CurrentPlanInfoBackend) => {
   const planType = data.billing.subscription.plan
   const planPreset = ALL_PLANS[planType]
-  const resolveLimit = (limit?: number, fallback?: number) => {
+  const resolveRateLimit = (limit?: number, fallback?: number) => {
     const value = limit ?? fallback ?? 0
-    return parseLimit(value)
+    return parseRateLimit(value)
   }
   const getQuotaUsage = (quota?: BillingQuota) => quota?.usage ?? 0
   const getQuotaResetInDays = (quota?: BillingQuota) => {
@@ -74,8 +81,8 @@ export const parseCurrentPlan = (data: CurrentPlanInfoBackend) => {
       teamMembers: parseLimit(data.members.limit),
       annotatedResponse: parseLimit(data.annotation_quota_limit.limit),
       documentsUploadQuota: parseLimit(data.documents_upload_quota.limit),
-      apiRateLimit: resolveLimit(data.api_rate_limit?.limit, planPreset?.apiRateLimit ?? NUM_INFINITE),
-      triggerEvents: resolveLimit(data.trigger_event?.limit, planPreset?.triggerEvents),
+      apiRateLimit: resolveRateLimit(data.api_rate_limit?.limit, planPreset?.apiRateLimit ?? NUM_INFINITE),
+      triggerEvents: resolveRateLimit(data.trigger_event?.limit, planPreset?.triggerEvents),
     },
     reset: {
       apiRateLimit: getQuotaResetInDays(data.api_rate_limit),


### PR DESCRIPTION
## Summary

When backend returns `-1` for `api_rate_limit` or `trigger_event` limits, frontend now displays "Unlimited" instead of showing the raw `-1` value.

## Changes

- Added `parseRateLimit()` function to handle both `0` and `-1` as unlimited values
- Applied to `api_rate_limit` and `trigger_event` fields only
- Other quota fields remain unchanged (still treat only `0` as unlimited)

## Testing

- Verified API rate limit displays correctly when backend returns `-1`
- Confirmed other quota fields are not affected by this change