### PR TITLE
feat: support parent_message_id in service API chat messages

### DIFF
--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import services
+from constants import UUID_NIL
 from controllers.common.schema import register_schema_models
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import (
@@ -87,7 +88,7 @@ def _validate_parent_message_request(
     conversation_id: str | None,
     parent_message_id: str | None,
 ) -> None:
-    if not parent_message_id:
+    if not parent_message_id or parent_message_id == UUID_NIL:
         return
 
     if not conversation_id:

--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import contexts
 from configs import dify_config
-from constants import UUID_NIL
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
 from core.app.apps.advanced_chat.app_config_manager import AdvancedChatAppConfigManager
 from core.app.apps.advanced_chat.app_runner import AdvancedChatAppRunner
@@ -168,7 +167,7 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
             ),
             query=query,
             files=list(file_objs),
-            parent_message_id=args.get("parent_message_id") if invoke_from != InvokeFrom.SERVICE_API else UUID_NIL,
+            parent_message_id=self._resolve_parent_message_id(args, invoke_from),
             user_id=user.id,
             stream=streaming,
             invoke_from=invoke_from,

--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -126,6 +126,14 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
                 app_model=app_model, conversation_id=conversation_id, user=user
             )
 
+        self._validate_parent_message_for_service_api(
+            app_model=app_model,
+            user=user,
+            conversation=conversation,
+            parent_message_id=args.get("parent_message_id"),
+            invoke_from=invoke_from,
+        )
+
         # parse files
         # TODO(QuantumGhost): Move file parsing logic to the API controller layer
         # for better separation of concerns.

--- a/api/core/app/apps/agent_chat/app_generator.py
+++ b/api/core/app/apps/agent_chat/app_generator.py
@@ -9,7 +9,6 @@ from flask import Flask, current_app
 from pydantic import ValidationError
 
 from configs import dify_config
-from constants import UUID_NIL
 from core.app.app_config.easy_ui_based_app.model_config.converter import ModelConfigConverter
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
 from core.app.apps.agent_chat.app_config_manager import AgentChatAppConfigManager
@@ -163,7 +162,7 @@ class AgentChatAppGenerator(MessageBasedAppGenerator):
             ),
             query=query,
             files=list(file_objs),
-            parent_message_id=args.get("parent_message_id") if invoke_from != InvokeFrom.SERVICE_API else UUID_NIL,
+            parent_message_id=self._resolve_parent_message_id(args, invoke_from),
             user_id=user.id,
             stream=streaming,
             invoke_from=invoke_from,

--- a/api/core/app/apps/agent_chat/app_generator.py
+++ b/api/core/app/apps/agent_chat/app_generator.py
@@ -104,6 +104,14 @@ class AgentChatAppGenerator(MessageBasedAppGenerator):
             conversation = ConversationService.get_conversation(
                 app_model=app_model, conversation_id=conversation_id, user=user
             )
+
+        self._validate_parent_message_for_service_api(
+            app_model=app_model,
+            user=user,
+            conversation=conversation,
+            parent_message_id=args.get("parent_message_id"),
+            invoke_from=invoke_from,
+        )
         # get app model config
         app_model_config = self._get_app_model_config(app_model=app_model, conversation=conversation)
 

--- a/api/core/app/apps/chat/app_generator.py
+++ b/api/core/app/apps/chat/app_generator.py
@@ -96,6 +96,14 @@ class ChatAppGenerator(MessageBasedAppGenerator):
             conversation = ConversationService.get_conversation(
                 app_model=app_model, conversation_id=conversation_id, user=user
             )
+
+        self._validate_parent_message_for_service_api(
+            app_model=app_model,
+            user=user,
+            conversation=conversation,
+            parent_message_id=args.get("parent_message_id"),
+            invoke_from=invoke_from,
+        )
         # get app model config
         app_model_config = self._get_app_model_config(app_model=app_model, conversation=conversation)
 

--- a/api/core/app/apps/chat/app_generator.py
+++ b/api/core/app/apps/chat/app_generator.py
@@ -8,7 +8,6 @@ from flask import Flask, copy_current_request_context, current_app
 from pydantic import ValidationError
 
 from configs import dify_config
