### PR TITLE
fix: account dropdown obscured by empty state overlay (#29241)

### DIFF
--- a/web/app/components/header/header-wrapper.tsx
+++ b/web/app/components/header/header-wrapper.tsx
@@ -28,7 +28,7 @@ const HeaderWrapper = ({
 
   return (
     <div className={classNames(
-      'sticky left-0 right-0 top-0 z-[15] flex min-h-[56px] shrink-0 grow-0 basis-auto flex-col',
+      'sticky left-0 right-0 top-0 z-[30] flex min-h-[56px] shrink-0 grow-0 basis-auto flex-col',
       s.header,
       isBordered ? 'border-b border-divider-regular' : '',
       hideHeader && (inWorkflowCanvas || isPipelineCanvas) && 'hidden',


### PR DESCRIPTION
The account dropdown menu was being visually obscured by the empty
state gradient overlay on the /apps page when no apps exist.

Root cause: HeaderWrapper has z-[15] which creates a stacking context,
while the Empty component overlay uses z-20. This caused the entire
header (including dropdown) to render below the empty state overlay,
making the dropdown appear faded from top to bottom due to the
gradient (bg-gradient-to-t from-background-body to-transparent).

Solution: Increased HeaderWrapper z-index from z-[15] to z-[30] to
ensure the header and all its children (including dropdowns) render
above page content overlays.

Fixes #29241

| Before | After |
|--------|-------|
|<img width="532" height="472" alt="image" src="https://github.com/user-attachments/assets/49d59dc7-ca81-4434-ab7d-5d0d2f8eaf2a" />|<img width="497" height="452" alt="image" src="https://github.com/user-attachments/assets/89d719a0-79ba-4b71-82cf-5481b7cb1bc8" />|
