### PR TITLE
fix(ci): use repository_dispatch for i18n sync workflow

### DIFF
--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -93,7 +93,8 @@ jobs:
             # Triggered by push via trigger-i18n-sync.yml workflow
             # Validate required payload fields
             if [ -z "${{ github.event.client_payload.changed_files }}" ]; then
-              echo "Warning: repository_dispatch payload missing 'changed_files' field" >&2
+              echo "Error: repository_dispatch payload missing required 'changed_files' field" >&2
+              exit 1
             fi
             echo "CHANGED_FILES=${{ github.event.client_payload.changed_files }}" >> $GITHUB_OUTPUT
             echo "TARGET_LANGS=" >> $GITHUB_OUTPUT

--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -91,14 +91,21 @@ jobs:
             fi
           elif [ "${{ github.event_name }}" == "repository_dispatch" ]; then
             # Triggered by push via trigger-i18n-sync.yml workflow
+            # Validate required payload fields
+            if [ -z "${{ github.event.client_payload.changed_files }}" ]; then
+              echo "Warning: repository_dispatch payload missing 'changed_files' field" >&2
+            fi
             echo "CHANGED_FILES=${{ github.event.client_payload.changed_files }}" >> $GITHUB_OUTPUT
             echo "TARGET_LANGS=" >> $GITHUB_OUTPUT
-            echo "SYNC_MODE=${{ github.event.client_payload.sync_mode }}" >> $GITHUB_OUTPUT
+            echo "SYNC_MODE=${{ github.event.client_payload.sync_mode || 'incremental' }}" >> $GITHUB_OUTPUT
 
             # Decode the base64-encoded diff from the trigger workflow
             if [ -n "${{ github.event.client_payload.diff_base64 }}" ]; then
-              echo "${{ github.event.client_payload.diff_base64 }}" | base64 -d > /tmp/i18n-diff.txt 2>/dev/null || echo "" > /tmp/i18n-diff.txt
-              if [ -s /tmp/i18n-diff.txt ]; then
+              if ! echo "${{ github.event.client_payload.diff_base64 }}" | base64 -d > /tmp/i18n-diff.txt 2>&1; then
+                echo "Warning: Failed to decode base64 diff payload" >&2
+                echo "" > /tmp/i18n-diff.txt
+                echo "DIFF_AVAILABLE=false" >> $GITHUB_OUTPUT
+              elif [ -s /tmp/i18n-diff.txt ]; then
                 echo "DIFF_AVAILABLE=true" >> $GITHUB_OUTPUT
               else
                 echo "DIFF_AVAILABLE=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -1,10 +1,12 @@
 name: Translate i18n Files with Claude Code
 
+# Note: claude-code-action doesn't support push events directly.
+# Push events are handled by trigger-i18n-sync.yml which sends repository_dispatch.
+# See: https://github.com/langgenius/dify/issues/30743
+
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'web/i18n/en-US/*.json'
+  repository_dispatch:
+    types: [i18n-sync]
   workflow_dispatch:
     inputs:
       files:
@@ -87,26 +89,27 @@ jobs:
                 echo "DIFF_AVAILABLE=false" >> $GITHUB_OUTPUT
               fi
             fi
