### PR TITLE
refactor: migrate log data fetching to react query

### DIFF
--- a/web/app/components/app/log/filter.tsx
+++ b/web/app/components/app/log/filter.tsx
@@ -2,7 +2,6 @@
 import type { FC } from 'react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import useSWR from 'swr'
 import dayjs from 'dayjs'
 import { RiCalendarLine } from '@remixicon/react'
 import quarterOfYear from 'dayjs/plugin/quarterOfYear'
@@ -10,7 +9,7 @@ import type { QueryParam } from './index'
 import Chip from '@/app/components/base/chip'
 import Input from '@/app/components/base/input'
 import Sort from '@/app/components/base/sort'
-import { fetchAnnotationsCount } from '@/service/log'
+import { useAnnotationsCount } from '@/service/use-log'
 dayjs.extend(quarterOfYear)
 
 const today = dayjs()
@@ -35,7 +34,7 @@ type IFilterProps = {
 }
 
 const Filter: FC<IFilterProps> = ({ isChatMode, appId, queryParams, setQueryParams }: IFilterProps) => {
-  const { data } = useSWR({ url: `/apps/${appId}/annotations/count` }, fetchAnnotationsCount)
+  const { data } = useAnnotationsCount(appId)
   const { t } = useTranslation()
   if (!data)
     return null

--- a/web/app/components/app/log/index.tsx
+++ b/web/app/components/app/log/index.tsx
@@ -71,6 +71,7 @@ const Logs: FC<ILogsProps> = ({ appDetail }) => {
 
   // Get the app type first
   const isChatMode = appDetail.mode !== AppModeEnum.COMPLETION
+  const { sort_by } = debouncedQueryParams
 
   const completionQuery = useMemo<CompletionConversationsRequest & { sort_by?: string }>(() => ({
     page: currPage + 1,
@@ -88,9 +89,9 @@ const Logs: FC<ILogsProps> = ({ appDetail }) => {
 
   const chatQuery = useMemo<ChatConversationsRequest & { sort_by?: string }>(() => ({
     ...completionQuery,
-    sort_by: debouncedQueryParams.sort_by,
-    message_count: (debouncedQueryParams as any).message_count ?? 0,
-  }), [completionQuery, debouncedQueryParams.sort_by, isChatMode])
+    sort_by,
+    message_count: 0,
+  }), [completionQuery, sort_by])
 
   // When the details are obtained, proceed to the next request
   const { data: chatConversations, refetch: refetchChatList } = useChatConversations(appDetail.id, chatQuery, isChatMode)

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -935,14 +935,12 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
     router.push(buildUrlWithConversation(log.id), { scroll: false })
   }, [buildUrlWithConversation, conversationIdInUrl, currentConversation, router, showDrawer])
 
-  const currentConversationId = currentConversation?.id
-
   useEffect(() => {
     if (!conversationIdInUrl) {
       if (pendingConversationIdRef.current)
         return
 
-      if (showDrawer || currentConversationId) {
+      if (showDrawer || currentConversation?.id) {
         setShowDrawer(false)
         setCurrentConversation(undefined)
       }
@@ -970,7 +968,7 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
 
     if (pendingConversationCacheRef.current?.id === conversationIdInUrl || matchedConversation)
       pendingConversationCacheRef.current = undefined
-  }, [conversationIdInUrl, currentConversation, currentConversationId, isChatMode, logs?.data, showDrawer])
+  }, [conversationIdInUrl, currentConversation, isChatMode, logs?.data, showDrawer])
 
   const onCloseDrawer = useCallback(() => {
     onRefresh()

--- a/web/service/log.ts
+++ b/web/service/log.ts
@@ -1,4 +1,3 @@
-import type { Fetcher } from 'swr'
 import { get, post } from './base'
 import type {
   AgentLogDetailRequest,
@@ -22,59 +21,33 @@ import type {
 } from '@/models/log'
 import type { NodeTracingListResponse } from '@/types/workflow'
 
-export const fetchConversationList: Fetcher<ConversationListResponse, { name: string; appId: string; params?: Record<string, any> }> = ({ appId, params }) => {
-  return get<ConversationListResponse>(`/console/api/apps/${appId}/messages`, params)
-}
+export const fetchConversationList = ({ appId, params }: { name: string; appId: string; params?: Record<string, any> }): Promise<ConversationListResponse> => get<ConversationListResponse>(`/console/api/apps/${appId}/messages`, params)
 
 // (Text Generation Application) Session List
-export const fetchCompletionConversations: Fetcher<CompletionConversationsResponse, { url: string; params?: CompletionConversationsRequest }> = ({ url, params }) => {
-  return get<CompletionConversationsResponse>(url, { params })
-}
+export const fetchCompletionConversations = ({ url, params }: { url: string; params?: CompletionConversationsRequest }): Promise<CompletionConversationsResponse> => get<CompletionConversationsResponse>(url, { params })
 
 // (Text Generation Application) Session Detail
-export const fetchCompletionConversationDetail: Fetcher<CompletionConversationFullDetailResponse, { url: string }> = ({ url }) => {
-  return get<CompletionConversationFullDetailResponse>(url, {})
-}
+export const fetchCompletionConversationDetail = ({ url }: { url: string }): Promise<CompletionConversationFullDetailResponse> => get<CompletionConversationFullDetailResponse>(url, {})
 
 // (Chat Application) Session List
-export const fetchChatConversations: Fetcher<ChatConversationsResponse, { url: string; params?: ChatConversationsRequest }> = ({ url, params }) => {
-  return get<ChatConversationsResponse>(url, { params })
-}
+export const fetchChatConversations = ({ url, params }: { url: string; params?: ChatConversationsRequest }): Promise<ChatConversationsResponse> => get<ChatConversationsResponse>(url, { params })
 
 // (Chat Application) Session Detail
-export const fetchChatConversationDetail: Fetcher<ChatConversationFullDetailResponse, { url: string }> = ({ url }) => {
-  return get<ChatConversationFullDetailResponse>(url, {})
-}
+export const fetchChatConversationDetail = ({ url }: { url: string }): Promise<ChatConversationFullDetailResponse> => get<ChatConversationFullDetailResponse>(url, {})
 
 // (Chat Application) Message list in one session
-export const fetchChatMessages: Fetcher<ChatMessagesResponse, { url: string; params: ChatMessagesRequest }> = ({ url, params }) => {
-  return get<ChatMessagesResponse>(url, { params })
-}
+export const fetchChatMessages = ({ url, params }: { url: string; params: ChatMessagesRequest }): Promise<ChatMessagesResponse> => get<ChatMessagesResponse>(url, { params })
 
-export const updateLogMessageFeedbacks: Fetcher<LogMessageFeedbacksResponse, { url: string; body: LogMessageFeedbacksRequest }> = ({ url, body }) => {
-  return post<LogMessageFeedbacksResponse>(url, { body })
-}
+export const updateLogMessageFeedbacks = ({ url, body }: { url: string; body: LogMessageFeedbacksRequest }): Promise<LogMessageFeedbacksResponse> => post<LogMessageFeedbacksResponse>(url, { body })
 
-export const updateLogMessageAnnotations: Fetcher<LogMessageAnnotationsResponse, { url: string; body: LogMessageAnnotationsRequest }> = ({ url, body }) => {
-  return post<LogMessageAnnotationsResponse>(url, { body })
-}
+export const updateLogMessageAnnotations = ({ url, body }: { url: string; body: LogMessageAnnotationsRequest }): Promise<LogMessageAnnotationsResponse> => post<LogMessageAnnotationsResponse>(url, { body })
 
-export const fetchAnnotationsCount: Fetcher<AnnotationsCountResponse, { url: string }> = ({ url }) => {
-  return get<AnnotationsCountResponse>(url)
-}
+export const fetchAnnotationsCount = ({ url }: { url: string }): Promise<AnnotationsCountResponse> => get<AnnotationsCountResponse>(url)
 
-export const fetchWorkflowLogs: Fetcher<WorkflowLogsResponse, { url: string; params: Record<string, any> }> = ({ url, params }) => {
-  return get<WorkflowLogsResponse>(url, { params })
-}
+export const fetchWorkflowLogs = ({ url, params }: { url: string; params: Record<string, any> }): Promise<WorkflowLogsResponse> => get<WorkflowLogsResponse>(url, { params })
 
-export const fetchRunDetail = (url: string) => {
-  return get<WorkflowRunDetailResponse>(url)
-}
+export const fetchRunDetail = (url: string): Promise<WorkflowRunDetailResponse> => get<WorkflowRunDetailResponse>(url)
 
-export const fetchTracingList: Fetcher<NodeTracingListResponse, { url: string }> = ({ url }) => {
-  return get<NodeTracingListResponse>(url)
-}
+export const fetchTracingList = ({ url }: { url: string }): Promise<NodeTracingListResponse> => get<NodeTracingListResponse>(url)
 
-export const fetchAgentLogDetail = ({ appID, params }: { appID: string; params: AgentLogDetailRequest }) => {
-  return get<AgentLogDetailResponse>(`/apps/${appID}/agent/logs`, { params })
-}
+export const fetchAgentLogDetail = ({ appID, params }: { appID: string; params: AgentLogDetailRequest }): Promise<AgentLogDetailResponse> => get<AgentLogDetailResponse>(`/apps/${appID}/agent/logs`, { params })

--- a/web/service/log.ts
+++ b/web/service/log.ts
@@ -24,13 +24,13 @@ import type { NodeTracingListResponse } from '@/types/workflow'
 export const fetchConversationList = ({ appId, params }: { name: string; appId: string; params?: Record<string, any> }): Promise<ConversationListResponse> => get<ConversationListResponse>(`/console/api/apps/${appId}/messages`, params)
 
 // (Text Generation Application) Session List
-export const fetchCompletionConversations = ({ url, params }: { url: string; params?: CompletionConversationsRequest }): Promise<CompletionConversationsResponse> => get<CompletionConversationsResponse>(url, { params })
+export const fetchCompletionConversations = ({ url, params }: { url: string; params?: Partial<CompletionConversationsRequest> & { sort_by?: string } }): Promise<CompletionConversationsResponse> => get<CompletionConversationsResponse>(url, { params })
 
 // (Text Generation Application) Session Detail
 export const fetchCompletionConversationDetail = ({ url }: { url: string }): Promise<CompletionConversationFullDetailResponse> => get<CompletionConversationFullDetailResponse>(url, {})
 
 // (Chat Application) Session List
-export const fetchChatConversations = ({ url, params }: { url: string; params?: ChatConversationsRequest }): Promise<ChatConversationsResponse> => get<ChatConversationsResponse>(url, { params })
+export const fetchChatConversations = ({ url, params }: { url: string; params?: Partial<ChatConversationsRequest> & { sort_by?: string } }): Promise<ChatConversationsResponse> => get<ChatConversationsResponse>(url, { params })
 
 // (Chat Application) Session Detail
 export const fetchChatConversationDetail = ({ url }: { url: string }): Promise<ChatConversationFullDetailResponse> => get<ChatConversationFullDetailResponse>(url, {})

--- a/web/service/use-log.ts
+++ b/web/service/use-log.ts
@@ -35,15 +35,18 @@ type AnnotationPayload = {
   value: string
 }
 
-export const chatConversationsKey = (appId?: string, params?: ChatConversationsRequest): QueryKey => ['chat-conversations', appId, params]
-export const completionConversationsKey = (appId?: string, params?: CompletionConversationsRequest): QueryKey => ['completion-conversations', appId, params]
+type ChatConversationsParams = Partial<ChatConversationsRequest> & { sort_by?: string }
+type CompletionConversationsParams = Partial<CompletionConversationsRequest> & { sort_by?: string }
+
+export const chatConversationsKey = (appId?: string, params?: ChatConversationsParams): QueryKey => ['chat-conversations', appId, params]
+export const completionConversationsKey = (appId?: string, params?: CompletionConversationsParams): QueryKey => ['completion-conversations', appId, params]
 export const completionConversationDetailKey = (appId?: string, conversationId?: string): QueryKey => ['completion-conversation-detail', appId, conversationId]
 
 export const chatConversationDetailKey = (appId?: string, conversationId?: string): QueryKey => ['chat-conversation-detail', appId, conversationId]
 
 export const annotationsCountKey = (appId?: string): QueryKey => ['annotations-count', appId]
 
-export const useChatConversations = (appId?: string, params?: ChatConversationsRequest, enabled = true) => {
+export const useChatConversations = (appId?: string, params?: ChatConversationsParams, enabled = true) => {
   const queryKey = chatConversationsKey(appId, params)
   const queryResult = useQuery<ChatConversationsResponse>({
     queryKey,
@@ -54,7 +57,7 @@ export const useChatConversations = (appId?: string, params?: ChatConversationsR
   return { ...queryResult, queryKey }
 }
 
-export const useCompletionConversations = (appId?: string, params?: CompletionConversationsRequest, enabled = true) => {
+export const useCompletionConversations = (appId?: string, params?: CompletionConversationsParams, enabled = true) => {
   const queryKey = completionConversationsKey(appId, params)
   const queryResult = useQuery<CompletionConversationsResponse>({
     queryKey,
@@ -103,6 +106,8 @@ export const useUpdateLogMessageFeedback = (appId?: string, invalidateKey?: Quer
 
   return useMutation({
     mutationFn: async ({ mid, rating, content }: FeedbackPayload) => {
+      if (!appId)
+        throw new Error('appId is required to update message feedback.')
       return await updateLogMessageFeedbacks({
         url: `/apps/${appId}/feedbacks`,
         body: { message_id: mid, rating, content: content ?? undefined },
@@ -120,6 +125,8 @@ export const useUpdateLogMessageAnnotation = (appId?: string, invalidateKey?: Qu
 
   return useMutation({
     mutationFn: async ({ mid, value }: AnnotationPayload) => {
+      if (!appId)
+        throw new Error('appId is required to update message annotation.')
       return await updateLogMessageAnnotations({
         url: `/apps/${appId}/annotations`,
         body: { message_id: mid, content: value },

--- a/web/service/use-log.ts
+++ b/web/service/use-log.ts
@@ -1,0 +1,133 @@
+import type { QueryKey } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import {
+  fetchAnnotationsCount,
+  fetchChatConversationDetail,
+  fetchChatConversations,
+  fetchCompletionConversationDetail,
+  fetchCompletionConversations,
+  updateLogMessageAnnotations,
+  updateLogMessageFeedbacks,
+} from '@/service/log'
+import type {
+  AnnotationsCountResponse,
+  ChatConversationFullDetailResponse,
+  ChatConversationsRequest,
+  ChatConversationsResponse,
+  CompletionConversationFullDetailResponse,
+  CompletionConversationsRequest,
+  CompletionConversationsResponse,
+  MessageRating,
+} from '@/models/log'
+
+type FeedbackPayload = {
+  mid: string
+  rating: MessageRating
+  content?: string | null
+}
+
+type AnnotationPayload = {
+  mid: string
+  value: string
+}
+
+export const chatConversationsKey = (appId?: string, params?: ChatConversationsRequest): QueryKey => ['chat-conversations', appId, params]
+export const completionConversationsKey = (appId?: string, params?: CompletionConversationsRequest): QueryKey => ['completion-conversations', appId, params]
+export const completionConversationDetailKey = (appId?: string, conversationId?: string): QueryKey => ['completion-conversation-detail', appId, conversationId]
+
+export const chatConversationDetailKey = (appId?: string, conversationId?: string): QueryKey => ['chat-conversation-detail', appId, conversationId]
+
+export const annotationsCountKey = (appId?: string): QueryKey => ['annotations-count', appId]
+
+export const useChatConversations = (appId?: string, params?: ChatConversationsRequest, enabled = true) => {
+  const queryKey = chatConversationsKey(appId, params)
+  const queryResult = useQuery<ChatConversationsResponse>({
+    queryKey,
+    queryFn: () => fetchChatConversations({ url: `/apps/${appId}/chat-conversations`, params }),
+    enabled: Boolean(appId && enabled),
+  })
+
+  return { ...queryResult, queryKey }
+}
+
+export const useCompletionConversations = (appId?: string, params?: CompletionConversationsRequest, enabled = true) => {
+  const queryKey = completionConversationsKey(appId, params)
+  const queryResult = useQuery<CompletionConversationsResponse>({
+    queryKey,
+    queryFn: () => fetchCompletionConversations({ url: `/apps/${appId}/completion-conversations`, params }),
+    enabled: Boolean(appId && enabled),
+  })
+
+  return { ...queryResult, queryKey }
+}
+
+export const useAnnotationsCount = (appId?: string) => {
+  const queryKey = annotationsCountKey(appId)
+  const queryResult = useQuery<AnnotationsCountResponse>({
+    queryKey,
+    queryFn: () => fetchAnnotationsCount({ url: `/apps/${appId}/annotations/count` }),
+    enabled: Boolean(appId),
+  })
+
+  return { ...queryResult, queryKey }
+}
+
+export const useCompletionConversationDetail = (appId?: string, conversationId?: string) => {
+  const queryKey = completionConversationDetailKey(appId, conversationId)
+  const queryResult = useQuery<CompletionConversationFullDetailResponse>({
+    queryKey,
+    queryFn: () => fetchCompletionConversationDetail({ url: `/apps/${appId}/completion-conversations/${conversationId}` }),
+    enabled: Boolean(appId && conversationId),
+  })
+
+  return { ...queryResult, queryKey }
+}
+
+export const useChatConversationDetail = (appId?: string, conversationId?: string) => {
+  const queryKey = chatConversationDetailKey(appId, conversationId)
+  const queryResult = useQuery<ChatConversationFullDetailResponse>({
+    queryKey,
+    queryFn: () => fetchChatConversationDetail({ url: `/apps/${appId}/chat-conversations/${conversationId}` }),
+    enabled: Boolean(appId && conversationId),
+  })
+
+  return { ...queryResult, queryKey }
+}
+
+export const useUpdateLogMessageFeedback = (appId?: string, invalidateKey?: QueryKey) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ mid, rating, content }: FeedbackPayload) => {
+      return await updateLogMessageFeedbacks({
+        url: `/apps/${appId}/feedbacks`,
+        body: { message_id: mid, rating, content: content ?? undefined },
+      })
+    },
+    onSuccess: () => {
+      if (invalidateKey)
+        queryClient.invalidateQueries({ queryKey: invalidateKey })
+    },
+  })
+}
+
+export const useUpdateLogMessageAnnotation = (appId?: string, invalidateKey?: QueryKey) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ mid, value }: AnnotationPayload) => {
+      return await updateLogMessageAnnotations({
+        url: `/apps/${appId}/annotations`,
+        body: { message_id: mid, content: value },
+      })
+    },
+    onSuccess: () => {
+      if (invalidateKey)
+        queryClient.invalidateQueries({ queryKey: invalidateKey })
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- migrate log fetchers to promise-based services and add React Query hooks for log lists/details, annotations, and feedback/annotations mutations
- replace useSWR in log list/detail/filter components with service hooks, keeping API contracts the same while centralizing cache/invalidations
- memoize and centralize refresh handlers to align with lint rules without changing behavior

## Testing
- pnpm lint:fix app/components/app/log/list.tsx app/components/app/log/index.tsx app/components/app/log/filter.tsx service/use-log.ts
- pnpm type-check:tsgo