### PR TITLE
fix(db): parameterize sessionmaker with Session

### DIFF
--- a/api/core/db/session_factory.py
+++ b/api/core/db/session_factory.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
-_session_maker: sessionmaker | None = None
+_session_maker: sessionmaker[Session] | None = None
 
 
 def configure_session_factory(engine: Engine, expire_on_commit: bool = False):
@@ -10,7 +10,7 @@ def configure_session_factory(engine: Engine, expire_on_commit: bool = False):
     _session_maker = sessionmaker(bind=engine, expire_on_commit=expire_on_commit)
 
 
-def get_session_maker() -> sessionmaker:
+def get_session_maker() -> sessionmaker[Session]:
     if _session_maker is None:
         raise RuntimeError("Session factory not configured. Call configure_session_factory() first.")
     return _session_maker
@@ -27,7 +27,7 @@ class SessionFactory:
         configure_session_factory(engine, expire_on_commit)
 
     @staticmethod
-    def get_session_maker() -> sessionmaker:
+    def get_session_maker() -> sessionmaker[Session]:
         return get_session_maker()
 
     @staticmethod


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #30610.

Update the global session factory typing in `api/core/db/session_factory.py` to use `sessionmaker[Session]`, preserving the inner `Session` type for consumers and improving type-checking accuracy without runtime changes. No dependencies required.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
