### PR TITLE
fix(App.deleted_tools): incorrect compare between UUID and map with string-typed key.

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -259,7 +259,7 @@ class App(Base):
                 provider_id = tool.get("provider_id", "")
 
                 if provider_type == ToolProviderType.API:
-                    if uuid.UUID(provider_id) not in existing_api_providers:
+                    if provider_id not in existing_api_providers:
                         deleted_tools.append(
                             {
                                 "type": ToolProviderType.API,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
The `App.deleted_tools` method incorrectly marks API tools as deleted even when their provider exists. This happens because the code compares a `uuid.UUID` object to a list of string IDs, causing the membership test to fail.

FIXES: #29333

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| <img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/cdad8757-e8d5-4bb7-a4f3-f4fd2a2b69af" /> | <img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/b567fc01-b5b7-46d5-8e15-31e6a6c626a6" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
