### PR TITLE
fix: handle list content type in Parameter Extraction node

### DIFF
--- a/api/core/workflow/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/api/core/workflow/nodes/parameter_extractor/parameter_extractor_node.py
@@ -281,7 +281,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
 
         # handle invoke result
 
-        text = invoke_result.message.content or ""
+        text = invoke_result.message.get_text_content()
         if not isinstance(text, str):
             raise InvalidTextContentTypeError(f"Invalid text content type: {type(text)}. Expected str.")
 


### PR DESCRIPTION
## Summary

Fix Parameter Extraction node failing with "Invalid text content type: <class 'list'>. Expected str." error when using certain models like Gemini 2.5 Pro.

### Problem

The `PromptMessage.content` field can be either `str`, `list[PromptMessageContentUnionTypes]`, or `None`. When models return responses in multi-modal content format, the content is a list instead of a string, causing the node to fail.

### Solution

Use the existing `get_text_content()` method which properly handles both string and list content types, extracting text content regardless of the response format.

Closes #30069

## Test Plan

- [ ] Create a workflow with a Parameter Extraction node using Gemini 2.5 Pro
- [ ] Configure input variable and Array[String] parameter to extract
- [ ] Run the workflow and verify successful parameter extraction
