### PR TITLE
fix(web): disable cache for trigger dynamic select options

### DIFF
--- a/web/service/use-triggers.ts
+++ b/web/service/use-triggers.ts
@@ -371,6 +371,8 @@ export const useTriggerPluginDynamicOptions = (payload: {
     },
     enabled: enabled && !!payload.plugin_id && !!payload.provider && !!payload.action && !!payload.parameter && !!payload.credential_id,
     retry: 0,
+    staleTime: 0,
+    gcTime: 0,
   })
 }
 


### PR DESCRIPTION
## Summary
- Add `staleTime: 0` and `gcTime: 0` to `useTriggerPluginDynamicOptions` hook to disable caching
- Ensures fresh data is fetched each time the trigger subscription edit modal is opened
- Aligns with existing patterns used in `useAllTriggerPlugins` and `useTriggerProviderInfo` hooks

Closes #30160

## Test plan
- [ ] Open trigger subscription edit modal
- [ ] Verify credentials and proceed to configuration step
- [ ] Close and reopen the modal
- [ ] Verify that dynamic select options are refreshed (not cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)