### PR TITLE
fix(i18n): resolve Claude Code sandbox path issues in workflow

### DIFF
--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -364,13 +364,13 @@ jobs:
             ```bash
             date +%Y%m%d-%H%M%S
             ```
-            (Note the output, e.g., "20250107-143052")
+            (Note the output, e.g., "20260115-143052")
 
             2. Then create branch using the timestamp value:
             ```bash
-            git -C ${{ github.workspace }} checkout -b chore/i18n-sync-20250107-143052
+            git -C ${{ github.workspace }} checkout -b chore/i18n-sync-20260115-143052
             ```
-            (Replace "20250107-143052" with the actual timestamp from step 1)
+            (Replace "20260115-143052" with the actual timestamp from step 1)
 
             3. Stage changes:
             ```bash

--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -132,6 +132,13 @@ jobs:
             - Use **Edit** tool to modify JSON files (NOT node, jq, or bash scripts)
             - Use **Bash** ONLY for: git commands, gh commands, pnpm commands
             - Run bash commands ONE BY ONE, never combine with && or ||
+            - NEVER use `$()` command substitution - it's not supported. Split into separate commands instead.
+
+            ## WORKING DIRECTORY
+            The Claude Code sandbox runs from `${{ github.workspace }}/web` directory.
+            - For pnpm commands: just use `pnpm` (no --dir needed)
+            - For git/gh commands: use `${{ github.workspace }}` as the repo root
+            - For file paths: use absolute paths like `${{ github.workspace }}/web/i18n/`
 
             ## EFFICIENCY RULES
             - **ONE Edit per language file** - batch all key additions into a single Edit
@@ -171,8 +178,10 @@ jobs:
 
             ### Step 1.3: Run i18n:check for Each Language
             ```bash
-            pnpm --dir web install --frozen-lockfile
-            pnpm --dir web run i18n:check
+            pnpm install --frozen-lockfile
+            ```
+            ```bash
+            pnpm run i18n:check
             ```
 
             This will report:
@@ -234,7 +243,7 @@ jobs:
 
             **IMPORTANT: Special handling for zh-Hans and ja-JP**
             If zh-Hans or ja-JP files were ALSO modified in the same push:
-            - Run: `git diff HEAD~1 --name-only | grep -E "(zh-Hans|ja-JP)"`
+            - Run: `git -C ${{ github.workspace }} diff HEAD~1 --name-only` and check for zh-Hans or ja-JP files
             - If found, it means someone manually translated them. Apply these rules:
 
             1. **Missing keys**: Still ADD them (completeness required)
@@ -254,7 +263,7 @@ jobs:
 
             ### Step 2.3: Process DELETE Operations
             For extra keys reported by i18n:check:
-            - Run: `pnpm --dir web run i18n:check --auto-remove`
+            - Run: `pnpm run i18n:check --auto-remove`
             - Or manually remove from target language JSON files
 
             ## Translation Guidelines
@@ -282,7 +291,7 @@ jobs:
 
             ### Step 3.1: Run Lint Fix (IMPORTANT!)
             ```bash
-            pnpm --dir web lint:fix --quiet -- 'i18n/**/*.json'
+            pnpm lint:fix --quiet -- 'i18n/**/*.json'
             ```
             This ensures:
             - JSON keys are sorted alphabetically (jsonc/sort-keys rule)
@@ -291,7 +300,7 @@ jobs:
 
             ### Step 3.2: Run Final i18n Check
             ```bash
-            pnpm --dir web run i18n:check
+            pnpm run i18n:check
             ```
 
             ### Step 3.3: Fix Any Remaining Issues
@@ -342,39 +351,45 @@ jobs:
 
             ### Step 4.1: Check for changes
             ```bash
-            git status --porcelain
+            git -C ${{ github.workspace }} status --porcelain
             ```
 
             If there are changes:
 
             ### Step 4.2: Create a new branch and commit
-            Run these git commands ONE BY ONE (not combined with &&):
+            Run these git commands ONE BY ONE (not combined with &&).
+            **IMPORTANT**: Do NOT use `$()` command substitution. Use two separate commands:
 
-            1. Create branch:
+            1. First, get the timestamp:
             ```bash
