### PR TITLE
fix(api): Permission denied: '/home/dify' when uploading .pptx file in Document Extractor Node

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -79,7 +79,7 @@ COPY --from=packages --chown=dify:dify ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Download nltk data
-RUN mkdir -p /usr/local/share/nltk_data && NLTK_DATA=/usr/local/share/nltk_data python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger'); nltk.download('averaged_perceptron_tagger_eng'); nltk.download('stopwords')" \
+RUN mkdir -p /usr/local/share/nltk_data && NLTK_DATA=/usr/local/share/nltk_data python -c "import nltk; nltk.download(['punkt', 'punkt_tab', 'averaged_perceptron_tagger', 'averaged_perceptron_tagger_eng', 'stopwords'])" \
     && chmod -R 755 /usr/local/share/nltk_data
 
 ENV TIKTOKEN_CACHE_DIR=/app/api/.tiktoken_cache

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -79,7 +79,7 @@ COPY --from=packages --chown=dify:dify ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Download nltk data
-RUN mkdir -p /usr/local/share/nltk_data && NLTK_DATA=/usr/local/share/nltk_data python -c "import nltk; nltk.download('punkt'); nltk.download('averaged_perceptron_tagger'); nltk.download('stopwords')" \
+RUN mkdir -p /usr/local/share/nltk_data && NLTK_DATA=/usr/local/share/nltk_data python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger'); nltk.download('averaged_perceptron_tagger_eng'); nltk.download('stopwords')" \
     && chmod -R 755 /usr/local/share/nltk_data
 
 ENV TIKTOKEN_CACHE_DIR=/app/api/.tiktoken_cache


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #30092 

The reason for the error is the unstructured parsing of the .pptx file, which requires the nltk averaged_perceptron_tagger_eng and punkt_tab packages. When automatically downloading, the directory selected was /home/dify, but there was no write permission. Simply pre-installing these two packages will solve the problem.

unstructured.nlp.tokenize.download_nltk_packages()
```python
def download_nltk_packages():
    """If required NLTK packages are not available, download them."""

    tagger_available = check_for_nltk_package(
        package_category="taggers",
        package_name="averaged_perceptron_tagger_eng",
    )
    tokenizer_available = check_for_nltk_package(
        package_category="tokenizers", package_name="punkt_tab"
    )

    if (not tokenizer_available) or (not tagger_available):
        nltk.download("averaged_perceptron_tagger_eng", quiet=True)
        nltk.download("punkt_tab", quiet=True)
```

error log
```
2025-12-31 17:42:15.761 | 2025-12-31 09:42:15.758 ERROR [GraphWorker-0] [node.py:336]  - Node 1767171946516 failed to run
2025-12-31 17:42:15.761 | Traceback (most recent call last):
2025-12-31 17:42:15.761 |   File "/app/api/core/workflow/nodes/base/node.py", line 318, in run
2025-12-31 17:42:15.761 |     result = self._run()
2025-12-31 17:42:15.761 |              ^^^^^^^^^^^
2025-12-31 17:42:15.761 |   File "/app/api/core/workflow/nodes/document_extractor/node.py", line 67, in _run
2025-12-31 17:42:15.761 |     extracted_text_list = list(map(_extract_text_from_file, value))
2025-12-31 17:42:15.761 |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-31 17:42:15.761 |   File "/app/api/core/workflow/nodes/document_extractor/node.py", line 426, in _extract_text_from_file
2025-12-31 17:42:15.761 |     extracted_text = _extract_text_by_file_extension(file_content=file_content, file_extension=file.extension)
2025-12-31 17:42:15.761 |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-31 17:42:15.761 |   File "/app/api/core/workflow/nodes/document_extractor/node.py", line 216, in _extract_text_by_file_extension
2025-12-31 17:42:15.761 |     return _extract_text_from_pptx(file_content)
2025-12-31 17:42:15.761 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-31 17:42:15.761 |   File "/app/api/core/workflow/nodes/document_extractor/node.py", line 548, in _extract_text_from_pptx
2025-12-31 17:42:15.761 |     from unstructured.partition.pptx import partition_pptx
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/unstructured/partition/pptx.py", line 39, in <module>
2025-12-31 17:42:15.761 |     from unstructured.partition.text_type import (
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/unstructured/partition/text_type.py", line 20, in <module>
2025-12-31 17:42:15.761 |     from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/unstructured/nlp/tokenize.py", line 48, in <module>
2025-12-31 17:42:15.761 |     download_nltk_packages()
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/unstructured/nlp/tokenize.py", line 42, in download_nltk_packages
2025-12-31 17:42:15.761 |     nltk.download("averaged_perceptron_tagger_eng", quiet=True)
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/nltk/downloader.py", line 762, in download
2025-12-31 17:42:15.761 |     for msg in self.incr_download(info_or_id, download_dir, force):
2025-12-31 17:42:15.761 |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/nltk/downloader.py", line 630, in incr_download
2025-12-31 17:42:15.761 |     yield from self._download_package(info, download_dir, force)
2025-12-31 17:42:15.761 |   File "/app/api/.venv/lib/python3.12/site-packages/nltk/downloader.py", line 686, in _download_package
2025-12-31 17:42:15.761 |     os.makedirs(download_dir, exist_ok=True)
2025-12-31 17:42:15.761 |   File "<frozen os>", line 215, in makedirs
2025-12-31 17:42:15.761 |   File "<frozen os>", line 225, in makedirs
2025-12-31 17:42:15.761 | PermissionError: [Errno 13] Permission denied: '/home/dify'
2025-12-31 17:42:15.836 | 2025-12-31 09:42:15.836 ERROR [GraphDispatcher] [error_handler.py:101]  - Node 1767171946516 failed with ABORT strategy: [Errno 13] Permission denied: '/home/dify'
2025-12-31 17:42:15.964 | 2025-12-31 09:42:15.963 ERROR [Thread-24 (_generate_worker)] [workflow_entry.py:116]  - Unknown Error when workflow entry running
2025-12-31 17:42:15.964 | Traceback (most recent call last):
2025-12-31 17:42:15.964 |   File "/app/api/core/workflow/workflow_entry.py", line 112, in run
2025-12-31 17:42:15.964 |     yield from generator
2025-12-31 17:42:15.964 |   File "/app/api/core/workflow/graph_engine/graph_engine.py", line 271, in run
2025-12-31 17:42:15.964 |     raise self._graph_execution.error
2025-12-31 17:42:15.964 | RuntimeError: [Errno 13] Permission denied: '/home/dify'
```

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
