### PR TITLE
fix(api): normalize dataset query roles

### DIFF
--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -9,6 +9,7 @@ from core.app.app_config.entities import EasyUIBasedAppConfig, WorkflowUIBasedAp
 from core.entities.provider_configuration import ProviderModelBundle
 from core.file import File, FileUploadConfig
 from core.model_runtime.entities.model_entities import AIModelEntity
+from models.enums import CreatorUserRole
 
 if TYPE_CHECKING:
     from core.ops.ops_trace_manager import TraceQueueManager
@@ -79,6 +80,11 @@ class InvokeFrom(StrEnum):
             return "api"
 
         return "dev"
+
+    def to_creator_user_role(self) -> CreatorUserRole:
+        if self in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}:
+            return CreatorUserRole.ACCOUNT
+        return CreatorUserRole.END_USER
 
 
 class ModelConfigWithCredentialsEntity(BaseModel):

--- a/api/core/callback_handler/index_tool_callback_handler.py
+++ b/api/core/callback_handler/index_tool_callback_handler.py
@@ -12,7 +12,7 @@ from core.rag.models.document import Document
 from extensions.ext_database import db
 from models.dataset import ChildChunk, DatasetQuery, DocumentSegment
 from models.dataset import Document as DatasetDocument
-from models.enums import UserFrom
+from models.enums import CreatorUserRole
 
 _logger = logging.getLogger(__name__)
 
@@ -39,9 +39,9 @@ class DatasetIndexToolCallbackHandler:
             source="app",
             source_app_id=self._app_id,
             created_by_role=(
-                UserFrom.ACCOUNT
+                CreatorUserRole.ACCOUNT
                 if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}
-                else UserFrom.END_USER
+                else CreatorUserRole.END_USER
             ),
             created_by=self._user_id,
         )

--- a/api/core/callback_handler/index_tool_callback_handler.py
+++ b/api/core/callback_handler/index_tool_callback_handler.py
@@ -12,6 +12,7 @@ from core.rag.models.document import Document
 from extensions.ext_database import db
 from models.dataset import ChildChunk, DatasetQuery, DocumentSegment
 from models.dataset import Document as DatasetDocument
+from models.enums import UserFrom
 
 _logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class DatasetIndexToolCallbackHandler:
             source="app",
             source_app_id=self._app_id,
             created_by_role=(
-                "account" if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else "end_user"
+                UserFrom.ACCOUNT if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else UserFrom.END_USER
             ),
             created_by=self._user_id,
         )

--- a/api/core/callback_handler/index_tool_callback_handler.py
+++ b/api/core/callback_handler/index_tool_callback_handler.py
@@ -39,7 +39,9 @@ class DatasetIndexToolCallbackHandler:
             source="app",
             source_app_id=self._app_id,
             created_by_role=(
-                UserFrom.ACCOUNT if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else UserFrom.END_USER
+                UserFrom.ACCOUNT
+                if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}
+                else UserFrom.END_USER
             ),
             created_by=self._user_id,
         )

--- a/api/core/callback_handler/index_tool_callback_handler.py
+++ b/api/core/callback_handler/index_tool_callback_handler.py
@@ -12,7 +12,6 @@ from core.rag.models.document import Document
 from extensions.ext_database import db
 from models.dataset import ChildChunk, DatasetQuery, DocumentSegment
 from models.dataset import Document as DatasetDocument
-from models.enums import CreatorUserRole
 
 _logger = logging.getLogger(__name__)
 
@@ -38,11 +37,7 @@ class DatasetIndexToolCallbackHandler:
             content=query,
             source="app",
             source_app_id=self._app_id,
-            created_by_role=(
-                CreatorUserRole.ACCOUNT
-                if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}
-                else CreatorUserRole.END_USER
-            ),
+            created_by_role=self._invoke_from.to_creator_user_role(),
             created_by=self._user_id,
         )
 

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -177,9 +177,7 @@ class DatasetRetrieval:
         )
 
         all_documents = []
