### PR TITLE
fix: Add JSON RPC request type guard

### DIFF
--- a/api/core/mcp/client/streamable_client.py
+++ b/api/core/mcp/client/streamable_client.py
@@ -313,17 +313,20 @@ class StreamableHTTPTransport:
             if is_initialization:
                 self._maybe_extract_session_id_from_response(response)
 
-            content_type = cast(str, response.headers.get(CONTENT_TYPE, "").lower())
+            # Per https://modelcontextprotocol.io/specification/2025-06-18/basic#notifications:
+            # The server MUST NOT send a response to notifications.
+            if isinstance(message.root, JSONRPCRequest):
+                content_type = cast(str, response.headers.get(CONTENT_TYPE, "").lower())
 
-            if content_type.startswith(JSON):
-                self._handle_json_response(response, ctx.server_to_client_queue)
-            elif content_type.startswith(SSE):
-                self._handle_sse_response(response, ctx)
-            else:
-                self._handle_unexpected_content_type(
-                    content_type,
-                    ctx.server_to_client_queue,
-                )
+                if content_type.startswith(JSON):
+                    self._handle_json_response(response, ctx.server_to_client_queue, is_initialization)
+                elif content_type.startswith(SSE):
+                    self._handle_sse_response(response, ctx, is_initialization)
+                else:
+                    self._handle_unexpected_content_type(
+                        content_type,
+                        ctx.server_to_client_queue,
+                    )
 
     def _handle_json_response(
         self,

--- a/api/core/mcp/client/streamable_client.py
+++ b/api/core/mcp/client/streamable_client.py
@@ -319,9 +319,9 @@ class StreamableHTTPTransport:
                 content_type = cast(str, response.headers.get(CONTENT_TYPE, "").lower())
 
                 if content_type.startswith(JSON):
-                    self._handle_json_response(response, ctx.server_to_client_queue, is_initialization)
+                    self._handle_json_response(response, ctx.server_to_client_queue)
                 elif content_type.startswith(SSE):
-                    self._handle_sse_response(response, ctx, is_initialization)
+                    self._handle_sse_response(response, ctx)
                 else:
                     self._handle_unexpected_content_type(
                         content_type,


### PR DESCRIPTION
## Summary

FIxes #30215
This PR prevents malformed payloads from being processed and keeps downstream logic stable.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
