### PR TITLE
fix: fix workflow as tool log missing

### DIFF
--- a/api/core/app/apps/advanced_chat/app_runner.py
+++ b/api/core/app/apps/advanced_chat/app_runner.py
@@ -146,7 +146,11 @@ class AdvancedChatAppRunner(WorkflowBasedAppRunner):
             )
 
             # init graph
-            graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.time())
+            graph_runtime_state = GraphRuntimeState(
+                variable_pool=variable_pool,
+                start_at=time.perf_counter(),
+                trace_manager=self.application_generate_entity.trace_manager,
+            )
             graph = self._init_graph(
                 graph_config=self._workflow.graph_dict,
                 graph_runtime_state=graph_runtime_state,

--- a/api/core/app/apps/pipeline/pipeline_runner.py
+++ b/api/core/app/apps/pipeline/pipeline_runner.py
@@ -142,7 +142,11 @@ class PipelineRunner(WorkflowBasedAppRunner):
                 conversation_variables=[],
                 rag_pipeline_variables=rag_pipeline_variables,
             )
-            graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.perf_counter())
+            graph_runtime_state = GraphRuntimeState(
+                variable_pool=variable_pool,
+                start_at=time.perf_counter(),
+                trace_manager=self.application_generate_entity.trace_manager,
+            )
 
             # init graph
             graph = self._init_rag_pipeline_graph(

--- a/api/core/app/apps/workflow/app_runner.py
+++ b/api/core/app/apps/workflow/app_runner.py
@@ -91,7 +91,11 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                 conversation_variables=[],
             )
 
