### PR TITLE
fix: remove validate=True to fix flask-restx AttributeError

### DIFF
--- a/api/controllers/console/app/workflow_trigger.py
+++ b/api/controllers/console/app/workflow_trigger.py
@@ -114,7 +114,7 @@ class AppTriggersApi(Resource):
 
 @console_ns.route("/apps/<uuid:app_id>/trigger-enable")
 class AppTriggerEnableApi(Resource):
-    @console_ns.expect(console_ns.models[ParserEnable.__name__], validate=True)
+    @console_ns.expect(console_ns.models[ParserEnable.__name__])
     @setup_required
     @login_required
     @account_initialization_required

--- a/api/controllers/console/datasets/rag_pipeline/datasource_content_preview.py
+++ b/api/controllers/console/datasets/rag_pipeline/datasource_content_preview.py
@@ -26,7 +26,7 @@ console_ns.schema_model(Parser.__name__, Parser.model_json_schema(ref_template=D
 
 @console_ns.route("/rag/pipelines/<uuid:pipeline_id>/workflows/published/datasource/nodes/<string:node_id>/preview")
 class DataSourceContentPreviewApi(Resource):
-    @console_ns.expect(console_ns.models[Parser.__name__], validate=True)
+    @console_ns.expect(console_ns.models[Parser.__name__])
     @setup_required
     @login_required
     @account_initialization_required


### PR DESCRIPTION
## Summary
- Remove `validate=True` from `@console_ns.expect()` decorators to fix 500 Internal Server Error
- This fixes a flask-restx bug where accessing `self.api.refresolver` fails with `AttributeError: Api does not have refresolver attribute`
- Pydantic validation via `model_validate()` is already in place, making flask-restx validation redundant

fixes #29554

## Test plan
- [ ] Test `/console/api/apps/<app_id>/trigger-enable` endpoint - should no longer return 500 error
- [ ] Test `/console/api/rag/pipelines/<pipeline_id>/workflows/published/datasource/nodes/<node_id>/preview` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)