### PR TITLE
fix: support to change NEXT_PUBLIC_BASE_PATH env using `--build-arg` in docker build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,8 @@ RUN apk add --no-cache tzdata
 RUN corepack enable
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV NEXT_PUBLIC_BASE_PATH=""
+ARG NEXT_PUBLIC_BASE_PATH=""
+ENV NEXT_PUBLIC_BASE_PATH="$NEXT_PUBLIC_BASE_PATH"
 
 
 # install packages


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #25352

To allow dify-web to use a different base path, users need to set the NEXT_PUBLIC_BASE_PATH environment variable at build time. However, in the current Dockerfile, NEXT_PUBLIC_BASE_PATH is an environment variable and cannot be configured at build time by default according to the [Docker documentation](vscode-file://vscode-app/c:/Users/kimi.wang/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Convert it to a build argument so users can change it by specifying --build-arg NEXT_PUBLIC_BASE_PATH=/CHANGEME when building the image.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