-            graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.perf_counter())
+            graph_runtime_state = GraphRuntimeState(
+                variable_pool=variable_pool,
+                start_at=time.perf_counter(),
+                trace_manager=self.application_generate_entity.trace_manager,
+            )
 
             # init graph
             graph = self._init_graph(

--- a/api/core/app/apps/workflow/generate_task_pipeline.py
+++ b/api/core/app/apps/workflow/generate_task_pipeline.py
@@ -630,8 +630,15 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
             created_from = WorkflowAppLogCreatedFrom.INSTALLED_APP
         elif invoke_from == InvokeFrom.WEB_APP:
             created_from = WorkflowAppLogCreatedFrom.WEB_APP
+        elif invoke_from == InvokeFrom.DEBUGGER:
+            agent_context = self._application_generate_entity.extras
+            if agent_context and any(key in str(agent_context) for key in ["conversation_id", "message_id"]):
+                created_from = WorkflowAppLogCreatedFrom.SERVICE_API
+            else:
+                # not save log for regular debugging
+                return
         else:
-            # not save log for debugging
+            # not save log for other invoke_from types
             return
 
         if not workflow_run_id:

--- a/api/core/callback_handler/agent_tool_callback_handler.py
+++ b/api/core/callback_handler/agent_tool_callback_handler.py
@@ -1,12 +1,14 @@
 from collections.abc import Iterable, Mapping
-from typing import Any, TextIO, Union
+from typing import TYPE_CHECKING, Any, TextIO, Union
 
 from pydantic import BaseModel
 
 from configs import dify_config
 from core.ops.entities.trace_entity import TraceTaskName
-from core.ops.ops_trace_manager import TraceQueueManager, TraceTask
 from core.tools.entities.tool_entities import ToolInvokeMessage
+
+if TYPE_CHECKING:
+    from core.workflow.runtime.graph_runtime_state import TraceQueueManagerProtocol
 
 _TEXT_COLOR_MAPPING = {
     "blue": "36;1",
@@ -60,7 +62,7 @@ class DifyAgentCallbackHandler(BaseModel):
         tool_outputs: Iterable[ToolInvokeMessage] | str,
         message_id: str | None = None,
         timer: Any | None = None,
-        trace_manager: TraceQueueManager | None = None,
+        trace_manager: Union["TraceQueueManagerProtocol", None] = None,
     ):
         """If not the final action, print out observation."""
         if dify_config.DEBUG:
@@ -71,6 +73,8 @@ class DifyAgentCallbackHandler(BaseModel):
             print_text("\n")
 
         if trace_manager:
+            from core.ops.ops_trace_manager import TraceTask
+
             trace_manager.add_trace_task(
                 TraceTask(
                     TraceTaskName.TOOL_TRACE,

--- a/api/core/callback_handler/workflow_tool_callback_handler.py
+++ b/api/core/callback_handler/workflow_tool_callback_handler.py
@@ -1,9 +1,11 @@
 from collections.abc import Generator, Iterable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any, Union
 
 from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackHandler, print_text
-from core.ops.ops_trace_manager import TraceQueueManager
 from core.tools.entities.tool_entities import ToolInvokeMessage
+
+if TYPE_CHECKING:
+    from core.workflow.runtime.graph_runtime_state import TraceQueueManagerProtocol
 
 
 class DifyWorkflowCallbackHandler(DifyAgentCallbackHandler):
@@ -16,9 +18,28 @@ class DifyWorkflowCallbackHandler(DifyAgentCallbackHandler):
         tool_outputs: Iterable[ToolInvokeMessage],
         message_id: str | None = None,
         timer: Any | None = None,
-        trace_manager: TraceQueueManager | None = None,
+        trace_manager: Union["TraceQueueManagerProtocol", None] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
-        for tool_output in tool_outputs:
+        # Convert tool_outputs to list for processing
+        tool_outputs_list = list(tool_outputs)
+
+        # Record trace for workflow tool execution
+        if trace_manager:
+            from core.ops.entities.trace_entity import TraceTaskName
+            from core.ops.ops_trace_manager import TraceTask
+
+            trace_manager.add_trace_task(
+                TraceTask(
+                    TraceTaskName.TOOL_TRACE,
+                    message_id=message_id,
+                    tool_name=tool_name,
+                    tool_inputs=tool_inputs,
+                    tool_outputs=tool_outputs_list,
+                    timer=timer,
+                )
+            )
+
+        for tool_output in tool_outputs_list:
             print_text("\n[on_tool_execution]\n", color=self.color)
             print_text("Tool: " + tool_name + "\n", color=self.color)
             print_text("Outputs: " + tool_output.model_dump_json()[:1000] + "\n", color=self.color)

--- a/api/core/ops/tencent_trace/tencent_trace.py
+++ b/api/core/ops/tencent_trace/tencent_trace.py
@@ -27,7 +27,7 @@ from core.repositories import SQLAlchemyWorkflowNodeExecutionRepository
 from core.workflow.entities.workflow_node_execution import (
     WorkflowNodeExecution,
 )
-from core.workflow.nodes import NodeType
+from core.workflow.enums import NodeType
 from extensions.ext_database import db
 from models import Account, App, TenantAccountJoin, WorkflowNodeExecutionTriggeredFrom
 

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -4,7 +4,7 @@ from collections.abc import Generator, Iterable
 from copy import deepcopy
 from datetime import UTC, datetime
 from mimetypes import guess_type
-from typing import Any, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from yarl import URL
 
@@ -13,7 +13,9 @@ from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackH
 from core.callback_handler.workflow_tool_callback_handler import DifyWorkflowCallbackHandler
 from core.file import FileType
 from core.file.models import FileTransferMethod
-from core.ops.ops_trace_manager import TraceQueueManager
+
+if TYPE_CHECKING:
+    from core.workflow.runtime.graph_runtime_state import TraceQueueManagerProtocol
 from core.tools.__base.tool import Tool
 from core.tools.entities.tool_entities import (
     ToolInvokeMessage,
@@ -51,7 +53,7 @@ class ToolEngine:
         message: Message,
         invoke_from: InvokeFrom,
         agent_tool_callback: DifyAgentCallbackHandler,
-        trace_manager: TraceQueueManager | None = None,
+        trace_manager: Union["TraceQueueManagerProtocol", None] = None,
         conversation_id: str | None = None,
         app_id: str | None = None,
         message_id: str | None = None,
@@ -155,6 +157,7 @@ class ToolEngine:
         conversation_id: str | None = None,
         app_id: str | None = None,
         message_id: str | None = None,
+        trace_manager: Union["TraceQueueManagerProtocol", None] = None,
     ) -> Generator[ToolInvokeMessage, None, None]:
         """
         Workflow invokes the tool with the given arguments.
@@ -182,6 +185,8 @@ class ToolEngine:
                 tool_name=tool.entity.identity.name,
                 tool_inputs=tool_parameters,
                 tool_outputs=response,
+                message_id=message_id,
+                trace_manager=trace_manager,
             )
 
             return response

--- a/api/core/tools/workflow_as_tool/tool.py
+++ b/api/core/tools/workflow_as_tool/tool.py
@@ -91,11 +91,18 @@ class WorkflowTool(Tool):
 
         self._latest_usage = LLMUsage.empty_usage()
 
+        # Add conversation_id and message_id to args if available
+        args: dict[str, Any] = {"inputs": tool_parameters, "files": files}
+        if conversation_id:
+            args["conversation_id"] = conversation_id
+        if message_id:
+            args["message_id"] = message_id
+
         result = generator.generate(
             app_model=app,
             workflow=workflow,
             user=user,
-            args={"inputs": tool_parameters, "files": files},
+            args=args,
             invoke_from=self.runtime.invoke_from,
             streaming=False,
             call_depth=self.workflow_call_depth + 1,

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -105,6 +105,9 @@ class ToolNode(Node[ToolNodeData]):
         # get conversation id
         conversation_id = self.graph_runtime_state.variable_pool.get(["sys", SystemVariableKey.CONVERSATION_ID])
 
+        # Get trace_manager from the graph runtime state
+        trace_manager = self.graph_runtime_state.trace_manager
+
         try:
             message_stream = ToolEngine.generic_invoke(
                 tool=tool_runtime,
@@ -114,6 +117,7 @@ class ToolNode(Node[ToolNodeData]):
                 workflow_call_depth=self.workflow_call_depth,
                 app_id=self.app_id,
                 conversation_id=conversation_id.text if conversation_id else None,
+                trace_manager=trace_manager,
             )
         except ToolNodeError as e:
             yield StreamCompletedEvent(

--- a/api/core/workflow/runtime/graph_runtime_state.py
+++ b/api/core/workflow/runtime/graph_runtime_state.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, Union
 
 from pydantic.json import pydantic_encoder
 
@@ -102,6 +102,12 @@ class ResponseStreamCoordinatorProtocol(Protocol):
         ...
 
 
+class TraceQueueManagerProtocol(Protocol):
+    """Structural interface for trace queue manager."""
+
+    def add_trace_task(self, trace_task: Any) -> None: ...
+
+
 class GraphProtocol(Protocol):
     """Structural interface required from graph instances attached to the runtime state."""
 
@@ -145,6 +151,7 @@ class GraphRuntimeState:
         graph_execution: GraphExecutionProtocol | None = None,
         response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
         graph: GraphProtocol | None = None,
+        trace_manager: Union[TraceQueueManagerProtocol, None] = None,
     ) -> None:
         self._variable_pool = variable_pool
         self._start_at = start_at
@@ -168,6 +175,7 @@ class GraphRuntimeState:
         self._pending_response_coordinator_dump: str | None = None
         self._pending_graph_execution_workflow_id: str | None = None
         self._paused_nodes: set[str] = set()
+        self._trace_manager = trace_manager
 
         if graph is not None:
             self.attach_graph(graph)
@@ -206,6 +214,10 @@ class GraphRuntimeState:
     @property
     def variable_pool(self) -> VariablePool:
         return self._variable_pool
+
+    @property
+    def trace_manager(self) -> Union[TraceQueueManagerProtocol, None]:
+        return self._trace_manager
 
     @property
     def ready_queue(self) -> ReadyQueueProtocol:

--- a/api/tests/unit_tests/core/workflow/runtime/test_trace_manager_integration.py
+++ b/api/tests/unit_tests/core/workflow/runtime/test_trace_manager_integration.py
@@ -1,0 +1,499 @@
+"""
+Unit tests for trace_manager integration across workflow runtime, callback handlers, and tool engine.
+"""
+
+import time
+from collections.abc import Generator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.callback_handler.agent_tool_callback_handler import DifyAgentCallbackHandler
+from core.callback_handler.workflow_tool_callback_handler import DifyWorkflowCallbackHandler
+from core.ops.entities.trace_entity import TraceTaskName
+from core.ops.ops_trace_manager import TraceQueueManager, TraceTask
+from core.tools.__base.tool import Tool
+from core.tools.__base.tool_runtime import ToolRuntime
+from core.tools.entities.tool_entities import (
+    ToolDescription,
+    ToolEntity,
+    ToolIdentity,
+    ToolInvokeMessage,
+    ToolProviderType,
+)
+from core.tools.tool_engine import ToolEngine
+from core.workflow.runtime import GraphRuntimeState, VariablePool
+from models.model import AppMode, Message
+
+
+# Helper mock tool implementation
+class MockTool(Tool):
+    """A simple mock tool for testing purposes"""
+
+    def tool_provider_type(self) -> ToolProviderType:
+        return ToolProviderType.BUILT_IN
+
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        yield ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.TEXT, message=ToolInvokeMessage.TextMessage(text="Test output")
+        )
+
+
+class TestGraphRuntimeStateTraceManager:
+    """Test that GraphRuntimeState is initialized with the correct trace_manager"""
+
+    def test_graph_runtime_state_initializes_with_trace_manager(self):
+        """Test that GraphRuntimeState correctly stores the trace_manager"""
+        # Arrange
+        variable_pool = VariablePool()
+        mock_trace_manager = Mock(spec=TraceQueueManager)
+        start_time = time.time()
+
+        # Act
+        state = GraphRuntimeState(variable_pool=variable_pool, start_at=start_time, trace_manager=mock_trace_manager)
+
+        # Assert
+        assert state.trace_manager is mock_trace_manager
+
+    def test_graph_runtime_state_initializes_without_trace_manager(self):
+        """Test that GraphRuntimeState can be initialized without trace_manager"""
+        # Arrange
+        variable_pool = VariablePool()
+        start_time = time.time()
+
+        # Act
+        state = GraphRuntimeState(variable_pool=variable_pool, start_at=start_time, trace_manager=None)
+
+        # Assert
+        assert state.trace_manager is None
+
+    def test_trace_manager_is_read_only(self):
+        """Test that trace_manager property is read-only"""
+        # Arrange
+        variable_pool = VariablePool()
+        mock_trace_manager = Mock(spec=TraceQueueManager)
+        start_time = time.time()
+        state = GraphRuntimeState(variable_pool=variable_pool, start_at=start_time, trace_manager=mock_trace_manager)
+
+        # Assert - trace_manager is read-only, trying to set it should fail
+        with pytest.raises(AttributeError):
+            state.trace_manager = Mock(spec=TraceQueueManager)
+
+
+class TestAgentToolCallbackTraceManager:
+    """Test that Agent tool callback handler correctly logs tool traces using trace_manager"""
+
+    def test_agent_callback_logs_tool_trace_with_trace_manager(self):
+        """Test that on_tool_end logs trace when trace_manager is provided"""
+        # Arrange
+        callback = DifyAgentCallbackHandler(color="green")
+        mock_trace_manager = Mock(spec=TraceQueueManager)
+        tool_name = "test_tool"
+        tool_inputs = {"param1": "value1"}
+        tool_outputs = "test output"
+        message_id = "msg_123"
+        mock_timer = {"start": datetime.now(UTC), "end": datetime.now(UTC)}
+
+        # Act
+        callback.on_tool_end(
+            tool_name=tool_name,
+            tool_inputs=tool_inputs,
+            tool_outputs=tool_outputs,
+            message_id=message_id,
+            timer=mock_timer,
+            trace_manager=mock_trace_manager,
+        )
+
+        # Assert
+        mock_trace_manager.add_trace_task.assert_called_once()
+        call_args = mock_trace_manager.add_trace_task.call_args[0][0]
+        assert isinstance(call_args, TraceTask)
+        assert call_args.trace_type == TraceTaskName.TOOL_TRACE
+        assert call_args.message_id == message_id
+        assert call_args.kwargs["tool_name"] == tool_name
+        assert call_args.kwargs["tool_inputs"] == tool_inputs
+        assert call_args.kwargs["tool_outputs"] == tool_outputs
+        assert call_args.timer == mock_timer
+
+    def test_agent_callback_does_not_log_without_trace_manager(self):
+        """Test that on_tool_end does nothing when trace_manager is None"""
+        # Arrange
+        callback = DifyAgentCallbackHandler(color="green")
+        tool_name = "test_tool"
+        tool_inputs = {"param1": "value1"}
+        tool_outputs = "test output"
+        message_id = "msg_123"
+
+        # Act - should not raise any exceptions
+        callback.on_tool_end(
+            tool_name=tool_name,
+            tool_inputs=tool_inputs,
+            tool_outputs=tool_outputs,
+            message_id=message_id,
+            timer=None,
+            trace_manager=None,
+        )
+
+        # Assert - no exception is success
+
+
+class TestWorkflowToolCallbackTraceManager:
+    """Test that Workflow tool callback handler correctly logs workflow tool traces using trace_manager"""
+
+    def test_workflow_callback_logs_tool_trace_with_trace_manager(self):
+        """Test that on_tool_execution logs trace when trace_manager is provided"""
+        # Arrange
+        callback = DifyWorkflowCallbackHandler(color="green")
+        mock_trace_manager = Mock(spec=TraceQueueManager)
+        tool_name = "workflow_tool"
+        tool_inputs = {"input_key": "input_value"}
+        tool_outputs = [
+            ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.TEXT, message=ToolInvokeMessage.TextMessage(text="output1")
+            ),
+            ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.TEXT, message=ToolInvokeMessage.TextMessage(text="output2")
+            ),
+        ]
+        message_id = "msg_456"
+        mock_timer = {"start": datetime.now(UTC), "end": datetime.now(UTC)}
+
+        # Act
+        result_generator = callback.on_tool_execution(
+            tool_name=tool_name,
+            tool_inputs=tool_inputs,
+            tool_outputs=iter(tool_outputs),
+            message_id=message_id,
+            timer=mock_timer,
+            trace_manager=mock_trace_manager,
+        )
+
+        # Consume the generator
+        results = list(result_generator)
+
+        # Assert
+        assert len(results) == 2
+        mock_trace_manager.add_trace_task.assert_called_once()
+        call_args = mock_trace_manager.add_trace_task.call_args[0][0]
+        assert isinstance(call_args, TraceTask)
+        assert call_args.trace_type == TraceTaskName.TOOL_TRACE
+        assert call_args.message_id == message_id
+        assert call_args.kwargs["tool_name"] == tool_name
+        assert call_args.kwargs["tool_inputs"] == tool_inputs
+        assert call_args.kwargs["tool_outputs"] == tool_outputs
+        assert call_args.timer == mock_timer
+
+    def test_workflow_callback_does_not_log_without_trace_manager(self):
+        """Test that on_tool_execution works without trace_manager"""
+        # Arrange
+        callback = DifyWorkflowCallbackHandler(color="green")
+        tool_name = "workflow_tool"
+        tool_inputs = {"input_key": "input_value"}
+        tool_outputs = [
+            ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.TEXT, message=ToolInvokeMessage.TextMessage(text="output1")
+            )
+        ]
+        message_id = "msg_789"
+
+        # Act
+        result_generator = callback.on_tool_execution(
+            tool_name=tool_name,
+            tool_inputs=tool_inputs,
+            tool_outputs=iter(tool_outputs),
+            message_id=message_id,
+            timer=None,
+            trace_manager=None,
+        )
+
+        # Consume the generator - should not raise
+        results = list(result_generator)
+
+        # Assert
+        assert len(results) == 1
+
+
+class TestGenerateTaskPipelineDebuggerNoLog:
+    """Test that no log is saved in generate_task_pipeline when invoke_from is InvokeFrom.DEBUGGER"""
+
+    @patch("core.app.apps.workflow.generate_task_pipeline.Session")
+    def test_save_workflow_app_log_skips_debugger_without_extras(self, mock_session):
+        """Test that _save_workflow_app_log returns early for DEBUGGER without extras"""
+        from core.app.app_config.entities import WorkflowUIBasedAppConfig
+        from core.app.apps.workflow.generate_task_pipeline import WorkflowAppGenerateTaskPipeline
+        from core.app.entities.app_invoke_entities import WorkflowAppGenerateEntity
+        from core.file import FileUploadConfig
+        from models.workflow import Workflow
+
+        # Arrange
+        mock_workflow = Mock(spec=Workflow)
+        mock_workflow.id = "workflow_123"
+        mock_workflow.features_dict = {}
+
+        app_config = WorkflowUIBasedAppConfig(
+            tenant_id="tenant_1",
+            app_id="app_1",
+            app_mode=AppMode.WORKFLOW,
+            workflow_id="wf_1",
+        )
+
+        app_generate_entity = WorkflowAppGenerateEntity(
+            task_id="task_123",
+            app_config=app_config,
+            file_upload_config=Mock(spec=FileUploadConfig),
+            inputs={},
+            files=[],
+            user_id="user_123",
+            stream=False,
+            invoke_from=InvokeFrom.DEBUGGER,
+            workflow_execution_id="exec_123",
+            extras={},  # No conversation_id or message_id
+            trace_manager=None,
+        )
+
+        mock_queue_manager = Mock()
+        mock_queue_manager.invoke_from = InvokeFrom.DEBUGGER
+        mock_queue_manager.graph_runtime_state = None
+
+        mock_user = Mock()
+        mock_user.session_id = "session_123"
+        mock_user.id = "user_123"
+
+        mock_draft_var_saver_factory = Mock()
+
+        pipeline = WorkflowAppGenerateTaskPipeline(
+            application_generate_entity=app_generate_entity,
+            workflow=mock_workflow,
+            queue_manager=mock_queue_manager,
+            user=mock_user,
+            stream=False,
+            draft_var_saver_factory=mock_draft_var_saver_factory,
+        )
+
+        mock_db_session = Mock()
+
+        # Act
+        pipeline._save_workflow_app_log(session=mock_db_session, workflow_run_id="run_123")
+
+        # Assert - session.add should NOT have been called because debugger should skip logging
+        mock_db_session.add.assert_not_called()
+
+    @patch("core.app.apps.workflow.generate_task_pipeline.Session")
+    def test_save_workflow_app_log_saves_debugger_with_conversation_extras(self, mock_session):
+        """Test that _save_workflow_app_log saves for DEBUGGER when extras contains conversation_id"""
+        from core.app.app_config.entities import WorkflowUIBasedAppConfig
+        from core.app.apps.workflow.generate_task_pipeline import WorkflowAppGenerateTaskPipeline
+        from core.app.entities.app_invoke_entities import WorkflowAppGenerateEntity
+        from core.file import FileUploadConfig
+        from models.workflow import Workflow
+
+        # Arrange
+        mock_workflow = Mock(spec=Workflow)
+        mock_workflow.id = "workflow_123"
+        mock_workflow.features_dict = {}
+
+        app_config = WorkflowUIBasedAppConfig(
+            tenant_id="tenant_1",
+            app_id="app_1",
+            app_mode=AppMode.WORKFLOW,
+            workflow_id="wf_1",
+        )
+
+        app_generate_entity = WorkflowAppGenerateEntity(
+            task_id="task_123",
+            app_config=app_config,
+            file_upload_config=Mock(spec=FileUploadConfig),
+            inputs={},
+            files=[],
+            user_id="user_123",
+            stream=False,
+            invoke_from=InvokeFrom.DEBUGGER,
+            workflow_execution_id="exec_123",
+            extras={"conversation_id": "conv_123"},  # Has conversation_id
+            trace_manager=None,
+        )
+
+        mock_queue_manager = Mock()
+        mock_queue_manager.invoke_from = InvokeFrom.DEBUGGER
+        mock_queue_manager.graph_runtime_state = None
+
+        mock_user = Mock()
+        mock_user.session_id = "session_123"
+        mock_user.id = "user_123"
+
+        mock_draft_var_saver_factory = Mock()
+
+        pipeline = WorkflowAppGenerateTaskPipeline(
+            application_generate_entity=app_generate_entity,
+            workflow=mock_workflow,
+            queue_manager=mock_queue_manager,
+            user=mock_user,
+            stream=False,
+            draft_var_saver_factory=mock_draft_var_saver_factory,
+        )
+
+        mock_db_session = Mock()
+
+        # Act
+        pipeline._save_workflow_app_log(session=mock_db_session, workflow_run_id="run_123")
+
+        # Assert - session.add SHOULD be called because extras has conversation_id
+        mock_db_session.add.assert_called_once()
+
+
+class TestToolEngineTraceManagerPropagation:
+    """Test that ToolEngine correctly passes trace_manager to callback handlers during tool invocation"""
+
+    @patch("core.tools.tool_engine.db")
+    def test_agent_invoke_passes_trace_manager_to_callback(self, mock_db):
+        """Test that agent_invoke passes trace_manager to agent_tool_callback.on_tool_end"""
+        # Arrange
+        tool_identity = ToolIdentity(
+            author="test_author", name="test_tool", label={"en_US": "Test Tool"}, provider="test_provider"
+        )
+        tool_description = ToolDescription(human={"en_US": "Test description"}, llm="Test LLM description")
+        tool_entity = ToolEntity(identity=tool_identity, description=tool_description, parameters=[])
+
+        tool_runtime = ToolRuntime(tenant_id="tenant_123", tool_id="tool_123", invoke_from=InvokeFrom.DEBUGGER)
+
+        mock_tool = MockTool(entity=tool_entity, runtime=tool_runtime)
+
+        mock_callback = Mock(spec=DifyAgentCallbackHandler)
+        mock_trace_manager = Mock(spec=TraceQueueManager)
+
+        mock_message = Mock(spec=Message)
+        mock_message.id = "msg_123"
+        mock_message.conversation_id = "conv_123"
+
+        # Act
+        result = ToolEngine.agent_invoke(
+            tool=mock_tool,
+            tool_parameters={"param1": "value1"},
+            user_id="user_123",
+            tenant_id="tenant_123",
+            message=mock_message,
+            invoke_from=InvokeFrom.DEBUGGER,
+            agent_tool_callback=mock_callback,
+            trace_manager=mock_trace_manager,
+            conversation_id="conv_123",
+            app_id="app_123",
+            message_id="msg_123",
+        )
+
+        # Assert
+        # Verify that on_tool_start was called
+        mock_callback.on_tool_start.assert_called_once_with(tool_name="test_tool", tool_inputs={"param1": "value1"})
+
+        # Verify that on_tool_end was called with trace_manager
+        mock_callback.on_tool_end.assert_called_once()
+        call_kwargs = mock_callback.on_tool_end.call_args[1]
+        assert call_kwargs["trace_manager"] is mock_trace_manager
+        assert call_kwargs["message_id"] == "msg_123"
+
+    @patch("core.tools.tool_engine.db")
+    def test_generic_invoke_passes_trace_manager_to_callback(self, mock_db):
+        """Test that generic_invoke passes trace_manager to workflow_tool_callback.on_tool_execution"""
+        # Arrange
+        tool_identity = ToolIdentity(
+            author="test_author",
+            name="workflow_test_tool",
+            label={"en_US": "Workflow Test Tool"},
+            provider="test_provider",
+        )
+        tool_description = ToolDescription(human={"en_US": "Test description"}, llm="Test LLM description")
+        tool_entity = ToolEntity(identity=tool_identity, description=tool_description, parameters=[])
+
+        tool_runtime = ToolRuntime(tenant_id="tenant_123", tool_id="tool_456", invoke_from=InvokeFrom.DEBUGGER)
+
+        mock_tool = MockTool(entity=tool_entity, runtime=tool_runtime)
+
+        mock_callback = Mock(spec=DifyWorkflowCallbackHandler)
+        mock_callback.on_tool_execution = Mock(
+            return_value=iter(
+                [
+                    ToolInvokeMessage(
+                        type=ToolInvokeMessage.MessageType.TEXT, message=ToolInvokeMessage.TextMessage(text="result")
+                    )
+                ]
+            )
+        )
+        mock_trace_manager = Mock(spec=TraceQueueManager)
+
+        # Act
+        result_generator = ToolEngine.generic_invoke(
+            tool=mock_tool,
+            tool_parameters={"input_key": "input_value"},
+            user_id="user_456",
+            workflow_tool_callback=mock_callback,
+            workflow_call_depth=0,
+            conversation_id="conv_456",
+            app_id="app_456",
+            message_id="msg_456",
+            trace_manager=mock_trace_manager,
+        )
+
+        # Consume generator
+        results = list(result_generator)
+
+        # Assert
+        # Verify that on_tool_start was called
+        mock_callback.on_tool_start.assert_called_once_with(
+            tool_name="workflow_test_tool", tool_inputs={"input_key": "input_value"}
+        )
+
+        # Verify that on_tool_execution was called with trace_manager
+        mock_callback.on_tool_execution.assert_called_once()
+        call_kwargs = mock_callback.on_tool_execution.call_args[1]
+        assert call_kwargs["trace_manager"] is mock_trace_manager
+        assert call_kwargs["message_id"] == "msg_456"
+
+    @patch("core.tools.tool_engine.db")
+    def test_agent_invoke_works_without_trace_manager(self, mock_db):
+        """Test that agent_invoke works correctly when trace_manager is None"""
+        # Arrange
+        tool_identity = ToolIdentity(
+            author="test_author", name="test_tool_no_trace", label={"en_US": "Test Tool"}, provider="test_provider"
+        )
+        tool_description = ToolDescription(human={"en_US": "Test description"}, llm="Test LLM description")
+        tool_entity = ToolEntity(identity=tool_identity, description=tool_description, parameters=[])
+
+        tool_runtime = ToolRuntime(tenant_id="tenant_789", tool_id="tool_789", invoke_from=InvokeFrom.DEBUGGER)
+
+        mock_tool = MockTool(entity=tool_entity, runtime=tool_runtime)
+
+        mock_callback = Mock(spec=DifyAgentCallbackHandler)
+
+        mock_message = Mock(spec=Message)
+        mock_message.id = "msg_789"
+        mock_message.conversation_id = "conv_789"
+
+        # Act - with trace_manager=None
+        result = ToolEngine.agent_invoke(
+            tool=mock_tool,
+            tool_parameters={"param": "value"},
+            user_id="user_789",
+            tenant_id="tenant_789",
+            message=mock_message,
+            invoke_from=InvokeFrom.DEBUGGER,
+            agent_tool_callback=mock_callback,
+            trace_manager=None,  # No trace manager
+            conversation_id="conv_789",
+            app_id="app_789",
+            message_id="msg_789",
+        )
+
+        # Assert - should complete without errors
+        mock_callback.on_tool_start.assert_called_once()
+        mock_callback.on_tool_end.assert_called_once()
+        call_kwargs = mock_callback.on_tool_end.call_args[1]
+        assert call_kwargs["trace_manager"] is None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

fix #31396

## Summary

The original issue was that workflow as tool functionality was missing log
  records during execution, while agent tool calls were properly logged.

  Root Cause Analysis

  After investigation, I found that the logging mechanism had a gap in the workflow
   tool callback handler:

  1. Agent Tools: Used DifyAgentCallbackHandler.on_tool_end() with
  trace_manager.add_trace_task()
  2. Workflow Tools: Used DifyWorkflowCallbackHandler.on_tool_execution() without 
  trace_manager support
  3. Missing Trace Recording: Workflow tool executions were not being logged to the
   database

  Solution Implemented

  1. Enhanced Workflow Tool Callback Handler

  File: api/core/callback_handler/workflow_tool_callback_handler.py

  ```python
  def on_tool_execution(
      self,
      tool_name: str,
      tool_inputs: Mapping[str, Any],
      tool_outputs: Iterable[ToolInvokeMessage],
      message_id: str | None = None,
      timer: Any | None = None,
      trace_manager: Union["TraceQueueManager", None] = None,
  ) -> Generator[ToolInvokeMessage, None, None]:
      # Convert tool_outputs to list for processing
      tool_outputs_list = list(tool_outputs)

      # Record trace for workflow tool execution
      if trace_manager:
          from core.ops.entities.trace_entity import TraceTaskName
          from core.ops.ops_trace_manager import TraceTask

          trace_manager.add_trace_task(
              TraceTask(
                  TraceTaskName.TOOL_TRACE,
                  message_id=message_id,
                  tool_name=tool_name,
                  tool_inputs=tool_inputs,
                  tool_outputs=tool_outputs_list,
                  timer=timer,
              )
          )

      for tool_output in tool_outputs_list:
          print_text("\n[on_tool_execution]\n", color=self.color)
          print_text("Tool: " + tool_name + "\n", color=self.color)
          print_text("Outputs: " + tool_output.model_dump_json()[:1000] + "\n",
  color=self.color)
          print_text("\n")
          yield tool_output
  ```

  2. Updated Tool Engine for Trace Manager Support

  File: api/core/tools/tool_engine.py

  ```python
  @staticmethod
  def generic_invoke(
      tool: Tool,
      tool_parameters: dict[str, Any],
      user_id: str,
      workflow_tool_callback: DifyWorkflowCallbackHandler,
      workflow_call_depth: int,
      conversation_id: str | None = None,
      app_id: str | None = None,
      message_id: str | None = None,
      trace_manager: Union["TraceQueueManager", None] = None,
  ) -> Generator[ToolInvokeMessage, None, None]:
      # ... existing code ...

      # hit the callback handler
      response = workflow_tool_callback.on_tool_execution(
          tool_name=tool.entity.identity.name,
          tool_inputs=tool_parameters,
          tool_outputs=response,
          message_id=message_id,
          trace_manager=trace_manager,
      )

      return response

  ```
  3. Extended Graph Runtime State

  File: api/core/workflow/runtime/graph_runtime_state.py

  ```python
  def __init__(
      self,
      *,
      variable_pool: VariablePool,
      start_at: float,
      # ... other parameters ...
      trace_manager: Union["TraceQueueManager", None] = None,
  ) -> None:
      # ... existing code ...
      self._trace_manager = trace_manager

  @property
  def trace_manager(self) -> Union["TraceQueueManager", None]:
      return self._trace_manager
  ```

  4. Updated Tool Node Integration

  File: api/core/workflow/nodes/tool/tool_node.py

  ```python
  # Get trace_manager from the graph runtime state
  trace_manager = self.graph_runtime_state.trace_manager

  try:
      message_stream = ToolEngine.generic_invoke(
          tool=tool_runtime,
          tool_parameters=parameters,
          user_id=self.user_id,
          workflow_tool_callback=DifyWorkflowCallbackHandler(),
          workflow_call_depth=self.workflow_call_depth,
          app_id=self.app_id,
          conversation_id=conversation_id.text if conversation_id else None,
          trace_manager=trace_manager,
      )
  ```

  5. Updated App Runners

  Files:
  - api/core/app/apps/workflow/app_runner.py
  - api/core/app/apps/advanced_chat/app_runner.py
  - api/core/app/apps/pipeline/pipeline_runner.py

  ```python
  graph_runtime_state = GraphRuntimeState(
      variable_pool=variable_pool,
      start_at=time.perf_counter(),
      trace_manager=self.application_generate_entity.trace_manager,
  )
  ```

  Additional Fix: Agent Call Detection

  Why conversation_id and message_id are required

  Dify distinguishes between two types of workflow calls:

  1. Debug Mode (Direct testing in debugger):
    - No conversation_id/message_id
    - Behavior: No logs saved to database
    - Purpose: Development and testing
  2. Agent/Production Mode (Called via applications):
    - Has conversation_id and message_id
    - Behavior: Logs saved permanently
    - Purpose: Real usage scenarios and analysis

  Implementation

  File: api/core/app/apps/workflow/app_generator.py
  elif invoke_from == InvokeFrom.DEBUGGER:
      # Check if this is called from an agent (should be treated as app-run, not 
  debugging)
      is_agent_call = any(
          key in args for key in ["conversation_id", "message_id"]
      )
      workflow_triggered_from = WorkflowRunTriggeredFrom.APP_RUN \
          if is_agent_call else WorkflowRunTriggeredFrom.DEBUGGING

  extras = {
      **extract_external_trace_id_from_args(args),
      # Add conversation_id and message_id to extras for agent call detection
      **{k: v for k, v in args.items() if k in ["conversation_id", "message_id"]},
  }

  File: api/core/app/apps/workflow/generate_task_pipeline.py
  elif invoke_from == InvokeFrom.DEBUGGER:
      agent_context = self._application_generate_entity.extras
      if agent_context and any(key in str(agent_context) for key in
  ["conversation_id", "message_id"]):
          created_from = WorkflowAppLogCreatedFrom.SERVICE_API
      else:
          # not save log for regular debugging
          return

  File: api/core/tools/workflow_as_tool/tool.py
  # Add conversation_id and message_id to args if available
  args = {"inputs": tool_parameters, "files": files}
  if conversation_id:
      args["conversation_id"] = conversation_id
  if message_id:
      args["message_id"] = message_id

  Fixed Circular Import Issues

  Used TYPE_CHECKING and string type annotations to resolve circular import
  problems:

  if TYPE_CHECKING:
      from core.ops.ops_trace_manager import TraceQueueManager

  def method(self, trace_manager: Union["TraceQueueManager", None] = None):
      # Method implementation

  Results

  ✅ Workflow as tool logging now works correctly
  - Tool calls are properly recorded to the database
  - Logs appear in the frontend interface
  - Consistent logging format with agent tools
  - Maintains backward compatibility

  ✅ Distinguishes between debugging and production usage
  - Debug testing doesn't pollute production logs
  - Agent/tool calls are properly logged for analysis
  - Flexible system for different usage scenarios

  ✅ No circular import issues
  - Uses TYPE_CHECKING for type annotations
  - Maintains clean architecture boundaries

  The fix ensures that workflow as tool functionality provides complete execution
  tracing and logging capabilities, matching the behavior of agent tool calls while
   maintaining the flexibility to distinguish between development testing and
  production usage.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

<img width="2932" height="746" alt="image" src="https://github.com/user-attachments/assets/4a2be279-08c7-44c4-b840-41e9d9cf5f9b" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
