### PR TITLE
fix: truncate auto-populated description to prevent 400-char limit error

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -111,7 +111,11 @@ class App(Base):
         else:
             app_model_config = self.app_model_config
             if app_model_config:
-                return app_model_config.pre_prompt
+                pre_prompt = app_model_config.pre_prompt or ""
+                # Truncate to 200 characters with ellipsis if using prompt as description
+                if len(pre_prompt) > 200:
+                    return pre_prompt[:200] + "..."
+                return pre_prompt
             else:
                 return ""
 


### PR DESCRIPTION
Fixes #28680 


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When application description is empty, the system automatically uses  the prompt as description via desc_or_prompt property. This caused  issues when prompts exceeded 400 characters, preventing users from  modifying application names due to description length validation.

Changes:
- Truncate pre_prompt to 200 characters when used as description
- Add ellipsis ("...") to indicate truncation
- Ensure auto-populated description stays well within 400-char limit

Fixes the issue where Agent/Chatbot applications with long prompts  could not be renamed after creation.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
