### PR TITLE
chore: bump plugin daemon image tag to 0.5.2-local

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -270,7 +270,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.1-local
+    image: langgenius/dify-plugin-daemon:0.5.2-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -123,7 +123,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.1-local
+    image: langgenius/dify-plugin-daemon:0.5.2-local
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -939,7 +939,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.1-local
+    image: langgenius/dify-plugin-daemon:0.5.2-local
     restart: always
     environment:
       # Use the shared environment variables.


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #29992.

Update the Docker compose definitions to reference the current plugin daemon image tag so self-hosted deployments stay aligned with the latest release.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
