### PR TITLE
perf: optimize generate conversation name

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -770,7 +770,7 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
             tts_publisher.publish(None)
 
         if self._conversation_name_generate_thread:
-            self._conversation_name_generate_thread.join()
+            logger.debug("Conversation name generation running as daemon thread")
 
     def _save_message(
         self,

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -366,7 +366,7 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
         if publisher:
             publisher.publish(None)
         if self._conversation_name_generate_thread:
-            self._conversation_name_generate_thread.join()
+            logger.debug("Conversation name generation running as daemon thread")
 
     def _save_message(self, *, session: Session, trace_manager: TraceQueueManager | None = None):
         """

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -108,7 +108,7 @@ class MessageCycleManager:
 
                 cached_name = redis_client.get(cache_key)
                 if cached_name:
-                    name = cached_name.decode('utf-8')
+                    name = cached_name.decode("utf-8")
                 else:
                     try:
                         name = LLMGenerator.generate_conversation_name(
@@ -117,8 +117,7 @@ class MessageCycleManager:
                         redis_client.setex(cache_key, 3600, name)
                     except Exception:
                         if dify_config.DEBUG:
-                            logger.exception(
-                                "generate conversation name failed, conversation_id: %s", conversation_id)
+                            logger.exception("generate conversation name failed, conversation_id: %s", conversation_id)
                         name = query[:47] + "..." if len(query) > 50 else query
                 conversation.name = name
                 db.session.commit()

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+import time
 from threading import Thread
 from typing import Union
 
@@ -31,6 +33,7 @@ from core.app.entities.task_entities import (
 from core.llm_generator.llm_generator import LLMGenerator
 from core.tools.signature import sign_tool_file
 from extensions.ext_database import db
+from extensions.ext_redis import redis_client
 from models.model import AppMode, Conversation, MessageAnnotation, MessageFile
 from services.annotation_service import AppAnnotationService
 
@@ -68,6 +71,8 @@ class MessageCycleManager:
 
         if auto_generate_conversation_name and is_first_message:
             # start generate thread
+            # time.sleep not block other logic
+            time.sleep(1)
             thread = Thread(
                 target=self._generate_conversation_name_worker,
                 kwargs={
@@ -76,7 +81,7 @@ class MessageCycleManager:
                     "query": query,
                 },
             )
-
+            thread.daemon = True
             thread.start()
 
             return thread
@@ -98,15 +103,24 @@ class MessageCycleManager:
                     return
 
                 # generate conversation name
-                try:
-                    name = LLMGenerator.generate_conversation_name(
-                        app_model.tenant_id, query, conversation_id, conversation.app_id
-                    )
-                    conversation.name = name
-                except Exception:
-                    if dify_config.DEBUG:
-                        logger.exception("generate conversation name failed, conversation_id: %s", conversation_id)
+                query_hash = hashlib.md5(query.encode()).hexdigest()[:16]
+                cache_key = f"conv_name:{conversation_id}:{query_hash}"
 
+                cached_name = redis_client.get(cache_key)
+                if cached_name:
+                    name = cached_name.decode('utf-8')
+                else:
+                    try:
+                        name = LLMGenerator.generate_conversation_name(
+                            app_model.tenant_id, query, conversation_id, conversation.app_id
+                        )
+                        redis_client.setex(cache_key, 3600, name)
+                    except Exception:
+                        if dify_config.DEBUG:
+                            logger.exception(
+                                "generate conversation name failed, conversation_id: %s", conversation_id)
+                        name = query[:47] + "..." if len(query) > 50 else query
+                conversation.name = name
                 db.session.commit()
                 db.session.close()
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

original:

User sends message
↓
Create session and message (Database operations) ~0.26s → 0.09s (Optimized)
↓
Start streaming response generation
↓
Concurrently start conversation title generation thread → LLM call 1-3s
↓
Streamed content gradually output to user
↓
Streaming output completes
↓
Wait for conversation title generation thread to complete join() ← 🚨 Bottleneck: Blocks for 1-3s
↓
Connection closes, user can begin second turn of conversation

new:

User sends message
↓
Create session & message (DB op) ~0.09 s
↓
Start streaming response generation
↓
Stream content to user chunk-by-chunk
↓
Stream finishes
↓
Connection closed immediately ← ✅ user can start round-2 at once
↓
[Background] 2 s later, launch dialog-title generation
↓
[Background] LLM call to generate title 1–3 s
↓
[Background] Update dialog title in DB

using daemon second conversation not wait first conversation, add redis cache increase the op

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
