### PR TITLE
fix: add explicit default to httpx.timeout

### DIFF
--- a/api/controllers/console/version.py
+++ b/api/controllers/console/version.py
@@ -58,7 +58,7 @@ class VersionApi(Resource):
             response = httpx.get(
                 check_update_url,
                 params={"current_version": args["current_version"]},
-                timeout=httpx.Timeout(10.0, connect=3.0),
+                timeout=httpx.Timeout(timeout=10.0, connect=3.0),
             )
         except Exception as error:
             logger.warning("Check update version error: %s.", str(error))

--- a/api/controllers/console/version.py
+++ b/api/controllers/console/version.py
@@ -58,7 +58,7 @@ class VersionApi(Resource):
             response = httpx.get(
                 check_update_url,
                 params={"current_version": args["current_version"]},
-                timeout=httpx.Timeout(connect=3, read=10),
+                timeout=httpx.Timeout(10.0, connect=3.0),
             )
         except Exception as error:
             logger.warning("Check update version error: %s.", str(error))


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

`WARNING [version.py:61] - Check update version error: httpx.Timeout must either include a default, or set all four parameters explicitly.`

This shows up while version checking. Fix to have explicit default.

reference: https://pypi.org/project/httpx/0.16.1/
`Usage of httpx.Timeout() should now always include an explicit default. Eg. httpx.Timeout(None, pool=5.0). (Pull #1085)`

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
