### PR TITLE
feat: allow user close the tab to sync the draft

### DIFF
--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -224,23 +224,31 @@ export const Workflow: FC<WorkflowProps> = memo(({
     return () => {
       handleSyncWorkflowDraft(true, true)
     }
-  }, [])
+  }, [handleSyncWorkflowDraft])
 
   const { handleRefreshWorkflowDraft } = useWorkflowRefreshDraft()
   const handleSyncWorkflowDraftWhenPageClose = useCallback(() => {
     if (document.visibilityState === 'hidden')
       syncWorkflowDraftWhenPageClose()
+
     else if (document.visibilityState === 'visible')
       setTimeout(() => handleRefreshWorkflowDraft(), 500)
-  }, [syncWorkflowDraftWhenPageClose, handleRefreshWorkflowDraft])
+  }, [syncWorkflowDraftWhenPageClose, handleRefreshWorkflowDraft, workflowStore])
+
+  // Also add beforeunload handler as additional safety net for tab close
+  const handleBeforeUnload = useCallback(() => {
+    syncWorkflowDraftWhenPageClose()
+  }, [syncWorkflowDraftWhenPageClose])
 
   useEffect(() => {
     document.addEventListener('visibilitychange', handleSyncWorkflowDraftWhenPageClose)
+    window.addEventListener('beforeunload', handleBeforeUnload)
 
     return () => {
       document.removeEventListener('visibilitychange', handleSyncWorkflowDraftWhenPageClose)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
     }
-  }, [handleSyncWorkflowDraftWhenPageClose])
+  }, [handleSyncWorkflowDraftWhenPageClose, handleBeforeUnload])
 
   useEventListener('keydown', (e) => {
     if ((e.key === 'd' || e.key === 'D') && (e.ctrlKey || e.metaKey))
@@ -419,7 +427,7 @@ export const Workflow: FC<WorkflowProps> = memo(({
         onPaneContextMenu={handlePaneContextMenu}
         onSelectionContextMenu={handleSelectionContextMenu}
         connectionLineComponent={CustomConnectionLine}
-        // TODO: For LOOP node, how to distinguish between ITERATION and LOOP here? Maybe both are the same?
+        // NOTE: For LOOP node, how to distinguish between ITERATION and LOOP here? Maybe both are the same?
         connectionLineContainerStyle={{ zIndex: ITERATION_CHILDREN_Z_INDEX }}
         defaultViewport={viewport}
         multiSelectionKeyCode={null}

--- a/web/app/components/workflow/store/workflow/workflow-draft-slice.ts
+++ b/web/app/components/workflow/store/workflow/workflow-draft-slice.ts
@@ -7,6 +7,12 @@ import type {
   Node,
 } from '@/app/components/workflow/types'
 
+type DebouncedFunc = {
+  (fn: () => void): void
+  cancel?: () => void
+  flush?: () => void
+}
+
 export type WorkflowDraftSliceShape = {
   backupDraft?: {
     nodes: Node[]
@@ -16,7 +22,7 @@ export type WorkflowDraftSliceShape = {
     environmentVariables: EnvironmentVariable[]
   }
   setBackupDraft: (backupDraft?: WorkflowDraftSliceShape['backupDraft']) => void
-  debouncedSyncWorkflowDraft: (fn: () => void) => void
+  debouncedSyncWorkflowDraft: DebouncedFunc
   syncWorkflowDraftHash: string
   setSyncWorkflowDraftHash: (hash: string) => void
   isSyncingWorkflowDraft: boolean
@@ -25,20 +31,31 @@ export type WorkflowDraftSliceShape = {
   setIsWorkflowDataLoaded: (loaded: boolean) => void
   nodes: Node[]
   setNodes: (nodes: Node[]) => void
+  flushPendingSync: () => void
 }
 
-export const createWorkflowDraftSlice: StateCreator<WorkflowDraftSliceShape> = set => ({
-  backupDraft: undefined,
-  setBackupDraft: backupDraft => set(() => ({ backupDraft })),
-  debouncedSyncWorkflowDraft: debounce((syncWorkflowDraft) => {
+export const createWorkflowDraftSlice: StateCreator<WorkflowDraftSliceShape> = (set) => {
+  // Create the debounced function and store it with access to cancel/flush methods
+  const debouncedFn = debounce((syncWorkflowDraft) => {
     syncWorkflowDraft()
-  }, 5000),
-  syncWorkflowDraftHash: '',
-  setSyncWorkflowDraftHash: syncWorkflowDraftHash => set(() => ({ syncWorkflowDraftHash })),
-  isSyncingWorkflowDraft: false,
-  setIsSyncingWorkflowDraft: isSyncingWorkflowDraft => set(() => ({ isSyncingWorkflowDraft })),
-  isWorkflowDataLoaded: false,
-  setIsWorkflowDataLoaded: loaded => set(() => ({ isWorkflowDataLoaded: loaded })),
-  nodes: [],
-  setNodes: nodes => set(() => ({ nodes })),
-})
+  }, 5000)
+
+  return {
+    backupDraft: undefined,
+    setBackupDraft: backupDraft => set(() => ({ backupDraft })),
+    debouncedSyncWorkflowDraft: debouncedFn,
+    syncWorkflowDraftHash: '',
+    setSyncWorkflowDraftHash: syncWorkflowDraftHash => set(() => ({ syncWorkflowDraftHash })),
+    isSyncingWorkflowDraft: false,
+    setIsSyncingWorkflowDraft: isSyncingWorkflowDraft => set(() => ({ isSyncingWorkflowDraft })),
+    isWorkflowDataLoaded: false,
+    setIsWorkflowDataLoaded: loaded => set(() => ({ isWorkflowDataLoaded: loaded })),
+    nodes: [],
+    setNodes: nodes => set(() => ({ nodes })),
+    flushPendingSync: () => {
+      // Flush any pending debounced sync operations
+      if (debouncedFn.flush)
+        debouncedFn.flush()
+    },
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #29411
allow user close the tab to sync the draft


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

when close the tab, check the dify api server log, call the draft api

<img width="2024" height="190" alt="image" src="https://github.com/user-attachments/assets/ed1175be-a02e-4ecd-b667-f027361d02ed" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
