### PR TITLE
fix: signin page stuck on loading when refresh token valid but access token expired

### DIFF
--- a/web/app/signin/normal-form.tsx
+++ b/web/app/signin/normal-form.tsx
@@ -28,7 +28,8 @@ const NormalForm = () => {
   const message = decodeURIComponent(searchParams.get('message') || '')
   const invite_token = decodeURIComponent(searchParams.get('invite_token') || '')
   const [isInitCheckLoading, setInitCheckLoading] = useState(true)
-  const isLoading = isCheckLoading || loginData?.logged_in || isInitCheckLoading
+  const [isRedirecting, setIsRedirecting] = useState(false)
+  const isLoading = isCheckLoading || isInitCheckLoading || isRedirecting
   const { systemFeatures } = useGlobalPublicStore()
   const [authType, updateAuthType] = useState<'code' | 'password'>('password')
   const [showORLine, setShowORLine] = useState(false)
@@ -40,6 +41,7 @@ const NormalForm = () => {
   const init = useCallback(async () => {
     try {
       if (isLoggedIn) {
+        setIsRedirecting(true)
         const redirectUrl = resolvePostLoginRedirect(searchParams)
         router.replace(redirectUrl || '/apps')
         return

--- a/web/service/use-common.ts
+++ b/web/service/use-common.ts
@@ -221,13 +221,12 @@ export const useIsLogin = () => {
         await get('/account/profile', {}, {
           silent: true,
         })
-      }
-      catch (e: any) {
-        if (e.status === 401)
-          return { logged_in: false }
         return { logged_in: true }
       }
-      return { logged_in: true }
+      catch {
+        // Any error (401, 500, network error, etc.) means not logged in
+        return { logged_in: false }
+      }
     },
   })
 }


### PR DESCRIPTION
## Summary

- Fix signin page getting stuck on loading when user has valid refresh token but expired access token
- Remove `loginData?.logged_in` from `isLoading` condition and use explicit `isRedirecting` state
- Fix error handling in `useIsLogin` hook to treat any error as "not logged in"

## Test plan

- [ ] Verify signin page loads correctly when not logged in
- [ ] Verify redirect works when user is already logged in
- [ ] Verify page doesn't get stuck when access token expires but refresh token is valid
- [ ] Verify error states (500, network errors) don't cause infinite loading

Fixes #30674

🤖 Generated with [Claude Code](https://claude.com/claude-code)