### PR TITLE
fix: treat empty default values for optional file inputs as unset

### DIFF
--- a/api/core/app/apps/base_app_generator.py
+++ b/api/core/app/apps/base_app_generator.py
@@ -99,6 +99,12 @@ class BaseAppGenerator:
             if value is None:
                 return None
 
+        # Treat empty placeholders for optional file inputs as unset
+        if variable_entity.type in {VariableEntityType.FILE, VariableEntityType.FILE_LIST} and not variable_entity.required:
+            # Treat empty string (frontend default) or empty list as unset
+            if not value and isinstance(value, (str, list)):
+                return None
+
         if variable_entity.type in {
             VariableEntityType.TEXT_INPUT,
             VariableEntityType.SELECT,

--- a/api/core/app/apps/base_app_generator.py
+++ b/api/core/app/apps/base_app_generator.py
@@ -100,7 +100,10 @@ class BaseAppGenerator:
                 return None
 
         # Treat empty placeholders for optional file inputs as unset
-        if variable_entity.type in {VariableEntityType.FILE, VariableEntityType.FILE_LIST} and not variable_entity.required:
+        if (
+            variable_entity.type in {VariableEntityType.FILE, VariableEntityType.FILE_LIST}
+            and not variable_entity.required
+        ):
             # Treat empty string (frontend default) or empty list as unset
             if not value and isinstance(value, (str, list)):
                 return None

--- a/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
@@ -265,3 +265,82 @@ def test_validate_inputs_with_default_value():
     )
 
     assert result == [{"id": "file1", "name": "doc1.pdf"}, {"id": "file2", "name": "doc2.pdf"}]
+
+
+def test_validate_inputs_optional_file_with_empty_string():
+    """Test that optional FILE variable with empty string returns None"""
+    base_app_generator = BaseAppGenerator()
+
+    var_file = VariableEntity(
+        variable="test_file",
+        label="test_file",
+        type=VariableEntityType.FILE,
+        required=False,
+    )
+
+    result = base_app_generator._validate_inputs(
+        variable_entity=var_file,
+        value="",
+    )
+
+    assert result is None
+
+
+def test_validate_inputs_optional_file_list_with_empty_list():
+    """Test that optional FILE_LIST variable with empty list returns None"""
+    base_app_generator = BaseAppGenerator()
+
+    var_file_list = VariableEntity(
+        variable="test_file_list",
+        label="test_file_list",
+        type=VariableEntityType.FILE_LIST,
+        required=False,
+    )
+
+    result = base_app_generator._validate_inputs(
+        variable_entity=var_file_list,
+        value=[],
+    )
+
+    assert result is None
+
+
+def test_validate_inputs_required_file_with_empty_string_fails():
+    """Test that required FILE variable with empty string still fails validation"""
+    base_app_generator = BaseAppGenerator()
+
+    var_file = VariableEntity(
+        variable="test_file",
+        label="test_file",
+        type=VariableEntityType.FILE,
+        required=True,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        base_app_generator._validate_inputs(
+            variable_entity=var_file,
+            value="",
+        )
+
+    assert "must be a file" in str(exc_info.value)
+
+
+def test_validate_inputs_optional_file_with_empty_string_ignores_default():
+    """Test that optional FILE variable with empty string returns None, not the default"""
+    base_app_generator = BaseAppGenerator()
+
+    var_file = VariableEntity(
+        variable="test_file",
+        label="test_file",
+        type=VariableEntityType.FILE,
+        required=False,
+        default={"id": "file123", "name": "default.pdf"},
+    )
+
+    # When value is empty string (from frontend), should return None, not default
+    result = base_app_generator._validate_inputs(
+        variable_entity=var_file,
+        value="",
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary

This PR fixes a validation bug where optional file/file-list variables fail validation when no file is uploaded.

- Treats empty string (frontend's default) or empty list as unset for optional file inputs
- Returns `None` instead of passing invalid values to type validation
- Maintains backward compatibility with required file variables

fixes #28947

## Root Cause

After commit `3841e8578f`, optional variables with `None` values are replaced with their default values before validation. However, the frontend sets `default: ''` for all variable types, including file types. When this empty string reaches file type validation, it fails because a string is not a valid file object.

## Changes

- **File:** `api/core/app/apps/base_app_generator.py`
- **Function:** `_validate_inputs`
- **Logic:** Before file type validation, check if the value is an empty placeholder (empty string or empty list) for optional file inputs. If so, return `None` to skip validation.

## Test Plan

- [x] Create a workflow with an optional `file` variable, run without uploading - should succeed
- [x] Create a workflow with an optional `file-list` variable, run without uploading - should succeed
- [x] Create a workflow with a **required** `file` variable, run without uploading - should still fail with "is required" error
- [x] Upload a file to an optional file variable - should work normally
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