-            git checkout -b "chore/i18n-sync-$(date +%Y%m%d-%H%M%S)"
+            date +%Y%m%d-%H%M%S
+            ```
+            (Note the output, e.g., "20250107-143052")
+
+            2. Then create branch using the timestamp value:
+            ```bash
+            git -C ${{ github.workspace }} checkout -b chore/i18n-sync-20250107-143052
+            ```
+            (Replace "20250107-143052" with the actual timestamp from step 1)
+
+            3. Stage changes:
+            ```bash
+            git -C ${{ github.workspace }} add web/i18n/
             ```
 
-            2. Stage changes:
+            4. Commit:
             ```bash
-            git add web/i18n/
+            git -C ${{ github.workspace }} commit -m "chore(i18n): sync translations with en-US - Mode: ${{ steps.detect_changes.outputs.SYNC_MODE }}"
             ```
 
-            3. Commit (use heredoc for multi-line message):
+            5. Push:
             ```bash
-            git commit -m "chore(i18n): sync translations with en-US - Mode: ${{ steps.detect_changes.outputs.SYNC_MODE }}"
-            ```
-
-            4. Push:
-            ```bash
-            git push origin HEAD
+            git -C ${{ github.workspace }} push origin HEAD
             ```
 
             ### Step 4.3: Create Pull Request
             ```bash
-            gh pr create \
-              --title "chore(i18n): sync translations with en-US" \
-              --body "## Summary
+            gh pr create --repo ${{ github.repository }} --title "chore(i18n): sync translations with en-US" --body "## Summary
 
             This PR was automatically generated to sync i18n translation files.
 
@@ -386,10 +401,9 @@ jobs:
             - [x] \`i18n:check\` passed
             - [x] \`lint:fix\` applied
 
-            🤖 Generated with Claude Code GitHub Action" \
-              --base main
+            🤖 Generated with Claude Code GitHub Action" --base main
             ```
 
           claude_args: |
             --max-turns 150
-            --allowedTools "Read,Write,Edit,Bash(git *),Bash(git:*),Bash(gh *),Bash(gh:*),Bash(pnpm *),Bash(pnpm:*),Glob,Grep"
+            --allowedTools "Read,Write,Edit,Bash(git *),Bash(git:*),Bash(gh *),Bash(gh:*),Bash(pnpm *),Bash(pnpm:*),Bash(date *),Bash(date:*),Glob,Grep"

--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -134,11 +134,12 @@ jobs:
             - Run bash commands ONE BY ONE, never combine with && or ||
             - NEVER use `$()` command substitution - it's not supported. Split into separate commands instead.
 
-            ## WORKING DIRECTORY
-            The Claude Code sandbox runs from `${{ github.workspace }}/web` directory.
-            - For pnpm commands: just use `pnpm` (no --dir needed)
-            - For git/gh commands: use `${{ github.workspace }}` as the repo root
-            - For file paths: use absolute paths like `${{ github.workspace }}/web/i18n/`
+            ## WORKING DIRECTORY & ABSOLUTE PATHS
+            Claude Code sandbox working directory may vary. Always use absolute paths:
+            - For pnpm: `pnpm --dir ${{ github.workspace }}/web <command>`
+            - For git: `git -C ${{ github.workspace }} <command>`
+            - For gh: `gh --repo ${{ github.repository }} <command>`
+            - For file paths: `${{ github.workspace }}/web/i18n/`
 
             ## EFFICIENCY RULES
             - **ONE Edit per language file** - batch all key additions into a single Edit
@@ -149,8 +150,8 @@ jobs:
             - Changed/target files: ${{ steps.detect_changes.outputs.CHANGED_FILES }}
             - Target languages (empty means all supported): ${{ steps.detect_changes.outputs.TARGET_LANGS }}
             - Sync mode: ${{ steps.detect_changes.outputs.SYNC_MODE }}
-            - Translation files are located in: web/i18n/{locale}/{filename}.json
-            - Language configuration is in: web/i18n-config/languages.ts
+            - Translation files are located in: ${{ github.workspace }}/web/i18n/{locale}/{filename}.json
+            - Language configuration is in: ${{ github.workspace }}/web/i18n-config/languages.ts
             - Git diff is available: ${{ steps.detect_changes.outputs.DIFF_AVAILABLE }}
 
             ## CRITICAL DESIGN: Verify First, Then Sync
@@ -173,15 +174,15 @@ jobs:
               * DELETE: Keys that appear only in `-` lines (removed keys)
 
             ### Step 1.2: Read Language Configuration
