### PR TITLE
chore(web): upgrade zustand from v4.5.7 to v5.0.9

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -141,7 +141,7 @@
     "uuid": "^10.0.0",
     "zod": "^3.25.76",
     "zundo": "^2.3.0",
-    "zustand": "^4.5.7"
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -347,10 +347,10 @@ importers:
         version: 3.25.76
       zundo:
         specifier: ^2.3.0
-        version: 2.3.0(zustand@4.5.7(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1))
+        version: 2.3.0(zustand@5.0.9(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1)))
       zustand:
-        specifier: ^4.5.7
-        version: 4.5.7(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)
+        specifier: ^5.0.9
+        version: 5.0.9(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1))
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^5.4.1
@@ -8443,6 +8443,24 @@ packages:
       immer:
         optional: true
       react:
+        optional: true
+
+  zustand@5.0.9:
+    resolution: {integrity: sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': ~19.1.17
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
         optional: true
 
   zwitch@2.0.4:
@@ -17931,9 +17949,9 @@ snapshots:
     dependencies:
       tslib: 2.3.0
 
-  zundo@2.3.0(zustand@4.5.7(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)):
+  zundo@2.3.0(zustand@5.0.9(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1))):
     dependencies:
-      zustand: 4.5.7(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)
+      zustand: 5.0.9(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1))
 
   zustand@4.5.7(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1):
     dependencies:
@@ -17942,5 +17960,12 @@ snapshots:
       '@types/react': 19.1.17
       immer: 10.1.3
       react: 19.1.1
+
+  zustand@5.0.9(@types/react@19.1.17)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1)):
+    optionalDependencies:
+      '@types/react': 19.1.17
+      immer: 10.1.3
+      react: 19.1.1
+      use-sync-external-store: 1.6.0(react@19.1.1)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Fixes #28944

Upgrade zustand to the latest v5 version. The codebase already follows
v5 best practices (named imports, useShallow for object/array selectors),
so no code changes are required.

Key changes in zustand v5:
- Stricter selector stability requirements (already handled via useShallow)
- Removed default exports (already using named imports)
- Stricter TypeScript types for setState replace flag
- React 18+ and TypeScript 4.5+ required (already satisfied)

Tested: lint passes, all 1207 tests pass.
