### PR TITLE
fix: fix race condition

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -20,6 +20,7 @@ from core.app.entities.queue_entities import (
     QueueStopEvent,
     WorkflowQueueMessage,
 )
+from core.moderation.moderation_coordinator import ModerationCoordinator
 from core.workflow.runtime import GraphRuntimeState
 from extensions.ext_redis import redis_client
 
@@ -39,6 +40,7 @@ class AppQueueManager:
         self._task_id = task_id
         self._user_id = user_id
         self._invoke_from = invoke_from
+        self.moderation_coordinator: ModerationCoordinator | None = None
         self.invoke_from = invoke_from  # Public accessor for invoke_from
 
         user_prefix = "account" if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else "end-user"
@@ -217,3 +219,6 @@ class AppQueueManager:
                 raise TypeError(
                     "Critical Error: Passing SQLAlchemy Model instances that cause thread safety issues is not allowed."
                 )
+
+    def set_moderation_coordinator(self, moderation_coordinator: ModerationCoordinator):
+        raise NotImplementedError

--- a/api/core/app/apps/message_based_app_queue_manager.py
+++ b/api/core/app/apps/message_based_app_queue_manager.py
@@ -1,3 +1,5 @@
+import time
+
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -9,6 +11,7 @@ from core.app.entities.queue_entities import (
     QueueMessageEndEvent,
     QueueStopEvent,
 )
+from core.moderation.moderation_coordinator import ModerationCoordinator
 
 
 class MessageBasedAppQueueManager(AppQueueManager):
@@ -20,6 +23,16 @@ class MessageBasedAppQueueManager(AppQueueManager):
         self._conversation_id = str(conversation_id)
         self._app_mode = app_mode
         self._message_id = str(message_id)
