### PR TITLE
fix(workflow): agent prompt editor canvas not covering full text height

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
@@ -91,7 +91,7 @@ export const AgentStrategy = memo((props: AgentStrategyProps) => {
             nodeId={nodeId}
             isSupportPromptGenerator={!!def.auto_generate?.type}
             titleTooltip={schema.tooltip && renderI18nObject(schema.tooltip)}
-            editorContainerClassName='px-0'
+            editorContainerClassName='px-0 bg-components-input-bg-normal focus-within:bg-components-input-bg-active rounded-lg'
             availableNodes={availableNodes}
             nodesOutputVars={nodeOutputVars}
             isSupportJinja={def.template?.enabled}
@@ -108,7 +108,7 @@ export const AgentStrategy = memo((props: AgentStrategyProps) => {
             }
             placeholderClassName='px-2 py-1'
             titleClassName='system-sm-semibold-uppercase text-text-secondary text-[13px]'
-            inputClassName='px-2 py-1 bg-components-input-bg-normal focus:bg-components-input-bg-active focus:border-components-input-border-active focus:border rounded-lg'
+            inputClassName='px-2 py-1'
           />
         }
         case FormTypeEnum.textNumber: {


### PR DESCRIPTION
## Summary

Fixed an issue where the prompt editor canvas/background in the Agent node does not extend to cover long text content. When users input lengthy system prompts, the background styling would clip and not follow the content height, creating a visual bug where text appears outside the styled area.

Root Cause: The background styling (bg-components-input-bg-normal, rounded-lg) was incorrectly applied to inputClassName which targets the ContentEditable component directly, instead of the container div that wraps and scrolls the content.

Solution:

> 1. Moved background and rounded styling from inputClassName to editorContainerClassName
> 2. Changed focus: to focus-within: for proper focus state handling on the container
> 3. Kept only padding (px-2 py-1) in inputClassName

## Screenshots


| Before | After |
| :---: | :---: |
|<img width="1918" height="888" alt="image" src="https://github.com/user-attachments/assets/bbbe11dc-0359-4758-ae20-6bebbdc11614" />| <img width="1918" height="888" alt="image" src="https://github.com/user-attachments/assets/f3bd8766-c1f7-4493-9b15-ac18d79201a9" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
