### PR TITLE
fix: return None from retrieve_tokens when access_token is empty

### DIFF
--- a/api/core/entities/mcp_provider.py
+++ b/api/core/entities/mcp_provider.py
@@ -222,6 +222,10 @@ class MCPProviderEntity(BaseModel):
             return None
         credentials = self.decrypt_credentials()
         access_token = credentials.get("access_token", "")
+        # Return None if access_token is empty to avoid generating invalid "Authorization: Bearer " header.
+        # Note: We don't check for whitespace-only strings here because:
+        # 1. OAuth servers don't return whitespace-only access tokens in practice
+        # 2. Even if they did, the server would return 401, triggering the OAuth flow correctly
         if not access_token:
             return None
         return OAuthTokens(

--- a/api/core/entities/mcp_provider.py
+++ b/api/core/entities/mcp_provider.py
@@ -213,7 +213,11 @@ class MCPProviderEntity(BaseModel):
         return None
 
     def retrieve_tokens(self) -> OAuthTokens | None:
-        """OAuth tokens if available"""
+        """Retrieve OAuth tokens if authentication is complete.
+
+        Returns:
+            OAuthTokens if the provider has been authenticated, None otherwise.
+        """
         if not self.credentials:
             return None
         credentials = self.decrypt_credentials()

--- a/api/core/entities/mcp_provider.py
+++ b/api/core/entities/mcp_provider.py
@@ -217,8 +217,11 @@ class MCPProviderEntity(BaseModel):
         if not self.credentials:
             return None
         credentials = self.decrypt_credentials()
+        access_token = credentials.get("access_token", "")
+        if not access_token:
+            return None
         return OAuthTokens(
-            access_token=credentials.get("access_token", ""),
+            access_token=access_token,
             token_type=credentials.get("token_type", DEFAULT_TOKEN_TYPE),
             expires_in=int(credentials.get("expires_in", str(DEFAULT_EXPIRES_IN)) or DEFAULT_EXPIRES_IN),
             refresh_token=credentials.get("refresh_token", ""),


### PR DESCRIPTION
## Summary

Fixes #29514

When adding an MCP server requiring OAuth authentication, clicking "Authorize" threw `ValueError: Illegal header value b'Bearer '` instead of initiating the OAuth flow.

### Root Cause
`MCPProviderEntity.retrieve_tokens()` returned an `OAuthTokens` object with an empty `access_token` string, which created an invalid `Authorization: Bearer ` header. The httpx library rejected this malformed header before the request was even sent.

### Solution
Check if `access_token` is empty and return `None` instead of constructing `OAuthTokens` with invalid credentials. This allows the request to proceed without an Authorization header, receive a 401 response from the server, and properly trigger the OAuth authorization flow.

## Screenshots

N/A (backend fix)

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
  - N/A - Bug fix only
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - N/A - Existing auth flow tests cover the case where `retrieve_tokens()` returns `None`
- [x] I've updated the documentation accordingly.
  - N/A - Bug fix only
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
