### PR TITLE
feat: use more universal C.UTF-8 instead of en_US.UTF-8

### DIFF
--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -3,8 +3,9 @@
 set -e
 
 # Set UTF-8 encoding to address potential encoding issues in containerized environments
-export LANG=${LANG:-en_US.UTF-8}
-export LC_ALL=${LC_ALL:-en_US.UTF-8}
+# Use C.UTF-8 which is universally available in all containers
+export LANG=${LANG:-C.UTF-8}
+export LC_ALL=${LC_ALL:-C.UTF-8}
 export PYTHONIOENCODING=${PYTHONIOENCODING:-utf-8}
 
 if [[ "${MIGRATION_ENABLED}" == "true" ]]; then

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -58,8 +58,8 @@ FILES_URL=
 INTERNAL_FILES_URL=
 
 # Ensure UTF-8 encoding
-LANG=en_US.UTF-8
-LC_ALL=en_US.UTF-8
+LANG=C.UTF-8
+LC_ALL=C.UTF-8
 PYTHONIOENCODING=utf-8
 
 # ------------------------------

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -475,7 +475,8 @@ services:
       OB_CLUSTER_NAME: ${OCEANBASE_CLUSTER_NAME:-difyai}
       OB_SERVER_IP: 127.0.0.1
       MODE: mini
-      LANG: en_US.UTF-8
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
     ports:
       - "${OCEANBASE_VECTOR_PORT:-2881}:2881"
     healthcheck:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,8 +13,8 @@ x-shared-env: &shared-api-worker-env
   APP_WEB_URL: ${APP_WEB_URL:-}
   FILES_URL: ${FILES_URL:-}
   INTERNAL_FILES_URL: ${INTERNAL_FILES_URL:-}
-  LANG: ${LANG:-en_US.UTF-8}
-  LC_ALL: ${LC_ALL:-en_US.UTF-8}
+  LANG: ${LANG:-C.UTF-8}
+  LC_ALL: ${LC_ALL:-C.UTF-8}
   PYTHONIOENCODING: ${PYTHONIOENCODING:-utf-8}
   LOG_LEVEL: ${LOG_LEVEL:-INFO}
   LOG_OUTPUT_FORMAT: ${LOG_OUTPUT_FORMAT:-text}
@@ -1157,7 +1157,8 @@ services:
       OB_CLUSTER_NAME: ${OCEANBASE_CLUSTER_NAME:-difyai}
       OB_SERVER_IP: 127.0.0.1
       MODE: mini
-      LANG: en_US.UTF-8
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
     ports:
       - "${OCEANBASE_VECTOR_PORT:-2881}:2881"
     healthcheck:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #30620

C.UTF-8 is the standard choice for Docker/container environments, while en_US.UTF-8 is mainly used for desktop applications targeting users in specific countries.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
