### PR TITLE
Fix 500 error in knowledge base, select weightedScore and click retrieve.

### DIFF
--- a/api/core/rag/datasource/keyword/jieba/jieba_keyword_table_handler.py
+++ b/api/core/rag/datasource/keyword/jieba/jieba_keyword_table_handler.py
@@ -79,7 +79,7 @@ class JiebaKeywordTableHandler:
                 self._lcut = getattr(jieba, "lcut", None)
 
             def extract_tags(self, sentence: str, top_k: int | None = 20, **kwargs):
-                # Basic frequency-based keywords as a degraded tf-idf substitute.
+                # Basic frequency-based keyword extraction as a fallback when TF-IDF is unavailable.
                 top_k = kwargs.pop("topK", top_k)
                 cut = getattr(jieba, "cut", None)
                 if self._lcut:

--- a/api/core/rag/datasource/keyword/jieba/jieba_keyword_table_handler.py
+++ b/api/core/rag/datasource/keyword/jieba/jieba_keyword_table_handler.py
@@ -1,5 +1,9 @@
 import re
-from typing import cast
+from operator import itemgetter
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from jieba.analyse import TFIDF  # type: ignore
 
 
 class JiebaKeywordTableHandler:
@@ -8,13 +12,66 @@ class JiebaKeywordTableHandler:
 
         from core.rag.datasource.keyword.jieba.stopwords import STOPWORDS
 
-        jieba.analyse.default_tfidf.stop_words = STOPWORDS  # type: ignore
+        # `default_tfidf` was removed in newer jieba versions, so create one if missing.
+        tfidf = getattr(jieba.analyse, "default_tfidf", None)
+        if tfidf is None:
+            tfidf_class = getattr(jieba.analyse, "TFIDF", None)
+            if tfidf_class is None:
+                try:
+                    from jieba.analyse.tfidf import TFIDF  # type: ignore
+                except Exception:
+                    tfidf_class = None
+                else:
+                    tfidf_class = TFIDF
+
+            if tfidf_class is not None:
+                tfidf = tfidf_class()
+                jieba.analyse.default_tfidf = tfidf  # type: ignore[attr-defined]
+            else:
+                tfidf = self._build_fallback_tfidf()
+
+        tfidf.stop_words = STOPWORDS  # type: ignore[attr-defined]
+        self._tfidf = cast("TFIDF", tfidf)
+
+    @staticmethod
+    def _build_fallback_tfidf():
+        """Fallback lightweight TFIDF for environments missing jieba's TFIDF."""
+        import jieba  # type: ignore
+
+        from core.rag.datasource.keyword.jieba.stopwords import STOPWORDS
+
+        class _SimpleTFIDF:
+            def __init__(self):
+                self.stop_words = STOPWORDS
+                self._lcut = getattr(jieba, "lcut", None)
+
+            def extract_tags(self, sentence: str, top_k: int | None = 20, **kwargs):
+                # Basic frequency-based keywords as a degraded tf-idf substitute.
+                top_k = kwargs.pop("topK", top_k)
+                cut = getattr(jieba, "cut", None)
+                if self._lcut:
+                    tokens = self._lcut(sentence)
+                elif callable(cut):
+                    tokens = list(cut(sentence))
+                else:
+                    tokens = re.findall(r"\w+", sentence)
+
+                words = [w for w in tokens if w and w not in self.stop_words]
+                freq: dict[str, int] = {}
+                for w in words:
+                    freq[w] = freq.get(w, 0) + 1
+
+                sorted_words = sorted(freq.items(), key=itemgetter(1), reverse=True)
+                if top_k is not None:
+                    sorted_words = sorted_words[:top_k]
+
+                return [item[0] for item in sorted_words]
+
+        return _SimpleTFIDF()
 
     def extract_keywords(self, text: str, max_keywords_per_chunk: int | None = 10) -> set[str]:
         """Extract keywords with JIEBA tfidf."""
-        import jieba.analyse  # type: ignore
-
-        keywords = jieba.analyse.extract_tags(
+        keywords = self._tfidf.extract_tags(
             sentence=text,
             topK=max_keywords_per_chunk,
         )


### PR DESCRIPTION
## Summary

Fix #28508 by provide a lightweight frequency-based extractor if TFIDF missing.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1198" height="647" alt="Image" src="https://github.com/user-attachments/assets/934a938e-9dd8-44bf-a929-962a07b35187" /> <img width="1047" height="515" alt="Image" src="https://github.com/user-attachments/assets/6bd0b0a1-e60a-4408-bbad-4b4acd377583" /> | No error |

## Checklist

- [x] This change *NO* requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] No test.
- [x] No need update the documentation.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
