### PR TITLE
refactor: remove unnecessary type: ignore from rag_pipeline_fields.py

### DIFF
--- a/api/fields/rag_pipeline_fields.py
+++ b/api/fields/rag_pipeline_fields.py
@@ -1,4 +1,4 @@
-from flask_restx import fields  # type: ignore
+from flask_restx import fields
 
 from fields.workflow_fields import workflow_partial_fields
 from libs.helper import AppIconUrlField, TimestampField


### PR DESCRIPTION
## Summary

Remove the unnecessary `# type: ignore` comment from the flask_restx import in `api/fields/rag_pipeline_fields.py`.

## Why

- The `# type: ignore` comment on this import is unnecessary
- Other files in the codebase import from `flask_restx` without type: ignore comments (e.g., `fields/data_source_fields.py`, `fields/api_based_extension_fields.py`, `libs/helper.py`)
- Type check passes without this comment

## Test plan

- [x] `make type-check` passes (0 errors)
- [x] `make lint` passes
- [x] All unit tests pass (4820 passed)

Part of #24494