### PR TITLE
fix: In the LLM model in dify, when a message is added, the first cli…

### DIFF
--- a/web/app/components/workflow/nodes/llm/components/config-prompt.tsx
+++ b/web/app/components/workflow/nodes/llm/components/config-prompt.tsx
@@ -105,12 +105,12 @@ const ConfigPrompt: FC<Props> = ({
   const handleAddPrompt = useCallback(() => {
     const newPrompt = produce(payload as PromptItem[], (draft) => {
       if (draft.length === 0) {
-        draft.push({ role: PromptRole.system, text: '' })
+        draft.push({ role: PromptRole.system, text: '', id: uuid4() })
 
         return
       }
       const isLastItemUser = draft[draft.length - 1].role === PromptRole.user
-      draft.push({ role: isLastItemUser ? PromptRole.assistant : PromptRole.user, text: '' })
+      draft.push({ role: isLastItemUser ? PromptRole.assistant : PromptRole.user, text: '', id: uuid4() })
     })
     onChange(newPrompt)
   }, [onChange, payload])


### PR DESCRIPTION
…ck on the delete or other buttons in the message is invalid, and a second click is required.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes https://github.com/langgenius/dify/issues/29536
In the LLM model in dify, when a message is added, the first click on the delete or other buttons in the message is invalid, and a second click is required.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
