### PR TITLE
improve dockerfile in multiline run commands by introducing heredoc syntax

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
+####################################################################################
 # base image
 FROM python:3.12-slim-bookworm AS base
 
@@ -11,7 +12,7 @@ ENV UV_VERSION=0.8.9
 
 RUN pip install --no-cache-dir uv==${UV_VERSION}
 
-
+####################################################################################
 FROM base AS packages
 
 # if you located in China, you can use aliyun mirror to speed up
@@ -20,14 +21,16 @@ FROM base AS packages
 RUN <<EOF
     apt-get update
     apt-get install -y --no-install-recommends \
-              g++ \
-              libmpfr-dev libmpc-dev
+        # basic environment
+        g++ \
+        libmpfr-dev libmpc-dev
 EOF
 
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
 RUN uv sync --locked --no-dev
 
+####################################################################################
 # production stage
 FROM base AS production
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,7 +21,6 @@ FROM base AS packages
 RUN <<EOF
     apt-get update
     apt-get install -y --no-install-recommends \
-        # basic environment
         g++ \
         libmpfr-dev libmpc-dev
 EOF

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
 # base image
 FROM python:3.12-slim-bookworm AS base
 
@@ -14,12 +17,12 @@ FROM base AS packages
 # if you located in China, you can use aliyun mirror to speed up
 # RUN sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list.d/debian.sources
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-          # basic environment
-          g++ \
-          # for building gmpy2
-          libmpfr-dev libmpc-dev
+RUN <<EOF
+    apt-get update
+    apt-get install -y --no-install-recommends \
+              g++ \
+              libmpfr-dev libmpc-dev
+EOF
 
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
@@ -45,47 +48,52 @@ ENV TZ=UTC
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV PYTHONIOENCODING=utf-8
+# NLTK_DATA environment variable for NLTK data, refering to https://www.nltk.org/data.html#interactive-installer
+ENV NLTK_DATA=/usr/local/share/nltk_data
+ENV TIKTOKEN_CACHE_DIR=/app/api/.tiktoken_cache
 
 WORKDIR /app/api
 
 # Create non-root user
 ARG dify_uid=1001
-RUN groupadd -r -g ${dify_uid} dify && \
-    useradd -r -u ${dify_uid} -g ${dify_uid} -s /bin/bash dify && \
+RUN <<EOF
+    groupadd -r -g ${dify_uid} dify
+    useradd -r -u ${dify_uid} -g ${dify_uid} -s /bin/bash dify
     chown -R dify:dify /app
+EOF
 
-RUN \
-    apt-get update \
+RUN <<EOF
+    set -ex
+    apt-get update
     # Install dependencies
-    && apt-get install -y --no-install-recommends \
-        # basic environment
+    apt-get install -y --no-install-recommends \
         curl nodejs \
-        # for gmpy2 \
         libgmp-dev libmpfr-dev libmpc-dev \
-        # For Security
         expat libldap-2.5-0=2.5.13+dfsg-5 perl libsqlite3-0=3.40.1-2+deb12u2 zlib1g=1:1.2.13.dfsg-1 \
-        # install fonts to support the use of tools like pypdfium2
         fonts-noto-cjk \
-        # install a package to improve the accuracy of guessing mime type and file extension
         media-types \
