### PR TITLE
fix: fix custom model credentials display as plaintext

### DIFF
--- a/api/tests/unit_tests/services/test_model_provider_service_sanitization.py
+++ b/api/tests/unit_tests/services/test_model_provider_service_sanitization.py
@@ -1,0 +1,88 @@
+import types
+
+import pytest
+
+from core.entities.provider_entities import CredentialConfiguration, CustomModelConfiguration
+from core.model_runtime.entities.common_entities import I18nObject
+from core.model_runtime.entities.model_entities import ModelType
+from core.model_runtime.entities.provider_entities import ConfigurateMethod
+from models.provider import ProviderType
+from services.model_provider_service import ModelProviderService
+
+
+class _FakeConfigurations:
+    def __init__(self, provider_configuration: types.SimpleNamespace) -> None:
+        self._provider_configuration = provider_configuration
+
+    def values(self) -> list[types.SimpleNamespace]:
+        return [self._provider_configuration]
+
+
+@pytest.fixture
+def service_with_fake_configurations():
+    # Build a fake provider schema with minimal fields used by ProviderResponse
+    fake_provider = types.SimpleNamespace(
+        provider="langgenius/openai_api_compatible/openai_api_compatible",
+        label=I18nObject(en_US="OpenAI API Compatible", zh_Hans="OpenAI API Compatible"),
+        description=None,
+        icon_small=None,
+        icon_small_dark=None,
+        icon_large=None,
+        background=None,
+        help=None,
+        supported_model_types=[ModelType.LLM],
+        configurate_methods=[ConfigurateMethod.CUSTOMIZABLE_MODEL],
+        provider_credential_schema=None,
+        model_credential_schema=None,
+    )
+
+    # Include decrypted credentials to simulate the leak source
+    custom_model = CustomModelConfiguration(
+        model="gpt-4o-mini",
+        model_type=ModelType.LLM,
+        credentials={"api_key": "sk-plain-text", "endpoint": "https://example.com"},
+        current_credential_id="cred-1",
+        current_credential_name="API KEY 1",
+        available_model_credentials=[],
+        unadded_to_model_list=False,
+    )
+
+    fake_custom_provider = types.SimpleNamespace(
+        current_credential_id="cred-1",
+        current_credential_name="API KEY 1",
+        available_credentials=[CredentialConfiguration(credential_id="cred-1", credential_name="API KEY 1")],
+    )
+
+    fake_custom_configuration = types.SimpleNamespace(
+        provider=fake_custom_provider, models=[custom_model], can_added_models=[]
+    )
+
+    fake_system_configuration = types.SimpleNamespace(enabled=False, current_quota_type=None, quota_configurations=[])
+
+    fake_provider_configuration = types.SimpleNamespace(
+        provider=fake_provider,
+        preferred_provider_type=ProviderType.CUSTOM,
+        custom_configuration=fake_custom_configuration,
+        system_configuration=fake_system_configuration,
+        is_custom_configuration_available=lambda: True,
+    )
+
+    class _FakeProviderManager:
+        def get_configurations(self, tenant_id: str) -> _FakeConfigurations:
+            return _FakeConfigurations(fake_provider_configuration)
+
+    svc = ModelProviderService()
+    svc.provider_manager = _FakeProviderManager()
+    return svc
+
+
+def test_get_provider_list_strips_credentials(service_with_fake_configurations: ModelProviderService):
+    providers = service_with_fake_configurations.get_provider_list(tenant_id="tenant-1", model_type=None)
+
+    assert len(providers) == 1
+    custom_models = providers[0].custom_configuration.custom_models
+
+    assert custom_models is not None
+    assert len(custom_models) == 1
+    # The sanitizer should drop credentials in list response
+    assert custom_models[0].credentials is None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #29416 fix custom model credentials display as plaintext

ProviderManager.get_configurations call `custom_configuration = self._to_custom_configuration(tenant_id, provider_entity, provider_records, provider_model_records, provider_model_credentials)` then call `def _get_custom_provider_configuration(` then call 

```
# Get and decrypt provider credentials
        provider_credentials = self._get_and_decrypt_credentials(
            tenant_id=tenant_id,
            record_id=[custom_provider_record.id](http://custom_provider_record.id/),
            encrypted_config=custom_provider_record.encrypted_config,
            secret_variables=provider_credential_secret_variables,
            cache_type=ProviderCredentialsCacheType.PROVIDER,
            is_provider=True)
```

this lead credentials is plaintext, now we set credentials to None, it will be safe


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

before

<img width="944" height="1078" alt="image" src="https://github.com/user-attachments/assets/7f105863-a217-4f69-a880-f384ca6d96d7" />


after

<img width="926" height="948" alt="image" src="https://github.com/user-attachments/assets/aa8976c5-1e89-40a9-8924-dd9c7511d5f5" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
