### PR TITLE
chore: update dockerignore

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -7,8 +7,12 @@ logs
 
 # node
 node_modules
+dist
+build
+coverage
 .husky
 .next
+.pnpm-store
 
 # vscode
 .vscode
@@ -22,3 +26,7 @@ node_modules
 
 # Jetbrains
 .idea
+
+# git
+.git
+.gitignore


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #30459 

This PR improves Docker build cache stability for the **web frontend** by updating `.dockerignore` to exclude Git metadata and other build-irrelevant files.

Previously, the `.git` directory was included in the Docker build context for `web/Dockerfile`. Since files under `.git/` change frequently during normal Git operations and CI checkouts, the `COPY . .` instruction invalidated Docker layer cache on every build, causing the `builder` stage (`pnpm build:docker`) to run repeatedly even when no web source code had changed.

By explicitly excluding `.git` and related files, Docker layer caching now behaves as expected, significantly reducing unnecessary rebuilds in both local development and CI pipelines.

This change only affects build configuration and does not modify application logic or runtime behavior.


## Screenshots

| Before | After |
|--------|-------|
| Web Docker image rebuilds on every run due to cache invalidation | Docker layer cache is reused; `pnpm build:docker` runs only when relevant files change |


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
