### PR TITLE
fix: prevent auto-scrolling from stopping in chat

### DIFF
--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -212,9 +212,9 @@ const Chat: FC<ChatProps> = ({
       if (isAutoScrollingRef.current) return
 
       const distanceToBottom = container.scrollHeight - container.clientHeight - container.scrollTop
-      const threshold = 100
+      const SCROLL_UP_THRESHOLD = 100
 
-      userScrolledRef.current = distanceToBottom > threshold
+      userScrolledRef.current = distanceToBottom > SCROLL_UP_THRESHOLD
     }
 
     const container = chatContainerRef.current


### PR DESCRIPTION
## Summary

Fixes #28642 

This PR fixes to prevent auto-scrolling from stopping in chat UI.

## Screenshots

| Before | After |
|--------|-------|
| https://github.com/user-attachments/assets/5bf2d081-5906-45f3-849a-70a644ca7a1f  | https://github.com/user-attachments/assets/a0c5e2c0-5523-4733-938b-9446c883ed90 |


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
