### PR TITLE
chore: bump dify release to 1.11.0

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.10.1"
+version = "1.11.0"
 requires-python = ">=3.11,<3.13"
 
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "dify-api"
-version = "1.10.1"
+version = "1.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -268,7 +268,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.0-local
+    image: langgenius/dify-plugin-daemon:0.5.1-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -21,7 +21,7 @@ services:
 
   # API service
   api:
-    image: langgenius/dify-api:1.10.1-fix.1
+    image: langgenius/dify-api:1.11.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -62,7 +62,7 @@ services:
   # worker service
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
-    image: langgenius/dify-api:1.10.1-fix.1
+    image: langgenius/dify-api:1.11.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -101,7 +101,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.10.1-fix.1
+    image: langgenius/dify-api:1.11.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -131,7 +131,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.10.1-fix.1
+    image: langgenius/dify-web:1.11.0
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
@@ -268,7 +268,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.4.1-local
+    image: langgenius/dify-plugin-daemon:0.5.0-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -123,7 +123,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.0-local
+    image: langgenius/dify-plugin-daemon:0.5.1-local
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -123,7 +123,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.4.1-local
+    image: langgenius/dify-plugin-daemon:0.5.0-local
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -658,7 +658,7 @@ services:
 
   # API service
   api:
-    image: langgenius/dify-api:1.10.1-fix.1
+    image: langgenius/dify-api:1.11.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -699,7 +699,7 @@ services:
   # worker service
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
-    image: langgenius/dify-api:1.10.1-fix.1
+    image: langgenius/dify-api:1.11.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -738,7 +738,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.10.1-fix.1
+    image: langgenius/dify-api:1.11.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -768,7 +768,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.10.1-fix.1
+    image: langgenius/dify-web:1.11.0
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
@@ -905,7 +905,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.4.1-local
+    image: langgenius/dify-plugin-daemon:0.5.0-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -905,7 +905,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.0-local
+    image: langgenius/dify-plugin-daemon:0.5.1-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "private": true,
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
   "engines": {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: Fixes #0000.

## Summary

Fixes #29356 by bumping dify api/web versions to 1.11.0 and updating docker compose images, including plugin daemon to 0.5.1-local.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
