### PR TITLE
fix(ci): use setup-python to avoid 504 errors and use project oxlint config

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -85,6 +85,6 @@ jobs:
 
       - name: oxlint
         working-directory: ./web
-        run: oxlint --config .oxlintrc.json --fix .
+        run: pnpm exec oxlint --config .oxlintrc.json --fix .
 
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,13 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      # Setup Python first to avoid uv downloading python-build-standalone (may 504)
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      # Use uv to ensure we have the same ruff version in CI and locally.
       - uses: astral-sh/setup-uv@v6
 
       - run: |

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -85,7 +85,6 @@ jobs:
 
       - name: oxlint
         working-directory: ./web
-        run: |
-          pnpx oxlint --fix
+        run: oxlint --config .oxlintrc.json --fix .
 
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -14,10 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Use uv to ensure we have the same ruff version in CI and locally.
-      - uses: astral-sh/setup-uv@v6
+      # Setup Python first to avoid uv downloading python-build-standalone (may 504)
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      # Use uv to ensure we have the same ruff version in CI and locally.
+      - uses: astral-sh/setup-uv@v6
+
       - run: |
           cd api
           uv sync --dev


### PR DESCRIPTION
Fixes #29612

## Summary

Use `actions/setup-python` before `setup-uv` in `autofix.yml` to provide Python from GitHub's official cache, avoiding intermittent 504 errors when uv tries to download `python-build-standalone`.

## Screenshots

N/A - CI workflow change

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods