### PR TITLE
refactor(workflow): add Jinja2 renderer abstraction for template transform

### DIFF
--- a/api/core/workflow/nodes/node_factory.py
+++ b/api/core/workflow/nodes/node_factory.py
@@ -15,6 +15,7 @@ from core.workflow.nodes.template_transform.template_renderer import (
     CodeExecutorJinja2TemplateRenderer,
     Jinja2TemplateRenderer,
 )
+from core.workflow.nodes.template_transform.template_transform_node import TemplateTransformNode
 from libs.typing import is_str, is_str_dict
 
 from .node_mapping import LATEST_VERSION, NODE_TYPE_CLASSES_MAPPING
@@ -113,13 +114,18 @@ class DifyNodeFactory(NodeFactory):
                 code_limits=self._code_limits,
             )
 
-        node_kwargs: dict[str, object] = {
-            "id": node_id,
-            "config": node_config,
-            "graph_init_params": self.graph_init_params,
-            "graph_runtime_state": self.graph_runtime_state,
-        }
         if node_type == NodeType.TEMPLATE_TRANSFORM:
-            node_kwargs["template_renderer"] = self._template_renderer
+            return TemplateTransformNode(
+                id=node_id,
+                config=node_config,
+                graph_init_params=self.graph_init_params,
+                graph_runtime_state=self.graph_runtime_state,
+                template_renderer=self._template_renderer,
+            )
 
-        return node_class(**node_kwargs)
+        return node_class(
+            id=node_id,
+            config=node_config,
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )

--- a/api/core/workflow/nodes/node_factory.py
+++ b/api/core/workflow/nodes/node_factory.py
@@ -11,6 +11,10 @@ from core.workflow.graph import NodeFactory
 from core.workflow.nodes.base.node import Node
 from core.workflow.nodes.code.code_node import CodeNode
 from core.workflow.nodes.code.limits import CodeNodeLimits
+from core.workflow.nodes.template_transform.template_renderer import (
+    CodeExecutorJinja2TemplateRenderer,
+    Jinja2TemplateRenderer,
+)
 from libs.typing import is_str, is_str_dict
 
 from .node_mapping import LATEST_VERSION, NODE_TYPE_CLASSES_MAPPING
@@ -37,6 +41,7 @@ class DifyNodeFactory(NodeFactory):
         code_executor: type[CodeExecutor] | None = None,
         code_providers: Sequence[type[CodeNodeProvider]] | None = None,
         code_limits: CodeNodeLimits | None = None,
+        template_renderer: Jinja2TemplateRenderer | None = None,
     ) -> None:
         self.graph_init_params = graph_init_params
         self.graph_runtime_state = graph_runtime_state
@@ -54,6 +59,7 @@ class DifyNodeFactory(NodeFactory):
             max_string_array_length=dify_config.CODE_MAX_STRING_ARRAY_LENGTH,
             max_object_array_length=dify_config.CODE_MAX_OBJECT_ARRAY_LENGTH,
         )
+        self._template_renderer = template_renderer or CodeExecutorJinja2TemplateRenderer()
 
     @override
     def create_node(self, node_config: dict[str, object]) -> Node:
@@ -114,6 +120,6 @@ class DifyNodeFactory(NodeFactory):
             "graph_runtime_state": self.graph_runtime_state,
         }
         if node_type == NodeType.TEMPLATE_TRANSFORM:
-            node_kwargs["code_executor"] = self._code_executor
+            node_kwargs["template_renderer"] = self._template_renderer
 
         return node_class(**node_kwargs)

--- a/api/core/workflow/nodes/node_factory.py
+++ b/api/core/workflow/nodes/node_factory.py
@@ -107,9 +107,13 @@ class DifyNodeFactory(NodeFactory):
                 code_limits=self._code_limits,
             )
 
