### PR TITLE
fix(i18n): remove unused credentialSelector translations from dataset-pipeline files

### DIFF
--- a/web/i18n/de-DE/dataset-pipeline.ts
+++ b/web/i18n/de-DE/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} ist nicht verbunden',
     notConnectedTip: 'Um mit {{name}} zu synchronisieren, muss zuerst eine Verbindung zu {{name}} hergestellt werden.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Bestätigung',

--- a/web/i18n/es-ES/dataset-pipeline.ts
+++ b/web/i18n/es-ES/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} no está conectado',
     notConnectedTip: 'Para sincronizar con {{name}}, primero se debe establecer conexión con {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}} de {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Confirmación',

--- a/web/i18n/fa-IR/dataset-pipeline.ts
+++ b/web/i18n/fa-IR/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} متصل نیست',
     notConnectedTip: 'برای همگام‌سازی با {{name}}، ابتدا باید اتصال به {{name}} برقرار شود.',
   },
-  credentialSelector: {
-    name: '{{pluginName}} {{credentialName}}',
-  },
   conversion: {
     confirm: {
       title: 'تایید',

--- a/web/i18n/fr-FR/dataset-pipeline.ts
+++ b/web/i18n/fr-FR/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} n\'est pas connecté',
     notConnectedTip: 'Pour se synchroniser avec {{name}}, une connexion à {{name}} doit d\'abord être établie.',
   },
-  credentialSelector: {
-    name: '{{credentialName}} de {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Confirmation',

--- a/web/i18n/hi-IN/dataset-pipeline.ts
+++ b/web/i18n/hi-IN/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} कनेक्ट नहीं है',
     notConnectedTip: '{{name}} के साथ सिंक करने के लिए, पहले {{name}} से कनेक्शन स्थापित करना आवश्यक है।',
   },
-  credentialSelector: {
-    name: '{{credentialName}} का {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'पुष्टि',

--- a/web/i18n/id-ID/dataset-pipeline.ts
+++ b/web/i18n/id-ID/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} tidak terhubung',
     notConnectedTip: 'Untuk menyinkronkan dengan {{name}}, koneksi ke {{name}} harus dibuat terlebih dahulu.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Konfirmasi',

--- a/web/i18n/it-IT/dataset-pipeline.ts
+++ b/web/i18n/it-IT/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} non è connesso',
     notConnectedTip: 'Per sincronizzarsi con {{name}}, è necessario prima stabilire la connessione a {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       content: 'Questa azione è permanente. Non sarà possibile ripristinare il metodo precedente. Si prega di confermare per convertire.',

--- a/web/i18n/ko-KR/dataset-pipeline.ts
+++ b/web/i18n/ko-KR/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}}가 연결되어 있지 않습니다',
     notConnectedTip: '{{name}}와(과) 동기화하려면 먼저 {{name}}에 연결해야 합니다.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}의 {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: '확인',

--- a/web/i18n/pl-PL/dataset-pipeline.ts
+++ b/web/i18n/pl-PL/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} nie jest połączony',
     notConnectedTip: 'Aby zsynchronizować się z {{name}}, najpierw należy nawiązać połączenie z {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Potwierdzenie',

--- a/web/i18n/pt-BR/dataset-pipeline.ts
+++ b/web/i18n/pt-BR/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} não está conectado',
     notConnectedTip: 'Para sincronizar com {{name}}, a conexão com {{name}} deve ser estabelecida primeiro.',
   },
-  credentialSelector: {
-    name: '{{credentialName}} de {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Confirmação',

--- a/web/i18n/ro-RO/dataset-pipeline.ts
+++ b/web/i18n/ro-RO/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} nu este conectat',
     notConnectedTip: 'Pentru a sincroniza cu {{name}}, trebuie mai întâi să se stabilească conexiunea cu {{name}}.',
   },
-  credentialSelector: {
-    name: '{{pluginName}} al/a lui {{credentialName}}',
-  },
   conversion: {
     confirm: {
       title: 'Confirmare',

--- a/web/i18n/ru-RU/dataset-pipeline.ts
+++ b/web/i18n/ru-RU/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} не подключен',
     notConnectedTip: 'Чтобы синхронизироваться с {{name}}, сначала необходимо установить соединение с {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Подтверждение',

--- a/web/i18n/sl-SI/dataset-pipeline.ts
+++ b/web/i18n/sl-SI/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} ni povezan',
     notConnectedTip: 'Za sinhronizacijo z {{name}} je treba najprej vzpostaviti povezavo z {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Potrditev',

--- a/web/i18n/th-TH/dataset-pipeline.ts
+++ b/web/i18n/th-TH/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} ไม่ได้เชื่อมต่อ',
     notConnectedTip: 'เพื่อซิงค์กับ {{name}} ต้องสร้างการเชื่อมต่อกับ {{name}} ก่อน',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'การยืนยัน',

--- a/web/i18n/tr-TR/dataset-pipeline.ts
+++ b/web/i18n/tr-TR/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} bağlı değil',
     notConnectedTip: '{{name}} ile senkronize olmak için önce {{name}} bağlantısının kurulması gerekir.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'un {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Onay',

--- a/web/i18n/uk-UA/dataset-pipeline.ts
+++ b/web/i18n/uk-UA/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} не підключено',
     notConnectedTip: 'Щоб синхронізувати з {{name}}, спершу потрібно встановити з’єднання з {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Підтвердження',

--- a/web/i18n/vi-VN/dataset-pipeline.ts
+++ b/web/i18n/vi-VN/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} không được kết nối',
     notConnectedTip: 'Để đồng bộ với {{name}}, trước tiên phải thiết lập kết nối với {{name}}.',
   },
-  credentialSelector: {
-    name: '{{credentialName}}\'s {{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: 'Sự xác nhận',

--- a/web/i18n/zh-Hant/dataset-pipeline.ts
+++ b/web/i18n/zh-Hant/dataset-pipeline.ts
@@ -137,9 +137,6 @@ const translation = {
     notConnected: '{{name}} 未連接',
     notConnectedTip: '要與 {{name}} 同步，必須先建立與 {{name}} 的連線。',
   },
-  credentialSelector: {
-    name: '{{credentialName}}的{{pluginName}}',
-  },
   conversion: {
     confirm: {
       title: '證實',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
