### PR TITLE
fix(ci): use dynamic branch name for i18n workflow to prevent race condition

### DIFF
--- a/.github/workflows/translate-i18n-base-on-english.yml
+++ b/.github/workflows/translate-i18n-base-on-english.yml
@@ -77,12 +77,15 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update i18n files and type definitions based on en-US changes
-          title: 'chore: translate i18n files and update type definitions'
+          commit-message: 'chore(i18n): update translations based on en-US changes'
+          title: 'chore(i18n): translate i18n files and update type definitions'
           body: |
             This PR was automatically created to update i18n files and TypeScript type definitions based on changes in en-US locale.
-            
+
+            **Triggered by:** ${{ github.sha }}
+
             **Changes included:**
             - Updated translation files for all locales
             - Regenerated TypeScript type definitions for type safety
-          branch: chore/automated-i18n-updates
+          branch: chore/automated-i18n-updates-${{ github.sha }}
+          delete-branch: true

--- a/web/i18n/de-DE/tools.ts
+++ b/web/i18n/de-DE/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     confirmTitle: 'Bestätigen, um zu speichern?',
     nameForToolCallPlaceHolder: 'Wird für die Maschinenerkennung verwendet, z. B. getCurrentWeather, list_pets',
     descriptionPlaceholder: 'Kurze Beschreibung des Zwecks des Werkzeugs, z. B. um die Temperatur für einen bestimmten Ort zu ermitteln.',