-from constants import UUID_NIL
 from core.app.app_config.easy_ui_based_app.model_config.converter import ModelConfigConverter
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
@@ -156,7 +155,7 @@ class ChatAppGenerator(MessageBasedAppGenerator):
             ),
             query=query,
             files=list(file_objs),
-            parent_message_id=args.get("parent_message_id") if invoke_from != InvokeFrom.SERVICE_API else UUID_NIL,
+            parent_message_id=self._resolve_parent_message_id(args, invoke_from),
             user_id=user.id,
             invoke_from=invoke_from,
             extras=extras,

--- a/api/core/app/apps/message_based_app_generator.py
+++ b/api/core/app/apps/message_based_app_generator.py
@@ -1,11 +1,12 @@
 import json
 import logging
-from collections.abc import Generator
-from typing import Union, cast
+from collections.abc import Generator, Mapping
+from typing import Any, Union, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from constants import UUID_NIL
 from core.app.app_config.entities import EasyUIBasedAppConfig, EasyUIBasedAppModelConfigFrom
 from core.app.apps.base_app_generator import BaseAppGenerator
 from core.app.apps.base_app_queue_manager import AppQueueManager
@@ -83,6 +84,12 @@ class MessageBasedAppGenerator(BaseAppGenerator):
             else:
                 logger.exception("Failed to handle response, conversation_id: %s", conversation.id)
                 raise e
+
+    def _resolve_parent_message_id(self, args: Mapping[str, Any], invoke_from: InvokeFrom) -> str | None:
+        parent_message_id = args.get("parent_message_id")
+        if invoke_from == InvokeFrom.SERVICE_API and not parent_message_id:
+            return UUID_NIL
+        return parent_message_id
 
     def _get_app_model_config(self, app_model: App, conversation: Conversation | None = None) -> AppModelConfig:
         if conversation:

--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -2,9 +2,8 @@ from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 
-from constants import UUID_NIL
 from core.app.app_config.entities import EasyUIBasedAppConfig, WorkflowUIBasedAppConfig
 from core.entities.provider_configuration import ProviderModelBundle
 from core.file import File, FileUploadConfig
@@ -158,19 +157,11 @@ class ConversationAppGenerateEntity(AppGenerateEntity):
     parent_message_id: str | None = Field(
         default=None,
         description=(
-            "Starting from v0.9.0, parent_message_id is used to support message regeneration for internal chat API."
-            "For service API, we need to ensure its forward compatibility, "
-            "so passing in the parent_message_id as request arg is not supported for now. "
-            "It needs to be set to UUID_NIL so that the subsequent processing will treat it as legacy messages."
+            "Starting from v0.9.0, parent_message_id is used to support message regeneration "
+            "and branching in chat APIs."
+            "For service API, when it is omitted, the system treats it as UUID_NIL to preserve legacy linear history."
         ),
     )
-
-    @field_validator("parent_message_id")
-    @classmethod
-    def validate_parent_message_id(cls, v, info: ValidationInfo):
-        if info.data.get("invoke_from") == InvokeFrom.SERVICE_API and v != UUID_NIL:
-            raise ValueError("parent_message_id should be UUID_NIL for service API")
-        return v
 
 
 class ChatAppGenerateEntity(ConversationAppGenerateEntity, EasyUIBasedAppGenerateEntity):

--- a/api/tests/unit_tests/controllers/service_api/app/test_chat_parent_message_validation.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_chat_parent_message_validation.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from werkzeug.exceptions import BadRequest, NotFound
 
+from constants import UUID_NIL
 from controllers.service_api.app.completion import _validate_parent_message_request
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import MessageNotExistsError
@@ -19,6 +20,25 @@ def test_validate_parent_message_skips_when_missing():
     ):
         _validate_parent_message_request(
             app_model=app_model, end_user=end_user, conversation_id=None, parent_message_id=None
+        )
+
+        get_conversation.assert_not_called()
+        get_message.assert_not_called()
+
+
+def test_validate_parent_message_skips_uuid_nil():
+    app_model = object()
+    end_user = object()
+
+    with (
+        patch("controllers.service_api.app.completion.ConversationService.get_conversation") as get_conversation,
+        patch("controllers.service_api.app.completion.MessageService.get_message") as get_message,
+    ):
+        _validate_parent_message_request(
+            app_model=app_model,
+            end_user=end_user,
+            conversation_id=None,
+            parent_message_id=UUID_NIL,
         )
 
         get_conversation.assert_not_called()

