### PR TITLE
fix: knowledge dataset description field validation error #29404

### DIFF
--- a/api/core/entities/knowledge_entities.py
+++ b/api/core/entities/knowledge_entities.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 

--- a/api/core/entities/knowledge_entities.py
+++ b/api/core/entities/knowledge_entities.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -21,7 +22,7 @@ class IndexingEstimate(BaseModel):
 class PipelineDataset(BaseModel):
     id: str
     name: str
-    description: Optional[str] = Field(default="", description="knowledge dataset description")
+    description: str | None = Field(default="", description="knowledge dataset description")
     chunk_structure: str
 
 

--- a/api/core/entities/knowledge_entities.py
+++ b/api/core/entities/knowledge_entities.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from typing import Optional
+from pydantic import BaseModel, Field
 
 
 class PreviewDetail(BaseModel):
@@ -20,7 +21,7 @@ class IndexingEstimate(BaseModel):
 class PipelineDataset(BaseModel):
     id: str
     name: str
-    description: str
+    description: Optional[str] = Field(default="", description="knowledge dataset description")
     chunk_structure: str
 
 


### PR DESCRIPTION
change description field to optional in PipelineDataset, fix #29404

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Knowledge Dataset Description Field: The description field within the PipelineDataset model has been updated to be optional, resolving a validation error.

Pydantic Model Update: The PipelineDataset model now uses Optional[str] with a Field default of an empty string for its description attribute, allowing for datasets without a specified description.

**The value for the description is either None or an empty string. Considering the flexibility in usage, an empty string was chosen. Otherwise, there might be compatibility issues during usage.**


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
