### PR TITLE
fix(mcp): add root-level OAuth metadata discovery fallback

### DIFF
--- a/api/core/mcp/auth/auth_flow.py
+++ b/api/core/mcp/auth/auth_flow.py
@@ -93,6 +93,9 @@ def build_oauth_authorization_server_metadata_discovery_urls(auth_server_url: st
     # Include the path component if present in the issuer URL
     if path:
         urls.append(urljoin(base, f".well-known/oauth-authorization-server{path}"))
+        # Also try root-level discovery as fallback (some servers like Atlassian MCP
+        # don't follow RFC 8414 path suffix convention)
+        urls.append(urljoin(base, ".well-known/oauth-authorization-server"))
     else:
         urls.append(urljoin(base, ".well-known/oauth-authorization-server"))
 


### PR DESCRIPTION
## Summary
- Add root-level OAuth Authorization Server Metadata discovery fallback for MCP servers that don't follow RFC 8414 path suffix convention

## Problem
When connecting to MCP servers like Atlassian (`https://mcp.atlassian.com/v1/sse`), OAuth metadata discovery fails with "Failed to discover OAuth metadata from server".

This happens because:
1. RFC 8414 specifies that when the issuer URL has a path, metadata should be at `/.well-known/oauth-authorization-server{path}`
2. Dify tries `/.well-known/oauth-authorization-server/v1/sse` which returns 404
3. Atlassian places metadata at root-level `/.well-known/oauth-authorization-server` without the path suffix

## Solution
Add root-level `/.well-known/oauth-authorization-server` as a fallback URL when the path-suffixed discovery fails.

## Test plan
- [x] Tested with Atlassian MCP server (`https://mcp.atlassian.com/v1/sse`)
- [x] OAuth authorization flow completes successfully