### PR TITLE
fix: remove unnecessary min-width css style from AllTools and Blocks components

### DIFF
--- a/web/app/components/workflow/block-selector/all-tools.tsx
+++ b/web/app/components/workflow/block-selector/all-tools.tsx
@@ -204,7 +204,7 @@ const AllTools = ({
   }, [onSelect])
 
   return (
-    <div className={cn('min-w-[400px] max-w-[500px]', className)}>
+    <div className={cn('max-w-[500px]', className)}>
       <div className='flex items-center justify-between border-b border-divider-subtle px-3'>
         <div className='flex h-8 items-center space-x-1'>
           {

--- a/web/app/components/workflow/block-selector/blocks.tsx
+++ b/web/app/components/workflow/block-selector/blocks.tsx
@@ -134,7 +134,7 @@ const Blocks = ({
   }, [groups, onSelect, t, store])
 
   return (
-    <div className='max-h-[480px] min-w-[400px] max-w-[500px] overflow-y-auto p-1'>
+    <div className='max-h-[480px] max-w-[500px] overflow-y-auto p-1'>
       {
         isEmpty && (
           <div className='flex h-[22px] items-center px-3 text-xs font-medium text-text-tertiary'>{t('workflow.tabs.noResult')}</div>


### PR DESCRIPTION
**fixes #29809**

## Screenshots

| Before | After |
<img width="1626" height="832" alt="image" src="https://github.com/user-attachments/assets/12ce5fdc-a3ba-44ce-80f0-765a5070f890" />

|--------|-------|
<img width="1642" height="838" alt="image" src="https://github.com/user-attachments/assets/06e211a5-238d-4282-af06-a1fb1fb04be7" />

| ... | ... |

## Checklist


- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


