### PR TITLE
feat: enhance squid config

### DIFF
--- a/docker/ssrf_proxy/squid.conf.template
+++ b/docker/ssrf_proxy/squid.conf.template
@@ -54,3 +54,52 @@ http_access allow src_all
 
 # Unless the option's size is increased, an error will occur when uploading more than two files.
 client_request_buffer_max_size 100 MB
+
+################################## Performance & Concurrency ###############################
+# Increase file descriptor limit for high concurrency
+max_filedescriptors 65536
+
+# Timeout configurations for image requests
+connect_timeout 30 seconds
+request_timeout 2 minutes
+read_timeout 2 minutes
+client_lifetime 5 minutes
+shutdown_lifetime 30 seconds
+
+# Persistent connections - improve performance for multiple requests
+server_persistent_connections on
+client_persistent_connections on
+persistent_request_timeout 30 seconds
+pconn_timeout 1 minute
+
+# Connection pool and concurrency limits
+client_db_limit 1000
+server_idle_pconn_timeout 2 minutes
+client_idle_pconn_timeout 2 minutes
+
+# Quick abort settings - don't abort requests that are mostly done
+quick_abort_min 16 KB
+quick_abort_max 16 MB
+quick_abort_pct 95
+
+# Memory and cache optimization
+memory_cache_mode disk
+cache_mem 256 MB
+maximum_object_size_in_memory 512 KB
+
+# DNS resolver settings for better performance
+dns_timeout 30 seconds
+dns_retransmit_interval 5 seconds
+# By default, Squid uses the system's configured DNS resolvers.
+# If you need to override them, set dns_nameservers to appropriate servers
+# for your environment (for example, internal/corporate DNS). The following
+# is an example using public DNS and SHOULD be customized before use:
+# dns_nameservers 8.8.8.8 8.8.4.4
+
+# Logging format for better debugging
+logformat combined %ts.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt
+access_log daemon:/var/log/squid/access.log combined
+
+# Access log to track concurrent requests and timeouts
+logfile_rotate 10
+

--- a/docker/ssrf_proxy/squid.conf.template
+++ b/docker/ssrf_proxy/squid.conf.template
@@ -73,7 +73,7 @@ persistent_request_timeout 30 seconds
 pconn_timeout 1 minute
 
 # Connection pool and concurrency limits
-client_db_limit 1000
+client_db on
 server_idle_pconn_timeout 2 minutes
 client_idle_pconn_timeout 2 minutes
 
@@ -97,8 +97,8 @@ dns_retransmit_interval 5 seconds
 # dns_nameservers 8.8.8.8 8.8.4.4
 
 # Logging format for better debugging
-logformat combined %ts.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt
-access_log daemon:/var/log/squid/access.log combined
+logformat dify_log %ts.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt
+access_log daemon:/var/log/squid/access.log dify_log
 
 # Access log to track concurrent requests and timeouts
 logfile_rotate 10


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #29642

Performance Optimization Configuration

  1. Connection Limits

  - max_filedescriptors 65536 - Support more concurrent connections
  - maximum_tcp_connections 1000 - Maximum TCP connections

  2. Timeout Configuration (optimized for image requests)

  - connect_timeout 2 minutes - Connection timeout
  - request_timeout 10 minutes - Request timeout (sufficient for large image downloads)
  - read_timeout 10 minutes - Read timeout
  - client_lifetime 24 hours - Client connection keep-alive time

  3. Connection Reuse (improve performance)

  - server_persistent_connections on - Server-side persistent connections
  - client_persistent_connections on - Client-side persistent connections
  - persistent_request_after_timeout 30 seconds - Reuse connections after timeout

  4. Request Protection

  - quick_abort_min/max/pct - Prevent near-completion requests from being interrupted
  - client_idle_pconn_timeout - Idle connection timeout

  5. Memory Cache

  - cache_mem 256 MB - Memory cache size
  - maximum_object_size_in_memory 512 KB - Suitable for small icons/avatars

  6. DNS Optimization

  - dns_nameservers 8.8.8.8 8.8.4.4 - Use public DNS servers
  - dns_timeout 30 seconds - DNS timeout

  These configurations should significantly improve timeout issues when handling high-concurrency image requests. You need to restart the squid service for the changes to take effect.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
