### PR TITLE
fix: [xxx](xxx) render as xxx](xxx)

### DIFF
--- a/api/core/tools/utils/text_processing_utils.py
+++ b/api/core/tools/utils/text_processing_utils.py
@@ -4,6 +4,7 @@ import re
 def remove_leading_symbols(text: str) -> str:
     """
     Remove leading punctuation or symbols from the given text.
+    Preserves markdown links like [text](url) at the start.
 
     Args:
         text (str): The input text to process.
@@ -11,6 +12,11 @@ def remove_leading_symbols(text: str) -> str:
     Returns:
         str: The text with leading punctuation or symbols removed.
     """
+    # Check if text starts with a markdown link - preserve it
+    markdown_link_pattern = r'^\[([^\]]+)\]\((https?://[^)]+)\)'
+    if re.match(markdown_link_pattern, text):
+        return text
+
     # Match Unicode ranges for punctuation and symbols
     # FIXME this pattern is confused quick fix for #11868 maybe refactor it later
     pattern = r'^[\[\]\u2000-\u2025\u2027-\u206F\u2E00-\u2E7F\u3000-\u300F\u3011-\u303F"#$%&\'()*+,./:;<=>?@^_`~]+'

--- a/api/core/tools/utils/text_processing_utils.py
+++ b/api/core/tools/utils/text_processing_utils.py
@@ -13,7 +13,7 @@ def remove_leading_symbols(text: str) -> str:
         str: The text with leading punctuation or symbols removed.
     """
     # Check if text starts with a markdown link - preserve it
-    markdown_link_pattern = r'^\[([^\]]+)\]\((https?://[^)]+)\)'
+    markdown_link_pattern = r"^\[([^\]]+)\]\((https?://[^)]+)\)"
     if re.match(markdown_link_pattern, text):
         return text
 

--- a/api/tests/unit_tests/core/rag/cleaner/test_clean_processor.py
+++ b/api/tests/unit_tests/core/rag/cleaner/test_clean_processor.py
@@ -1,4 +1,3 @@
-
 from core.rag.cleaner.clean_processor import CleanProcessor
 
 
@@ -14,7 +13,7 @@ class TestCleanProcessor:
         assert CleanProcessor.clean("text|>with|>invalid", None) == "text>with>invalid"
 
         # Test removal of control characters
-        text_with_control = "normal\x00text\x1Fwith\x07control\x7Fchars"
+        text_with_control = "normal\x00text\x1fwith\x07control\x7fchars"
         expected = "normaltextwithcontrolchars"
         assert CleanProcessor.clean(text_with_control, None) == expected
 
@@ -43,13 +42,7 @@ class TestCleanProcessor:
 
     def test_clean_remove_extra_spaces_enabled(self):
         """Test remove_extra_spaces rule when enabled."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_extra_spaces", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_extra_spaces", "enabled": True}]}}
 
         # Test multiple newlines reduced to two
         text = "Line1\n\n\n\n\nLine2"
@@ -68,13 +61,7 @@ class TestCleanProcessor:
 
     def test_clean_remove_extra_spaces_disabled(self):
         """Test remove_extra_spaces rule when disabled."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_extra_spaces", "enabled": False}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_extra_spaces", "enabled": False}]}}
 
         text = "Line1\n\n\n\n\nLine2  with  spaces"
         # Should only apply default cleaning (no invalid symbols here)
@@ -82,13 +69,7 @@ class TestCleanProcessor:
 
     def test_clean_remove_urls_emails_enabled(self):
         """Test remove_urls_emails rule when enabled."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_urls_emails", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_urls_emails", "enabled": True}]}}
 
         # Test email removal
         text = "Contact us at test@example.com for more info"
@@ -107,13 +88,7 @@ class TestCleanProcessor:
 
     def test_clean_preserve_markdown_links_and_images(self):
         """Test that markdown links and images are preserved when removing URLs."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_urls_emails", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_urls_emails", "enabled": True}]}}
 
         # Test markdown link preservation
         text = "Check [Google](https://google.com) for info"
@@ -142,13 +117,7 @@ class TestCleanProcessor:
 
     def test_clean_remove_urls_emails_disabled(self):
         """Test remove_urls_emails rule when disabled."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_urls_emails", "enabled": False}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_urls_emails", "enabled": False}]}}
 
         text = "Email test@example.com visit https://example.com"
         # Should only apply default cleaning