+    toolOutput: {
+      title: 'Werkzeugausgabe',
+      name: 'Name',
+      reserved: 'Reserviert',
+      reservedParameterDuplicateTip: 'Text, JSON und Dateien sind reservierte Variablen. Variablen mit diesen Namen dürfen im Ausgabeschema nicht erscheinen.',
+      description: 'Beschreibung',
+    },
   },
   test: {
     title: 'Test',

--- a/web/i18n/es-ES/tools.ts
+++ b/web/i18n/es-ES/tools.ts
@@ -122,7 +122,7 @@ const translation = {
     toolOutput: {
       title: 'Salida de la herramienta',
       name: 'Nombre',
-      reserved: 'reservado',
+      reserved: 'Reservado',
       reservedParameterDuplicateTip: 'text, json y files son variables reservadas. Las variables con estos nombres no pueden aparecer en el esquema de salida.',
       description: 'Descripción',
     },

--- a/web/i18n/es-ES/tools.ts
+++ b/web/i18n/es-ES/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'Las aplicaciones que usen esta herramienta se verán afectadas',
     deleteToolConfirmTitle: '¿Eliminar esta Herramienta?',
     deleteToolConfirmContent: 'Eliminar la herramienta es irreversible. Los usuarios ya no podrán acceder a tu herramienta.',
+    toolOutput: {
+      title: 'Salida de la herramienta',
+      name: 'Nombre',
+      reserved: 'reservado',
+      reservedParameterDuplicateTip: 'text, json y files son variables reservadas. Las variables con estos nombres no pueden aparecer en el esquema de salida.',
+      description: 'Descripción',
+    },
   },
   test: {
     title: 'Probar',

--- a/web/i18n/fa-IR/tools.ts
+++ b/web/i18n/fa-IR/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'برنامه‌هایی که از این ابزار استفاده می‌کنند تحت تأثیر قرار خواهند گرفت',
     deleteToolConfirmTitle: 'آیا این ابزار را حذف کنید؟',
     deleteToolConfirmContent: 'حذف ابزار غیرقابل بازگشت است. کاربران دیگر قادر به دسترسی به ابزار شما نخواهند بود.',
+    toolOutput: {
+      title: 'خروجی ابزار',
+      name: 'نام',
+      reserved: 'رزرو شده',
+      reservedParameterDuplicateTip: 'متن، JSON و فایل‌ها متغیرهای رزرو شده هستند. متغیرهایی با این نام‌ها نمی‌توانند در طرح خروجی ظاهر شوند.',
+      description: 'توضیحات',
+    },
   },
   test: {
     title: 'آزمایش',

--- a/web/i18n/fr-FR/tools.ts
+++ b/web/i18n/fr-FR/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     description: 'Description',
     nameForToolCallPlaceHolder: 'Utilisé pour la reconnaissance automatique, tels que getCurrentWeather, list_pets',
     descriptionPlaceholder: 'Brève description de l’objectif de l’outil, par exemple, obtenir la température d’un endroit spécifique.',
+    toolOutput: {
+      title: 'Sortie de l\'outil',
+      name: 'Nom',
+      reserved: 'Réservé',
+      reservedParameterDuplicateTip: 'text, json et files sont des variables réservées. Les variables portant ces noms ne peuvent pas apparaître dans le schéma de sortie.',
+      description: 'Description',
+    },
   },
   test: {
     title: 'Test',

--- a/web/i18n/hi-IN/tools.ts
+++ b/web/i18n/hi-IN/tools.ts
@@ -123,6 +123,13 @@ const translation = {
     confirmTip: 'इस उपकरण का उपयोग करने वाले ऐप्स प्रभावित होंगे',
     deleteToolConfirmTitle: 'इस उपकरण को हटाएं?',
     deleteToolConfirmContent: 'इस उपकरण को हटाने से वापस नहीं आ सकता है। उपयोगकर्ता अब तक आपके उपकरण पर अन्तराल नहीं कर सकेंगे।',
+    toolOutput: {
+      title: 'उपकरण आउटपुट',
+      name: 'नाम',
+      reserved: 'आरक्षित',
+      reservedParameterDuplicateTip: 'text, json, और फाइलें आरक्षित वेरिएबल हैं। इन नामों वाले वेरिएबल आउटपुट स्कीमा में दिखाई नहीं दे सकते।',
+      description: 'विवरण',
+    },
   },
   test: {
     title: 'परीक्षण',

--- a/web/i18n/id-ID/tools.ts
+++ b/web/i18n/id-ID/tools.ts
@@ -117,7 +117,7 @@ const translation = {
     toolOutput: {
       title: 'Keluaran Alat',
       name: 'Nama',
-      reserved: 'Dipesan',
+      reserved: 'Dicadangkan',
       reservedParameterDuplicateTip: 'text, json, dan file adalah variabel yang dicadangkan. Variabel dengan nama-nama ini tidak dapat muncul dalam skema keluaran.',
       description: 'Deskripsi',
     },

--- a/web/i18n/id-ID/tools.ts
+++ b/web/i18n/id-ID/tools.ts
@@ -114,6 +114,13 @@ const translation = {
     importFromUrlPlaceHolder: 'https://...',
     descriptionPlaceholder: 'Deskripsi singkat tentang tujuan alat, misalnya, mendapatkan suhu untuk lokasi tertentu.',
     confirmTitle: 'Konfirmasi untuk menyimpan?',
+    toolOutput: {
+      title: 'Keluaran Alat',
+      name: 'Nama',
+      reserved: 'Dipesan',
+      reservedParameterDuplicateTip: 'text, json, dan file adalah variabel yang dicadangkan. Variabel dengan nama-nama ini tidak dapat muncul dalam skema keluaran.',
+      description: 'Deskripsi',
+    },
   },
   test: {
     testResult: 'Hasil Tes',

--- a/web/i18n/it-IT/tools.ts
+++ b/web/i18n/it-IT/tools.ts
@@ -126,6 +126,13 @@ const translation = {
     deleteToolConfirmTitle: 'Eliminare questo Strumento?',
     deleteToolConfirmContent:
       'L\'eliminazione dello Strumento è irreversibile. Gli utenti non potranno più accedere al tuo Strumento.',
+    toolOutput: {
+      title: 'Output dello strumento',
+      name: 'Nome',
+      reserved: 'Riservato',
+      reservedParameterDuplicateTip: 'text, json e files sono variabili riservate. Le variabili con questi nomi non possono comparire nello schema di output.',
+      description: 'Descrizione',
+    },
   },
   test: {
     title: 'Test',

--- a/web/i18n/ja-JP/tools.ts
+++ b/web/i18n/ja-JP/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'このツールを使用しているアプリは影響を受けます',
     deleteToolConfirmTitle: 'このツールを削除しますか？',
     deleteToolConfirmContent: 'ツールの削除は取り消しできません。ユーザーはもうあなたのツールにアクセスできません。',
+    toolOutput: {
+      title: 'ツール出力',
+      name: '名前',
+      reserved: '予約済み',
+      reservedParameterDuplicateTip: 'text、json、および files は予約語です。これらの名前の変数は出力スキーマに表示することはできません。',
+      description: '説明',
+    },
   },
   test: {
     title: 'テスト',

--- a/web/i18n/ko-KR/tools.ts
+++ b/web/i18n/ko-KR/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: '이 도구를 사용하는 앱은 영향을 받습니다.',
     deleteToolConfirmTitle: '이 도구를 삭제하시겠습니까?',
     deleteToolConfirmContent: '이 도구를 삭제하면 되돌릴 수 없습니다. 사용자는 더 이상 당신의 도구에 액세스할 수 없습니다.',
+    toolOutput: {
+      title: '도구 출력',
+      name: '이름',
+      reserved: '예약됨',
+      reservedParameterDuplicateTip: 'text, json, 파일은 예약된 변수입니다. 이러한 이름을 가진 변수는 출력 스키마에 나타날 수 없습니다.',
+      description: '설명',
+    },
   },
   test: {
     title: '테스트',

--- a/web/i18n/pl-PL/tools.ts
+++ b/web/i18n/pl-PL/tools.ts
@@ -102,7 +102,7 @@ const translation = {
     confirmTitle: 'Potwierdź, aby zapisać ?',
     toolOutput: {
       title: 'Wynik narzędzia',
-      name: 'Imię',
+      name: 'Nazwa',
       reserved: 'Zarezerwowane',
       reservedParameterDuplicateTip: 'text, json i pliki są zastrzeżonymi zmiennymi. Zmienne o tych nazwach nie mogą pojawiać się w schemacie wyjściowym.',
       description: 'Opis',

--- a/web/i18n/pl-PL/tools.ts
+++ b/web/i18n/pl-PL/tools.ts
@@ -100,6 +100,13 @@ const translation = {
     nameForToolCallPlaceHolder: 'Służy do rozpoznawania maszyn, takich jak getCurrentWeather, list_pets',
     confirmTip: 'Będzie to miało wpływ na aplikacje korzystające z tego narzędzia',
     confirmTitle: 'Potwierdź, aby zapisać ?',
+    toolOutput: {
+      title: 'Wynik narzędzia',
+      name: 'Imię',
+      reserved: 'Zarezerwowane',
+      reservedParameterDuplicateTip: 'text, json i pliki są zastrzeżonymi zmiennymi. Zmienne o tych nazwach nie mogą pojawiać się w schemacie wyjściowym.',
+      description: 'Opis',
+    },
   },
   test: {
     title: 'Test',

--- a/web/i18n/pt-BR/tools.ts
+++ b/web/i18n/pt-BR/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     nameForToolCallTip: 'Suporta apenas números, letras e sublinhados.',
     descriptionPlaceholder: 'Breve descrição da finalidade da ferramenta, por exemplo, obter a temperatura para um local específico.',
     nameForToolCallPlaceHolder: 'Usado para reconhecimento de máquina, como getCurrentWeather, list_pets',
+    toolOutput: {
+      title: 'Saída da ferramenta',
+      name: 'Nome',
+      reserved: 'Reservado',
+      reservedParameterDuplicateTip: 'texto, json e arquivos são variáveis reservadas. Variáveis com esses nomes não podem aparecer no esquema de saída.',
+      description: 'Descrição',
+    },
   },
   test: {
     title: 'Testar',

--- a/web/i18n/ro-RO/tools.ts
+++ b/web/i18n/ro-RO/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     confirmTitle: 'Confirmați pentru a salva?',
     customDisclaimerPlaceholder: 'Vă rugăm să introduceți declinarea responsabilității personalizate',
     nameForToolCallTip: 'Acceptă doar numere, litere și caractere de subliniere.',
+    toolOutput: {
+      title: 'Ieșire instrument',
+      name: 'Nume',
+      reserved: 'Rezervat',
+      reservedParameterDuplicateTip: 'text, json și fișiere sunt variabile rezervate. Variabilele cu aceste nume nu pot apărea în schema de ieșire.',
+      description: 'Descriere',
+    },
   },
   test: {
     title: 'Testează',

--- a/web/i18n/ru-RU/tools.ts
+++ b/web/i18n/ru-RU/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'Приложения, использующие этот инструмент, будут затронуты',
     deleteToolConfirmTitle: 'Удалить этот инструмент?',
     deleteToolConfirmContent: 'Удаление инструмента необратимо. Пользователи больше не смогут получить доступ к вашему инструменту.',
+    toolOutput: {
+      title: 'Результат инструмента',
+      name: 'Имя',
+      reserved: 'Зарезервировано',
+      reservedParameterDuplicateTip: 'text, json и files — зарезервированные переменные. Переменные с этими именами не могут появляться в схеме вывода.',
+      description: 'Описание',
+    },
   },
   test: {
     title: 'Тест',

--- a/web/i18n/ru-RU/tools.ts
+++ b/web/i18n/ru-RU/tools.ts
@@ -120,7 +120,7 @@ const translation = {
     deleteToolConfirmTitle: 'Удалить этот инструмент?',
     deleteToolConfirmContent: 'Удаление инструмента необратимо. Пользователи больше не смогут получить доступ к вашему инструменту.',
     toolOutput: {
-      title: 'Результат инструмента',
+      title: 'Вывод инструмента',
       name: 'Имя',
       reserved: 'Зарезервировано',
       reservedParameterDuplicateTip: 'text, json и files — зарезервированные переменные. Переменные с этими именами не могут появляться в схеме вывода.',

--- a/web/i18n/sl-SI/tools.ts
+++ b/web/i18n/sl-SI/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'Aplikacije, ki uporabljajo to orodje, bodo vplivane',
     deleteToolConfirmTitle: 'Izbrisati to orodje?',
     deleteToolConfirmContent: 'Brisanje orodja je nepovratno. Uporabniki ne bodo več imeli dostopa do vašega orodja.',
+    toolOutput: {
+      title: 'Izhod orodja',
+      name: 'Ime',
+      reserved: 'Rezervirano',
+      reservedParameterDuplicateTip: 'text, json in datoteke so rezervirane spremenljivke. Spremenljivke s temi imeni se ne smejo pojaviti v izhodni shemi.',
+      description: 'Opis',
+    },
   },
   test: {
     title: 'Test',

--- a/web/i18n/th-TH/tools.ts
+++ b/web/i18n/th-TH/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'แอปที่ใช้เครื่องมือนี้จะได้รับผลกระทบ',
     deleteToolConfirmTitle: 'ลบเครื่องมือนี้?',
     deleteToolConfirmContent: 'การลบเครื่องมือนั้นไม่สามารถย้อนกลับได้ ผู้ใช้จะไม่สามารถเข้าถึงเครื่องมือของคุณได้อีกต่อไป',
+    toolOutput: {
+      title: 'ผลลัพธ์ของเครื่องมือ',
+      name: 'ชื่อ',
+      reserved: 'สงวน',
+      reservedParameterDuplicateTip: 'text, json และ files เป็นตัวแปรที่สงวนไว้ ไม่สามารถใช้ชื่อตัวแปรเหล่านี้ในโครงสร้างผลลัพธ์ได้',
+      description: 'คำอธิบาย',
+    },
   },
   test: {
     title: 'ทดสอบ',

--- a/web/i18n/th-TH/tools.ts
+++ b/web/i18n/th-TH/tools.ts
@@ -120,7 +120,7 @@ const translation = {
     deleteToolConfirmTitle: 'ลบเครื่องมือนี้?',
     deleteToolConfirmContent: 'การลบเครื่องมือนั้นไม่สามารถย้อนกลับได้ ผู้ใช้จะไม่สามารถเข้าถึงเครื่องมือของคุณได้อีกต่อไป',
     toolOutput: {
-      title: 'ผลลัพธ์ของเครื่องมือ',
+      title: 'เอาต์พุตของเครื่องมือ',
       name: 'ชื่อ',
       reserved: 'สงวน',
       reservedParameterDuplicateTip: 'text, json และ files เป็นตัวแปรที่สงวนไว้ ไม่สามารถใช้ชื่อตัวแปรเหล่านี้ในโครงสร้างผลลัพธ์ได้',

--- a/web/i18n/tr-TR/tools.ts
+++ b/web/i18n/tr-TR/tools.ts
@@ -119,6 +119,13 @@ const translation = {
     confirmTip: 'Bu aracı kullanan uygulamalar etkilenecek',
     deleteToolConfirmTitle: 'Bu Aracı silmek istiyor musunuz?',
     deleteToolConfirmContent: 'Aracın silinmesi geri alınamaz. Kullanıcılar artık aracınıza erişemeyecek.',
+    toolOutput: {
+      title: 'Araç Çıktısı',
+      name: 'İsim',
+      reserved: 'Rezerve',
+      reservedParameterDuplicateTip: 'text, json ve dosyalar ayrılmış değişkenlerdir. Bu isimlere sahip değişkenler çıktı şemasında yer alamaz.',
+      description: 'Açıklama',
+    },
   },
   test: {
     title: 'Test',

--- a/web/i18n/tr-TR/tools.ts
+++ b/web/i18n/tr-TR/tools.ts
@@ -122,7 +122,7 @@ const translation = {
     toolOutput: {
       title: 'Araç Çıktısı',
       name: 'İsim',
-      reserved: 'Rezerve',
+      reserved: 'Ayrılmış',
       reservedParameterDuplicateTip: 'text, json ve dosyalar ayrılmış değişkenlerdir. Bu isimlere sahip değişkenler çıktı şemasında yer alamaz.',
       description: 'Açıklama',
     },

--- a/web/i18n/uk-UA/tools.ts
+++ b/web/i18n/uk-UA/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     confirmTip: 'Це вплине на програми, які використовують цей інструмент',
     nameForToolCallPlaceHolder: 'Використовується для розпізнавання машин, таких як getCurrentWeather, list_pets',
     descriptionPlaceholder: 'Короткий опис призначення інструменту, наприклад, отримання температури для конкретного місця.',
+    toolOutput: {
+      title: 'Вихідні дані інструменту',
+      name: 'Ім\'я',
+      reserved: 'Зарезервовано',
+      reservedParameterDuplicateTip: 'text, json та файли є зарезервованими змінними. Змінні з такими іменами не можуть з’являтися в схемі вихідних даних.',
+      description: 'Опис',
+    },
   },
   test: {
     title: 'Тест',

--- a/web/i18n/vi-VN/tools.ts
+++ b/web/i18n/vi-VN/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     description: 'Sự miêu tả',
     confirmTitle: 'Xác nhận để lưu ?',
     confirmTip: 'Các ứng dụng sử dụng công cụ này sẽ bị ảnh hưởng',
+    toolOutput: {
+      title: 'Kết quả công cụ',
+      name: 'Tên',
+      reserved: 'Đã đặt trước',
+      reservedParameterDuplicateTip: 'text, json và files là các biến được đặt trước. Các biến có tên này không thể xuất hiện trong sơ đồ đầu ra.',
+      description: 'Mô tả',
+    },
   },
   test: {
     title: 'Kiểm tra',

--- a/web/i18n/vi-VN/tools.ts
+++ b/web/i18n/vi-VN/tools.ts
@@ -99,7 +99,7 @@ const translation = {
     confirmTitle: 'Xác nhận để lưu ?',
     confirmTip: 'Các ứng dụng sử dụng công cụ này sẽ bị ảnh hưởng',
     toolOutput: {
-      title: 'Kết quả công cụ',
+      title: 'Đầu ra của công cụ',
       name: 'Tên',
       reserved: 'Dành riêng',
       reservedParameterDuplicateTip: 'text, json và files là các biến dành riêng. Các biến có tên này không thể xuất hiện trong sơ đồ đầu ra.',

--- a/web/i18n/vi-VN/tools.ts
+++ b/web/i18n/vi-VN/tools.ts
@@ -101,8 +101,8 @@ const translation = {
     toolOutput: {
       title: 'Kết quả công cụ',
       name: 'Tên',
-      reserved: 'Đã đặt trước',
-      reservedParameterDuplicateTip: 'text, json và files là các biến được đặt trước. Các biến có tên này không thể xuất hiện trong sơ đồ đầu ra.',
+      reserved: 'Dành riêng',
+      reservedParameterDuplicateTip: 'text, json và files là các biến dành riêng. Các biến có tên này không thể xuất hiện trong sơ đồ đầu ra.',
       description: 'Mô tả',
     },
   },

--- a/web/i18n/zh-Hant/tools.ts
+++ b/web/i18n/zh-Hant/tools.ts
@@ -98,6 +98,13 @@ const translation = {
     nameForToolCallTip: '僅支援數位、字母和下劃線。',
     confirmTip: '使用此工具的應用程式將受到影響',
     nameForToolCallPlaceHolder: '用於機器識別，例如 getCurrentWeather、list_pets',
+    toolOutput: {
+      title: '工具輸出',
+      name: '姓名',
+      reserved: '已保留',
+      reservedParameterDuplicateTip: 'text、json 和 files 是保留變數。這些名稱的變數不能出現在輸出結構中。',
+      description: '描述',
+    },
   },
   test: {
     title: '測試',

--- a/web/i18n/zh-Hant/tools.ts
+++ b/web/i18n/zh-Hant/tools.ts
@@ -100,7 +100,7 @@ const translation = {
     nameForToolCallPlaceHolder: '用於機器識別，例如 getCurrentWeather、list_pets',
     toolOutput: {
       title: '工具輸出',
-      name: '姓名',
+      name: '名稱',
       reserved: '已保留',
       reservedParameterDuplicateTip: 'text、json 和 files 是保留變數。這些名稱的變數不能出現在輸出結構中。',
       description: '描述',


### PR DESCRIPTION
Fixes #28822

## Summary

Use commit SHA in branch name to ensure each i18n CI run creates an independent PR, preventing race conditions where later runs overwrite earlier translation changes.

**Changes:**
- Branch name: `chore/automated-i18n-updates` → `chore/automated-i18n-updates-${{ github.sha }}`
- Added `delete-branch: true` for automatic cleanup after merge
- Added trigger commit SHA to PR body for traceability

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods