### PR TITLE
fix(web): restrict postMessage targetOrigin from wildcard to specific origins

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/header/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/header/index.tsx
@@ -66,7 +66,9 @@ const Header: FC<IHeaderProps> = ({
     const listener = (event: MessageEvent) => handleMessageReceived(event)
     window.addEventListener('message', listener)
 
-    window.parent.postMessage({ type: 'dify-chatbot-iframe-ready' }, '*')
+    // Security: Use document.referrer to get parent origin
+    const targetOrigin = document.referrer ? new URL(document.referrer).origin : '*'
+    window.parent.postMessage({ type: 'dify-chatbot-iframe-ready' }, targetOrigin)
 
     return () => window.removeEventListener('message', listener)
   }, [isIframe, handleMessageReceived])

--- a/web/hooks/use-oauth.ts
+++ b/web/hooks/use-oauth.ts
@@ -10,12 +10,15 @@ export const useOAuthCallback = () => {
     const errorDescription = urlParams.get('error_description')
 
     if (window.opener) {
+      // Use window.opener.origin instead of '*' for security
+      const targetOrigin = window.opener?.origin || '*'
+
       if (subscriptionId) {
         window.opener.postMessage({
           type: 'oauth_callback',
           success: true,
           subscriptionId,
-        }, '*')
+        }, targetOrigin)
       }
       else if (error) {
         window.opener.postMessage({
@@ -23,12 +26,12 @@ export const useOAuthCallback = () => {
           success: false,
           error,
           errorDescription,
-        }, '*')
+        }, targetOrigin)
       }
       else {
         window.opener.postMessage({
           type: 'oauth_callback',
-        }, '*')
+        }, targetOrigin)
       }
       window.close()
     }


### PR DESCRIPTION
  ## Summary

  This PR fixes a security vulnerability (CVE) related to `postMessage` usage in the web frontend. The changes restrict the `targetOrigin` parameter from wildcard (`*`) to specific origins.

Fixes #30723 

  ## Changes

  1. **Embedded Chatbot** (`web/app/components/base/chat/embedded-chatbot/header/index.tsx`):
     - Changed from `postMessage(..., '*')` to using `document.referrer` to determine parent origin
     - Falls back to `'*'` only if referrer is unavailable

  2. **OAuth Hook** (`web/hooks/use-oauth.ts`):
     - Changed from `postMessage(..., '*')` to using `window.opener.origin`    
     - Falls back to `'*'` only if opener origin is unavailable

  ## Checklist

  - [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
  - [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [ ] I've updated the documentation accordingly.
  - [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

