### PR TITLE
Fix-Setting administrator account does not have permission #29175

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -704,6 +704,8 @@ services:
     networks:
       - ssrf_proxy_network
       - default
+    entrypoint: ["/bin/sh", "-c", "chown dify:dify -R /app/api/storage"]
+    user: root
 
   # worker_beat service
   # Celery beat for scheduling periodic tasks.


### PR DESCRIPTION
Fix Bug Setting administrator account does not have permission

fix #29149 

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

After fixing this issue, when you first enter the homepage, you can easily set up the Dify page by clicking on the settings (after filling in the required options), and then you can delve into the various modules of the Dify platform
<img width="1594" height="561" alt="图片" src="https://github.com/user-attachments/assets/ff923ac5-c2db-45c8-9c7e-847c0037a66e" />
<img width="1929" height="643" alt="图片" src="https://github.com/user-attachments/assets/b006b421-8428-4750-84aa-3403963385ef" />

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |
before：
<img width="3443" height="834" alt="522438296-5d8b5e77-86bd-42c9-901e-c302d028f801" src="https://github.com/user-attachments/assets/624097c9-cb0c-4103-b384-d2a8ff6714bc" />
tuck in the settings interface and unable to enter

after fix the bug:
<img width="1929" height="643" alt="图片" src="https://github.com/user-attachments/assets/2aa11036-44b8-4a77-a437-c02360c6508b" />
Successfully entered the page for use


## Checklist

- [√] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [√] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [√] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [√] I've updated the documentation accordingly.
- [√] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
