### PR TITLE
fix: workflow end node validate error

### DIFF
--- a/api/core/workflow/nodes/base/entities.py
+++ b/api/core/workflow/nodes/base/entities.py
@@ -59,7 +59,7 @@ class OutputVariableEntity(BaseModel):
     """
 
     variable: str
-    value_type: OutputVariableType
+    value_type: OutputVariableType = OutputVariableType.ANY
     value_selector: Sequence[str]
 
     @field_validator("value_type", mode="before")

--- a/api/tests/fixtures/workflow/end_node_without_value_type_field_workflow.yml
+++ b/api/tests/fixtures/workflow/end_node_without_value_type_field_workflow.yml
@@ -75,15 +75,24 @@ workflow:
         selected: false
         title: 用户输入
         type: start
-        variables: []
-      height: 73
+        variables:
+        - default: ''
+          hint: ''
+          label: query
+          max_length: 48
+          options: []
+          placeholder: ''
+          required: true
+          type: text-input
+          variable: query
+      height: 109
       id: '1765423445456'
       position:
-        x: 80
-        y: 282
+        x: -48
+        y: 261
       positionAbsolute:
-        x: 80
-        y: 282
+        x: -48
+        y: 261
       selected: false
       sourcePosition: right
       targetPosition: left
@@ -92,13 +101,13 @@ workflow:
     - data:
         outputs:
         - value_selector:
-          - sys
-          - app_id
-          variable: app_id
-        selected: false
+          - '1765423445456'
+          - query
+          variable: query
+        selected: true
         title: 输出
         type: end
-      height: 89
+      height: 88
       id: '1765423454810'
       position:
         x: 382
@@ -112,7 +121,7 @@ workflow:
       type: custom
       width: 242
     viewport:
-      x: 35
-      y: -101
+      x: 139
+      y: -135
       zoom: 1
   rag_pipeline_variables: []

--- a/api/tests/fixtures/workflow/end_node_without_value_type_field_workflow.yml
+++ b/api/tests/fixtures/workflow/end_node_without_value_type_field_workflow.yml
@@ -1,0 +1,118 @@
+app:
+  description: 'End node without value_type field reproduction'
+  icon: 🤖
+  icon_background: '#FFEAD5'
+  mode: workflow
+  name: end_node_without_value_type_field_reproduction
+  use_icon_as_answer_icon: false
+dependencies: []
+kind: app
+version: 0.5.0
+workflow:
+  conversation_variables: []
+  environment_variables: []
+  features:
+    file_upload:
+      allowed_file_extensions:
+      - .JPG
+      - .JPEG
+      - .PNG
+      - .GIF
+      - .WEBP
+      - .SVG
+      allowed_file_types:
+      - image
+      allowed_file_upload_methods:
+      - local_file
+      - remote_url
+      enabled: false
+      fileUploadConfig:
+        audio_file_size_limit: 50
+        batch_count_limit: 5
+        file_size_limit: 15
+        image_file_batch_limit: 10
+        image_file_size_limit: 10
+        single_chunk_attachment_limit: 10
+        video_file_size_limit: 100
+        workflow_file_upload_limit: 10
+      image:
+        enabled: false
+        number_limits: 3
+        transfer_methods:
+        - local_file
+        - remote_url
+      number_limits: 3
+    opening_statement: ''
+    retriever_resource:
+      enabled: true
+    sensitive_word_avoidance:
+      enabled: false
+    speech_to_text:
+      enabled: false
+    suggested_questions: []
+    suggested_questions_after_answer:
+      enabled: false
+    text_to_speech:
+      enabled: false
+      language: ''
+      voice: ''
+  graph:
+    edges:
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: start
+        targetType: end
+      id: 1765423445456-source-1765423454810-target
+      source: '1765423445456'
+      sourceHandle: source
+      target: '1765423454810'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    nodes:
+    - data:
+        selected: false
+        title: 用户输入
+        type: start
+        variables: []
+      height: 73
+      id: '1765423445456'
+      position:
+        x: 80
+        y: 282
+      positionAbsolute:
+        x: 80
+        y: 282
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 242
+    - data:
+        outputs:
+        - value_selector:
+          - sys
+          - app_id
+          variable: app_id
+        selected: false
+        title: 输出
+        type: end
+      height: 89
+      id: '1765423454810'
+      position:
+        x: 382
+        y: 282
+      positionAbsolute:
+        x: 382
+        y: 282
+      selected: true
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 242
+    viewport:
+      x: 35
+      y: -101
+      zoom: 1
+  rag_pipeline_variables: []

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_end_node_without_value_type.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_end_node_without_value_type.py
@@ -1,0 +1,60 @@
+"""
+Test case for end node without value_type field (backward compatibility).
+
+This test validates that end nodes work correctly even when the value_type
+field is missing from the output configuration, ensuring backward compatibility
+with older workflow definitions.
+"""
+
+from core.workflow.graph_events import (
+    GraphRunStartedEvent,
+    GraphRunSucceededEvent,
+    NodeRunStartedEvent,
+    NodeRunStreamChunkEvent,
+    NodeRunSucceededEvent,
+)
+
+from .test_table_runner import TableTestRunner, WorkflowTestCase
+
+
+def test_end_node_without_value_type_field():
+    """
+    Test that end node works without explicit value_type field.
+
+    The fixture implements a simple workflow that:
+    1. Takes a query input from start node
+    2. Passes it directly to end node
+    3. End node outputs the value without specifying value_type
+    4. Should correctly infer the type and output the value
+
+    This ensures backward compatibility with workflow definitions
+    created before value_type became a required field.
+    """
+    fixture_name = "end_node_without_value_type_field_workflow"
+
+    case = WorkflowTestCase(
+        fixture_path=fixture_name,
+        inputs={"query": "test query"},
+        expected_outputs={"query": "test query"},
+        expected_event_sequence=[
+            # Graph start
+            GraphRunStartedEvent,
+            # Start node
+            NodeRunStartedEvent,
+            NodeRunStreamChunkEvent,  # Start node streams the input value
+            NodeRunSucceededEvent,
+            # End node
+            NodeRunStartedEvent,
+            NodeRunSucceededEvent,
+            # Graph end
+            GraphRunSucceededEvent,
+        ],
+        description="End node without value_type field should work correctly",
+    )
+
+    runner = TableTestRunner()
+    result = runner.run_test_case(case)
+    assert result.success, f"Test failed: {result.error}"
+    assert result.actual_outputs == {"query": "test query"}, (
+        f"Expected output to be {{'query': 'test query'}}, got {result.actual_outputs}"
+    )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes https://github.com/langgenius/dify/issues/29466

End node `value_type` field add default value, avoid old version workflow dsl appear validate error.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
