### PR TITLE
fix: Workflow Start node optional enum parameter is treated as required

### DIFF
--- a/web/app/components/app/configuration/config-var/config-modal/index.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/index.tsx
@@ -47,6 +47,12 @@ const getCheckboxDefaultSelectValue = (value: InputVar['default']) => {
 const parseCheckboxSelectValue = (value: string) =>
   value === CHECKBOX_DEFAULT_TRUE_VALUE
 
+const normalizeSelectDefaultValue = (inputVar: InputVar) => {
+  if (inputVar.type === InputVarType.select && inputVar.default === '')
+    return { ...inputVar, default: undefined }
+  return inputVar
+}
+
 export type IConfigModalProps = {
   isCreate?: boolean
   payload?: InputVar
@@ -67,7 +73,7 @@ const ConfigModal: FC<IConfigModalProps> = ({
 }) => {
   const { modelConfig } = useContext(ConfigContext)
   const { t } = useTranslation()
-  const [tempPayload, setTempPayload] = useState<InputVar>(() => payload || getNewVarInWorkflow('') as any)
+  const [tempPayload, setTempPayload] = useState<InputVar>(() => normalizeSelectDefaultValue(payload || getNewVarInWorkflow('') as any))
   const { type, label, variable, options, max_length } = tempPayload
   const modalRef = useRef<HTMLDivElement>(null)
   const appDetail = useAppStore(state => state.appDetail)
@@ -182,6 +188,8 @@ const ConfigModal: FC<IConfigModalProps> = ({
 
     const newPayload = produce(tempPayload, (draft) => {
       draft.type = type
+      if (type === InputVarType.select)
+        draft.default = undefined
       if ([InputVarType.singleFile, InputVarType.multiFiles].includes(type)) {
         (Object.keys(DEFAULT_FILE_UPLOAD_SETTING)).forEach((key) => {
           if (key !== 'max_length')


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fix https://github.com/langgenius/dify/issues/30283

The issue is in the code [here](https://github.com/langgenius/dify/blob/1e86535c4a2e7ca26d49f07b072143eb0458b9ba/api/core/app/apps/base_app_generator.py#L98).
The validation logic currently mishandles `None` values for variables. Specifically, when a variable's value is `None`, the line `value = variable_entity.default` overwrites it with the default value (an empty string for select fields). This empty string then proceeds to be incorrectly checked against the field's defined options.

This bug could be resolved by modifications in either the frontend or the backend. I suggest a frontend fix as a potentially better approach.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
