### PR TITLE
feat: Workflow-Level Credential Override for Model Providers

### DIFF
--- a/api/core/workflow/nodes/llm/entities.py
+++ b/api/core/workflow/nodes/llm/entities.py
@@ -9,11 +9,19 @@ from core.workflow.nodes.base import BaseNodeData
 from core.workflow.nodes.base.entities import VariableSelector
 
 
+class CredentialOverride(BaseModel):
+    # Allow specifying a specific credential by ID
+    credential_id: str | None = None
+    # Or allow specifying credential by name (for UI friendliness)
+    credential_name: str | None = None
+
+
 class ModelConfig(BaseModel):
     provider: str
     name: str
     mode: LLMMode
     completion_params: dict[str, Any] = Field(default_factory=dict)
+    credential_override: CredentialOverride | None = None
 
 
 class ContextConfig(BaseModel):
@@ -76,7 +84,7 @@ class LLMNodeData(BaseNodeData):
             Strategy for handling model reasoning output.
 
             separated: Return clean text (without <think> tags) + reasoning_content field.
-                      Recommended for new workflows. Enables safe downstream parsing and 
+                      Recommended for new workflows. Enables safe downstream parsing and
                       workflow variable access: {{#node_id.reasoning_content#}}
 
             tagged   : Return original text (with <think> tags) + reasoning_content field.

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -81,6 +81,7 @@ from models.model import UploadFile
 
 from . import llm_utils
 from .entities import (
+    CredentialOverride,
     LLMNodeChatModelMessage,
     LLMNodeCompletionModelPromptTemplate,
     LLMNodeData,
@@ -200,6 +201,7 @@ class LLMNode(Node[LLMNodeData]):
             model_instance, model_config = LLMNode._fetch_model_config(
                 node_data_model=self.node_data.model,
                 tenant_id=self.tenant_id,
+                credential_override=self._node_data.model.credential_override,
             )
 
             # fetch memory
@@ -749,12 +751,10 @@ class LLMNode(Node[LLMNodeData]):
 
     @staticmethod
     def _fetch_model_config(
-        *,
-        node_data_model: ModelConfig,
-        tenant_id: str,
+        *, node_data_model: ModelConfig, tenant_id: str, credential_override: CredentialOverride | None = None
     ) -> tuple[ModelInstance, ModelConfigWithCredentialsEntity]:
         model, model_config_with_cred = llm_utils.fetch_model_config(
-            tenant_id=tenant_id, node_data_model=node_data_model
+            tenant_id=tenant_id, node_data_model=node_data_model, workflow_credential_override=credential_override
         )
         completion_params = model_config_with_cred.parameters
 

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_credential_override.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_credential_override.py
@@ -1,0 +1,129 @@
+"""
+Test cases for workflow-level credential override functionality.
+Tests the CredentialOverride class and _fetch_override_credentials function.
+"""
+
+import re
+from unittest.mock import Mock, patch
+
+import pytest
+
+from core.workflow.nodes.llm.entities import CredentialOverride
+from core.workflow.nodes.llm.llm_utils import _fetch_override_credentials
+
+
+class TestCredentialOverride:
+    """Test credential override functionality"""
+
+    def test_fetch_override_credentials_by_id(self):
+        """Test fetching credentials by credential ID"""
+        # Mock provider configuration
+        mock_provider_config = Mock()
+        mock_provider_config.get_provider_credential.return_value = {
+            "openai_api_key": "sk-test-key-123",
+            "model": "gpt-4",
+        }
+
+        with patch("core.provider_manager.ProviderManager.get_configurations") as mock_get_configs:
+            mock_get_configs.return_value = {
+                "openai": mock_provider_config,
+            }
+
+            # Test successful fetch by ID
+            result = _fetch_override_credentials(
+                tenant_id="test-tenant",
+                provider="openai",
+                model="gpt-4",
+                credential_override=CredentialOverride(credential_id="test-cred-123"),
+            )
+
+            assert result["openai_api_key"] == "sk-test-key-123"
+            assert result["model"] == "gpt-4"
+
+    def test_fetch_override_credentials_by_name(self):
+        """Test fetching credentials by credential name"""
+        mock_provider_config = Mock()
+        mock_provider_config.get_custom_model_credential.return_value = {
+            "openai_api_key": "sk-test-key-456",
+            "model": "gpt-3.5-turbo",
+        }
+
+        with patch("core.provider_manager.ProviderManager.get_configurations") as mock_get_configs:
+            mock_get_configs.return_value = {
+                "openai": mock_provider_config,
+            }
+
+            # Mock model configuration with available credentials
+            mock_model_config = Mock()
+            mock_model_config.available_model_credentials = [
+                Mock(credential_name="API Key 1 (Production)"),
+                Mock(credential_name="API Key 2 (Staging)"),
+            ]
+            mock_provider_config.custom_configuration.models = [mock_model_config]
+
+            # Test successful fetch by name
+            result = _fetch_override_credentials(
+                tenant_id="test-tenant",
+                provider="openai",
+                model="gpt-3.5-turbo",
+                credential_override=CredentialOverride(credential_name="API Key 1 (Production)"),
+            )
+
+            assert result["openai_api_key"] == "sk-test-key-456"
+
+    def test_fetch_override_credentials_not_found(self):
+        """Test error handling when credential not found"""
+        mock_provider_config = Mock()
+        mock_provider_config.get_provider_credential.side_effect = ValueError("Credential not found")
+        mock_provider_config.get_custom_model_credential.side_effect = ValueError("Credential not found")
+        mock_provider_config.custom_configuration.models = []
+
+        with patch("core.provider_manager.ProviderManager.get_configurations") as mock_get_configs:
+            mock_get_configs.return_value = {
+                "openai": mock_provider_config,
+            }
+
+            # Test ID not found
+            with pytest.raises(ValueError, match="Credential with ID test-cred-123 not found"):
+                _fetch_override_credentials(
+                    tenant_id="test-tenant",
+                    provider="openai",
+                    model="gpt-4",
+                    credential_override=CredentialOverride(credential_id="test-cred-123"),
+                )
+
+            # Test name not found (escape regex metacharacters in message)
+            with pytest.raises(ValueError, match=re.escape("Credential with name 'API Key 1 (Production)' not found")):
+                _fetch_override_credentials(
+                    tenant_id="test-tenant",
+                    provider="openai",
+                    model="gpt-3.5-turbo",
+                    credential_override=CredentialOverride(credential_name="API Key 1 (Production)"),
+                )
+
+    def test_fetch_override_credentials_fallback_to_default(self):
+        """Test fallback to default credentials when override is invalid"""
+        with patch("core.provider_manager.ProviderManager.get_configurations") as mock_get_configs:
+            mock_get_configs.return_value = {
+                "openai": Mock(),  # No provider configuration
+            }
+
+            # Should not raise error, should return None and log warning
+            result = _fetch_override_credentials(
+                tenant_id="test-tenant",
+                provider="openai",
+                model="gpt-4",
+                credential_override=CredentialOverride(credential_id="invalid-id"),
+            )
+
+            # Function should handle the error gracefully and return None
+            assert result is None
+
+    def test_empty_credential_override(self):
+        """Test handling of empty credential override"""
+        # Should not raise error for empty override
+        result = _fetch_override_credentials(
+            tenant_id="test-tenant", provider="openai", model="gpt-4", credential_override=CredentialOverride()
+        )
+
+        assert result is None

--- a/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
@@ -48,6 +48,7 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
     handleUpdateCondition,
     handleMetadataModelChange,
     handleMetadataCompletionParamsChange,
+    handleMetadataCredentialOverrideChange,
     availableStringVars,
     availableStringNodesWithParent,
     availableNumberVars,
@@ -142,6 +143,8 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
           metadataModelConfig={inputs.metadata_model_config}
           handleMetadataModelChange={handleMetadataModelChange}
           handleMetadataCompletionParamsChange={handleMetadataCompletionParamsChange}
+          handleMetadataCredentialOverrideChange={handleMetadataCredentialOverrideChange}
+          readOnly={readOnly}
           availableStringVars={availableStringVars}
           availableStringNodesWithParent={availableStringNodesWithParent}
           availableNumberVars={availableNumberVars}

--- a/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
@@ -5,6 +5,7 @@ import type {
   NodeOutPutVar,
   ValueSelector,
 } from '@/app/components/workflow/types'
+import type { CredentialOverride } from '../llm/types'
 import type { RETRIEVE_TYPE } from '@/types/app'
 import type {
   DataSet,
@@ -36,7 +37,9 @@ export type MultipleRetrievalConfig = {
 }
 
 export type SingleRetrievalConfig = {
-  model: ModelConfig
+  model: ModelConfig & {
+    credential_override?: CredentialOverride
+  }
 }
 
 export enum LogicalOperator {
@@ -105,7 +108,9 @@ export type KnowledgeRetrievalNodeType = CommonNodeType & {
   _datasets?: DataSet[]
   metadata_filtering_mode?: MetadataFilteringModeEnum
   metadata_filtering_conditions?: MetadataFilteringConditions
-  metadata_model_config?: ModelConfig
+  metadata_model_config?: ModelConfig & {
+    credential_override?: CredentialOverride
+  }
 }
 
 export type HandleAddCondition = (metadataItem: MetadataInDoc) => void

--- a/web/app/components/workflow/nodes/llm/types.ts
+++ b/web/app/components/workflow/nodes/llm/types.ts
@@ -1,7 +1,14 @@
 import type { CommonNodeType, Memory, ModelConfig, PromptItem, ValueSelector, Variable, VisionSetting } from '@/app/components/workflow/types'
 
+export type CredentialOverride = {
+  credential_id?: string
+  credential_name?: string
+}
+
 export type LLMNodeType = CommonNodeType & {
-  model: ModelConfig
+  model: ModelConfig & {
+    credential_override?: CredentialOverride
+  }
   prompt_template: PromptItem[] | PromptItem
   prompt_config?: {
     jinja2_variables?: Variable[]

--- a/web/app/components/workflow/nodes/llm/use-config.ts
+++ b/web/app/components/workflow/nodes/llm/use-config.ts
@@ -9,7 +9,7 @@ import {
 } from '../../hooks'
 import useAvailableVarList from '../_base/hooks/use-available-var-list'
 import useConfigVision from '../../hooks/use-config-vision'
-import type { LLMNodeType, StructuredOutput } from './types'
+import type { CredentialOverride, LLMNodeType, StructuredOutput } from './types'
 import { useModelList, useModelListAndDefaultModelAndCurrentProviderAndModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import {
   ModelFeatureEnum,
@@ -128,11 +128,13 @@ const useConfig = (id: string, payload: LLMNodeType) => {
     },
   })
 
-  const handleModelChanged = useCallback((model: { provider: string; modelId: string; mode?: string }) => {
+  const handleModelChanged = useCallback((model: { provider: string; modelId: string; mode?: string; credential_override?: CredentialOverride }) => {
     const newInputs = produce(inputRef.current, (draft) => {
       draft.model.provider = model.provider
       draft.model.name = model.modelId
       draft.model.mode = model.mode!
+      if (model.credential_override !== undefined)
+        draft.model.credential_override = model.credential_override
       const isModeChange = model.mode !== inputRef.current.model.mode
       if (isModeChange && defaultConfig && Object.keys(defaultConfig).length > 0)
         appendDefaultPromptConfig(draft, defaultConfig, model.mode === AppModeEnum.CHAT)
@@ -140,6 +142,13 @@ const useConfig = (id: string, payload: LLMNodeType) => {
     setInputs(newInputs)
     setModelChanged(true)
   }, [setInputs, defaultConfig, appendDefaultPromptConfig])
+
+  const handleCredentialOverrideChange = useCallback((credential_override: CredentialOverride | undefined) => {
+    const newInputs = produce(inputRef.current, (draft) => {
+      draft.model.credential_override = credential_override
+    })
+    setInputs(newInputs)
+  }, [setInputs])
 
   useEffect(() => {
     if (currentProvider?.provider && currentModel?.model && !model.provider) {
@@ -368,6 +377,7 @@ const useConfig = (id: string, payload: LLMNodeType) => {
     handleStructureOutputEnableChange,
     filterJinja2InputVar,
     handleReasoningFormatChange,
+    handleCredentialOverrideChange,
   }
 }
 

--- a/web/app/components/workflow/nodes/parameter-extractor/panel.tsx
+++ b/web/app/components/workflow/nodes/parameter-extractor/panel.tsx
@@ -19,6 +19,10 @@ import type { NodePanelProps } from '@/app/components/workflow/types'
 import Tooltip from '@/app/components/base/tooltip'
 import { VarType } from '@/app/components/workflow/types'
 import { FieldCollapse } from '@/app/components/workflow/nodes/_base/components/collapse'
+import { SimpleSelect } from '@/app/components/base/select'
+import type { Item as SelectItem } from '@/app/components/base/select'
+import useSWR from 'swr'
+import { fetchAvailableCredentials } from '@/service/common'
 
 const i18nPrefix = 'workflow.nodes.parameterExtractor'
 const i18nCommonPrefix = 'workflow.common'
@@ -52,9 +56,33 @@ const Panel: FC<NodePanelProps<ParameterExtractorNodeType>> = ({
     isVisionModel,
     handleVisionResolutionChange,
     handleVisionResolutionEnabledChange,
+    handleCredentialOverrideChange,
   } = useConfig(id, data)
 
   const model = inputs.model
+
+  // available credentials for override select
+  const providerForCreds = model?.provider
+  const modelNameForCreds = model?.name
+  const { data: availableCreds, isLoading: credsLoading } = useSWR(
+    providerForCreds ? `/workspaces/current/model-providers/${providerForCreds}/available-credentials${modelNameForCreds ? `?model=${encodeURIComponent(modelNameForCreds)}&model_type=llm` : ''}` : null,
+    fetchAvailableCredentials,
+  )
+  const overrideItems: SelectItem[] = React.useMemo(() => {
+    const list = [
+      ...((availableCreds?.provider_available_credentials || []).map(c => ({ value: c.credential_id, name: c.credential_name || c.credential_id })) as SelectItem[]),
+      ...((availableCreds?.model_available_credentials || []).map(c => ({ value: c.credential_id, name: c.credential_name || c.credential_id })) as SelectItem[]),
+    ]
+    const seen = new Set<string>()
+    const deduped = list.filter((it) => {
+      const v = String(it.value)
+      if (seen.has(v)) return false
+      seen.add(v)
+      return true
+    })
+    // Add explicit option label to allow resetting to default credentials
+    return [{ value: '', name: t('common.label.noOverride') }, ...deduped]
+  }, [availableCreds, t])
 
   return (
     <div className='pt-2'>
@@ -77,6 +105,34 @@ const Panel: FC<NodePanelProps<ParameterExtractorNodeType>> = ({
             readonly={readOnly}
           />
         </Field>
+        {model?.provider && !readOnly && (
+          <Field
+            title={t('API keys')}
+            tooltip={t(`${i18nPrefix} credential override`)!}
+          >
+            <div className='space-y-2'>
+              <SimpleSelect
+                items={overrideItems}
+                defaultValue={inputs.model?.credential_override?.credential_id || ''}
+                onSelect={(item) => {
+                  const v = String(item.value || '')
+                  handleCredentialOverrideChange(v
+                    ? { credential_id: v, credential_name: undefined }
+                    : undefined,
+                  )
+                }}
+                isLoading={credsLoading}
+                notClearable={false}
+                className="system-sm-regular h-8 w-full items-center justify-between rounded-lg bg-components-input-bg-normal px-2 hover:bg-state-base-hover-alt"
+                wrapperClassName="h-8"
+                optionClassName="system-sm-regular"
+              />
+              <div className='text-xs text-text-tertiary'>
+                {t('override the credential')}
+              </div>
+            </div>
+          </Field>
+        )}
         <Field
           title={t(`${i18nPrefix}.inputVar`)}
           required

--- a/web/app/components/workflow/nodes/parameter-extractor/types.ts
+++ b/web/app/components/workflow/nodes/parameter-extractor/types.ts
@@ -1,4 +1,5 @@
 import type { CommonNodeType, Memory, ModelConfig, ValueSelector, VisionSetting } from '@/app/components/workflow/types'
+import type { CredentialOverride } from '../llm/types'
 
 export enum ParamType {
   string = 'string',
@@ -25,7 +26,9 @@ export enum ReasoningModeType {
 }
 
 export type ParameterExtractorNodeType = CommonNodeType & {
-  model: ModelConfig
+  model: ModelConfig & {
+    credential_override?: CredentialOverride
+  }
   query: ValueSelector
   reasoning_mode: ReasoningModeType
   parameters: Param[]

--- a/web/app/components/workflow/nodes/parameter-extractor/use-config.ts
+++ b/web/app/components/workflow/nodes/parameter-extractor/use-config.ts
@@ -18,6 +18,7 @@ import useAvailableVarList from '@/app/components/workflow/nodes/_base/hooks/use
 import { supportFunctionCall } from '@/utils/tool-call'
 import useInspectVarsCrud from '../../hooks/use-inspect-vars-crud'
 import { AppModeEnum } from '@/types/app'
+import type { CredentialOverride } from '../llm/types'
 
 const useConfig = (id: string, payload: ParameterExtractorNodeType) => {
   const {
@@ -222,6 +223,13 @@ const useConfig = (id: string, payload: ParameterExtractorNodeType) => {
     setInputs(newInputs)
   }, [inputs, setInputs])
 
+  const handleCredentialOverrideChange = useCallback((override?: CredentialOverride) => {
+    const newInputs = produce(inputs, (draft) => {
+      draft.model.credential_override = override
+    })
+    setInputs(newInputs)
+  }, [inputs, setInputs])
+
   return {
     readOnly,
     handleInputVarChange,
@@ -245,6 +253,7 @@ const useConfig = (id: string, payload: ParameterExtractorNodeType) => {
     isVisionModel,
     handleVisionResolutionEnabledChange,
     handleVisionResolutionChange,
+    handleCredentialOverrideChange,
   }
 }
 

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -90,6 +90,7 @@ const translation = {
   noData: 'No data',
   label: {
     optional: '(optional)',
+    noOverride: 'No override',
   },
   voice: {
     language: {

--- a/web/service/common.ts
+++ b/web/service/common.ts
@@ -199,6 +199,14 @@ export const fetchModelProviderCredentials: Fetcher<ModelProviderCredentials, st
   return get<ModelProviderCredentials>(url)
 }
 
+export type AvailableCredentialsRes = {
+  provider_available_credentials: { credential_id: string; credential_name?: string }[]
+  model_available_credentials: { credential_id: string; credential_name?: string }[]
+}
+export const fetchAvailableCredentials: Fetcher<AvailableCredentialsRes, string> = (url) => {
+  return get<AvailableCredentialsRes>(url)
+}
+
 export const fetchModelLoadBalancingConfig: Fetcher<{
   credentials?: Record<string, string | undefined | boolean>
   load_balancing: ModelLoadBalancingConfig


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix issue #28815 enable llm node can have a api key config instead of using global api key config

## Screenshots

before 

<img width="1024" height="1544" alt="image" src="https://github.com/user-attachments/assets/0a2a625b-c8fb-4692-a46a-c1395d08529c" />

after

<img width="2294" height="1704" alt="image" src="https://github.com/user-attachments/assets/72265eb4-ef35-43e0-a1ce-7a504ee9bb14" />

test result

using default api key

<img width="2030" height="1546" alt="image" src="https://github.com/user-attachments/assets/70c835d8-8433-4982-b9e9-e534f69adc70" />

using select api key

<img width="1836" height="1606" alt="image" src="https://github.com/user-attachments/assets/ceae69ff-a49b-48ed-8b98-abf2fff2714c" />

knowledge node

<img width="874" height="1746" alt="image" src="https://github.com/user-attachments/assets/2bebee54-127a-4604-89e6-de0d5d68188c" />

parameter extractor node

<img width="1930" height="1772" alt="image" src="https://github.com/user-attachments/assets/13ea93f8-e9a7-40e2-bdac-f4b24193676b" />

<img width="1126" height="1200" alt="image" src="https://github.com/user-attachments/assets/b07e2b38-384a-4776-8593-80d3177dab57" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
