### PR TITLE
Fix ops_trace delete err

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -146,7 +146,14 @@ class AppApiStatusPayload(BaseModel):
 
 class AppTracePayload(BaseModel):
     enabled: bool = Field(..., description="Enable or disable tracing")
-    tracing_provider: str = Field(..., description="Tracing provider")
+    tracing_provider: str | None = Field(default=None, description="Tracing provider")
+
+    @field_validator("tracing_provider")
+    @classmethod
+    def validate_tracing_provider(cls, value: str | None, info) -> str | None:
+        if info.data.get("enabled") and not value:
+            raise ValueError("tracing_provider is required when enabled is True")
+        return value
 
 
 def reg(cls: type[BaseModel]):

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -377,20 +377,20 @@ class OpsTraceManager:
         return app_model_config
 
     @classmethod
-    def update_app_tracing_config(cls, app_id: str, enabled: bool, tracing_provider: str):
+    def update_app_tracing_config(cls, app_id: str, enabled: bool, tracing_provider: str | None):
         """
         Update app tracing config
         :param app_id: app id
         :param enabled: enabled
-        :param tracing_provider: tracing provider
+        :param tracing_provider: tracing provider (None when disabling)
         :return:
         """
         # auth check
-        try:
-            if enabled or tracing_provider is not None:
+        if tracing_provider is not None:
+            try:
                 provider_config_map[tracing_provider]
-        except KeyError:
-            raise ValueError(f"Invalid tracing provider: {tracing_provider}")
+            except KeyError:
+                raise ValueError(f"Invalid tracing provider: {tracing_provider}")
 
         app_config: App | None = db.session.query(App).where(App.id == app_id).first()
         if not app_config:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

close https://github.com/langgenius/dify/issues/29133

### Root Cause
`AppTracePayload` model defines `tracing_provider: str` (required), but the frontend sends `null` when disabling tracing.

<img alt="455C1C28-9300-476D-AB0D-E629AB0740E4" src="https://github.com/user-attachments/assets/5c6d6055-4477-4bf5-b2f3-4e21bf42af81" />


### Solution
Modify `AppTracePayload` to accept `None` for `tracing_provider` when `enabled=False`:


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
