### PR TITLE
feat: creates logs immediately when workflows start (not at completion)

### DIFF
--- a/api/core/app/apps/workflow/generate_task_pipeline.py
+++ b/api/core/app/apps/workflow/generate_task_pipeline.py
@@ -258,6 +258,10 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
 
         run_id = self._extract_workflow_run_id(runtime_state)
         self._workflow_execution_id = run_id
+
+        with self._database_session() as session:
+            self._save_workflow_app_log(session=session, workflow_run_id=self._workflow_execution_id)
+
         start_resp = self._workflow_response_converter.workflow_start_to_stream_response(
             task_id=self._application_generate_entity.task_id,
             workflow_run_id=run_id,
@@ -414,9 +418,6 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
             graph_runtime_state=validated_state,
         )
 
-        with self._database_session() as session:
-            self._save_workflow_app_log(session=session, workflow_run_id=self._workflow_execution_id)
-
         yield workflow_finish_resp
 
     def _handle_workflow_partial_success_event(
@@ -437,10 +438,6 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
             graph_runtime_state=validated_state,
             exceptions_count=event.exceptions_count,
         )
-
-        with self._database_session() as session:
-            self._save_workflow_app_log(session=session, workflow_run_id=self._workflow_execution_id)
-
         yield workflow_finish_resp
 
     def _handle_workflow_failed_and_stop_events(
@@ -471,10 +468,6 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
             error=error,
             exceptions_count=exceptions_count,
         )
-
-        with self._database_session() as session:
-            self._save_workflow_app_log(session=session, workflow_run_id=self._workflow_execution_id)
-
         yield workflow_finish_resp
 
     def _handle_text_chunk_event(
@@ -655,7 +648,6 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
         )
 
         session.add(workflow_app_log)
-        session.commit()
 
     def _text_chunk_to_stream_response(
         self, text: str, from_variable_selector: list[str] | None = None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #28697

- Creates logs immediately when workflows start (not at completion)
- Ensures log persistence even when SSE connections close prematurely
- Provides connection-independent log writing mechanism

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
