### PR TITLE
fix: fix markdown escape issue

### DIFF
--- a/web/app/components/base/chat/chat/answer/basic-content.tsx
+++ b/web/app/components/base/chat/chat/answer/basic-content.tsx
@@ -18,12 +18,19 @@ const BasicContent: FC<BasicContentProps> = ({
   if (annotation?.logAnnotation)
     return <Markdown content={annotation?.logAnnotation.content || ''} />
 
+  // Preserve Windows UNC paths and similar backslash-heavy strings by
+  // wrapping them in inline code so Markdown renders backslashes verbatim.
+  let displayContent = content
+  if (typeof content === 'string' && /^\\\\\S.*/.test(content) && !/^`.*`$/.test(content)) {
+    displayContent = `\`${content}\``
+  }
+
   return (
     <Markdown
       className={cn(
         item.isError && '!text-[#F04438]',
       )}
-      content={content}
+      content={displayContent}
     />
   )
 }

--- a/web/app/components/base/chat/chat/answer/index.tsx
+++ b/web/app/components/base/chat/chat/answer/index.tsx
@@ -111,7 +111,7 @@ const Answer: FC<AnswerProps> = ({
     }
   }, [switchSibling, item.prevSibling, item.nextSibling])
 
-  const contentIsEmpty = content.trim() === ''
+  const contentIsEmpty = typeof content === 'string' && content.trim() === ''
 
   return (
     <div className="mb-2 flex last:mb-0">


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #30298 

because \\ in markdown \ mean escape, so it render with only one \



## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

before


https://github.com/user-attachments/assets/7abf591f-f368-4ea9-9589-58572b83dc5e



after


https://github.com/user-attachments/assets/dc01df19-a5d1-4123-baa3-4e0c990cdd11



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