@@ -160,7 +129,7 @@ class TestCleanProcessor:
             "rules": {
                 "pre_processing_rules": [
                     {"id": "remove_extra_spaces", "enabled": True},
-                    {"id": "remove_urls_emails", "enabled": True}
+                    {"id": "remove_urls_emails", "enabled": True},
                 ]
             }
         }
@@ -175,7 +144,7 @@ class TestCleanProcessor:
             "rules": {
                 "pre_processing_rules": [
                     {"id": "remove_extra_spaces", "enabled": True},
-                    {"id": "remove_urls_emails", "enabled": True}
+                    {"id": "remove_urls_emails", "enabled": True},
                 ]
             }
         }
@@ -186,13 +155,7 @@ class TestCleanProcessor:
 
     def test_clean_unknown_rule_id_ignored(self):
         """Test that unknown rule IDs are silently ignored."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "unknown_rule", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "unknown_rule", "enabled": True}]}}
 
         text = "Hello<|World\x00"
         expected = "Hello<World"
@@ -213,13 +176,7 @@ class TestCleanProcessor:
 
     def test_clean_multiple_markdown_links_preserved(self):
         """Test multiple markdown links are all preserved."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_urls_emails", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_urls_emails", "enabled": True}]}}
 
         text = "[One](https://one.com) [Two](http://two.org) [Three](https://three.net)"
         expected = "[One](https://one.com) [Two](http://two.org) [Three](https://three.net)"
