### PR TITLE
fix: INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH settings

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -47,6 +47,8 @@ NEXT_PUBLIC_TOP_K_MAX_VALUE=10
 
 # The maximum number of tokens for segmentation
 NEXT_PUBLIC_INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=4000
+# Used by web/docker/entrypoint.sh to overwrite/export NEXT_PUBLIC_INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH at container startup (Docker only)
+INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=4000
 
 # Maximum loop count in the workflow
 NEXT_PUBLIC_LOOP_NODE_MAX_COUNT=100


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix #30461 

## Screenshots

| Before | After |
|--------|-------|
| <img width="2276" height="627" alt="image" src="https://github.com/user-attachments/assets/95374b8b-9b88-46dc-a254-31f9eff398c5" /> | <img width="2257" height="632" alt="image" src="https://github.com/user-attachments/assets/ee19a16c-c739-4adb-bd59-a8ec975d7fd9" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
