### PR TITLE
Sanitize share markdown rendering to prevent XSS

### DIFF
--- a/web/__tests__/xss-prevention.test.tsx
+++ b/web/__tests__/xss-prevention.test.tsx
@@ -10,6 +10,7 @@ import { cleanup, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import BlockInput from '../app/components/base/block-input'
 import SupportVarInput from '../app/components/workflow/nodes/_base/components/support-var-input'
+import { sanitizeMarkdownContent } from '../app/components/base/markdown'
 
 // Mock styles
 jest.mock('../app/components/app/configuration/base/var-highlight/style.module.css', () => ({
@@ -69,6 +70,18 @@ describe('XSS Prevention - Block Input and Support Var Input Security', () => {
 
       expect(spanElement?.textContent).toBe('<script>alert("xss")</script>')
       expect(scriptElements).toHaveLength(0)
+    })
+  })
+
+  describe('Markdown Sanitization', () => {
+    it('strips dangerous attributes and protocols from raw HTML blocks', () => {
+      const jsProtocol = 'java' + 'script:alert(1)'
+      const malicious = `<img src="x" onerror="alert(1)"><a href="${jsProtocol}">click</a><script>alert(1)</script>`
+      const sanitized = sanitizeMarkdownContent(malicious)
+      expect(sanitized).not.toContain('onerror')
+      expect(sanitized).not.toContain('<script')
+      const protoLower = jsProtocol.toLowerCase().split('alert')[0] // java + script:
+      expect(sanitized.toLowerCase()).not.toContain(protoLower)
     })
   })
 })

--- a/web/app/components/base/markdown/index.tsx
+++ b/web/app/components/base/markdown/index.tsx
@@ -1,11 +1,22 @@
+'use client'
 import dynamic from 'next/dynamic'
 import 'katex/dist/katex.min.css'
 import { flow } from 'lodash-es'
+import DOMPurify from 'dompurify'
+import { useMemo } from 'react'
 import cn from '@/utils/classnames'
 import { preprocessLaTeX, preprocessThinkTag } from './markdown-utils'
 import type { ReactMarkdownWrapperProps, SimplePluginInfo } from './react-markdown-wrapper'
 
 const ReactMarkdown = dynamic(() => import('./react-markdown-wrapper').then(mod => mod.ReactMarkdownWrapper), { ssr: false })
+
+const SANITIZE_OPTIONS: DOMPurify.Config = {
+  USE_PROFILES: { html: true },
+  ADD_TAGS: ['details', 'summary'],
+  FORBID_TAGS: ['style', 'script'],
+}
+
+export const sanitizeMarkdownContent = (content: string) => DOMPurify.sanitize(content, SANITIZE_OPTIONS)
 
 /**
  * @fileoverview Main Markdown rendering component.
@@ -26,10 +37,11 @@ export const Markdown = (props: MarkdownProps) => {
     preprocessThinkTag,
     preprocessLaTeX,
   ])(props.content)
+  const sanitizedContent = useMemo(() => sanitizeMarkdownContent(latexContent), [latexContent])
 
   return (
     <div className={cn('markdown-body', '!text-text-primary', props.className)}>
-      <ReactMarkdown pluginInfo={pluginInfo} latexContent={latexContent} customComponents={customComponents} customDisallowedElements={props.customDisallowedElements} />
+      <ReactMarkdown pluginInfo={pluginInfo} latexContent={sanitizedContent} customComponents={customComponents} customDisallowedElements={props.customDisallowedElements} />
     </div>
   )
 }

--- a/web/app/components/share/text-generation/result/content.tsx
+++ b/web/app/components/share/text-generation/result/content.tsx
@@ -1,8 +1,9 @@
+'use client'
 import type { FC } from 'react'
 import React from 'react'
+import { Markdown } from '@/app/components/base/markdown'
 import Header from './header'
 import type { FeedbackType } from '@/app/components/base/chat/chat/type'
-import { format } from '@/service/base'
 
 export type IResultProps = {
   content: string
@@ -24,10 +25,9 @@ const Result: FC<IResultProps> = ({
         style={{
           maxHeight: '70vh',
         }}
-        dangerouslySetInnerHTML={{
-          __html: format(content),
-        }}
-      ></div>
+      >
+        <Markdown content={content} className='w-full' />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #28676.
- Sanitize Markdown content with DOMPurify before rendering to close the share/completion XSS vector.
- Replace the share result `dangerouslySetInnerHTML` with the shared Markdown renderer so responses always go through the sanitizer.
- Add a unit test covering removal of event handlers/scripts and javascript: protocols from raw HTML blocks.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
