### PR TITLE
fix(web): resolve readme-panel display and styling issues

### DIFF
--- a/web/app/components/plugins/readme-panel/entrance.tsx
+++ b/web/app/components/plugins/readme-panel/entrance.tsx
@@ -24,7 +24,7 @@ export const ReadmeEntrance = ({
     if (pluginDetail)
       setCurrentPluginDetail(pluginDetail, showType)
   }
-  if (!pluginDetail || BUILTIN_TOOLS_ARRAY.includes(pluginDetail.id))
+  if (!pluginDetail || !pluginDetail?.plugin_unique_identifier || BUILTIN_TOOLS_ARRAY.includes(pluginDetail.id))
     return null
 
   return (

--- a/web/app/components/plugins/readme-panel/index.tsx
+++ b/web/app/components/plugins/readme-panel/index.tsx
@@ -86,18 +86,21 @@ const ReadmePanel: FC = () => {
 
   const portalContent = showType === ReadmeShowType.drawer
     ? (
-      <div className='pointer-events-none fixed inset-0 z-[9997] flex justify-start'>
+      <div className='fixed inset-0 z-[999] flex justify-start' onClick={onClose}>
         <div
           className={cn(
             'pointer-events-auto mb-2 ml-2 mr-2 mt-16 w-[600px] max-w-[600px] justify-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0 shadow-xl',
           )}
+          onClick={(event) => {
+            event.stopPropagation()
+          }}
         >
           {children}
         </div>
       </div>
     )
     : (
-      <div className='pointer-events-none fixed inset-0 z-[9997] flex items-center justify-center p-2'>
+      <div className='fixed inset-0 z-[999] flex items-center justify-center p-2' onClick={onClose}>
         <div
           className={cn(
             'pointer-events-auto relative h-[calc(100vh-16px)] w-full max-w-[800px] rounded-2xl bg-components-panel-bg p-0 shadow-xl',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #28657

- Do not display readme-panel entrance if pluginDetail.plugin_unique_identifier is null, since the readmeData is query by plugin_unique_identifier
- Fix the styling issues of the readme-panel component

## Screenshots

### Before

- click custom tool readme

https://github.com/user-attachments/assets/d81d617f-d37c-43d4-9a91-d273a4258e7c

- click the image in the readme

https://github.com/user-attachments/assets/bdd0e778-b7bb-443f-b1dc-59710b4deb70

- click outside of the readme

https://github.com/user-attachments/assets/f816c89b-0400-454a-9f36-b18f10473f8a

### After

- do not display custom tool readme

<img width="1440" height="756" alt="display修复后" src="https://github.com/user-attachments/assets/a96fad13-83ec-4138-b79c-e76cde098e3c" /> 

- click the image in the readme

https://github.com/user-attachments/assets/72743762-9f7f-4f43-b4f1-6228a53e482c

- click outside of the readme

https://github.com/user-attachments/assets/86822de0-2493-4d46-a073-321953e39881

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