--- a/api/tests/unit_tests/controllers/service_api/app/test_chat_parent_message_validation.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_chat_parent_message_validation.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from werkzeug.exceptions import BadRequest, NotFound
+
+from controllers.service_api.app.completion import _validate_parent_message_request
+from services.errors.conversation import ConversationNotExistsError
+from services.errors.message import MessageNotExistsError
+
+
+def test_validate_parent_message_skips_when_missing():
+    app_model = object()
+    end_user = object()
+
+    with (
+        patch("controllers.service_api.app.completion.ConversationService.get_conversation") as get_conversation,
+        patch("controllers.service_api.app.completion.MessageService.get_message") as get_message,
+    ):
+        _validate_parent_message_request(
+            app_model=app_model, end_user=end_user, conversation_id=None, parent_message_id=None
+        )
+
+        get_conversation.assert_not_called()
+        get_message.assert_not_called()
+
+
+def test_validate_parent_message_requires_conversation_id():
+    app_model = object()
+    end_user = object()
+
+    with pytest.raises(BadRequest):
+        _validate_parent_message_request(
+            app_model=app_model, end_user=end_user, conversation_id=None, parent_message_id="parent-id"
+        )
+
+
+def test_validate_parent_message_missing_conversation_raises_not_found():
+    app_model = object()
+    end_user = object()
+
+    with patch(
+        "controllers.service_api.app.completion.ConversationService.get_conversation",
+        side_effect=ConversationNotExistsError(),
+    ):
+        with pytest.raises(NotFound):
+            _validate_parent_message_request(
+                app_model=app_model,
+                end_user=end_user,
+                conversation_id="conversation-id",
+                parent_message_id="parent-id",
+            )
+
+
+def test_validate_parent_message_missing_message_raises_not_found():
+    app_model = object()
+    end_user = object()
+    conversation = SimpleNamespace(id="conversation-id")
+
+    with (
+        patch("controllers.service_api.app.completion.ConversationService.get_conversation", return_value=conversation),
+        patch(
+            "controllers.service_api.app.completion.MessageService.get_message",
+            side_effect=MessageNotExistsError(),
+        ),
+    ):
+        with pytest.raises(NotFound):
+            _validate_parent_message_request(
+                app_model=app_model,
+                end_user=end_user,
+                conversation_id="conversation-id",
+                parent_message_id="parent-id",
+            )
+
+
+def test_validate_parent_message_mismatch_conversation_raises_bad_request():
+    app_model = object()
+    end_user = object()
+    conversation = SimpleNamespace(id="conversation-id")
+    message = SimpleNamespace(conversation_id="different-id")
+
+    with (
+        patch("controllers.service_api.app.completion.ConversationService.get_conversation", return_value=conversation),
+        patch("controllers.service_api.app.completion.MessageService.get_message", return_value=message),
+    ):
+        with pytest.raises(BadRequest):
+            _validate_parent_message_request(
+                app_model=app_model,
+                end_user=end_user,
+                conversation_id="conversation-id",
+                parent_message_id="parent-id",
+            )
+
+
+def test_validate_parent_message_matches_conversation():
+    app_model = object()
+    end_user = object()
+    conversation = SimpleNamespace(id="conversation-id")
+    message = SimpleNamespace(conversation_id="conversation-id")
+
+    with (
+        patch("controllers.service_api.app.completion.ConversationService.get_conversation", return_value=conversation),
+        patch("controllers.service_api.app.completion.MessageService.get_message", return_value=message),
+    ):
+        _validate_parent_message_request(
+            app_model=app_model,
+            end_user=end_user,
+            conversation_id="conversation-id",
+            parent_message_id="parent-id",
+        )

--- a/api/tests/unit_tests/controllers/service_api/app/test_chat_request_payload.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_chat_request_payload.py
@@ -23,3 +23,24 @@ def test_chat_request_payload_validates_uuid():
 def test_chat_request_payload_rejects_invalid_uuid():
     with pytest.raises(ValidationError):
         ChatRequestPayload.model_validate({"inputs": {}, "query": "hello", "conversation_id": "invalid"})
