### PR TITLE
chore: Bump version references to 1.11.1

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.11.0"
+version = "1.11.1"
 requires-python = ">=3.11,<3.13"
 
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "dify-api"
-version = "1.11.0"
+version = "1.11.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -21,7 +21,7 @@ services:
 
   # API service
   api:
-    image: langgenius/dify-api:1.11.0
+    image: langgenius/dify-api:1.11.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -62,7 +62,7 @@ services:
   # worker service
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
-    image: langgenius/dify-api:1.11.0
+    image: langgenius/dify-api:1.11.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -101,7 +101,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.11.0
+    image: langgenius/dify-api:1.11.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -131,7 +131,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.11.0
+    image: langgenius/dify-web:1.11.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -659,7 +659,7 @@ services:
 
   # API service
   api:
-    image: langgenius/dify-api:1.11.0
+    image: langgenius/dify-api:1.11.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -700,7 +700,7 @@ services:
   # worker service
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
-    image: langgenius/dify-api:1.11.0
+    image: langgenius/dify-api:1.11.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -739,7 +739,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.11.0
+    image: langgenius/dify-api:1.11.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -769,7 +769,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.11.0
+    image: langgenius/dify-web:1.11.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "packageManager": "pnpm@10.25.0+sha512.5e82639027af37cf832061bcc6d639c219634488e0f2baebe785028a793de7b525ffcd3f7ff574f5e9860654e098fe852ba8ac5dd5cefe1767d23a020a92f501",
   "engines": {


### PR DESCRIPTION
## Summary
- bump backend package metadata to version 1.11.1
- update Docker Compose images to the 1.11.1 API and web tags
- align web package.json version with the 1.11.1 release

Fixes #29567.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: https://github.com/langgenius/dify-docs
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn\'t apply to typos!)
- [ ] I\'ve added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I\'ve updated the documentation accordingly.
- [ ] I ran dev/reformat(backend) and cd web && npx lint-staged(frontend) to appease the lint gods