### PR TITLE
fix: add secondary text color to plugin task headers

### DIFF
--- a/web/app/components/plugins/plugin-page/plugin-tasks/index.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/index.tsx
@@ -187,7 +187,7 @@ const PluginTasks = () => {
             {/* Running Plugins */}
             {runningPlugins.length > 0 && (
               <>
-                <div className='system-sm-semibold-uppercase sticky top-0 flex h-7 items-center justify-between px-2 pt-1'>
+                <div className='system-sm-semibold-uppercase sticky top-0 flex h-7 items-center justify-between px-2 pt-1 text-text-secondary'>
                   {t('plugin.task.installing')} ({runningPlugins.length})
                 </div>
                 <div className='max-h-[200px] overflow-y-auto'>
@@ -220,7 +220,7 @@ const PluginTasks = () => {
             {/* Success Plugins */}
             {successPlugins.length > 0 && (
               <>
-                <div className='system-sm-semibold-uppercase sticky top-0 flex h-7 items-center justify-between px-2 pt-1'>
+                <div className='system-sm-semibold-uppercase sticky top-0 flex h-7 items-center justify-between px-2 pt-1 text-text-secondary'>
                   {t('plugin.task.installed')} ({successPlugins.length})
                   <Button
                     className='shrink-0'
@@ -261,7 +261,7 @@ const PluginTasks = () => {
             {/* Error Plugins */}
             {errorPlugins.length > 0 && (
               <>
-                <div className='system-sm-semibold-uppercase sticky top-0 flex h-7 items-center justify-between px-2 pt-1'>
+                <div className='system-sm-semibold-uppercase sticky top-0 flex h-7 items-center justify-between px-2 pt-1 text-text-secondary'>
                   {t('plugin.task.installError', { errorLength: errorPlugins.length })}
                   <Button
                     className='shrink-0'


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix #29515 

Applied the 'text-text-secondary' class to the headers for running, success, and error plugin sections to improve visual consistency and readability in the plugin tasks component.

## Screenshots

| Before | After |
|--------|-------|
| <img width="369" height="163" src="https://github.com/user-attachments/assets/f85669cd-000e-4a7b-b8d4-edef92e45313" /> | <img width="369" height="163" src="https://github.com/user-attachments/assets/b0ea0d73-c4a1-451d-9474-6760f72ffaf5" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