-        # install libmagic to support the use of python-magic guess MIMETYPE
-        libmagic1 \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+        libmagic1
+    apt-get autoremove -y
+    rm -rf /var/lib/apt/lists/*
+EOF
 
 # Copy Python environment and packages
 ENV VIRTUAL_ENV=/app/api/.venv
 COPY --from=packages --chown=dify:dify ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-# Download nltk data
-RUN mkdir -p /usr/local/share/nltk_data && NLTK_DATA=/usr/local/share/nltk_data python -c "import nltk; nltk.download('punkt'); nltk.download('averaged_perceptron_tagger'); nltk.download('stopwords')" \
-    && chmod -R 755 /usr/local/share/nltk_data
+RUN <<EOF
+    set -ex
 
-ENV TIKTOKEN_CACHE_DIR=/app/api/.tiktoken_cache
+    # Download nltk data
+    mkdir -p ${NLTK_DATA}
+    python -c "import nltk; nltk.download('punkt'); nltk.download('averaged_perceptron_tagger'); nltk.download('stopwords')"
+    chmod -R 755 ${NLTK_DATA}
 
-RUN python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')" \
-    && chown -R dify:dify ${TIKTOKEN_CACHE_DIR}
+    # Preload tiktoken encodings
+    python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')"
+    chown -R dify:dify ${TIKTOKEN_CACHE_DIR}
+EOF
 
 # Copy source code
 COPY --chown=dify:dify . /app/api/
@@ -96,8 +104,8 @@ COPY --chown=dify:dify --chmod=755 docker/entrypoint.sh /entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
-ENV NLTK_DATA=/usr/local/share/nltk_data
 
+# Switch to non-root user
 USER dify
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -23,12 +23,14 @@ FROM base AS packages
 
 WORKDIR /app/web
 
-COPY package.json pnpm-lock.yaml /app/web/
+COPY package.json pnpm-lock.yaml ./
 
-# Use packageManager from package.json
-RUN corepack install
-
-RUN pnpm install --frozen-lockfile
+RUN <<EOF
+  # Use packageManager from package.json
+  corepack install
+  # Install dependencies with PNPM based on the lockfile
+  pnpm install --frozen-lockfile
+EOF
 
 # build resources
 FROM base AS builder

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
 # base image
 FROM node:22-alpine3.21 AS base
 LABEL maintainer="takatost@gmail.com"
@@ -50,36 +53,41 @@ ENV MARKETPLACE_URL=https://marketplace.dify.ai
 ENV PORT=3000
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PM2_INSTANCES=2
-
-# set timezone
 ENV TZ=UTC
-RUN ln -s /usr/share/zoneinfo/${TZ} /etc/localtime \
-    && echo ${TZ} > /etc/timezone
+ARG dify_uid=1001
 
 # global runtime packages
 RUN pnpm add -g pm2
 
+RUN <<EOF
+    set -ex
+    # set timezone
+    ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
+    echo ${TZ} > /etc/timezone
 
-# Create non-root user
-ARG dify_uid=1001
-RUN addgroup -S -g ${dify_uid} dify && \
-    adduser -S -u ${dify_uid} -G dify -s /bin/ash -h /home/dify dify && \
-    mkdir /app && \
-    mkdir /.pm2 && \
+    # Create non-root user
+    addgroup -S -g ${dify_uid} dify
+    adduser -S -u ${dify_uid} -G dify -s /bin/ash -h /home/dify dify
+    mkdir /app
+    mkdir /.pm2
     chown -R dify:dify /app /.pm2
-
+EOF
 
 WORKDIR /app/web
 
+# Copy built web files
 COPY --from=builder --chown=dify:dify /app/web/public ./public
 COPY --from=builder --chown=dify:dify /app/web/.next/standalone ./
 COPY --from=builder --chown=dify:dify /app/web/.next/static ./.next/static
 
+# Prepare entrypoint script
 COPY --chown=dify:dify --chmod=755 docker/entrypoint.sh ./entrypoint.sh
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
 
+# Switch to non-root user
 USER dify
+
 EXPOSE 3000
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,10 +26,10 @@ WORKDIR /app/web
 COPY package.json pnpm-lock.yaml ./
 
 RUN <<EOF
-  # Use packageManager from package.json
-  corepack install
-  # Install dependencies with PNPM based on the lockfile
-  pnpm install --frozen-lockfile
+    # Use packageManager from package.json
+    corepack install
+    # Install dependencies with PNPM based on the lockfile
+    pnpm install --frozen-lockfile
 EOF
 
 # build resources

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
+####################################################################################
 # base image
 FROM node:22-alpine3.21 AS base
 LABEL maintainer="takatost@gmail.com"
@@ -17,7 +18,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV NEXT_PUBLIC_BASE_PATH=""
 
-
+####################################################################################
 # install packages
 FROM base AS packages
 
@@ -32,6 +33,7 @@ RUN <<EOF
     pnpm install --frozen-lockfile
 EOF
 
+####################################################################################
 # build resources
 FROM base AS builder
 WORKDIR /app/web
@@ -41,7 +43,7 @@ COPY . .
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm build:docker
 
-
+####################################################################################
 # production stage
 FROM base AS production
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Introduce dockerfile heredoc syntax v1 with checks
```
# syntax=docker/dockerfile:1
# check=error=true
```
- Prefer `RUN <<EOF` for multi-line scirpts over the fragile and legacy way as ` ... && \` line ends.
- Squashing RUN commands into less layers
- Remove repeated `NLTK_DATA` system envrionment declaration


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
