### PR TITLE
fix(web): use atomic selectors in AccessControlItem

### DIFF
--- a/web/app/components/app/app-access-control/access-control-item.tsx
+++ b/web/app/components/app/app-access-control/access-control-item.tsx
@@ -8,7 +8,8 @@ type AccessControlItemProps = PropsWithChildren<{
 }>
 
 const AccessControlItem: FC<AccessControlItemProps> = ({ type, children }) => {
-  const { currentMenu, setCurrentMenu } = useAccessControlStore(s => ({ currentMenu: s.currentMenu, setCurrentMenu: s.setCurrentMenu }))
+  const currentMenu = useAccessControlStore(s => s.currentMenu)
+  const setCurrentMenu = useAccessControlStore(s => s.setCurrentMenu)
   if (currentMenu !== type) {
     return <div
       className="cursor-pointer rounded-[10px] border-[1px]

--- a/web/app/components/app/app-access-control/access-control-item.tsx
+++ b/web/app/components/app/app-access-control/access-control-item.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { FC, PropsWithChildren } from 'react'
-import useAccessControlStore from '../../../../context/access-control-store'
+import useAccessControlStore from '@/context/access-control-store'
 import type { AccessMode } from '@/models/access-control'
 
 type AccessControlItemProps = PropsWithChildren<{


### PR DESCRIPTION
Related to #28976

## Summary

Fix potential Zustand v5 selector issue in `AccessControlItem` component.

The selector was returning a new object on every render, which can cause infinite loops with Zustand v5's `useSyncExternalStore`.

```diff
- const { currentMenu, setCurrentMenu } = useAccessControlStore(s => ({ 
-   currentMenu: s.currentMenu, 
-   setCurrentMenu: s.setCurrentMenu 
- }))
+ const currentMenu = useAccessControlStore(s => s.currentMenu)
+ const setCurrentMenu = useAccessControlStore(s => s.setCurrentMenu)
```

This follows the same fix pattern as #28977.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods