### PR TITLE
fix: consolidate duplicate InvokeRateLimitError definitions

### DIFF
--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -14,7 +14,8 @@ from enums.quota_type import QuotaType, unlimited
 from extensions.otel import AppGenerateHandler, trace_span
 from models.model import Account, App, AppMode, EndUser
 from models.workflow import Workflow
-from services.errors.app import InvokeRateLimitError, QuotaExceededError, WorkflowIdFormatError, WorkflowNotFoundError
+from services.errors.app import QuotaExceededError, WorkflowIdFormatError, WorkflowNotFoundError
+from services.errors.llm import InvokeRateLimitError
 from services.workflow_service import WorkflowService
 
 

--- a/api/services/async_workflow_service.py
+++ b/api/services/async_workflow_service.py
@@ -21,7 +21,7 @@ from models.model import App, EndUser
 from models.trigger import WorkflowTriggerLog
 from models.workflow import Workflow
 from repositories.sqlalchemy_workflow_trigger_log_repository import SQLAlchemyWorkflowTriggerLogRepository
-from services.errors.app import InvokeRateLimitError, QuotaExceededError, WorkflowNotFoundError
+from services.errors.app import QuotaExceededError, WorkflowNotFoundError, WorkflowQuotaLimitError
 from services.workflow.entities import AsyncTriggerResponse, TriggerData, WorkflowTaskData
 from services.workflow.queue_dispatcher import QueueDispatcherManager, QueuePriority
 from services.workflow_service import WorkflowService
@@ -141,7 +141,7 @@ class AsyncWorkflowService:
             trigger_log_repo.update(trigger_log)
             session.commit()
 
-            raise InvokeRateLimitError(
+            raise WorkflowQuotaLimitError(
                 f"Workflow execution quota limit reached for tenant {trigger_data.tenant_id}"
             ) from e
 

--- a/api/services/errors/app.py
+++ b/api/services/errors/app.py
@@ -18,8 +18,8 @@ class WorkflowIdFormatError(Exception):
     pass
 
 
-class InvokeRateLimitError(Exception):
-    """Raised when rate limit is exceeded for workflow invocations."""
+class WorkflowQuotaLimitError(Exception):
+    """Raised when workflow execution quota is exceeded (for async/background workflows)."""
 
     pass
 


### PR DESCRIPTION
## Summary

- Remove duplicate `InvokeRateLimitError` from `services/errors/app.py`
- Use `services.errors.llm.InvokeRateLimitError` in `app_generate_service.py` for sync user requests (has `description` attribute for HTTP responses)
- Add `WorkflowQuotaLimitError` in `services/errors/app.py` for async workflow execution (simple Exception for background processing)
- Update `async_workflow_service.py` to use `WorkflowQuotaLimitError`

Closes #30228

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify `make type-check` passes
- [ ] Test rate limit scenario returns HTTP 429 instead of 500