### PR TITLE
fix: trigger call workflow_as_tool error

### DIFF
--- a/api/tests/unit_tests/core/tools/workflow_as_tool/test_tool.py
+++ b/api/tests/unit_tests/core/tools/workflow_as_tool/test_tool.py
@@ -1,5 +1,6 @@
-import pytest
 from types import SimpleNamespace
+
+import pytest
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.tools.__base.tool_runtime import ToolRuntime

--- a/api/tests/unit_tests/core/tools/workflow_as_tool/test_tool.py
+++ b/api/tests/unit_tests/core/tools/workflow_as_tool/test_tool.py
@@ -1,4 +1,5 @@
 import pytest
+from types import SimpleNamespace
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.tools.__base.tool_runtime import ToolRuntime
@@ -214,3 +215,76 @@ def test_create_variable_message():
         assert message.message.variable_name == var_name
         assert message.message.variable_value == var_value
         assert message.message.stream is False
+
+
+def test_resolve_user_from_database_falls_back_to_end_user(monkeypatch: pytest.MonkeyPatch):
+    """Ensure worker context can resolve EndUser when Account is missing."""
+
+    class StubSession:
+        def __init__(self, results: list):
+            self.results = results
+
+        def scalar(self, _stmt):
+            return self.results.pop(0)
+
+    tenant = SimpleNamespace(id="tenant_id")
+    end_user = SimpleNamespace(id="end_user_id", tenant_id="tenant_id")
+    db_stub = SimpleNamespace(session=StubSession([tenant, None, end_user]))
+
+    monkeypatch.setattr("core.tools.workflow_as_tool.tool.db", db_stub)
+
+    entity = ToolEntity(
+        identity=ToolIdentity(author="test", name="test tool", label=I18nObject(en_US="test tool"), provider="test"),
+        parameters=[],
+        description=None,
+        has_runtime_parameters=False,
+    )
+    runtime = ToolRuntime(tenant_id="tenant_id", invoke_from=InvokeFrom.SERVICE_API)
+    tool = WorkflowTool(
+        workflow_app_id="",
+        workflow_as_tool_id="",
+        version="1",
+        workflow_entities={},
+        workflow_call_depth=1,
+        entity=entity,
+        runtime=runtime,
+    )
+
+    resolved_user = tool._resolve_user_from_database(user_id=end_user.id)
+
+    assert resolved_user is end_user
+
+
+def test_resolve_user_from_database_returns_none_when_no_tenant(monkeypatch: pytest.MonkeyPatch):
+    """Return None if tenant cannot be found in worker context."""
+
+    class StubSession:
+        def __init__(self, results: list):
+            self.results = results
+
+        def scalar(self, _stmt):
+            return self.results.pop(0)
+
+    db_stub = SimpleNamespace(session=StubSession([None]))
+    monkeypatch.setattr("core.tools.workflow_as_tool.tool.db", db_stub)
+
+    entity = ToolEntity(
+        identity=ToolIdentity(author="test", name="test tool", label=I18nObject(en_US="test tool"), provider="test"),
+        parameters=[],
+        description=None,
+        has_runtime_parameters=False,
+    )
+    runtime = ToolRuntime(tenant_id="missing_tenant", invoke_from=InvokeFrom.SERVICE_API)
+    tool = WorkflowTool(
+        workflow_app_id="",
+        workflow_as_tool_id="",
+        version="1",
+        workflow_entities={},
+        workflow_call_depth=1,
+        entity=entity,
+        runtime=runtime,
+    )
+
+    resolved_user = tool._resolve_user_from_database(user_id="any")
+
+    assert resolved_user is None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fix https://github.com/langgenius/dify/issues/29057

The knowledge pipeline transfers a `user_id` from `Account`, while the trigger transfers a `user_id` from `EndUser`.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
