### PR TITLE
fix:workflow product page,the clear button can’t clear the file field…

### DIFF
--- a/web/app/components/base/file-uploader/store.tsx
+++ b/web/app/components/base/file-uploader/store.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useRef,
 } from 'react'
 import {
@@ -58,6 +59,23 @@ export const FileContextProvider = ({
 
   if (!storeRef.current)
     storeRef.current = createFileStore(value, onChange)
+
+  // 当外部传入的value发生变化时，同步更新store中的files
+  useEffect(() => {
+    if (storeRef.current && value) {
+      // 检查当前存储的文件和传入的值是否不同
+      const currentFiles = storeRef.current.getState().files
+      const isDifferent = currentFiles.length !== value.length
+        || currentFiles.some((file, index) => file.id !== value[index]?.id)
+
+      if (isDifferent)
+        storeRef.current.getState().setFiles(value)
+    }
+    else if (storeRef.current && !value) {
+      // 如果value为空，清空store中的文件
+      storeRef.current.getState().setFiles([])
+    }
+  }, [value])
 
   return (
     <FileContext.Provider value={storeRef.current}>


### PR DESCRIPTION
## description

In the Dify workflow application, the "Clear" button fails to properly clear the UI display of form attachments. When the user clicks the "Clear" button, the attachments still appear visible in the interface. However, the attached files have already been deleted from the server, leading to data inconsistency.

## Screenshots

<img width="852" height="555" alt="image" src="https://github.com/user-attachments/assets/50ec0de1-b231-43d9-bf8d-2f9b1f0a14cc" />

## Test Verification
✅ The "Clear" button correctly triggers attachment deletion
✅ The interface updates correctly after successful deletion
