### PR TITLE
fix: Can not blank conversation ID validation in chat payloads

### DIFF
--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from flask import request
 from flask_restx import Resource
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import services
@@ -52,10 +52,27 @@ class ChatRequestPayload(BaseModel):
     query: str
     files: list[dict[str, Any]] | None = None
     response_mode: Literal["blocking", "streaming"] | None = None
-    conversation_id: UUID | None = None
+    conversation_id: str | None = Field(default=None, description="Conversation UUID")
     retriever_from: str = Field(default="dev")
     auto_generate_name: bool = Field(default=True, description="Auto generate conversation name")
     workflow_id: str | None = Field(default=None, description="Workflow ID for advanced chat")
+
+    @field_validator("conversation_id", mode="before")
+    @classmethod
+    def normalize_conversation_id(cls, value: str | UUID | None) -> str | None:
+        """Allow missing or blank conversation IDs; enforce UUID format when provided."""
+        if value is None:
+            return None
+
+        try:
+            normalized = helper.uuid_value(value)
+        except ValueError as exc:
+            raise ValueError("conversation_id must be a valid UUID") from exc
+
+        if normalized == "":
+            return None
+
+        return normalized
 
 
 register_schema_models(service_api_ns, CompletionRequestPayload, ChatRequestPayload)

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -61,18 +61,13 @@ class ChatRequestPayload(BaseModel):
     @classmethod
     def normalize_conversation_id(cls, value: str | UUID | None) -> str | None:
         """Allow missing or blank conversation IDs; enforce UUID format when provided."""
-        if value is None:
+        if not value:
             return None
 
         try:
-            normalized = helper.uuid_value(value)
+            return helper.uuid_value(value)
         except ValueError as exc:
             raise ValueError("conversation_id must be a valid UUID") from exc
-
-        if normalized == "":
-            return None
-
-        return normalized
 
 
 register_schema_models(service_api_ns, CompletionRequestPayload, ChatRequestPayload)

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -107,7 +107,7 @@ def email(email):
 EmailStr = Annotated[str, AfterValidator(email)]
 
 
-def uuid_value(value):
+def uuid_value(value: Any) -> str:
     if value == "":
         return str(value)
 

--- a/api/tests/unit_tests/controllers/service_api/app/test_chat_request_payload.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_chat_request_payload.py
@@ -1,0 +1,25 @@
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from controllers.service_api.app.completion import ChatRequestPayload
+
+
+def test_chat_request_payload_accepts_blank_conversation_id():
+    payload = ChatRequestPayload.model_validate({"inputs": {}, "query": "hello", "conversation_id": ""})
+
+    assert payload.conversation_id is None
+
+
+def test_chat_request_payload_validates_uuid():
+    conversation_id = str(uuid.uuid4())
+
+    payload = ChatRequestPayload.model_validate({"inputs": {}, "query": "hello", "conversation_id": conversation_id})
+
+    assert payload.conversation_id == conversation_id
+
+
+def test_chat_request_payload_rejects_invalid_uuid():
+    with pytest.raises(ValidationError):
+        ChatRequestPayload.model_validate({"inputs": {}, "query": "hello", "conversation_id": "invalid"})


### PR DESCRIPTION
## Summary

- allow chat requests to accept empty conversation_id by normalizing blank values to None while keeping UUID validation
- raise a clear validation error when conversation_id strings are malformed instead of generic UUID parsing failures
- add unit coverage for chat request conversation_id handling to guard the new behavior

Fixes #29435.

## Screenshots

| Before | After |
|--------|-------|
| n/a | n/a |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
