### PR TITLE
fix: querying and setting the system default model

### DIFF
--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 from flask import request
 from flask_restx import Resource
@@ -186,7 +186,7 @@ class DefaultModelApi(Resource):
                     tenant_id=tenant_id,
                     model_type=model_setting.model_type,
                     provider=model_setting.provider,
-                    model=model_setting.model,
+                    model=cast(str, model_setting.model),
                 )
             except Exception as ex:
                 logger.exception(

--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -26,7 +26,7 @@ class ParserGetDefault(BaseModel):
 class ParserPostDefault(BaseModel):
     class Inner(BaseModel):
         model_type: ModelType
-        model: str
+        model: str | None = None
         provider: str | None = None
 
     model_settings: list[Inner]
@@ -150,7 +150,7 @@ console_ns.schema_model(
 
 @console_ns.route("/workspaces/current/default-model")
 class DefaultModelApi(Resource):
-    @console_ns.expect(console_ns.models[ParserGetDefault.__name__], validate=True)
+    @console_ns.expect(console_ns.models[ParserGetDefault.__name__])
     @setup_required
     @login_required
     @account_initialization_required


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #28742

- since GET requests don’t carry a body and validate=True would incorrectly enforce body validation.
- allow the model field to be None to accommodate scenarios where other models are not configured.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
