### PR TITLE
feat: allow admin api key to bypass csrf validation

### DIFF
--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -189,6 +189,11 @@ def build_force_logout_cookie_headers() -> list[str]:
 def check_csrf_token(request: Request, user_id: str):
     # some apis are sent by beacon, so we need to bypass csrf token check
     # since these APIs are post, they are already protected by SameSite: Lax, so csrf is not required.
+    if dify_config.ADMIN_API_KEY_ENABLE:
+        auth_token = extract_access_token(request)
+        if auth_token and auth_token == dify_config.ADMIN_API_KEY:
+            return
+
     def _unauthorized():
         raise Unauthorized("CSRF token is missing or invalid.")
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #29137

set `.env`
```
ADMIN_API_KEY=12345678
ADMIN_API_KEY_ENABLE=true
```
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
|<img width="2002" height="908" alt="image" src="https://github.com/user-attachments/assets/1f3fe5d8-4e76-4ae5-be84-1618b7a7073a" />|<img width="1986" height="1416" alt="image" src="https://github.com/user-attachments/assets/71ac32a9-3b7a-4875-ac80-a356d4858482" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