+
+
+def test_chat_request_payload_accepts_blank_parent_message_id():
+    payload = ChatRequestPayload.model_validate({"inputs": {}, "query": "hello", "parent_message_id": ""})
+
+    assert payload.parent_message_id is None
+
+
+def test_chat_request_payload_validates_parent_message_id_uuid():
+    parent_message_id = str(uuid.uuid4())
+
+    payload = ChatRequestPayload.model_validate(
+        {"inputs": {}, "query": "hello", "parent_message_id": parent_message_id}
+    )
+
+    assert payload.parent_message_id == parent_message_id
+
+
+def test_chat_request_payload_rejects_invalid_parent_message_id():
+    with pytest.raises(ValidationError):
+        ChatRequestPayload.model_validate({"inputs": {}, "query": "hello", "parent_message_id": "invalid"})

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_generator_parent_message.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_generator_parent_message.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from constants import UUID_NIL
+from core.app.apps.message_based_app_generator import MessageBasedAppGenerator
+from core.app.entities.app_invoke_entities import InvokeFrom
+from services.errors.conversation import ConversationNotExistsError
+from services.errors.message import MessageNotExistsError
+
+
+def test_validate_parent_message_service_api_skips_missing():
+    generator = MessageBasedAppGenerator()
+
+    with patch("core.app.apps.message_based_app_generator.MessageService.get_message") as get_message:
+        generator._validate_parent_message_for_service_api(
+            app_model=object(),
+            user=object(),
+            conversation=None,
+            parent_message_id=None,
+            invoke_from=InvokeFrom.SERVICE_API,
+        )
+
+        get_message.assert_not_called()
+
+
+def test_validate_parent_message_service_api_skips_uuid_nil():
+    generator = MessageBasedAppGenerator()
+
+    with patch("core.app.apps.message_based_app_generator.MessageService.get_message") as get_message:
+        generator._validate_parent_message_for_service_api(
+            app_model=object(),
+            user=object(),
+            conversation=None,
+            parent_message_id=UUID_NIL,
+            invoke_from=InvokeFrom.SERVICE_API,
+        )
+
+        get_message.assert_not_called()
+
+
+def test_validate_parent_message_service_api_requires_conversation():
+    generator = MessageBasedAppGenerator()
+
+    with pytest.raises(ConversationNotExistsError):
+        generator._validate_parent_message_for_service_api(
+            app_model=object(),
+            user=object(),
+            conversation=None,
+            parent_message_id="parent-id",
+            invoke_from=InvokeFrom.SERVICE_API,
+        )
+
+
+def test_validate_parent_message_service_api_mismatch_conversation():
+    generator = MessageBasedAppGenerator()
+    conversation = SimpleNamespace(id="conversation-id")
+    parent_message = SimpleNamespace(conversation_id="different-id")
+
+    with patch(
+        "core.app.apps.message_based_app_generator.MessageService.get_message",
+        return_value=parent_message,
+    ):
+        with pytest.raises(MessageNotExistsError):
+            generator._validate_parent_message_for_service_api(
+                app_model=object(),
+                user=object(),
+                conversation=conversation,
+                parent_message_id="parent-id",
+                invoke_from=InvokeFrom.SERVICE_API,
+            )
+
+
+def test_validate_parent_message_service_api_matches_conversation():
+    generator = MessageBasedAppGenerator()
+    conversation = SimpleNamespace(id="conversation-id")
+    parent_message = SimpleNamespace(conversation_id="conversation-id")
+
+    with patch(
+        "core.app.apps.message_based_app_generator.MessageService.get_message",
+        return_value=parent_message,
+    ):
+        generator._validate_parent_message_for_service_api(
+            app_model=object(),
+            user=object(),
+            conversation=conversation,
+            parent_message_id="parent-id",
+            invoke_from=InvokeFrom.SERVICE_API,
+        )

--- a/web/app/components/develop/template/template_advanced_chat.en.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.en.mdx
@@ -56,6 +56,9 @@ Chat applications support session persistence, allowing previous chat history to
       <Property name='conversation_id' type='string' key='conversation_id'>
       Conversation ID, to continue the conversation based on previous chat records, it is necessary to pass the previous message's conversation_id.
       </Property>
