### PR TITLE
perf(extractor): Optimize Excel extractor performance and memory usage.

### DIFF
--- a/api/core/rag/extractor/excel_extractor.py
+++ b/api/core/rag/extractor/excel_extractor.py
@@ -30,32 +30,61 @@ class ExcelExtractor(BaseExtractor):
         file_extension = os.path.splitext(self._file_path)[-1].lower()
 
         if file_extension == ".xlsx":
-            wb = load_workbook(self._file_path, data_only=True)
+            # Read only mode is faster and uses less memory
+            wb = load_workbook(self._file_path, read_only=True, data_only=True)
             for sheet_name in wb.sheetnames:
                 sheet = wb[sheet_name]
-                data = sheet.values
-                cols = next(data, None)
-                if cols is None:
+                
+                # 1. Find Header Row and determine valid columns
+                header_row_idx, column_map, max_col_idx = self._find_header_and_columns(sheet)
+                
+                if not column_map:
                     continue
-                df = pd.DataFrame(data, columns=cols)
 
-                df.dropna(how="all", inplace=True)
-
-                for index, row in df.iterrows():
+                # 2. Stream rows using the determined boundaries
+                # min_row is 1-based index in openpyxl
+                # We start reading from the next row after header
+                start_row = header_row_idx + 1
+                
+                # iter_rows yields tuples of cells. 
+                # We strictly limit max_col to avoid reading ghost columns (memory leak protection).
+                for row in sheet.iter_rows(min_row=start_row, max_col=max_col_idx, values_only=False):
+                    # Check if row is completely empty
+                    if all(cell.value is None for cell in row):
+                        continue
+                        
                     page_content = []
-                    for col_index, (k, v) in enumerate(row.items()):
-                        if pd.notna(v):
-                            cell = sheet.cell(
-                                row=cast(int, index) + 2, column=col_index + 1
-                            )  # +2 to account for header and 1-based index
-                            if cell.hyperlink:
-                                value = f"[{v}]({cell.hyperlink.target})"
-                                page_content.append(f'"{k}":"{value}"')
-                            else:
-                                page_content.append(f'"{k}":"{v}"')
-                    documents.append(
-                        Document(page_content=";".join(page_content), metadata={"source": self._file_path})
-                    )
+                    for col_idx, cell in enumerate(row):
+                        value = cell.value
+                        # col_idx is 0-based, matches our column_map keys
+                        if col_idx in column_map:
+                            col_name = column_map[col_idx]
+                            
+                            # Handle Hyperlinks
+                            if hasattr(cell, "hyperlink") and cell.hyperlink:
+                                target = getattr(cell.hyperlink, "target", None)
+                                if target:
+                                    value = f"[{value}]({target})"
+
+                            # Handle None and basic types
+                            if value is None:
+                                value = ""
+                            elif not isinstance(value, str):
+                                value = str(value)
+                                
+                            value = value.strip()
+                            # Always append the key-value pair, even if value is empty.
+                            # This ensures that all columns from the header are present in the document content.
+                            page_content.append(f'"{col_name}":"{value}"')
+
+                    
+                    if page_content:
+                        documents.append(
+                            Document(page_content=";".join(page_content), metadata={"source": self._file_path})
+                        )
+            
+            # Close the workbook if opened in read_only mode
+            wb.close()
 
         elif file_extension == ".xls":
             excel_file = pd.ExcelFile(self._file_path, engine="xlrd")
@@ -75,3 +104,86 @@ class ExcelExtractor(BaseExtractor):
             raise ValueError(f"Unsupported file extension: {file_extension}")
 
         return documents
