### PR TITLE
Use pnpm dev in dev/start-web

### DIFF
--- a/dev/start-web
+++ b/dev/start-web
@@ -5,4 +5,4 @@ set -x
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 cd "$SCRIPT_DIR/../web"
 
-pnpm install && pnpm build && pnpm start
+pnpm install && pnpm dev


### PR DESCRIPTION
## Summary
- adjust `dev/start-web` to run the Next.js dev server instead of building/starting production
- speed up local iteration by avoiding production build steps while using the helper script

Fixes #28683.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
