### PR TITLE
Fix CODEOWNERS workflow owner handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,10 @@ api/core/workflow/node_events/ @laipz8200 @QuantumGhost
 api/core/model_runtime/ @laipz8200 @QuantumGhost
 
 # Backend - Workflow - Nodes (Agent, Iteration, Loop, LLM)
-api/core/workflow/nodes/agent/ @Novice
-api/core/workflow/nodes/iteration/ @Novice
-api/core/workflow/nodes/loop/ @Novice
-api/core/workflow/nodes/llm/ @Novice
+api/core/workflow/nodes/agent/ @Nov1c444
+api/core/workflow/nodes/iteration/ @Nov1c444
+api/core/workflow/nodes/loop/ @Nov1c444
+api/core/workflow/nodes/llm/ @Nov1c444
 
 # Backend - RAG (Retrieval Augmented Generation)
 api/core/rag/ @JohnJyong
@@ -141,7 +141,7 @@ web/app/components/app/log-annotation/ @JzoNgKVO @iamjoel
 web/app/components/app/annotation/ @JzoNgKVO @iamjoel
 
 # Frontend - App - Monitoring
-web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/ @JzoNgKVO @iamjoel
+web/app/(commonLayout)/app/(appDetailLayout)/\[appId\]/overview/ @JzoNgKVO @iamjoel
 web/app/components/app/overview/ @JzoNgKVO @iamjoel
 
 # Frontend - App - Settings


### PR DESCRIPTION
## Summary
Fixes #28865. Correct CODEOWNERS to point workflow node paths at `@Nov1c444` and escape the `[appId]` segment in the monitoring route so the glob matches the intended directory.

close https://github.com/langgenius/dify/pull/28864
Fix https://github.com/langgenius/dify/issues/28863
## Screenshots
| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
