### PR TITLE
fix: prevent empty state flash and add skeleton loading for app list

### DIFF
--- a/web/app/components/apps/app-card-skeleton.tsx
+++ b/web/app/components/apps/app-card-skeleton.tsx
@@ -11,7 +11,7 @@ type AppCardSkeletonProps = {
  * Skeleton placeholder for App cards during loading states.
  * Matches the visual layout of AppCard component.
  */
-const AppCardSkeleton = ({ count = 6 }: AppCardSkeletonProps) => {
+export const AppCardSkeleton = React.memo(({ count = 6 }: AppCardSkeletonProps) => {
   return (
     <>
       {Array.from({ length: count }).map((_, index) => (
@@ -36,6 +36,6 @@ const AppCardSkeleton = ({ count = 6 }: AppCardSkeletonProps) => {
       ))}
     </>
   )
-}
+})
 
-export default React.memo(AppCardSkeleton)
+AppCardSkeleton.displayName = 'AppCardSkeleton'

--- a/web/app/components/apps/app-card-skeleton.tsx
+++ b/web/app/components/apps/app-card-skeleton.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import * as React from 'react'
+import { SkeletonContainer, SkeletonRectangle, SkeletonRow } from '@/app/components/base/skeleton'
+
+type AppCardSkeletonProps = {
+  count?: number
+}
+
+/**
+ * Skeleton placeholder for App cards during loading states.
+ * Matches the visual layout of AppCard component.
+ */
+const AppCardSkeleton = ({ count = 6 }: AppCardSkeletonProps) => {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={index}
+          className="h-[160px] rounded-xl border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg p-4"
+        >
+          <SkeletonContainer className="h-full">
+            <SkeletonRow>
+              <SkeletonRectangle className="h-10 w-10 rounded-lg" />
+              <div className="flex flex-1 flex-col gap-1">
+                <SkeletonRectangle className="h-4 w-2/3" />
+                <SkeletonRectangle className="h-3 w-1/3" />
+              </div>
+            </SkeletonRow>
+            <div className="mt-4 flex flex-col gap-2">
+              <SkeletonRectangle className="h-3 w-full" />
+              <SkeletonRectangle className="h-3 w-4/5" />
+            </div>
+          </SkeletonContainer>
+        </div>
+      ))}
+    </>
+  )
+}
+
+export default React.memo(AppCardSkeleton)

