### PR TITLE
fix(web): use atomic selectors to fix Zustand v5 infinite loop

### DIFF
--- a/web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx
@@ -47,10 +47,8 @@ const ChatWrapper = (
   const startVariables = startNode?.data.variables
   const appDetail = useAppStore(s => s.appDetail)
   const workflowStore = useWorkflowStore()
-  const { inputs, setInputs } = useStore(s => ({
-    inputs: s.inputs,
-    setInputs: s.setInputs,
-  }))
+  const inputs = useStore(s => s.inputs)
+  const setInputs = useStore(s => s.setInputs)
 
   const initialInputs = useMemo(() => {
     const initInputs: Record<string, any> = {}

--- a/web/app/components/workflow/panel/inputs-panel.tsx
+++ b/web/app/components/workflow/panel/inputs-panel.tsx
@@ -32,10 +32,7 @@ type Props = {
 const InputsPanel = ({ onRun }: Props) => {
   const { t } = useTranslation()
   const workflowStore = useWorkflowStore()
-  const { inputs } = useStore(s => ({
-    inputs: s.inputs,
-    setInputs: s.setInputs,
-  }))
+  const inputs = useStore(s => s.inputs)
   const fileSettings = useHooksStore(s => s.configsMap?.fileSettings)
   const nodes = useNodes<StartNodeType>()
   const files = useStore(s => s.files)


### PR DESCRIPTION
Fixes #28976

## Summary

After upgrading Zustand from v4.5.7 to v5.0.9, workflow test run triggers an infinite loop error:
```
The result of getSnapshot should be cached to avoid an infinite loop
```

**Root cause**: Zustand v5 uses React 18's `useSyncExternalStore` which actively detects unstable selector outputs. Selectors returning new objects/arrays on every call are now caught and throw errors, whereas v4's custom subscription mechanism allowed this as a silent performance bug (infinite re-renders without crashing).

**Solution**: Replace object-returning selectors with atomic selectors (Zustand recommended best practice).

```diff
- const { inputs, setInputs } = useStore(s => ({
-   inputs: s.inputs,
-   setInputs: s.setInputs,
- }))
+ const inputs = useStore(s => s.inputs)
+ const setInputs = useStore(s => s.setInputs)
```

**Files changed**:
- `web/app/components/workflow/panel/inputs-panel.tsx`
- `web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx`

## Screenshots

| Before | After |
|--------|-------|
| Console error: infinite loop | No errors |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods