### PR TITLE
chore: rename ralph-wiggum plugin to ralph-loop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,6 @@
     "context7@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "ralph-wiggum@claude-plugins-official": true
+    "ralph-loop@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Update Claude settings to use the renamed `ralph-loop` plugin

## Context
The upstream `ralph-wiggum` plugin in claude-plugins-official has been renamed to `ralph-loop` per legal guidance (to avoid trademark concerns with "Wiggum" name).

**Reference PR**: https://github.com/anthropics/claude-plugins-official/pull/142

## Changes
- Updated `.claude/settings.json` to reference `ralph-loop@claude-plugins-official` instead of `ralph-wiggum@claude-plugins-official`

## Test plan
- [x] Verify `.claude/settings.json` is properly formatted
- [x] Confirm plugin name matches upstream

Closes #30663

🤖 Generated with [Claude Code](https://claude.com/claude-code)