### PR TITLE
fix: remove 1px border from knowledge pipeline editor

### DIFF
--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
@@ -121,7 +121,7 @@ const DatasetDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     <div
       className={cn(
         'flex grow overflow-hidden',
-        hideHeader && isPipelineCanvas ? '' : 'rounded-t-2xl border-t border-effects-highlight',
+        hideHeader && isPipelineCanvas ? '' : 'rounded-t-2xl',
       )}
     >
       <DatasetDetailContext.Provider value={{


### PR DESCRIPTION
## Summary

This PR removes the 1px white border at the top of the Knowledge Pipeline editor screen.

By doing this, the significant performance degradation seen in environments where **graphics acceleration is not available** (such as enterprise VDI or DaaS) is completely resolved, and users will experience smooth operation comparable to the Workflow editor screen.

For more details about the issue, please see [the comments in the Issue](https://github.com/langgenius/dify/issues/29153).
To summarize, when a 1px border is present, the browser tries to offload composition of the screen to the GPU. In environments without graphics acceleration, this request falls back to the CPU, causing a noticeable drop in performance.

I apologize if this PR alters the intended design of the screen.
As someone who does design work myself, I understand that even a single 1px line can carry a lot of meaning.

If you prefer to keep the design (i.e., retain the 1px border), as an alternative, removing `overflow: hidden` (changing it to `visible`) on the same div element also solves the problem. However, this option does require careful testing for potential side effects.

Please let me know if you need any further action from my side.

Closes #29153 

## Screenshots

### Before: FPS is 3 or less, with 1px border on the top of the container
<img width="678" height="152" alt="image" src="https://github.com/user-attachments/assets/f123f529-83d7-4091-9f47-4becea270156" />

https://github.com/user-attachments/assets/f4106246-07e5-4dbb-ac2a-ebdd1191fa3e

### After: FPS is around 50, without any border on the top of the container (the same as the workflow editor)
<img width="498" height="154" alt="image" src="https://github.com/user-attachments/assets/086030ce-883d-4b5c-9192-46965a7b211b" />

https://github.com/user-attachments/assets/a193febe-56a0-48d9-a977-07b153ee4b4d

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