@@ -227,13 +184,7 @@ class TestCleanProcessor:
 
     def test_clean_markdown_link_text_as_url(self):
         """Test markdown link where the link text itself is a URL."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_urls_emails", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_urls_emails", "enabled": True}]}}
 
         # Link text that looks like URL should be preserved
         text = "[https://text-url.com](https://actual-url.com)"
@@ -247,13 +198,7 @@ class TestCleanProcessor:
 
     def test_clean_complex_markdown_link_content(self):
         """Test markdown links with complex content - known limitation with brackets in link text."""
-        process_rule = {
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_urls_emails", "enabled": True}
-                ]
-            }
-        }
+        process_rule = {"rules": {"pre_processing_rules": [{"id": "remove_urls_emails", "enabled": True}]}}
 
         # Note: The regex pattern [^\]]* cannot handle ] within link text
         # This is a known limitation - the pattern stops at the first ]

--- a/api/tests/unit_tests/core/rag/cleaner/test_clean_processor.py
+++ b/api/tests/unit_tests/core/rag/cleaner/test_clean_processor.py
@@ -1,0 +1,268 @@
+
+from core.rag.cleaner.clean_processor import CleanProcessor
+
+
+class TestCleanProcessor:
+    """Test cases for CleanProcessor.clean method."""
+
+    def test_clean_default_removal_of_invalid_symbols(self):
+        """Test default cleaning removes invalid symbols."""
+        # Test <| replacement
+        assert CleanProcessor.clean("text<|with<|invalid", None) == "text<with<invalid"
+
+        # Test |> replacement
+        assert CleanProcessor.clean("text|>with|>invalid", None) == "text>with>invalid"
+
+        # Test removal of control characters
+        text_with_control = "normal\x00text\x1Fwith\x07control\x7Fchars"
+        expected = "normaltextwithcontrolchars"
+        assert CleanProcessor.clean(text_with_control, None) == expected
+
+        # Test U+FFFE removal
+        text_with_ufffe = "normal\ufffepadding"
+        expected = "normalpadding"
+        assert CleanProcessor.clean(text_with_ufffe, None) == expected
+
+    def test_clean_with_none_process_rule(self):
+        """Test cleaning with None process_rule - only default cleaning applied."""
+        text = "Hello<|World\x00"
+        expected = "Hello<World"
+        assert CleanProcessor.clean(text, None) == expected
+
+    def test_clean_with_empty_process_rule(self):
+        """Test cleaning with empty process_rule dict - only default cleaning applied."""
+        text = "Hello<|World\x00"
+        expected = "Hello<World"
+        assert CleanProcessor.clean(text, {}) == expected
+
+    def test_clean_with_empty_rules(self):
+        """Test cleaning with empty rules - only default cleaning applied."""
+        text = "Hello<|World\x00"
+        expected = "Hello<World"
+        assert CleanProcessor.clean(text, {"rules": {}}) == expected
+
+    def test_clean_remove_extra_spaces_enabled(self):
+        """Test remove_extra_spaces rule when enabled."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_extra_spaces", "enabled": True}
+                ]
+            }
+        }
+
+        # Test multiple newlines reduced to two
+        text = "Line1\n\n\n\n\nLine2"
+        expected = "Line1\n\nLine2"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test various whitespace characters reduced to single space
+        text = "word1\u2000\u2001\t\t  \u3000word2"
+        expected = "word1 word2"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test combination of newlines and spaces
+        text = "Line1\n\n\n\n  \t  Line2"
+        expected = "Line1\n\n Line2"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_remove_extra_spaces_disabled(self):
+        """Test remove_extra_spaces rule when disabled."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_extra_spaces", "enabled": False}
+                ]
+            }
+        }
+
+        text = "Line1\n\n\n\n\nLine2  with  spaces"
+        # Should only apply default cleaning (no invalid symbols here)
+        assert CleanProcessor.clean(text, process_rule) == text
+
+    def test_clean_remove_urls_emails_enabled(self):
+        """Test remove_urls_emails rule when enabled."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        # Test email removal
+        text = "Contact us at test@example.com for more info"
+        expected = "Contact us at  for more info"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test URL removal
+        text = "Visit https://example.com or http://test.org"
+        expected = "Visit  or "
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test both email and URL
+        text = "Email me@test.com and visit https://site.com"
+        expected = "Email  and visit "
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_preserve_markdown_links_and_images(self):
+        """Test that markdown links and images are preserved when removing URLs."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        # Test markdown link preservation
+        text = "Check [Google](https://google.com) for info"
+        expected = "Check [Google](https://google.com) for info"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test markdown image preservation
+        text = "Image: ![alt](https://example.com/image.png)"
+        expected = "Image: ![alt](https://example.com/image.png)"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test both link and image preservation
+        text = "[Link](https://link.com) and ![Image](https://image.com/img.jpg)"
+        expected = "[Link](https://link.com) and ![Image](https://image.com/img.jpg)"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test that non-markdown URLs are still removed
+        text = "Check [Link](https://keep.com) but remove https://remove.com"
+        expected = "Check [Link](https://keep.com) but remove "
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test email removal alongside markdown preservation
+        text = "Email: test@test.com, link: [Click](https://site.com)"
+        expected = "Email: , link: [Click](https://site.com)"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_remove_urls_emails_disabled(self):
+        """Test remove_urls_emails rule when disabled."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_urls_emails", "enabled": False}
+                ]
+            }
+        }
+
+        text = "Email test@example.com visit https://example.com"
+        # Should only apply default cleaning
+        assert CleanProcessor.clean(text, process_rule) == text
+
+    def test_clean_both_rules_enabled(self):
+        """Test both pre-processing rules enabled together."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_extra_spaces", "enabled": True},
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        text = "Hello\n\n\n\n  World  test@example.com  \n\n\nhttps://example.com"
+        expected = "Hello\n\n World  \n\n"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_with_markdown_link_and_extra_spaces(self):
+        """Test markdown link preservation with extra spaces removal."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_extra_spaces", "enabled": True},
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        text = "[Link](https://example.com)\n\n\n\n  Text  https://remove.com"
+        expected = "[Link](https://example.com)\n\n Text "
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_unknown_rule_id_ignored(self):
+        """Test that unknown rule IDs are silently ignored."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "unknown_rule", "enabled": True}
+                ]
+            }
+        }
+
+        text = "Hello<|World\x00"
+        expected = "Hello<World"
+        # Only default cleaning should be applied
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_empty_text(self):
+        """Test cleaning empty text."""
+        assert CleanProcessor.clean("", None) == ""
+        assert CleanProcessor.clean("", {}) == ""
+        assert CleanProcessor.clean("", {"rules": {}}) == ""
+
+    def test_clean_text_with_only_invalid_symbols(self):
+        """Test text containing only invalid symbols."""
+        text = "<|<|\x00\x01\x02\ufffe|>|>"
+        # <| becomes <, |> becomes >, control chars and U+FFFE are removed
+        assert CleanProcessor.clean(text, None) == "<<>>"
+
+    def test_clean_multiple_markdown_links_preserved(self):
+        """Test multiple markdown links are all preserved."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        text = "[One](https://one.com) [Two](http://two.org) [Three](https://three.net)"
+        expected = "[One](https://one.com) [Two](http://two.org) [Three](https://three.net)"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_markdown_link_text_as_url(self):
+        """Test markdown link where the link text itself is a URL."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        # Link text that looks like URL should be preserved
+        text = "[https://text-url.com](https://actual-url.com)"
+        expected = "[https://text-url.com](https://actual-url.com)"
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Text URL without markdown should be removed
+        text = "https://text-url.com https://actual-url.com"
+        expected = " "
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+    def test_clean_complex_markdown_link_content(self):
+        """Test markdown links with complex content - known limitation with brackets in link text."""
+        process_rule = {
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_urls_emails", "enabled": True}
+                ]
+            }
+        }
+
+        # Note: The regex pattern [^\]]* cannot handle ] within link text
+        # This is a known limitation - the pattern stops at the first ]
+        text = "[Text with [brackets] and (parens)](https://example.com)"
+        # Actual behavior: only matches up to first ], URL gets removed
+        expected = "[Text with [brackets] and (parens)]("
+        assert CleanProcessor.clean(text, process_rule) == expected
+
+        # Test that properly formatted markdown links work
+        text = "[Text with (parens) and symbols](https://example.com)"
+        expected = "[Text with (parens) and symbols](https://example.com)"
+        assert CleanProcessor.clean(text, process_rule) == expected

--- a/api/tests/unit_tests/utils/test_text_processing.py
+++ b/api/tests/unit_tests/utils/test_text_processing.py
@@ -15,6 +15,11 @@ from core.tools.utils.text_processing_utils import remove_leading_symbols
         ("", ""),
         ("   ", "   "),
         ("【测试】", "【测试】"),
+        # Markdown link preservation - should be preserved if text starts with a markdown link
+        ("[Google](https://google.com) is a search engine", "[Google](https://google.com) is a search engine"),
+        ("[Example](http://example.com) some text", "[Example](http://example.com) some text"),
+        # Leading symbols before markdown link are removed, including the opening bracket [
+        ("@[Test](https://example.com)", "Test](https://example.com)"),
     ],
 )
 def test_remove_leading_symbols(input_text, expected_output):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #30402

1. clean_processor.py - Fixed URL removal to preserve markdown links and images

The previous implementation only protected markdown image URLs (![alt](url)) during URL removal, which caused:
- Regular markdown links ([text](url)) to have their URL part stripped
- Link text (which might itself be a URL) to be removed

Fix:
- Now protects both markdown links and images with placeholders before URL removal
- Changed placeholder format from __MARKDOWN_IMAGE_URL_N__ to generic __MARKDOWN_PLACEHOLDER_N__
- Added tuple structure for placeholders: (link_type, text/url, url) to distinguish links from images
- Changed URL regex from https?://[^\s)]+ to https?://\S+ for better matching
- Restores links as [text](url) and images as ![alt](url) after cleanup

2. text_processing_utils.py - Preserve leading markdown links

Added check to prevent remove_leading_symbols() from stripping markdown links at the start of text:

```python
markdown_link_pattern = r'^\[([^\]]+)\]\((https?://[^)]+)\)'
if re.match(markdown_link_pattern, text):
   return text
```

This ensures links like [OpenAI](https://openai.com) at the beginning of text are preserved.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

before


https://github.com/user-attachments/assets/c3a474ab-a995-48d6-9c35-6eb0b871b729

after


https://github.com/user-attachments/assets/9f50c7d5-9833-46c5-ad89-e1ae7f31da3b



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