+    
+    def _find_header_and_columns(self, sheet, scan_rows=10) -> tuple[int, dict[int, str], int]:
+        """
+        Scan first N rows to find the most likely header row.
+        Returns:
+            header_row_idx: 1-based index of the header row
+            column_map: Dict mapping 0-based column index to column name
+            max_col_idx: 1-based index of the last valid column (for iter_rows boundary)
+        """
+        # Store potential candidates: (row_index, non_empty_count, column_map)
+        candidates = []
+        
+        # Limit scan to avoid performance issues on huge files
+        # We iterate manually to control the read scope
+        current_row_idx = 0
+        for row in sheet.iter_rows(min_row=1, max_row=scan_rows, values_only=True):
+            current_row_idx += 1
+            
+            # Filter out empty cells and build a temp map for this row
+            # col_idx is 0-based
+            row_map = {}
+            for col_idx, cell_value in enumerate(row):
+                if cell_value is not None and str(cell_value).strip():
+                    row_map[col_idx] = str(cell_value).strip()
+            
+            if not row_map:
+                continue
+                
+            non_empty_count = len(row_map)
+            
+            # Heuristic: 
+            # 1. Prefer rows with multiple columns (unless file is single column)
+            # 2. Prefer rows where values are strings (headers usually are) - implicit in str() conversion above but we could be stricter
+            candidates.append({
+                "idx": current_row_idx,
+                "count": non_empty_count,
+                "map": row_map
+            })
+
+        if not candidates:
+            return 0, {}, 0
+
+        # Sort candidates to find the best header
+        # Primary key: non_empty_count (descending)
+        # Secondary key: row index (ascending) - handled by stable sort or manual logic
+        # But we want to prioritize the FIRST row that looks "good enough" (e.g. > 1 column)
+        # rather than just the absolute max, to handle cases where data rows might have extra columns.
+        
+        best_candidate = None
+        
+        # Strategy: Pick the first row that has a "significant" number of columns.
+        # If the max column count across all scanned rows is small (e.g. 1 or 2), just take the max.
+        # If there are rows with many columns, pick the first one that reaches a threshold (e.g. > 50% of max width).
+        
+        for cand in candidates:
+            # If we find a row that has close to the max columns found (e.g. at least 80% of max),
+            # and it's early in the file, it's likely the header.
+            # Using 0.8 factor allows for some missing header names compared to a fully populated data row,
+            # but usually header row is fully populated for valid columns.
+            # Let's be simple: The first row that has > 1 column is a strong candidate for header 
+            # if we assume headers are at top.
+            
+            # User case: Row 1 has 1 col (Title), Row 2 has N cols (Header).
+            # We want Row 2.
+            if cand["count"] >= 2:
+                best_candidate = cand
+                break
+        
+        # Fallback: if no row has >= 2 columns, or all have 1, just take the one with max columns
+        if not best_candidate:
+            # Sort by count desc, then index asc
+            candidates.sort(key=lambda x: (-x["count"], x["idx"]))
+            best_candidate = candidates[0]
+
+        # Determine max_col_idx (1-based for openpyxl)
+        # It is the index of the last valid column in our map + 1
+        if best_candidate["map"]:
+            max_col_idx = max(best_candidate["map"].keys()) + 1
+        else:
+            max_col_idx = 1
+            
+        return best_candidate["idx"], best_candidate["map"], max_col_idx
+


### PR DESCRIPTION
- Load workbooks using read_only mode to reduce memory consumption

- Implement streaming row processing to avoid loading all data into memory

- Add the `_header_and_columns` method for intelligent header detection

- Handle empty rows and ghost columns to prevent memory leaks

- Improve hyperlink and null value handling logic

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The ExcelExtractor implementation for .xlsx files has severe memory leak issues due to full loading of data into Pandas DataFrames, especially when processing files with "ghost columns" (empty columns that are technically part of the sheet). Additionally, the header detection logic is simplistic (always assuming the first row is the header), which fails for files with titles or metadata in the first few rows, leading to incorrect column mapping and data loss.

**Steps To Reproduce**
1.  Upload an `.xlsx` file that has:
    -   A title in the first row (merged cells).
    -   The actual header in the second row.
    -   A large number of empty "ghost columns" (e.g., formatting applied to 16,000+ columns).
2.  Trigger the indexing estimate or extraction process.
3.  Observe:
    -   **Memory Usage**: Rapid spike in memory usage leading to OOM (Out Of Memory) crashes because `openpyxl`'s `sheet.values` combined with `pd.DataFrame` attempts to materialize millions of `None` cells.
    -   **Data Extraction**: Incorrect data parsing because the first row (title) is treated as the header, causing subsequent rows to misalign or lose data.
    
**Root Cause**
1.  **Memory Leak**: Using `pd.DataFrame(sheet.values)` forces the loading of all cells, including empty ones in the used range. If the used range is large (due to ghost columns), this consumes gigabytes of memory.
2.  **Header Logic**: The code assumes `row[0]` is the header.
3.  **Data Consistency**: The extraction logic `if value:` skips empty cells, resulting in missing keys in the JSON output for sparse columns.

**Proposed Fix**
1.  **Switch to Streaming**: Use `openpyxl.load_workbook(..., read_only=True)` and `sheet.iter_rows()` to process data row by row.
2.  **Smart Header Detection**: Implement a heuristic to scan the first N rows (e.g., 10) to find the best header candidate (prioritizing rows with multiple string columns).
3.  **Boundary Limiting**: Calculate `max_col_idx` from the detected header and enforce this limit in `iter_rows(max_col=...)` to prevent reading ghost columns.
4.  **Consistency**: Ensure all columns defined in the header are present in the output `Document`, setting empty values to `""` instead of omitting the key.

**Acceptance Criteria**
-   Process large `.xlsx` files with ghost columns with constant low memory usage.
-   Correctly identify headers in files where the header is not the first row (e.g., Row 2).
-   Output documents must contain all keys defined in the header, even for empty cells.
-   Preserve existing hyperlink formatting logic.

**Severity**
-   **High**: The memory leak can crash the entire API service when a user uploads a single malformed/complex Excel file.

#29523 
## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