--- a/web/app/components/apps/app-card-skeleton.tsx
+++ b/web/app/components/apps/app-card-skeleton.tsx
@@ -17,7 +17,7 @@ export const AppCardSkeleton = React.memo(({ count = 6 }: AppCardSkeletonProps) 
       {Array.from({ length: count }).map((_, index) => (
         <div
           key={index}
-          className="h-[160px] rounded-xl border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg p-4"
+          className="h-[160px] rounded-xl border-[0.5px] border-components-card-border bg-components-card-bg p-4"
         >
           <SkeletonContainer className="h-full">
             <SkeletonRow>

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -229,9 +229,9 @@ const List = () => {
               return <AppCardSkeleton count={6} />
 
             if (hasAnyApp) {
-              return pages.map(({ data: apps }) => apps.map(app => (
+              return pages.flatMap(({ data: apps }) => apps).map(app => (
                 <AppCard key={app.id} app={app} onRefresh={refetch} />
-              )))
+              ))
             }
 
             // No apps - show empty state

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -177,8 +177,6 @@ const List = () => {
   const hasAnyApp = (pages[0]?.total ?? 0) > 0
   // Show skeleton during initial load or when refetching with no previous data
   const showSkeleton = isLoading || (isFetching && pages.length === 0)
-  // Only show empty state when we're sure there's no data and not loading
-  const showEmpty = !isFetching && !hasAnyApp
 
   return (
     <>
@@ -214,7 +212,7 @@ const List = () => {
         </div>
         <div className={cn(
           'relative grid grow grid-cols-1 content-start gap-4 px-12 pt-2 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5 2k:grid-cols-6',
-          showEmpty && 'overflow-hidden',
+          !hasAnyApp && 'overflow-hidden',
         )}
         >
           {(isCurrentWorkspaceEditor || isLoadingCurrentWorkspace) && (
@@ -223,7 +221,7 @@ const List = () => {
               isLoading={isLoadingCurrentWorkspace}
               onSuccess={refetch}
               selectedAppType={activeTab}
-              className={cn(showEmpty && 'z-10')}
+              className={cn(!hasAnyApp && 'z-10')}
             />
           )}
           {(() => {
@@ -236,10 +234,8 @@ const List = () => {
               )))
             }
 
-            if (showEmpty)
-              return <Empty />
-
-            return null
+            // No apps - show empty state
+            return <Empty />
           })()}
         </div>
 

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -27,8 +27,9 @@ import { useGlobalPublicStore } from '@/context/global-public-context'
 import { CheckModal } from '@/hooks/use-pay'
 import { useInfiniteAppList } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
+import { cn } from '@/utils/classnames'
 import AppCard from './app-card'
-import AppCardSkeleton from './app-card-skeleton'
+import { AppCardSkeleton } from './app-card-skeleton'
 import Empty from './empty'
 import Footer from './footer'
 import useAppsQueryState from './hooks/use-apps-query-state'
@@ -211,33 +212,36 @@ const List = () => {
             />
           </div>
         </div>
-        {showSkeleton
-          ? (
-              <div className="relative grid grow grid-cols-1 content-start gap-4 px-12 pt-2 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5 2k:grid-cols-6">
-                {(isCurrentWorkspaceEditor || isLoadingCurrentWorkspace)
-                  && <NewAppCard ref={newAppCardRef} isLoading={isLoadingCurrentWorkspace} onSuccess={refetch} selectedAppType={activeTab} />}
-                <AppCardSkeleton count={6} />
-              </div>
-            )
-          : hasAnyApp
-            ? (
-                <div className="relative grid grow grid-cols-1 content-start gap-4 px-12 pt-2 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5 2k:grid-cols-6">
-                  {(isCurrentWorkspaceEditor || isLoadingCurrentWorkspace)
-                    && <NewAppCard ref={newAppCardRef} isLoading={isLoadingCurrentWorkspace} onSuccess={refetch} selectedAppType={activeTab} />}
-                  {pages.map(({ data: apps }) => apps.map(app => (
-                    <AppCard key={app.id} app={app} onRefresh={refetch} />
-                  )))}
-                </div>
-              )
-            : showEmpty
-              ? (
-                  <div className="relative grid grow grid-cols-1 content-start gap-4 overflow-hidden px-12 pt-2 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5 2k:grid-cols-6">
-                    {(isCurrentWorkspaceEditor || isLoadingCurrentWorkspace)
-                      && <NewAppCard ref={newAppCardRef} isLoading={isLoadingCurrentWorkspace} className="z-10" onSuccess={refetch} selectedAppType={activeTab} />}
-                    <Empty />
-                  </div>
-                )
-              : null}
+        <div className={cn(
+          'relative grid grow grid-cols-1 content-start gap-4 px-12 pt-2 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5 2k:grid-cols-6',
+          showEmpty && 'overflow-hidden',
+        )}
+        >
+          {(isCurrentWorkspaceEditor || isLoadingCurrentWorkspace) && (
+            <NewAppCard
+              ref={newAppCardRef}
+              isLoading={isLoadingCurrentWorkspace}
+              onSuccess={refetch}
+              selectedAppType={activeTab}
+              className={cn(showEmpty && 'z-10')}
+            />
+          )}
+          {(() => {
+            if (showSkeleton)
+              return <AppCardSkeleton count={6} />
+
+            if (hasAnyApp) {
+              return pages.map(({ data: apps }) => apps.map(app => (
+                <AppCard key={app.id} app={app} onRefresh={refetch} />
+              )))
+            }
+
+            if (showEmpty)
+              return <Empty />
+
+            return null
+          })()}
+        </div>
 
         {isCurrentWorkspaceEditor && (
           <div

--- a/web/app/components/apps/new-app-card.tsx
+++ b/web/app/components/apps/new-app-card.tsx
@@ -25,6 +25,7 @@ const CreateFromDSLModal = dynamic(() => import('@/app/components/app/create-fro
 
 export type CreateAppCardProps = {
   className?: string
+  isLoading?: boolean
   onSuccess?: () => void
   ref: React.RefObject<HTMLDivElement | null>
   selectedAppType?: string
@@ -33,6 +34,7 @@ export type CreateAppCardProps = {
 const CreateAppCard = ({
   ref,
   className,
+  isLoading = false,
   onSuccess,
   selectedAppType,
 }: CreateAppCardProps) => {
@@ -56,7 +58,11 @@ const CreateAppCard = ({
   return (
     <div
       ref={ref}
-      className={cn('relative col-span-1 inline-flex h-[160px] flex-col justify-between rounded-xl border-[0.5px] border-components-card-border bg-components-card-bg', className)}
+      className={cn(
+        'relative col-span-1 inline-flex h-[160px] flex-col justify-between rounded-xl border-[0.5px] border-components-card-border bg-components-card-bg transition-opacity',
+        isLoading && 'pointer-events-none opacity-50',
+        className,
+      )}
     >
       <div className="grow rounded-t-xl p-2">
         <div className="px-6 pb-1 pt-2 text-xs font-medium leading-[18px] text-text-tertiary">{t('createApp', { ns: 'app' })}</div>

--- a/web/service/use-apps.ts
+++ b/web/service/use-apps.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/models/app'
 import type { App, AppModeEnum } from '@/types/app'
 import {
+  keepPreviousData,
   useInfiniteQuery,
   useQuery,
   useQueryClient,
@@ -107,6 +108,7 @@ export const useInfiniteAppList = (params: AppListParams, options?: { enabled?: 
     queryFn: ({ pageParam = normalizedParams.page }) => get<AppListResponse>('/apps', { params: { ...normalizedParams, page: pageParam } }),
     getNextPageParam: lastPage => lastPage.has_more ? lastPage.page + 1 : undefined,
     initialPageParam: normalizedParams.page,
+    placeholderData: keepPreviousData,
     ...options,
   })
 }


### PR DESCRIPTION
## Summary
This PR fixes two UX issues with the Apps list page:

1. **Empty state flash when switching filters** - Fixed by using TanStack Query's `keepPreviousData` to retain previous data while new data is being fetched
2. **Missing skeleton loading state and NewAppCard timing issue** - Fixed by adding proper loading state handling and skeleton placeholders

## Changes

### `web/service/use-apps.ts`
- Added `keepPreviousData` import from TanStack Query
- Added `placeholderData: keepPreviousData` to `useInfiniteAppList` hook

### `web/app/components/apps/list.tsx`
- Added `isFetching` and `isLoadingCurrentWorkspace` state handling
- Added `showSkeleton` and `showEmpty` computed values for cleaner conditional rendering
- Updated NewAppCard rendering to show during permission loading with `isLoading` prop
- Changed condition from `isCurrentWorkspaceEditor` to `(isCurrentWorkspaceEditor || isLoadingCurrentWorkspace)`

### `web/app/components/apps/new-app-card.tsx`
- Added `isLoading` prop (default: false)
- Applied loading styles: `opacity-50` and `pointer-events-none` when loading

### `web/app/components/apps/app-card-skeleton.tsx` (NEW)
- Created skeleton placeholder component that matches AppCard visual layout
- Uses existing `Skeleton` base components

## Screenshots
| Before | After |
|--------|-------|
|![CleanShot 2026-01-06 at 15 21 43](https://github.com/user-attachments/assets/c42d021b-c48e-42cc-9a8a-1fac7d1b4a1d)|![CleanShot 2026-01-06 at 15 22 44](https://github.com/user-attachments/assets/95565850-7db1-4220-9dfd-6428174222ed)|

## Related Issues
Closes #30614
Closes #30615