-        user_from = (
-            UserFrom.ACCOUNT if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else UserFrom.END_USER
-        )
+        user_from = UserFrom.ACCOUNT if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else UserFrom.END_USER
         if retrieve_config.retrieve_strategy == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE:
             all_documents = self.single_retrieve(
                 app_id,

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -63,7 +63,6 @@ from libs.json_in_md_parser import parse_and_check_json_markdown
 from models import UploadFile
 from models.dataset import ChildChunk, Dataset, DatasetMetadata, DatasetQuery, DocumentSegment, SegmentAttachmentBinding
 from models.dataset import Document as DatasetDocument
-from models.enums import CreatorUserRole
 from services.external_knowledge_service import ExternalDatasetService
 
 default_retrieval_model: dict[str, Any] = {
@@ -177,11 +176,7 @@ class DatasetRetrieval:
         )
 
         all_documents = []
-        user_from = (
-            CreatorUserRole.ACCOUNT
-            if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}
-            else CreatorUserRole.END_USER
-        )
+        user_from = "account" if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else "end_user"
         if retrieve_config.retrieve_strategy == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE:
             all_documents = self.single_retrieve(
                 app_id,

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -63,6 +63,7 @@ from libs.json_in_md_parser import parse_and_check_json_markdown
 from models import UploadFile
 from models.dataset import ChildChunk, Dataset, DatasetMetadata, DatasetQuery, DocumentSegment, SegmentAttachmentBinding
 from models.dataset import Document as DatasetDocument
+from models.enums import UserFrom
 from services.external_knowledge_service import ExternalDatasetService
 
 default_retrieval_model: dict[str, Any] = {
@@ -176,7 +177,9 @@ class DatasetRetrieval:
         )
 
         all_documents = []
-        user_from = "account" if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else "end_user"
+        user_from = (
+            UserFrom.ACCOUNT if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else UserFrom.END_USER
+        )
         if retrieve_config.retrieve_strategy == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE:
             all_documents = self.single_retrieve(
                 app_id,

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -63,7 +63,7 @@ from libs.json_in_md_parser import parse_and_check_json_markdown
 from models import UploadFile
 from models.dataset import ChildChunk, Dataset, DatasetMetadata, DatasetQuery, DocumentSegment, SegmentAttachmentBinding
 from models.dataset import Document as DatasetDocument
-from models.enums import UserFrom
+from models.enums import CreatorUserRole
 from services.external_knowledge_service import ExternalDatasetService
 
 default_retrieval_model: dict[str, Any] = {
@@ -177,7 +177,11 @@ class DatasetRetrieval:
         )
 
         all_documents = []
-        user_from = UserFrom.ACCOUNT if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else UserFrom.END_USER
+        user_from = (
+            CreatorUserRole.ACCOUNT
+            if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}
+            else CreatorUserRole.END_USER
+        )
         if retrieve_config.retrieve_strategy == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE:
             all_documents = self.single_retrieve(
                 app_id,

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -55,6 +55,7 @@ from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from libs.json_in_md_parser import parse_and_check_json_markdown
 from models.dataset import Dataset, DatasetMetadata, Document, RateLimitLog
+from models.enums import CreatorUserRole, UserFrom
 from services.feature_service import FeatureService
 
 from .entities import KnowledgeRetrievalNodeData
@@ -268,6 +269,7 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
             usage = self._merge_usage(usage, metadata_usage)
         all_documents = []
         dataset_retrieval = DatasetRetrieval()
+        creator_user_role = CreatorUserRole.ACCOUNT if self.user_from == UserFrom.ACCOUNT else CreatorUserRole.END_USER
         if str(node_data.retrieval_mode) == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE and query:
             # fetch model config
             if node_data.single_retrieval_config is None:
@@ -292,7 +294,7 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
                     tenant_id=self.tenant_id,
                     user_id=self.user_id,
                     app_id=self.app_id,
-                    user_from=self.user_from.value,
+                    creator_user_role=creator_user_role,
                     query=query,
                     model_config=model_config,
                     model_instance=model_instance,
@@ -334,7 +336,7 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
                 app_id=self.app_id,
                 tenant_id=self.tenant_id,
                 user_id=self.user_id,
-                user_from=self.user_from.value,
+                creator_user_role=creator_user_role,
                 available_datasets=available_datasets,
                 query=query,
                 top_k=node_data.multiple_retrieval_config.top_k,

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -55,7 +55,7 @@ from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from libs.json_in_md_parser import parse_and_check_json_markdown
 from models.dataset import Dataset, DatasetMetadata, Document, RateLimitLog
-from models.enums import CreatorUserRole, UserFrom
+from models.enums import UserFrom
 from services.feature_service import FeatureService
 
 from .entities import KnowledgeRetrievalNodeData
@@ -269,7 +269,7 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
             usage = self._merge_usage(usage, metadata_usage)
         all_documents = []
         dataset_retrieval = DatasetRetrieval()
-        creator_user_role = CreatorUserRole.ACCOUNT if self.user_from == UserFrom.ACCOUNT else CreatorUserRole.END_USER
+        creator_user_role = self.user_from.to_creator_user_role()
         if str(node_data.retrieval_mode) == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE and query:
             # fetch model config
             if node_data.single_retrieval_config is None:

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -55,7 +55,6 @@ from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from libs.json_in_md_parser import parse_and_check_json_markdown
 from models.dataset import Dataset, DatasetMetadata, Document, RateLimitLog
-from models.enums import UserFrom
 from services.feature_service import FeatureService
 
 from .entities import KnowledgeRetrievalNodeData

--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -12,6 +12,11 @@ class UserFrom(StrEnum):
     ACCOUNT = "account"
     END_USER = "end-user"
 
+    def to_creator_user_role(self) -> "CreatorUserRole":
+        if self == UserFrom.ACCOUNT:
+            return CreatorUserRole.ACCOUNT
+        return CreatorUserRole.END_USER
+
 
 class WorkflowRunTriggeredFrom(StrEnum):
     DEBUGGING = "debugging"

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -13,7 +13,7 @@ from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from extensions.ext_database import db
 from models import Account
 from models.dataset import Dataset, DatasetQuery
-from models.enums import UserFrom
+from models.enums import CreatorUserRole
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class HitTestingService:
                 content=json.dumps(dataset_queries),
                 source="hit_testing",
                 source_app_id=None,
-                created_by_role=UserFrom.ACCOUNT,
+                created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
             )
             db.session.add(dataset_query)
@@ -139,7 +139,7 @@ class HitTestingService:
             content=query,
             source="hit_testing",
             source_app_id=None,
-            created_by_role=UserFrom.ACCOUNT,
+            created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
         )
 

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -13,6 +13,7 @@ from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from extensions.ext_database import db
 from models import Account
 from models.dataset import Dataset, DatasetQuery
+from models.enums import UserFrom
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,7 @@ class HitTestingService:
                 content=json.dumps(dataset_queries),
                 source="hit_testing",
                 source_app_id=None,
-                created_by_role="account",
+                created_by_role=UserFrom.ACCOUNT,
                 created_by=account.id,
             )
             db.session.add(dataset_query)
@@ -138,7 +139,7 @@ class HitTestingService:
             content=query,
             source="hit_testing",
             source_app_id=None,
-            created_by_role="account",
+            created_by_role=UserFrom.ACCOUNT,
             created_by=account.id,
         )
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Normalize dataset query `created_by_role` to use the `CreatorUserRole` enum across retrieval, index tool callbacks, and hit testing for consistent role values.
- Fixes #30640.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
