### PR TITLE
Improve translations for tracing provider fields

### DIFF
--- a/web/i18n/fa-IR/app.ts
+++ b/web/i18n/fa-IR/app.ts
@@ -163,7 +163,7 @@ const translation = {
       experimentId: 'شناسه آزمایش',
       personalAccessToken: 'نشانه دسترسی شخصی (قدیمی)',
       databricksHost: 'نشانی اینترنتی محیط کاری دیتابریکس',
-      trackingUri: 'ردیابی URI',
+      trackingUri: 'آدرس URI ردیابی',
       clientSecret: 'رمز مخفی مشتری OAuth',
     },
     view: 'مشاهده',

--- a/web/i18n/ja-JP/app.ts
+++ b/web/i18n/ja-JP/app.ts
@@ -172,7 +172,7 @@ const translation = {
       removeConfirmContent: '現在の設定は使用中です。これを削除すると、トレース機能が無効になります。',
       clientId: 'OAuthクライアントID',
       clientSecret: 'OAuthクライアントシークレット',
-      personalAccessToken: '（非推奨）アクセストークン',
+      personalAccessToken: 'パーソナルアクセストークン（レガシー）',
       databricksHost: 'DatabricksワークスペースのURL',
     },
     weave: {


### PR DESCRIPTION
## Summary
- refine the Persian wording for the tracing provider Tracking URI field
- clarify the Japanese translation for the legacy personal access token label

## Testing
- `tsc --noEmit`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b942570c83319560125ac4064c3c)