### PR TITLE
feat: add datasource_parameters handling for API requests

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -147,6 +147,8 @@ class DataSourceNotionListApi(Resource):
         if datasource_parameters_str:
             try:
                 datasource_parameters = json.loads(datasource_parameters_str)
+                if not isinstance(datasource_parameters, dict):
+                    raise ValueError("datasource_parameters must be a JSON object.")
             except json.JSONDecodeError:
                 raise ValueError("Invalid datasource_parameters JSON format.")
 

--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -140,6 +140,16 @@ class DataSourceNotionListApi(Resource):
         credential_id = request.args.get("credential_id", default=None, type=str)
         if not credential_id:
             raise ValueError("Credential id is required.")
+
+        # Get datasource_parameters from query string (optional, for GitHub and other datasources)
+        datasource_parameters_str = request.args.get("datasource_parameters", default=None, type=str)
+        datasource_parameters = {}
+        if datasource_parameters_str:
+            try:
+                datasource_parameters = json.loads(datasource_parameters_str)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid datasource_parameters JSON format.")
+
         datasource_provider_service = DatasourceProviderService()
         credential = datasource_provider_service.get_datasource_credentials(
             tenant_id=current_tenant_id,
@@ -187,7 +197,7 @@ class DataSourceNotionListApi(Resource):
             online_document_result: Generator[OnlineDocumentPagesMessage, None, None] = (
                 datasource_runtime.get_online_document_pages(
                     user_id=current_user.id,
-                    datasource_parameters={},
+                    datasource_parameters=datasource_parameters,
                     provider_type=datasource_runtime.datasource_provider_type(),
                 )
             )

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-documents/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-documents/index.tsx
@@ -75,11 +75,17 @@ const OnlineDocuments = ({
 
   const getOnlineDocuments = useCallback(async () => {
     const { currentCredentialId } = dataSourceStore.getState()
+    // Convert datasource_parameters to inputs format for the API
+    const inputs = Object.entries(nodeData.datasource_parameters || {}).reduce((acc, [key, value]) => {
+      acc[key] = typeof value === 'object' && value !== null && 'value' in value ? value.value : value
+      return acc
+    }, {} as Record<string, any>)
+
     ssePost(
       datasourceNodeRunURL,
       {
         body: {
-          inputs: {},
+          inputs,
           credential_id: currentCredentialId,
           datasource_type: DatasourceType.onlineDocument,
         },
@@ -97,7 +103,7 @@ const OnlineDocuments = ({
         },
       },
     )
-  }, [dataSourceStore, datasourceNodeRunURL])
+  }, [dataSourceStore, datasourceNodeRunURL, nodeData.datasource_parameters])
 
   useEffect(() => {
     if (!currentCredentialId) return


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fix empty datasource_parameters being passed to online document datasources.

### Problem
The datasource_parameters was hardcoded as {} in both backend and frontend, preventing GitHub and other online document datasources from receiving required configuration (repo URL, branch, etc.).

### Changes
- Backend: Modified /notion/pre-import/pages endpoint to accept optional datasource_parameters query parameter and pass it to get_online_document_pages()
 - Frontend: Extract datasource_parameters from nodeData and pass as inputs to the API request

### Files Changed
- api/controllers/console/datasets/data_source.py
- web/app/components/datasets/documents/create-from-pipeline/data-source/online-documents/index.tsx

Fixes #29756

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
