### PR TITLE
fix(i18n): load server namespaces by kebab-case

### DIFF
--- a/web/i18n-config/server.ts
+++ b/web/i18n-config/server.ts
@@ -2,7 +2,7 @@ import type { i18n as I18nInstance } from 'i18next'
 import type { Locale } from '.'
 import type { NamespaceCamelCase, NamespaceKebabCase } from './i18next-config'
 import { match } from '@formatjs/intl-localematcher'
-import { camelCase } from 'es-toolkit/compat'
+import { camelCase, kebabCase } from 'es-toolkit/compat'
 import { createInstance } from 'i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
 import Negotiator from 'negotiator'
@@ -22,8 +22,9 @@ const getOrCreateI18next = async (lng: Locale) => {
   instance = createInstance()
   await instance
     .use(initReactI18next)
-    .use(resourcesToBackend((language: Locale, namespace: NamespaceKebabCase) => {
-      return import(`../i18n/${language}/${namespace}.json`)
+    .use(resourcesToBackend((language: Locale, namespace: NamespaceCamelCase | NamespaceKebabCase) => {
+      const fileNamespace = kebabCase(namespace) as NamespaceKebabCase
+      return import(`../i18n/${language}/${fileNamespace}.json`)
     }))
     .init({
       lng,


### PR DESCRIPTION
## Summary
- Load server i18n JSON files by kebab-case filenames while keeping camelCase namespaces internally.

## Context
After PR #30336, `getTranslation` camelCases namespaces before calling `loadNamespaces`. The server backend then builds import paths like `../i18n/${language}/${namespace}.json`, which becomes `datasetSettings.json` for `dataset-settings`. That file doesn't exist, so server translations for dashed namespaces fail.

## Repro
1. Ensure the locale cookie is set (e.g., `zh-Hans`).
2. Open `/datasets/<id>/settings` (uses `dataset-settings`).
3. Server tries to load `datasetSettings.json` and misses; translations fall back to keys.

## Fix
- Convert the backend `namespace` to kebab-case before building the import path.
