### PR TITLE
fix: allow None values in VariableMessage validation

### DIFF
--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -153,11 +153,11 @@ class ToolInvokeMessage(BaseModel):
         @classmethod
         def transform_variable_value(cls, values):
             """
-            Only basic types and lists are allowed.
+            Only basic types, lists, and None are allowed.
             """
             value = values.get("variable_value")
-            if not isinstance(value, dict | list | str | int | float | bool):
-                raise ValueError("Only basic types and lists are allowed.")
+            if value is not None and not isinstance(value, dict | list | str | int | float | bool):
+                raise ValueError("Only basic types, lists, and None are allowed.")
 
             # if stream is true, the value must be a string
             if values.get("stream"):


### PR DESCRIPTION
## Summary

Fix workflow-as-tool invocation failing when output variables contain `null` values.

### Problem

When calling a workflow as a tool, if any output variable has a `null` value, the tool invocation fails with:
```
1 validation error for VariableMessage
Value error, Only basic types and lists are allowed.
```

### Root Cause

In `api/core/tools/entities/tool_entities.py`, the `VariableMessage.transform_variable_value` validator only allows `dict | list | str | int | float | bool` types, but does not allow `None`.

When a workflow End node outputs contain `null` values (e.g., `{"result": "data", "optional_field": null}`), the `WorkflowTool._invoke()` method passes these `None` values to `create_variable_message()`, which fails the validation.

### Solution

Update the validation to allow `None` values by checking `if value is not None` before the isinstance check.

Related to #30069

## Test Plan

- [ ] Create a workflow with multiple output variables where some may be null
- [ ] Call the workflow as a tool from another workflow or agent
- [ ] Verify that null output values no longer cause validation errors