### PR TITLE
fix: remove unnecessary error log when trigger endpoint returns 404

### DIFF
--- a/api/controllers/trigger/trigger.py
+++ b/api/controllers/trigger/trigger.py
@@ -33,7 +33,7 @@ def trigger_endpoint(endpoint_id: str):
             if response:
                 break
         if not response:
-            logger.error("Endpoint not found for {endpoint_id}")
+            logger.info("Endpoint not found for %s", endpoint_id)
             return jsonify({"error": "Endpoint not found"}), 404
         return response
     except ValueError as e:


### PR DESCRIPTION
## Summary
- Remove unnecessary `logger.error()` call when trigger endpoint returns 404
- 404 is expected behavior for non-existent endpoints and should not pollute error logs

## Test plan
- [x] Lint check passed
- [x] Type check passed

Closes #29586

🤖 Generated with [Claude Code](https://claude.com/claude-code)