### PR TITLE
refactor: rename VariableAssignerNodeData to VariableAggregatorNodeData

### DIFF
--- a/api/core/workflow/nodes/variable_aggregator/entities.py
+++ b/api/core/workflow/nodes/variable_aggregator/entities.py
@@ -23,12 +23,11 @@ class AdvancedSettings(BaseModel):
     groups: list[Group]
 
 
-class VariableAssignerNodeData(BaseNodeData):
+class VariableAggregatorNodeData(BaseNodeData):
     """
-    Variable Assigner Node Data.
+    Variable Aggregator Node Data.
     """
 
-    type: str = "variable-assigner"
     output_type: str
     variables: list[list[str]]
     advanced_settings: AdvancedSettings | None = None

--- a/api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py
+++ b/api/core/workflow/nodes/variable_aggregator/variable_aggregator_node.py
@@ -4,13 +4,13 @@ from core.variables.segments import Segment
 from core.workflow.enums import NodeType, WorkflowNodeExecutionStatus
 from core.workflow.node_events import NodeRunResult
 from core.workflow.nodes.base.node import Node
-from core.workflow.nodes.variable_aggregator.entities import VariableAssignerNodeData
+from core.workflow.nodes.variable_aggregator.entities import VariableAggregatorNodeData
 
 
-class VariableAggregatorNode(Node[VariableAssignerNodeData]):
+class VariableAggregatorNode(Node[VariableAggregatorNodeData]):
     node_type = NodeType.VARIABLE_AGGREGATOR
 
-    _node_data: VariableAssignerNodeData
+    _node_data: VariableAggregatorNodeData
 
     @classmethod
     def version(cls) -> str:


### PR DESCRIPTION
Fixes #28779

## Summary

Rename `VariableAssignerNodeData` to `VariableAggregatorNodeData` to fix naming inconsistency.

When the `VariableAssigner` node was renamed to `VariableAggregator`, the data class was not updated. This PR corrects the oversight by renaming the data class and updating all related imports and type hints.

## Screenshots

N/A - No UI changes

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods