### PR TITLE
fix: add BILLING_ENABLED check to delete_account_task

### DIFF
--- a/api/tasks/delete_account_task.py
+++ b/api/tasks/delete_account_task.py
@@ -2,6 +2,7 @@ import logging
 
 from celery import shared_task
 
+from configs import dify_config
 from extensions.ext_database import db
 from models import Account
 from services.billing_service import BillingService
@@ -13,11 +14,12 @@ logger = logging.getLogger(__name__)
 @shared_task(queue="dataset")
 def delete_account_task(account_id):
     account = db.session.query(Account).where(Account.id == account_id).first()
-    try:
-        BillingService.delete_account(account_id)
-    except Exception:
-        logger.exception("Failed to delete account %s from billing service.", account_id)
-        raise
+    if dify_config.BILLING_ENABLED:
+        try:
+            BillingService.delete_account(account_id)
+        except Exception:
+            logger.exception("Failed to delete account %s from billing service.", account_id)
+            raise
 
     if not account:
         logger.error("Account %s not found.", account_id)

--- a/api/tests/unit_tests/tasks/test_delete_account_task.py
+++ b/api/tests/unit_tests/tasks/test_delete_account_task.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestDeleteAccountTask:
+    """Unit tests for delete_account_task."""
+
+    @patch("tasks.delete_account_task.send_deletion_success_task")
+    @patch("tasks.delete_account_task.BillingService")
+    @patch("tasks.delete_account_task.db")
+    @patch("tasks.delete_account_task.dify_config")
+    def test_delete_account_task_with_billing_enabled(
+        self, mock_config, mock_db, mock_billing_service, mock_send_email
+    ):
+        """Test delete_account_task calls BillingService when BILLING_ENABLED is True."""
+        from tasks.delete_account_task import delete_account_task
+
+        account_id = "test-account-id"
+        mock_account = MagicMock()
+        mock_account.email = "test@example.com"
+
+        mock_config.BILLING_ENABLED = True
+        mock_db.session.query.return_value.where.return_value.first.return_value = mock_account
+
+        delete_account_task(account_id)
+
+        mock_billing_service.delete_account.assert_called_once_with(account_id)
+        mock_send_email.delay.assert_called_once_with("test@example.com")
+
+    @patch("tasks.delete_account_task.send_deletion_success_task")
+    @patch("tasks.delete_account_task.BillingService")
+    @patch("tasks.delete_account_task.db")
+    @patch("tasks.delete_account_task.dify_config")
+    def test_delete_account_task_with_billing_disabled(
+        self, mock_config, mock_db, mock_billing_service, mock_send_email
+    ):
+        """Test delete_account_task skips BillingService when BILLING_ENABLED is False."""
+        from tasks.delete_account_task import delete_account_task
+
+        account_id = "test-account-id"
+        mock_account = MagicMock()
+        mock_account.email = "test@example.com"
+
+        mock_config.BILLING_ENABLED = False
+        mock_db.session.query.return_value.where.return_value.first.return_value = mock_account
+
+        delete_account_task(account_id)
+
+        mock_billing_service.delete_account.assert_not_called()
+        mock_send_email.delay.assert_called_once_with("test@example.com")
+
+    @patch("tasks.delete_account_task.send_deletion_success_task")
+    @patch("tasks.delete_account_task.BillingService")
+    @patch("tasks.delete_account_task.db")
+    @patch("tasks.delete_account_task.dify_config")
+    def test_delete_account_task_account_not_found(
+        self, mock_config, mock_db, mock_billing_service, mock_send_email
+    ):
+        """Test delete_account_task handles account not found gracefully."""
+        from tasks.delete_account_task import delete_account_task
+
+        account_id = "nonexistent-account-id"
+
+        mock_config.BILLING_ENABLED = False
+        mock_db.session.query.return_value.where.return_value.first.return_value = None
+
+        delete_account_task(account_id)
+
+        mock_send_email.delay.assert_not_called()
+
+    @patch("tasks.delete_account_task.send_deletion_success_task")
+    @patch("tasks.delete_account_task.BillingService")
+    @patch("tasks.delete_account_task.db")
+    @patch("tasks.delete_account_task.dify_config")
+    def test_delete_account_task_billing_service_failure(
+        self, mock_config, mock_db, mock_billing_service, mock_send_email
+    ):
+        """Test delete_account_task raises exception when BillingService fails."""
+        from tasks.delete_account_task import delete_account_task
+
+        account_id = "test-account-id"
+        mock_account = MagicMock()
+        mock_account.email = "test@example.com"
+
+        mock_config.BILLING_ENABLED = True
+        mock_db.session.query.return_value.where.return_value.first.return_value = mock_account
+        mock_billing_service.delete_account.side_effect = Exception("Billing service error")
+
+        with pytest.raises(Exception, match="Billing service error"):
+            delete_account_task(account_id)
+
+        mock_send_email.delay.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `BILLING_ENABLED` check before calling `BillingService.delete_account()` in `delete_account_task`
- Prevents errors in self-hosted deployments where billing is disabled

Fixes #29557

## Test plan
- [x] Added unit tests for `delete_account_task`
- [x] Tests verify BillingService is called when BILLING_ENABLED=True
- [x] Tests verify BillingService is skipped when BILLING_ENABLED=False
- [x] All tests pass locally