### PR TITLE
fix(agent): fix model type mismatch error in agent node with multiple model selectors

### DIFF
--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -305,7 +305,7 @@ class AgentNode(Node[AgentNodeData]):
                     model_instance, model_schema = self._fetch_model(value)
                     # memory config - only for LLM models
                     history_prompt_messages = []
-                    model_type_str = value.get("model_type", "")
+                    model_type_str = value.get("model_type", ModelType.LLM.value)
                     if node_data.memory and model_type_str == ModelType.LLM.value:
                         memory = self._fetch_memory(model_instance)
                         if memory:

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -303,9 +303,10 @@ class AgentNode(Node[AgentNodeData]):
                 if parameter.type == AgentStrategyParameter.AgentStrategyParameterType.MODEL_SELECTOR:
                     value = cast(dict[str, Any], value)
                     model_instance, model_schema = self._fetch_model(value)
-                    # memory config
+                    # memory config - only for LLM models
                     history_prompt_messages = []
-                    if node_data.memory:
+                    model_type_str = value.get("model_type", "")
+                    if node_data.memory and model_type_str == ModelType.LLM.value:
                         memory = self._fetch_memory(model_instance)
                         if memory:
                             prompt_messages = memory.get_history_prompt_messages(
@@ -415,12 +416,13 @@ class AgentNode(Node[AgentNodeData]):
 
     def _fetch_model(self, value: dict[str, Any]) -> tuple[ModelInstance, AIModelEntity | None]:
         provider_manager = ProviderManager()
+        model_type = ModelType(value.get("model_type", ModelType.LLM.value))
         provider_model_bundle = provider_manager.get_provider_model_bundle(
-            tenant_id=self.tenant_id, provider=value.get("provider", ""), model_type=ModelType.LLM
+            tenant_id=self.tenant_id, provider=value.get("provider", ""), model_type=model_type
         )
         model_name = value.get("model", "")
         model_credentials = provider_model_bundle.configuration.get_current_credentials(
-            model_type=ModelType.LLM, model=model_name
+            model_type=model_type, model=model_name
         )
         provider_name = provider_model_bundle.configuration.provider.provider
         model_type_instance = provider_model_bundle.model_type_instance


### PR DESCRIPTION
## Summary
- Fix "Model type instance is not LargeLanguageModel" error when using custom agent strategy with multiple models (LLM + Embedding model)
- The error occurs on the second query when memory is enabled

## Problem
When using a custom agent strategy with multiple model selectors (e.g., one LLM model and one Embedding model), the workflow fails on the second query with error:
```
RuntimeError: Model type instance is not LargeLanguageModel
```

## Root Cause
1. **`_fetch_model()` method**: Hardcoded `ModelType.LLM` when calling `get_provider_model_bundle()` and `get_current_credentials()`, but used the actual model type from config when calling `get_model_instance()`. This caused a type mismatch for non-LLM models.

2. **`_generate_agent_parameters()` method**: Attempted to create memory for ALL `MODEL_SELECTOR` parameters, but memory requires LLM model to calculate tokens via `get_llm_num_tokens()`. When processing embedding model parameters, it failed because embedding models don't support this method.

## Solution
1. Use the actual model type from config consistently in `_fetch_model()` method
2. Only create memory when the model type is LLM in `_generate_agent_parameters()`

## Test plan
- [x] Create an agent strategy with both LLM and Embedding model selectors
- [x] Enable memory feature
- [x] Send multiple consecutive queries
- [x] Verify no error occurs on subsequent queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)