-          else
-            # Push trigger - detect changed files from the push
-            BEFORE_SHA="${{ github.event.before }}"
-            # Handle edge case: first push or force push may have null/zero SHA
-            if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
-              # Fallback to comparing with parent commit
-              BEFORE_SHA="HEAD~1"
-            fi
-            changed=$(git diff --name-only "$BEFORE_SHA" ${{ github.sha }} -- 'web/i18n/en-US/*.json' 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/.json$//' | tr '\n' ' ' || echo "")
-            echo "CHANGED_FILES=$changed" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+            # Triggered by push via trigger-i18n-sync.yml workflow
+            echo "CHANGED_FILES=${{ github.event.client_payload.changed_files }}" >> $GITHUB_OUTPUT
             echo "TARGET_LANGS=" >> $GITHUB_OUTPUT
-            echo "SYNC_MODE=incremental" >> $GITHUB_OUTPUT
+            echo "SYNC_MODE=${{ github.event.client_payload.sync_mode }}" >> $GITHUB_OUTPUT
 
-            # Generate detailed diff for the push
-            git diff "$BEFORE_SHA"..${{ github.sha }} -- 'web/i18n/en-US/*.json' > /tmp/i18n-diff.txt 2>/dev/null || echo "" > /tmp/i18n-diff.txt
-            if [ -s /tmp/i18n-diff.txt ]; then
-              echo "DIFF_AVAILABLE=true" >> $GITHUB_OUTPUT
+            # Decode the base64-encoded diff from the trigger workflow
+            if [ -n "${{ github.event.client_payload.diff_base64 }}" ]; then
+              echo "${{ github.event.client_payload.diff_base64 }}" | base64 -d > /tmp/i18n-diff.txt 2>/dev/null || echo "" > /tmp/i18n-diff.txt
+              if [ -s /tmp/i18n-diff.txt ]; then
+                echo "DIFF_AVAILABLE=true" >> $GITHUB_OUTPUT
+              else
+                echo "DIFF_AVAILABLE=false" >> $GITHUB_OUTPUT
+              fi
             else
+              echo "" > /tmp/i18n-diff.txt
               echo "DIFF_AVAILABLE=false" >> $GITHUB_OUTPUT
             fi
+          else
+            echo "Unsupported event type: ${{ github.event_name }}"
+            exit 1
           fi
 
           # Truncate diff if too large (keep first 50KB)

--- a/.github/workflows/trigger-i18n-sync.yml
+++ b/.github/workflows/trigger-i18n-sync.yml
@@ -33,6 +33,11 @@ jobs:
           if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             BEFORE_SHA="HEAD~1"
           fi
+          # If HEAD~1 doesn't exist (e.g., first commit), fall back to empty tree
+          if ! git rev-parse --verify "$BEFORE_SHA" >/dev/null 2>&1; then
+            echo "Detected missing parent commit; falling back to empty tree for diff baseline."
+            BEFORE_SHA="$(git hash-object -t tree /dev/null)"
+          fi
 
           # Detect changed i18n files
           changed=$(git diff --name-only "$BEFORE_SHA" "${{ github.sha }}" -- 'web/i18n/en-US/*.json' 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/.json$//' | tr '\n' ' ' || echo "")

--- a/.github/workflows/trigger-i18n-sync.yml
+++ b/.github/workflows/trigger-i18n-sync.yml
@@ -35,18 +35,18 @@ jobs:
           fi
 
           # Detect changed i18n files
-          changed=$(git diff --name-only "$BEFORE_SHA" ${{ github.sha }} -- 'web/i18n/en-US/*.json' 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/.json$//' | tr '\n' ' ' || echo "")
+          changed=$(git diff --name-only "$BEFORE_SHA" "${{ github.sha }}" -- 'web/i18n/en-US/*.json' 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/.json$//' | tr '\n' ' ' || echo "")
           echo "changed_files=$changed" >> $GITHUB_OUTPUT
 
           # Generate diff for context
-          git diff "$BEFORE_SHA"..${{ github.sha }} -- 'web/i18n/en-US/*.json' > /tmp/i18n-diff.txt 2>/dev/null || echo "" > /tmp/i18n-diff.txt
+          git diff "$BEFORE_SHA" "${{ github.sha }}" -- 'web/i18n/en-US/*.json' > /tmp/i18n-diff.txt 2>/dev/null || echo "" > /tmp/i18n-diff.txt
 
-          # Truncate if too large (keep first 30KB to stay within payload limits)
-          head -c 30000 /tmp/i18n-diff.txt > /tmp/i18n-diff-truncated.txt
+          # Truncate if too large (keep first 50KB to match receiving workflow)
+          head -c 50000 /tmp/i18n-diff.txt > /tmp/i18n-diff-truncated.txt
           mv /tmp/i18n-diff-truncated.txt /tmp/i18n-diff.txt
 
-          # Base64 encode the diff for safe JSON transport
-          diff_base64=$(base64 -w 0 < /tmp/i18n-diff.txt 2>/dev/null || base64 < /tmp/i18n-diff.txt)
+          # Base64 encode the diff for safe JSON transport (portable, single-line)
+          diff_base64=$(base64 < /tmp/i18n-diff.txt | tr -d '\n')
           echo "diff_base64=$diff_base64" >> $GITHUB_OUTPUT
 
           if [ -n "$changed" ]; then

--- a/.github/workflows/trigger-i18n-sync.yml
+++ b/.github/workflows/trigger-i18n-sync.yml
@@ -11,7 +11,7 @@ on:
       - 'web/i18n/en-US/*.json'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   trigger:
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect changed files and generate diff
         id: detect

--- a/.github/workflows/trigger-i18n-sync.yml
+++ b/.github/workflows/trigger-i18n-sync.yml
@@ -29,14 +29,9 @@ jobs:
         id: detect
         run: |
           BEFORE_SHA="${{ github.event.before }}"
-          # Handle edge case: first push or force push may have null/zero SHA
+          # Handle edge case: force push may have null/zero SHA
           if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             BEFORE_SHA="HEAD~1"
-          fi
-          # If HEAD~1 doesn't exist (e.g., first commit), fall back to empty tree
-          if ! git rev-parse --verify "$BEFORE_SHA" >/dev/null 2>&1; then
-            echo "Detected missing parent commit; falling back to empty tree for diff baseline."
-            BEFORE_SHA="$(git hash-object -t tree /dev/null)"
           fi
 
           # Detect changed i18n files

--- a/.github/workflows/trigger-i18n-sync.yml
+++ b/.github/workflows/trigger-i18n-sync.yml
@@ -1,0 +1,66 @@
+name: Trigger i18n Sync on Push
+
+# This workflow bridges the push event to repository_dispatch
+# because claude-code-action doesn't support push events directly.
+# See: https://github.com/langgenius/dify/issues/30743
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/i18n/en-US/*.json'
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    if: github.repository == 'langgenius/dify'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed files and generate diff
+        id: detect
+        run: |
+          BEFORE_SHA="${{ github.event.before }}"
+          # Handle edge case: first push or force push may have null/zero SHA
+          if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE_SHA="HEAD~1"
+          fi
+
+          # Detect changed i18n files
+          changed=$(git diff --name-only "$BEFORE_SHA" ${{ github.sha }} -- 'web/i18n/en-US/*.json' 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/.json$//' | tr '\n' ' ' || echo "")
+          echo "changed_files=$changed" >> $GITHUB_OUTPUT
+
+          # Generate diff for context
+          git diff "$BEFORE_SHA"..${{ github.sha }} -- 'web/i18n/en-US/*.json' > /tmp/i18n-diff.txt 2>/dev/null || echo "" > /tmp/i18n-diff.txt
+
+          # Truncate if too large (keep first 30KB to stay within payload limits)
+          head -c 30000 /tmp/i18n-diff.txt > /tmp/i18n-diff-truncated.txt
+          mv /tmp/i18n-diff-truncated.txt /tmp/i18n-diff.txt
+
+          # Base64 encode the diff for safe JSON transport
+          diff_base64=$(base64 -w 0 < /tmp/i18n-diff.txt 2>/dev/null || base64 < /tmp/i18n-diff.txt)
+          echo "diff_base64=$diff_base64" >> $GITHUB_OUTPUT
+
+          if [ -n "$changed" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Detected changed files: $changed"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No i18n changes detected"
+          fi
+
+      - name: Trigger i18n sync workflow
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: i18n-sync
+          client-payload: '{"changed_files": "${{ steps.detect.outputs.changed_files }}", "diff_base64": "${{ steps.detect.outputs.diff_base64 }}", "sync_mode": "incremental", "trigger_sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary

This PR fixes the `translate-i18n-claude.yml` workflow which fails when triggered by push events because `claude-code-action` doesn't support the `push` event type.

**Error from failed run:**
```
##[error]Prepare step failed with error: Unsupported event type: push
```

**Failed run:** https://github.com/langgenius/dify/actions/runs/20807450920

## Solution

Split the workflow into two files using the `repository_dispatch` pattern:

### 1. `trigger-i18n-sync.yml` (NEW)
- Listens for `push` events on main branch with changes to `web/i18n/en-US/*.json`
- Detects changed files and generates git diff
- Sends `repository_dispatch` event with payload containing:
  - `changed_files`: Space-separated list of changed file names
  - `diff_base64`: Base64-encoded git diff for context
  - `sync_mode`: Always "incremental" for push triggers

### 2. `translate-i18n-claude.yml` (MODIFIED)
- Now listens for `repository_dispatch` (type: `i18n-sync`) instead of `push`
- Decodes the base64 diff from the trigger workflow
- Continues to support `workflow_dispatch` for manual triggers

## Why `repository_dispatch`?

According to the [claude-code-action source code](https://github.com/anthropics/claude-code-action/blob/main/src/github/context.ts), the supported events are:
- `pull_request` / `pull_request_target`
- `pull_request_review` / `pull_request_review_comment`
- `issue_comment` / `issues`
- `workflow_dispatch`
- **`repository_dispatch`** ✓
- `schedule`
- `workflow_run`

The `push` event is NOT supported.

## Test Plan

- [ ] Merge this PR to main
- [ ] Make a change to any `web/i18n/en-US/*.json` file and push to main
- [ ] Verify `trigger-i18n-sync.yml` workflow runs and sends `repository_dispatch`
- [ ] Verify `translate-i18n-claude.yml` workflow is triggered and runs successfully
- [ ] Test manual trigger via `workflow_dispatch` still works

Fixes #30743