### PR TITLE
docker:  use `COPY --chown` in api Dockerfile to avoid adding layers by explicit `chown` calls

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -90,9 +90,8 @@ RUN python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')" \
 # Copy source code
 COPY --chown=dify:dify . /app/api/
 
-# Copy entrypoint
+# Prepare entrypoint script
 COPY --chown=dify:dify docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 
 ARG COMMIT_SHA

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -91,7 +91,7 @@ RUN python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')" \
 COPY --chown=dify:dify . /app/api/
 
 # Prepare entrypoint script
-COPY --chown=dify:dify docker/entrypoint.sh /entrypoint.sh
+COPY --chown=dify:dify --chmod=755 docker/entrypoint.sh /entrypoint.sh
 
 
 ARG COMMIT_SHA

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -48,6 +48,12 @@ ENV PYTHONIOENCODING=utf-8
 
 WORKDIR /app/api
 
+# Create non-root user
+ARG dify_uid=1001
+RUN groupadd -r -g ${dify_uid} dify && \
+    useradd -r -u ${dify_uid} -g ${dify_uid} -s /bin/bash dify && \
+    chown -R dify:dify /app
+
 RUN \
     apt-get update \
     # Install dependencies
@@ -69,7 +75,7 @@ RUN \
 
 # Copy Python environment and packages
 ENV VIRTUAL_ENV=/app/api/.venv
-COPY --from=packages ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=packages --chown=dify:dify ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Download nltk data
@@ -78,24 +84,21 @@ RUN mkdir -p /usr/local/share/nltk_data && NLTK_DATA=/usr/local/share/nltk_data 
 
 ENV TIKTOKEN_CACHE_DIR=/app/api/.tiktoken_cache
 
-RUN python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')"
+RUN python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')" \
+    && chown -R dify:dify ${TIKTOKEN_CACHE_DIR}
 
 # Copy source code
-COPY . /app/api/
+COPY --chown=dify:dify . /app/api/
 
 # Copy entrypoint
-COPY docker/entrypoint.sh /entrypoint.sh
+COPY --chown=dify:dify docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Create non-root user and set permissions
-RUN groupadd -r -g 1001 dify && \
-    useradd -r -u 1001 -g 1001 -s /bin/bash dify && \
-    mkdir -p /home/dify && \
-    chown -R 1001:1001 /app /home/dify ${TIKTOKEN_CACHE_DIR} /entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
 ENV NLTK_DATA=/usr/local/share/nltk_data
-USER 1001
+
+USER dify
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,8 +20,7 @@ FROM base AS packages
 
 WORKDIR /app/web
 
-COPY package.json .
-COPY pnpm-lock.yaml .
+COPY package.json pnpm-lock.yaml /app/web/
 
 # Use packageManager from package.json
 RUN corepack install

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -75,7 +75,7 @@ COPY --from=builder --chown=dify:dify /app/web/public ./public
 COPY --from=builder --chown=dify:dify /app/web/.next/standalone ./
 COPY --from=builder --chown=dify:dify /app/web/.next/static ./.next/static
 
-COPY --chown=dify:dify docker/entrypoint.sh ./entrypoint.sh
+COPY --chown=dify:dify --chmod=755 docker/entrypoint.sh ./entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache tzdata
 RUN corepack enable
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV NEXT_PUBLIC_BASE_PATH=
+ENV NEXT_PUBLIC_BASE_PATH=""
 
 
 # install packages

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -57,24 +57,30 @@ ENV TZ=UTC
 RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone
 
+# global runtime packages
+RUN pnpm add -g pm2
+
+
+# Create non-root user
+ARG dify_uid=1001
+RUN addgroup -S -g ${dify_uid} dify && \
+    adduser -S -u ${dify_uid} -G dify -s /bin/ash -h /home/dify dify && \
+    mkdir /app && \
+    mkdir /.pm2 && \
+    chown -R dify:dify /app /.pm2
+
 
 WORKDIR /app/web
-COPY --from=builder /app/web/public ./public
-COPY --from=builder /app/web/.next/standalone ./
-COPY --from=builder /app/web/.next/static ./.next/static
 
-COPY docker/entrypoint.sh ./entrypoint.sh
+COPY --from=builder --chown=dify:dify /app/web/public ./public
+COPY --from=builder --chown=dify:dify /app/web/.next/standalone ./
+COPY --from=builder --chown=dify:dify /app/web/.next/static ./.next/static
 
-
-# global runtime packages
-RUN pnpm add -g pm2 \
-    && mkdir /.pm2 \
-    && chown -R 1001:0 /.pm2 /app/web \
-    && chmod -R g=u /.pm2 /app/web
+COPY --chown=dify:dify docker/entrypoint.sh ./entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
 
-USER 1001
+USER dify
 EXPOSE 3000
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- to close #28769
- Referencing practical experience for creating non-root user in Spark Dockerfile as in https://github.com/apache/spark-docker/blob/master/3.5.0/scala2.12-java17-ubuntu/Dockerfile
- use COPY --chown in api Dockerfile to avoid adding layer by explicit chown command
- use `useradd -m` option to create home folder in the place of user creation

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
