### PR TITLE
Use naive_utc_now in graph engine tests

### DIFF
--- a/api/tests/unit_tests/core/workflow/graph_engine/event_management/test_event_handlers.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/event_management/test_event_handlers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from libs.datetime_utils import naive_utc_now
 
 from core.workflow.enums import NodeExecutionType, NodeState, NodeType, WorkflowNodeExecutionStatus
 from core.workflow.graph import Graph
@@ -75,7 +75,7 @@ def test_retry_does_not_emit_additional_start_event() -> None:
 
     execution_id = "exec-1"
     node_type = NodeType.CODE
-    start_time = datetime.utcnow()
+    start_time = naive_utc_now()
 
     start_event = NodeRunStartedEvent(
         id=execution_id,

--- a/api/tests/unit_tests/core/workflow/graph_engine/event_management/test_event_handlers.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/event_management/test_event_handlers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from libs.datetime_utils import naive_utc_now
-
 from core.workflow.enums import NodeExecutionType, NodeState, NodeType, WorkflowNodeExecutionStatus
 from core.workflow.graph import Graph
 from core.workflow.graph_engine.domain.graph_execution import GraphExecution
@@ -16,6 +14,7 @@ from core.workflow.graph_events import NodeRunRetryEvent, NodeRunStartedEvent
 from core.workflow.node_events import NodeRunResult
 from core.workflow.nodes.base.entities import RetryConfig
 from core.workflow.runtime import GraphRuntimeState, VariablePool
+from libs.datetime_utils import naive_utc_now
 
 
 class _StubEdgeProcessor:

--- a/api/tests/unit_tests/core/workflow/graph_engine/orchestration/test_dispatcher.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/orchestration/test_dispatcher.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import queue
-from datetime import datetime
 from unittest import mock
 
 from core.workflow.entities.pause_reason import SchedulingPause
@@ -18,6 +17,7 @@ from core.workflow.graph_events import (
     NodeRunSucceededEvent,
 )
 from core.workflow.node_events import NodeRunResult
+from libs.datetime_utils import naive_utc_now
 
 
 def test_dispatcher_should_consume_remains_events_after_pause():
@@ -109,7 +109,7 @@ def _make_started_event() -> NodeRunStartedEvent:
         node_id="node-1",
         node_type=NodeType.CODE,
         node_title="Test Node",
-        start_at=datetime.utcnow(),
+        start_at=naive_utc_now(),
     )
 
 
@@ -119,7 +119,7 @@ def _make_succeeded_event() -> NodeRunSucceededEvent:
         node_id="node-1",
         node_type=NodeType.CODE,
         node_title="Test Node",
-        start_at=datetime.utcnow(),
+        start_at=naive_utc_now(),
         node_run_result=NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED),
     )
 
@@ -153,7 +153,7 @@ def test_dispatcher_drain_event_queue():
             node_id="node-1",
             node_type=NodeType.CODE,
             node_title="Code",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
         ),
         NodeRunPauseRequestedEvent(
             id="pause-event",
@@ -165,7 +165,7 @@ def test_dispatcher_drain_event_queue():
             id="success-event",
             node_id="node-1",
             node_type=NodeType.CODE,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_result=NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED),
         ),
     ]


### PR DESCRIPTION
## Summary
- Fixes #28734.
- Replace `datetime.utcnow()` with `libs.datetime_utils.naive_utc_now()` in graph engine unit tests to eliminate deprecation warnings and align with the shared UTC helper.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
