### PR TITLE
fix: YAML URL import rewrite for GitHub attachments

### DIFF
--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -155,6 +155,7 @@ class AppDslService:
                     parsed_url.scheme == "https"
                     and parsed_url.netloc == "github.com"
                     and parsed_url.path.endswith((".yml", ".yaml"))
+                    and "/blob/" in parsed_url.path
                 ):
                     yaml_url = yaml_url.replace("https://github.com", "https://raw.githubusercontent.com")
                     yaml_url = yaml_url.replace("/blob/", "/")

--- a/api/tests/unit_tests/services/test_app_dsl_service_import_yaml_url.py
+++ b/api/tests/unit_tests/services/test_app_dsl_service_import_yaml_url.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+
+import httpx
+
+from models import Account
+from services import app_dsl_service
+from services.app_dsl_service import AppDslService, ImportMode, ImportStatus
+
+
+def _build_response(url: str, status_code: int, content: bytes = b"") -> httpx.Response:
+    request = httpx.Request("GET", url)
+    return httpx.Response(status_code=status_code, request=request, content=content)
+
+
+def _pending_yaml_content(version: str = "99.0.0") -> bytes:
+    return (
+        f'version: "{version}"\n'
+        "kind: app\n"
+        "app:\n"
+        "  name: Loop Test\n"
+        "  mode: workflow\n"
+    ).encode()
+
+
+def _account_mock() -> MagicMock:
+    account = MagicMock(spec=Account)
+    account.current_tenant_id = "tenant-1"
+    return account
+
+
+def test_import_app_yaml_url_user_attachments_keeps_original_url(monkeypatch):
+    yaml_url = "https://github.com/user-attachments/files/24290802/loop-test.yml"
+    raw_url = "https://raw.githubusercontent.com/user-attachments/files/24290802/loop-test.yml"
+    yaml_bytes = _pending_yaml_content()
+
+    def fake_get(url: str, **kwargs):
+        if url == raw_url:
+            return _build_response(url, status_code=404)
+        assert url == yaml_url
+        return _build_response(url, status_code=200, content=yaml_bytes)
+
+    monkeypatch.setattr(app_dsl_service.ssrf_proxy, "get", fake_get)
+
+    service = AppDslService(MagicMock())
+    result = service.import_app(
+        account=_account_mock(),
+        import_mode=ImportMode.YAML_URL,
+        yaml_url=yaml_url,
+    )
+
+    assert result.status == ImportStatus.PENDING
+    assert result.imported_dsl_version == "99.0.0"
+
+
+def test_import_app_yaml_url_github_blob_rewrites_to_raw(monkeypatch):
+    yaml_url = "https://github.com/acme/repo/blob/main/app.yml"
+    raw_url = "https://raw.githubusercontent.com/acme/repo/main/app.yml"
+    yaml_bytes = _pending_yaml_content()
+
+    requested_urls: list[str] = []
+
+    def fake_get(url: str, **kwargs):
+        requested_urls.append(url)
+        assert url == raw_url
+        return _build_response(url, status_code=200, content=yaml_bytes)
+
+    monkeypatch.setattr(app_dsl_service.ssrf_proxy, "get", fake_get)
+
+    service = AppDslService(MagicMock())
+    result = service.import_app(
+        account=_account_mock(),
+        import_mode=ImportMode.YAML_URL,
+        yaml_url=yaml_url,
+    )
+
+    assert result.status == ImportStatus.PENDING
+    assert requested_urls == [raw_url]

--- a/api/tests/unit_tests/services/test_app_dsl_service_import_yaml_url.py
+++ b/api/tests/unit_tests/services/test_app_dsl_service_import_yaml_url.py
@@ -13,13 +13,7 @@ def _build_response(url: str, status_code: int, content: bytes = b"") -> httpx.R
 
 
 def _pending_yaml_content(version: str = "99.0.0") -> bytes:
-    return (
-        f'version: "{version}"\n'
-        "kind: app\n"
-        "app:\n"
-        "  name: Loop Test\n"
-        "  mode: workflow\n"
-    ).encode()
+    return (f'version: "{version}"\nkind: app\napp:\n  name: Loop Test\n  mode: workflow\n').encode()
 
 
 def _account_mock() -> MagicMock:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #30002.

Prevent GitHub YAML URL imports from rewriting `user-attachments` links to `raw.githubusercontent.com`. Only repository `/blob/` URLs are rewritten, and URL imports keep working for attachments hosted on GitHub.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
