### PR TITLE
refactor: use contains_any instead of  Chaining where = where | f

### DIFF
--- a/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
+++ b/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
@@ -49,6 +49,7 @@ class WeaviateConfig(BaseModel):
     api_key: str | None = None
     batch_size: int = 100
 
+
     @model_validator(mode="before")
     @classmethod
     def validate_config(cls, values: dict) -> dict:
@@ -65,6 +66,7 @@ class WeaviateVector(BaseVector):
     Handles creation, insertion, deletion, and querying of document embeddings
     in a Weaviate collection.
     """
+    _DOCUMENT_ID_PROPERTY = "document_id"
 
     def __init__(self, collection_name: str, config: WeaviateConfig, attributes: list):
         """
@@ -353,15 +355,12 @@ class WeaviateVector(BaseVector):
             return []
 
         col = self._client.collections.use(self._collection_name)
-        props = list({*self._attributes, "document_id", Field.TEXT_KEY.value})
+        props = list({*self._attributes, self._DOCUMENT_ID_PROPERTY, Field.TEXT_KEY.value})
 
         where = None
         doc_ids = kwargs.get("document_ids_filter") or []
         if doc_ids:
-            ors = [Filter.by_property("document_id").equal(x) for x in doc_ids]
-            where = ors[0]
-            for f in ors[1:]:
-                where = where | f
+            where = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids)
 
         top_k = int(kwargs.get("top_k", 4))
         score_threshold = float(kwargs.get("score_threshold") or 0.0)
@@ -408,10 +407,7 @@ class WeaviateVector(BaseVector):
         where = None
         doc_ids = kwargs.get("document_ids_filter") or []
         if doc_ids:
-            ors = [Filter.by_property("document_id").equal(x) for x in doc_ids]
-            where = ors[0]
-            for f in ors[1:]:
-                where = where | f
+            where = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids)
 
         top_k = int(kwargs.get("top_k", 4))
 

--- a/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
+++ b/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
@@ -49,7 +49,6 @@ class WeaviateConfig(BaseModel):
     api_key: str | None = None
     batch_size: int = 100
 
-
     @model_validator(mode="before")
     @classmethod
     def validate_config(cls, values: dict) -> dict:
@@ -66,6 +65,7 @@ class WeaviateVector(BaseVector):
     Handles creation, insertion, deletion, and querying of document embeddings
     in a Weaviate collection.
     """
+
     _DOCUMENT_ID_PROPERTY = "document_id"
 
     def __init__(self, collection_name: str, config: WeaviateConfig, attributes: list):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #29750

use contains_any instead of  Chaining where = where | f

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

  | Method              | Line | Change                     |
  |---------------------|------|----------------------------|
  | search_by_vector    | 361  | Uses contains_any(doc_ids) |
  | search_by_full_text | 408  | Uses contains_any(doc_ids) |

  Before (problematic - deep nesting):
  ors = [Filter.by_property("document_id").equal(x) for x in doc_ids]
  where = ors[0]
  for f in ors[1:]:
      where = where | f  # Creates (A | (B | (C | ...))) nesting

  After (efficient - flat structure):
  where = Filter.by_property("document_id").contains_any(doc_ids)

  Benefits:
  - Avoids deep nesting issues with 100+ document IDs
  - Better performance (single operation vs. recursive tree evaluation)
  - Cleaner, more idiomatic Weaviate code

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
