### PR TITLE
fix(web): rollback React Scan dynamic import

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Viewport } from 'next'
 import { ThemeProvider } from 'next-themes'
-import dynamic from 'next/dynamic'
 import { Instrument_Serif } from 'next/font/google'
-import { IS_DEV } from '@/config'
 import GlobalPublicStoreProvider from '@/context/global-public-context'
 import { TanstackQueryInitializer } from '@/context/query-client'
 import { getLocaleOnServer } from '@/i18n-config/server'
@@ -10,14 +8,11 @@ import { DatasetAttr } from '@/types/feature'
 import { cn } from '@/utils/classnames'
 import BrowserInitializer from './components/browser-initializer'
 import I18nServer from './components/i18n-server'
+import { ReactScan } from './components/react-scan'
 import SentryInitializer from './components/sentry-initializer'
 import RoutePrefixHandle from './routePrefixHandle'
 import './styles/globals.css'
 import './styles/markdown.scss'
-
-const ReactScan = IS_DEV
-  ? dynamic(() => import('./components/react-scan').then(m => m.ReactScan), { ssr: false })
-  : () => null
 
 export const viewport: Viewport = {
   width: 'device-width',


### PR DESCRIPTION
## Summary
- Roll back the React Scan dynamic import added in #30279.

## Background
#30279 moved React Scan to `next/dynamic` with `ssr: false` inside `web/app/layout.tsx`, which is a Server Component. Next.js rejects `ssr: false` in Server Components, so the build fails.

## Fix
- Restore the static `ReactScan` import in `web/app/layout.tsx`.
- Remove the server-side `next/dynamic`/`IS_DEV` gate (React Scan still guards itself at runtime).

## Testing
- `cd web && pnpm lint-staged`
- `cd web && pnpm type-check:tsgo`
