### PR TITLE
fix(web): correct deleted tools matching to use provider_id instead of id

### DIFF
--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -679,7 +679,7 @@ const Configuration: FC = () => {
               const toolInCollectionList = collectionList.find(c => tool.provider_id === c.id)
               return {
                 ...tool,
-                isDeleted: res.deleted_tools?.some((deletedTool: any) => deletedTool.id === tool.id && deletedTool.tool_name === tool.tool_name) ?? false,
+                isDeleted: res.deleted_tools?.some((deletedTool: any) => deletedTool.provider_id === tool.provider_id && deletedTool.tool_name === tool.tool_name) ?? false,
                 notAuthor: toolInCollectionList?.is_team_authorization === false,
                 ...(tool.provider_type === 'builtin'
                   ? {


### PR DESCRIPTION
## Summary
- Fixed the deleted tools matching logic in agent configuration
- Changed `deletedTool.id === tool.id` to `deletedTool.provider_id === tool.provider_id`
- Backend `deleted_tools` response contains `provider_id`, not `id`, causing matching to fail

## Root Cause
The backend API returns `deleted_tools` with fields: `type`, `tool_name`, `provider_id` (see `api/fields/app_fields.py:171-175`). The frontend was incorrectly trying to match using `deletedTool.id` which doesn't exist.

## Test plan
- [x] Verified agent-tools unit tests pass
- [x] Fix matches backend field structure

fixes #30048