-        return node_class(
-            id=node_id,
-            config=node_config,
-            graph_init_params=self.graph_init_params,
-            graph_runtime_state=self.graph_runtime_state,
-        )
+        node_kwargs: dict[str, object] = {
+            "id": node_id,
+            "config": node_config,
+            "graph_init_params": self.graph_init_params,
+            "graph_runtime_state": self.graph_runtime_state,
+        }
+        if node_type == NodeType.TEMPLATE_TRANSFORM:
+            node_kwargs["code_executor"] = self._code_executor
+
+        return node_class(**node_kwargs)

--- a/api/core/workflow/nodes/template_transform/template_renderer.py
+++ b/api/core/workflow/nodes/template_transform/template_renderer.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from core.helper.code_executor.code_executor import CodeExecutionError, CodeExecutor, CodeLanguage
+
+
+class TemplateRenderError(RuntimeError):
+    """Raised when rendering a Jinja2 template fails."""
+
+
+class Jinja2TemplateRenderer(Protocol):
+    """Render Jinja2 templates for template transform nodes."""
+
+    def render_template(self, template: str, variables: Mapping[str, Any]) -> str:
+        """Render a Jinja2 template with provided variables."""
+        raise NotImplementedError
+
+
+class CodeExecutorJinja2TemplateRenderer:
+    """Adapter that renders Jinja2 templates via CodeExecutor."""
+
+    _code_executor: type[CodeExecutor]
+
+    def __init__(self, code_executor: type[CodeExecutor] | None = None) -> None:
+        self._code_executor = code_executor or CodeExecutor
+
+    def render_template(self, template: str, variables: Mapping[str, Any]) -> str:
+        try:
+            result = self._code_executor.execute_workflow_code_template(
+                language=CodeLanguage.JINJA2, code=template, inputs=variables
+            )
+        except CodeExecutionError as exc:
+            raise TemplateRenderError(str(exc)) from exc
+
+        rendered = result.get("result")
+        if not isinstance(rendered, str):
+            raise TemplateRenderError("Template render result must be a string.")
+        return rendered

--- a/api/core/workflow/nodes/template_transform/template_renderer.py
+++ b/api/core/workflow/nodes/template_transform/template_renderer.py
@@ -18,7 +18,7 @@ class Jinja2TemplateRenderer(Protocol):
         raise NotImplementedError
 
 
-class CodeExecutorJinja2TemplateRenderer:
+class CodeExecutorJinja2TemplateRenderer(Jinja2TemplateRenderer):
     """Adapter that renders Jinja2 templates via CodeExecutor."""
 
     _code_executor: type[CodeExecutor]

--- a/api/core/workflow/nodes/template_transform/template_renderer.py
+++ b/api/core/workflow/nodes/template_transform/template_renderer.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol
 from core.helper.code_executor.code_executor import CodeExecutionError, CodeExecutor, CodeLanguage
 
 
-class TemplateRenderError(RuntimeError):
+class TemplateRenderError(ValueError):
     """Raised when rendering a Jinja2 template fails."""
 
 

--- a/api/core/workflow/nodes/template_transform/template_transform_node.py
+++ b/api/core/workflow/nodes/template_transform/template_transform_node.py
@@ -2,11 +2,15 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from configs import dify_config
-from core.helper.code_executor.code_executor import CodeExecutionError, CodeExecutor, CodeLanguage
 from core.workflow.enums import NodeType, WorkflowNodeExecutionStatus
 from core.workflow.node_events import NodeRunResult
 from core.workflow.nodes.base.node import Node
 from core.workflow.nodes.template_transform.entities import TemplateTransformNodeData
+from core.workflow.nodes.template_transform.template_renderer import (
+    CodeExecutorJinja2TemplateRenderer,
+    Jinja2TemplateRenderer,
+    TemplateRenderError,
+)
 
 if TYPE_CHECKING:
     from core.workflow.entities import GraphInitParams
@@ -17,7 +21,7 @@ MAX_TEMPLATE_TRANSFORM_OUTPUT_LENGTH = dify_config.TEMPLATE_TRANSFORM_MAX_LENGTH
 
 class TemplateTransformNode(Node[TemplateTransformNodeData]):
     node_type = NodeType.TEMPLATE_TRANSFORM
