### PR TITLE
refactor: simplify InputNumber implementation

### DIFF
--- a/web/app/components/base/input-number/index.tsx
+++ b/web/app/components/base/input-number/index.tsx
@@ -92,7 +92,7 @@ export const InputNumber: FC<InputNumberProps> = (props) => {
         // disable default controller
         type="number"
         className={cn('no-spinner rounded-r-none', className)}
-        value={value ?? 0}
+        value={`${value ?? 0}`}
         max={max}
         min={min}
         disabled={disabled}

--- a/web/app/components/base/input/index.tsx
+++ b/web/app/components/base/input/index.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority'
-import type { ChangeEventHandler, CSSProperties, FocusEventHandler } from 'react'
+import type { CSSProperties } from 'react'
 import { RiCloseCircleFill, RiErrorWarningLine, RiSearchLine } from '@remixicon/react'
 import { cva } from 'class-variance-authority'
 import { noop } from 'es-toolkit/compat'
@@ -35,8 +35,6 @@ export type InputProps = {
   unit?: string
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> & VariantProps<typeof inputVariants>
 
-const removeLeadingZeros = (value: string) => value.replace(/^(-?)0+(?=\d)/, '$1')
-
 const Input = React.forwardRef<HTMLInputElement, InputProps>(({
   size,
   disabled,
@@ -56,31 +54,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
   ...props
 }, ref) => {
   const { t } = useTranslation()
-  const handleNumberChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    if (value === 0) {
-      // remove leading zeros
-      const formattedValue = removeLeadingZeros(e.target.value)
-      if (e.target.value !== formattedValue)
-        e.target.value = formattedValue
-    }
-    onChange(e)
-  }
-  const handleNumberBlur: FocusEventHandler<HTMLInputElement> = (e) => {
-    // remove leading zeros
-    const formattedValue = removeLeadingZeros(e.target.value)
-    if (e.target.value !== formattedValue) {
-      e.target.value = formattedValue
-      onChange({
-        ...e,
-        type: 'change',
-        target: {
-          ...e.target,
-          value: formattedValue,
-        },
-      })
-    }
-    onBlur(e)
-  }
+
   return (
     <div className={cn('relative w-full', wrapperClassName)}>
       {showLeftIcon && <RiSearchLine className={cn('absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-components-input-text-placeholder')} />}
@@ -104,8 +78,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
           ? (t('common.operation.search') || '')
           : (t('common.placeholder.input') || ''))}
         value={value}
-        onChange={props.type === 'number' ? handleNumberChange : onChange}
-        onBlur={props.type === 'number' ? handleNumberBlur : onBlur}
+        onChange={onChange}
+        onBlur={onBlur}
         disabled={disabled}
         {...props}
       />


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fix #30175 
**Simplify the `InputNumber` implementation by ensuring it passes a string value to `Input`.**

The current InputNumber implementation includes confusing and unsafe logic.
The root cause is that a plain React <input> (default type="text") can’t reliably accept a numeric value. With that in mind, we can simplify the implementation and remove these logic smells.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots
<img width="1611" height="1076" alt="image" src="https://github.com/user-attachments/assets/a25843c2-6afe-43e5-9635-dc96660340a6" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