+      <Property name='parent_message_id' type='string' key='parent_message_id'>
+      Parent message ID to continue from a specific message or regenerate. Requires `conversation_id` and must belong to that conversation.
+      </Property>
       <Property name='files' type='array[object]' key='files'>
           File list, suitable for inputting files combined with text understanding and answering questions, available only when the model supports Vision/Video capability.
           - `type` (string) Supported type:

--- a/web/app/components/develop/template/template_advanced_chat.ja.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.ja.mdx
@@ -56,6 +56,9 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       <Property name='conversation_id' type='string' key='conversation_id'>
       会話ID、以前のチャット記録に基づいて会話を続けるには、以前のメッセージのconversation_idを渡す必要があります。
       </Property>
+      <Property name='parent_message_id' type='string' key='parent_message_id'>
+      特定のメッセージから続けたり再生成するための親メッセージID。`conversation_id` が必須で、その会話に属している必要があります。
+      </Property>
       <Property name='files' type='array[object]' key='files'>
           ファイルリスト、モデルが Vision/Video 機能をサポートしている場合に限り、ファイルをテキスト理解および質問応答に組み合わせて入力するのに適しています。
           - `type` (string) サポートされるタイプ：

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -54,6 +54,9 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       <Property name='conversation_id' type='string' key='conversation_id'>
       （选填）会话 ID，需要基于之前的聊天记录继续对话，必须传之前消息的 conversation_id。
       </Property>
+      <Property name='parent_message_id' type='string' key='parent_message_id'>
+      用于从特定消息继续或重新生成的父消息 ID。需要提供 `conversation_id`，且必须属于该对话。
+      </Property>
       <Property name='files' type='array[object]' key='files'>
           文件列表，适用于传入文件结合文本理解并回答问题，仅当模型支持 Vision/Video 能力时可用。
           - `type` (string) 支持类型：

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -55,6 +55,9 @@ Chat applications support session persistence, allowing previous chat history to
       <Property name='conversation_id' type='string' key='conversation_id'>
       Conversation ID, to continue the conversation based on previous chat records, it is necessary to pass the previous message's conversation_id.
       </Property>
+      <Property name='parent_message_id' type='string' key='parent_message_id'>
+      Parent message ID to continue from a specific message or regenerate. Requires `conversation_id` and must belong to that conversation.
+      </Property>
       <Property name='files' type='array[object]' key='files'>
           File list, suitable for inputting files combined with text understanding and answering questions, available only when the model supports Vision/Video capability.
           - `type` (string) Supported type:

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -55,6 +55,9 @@ import { Row, Col, Properties, Property, Heading, SubProperty, Paragraph } from 
       <Property name='conversation_id' type='string' key='conversation_id'>
       会話ID、以前のチャット記録に基づいて会話を続けるには、前のメッセージのconversation_idを渡す必要があります。
       </Property>
+      <Property name='parent_message_id' type='string' key='parent_message_id'>
+      特定のメッセージから続けたり再生成するための親メッセージID。`conversation_id` が必須で、その会話に属している必要があります。
+      </Property>
       <Property name='files' type='array[object]' key='files'>
           ファイルリスト、モデルが Vision/Video 機能をサポートしている場合に限り、ファイルをテキスト理解および質問応答に組み合わせて入力するのに適しています。
           - `type` (string) サポートされるタイプ：

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -54,6 +54,9 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       <Property name='conversation_id' type='string' key='conversation_id'>
       （选填）会话 ID，需要基于之前的聊天记录继续对话，必须传之前消息的 conversation_id。
       </Property>
+      <Property name='parent_message_id' type='string' key='parent_message_id'>
+      用于从特定消息继续或重新生成的父消息 ID。需要提供 `conversation_id`，且必须属于该对话。
+      </Property>
       <Property name='files' type='array[object]' key='files'>
           文件列表，适用于传入文件结合文本理解并回答问题，仅当模型支持 Vision/Video 能力时可用。
           - `type` (string) 支持类型：


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #30153
- Allow Service API `/chat-messages` to accept optional `parent_message_id` with validation and legacy UUID_NIL defaults.
- Add generator-level validation to prevent cross-conversation/service API bypasses.
- Update API templates and add unit tests.

Tests:
- `make lint`
- `make type-check`
- `uv run --project api --dev dev/pytest/pytest_unit_tests.sh`

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
