### PR TITLE
hotfix(otel): replace hardcoded span attributes with shared constants

### DIFF
--- a/api/extensions/otel/runtime.py
+++ b/api/extensions/otel/runtime.py
@@ -11,6 +11,7 @@ from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from configs import dify_config
+from extensions.otel.semconv import DifySpanAttributes, GenAIAttributes
 from libs.helper import extract_tenant_id
 from models import Account, EndUser
 
@@ -51,8 +52,8 @@ def on_user_loaded(_sender, user: Union["Account", "EndUser"]):
                 if not tenant_id:
                     return
                 if current_span:
-                    current_span.set_attribute("service.tenant.id", tenant_id)
-                    current_span.set_attribute("service.user.id", user.id)
+                    current_span.set_attribute(DifySpanAttributes.TENANT_ID, tenant_id)
+                    current_span.set_attribute(GenAIAttributes.USER_ID, user.id)
             except Exception:
                 logger.exception("Error setting tenant and user attributes")
                 pass


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Replace hardcoded attribute names "service.tenant.id" and "service.user.id"
with DifySpanAttributes.TENANT_ID and GenAIAttributes.USER_ID respectively
in the on_user_loaded signal handler to ensure consistent attribute naming
across all OpenTelemetry handlers.

This change aligns the runtime.py implementation with other handlers
(generate_handler, workflow_app_runner_handler) that already use these
shared constants, improving code maintainability and consistency.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
