### PR TITLE
fix: load i18n on server

### DIFF
--- a/web/i18n-config/server.ts
+++ b/web/i18n-config/server.ts
@@ -1,7 +1,6 @@
 import type { Locale } from '.'
-import type { KeyPrefix, Namespace } from './i18next-config'
+import type { Namespace } from './i18next-config'
 import { match } from '@formatjs/intl-localematcher'
-import { camelCase } from 'es-toolkit/compat'
 import { createInstance } from 'i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
 import Negotiator from 'negotiator'
@@ -23,10 +22,11 @@ const initI18next = async (lng: Locale, ns: Namespace) => {
   return i18nInstance
 }
 
-export async function getTranslation(lng: Locale, ns: Namespace) {
+export async function getTranslation(lng: Locale, ns: Namespace, options: Record<string, any> = {}) {
   const i18nextInstance = await initI18next(lng, ns)
   return {
-    t: i18nextInstance.getFixedT(lng, 'translation', camelCase(ns) as KeyPrefix),
+    // @ts-expect-error types mismatch
+    t: i18nextInstance.getFixedT(lng, ns, options.keyPrefix),
     i18n: i18nextInstance,
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes

<img width="3024" height="1898" alt="img_v3_02ta_dfac3c45-6c14-4a43-b661-511f7c094b7g" src="https://github.com/user-attachments/assets/b5c22b56-5d83-4b0e-9520-ab5e71b5382f" />

This revert changes in https://github.com/langgenius/dify/pull/30058/changes#diff-417f39e7a353892a34753f65dfd3e6f97517d540dc45f07efd55c805582c25f5

<img width="1434" height="384" alt="CleanShot 2025-12-25 at 18 55 58@2x" src="https://github.com/user-attachments/assets/ace2b3d0-6f51-40aa-9082-f54329fd0e1a" />

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
