### PR TITLE
refactor(web): remove unused type alias VoiceLanguageKey

### DIFF
--- a/web/app/components/base/features/new-feature-panel/text-to-speech/param-config-content.tsx
+++ b/web/app/components/base/features/new-feature-panel/text-to-speech/param-config-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 import type { OnFeaturesChange } from '@/app/components/base/features/types'
 import type { Item } from '@/app/components/base/select'
-import type { I18nKeysWithPrefix } from '@/types/i18n'
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions, Transition } from '@headlessui/react'
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 import { RiCloseLine } from '@remixicon/react'
@@ -19,8 +18,6 @@ import { languages } from '@/i18n-config/language'
 import { useAppVoices } from '@/service/use-apps'
 import { TtsAutoPlay } from '@/types/app'
 import { cn } from '@/utils/classnames'
-
-type VoiceLanguageKey = I18nKeysWithPrefix<'common', 'voice.language.'>
 
 type VoiceParamConfigProps = {
   onClose: () => void


### PR DESCRIPTION
## Summary

Remove unused type alias `VoiceLanguageKey` and its unused import `I18nKeysWithPrefix` from `param-config-content.tsx`.

## Why

- The type alias `VoiceLanguageKey` was declared but never used
- Detected by `npx oxlint`
- Clean up codebase by removing unused code

## Test plan

- [x] `pnpm lint:fix` passes
- [x] `pnpm type-check:tsgo` passes  
- [x] All 9449 frontend tests pass

Part of #25189