### PR TITLE
Add file upload enabled check and new i18n message

### DIFF
--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -246,6 +246,11 @@ export const useFile = (fileConfig: FileUpload) => {
   }, [fileStore])
 
   const handleLocalFileUpload = useCallback((file: File) => {
+    // Check file upload enabled
+    if (!fileConfig.enabled) {
+      notify({ type: 'error', message: t('common.fileUploader.uploadDisabled') })
+      return
+    }
     if (!isAllowedFileExtension(file.name, file.type, fileConfig.allowed_file_types || [], fileConfig.allowed_file_extensions || [])) {
       notify({ type: 'error', message: `${t('common.fileUploader.fileExtensionNotSupport')} ${file.type}` })
       return
@@ -305,23 +310,9 @@ export const useFile = (fileConfig: FileUpload) => {
     const text = e.clipboardData?.getData('text/plain')
     if (file && !text) {
       e.preventDefault()
-
-      const allowedFileTypes = fileConfig.allowed_file_types || []
-      const fileType = getSupportFileType(file.name, file.type, allowedFileTypes?.includes(SupportUploadFileTypes.custom))
-      const isFileTypeAllowed = allowedFileTypes.includes(fileType)
-
-      // Check if file type is in allowed list
-      if (!isFileTypeAllowed || !fileConfig.enabled) {
-        notify({
-          type: 'error',
-          message: t('common.fileUploader.fileExtensionNotSupport'),
-        })
-        return
-      }
-
       handleLocalFileUpload(file)
     }
-  }, [handleLocalFileUpload, fileConfig, notify, t])
+  }, [handleLocalFileUpload])
 
   const [isDragActive, setIsDragActive] = useState(false)
   const handleDragFileEnter = useCallback((e: React.DragEvent<HTMLElement>) => {

--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -303,7 +303,7 @@ export const useFile = (fileConfig: FileUpload) => {
       false,
     )
     reader.readAsDataURL(file)
-  }, [checkSizeLimit, notify, t, handleAddFile, handleUpdateFile, params.token, fileConfig?.allowed_file_types, fileConfig?.allowed_file_extensions])
+  }, [checkSizeLimit, notify, t, handleAddFile, handleUpdateFile, params.token, fileConfig?.allowed_file_types, fileConfig?.allowed_file_extensions, fileConfig?.enabled])
 
   const handleClipboardPasteFile = useCallback((e: ClipboardEvent<HTMLTextAreaElement>) => {
     const file = e.clipboardData?.files[0]

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -743,6 +743,7 @@ const translation = {
     pasteFileLinkInvalid: 'Invalid file link',
     fileExtensionNotSupport: 'File extension not supported',
     fileExtensionBlocked: 'This file type is blocked for security reasons',
+    uploadDisabled: 'File upload is disabled',
   },
   tag: {
     placeholder: 'All Tags',

--- a/web/i18n/ja-JP/common.ts
+++ b/web/i18n/ja-JP/common.ts
@@ -747,6 +747,7 @@ const translation = {
     uploadFromComputerReadError: 'ファイルの読み取りに失敗しました。もう一度やり直してください。',
     fileExtensionNotSupport: 'ファイル拡張子はサポートされていません',
     pasteFileLinkInvalid: '無効なファイルリンク',
+    uploadDisabled: 'ファイルアップロードは無効です',
     fileExtensionBlocked: 'このファイルタイプは、セキュリティ上の理由でブロックされています',
   },
   license: {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes # 28945`.

## Summary
I fixed #28945 .
The current implementation allows files to be uploaded via drag-and-drop even when the file upload feature is explicitly disabled in the configuration.
### Root Cause
The issue arises because the system only checks for allowed file types (e.g., image extensions) before uploading, but does not check if the entire feature is enabled. 
https://github.com/langgenius/dify/blob/247069c7e96fa1763fc9dd9da001bc5683c73a64/web/app/components/base/file-uploader/hooks.ts#L249
Since image types are allowed by default, fileConfig.allowed_file_types includes images. Consequently, even when the file upload feature is disabled (fileConfig.enabled: false), the isAllowedFileExtension function returns True, allowing the upload process to proceed.

### Fix
1. Enforced Feature Check: Added a condition to the handleLocalFileUpload function to check the status of fileConfig.enabled. If it is false, the function now immediately returns an error.

2. Improved Error Messaging: Introduced a clearer error message for when file uploads are disabled.

3. Code Cleanup: Removed redundant checks in the clipboard handling logic to standardize the error message and streamline the process, ensuring consistent behavior across different upload methods.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