-    _code_executor: type[CodeExecutor]
+    _template_renderer: Jinja2TemplateRenderer
 
     def __init__(
         self,
@@ -26,7 +30,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
         *,
-        code_executor: type[CodeExecutor] | None = None,
+        template_renderer: Jinja2TemplateRenderer | None = None,
     ) -> None:
         super().__init__(
             id=id,
@@ -34,7 +38,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
-        self._code_executor = code_executor or CodeExecutor
+        self._template_renderer = template_renderer or CodeExecutorJinja2TemplateRenderer()
 
     @classmethod
     def get_default_config(cls, filters: Mapping[str, object] | None = None) -> Mapping[str, object]:
@@ -61,13 +65,11 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
             variables[variable_name] = value.to_object() if value else None
         # Run code
         try:
-            result = self._code_executor.execute_workflow_code_template(
-                language=CodeLanguage.JINJA2, code=self.node_data.template, inputs=variables
-            )
-        except CodeExecutionError as e:
+            rendered = self._template_renderer.render_template(self.node_data.template, variables)
+        except TemplateRenderError as e:
             return NodeRunResult(inputs=variables, status=WorkflowNodeExecutionStatus.FAILED, error=str(e))
 
-        if len(result["result"]) > MAX_TEMPLATE_TRANSFORM_OUTPUT_LENGTH:
+        if len(rendered) > MAX_TEMPLATE_TRANSFORM_OUTPUT_LENGTH:
             return NodeRunResult(
                 inputs=variables,
                 status=WorkflowNodeExecutionStatus.FAILED,
@@ -75,7 +77,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
             )
 
         return NodeRunResult(
-            status=WorkflowNodeExecutionStatus.SUCCEEDED, inputs=variables, outputs={"output": result["result"]}
+            status=WorkflowNodeExecutionStatus.SUCCEEDED, inputs=variables, outputs={"output": rendered}
         )
 
     @classmethod

--- a/api/tests/unit_tests/core/workflow/nodes/template_transform/template_transform_node_spec.py
+++ b/api/tests/unit_tests/core/workflow/nodes/template_transform/template_transform_node_spec.py
@@ -5,9 +5,9 @@ from core.workflow.graph_engine.entities.graph import Graph
 from core.workflow.graph_engine.entities.graph_init_params import GraphInitParams
 from core.workflow.graph_engine.entities.graph_runtime_state import GraphRuntimeState
 
-from core.helper.code_executor.code_executor import CodeExecutionError
 from core.workflow.enums import ErrorStrategy, NodeType, WorkflowNodeExecutionStatus
 from core.workflow.nodes.template_transform.template_transform_node import TemplateTransformNode
+from core.workflow.nodes.template_transform.template_renderer import TemplateRenderError
 from models.workflow import WorkflowType
 
 
@@ -127,7 +127,7 @@ class TestTemplateTransformNode:
         """Test version class method."""
         assert TemplateTransformNode.version() == "1"
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_simple_template(
         self, mock_execute, basic_node_data, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
@@ -145,7 +145,7 @@ class TestTemplateTransformNode:
         mock_graph_runtime_state.variable_pool.get.side_effect = lambda selector: variable_map.get(tuple(selector))
 
         # Setup mock executor
-        mock_execute.return_value = {"result": "Hello Alice, you are 30 years old!"}
+        mock_execute.return_value = "Hello Alice, you are 30 years old!"
 
         node = TemplateTransformNode(
             id="test_node",
@@ -162,7 +162,7 @@ class TestTemplateTransformNode:
         assert result.inputs["name"] == "Alice"
         assert result.inputs["age"] == 30
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_none_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with None variable values."""
         node_data = {
@@ -172,7 +172,7 @@ class TestTemplateTransformNode:
         }
 
         mock_graph_runtime_state.variable_pool.get.return_value = None
-        mock_execute.return_value = {"result": "Value: "}
+        mock_execute.return_value = "Value: "
 
         node = TemplateTransformNode(
             id="test_node",
@@ -187,13 +187,13 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
         assert result.inputs["value"] is None
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_code_execution_error(
         self, mock_execute, basic_node_data, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
         """Test _run when code execution fails."""
         mock_graph_runtime_state.variable_pool.get.return_value = MagicMock()
-        mock_execute.side_effect = CodeExecutionError("Template syntax error")
+        mock_execute.side_effect = TemplateRenderError("Template syntax error")
 
         node = TemplateTransformNode(
             id="test_node",
@@ -208,14 +208,14 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.FAILED
         assert "Template syntax error" in result.error
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     @patch("core.workflow.nodes.template_transform.template_transform_node.MAX_TEMPLATE_TRANSFORM_OUTPUT_LENGTH", 10)
     def test_run_output_length_exceeds_limit(
         self, mock_execute, basic_node_data, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
         """Test _run when output exceeds maximum length."""
         mock_graph_runtime_state.variable_pool.get.return_value = MagicMock()
-        mock_execute.return_value = {"result": "This is a very long output that exceeds the limit"}
+        mock_execute.return_value = "This is a very long output that exceeds the limit"
 
         node = TemplateTransformNode(
             id="test_node",
@@ -230,7 +230,7 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.FAILED
         assert "Output length exceeds" in result.error
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_complex_jinja2_template(
         self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
@@ -257,7 +257,7 @@ class TestTemplateTransformNode:
             ("sys", "show_total"): mock_show_total,
         }
         mock_graph_runtime_state.variable_pool.get.side_effect = lambda selector: variable_map.get(tuple(selector))
-        mock_execute.return_value = {"result": "apple, banana, orange (Total: 3)"}
+        mock_execute.return_value = "apple, banana, orange (Total: 3)"
 
         node = TemplateTransformNode(
             id="test_node",
@@ -292,7 +292,7 @@ class TestTemplateTransformNode:
         assert mapping["node_123.var1"] == ["sys", "input1"]
         assert mapping["node_123.var2"] == ["sys", "input2"]
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_empty_variables(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with no variables (static template)."""
         node_data = {
@@ -301,7 +301,7 @@ class TestTemplateTransformNode:
             "template": "This is a static message.",
         }
 
-        mock_execute.return_value = {"result": "This is a static message."}
+        mock_execute.return_value = "This is a static message."
 
         node = TemplateTransformNode(
             id="test_node",
@@ -317,7 +317,7 @@ class TestTemplateTransformNode:
         assert result.outputs["output"] == "This is a static message."
         assert result.inputs == {}
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_numeric_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with numeric variable values."""
         node_data = {
@@ -339,7 +339,7 @@ class TestTemplateTransformNode:
             ("sys", "quantity"): mock_quantity,
         }
         mock_graph_runtime_state.variable_pool.get.side_effect = lambda selector: variable_map.get(tuple(selector))
-        mock_execute.return_value = {"result": "Total: $31.5"}
+        mock_execute.return_value = "Total: $31.5"
 
         node = TemplateTransformNode(
             id="test_node",
@@ -354,7 +354,7 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
         assert result.outputs["output"] == "Total: $31.5"
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_dict_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with dictionary variable values."""
         node_data = {
@@ -367,7 +367,7 @@ class TestTemplateTransformNode:
         mock_user.to_object.return_value = {"name": "John Doe", "email": "john@example.com"}
 
         mock_graph_runtime_state.variable_pool.get.return_value = mock_user
-        mock_execute.return_value = {"result": "Name: John Doe, Email: john@example.com"}
+        mock_execute.return_value = "Name: John Doe, Email: john@example.com"
 
         node = TemplateTransformNode(
             id="test_node",
@@ -383,7 +383,7 @@ class TestTemplateTransformNode:
         assert "John Doe" in result.outputs["output"]
         assert "john@example.com" in result.outputs["output"]
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutor.execute_workflow_code_template")
+    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
     def test_run_with_list_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with list variable values."""
         node_data = {
@@ -396,7 +396,7 @@ class TestTemplateTransformNode:
         mock_tags.to_object.return_value = ["python", "ai", "workflow"]
 
         mock_graph_runtime_state.variable_pool.get.return_value = mock_tags
-        mock_execute.return_value = {"result": "Tags: #python #ai #workflow "}
+        mock_execute.return_value = "Tags: #python #ai #workflow "
 
         node = TemplateTransformNode(
             id="test_node",

--- a/api/tests/unit_tests/core/workflow/nodes/template_transform/template_transform_node_spec.py
+++ b/api/tests/unit_tests/core/workflow/nodes/template_transform/template_transform_node_spec.py
@@ -6,8 +6,8 @@ from core.workflow.graph_engine.entities.graph_init_params import GraphInitParam
 from core.workflow.graph_engine.entities.graph_runtime_state import GraphRuntimeState
 
 from core.workflow.enums import ErrorStrategy, NodeType, WorkflowNodeExecutionStatus
-from core.workflow.nodes.template_transform.template_transform_node import TemplateTransformNode
 from core.workflow.nodes.template_transform.template_renderer import TemplateRenderError
+from core.workflow.nodes.template_transform.template_transform_node import TemplateTransformNode
 from models.workflow import WorkflowType
 
 
@@ -127,7 +127,9 @@ class TestTemplateTransformNode:
         """Test version class method."""
         assert TemplateTransformNode.version() == "1"
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_simple_template(
         self, mock_execute, basic_node_data, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
@@ -162,7 +164,9 @@ class TestTemplateTransformNode:
         assert result.inputs["name"] == "Alice"
         assert result.inputs["age"] == 30
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_none_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with None variable values."""
         node_data = {
@@ -187,7 +191,9 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
         assert result.inputs["value"] is None
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_code_execution_error(
         self, mock_execute, basic_node_data, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
@@ -208,7 +214,9 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.FAILED
         assert "Template syntax error" in result.error
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     @patch("core.workflow.nodes.template_transform.template_transform_node.MAX_TEMPLATE_TRANSFORM_OUTPUT_LENGTH", 10)
     def test_run_output_length_exceeds_limit(
         self, mock_execute, basic_node_data, mock_graph, mock_graph_runtime_state, graph_init_params
@@ -230,7 +238,9 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.FAILED
         assert "Output length exceeds" in result.error
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_complex_jinja2_template(
         self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params
     ):
@@ -292,7 +302,9 @@ class TestTemplateTransformNode:
         assert mapping["node_123.var1"] == ["sys", "input1"]
         assert mapping["node_123.var2"] == ["sys", "input2"]
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_empty_variables(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with no variables (static template)."""
         node_data = {
@@ -317,7 +329,9 @@ class TestTemplateTransformNode:
         assert result.outputs["output"] == "This is a static message."
         assert result.inputs == {}
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_numeric_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with numeric variable values."""
         node_data = {
@@ -354,7 +368,9 @@ class TestTemplateTransformNode:
         assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
         assert result.outputs["output"] == "Total: $31.5"
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_dict_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with dictionary variable values."""
         node_data = {
@@ -383,7 +399,9 @@ class TestTemplateTransformNode:
         assert "John Doe" in result.outputs["output"]
         assert "john@example.com" in result.outputs["output"]
 
-    @patch("core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template")
+    @patch(
+        "core.workflow.nodes.template_transform.template_transform_node.CodeExecutorJinja2TemplateRenderer.render_template"
+    )
     def test_run_with_list_values(self, mock_execute, mock_graph, mock_graph_runtime_state, graph_init_params):
         """Test _run with list variable values."""
         node_data = {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Part of #30506
- Introduce a Jinja2 template renderer abstraction for TemplateTransform with a CodeExecutor-backed adapter.
- Inject the renderer via TemplateTransformNode and DifyNodeFactory while keeping default behavior intact.
- Update TemplateTransform unit tests to mock the renderer output.
- Tests: `make lint`, `make type-check`.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods