### PR TITLE
fix: incorrect last run result

### DIFF
--- a/web/service/use-workflow.ts
+++ b/web/service/use-workflow.ts
@@ -123,7 +123,7 @@ export const useInvalidLastRun = (flowType: FlowType, flowId: string, nodeId: st
 
 // Rerun workflow or change the version of workflow
 export const useInvalidAllLastRun = (flowType?: FlowType, flowId?: string) => {
-  return useInvalid([NAME_SPACE, flowType, 'last-run', flowId])
+  return useInvalid([...useLastRunKey, flowType, flowId])
 }
 
 export const useConversationVarValues = (flowType?: FlowType, flowId?: string) => {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/28903

When debugging a workflow and checking the last run panel, it sends a request and generates a cache. During the next debug run, it clears the cache; however, if the cache key is incorrect, it will not clear properly. As a result, the user will see the old last run result.


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
