### PR TITLE
fix: i18n: standardize trigger events terminology in billing translations

### DIFF
--- a/web/i18n/it-IT/billing.ts
+++ b/web/i18n/it-IT/billing.ts
@@ -115,7 +115,7 @@ const translation = {
       tooltip: 'Priorità e velocità della coda di esecuzione del flusso di lavoro.',
     },
     startNodes: {
-      unlimited: 'Trigger/workflow illimitati',
+      unlimited: 'Eventi di attivazione/workflow illimitati',
     },
   },
   plans: {
@@ -211,15 +211,15 @@ const translation = {
     documentsUploadQuota: 'Quota di Caricamento Documenti',
     vectorSpaceTooltip: 'I documenti con la modalità di indicizzazione ad alta qualità consumeranno risorse di Knowledge Data Storage. Quando il Knowledge Data Storage raggiunge il limite, nuovi documenti non verranno caricati.',
     perMonth: 'al mese',
-    triggerEvents: 'Eventi scatenanti',
+    triggerEvents: 'Eventi di attivazione',
   },
   teamMembers: 'Membri del team',
   triggerLimitModal: {
     upgrade: 'Aggiornamento',
     dismiss: 'Ignora',
-    usageTitle: 'EVENTI SCATENANTI',
-    title: 'Aggiorna per sbloccare più eventi trigger',
-    description: 'Hai raggiunto il limite dei trigger degli eventi del flusso di lavoro per questo piano.',
+    usageTitle: 'EVENTI DI ATTIVAZIONE',
+    title: 'Aggiorna per sbloccare più eventi di attivazione',
+    description: 'Hai raggiunto il limite degli eventi di attivazione del flusso di lavoro per questo piano.',
   },
 }
 

--- a/web/i18n/pt-BR/billing.ts
+++ b/web/i18n/pt-BR/billing.ts
@@ -107,7 +107,7 @@ const translation = {
       standard: 'Execução Padrão de Fluxo de Trabalho',
     },
     startNodes: {
-      unlimited: 'Gatilhos/fluxo de trabalho ilimitados',
+      unlimited: 'Eventos de Gatilho/fluxo de trabalho ilimitados',
     },
   },
   plans: {

--- a/web/i18n/pt-BR/billing.ts
+++ b/web/i18n/pt-BR/billing.ts
@@ -107,7 +107,7 @@ const translation = {
       standard: 'Execução Padrão de Fluxo de Trabalho',
     },
     startNodes: {
-      unlimited: 'Gatilhos/workflow ilimitados',
+      unlimited: 'Gatilhos/fluxo de trabalho ilimitados',
     },
   },
   plans: {
@@ -200,15 +200,15 @@ const translation = {
     vectorSpaceTooltip: 'Documentos com o modo de indexação de Alta Qualidade consumirã recursos de Armazenamento de Dados de Conhecimento. Quando o Armazenamento de Dados de Conhecimento atingir o limite, novos documentos não serão carregados.',
     buildApps: 'Desenvolver Apps',
     perMonth: 'por mês',
-    triggerEvents: 'Eventos Desencadeadores',
+    triggerEvents: 'Eventos de Gatilho',
   },
   teamMembers: 'Membros da equipe',
   triggerLimitModal: {
     dismiss: 'Dispensar',
-    usageTitle: 'EVENTOS DESENCADEADORES',
-    title: 'Atualize para desbloquear mais eventos de gatilho',
+    usageTitle: 'EVENTOS DE GATILHO',
+    title: 'Atualize para desbloquear mais Eventos de Gatilho',
     upgrade: 'Atualizar',
-    description: 'Você atingiu o limite de gatilhos de eventos de fluxo de trabalho para este plano.',
+    description: 'Você atingiu o limite de eventos de gatilho de fluxo de trabalho para este plano.',
   },
 }
 

--- a/web/i18n/pt-BR/billing.ts
+++ b/web/i18n/pt-BR/billing.ts
@@ -206,7 +206,7 @@ const translation = {
   triggerLimitModal: {
     dismiss: 'Dispensar',
     usageTitle: 'EVENTOS DE GATILHO',
-    title: 'Atualize para desbloquear mais Eventos de Gatilho',
+    title: 'Atualize para desbloquear mais eventos de gatilho',
     upgrade: 'Atualizar',
     description: 'Você atingiu o limite de eventos de gatilho de fluxo de trabalho para este plano.',
   },

--- a/web/i18n/ro-RO/billing.ts
+++ b/web/i18n/ro-RO/billing.ts
@@ -206,7 +206,7 @@ const translation = {
   triggerLimitModal: {
     dismiss: 'Respinge',
     upgrade: 'Actualizare',
-    usageTitle: 'EVENIMENTE TRIGER',
+    usageTitle: 'EVENIMENTE DECLANȘATOARE',
     description: 'Ai atins limita de declanșatoare de evenimente de flux de lucru pentru acest plan.',
     title: 'Actualizează pentru a debloca mai multe evenimente declanșatoare',
   },

--- a/web/i18n/ro-RO/billing.ts
+++ b/web/i18n/ro-RO/billing.ts
@@ -207,7 +207,7 @@ const translation = {
     dismiss: 'Respinge',
     upgrade: 'Actualizare',
     usageTitle: 'EVENIMENTE DECLANȘATOARE',
-    description: 'Ai atins limita de declanșatoare de evenimente de flux de lucru pentru acest plan.',
+    description: 'Ai atins limita de evenimente declanșatoare de flux de lucru pentru acest plan.',
     title: 'Actualizează pentru a debloca mai multe evenimente declanșatoare',
   },
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix i18n: unify trigger events terminology in billing translations

- Standardize Italian (it-IT) to "eventi di attivazione"
- Standardize Portuguese (pt-BR) to "Eventos de Gatilho" and translate "workflow"
- Fix Romanian (ro-RO) typo: "EVENIMENTE TRIGER" → "EVENIMENTE DECLANȘATOARE"

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
