### PR TITLE
fix(ops): correct LangSmith dotted_order timestamp format

### DIFF
--- a/api/core/ops/utils.py
+++ b/api/core/ops/utils.py
@@ -54,7 +54,7 @@ def generate_dotted_order(run_id: str, start_time: Union[str, datetime], parent_
     generate dotted_order for langsmith
     """
     start_time = datetime.fromisoformat(start_time) if isinstance(start_time, str) else start_time
-    timestamp = start_time.strftime("%Y%m%dT%H%M%S%f")[:-3] + "Z"
+    timestamp = start_time.strftime("%Y%m%dT%H%M%S%f") + "Z"
     current_segment = f"{timestamp}{run_id}"
 
     if parent_dotted_order is None:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #30021 

The LangSmith API requires microseconds with 6 digits in the dotted_order timestamp, but the current implementation truncates to 3 digits (milliseconds).

This causes the error:
"invalid timestamp format in dotted_order: cannot parse '.111' as '.000000'"

The fix removes the `[:-3]` slice that was truncating the microseconds.

Before: 20251223T041955111Z (3 digits)
After:  20251223T041955111000Z (6 digits)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