-            Use the Read tool to read `web/i18n-config/languages.ts`.
+            Use the Read tool to read `${{ github.workspace }}/web/i18n-config/languages.ts`.
             Extract all languages with `supported: true`.
 
             ### Step 1.3: Run i18n:check for Each Language
             ```bash
-            pnpm install --frozen-lockfile
+            pnpm --dir ${{ github.workspace }}/web install --frozen-lockfile
             ```
             ```bash
-            pnpm run i18n:check
+            pnpm --dir ${{ github.workspace }}/web run i18n:check
             ```
 
             This will report:
@@ -263,7 +264,7 @@ jobs:
 
             ### Step 2.3: Process DELETE Operations
             For extra keys reported by i18n:check:
-            - Run: `pnpm run i18n:check --auto-remove`
+            - Run: `pnpm --dir ${{ github.workspace }}/web run i18n:check --auto-remove`
             - Or manually remove from target language JSON files
 
             ## Translation Guidelines
@@ -291,7 +292,7 @@ jobs:
 
             ### Step 3.1: Run Lint Fix (IMPORTANT!)
             ```bash
-            pnpm lint:fix --quiet -- 'i18n/**/*.json'
+            pnpm --dir ${{ github.workspace }}/web lint:fix --quiet -- 'i18n/**/*.json'
             ```
             This ensures:
             - JSON keys are sorted alphabetically (jsonc/sort-keys rule)
@@ -300,7 +301,7 @@ jobs:
 
             ### Step 3.2: Run Final i18n Check
             ```bash
-            pnpm run i18n:check
+            pnpm --dir ${{ github.workspace }}/web run i18n:check
             ```
 
             ### Step 3.3: Fix Any Remaining Issues


### PR DESCRIPTION
## Summary

Follow-up fix for #30692. Resolves issues discovered during workflow execution when Claude Code sandbox working directory may vary.

## Issues Fixed

### 1. Command Substitution Not Supported
**Problem**: `git checkout -b "chore/i18n-sync-$(date +%Y%m%d-%H%M%S)"` fails because Claude Code's Bash tool doesn't support `$()` command substitution.

**Fix**: Split into two separate commands:
```bash
# First, get timestamp
date +%Y%m%d-%H%M%S
# → 20260115-143052

# Then create branch using the output
git -C ${{ github.workspace }} checkout -b chore/i18n-sync-20260115-143052
```

### 2. Working Directory Path Resolution
**Problem**: Claude Code sandbox working directory may vary (could be repo root or `web/` subdirectory). Relative paths like `git add web/i18n/` or `pnpm --dir web` may fail depending on the actual working directory.

**Fix**: Use absolute paths for ALL commands to ensure reliability regardless of working directory:
- `pnpm --dir ${{ github.workspace }}/web <command>`
- `git -C ${{ github.workspace }} <command>`
- `gh --repo ${{ github.repository }} <command>`
- File paths: `${{ github.workspace }}/web/i18n/...`

### 3. Missing Tool Permission
**Problem**: `date` command needed for timestamp but not in allowedTools.

**Fix**: Added `Bash(date *),Bash(date:*)` to allowedTools.

## Changes

| Category | Before | After |
|----------|--------|-------|
| pnpm commands | `pnpm --dir web install` | `pnpm --dir ${{ github.workspace }}/web install` |
| git commands | `git add web/i18n/` | `git -C ${{ github.workspace }} add web/i18n/` |
| gh commands | `gh pr create` | `gh pr create --repo ${{ github.repository }}` |
| File paths | `web/i18n-config/languages.ts` | `${{ github.workspace }}/web/i18n-config/languages.ts` |
| Branch creation | `$(date +%Y%m%d)` substitution | Two separate commands |
| allowedTools | 10 patterns | 12 patterns (+date) |

## Best Practices Applied

1. **Always use absolute paths** - Claude Code sandbox working directory is not guaranteed
2. **Never use command substitution** - `$()` is not supported in Claude Code's Bash tool
3. **Run commands one by one** - Don't combine with `&&` or `||`
4. **Document clearly** - Added "WORKING DIRECTORY & ABSOLUTE PATHS" section in prompt

## Test Plan

- [ ] Trigger workflow manually with `workflow_dispatch`
- [ ] Verify pnpm commands work with absolute paths
- [ ] Verify git commands use correct absolute paths
- [ ] Verify branch creation works with two-step approach
- [ ] Verify PR creation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)