### PR TITLE
refactor: clean unnecessary type: ignore in workflow_app_log.py

### DIFF
--- a/api/controllers/console/app/workflow_app_log.py
+++ b/api/controllers/console/app/workflow_app_log.py
@@ -38,7 +38,7 @@ class WorkflowAppLogQuery(BaseModel):
     def parse_datetime(cls, value: str | None) -> datetime | None:
         if value in (None, ""):
             return None
-        return isoparse(value)  # type: ignore
+        return isoparse(value)
 
     @field_validator("detail", mode="before")
     @classmethod
@@ -79,7 +79,7 @@ class WorkflowAppLogApi(Resource):
         """
         Get workflow app logs
         """
-        args = WorkflowAppLogQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
+        args = WorkflowAppLogQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore[arg-type]
 
         # get paginate workflow app logs
         workflow_app_service = WorkflowAppService()


### PR DESCRIPTION
## Summary
- Remove unnecessary `type: ignore` from `isoparse` return (dateutil has proper type stubs)
- Make remaining `type: ignore` more specific (`arg-type` instead of blanket ignore)

Part of #24494

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods