### PR TITLE
fix(web): prevent navbar clearing app state on cmd+click

### DIFF
--- a/web/app/components/header/nav/index.tsx
+++ b/web/app/components/header/nav/index.tsx
@@ -52,7 +52,12 @@ const Nav = ({
     `}>
       <Link href={link + (linkLastSearchParams && `?${linkLastSearchParams}`)}>
         <div
-          onClick={() => setAppDetail()}
+          onClick={(e) => {
+            // Don't clear state if opening in new tab/window
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0)
+              return
+            setAppDetail()
+          }}
           className={classNames(
             'flex h-7 cursor-pointer items-center rounded-[10px] px-2.5',
             isActivated ? 'text-components-main-nav-nav-button-text-active' : 'text-components-main-nav-nav-button-text',


### PR DESCRIPTION
## Summary

  When on an app detail page (e.g., `/app/{id}/configuration`) and cmd+clicking a navbar link like "Knowledge" to open in a new tab, the original tab shows a loading spinner and
  gets stuck.

  **Root cause:** The `onClick` handler in `web/app/components/header/nav/index.tsx` always calls `setAppDetail()` which clears the app state, even when cmd+clicking. This triggers
   the loading screen in the original tab since `appDetail` becomes undefined.

  **Fix:** Added check for modifier keys (`metaKey`, `ctrlKey`, `shiftKey`) and non-left clicks to skip state clearing when user intends to open in new tab/window.

fix https://github.com/langgenius/dify/issues/28936

  ## Checklist

  - [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [x] I've updated the documentation accordingly.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods