### PR TITLE
fix: hide supplementary text for platform logo properly in Safari

### DIFF
--- a/web/app/components/header/index.tsx
+++ b/web/app/components/header/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { useCallback } from 'react'
 import Link from 'next/link'
-import Image from 'next/image'
 import AccountDropdown from './account-dropdown'
 import AppNav from './app-nav'
 import DatasetNav from './dataset-nav'
@@ -49,7 +48,7 @@ const Header = () => {
       <Link href="/apps" className='flex h-8 shrink-0 items-center justify-center overflow-hidden whitespace-nowrap px-0.5 indent-[-9999px]'>
         {isBrandingEnabled && systemFeatures.branding.application_title ? systemFeatures.branding.application_title : 'Dify'}
         {systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo
-          ? <Image
+          ? <img
             src={systemFeatures.branding.workspace_logo}
             className='block h-[22px] w-auto object-contain'
             alt='logo'

--- a/web/app/components/header/index.tsx
+++ b/web/app/components/header/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useCallback } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import AccountDropdown from './account-dropdown'
 import AppNav from './app-nav'
 import DatasetNav from './dataset-nav'
@@ -45,15 +46,15 @@ const Header = () => {
 
   const renderLogo = () => (
     <h1>
-      <Link href="/apps" className='flex h-8 shrink-0 items-center justify-center px-0.5 indent-[-9999px]'>
+      <Link href="/apps" className='flex h-8 shrink-0 items-center justify-center overflow-hidden whitespace-nowrap px-0.5 indent-[-9999px]'>
+        {isBrandingEnabled && systemFeatures.branding.application_title ? systemFeatures.branding.application_title : 'Dify'}
         {systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo
-          ? <img
+          ? <Image
             src={systemFeatures.branding.workspace_logo}
             className='block h-[22px] w-auto object-contain'
             alt='logo'
           />
           : <DifyLogo />}
-        {isBrandingEnabled && systemFeatures.branding.application_title ? systemFeatures.branding.application_title : 'dify'}
       </Link>
     </h1>
   )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Hide supplementary text for platform logo properly in Safari.

## Screenshots

| Before | After |
|--------|-------|
| <img width="274" height="106" alt="image" src="https://github.com/user-attachments/assets/03e3f840-3105-4bf5-a0da-5a4b45217e38" /> | <img width="226" height="108" alt="image" src="https://github.com/user-attachments/assets/217ce93a-a38e-44c9-a70b-8cae1885080f" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
