### PR TITLE
fix: code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,10 @@ api/core/workflow/node_events/ @laipz8200 @QuantumGhost
 api/core/model_runtime/ @laipz8200 @QuantumGhost
 
 # Backend - Workflow - Nodes (Agent, Iteration, Loop, LLM)
-api/core/workflow/nodes/agent/ @Novice
-api/core/workflow/nodes/iteration/ @Novice
-api/core/workflow/nodes/loop/ @Novice
-api/core/workflow/nodes/llm/ @Novice
+api/core/workflow/nodes/agent/ Nov1c444
+api/core/workflow/nodes/iteration/ Nov1c444
+api/core/workflow/nodes/loop/ Nov1c444
+api/core/workflow/nodes/llm/ Nov1c444
 
 # Backend - RAG (Retrieval Augmented Generation)
 api/core/rag/ @JohnJyong
@@ -141,7 +141,7 @@ web/app/components/app/log-annotation/ @JzoNgKVO @iamjoel
 web/app/components/app/annotation/ @JzoNgKVO @iamjoel
 
 # Frontend - App - Monitoring
-web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/ @JzoNgKVO @iamjoel
+web/app/(commonLayout)/app/(appDetailLayout)/\[appId\]/overview/ @JzoNgKVO @iamjoel
 web/app/components/app/overview/ @JzoNgKVO @iamjoel
 
 # Frontend - App - Settings


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This pull request updates the `.github/CODEOWNERS` file to correct ownership assignments for several backend workflow node directories and to fix a path escaping issue for a frontend app monitoring route. These changes help ensure code ownership is properly tracked and that path patterns are interpreted correctly.

Ownership assignment updates:

* Changed ownership of backend workflow node directories (`agent`, `iteration`, `loop`, `llm`) from `@Novice` to `Nov1c444` to reflect the correct owner.

Path pattern correction:

* Escaped square brackets in the frontend app monitoring route path (`web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/`) to ensure proper matching in CODEOWNERS.

Fix https://github.com/langgenius/dify/issues/28863
## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
