### PR TITLE
fix: when first setup after auto login error

### DIFF
--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -19,8 +19,8 @@ import { useDocLink } from '@/context/i18n'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { fetchInitValidateStatus, fetchSetupStatus, login, setup } from '@/service/common'
 import { cn } from '@/utils/classnames'
-import Loading from '../components/base/loading'
 import { encryptPassword as encodePassword } from '@/utils/encryption'
+import Loading from '../components/base/loading'
 
 const accountFormSchema = z.object({
   email: z

--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -20,6 +20,7 @@ import useDocumentTitle from '@/hooks/use-document-title'
 import { fetchInitValidateStatus, fetchSetupStatus, login, setup } from '@/service/common'
 import { cn } from '@/utils/classnames'
 import Loading from '../components/base/loading'
+import { encryptPassword } from '@/utils/encryption'
 
 const accountFormSchema = z.object({
   email: z
@@ -68,7 +69,7 @@ const InstallForm = () => {
       url: '/login',
       body: {
         email: data.email,
-        password: data.password,
+        password: encryptPassword(data.password),
       },
     })
 

--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -20,7 +20,7 @@ import useDocumentTitle from '@/hooks/use-document-title'
 import { fetchInitValidateStatus, fetchSetupStatus, login, setup } from '@/service/common'
 import { cn } from '@/utils/classnames'
 import Loading from '../components/base/loading'
-import { encryptPassword } from '@/utils/encryption'
+import { encryptPassword as encodePassword } from '@/utils/encryption'
 
 const accountFormSchema = z.object({
   email: z
@@ -69,7 +69,7 @@ const InstallForm = () => {
       url: '/login',
       body: {
         email: data.email,
-        password: encryptPassword(data.password),
+        password: encodePassword(data.password),
       },
     })
 


### PR DESCRIPTION
## Summary
when first setup  auto login error 
the password should base64 

before
<img width="1464" height="673" alt="image" src="https://github.com/user-attachments/assets/15bbea3f-db3e-4ea7-863e-f7012cda6f39" />

after
<img width="1483" height="379" alt="image" src="https://github.com/user-attachments/assets/3592713d-827d-456a-a32e-52603d87b255" />

<img width="1500" height="549" alt="image" src="https://github.com/user-attachments/assets/30bed181-6df7-4ee9-b543-0e1166b83250" />



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
