### PR TITLE
feat: add stop event check

### DIFF
--- a/api/core/workflow/graph_engine/worker.py
+++ b/api/core/workflow/graph_engine/worker.py
@@ -141,6 +141,8 @@ class Worker(threading.Thread):
                     node_events = node.run()
                     for event in node_events:
                         self._event_queue.put(event)
+                        if self._stop_event.is_set():
+                            break
                 except Exception as exc:
                     error = exc
                     raise
@@ -152,6 +154,8 @@ class Worker(threading.Thread):
                 node_events = node.run()
                 for event in node_events:
                     self._event_queue.put(event)
+                    if self._stop_event.is_set():
+                        break
             except Exception as exc:
                 error = exc
                 raise

--- a/api/core/workflow/graph_engine/worker.py
+++ b/api/core/workflow/graph_engine/worker.py
@@ -145,9 +145,12 @@ class Worker(threading.Thread):
                 try:
                     node_events = node.run()
                     for event in node_events:
-                        logger.debug("worker %s"
-                                    "node_id %s receive event  and stop event: %s",
-                                    self._worker_id, event.node_id, self._stop_event.is_set())
+                        logger.debug(
+                            "worker %snode_id %s receive event  and stop event: %s",
+                            self._worker_id,
+                            event.node_id,
+                            self._stop_event.is_set(),
+                        )
                         self._event_queue.put(event)
                 except Exception as exc:
                     error = exc
@@ -159,9 +162,12 @@ class Worker(threading.Thread):
             try:
                 node_events = node.run()
                 for event in node_events:
-                    logger.debug("worker %s"
-                                "node_id %s receive event  and stop event: %s",
-                                self._worker_id, event.node_id, self._stop_event.is_set())
+                    logger.debug(
+                        "worker %snode_id %s receive event  and stop event: %s",
+                        self._worker_id,
+                        event.node_id,
+                        self._stop_event.is_set(),
+                    )
                     self._event_queue.put(event)
             except Exception as exc:
                 error = exc

--- a/api/core/workflow/graph_engine/worker.py
+++ b/api/core/workflow/graph_engine/worker.py
@@ -134,7 +134,7 @@ class Worker(threading.Thread):
 
         error: Exception | None = None
 
-        logger.info("Worker %s executing node %s", self._worker_id, node.id)
+        logger.debug("Worker %s executing node %s", self._worker_id, node.id)
 
         if self._flask_app and self._context_vars:
             with preserve_flask_contexts(
@@ -145,7 +145,7 @@ class Worker(threading.Thread):
                 try:
                     node_events = node.run()
                     for event in node_events:
-                        logger.info("worker %s"
+                        logger.debug("worker %s"
                                     "node_id %s receive event  and stop event: %s",
                                     self._worker_id, event.node_id, self._stop_event.is_set())
                         self._event_queue.put(event)
@@ -159,7 +159,7 @@ class Worker(threading.Thread):
             try:
                 node_events = node.run()
                 for event in node_events:
-                    logger.info("worker %s"
+                    logger.debug("worker %s"
                                 "node_id %s receive event  and stop event: %s",
                                 self._worker_id, event.node_id, self._stop_event.is_set())
                     self._event_queue.put(event)

--- a/api/core/workflow/graph_engine/worker_management/worker_pool.py
+++ b/api/core/workflow/graph_engine/worker_management/worker_pool.py
@@ -135,7 +135,7 @@ class WorkerPool:
             # Wait for workers to finish
             for worker in self._workers:
                 if worker.is_alive():
-                    worker.join(timeout=10.0)
+                    worker.join(timeout=2.0)
 
             self._workers.clear()
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #30390

here is a user log 
[log.txt](https://github.com/user-attachments/files/24392371/log.txt)

```
2025-12-31 14:05:06 2025-12-31 06:05:06.326 DEBUG [Thread-26 (_generate_worker)] [worker_pool.py:129]  - Stopping worker pool: 1 workers
2025-12-31 14:05:16 2025-12-31 06:05:16.333 DEBUG [Thread-26 (_generate_worker)] [execution_limits.py:110]  - Execution completed: 8 steps in 33.43 seconds
```

we can see here, wait about 10s

```
14:05:06.326  WorkerPool.stop()
                ├─ worker.stop() → _stop_event.set()
                └─ worker.join(timeout=10.0) # start wait
                    ↓
                    ↓ 
                    ↓ （possible node.run() iteration）
                    ↓
  14:05:16.333  join() # timeout
                ↓
                ↓ print "Execution completed"
```

so we need check the stop_event is set or not in the iteration

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