+
+    def set_moderation_coordinator(self, moderation_coordinator: ModerationCoordinator | None):
+        self.moderation_coordinator: ModerationCoordinator | None = moderation_coordinator
+
+    def stop_when_ready(self, poll_ms=50):
+        if self.moderation_coordinator is not None:
+            while not self.moderation_coordinator.ready_to_close():
+                time.sleep(poll_ms / 1000.0)
+
+        self.stop_listen()
 
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom):
         """
@@ -38,9 +51,9 @@ class MessageBasedAppQueueManager(AppQueueManager):
 
         self._q.put(message)
 
-        if isinstance(
-            event, QueueStopEvent | QueueErrorEvent | QueueMessageEndEvent | QueueAdvancedChatMessageEndEvent
-        ):
+        if isinstance(event, QueueMessageEndEvent | QueueAdvancedChatMessageEndEvent):
+            self.stop_when_ready()
+        elif isinstance(event, QueueStopEvent | QueueErrorEvent):
             self.stop_listen()
 
         if pub_from == PublishFrom.APPLICATION_MANAGER and self._is_stopped():

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -51,6 +51,7 @@ from core.model_runtime.entities.message_entities import (
     TextPromptMessageContent,
 )
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
+from core.moderation.moderation_coordinator import ModerationCoordinator
 from core.ops.entities.trace_entity import TraceTaskName
 from core.ops.ops_trace_manager import TraceQueueManager, TraceTask
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
@@ -81,6 +82,10 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
         message: Message,
         stream: bool,
     ):
+        self._conversation_name_generate_thread: Thread | None = None
+        self.moderation_coordinator = ModerationCoordinator()
+        if hasattr(queue_manager, "set_moderation_coordinator"):
+            queue_manager.set_moderation_coordinator(self.moderation_coordinator)
         super().__init__(
             application_generate_entity=application_generate_entity,
             queue_manager=queue_manager,
@@ -108,8 +113,6 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
             application_generate_entity=application_generate_entity,
             task_state=self._task_state,
         )
-
-        self._conversation_name_generate_thread: Thread | None = None
 
     def process(
         self,
@@ -291,6 +294,8 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
                     self._save_message(session=session, trace_manager=trace_manager)
                     session.commit()
                 message_end_resp = self._message_end_to_stream_response()
+                self.moderation_coordinator.mark_stream_end_seen()
+                self.moderation_coordinator.async_done.wait(timeout=2.0)
                 yield message_end_resp
             elif isinstance(event, QueueRetrieverResourcesEvent):
                 self._message_cycle_manager.handle_retriever_resources(event)

--- a/api/core/moderation/moderation_coordinator.py
+++ b/api/core/moderation/moderation_coordinator.py
@@ -1,0 +1,16 @@
+import threading
+
+
+class ModerationCoordinator:
+    def __init__(self):
+        self._end_seen = False
+        self._lock = threading.Lock()
+        self.async_done = threading.Event()
+
+    def mark_stream_end_seen(self):
+        with self._lock:
+            self._end_seen = True
+
+    def ready_to_close(self) -> bool:
+        with self._lock:
+            return self._end_seen and self.async_done.is_set()

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager_moderation.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager_moderation.py
@@ -1,0 +1,43 @@
+import threading
+import time
+
+from core.app.apps.message_based_app_queue_manager import MessageBasedAppQueueManager
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.moderation.moderation_coordinator import ModerationCoordinator
+
+
+def test_stop_when_ready_blocks_until_coordinator_ready(monkeypatch):
+    mgr = MessageBasedAppQueueManager(
+        task_id="t1",
+        user_id="u1",
+        invoke_from=InvokeFrom.SERVICE_API,
+        conversation_id="c1",
+        app_mode="chat",
+        message_id="m1",
+    )
+
+    coord = ModerationCoordinator()
+    mgr.set_moderation_coordinator(coord)
+
+    stopped = {"called": False}
+
+    def fake_stop_listen():
+        stopped["called"] = True
+
+    monkeypatch.setattr(mgr, "stop_listen", fake_stop_listen)
+
+    # Run the stop_when_ready in a background thread (it should block initially)
+    t = threading.Thread(target=mgr.stop_when_ready, kwargs={"poll_ms": 10})
+    t.start()
+
+    # While not ready, stop_listen must not be called
+    time.sleep(0.1)
+    assert stopped["called"] is False
+
+    # Now make the coordinator ready
+    coord.mark_stream_end_seen()
+    coord.async_done.set()
+
+    # Thread should finish and stop_listen should be called
+    t.join(timeout=2)
+    assert stopped["called"] is True

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager_publish_paths.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager_publish_paths.py
@@ -1,0 +1,55 @@
+from core.app.apps.base_app_queue_manager import PublishFrom
+from core.app.apps.message_based_app_queue_manager import MessageBasedAppQueueManager
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.app.entities.queue_entities import (
+    QueueAdvancedChatMessageEndEvent,
+    QueueErrorEvent,
+    QueueMessageEndEvent,
+    QueueStopEvent,
+)
+
+
+def test_publish_calls_stop_when_ready_on_end_events(monkeypatch):
+    mgr = MessageBasedAppQueueManager(
+        task_id="t1",
+        user_id="u1",
+        invoke_from=InvokeFrom.SERVICE_API,
+        conversation_id="c1",
+        app_mode="chat",
+        message_id="m1",
+    )
+
+    called = {"stop_when_ready": 0, "stop_listen": 0}
+    monkeypatch.setattr(
+        mgr, "stop_when_ready", lambda **kw: called.__setitem__("stop_when_ready", called["stop_when_ready"] + 1)
+    )
+    monkeypatch.setattr(mgr, "stop_listen", lambda: called.__setitem__("stop_listen", called["stop_listen"] + 1))
+
+    mgr.publish(QueueMessageEndEvent(), pub_from=PublishFrom.TASK_PIPELINE)
+    mgr.publish(QueueAdvancedChatMessageEndEvent(), pub_from=PublishFrom.TASK_PIPELINE)
+
+    assert called["stop_when_ready"] == 2
+    assert called["stop_listen"] == 0
+
+
+def test_publish_calls_stop_listen_on_stop_and_error(monkeypatch):
+    mgr = MessageBasedAppQueueManager(
+        task_id="t1",
+        user_id="u1",
+        invoke_from=InvokeFrom.SERVICE_API,
+        conversation_id="c1",
+        app_mode="chat",
+        message_id="m1",
+    )
+
+    called = {"stop_when_ready": 0, "stop_listen": 0}
+    monkeypatch.setattr(
+        mgr, "stop_when_ready", lambda **kw: called.__setitem__("stop_when_ready", called["stop_when_ready"] + 1)
+    )
+    monkeypatch.setattr(mgr, "stop_listen", lambda: called.__setitem__("stop_listen", called["stop_listen"] + 1))
+
+    mgr.publish(QueueStopEvent(stopped_by=QueueStopEvent.StopBy.USER_MANUAL), pub_from=PublishFrom.TASK_PIPELINE)
+    mgr.publish(QueueErrorEvent(error=ValueError("boom")), pub_from=PublishFrom.TASK_PIPELINE)
+
+    assert called["stop_listen"] == 2
+    assert called["stop_when_ready"] == 0

--- a/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline_injection.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline_injection.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
+from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
+from core.moderation.moderation_coordinator import ModerationCoordinator
+
+
+class _QM(AppQueueManager):
+    def __init__(self, c):
+        # Skip base __init__ to avoid Redis and other side effects
+        self.moderation_coordinator = c
+
+    def _publish(self, event, pub_from: PublishFrom):  # type: ignore[override]
+        pass
+
+
+def test_based_pipeline_injects_coordinator_into_output_moderation():
+    coord = ModerationCoordinator()
+    qm = _QM(coord)
+
+    app_entity = SimpleNamespace(
+        app_config=SimpleNamespace(
+            tenant_id="tenant",
+            app_id="app",
+            sensitive_word_avoidance=SimpleNamespace(type="sensitive_word", config={}),
+        )
+    )
+
+    p = BasedGenerateTaskPipeline(application_generate_entity=app_entity, queue_manager=qm, stream=True)
+
+    assert p.output_moderation_handler is not None
+    assert p.output_moderation_handler.coordinator is coord

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_pipeline_moderation_wait.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_pipeline_moderation_wait.py
@@ -1,0 +1,108 @@
+import threading
+import time
+from datetime import datetime
+from types import SimpleNamespace
+
+from core.app.entities.queue_entities import MessageQueueMessage, QueueMessageEndEvent
+from core.app.task_pipeline.easy_ui_based_generate_task_pipeline import EasyUIBasedGenerateTaskPipeline
+from core.moderation.moderation_coordinator import ModerationCoordinator
+from models.model import AppMode
+
+
+class _FakeQueueManager:
+    def __init__(self):
+        self.moderation_coordinator = None
+        self._messages = []
+
+    def set_moderation_coordinator(self, c):
+        self.moderation_coordinator = c
+
+    def listen(self):
+        # Yield a single message-end event
+        yield from self._messages
+
+    def publish(self, *args, **kwargs):
+        pass
+
+
+class _DummySession:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def commit(self):
+        pass
+
+
+def test_pipeline_marks_end_and_waits_before_yield(monkeypatch):
+    # Arrange minimal app entity, conversation, and message
+    app_entity = SimpleNamespace(
+        task_id="t1",
+        app_config=SimpleNamespace(
+            tenant_id="tenant", app_id="app", app_model_config_dict={}, sensitive_word_avoidance=None
+        ),
+        model_conf=SimpleNamespace(model="dummy-model"),
+    )
+
+    conversation = SimpleNamespace(id="c1", mode=AppMode.CHAT)
+    message = SimpleNamespace(id="m1", created_at=datetime.utcnow())
+
+    qm = _FakeQueueManager()
+
+    # Build the message end event envelope the pipeline expects from listen()
+    end_event = QueueMessageEndEvent()
+    qm._messages = [
+        MessageQueueMessage(task_id="t1", app_mode="chat", event=end_event, message_id="m1", conversation_id="c1")
+    ]
+
+    # Patch DB Session and db.engine used in the pipeline to avoid real DB access
+    import core.app.task_pipeline.easy_ui_based_generate_task_pipeline as mod
+
+    monkeypatch.setattr(mod, "Session", _DummySession)
+    monkeypatch.setattr(mod, "db", SimpleNamespace(engine=None))
+    # Avoid DB fetch/update logic entirely in this unit test
+    monkeypatch.setattr(mod.EasyUIBasedGenerateTaskPipeline, "_save_message", lambda self, **kwargs: None)
+
+    # Act
+    pipeline = EasyUIBasedGenerateTaskPipeline(
+        application_generate_entity=app_entity,
+        queue_manager=qm,
+        conversation=conversation,
+        message=message,
+        stream=True,
+    )
+
+    # The coordinator should have been set on the queue manager by the pipeline's __init__
+    coord: ModerationCoordinator = pipeline.moderation_coordinator
+    assert qm.moderation_coordinator is coord
+
+    results = []
+
+    def consume():
+        for item in pipeline._process_stream_response(publisher=None, trace_manager=None):
+            results.append(item)
+            break  # Stop after the first (MessageEnd) response
+
+    t = threading.Thread(target=consume)
+    t.start()
+
+    # Give the generator a moment to reach the wait point
+    time.sleep(0.1)
+
+    # Before signaling async_done, no response should have been yielded
+    assert results == []
+    # And the coordinator should have seen the end already
+    assert coord.ready_to_close() is False  # end seen but async_done not set
+
+    # Now allow completion of moderation background work
+    coord.async_done.set()
+
+    t.join(timeout=2)
+
+    # After async_done, the MessageEndStreamResponse should be yielded
+    assert len(results) == 1

--- a/api/tests/unit_tests/core/moderation/test_moderation_coordinator.py
+++ b/api/tests/unit_tests/core/moderation/test_moderation_coordinator.py
@@ -1,0 +1,70 @@
+from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
+from core.moderation.moderation_coordinator import ModerationCoordinator
+from core.moderation.output_moderation import ModerationRule, OutputModeration
+
+
+class _DummyQueueManager(AppQueueManager):
+    """Minimal AppQueueManager subclass suitable for OutputModeration tests.
+
+    Avoids side effects by not calling super().__init__ and no-op publishing.
+    """
+
+    def __init__(self):
+        # Intentionally skip base __init__ to avoid Redis and thread setup.
+        self.moderation_coordinator = None
+
+    def _publish(self, event, pub_from: PublishFrom):  # type: ignore[override]
+        # No-op in unit tests
+        pass
+
+
+def test_ready_to_close_only_true_after_end_and_done():
+    c = ModerationCoordinator()
+    assert c.ready_to_close() is False
+
+    c.mark_stream_end_seen()
+    assert c.ready_to_close() is False
+
+    c.async_done.set()
+    assert c.ready_to_close() is True
+
+
+def test_output_moderation_sets_async_done_when_no_thread(monkeypatch):
+    c = ModerationCoordinator()
+    om = OutputModeration(
+        tenant_id="t1",
+        app_id="a1",
+        rule=ModerationRule(type="sensitive_word", config={}),
+        queue_manager=_DummyQueueManager(),
+        coordinator=c,
+    )
+
+    # Ensure no worker thread is started
+    assert om.thread is None
+
+    om.stop_thread()
+    assert c.async_done.is_set() is True
+
+
+def test_output_moderation_worker_signals_async_done(monkeypatch):
+    c = ModerationCoordinator()
+    om = OutputModeration(
+        tenant_id="t1",
+        app_id="a1",
+        rule=ModerationRule(type="sensitive_word", config={}),
+        queue_manager=_DummyQueueManager(),
+        coordinator=c,
+    )
+
+    # Avoid real moderation work
+    monkeypatch.setattr(om, "moderation", lambda **kwargs: None)
+
+    # Start a worker thread by appending a token
+    om.append_new_token("hello")
+    assert om.thread is not None
+
+    # Ask it to stop and wait for thread to finish
+    om.flush_and_stop()
+
+    # The worker's finally block should set async_done
+    assert c.async_done.is_set() is True


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #29334

Goal
- Eliminate a race condition between streaming completion and output moderation so the final “replace” event isn’t lost before the pipeline shuts down.

Core changes
- Introduced ModerationCoordinator

  -  New class providing thread-safe coordination: marks when the stream end is seen and exposes an async_done Event to signal moderation completion.

- Queue manager integration

  - AppQueueManager: added a moderation_coordinator slot and a set_moderation_coordinator abstract method.

  - MessageBasedAppQueueManager:

    - Added set_moderation_coordinator and a stop_when_ready(poll_ms) helper that waits until ModerationCoordinator.ready_to_close() before stopping.

- Adjusted publish path logic:
  - On QueueMessageEndEvent/QueueAdvancedChatMessageEndEvent: wait (stop_when_ready) then stop.
  - On QueueStopEvent/QueueErrorEvent: stop immediately.


- Pipeline wiring
  - BasedGenerateTaskPipeline:
    - _init_output_moderation now accepts and passes the queue manager’s moderation_coordinator to OutputModeration.
  - EasyUIBasedGenerateTaskPipeline:
   - Instantiates a ModerationCoordinator, injects it into the queue manager if supported.
   - After the end event, marks “stream end seen” and waits up to 2s for async_done before yielding the final response.

- Output moderation robustness
  - OutputModeration:
   - Added coordinator field.
   - New flush_and_stop with bounded thread join.
   - stop_thread now joins with a timeout and sets async_done when no thread ran.
   - worker wrapped with try/finally to always set async_done on exit; logs errors without breaking shutdown.
   - Behavior for publishing replace events unchanged; coordination guarantees they’re not dropped.


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
