### PR TITLE
feat: Support displaying non-image tool files in agent runs

### DIFF
--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -153,6 +153,13 @@ class MessageFileStreamResponse(StreamResponse):
     type: str
     belongs_to: str
     url: str
+    upload_file_id: str | None = None
+    transfer_method: str
+    mime_type: str
+    filename: str
+    size: int
+    related_id: str | None = None
+    extension: str
 
 
 class MessageReplaceStreamResponse(StreamResponse):

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -254,6 +254,8 @@ class ToolEngine:
                         ensure_ascii=False,
                     )
                 )
+            elif response.type == ToolInvokeMessage.MessageType.BINARY_LINK:
+                parts.append("A result with a file link has been returned, please tell user to check it.")
             else:
                 parts.append(str(response.message))
 
@@ -310,6 +312,16 @@ class ToolEngine:
                         else "application/octet-stream",
                         url=cast(ToolInvokeMessage.TextMessage, response.message).text,
                     )
+            elif response.type == ToolInvokeMessage.MessageType.BINARY_LINK:
+                # check if there is a mime type in meta
+                if response.meta and "mime_type" in response.meta:
+                    result = ToolInvokeMessageBinary(
+                        mimetype=response.meta.get("mime_type", "application/octet-stream")
+                        if response.meta
+                        else "application/octet-stream",
+                        url=cast(ToolInvokeMessage.TextMessage, response.message).text,
+                    )
+                    yield result
 
     @staticmethod
     def _create_message_files(

--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -316,9 +316,7 @@ class ToolEngine:
                 # check if there is a mime type in meta
                 if response.meta and "mime_type" in response.meta:
                     result = ToolInvokeMessageBinary(
-                        mimetype=response.meta.get("mime_type", "application/octet-stream")
-                        if response.meta
-                        else "application/octet-stream",
+                        mimetype=response.meta["mime_type"],
                         url=cast(ToolInvokeMessage.TextMessage, response.message).text,
                     )
                     yield result

--- a/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_message_file.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_message_file.py
@@ -1,0 +1,160 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from core.app.entities.queue_entities import QueueMessageFileEvent
+from core.app.entities.task_entities import MessageFileStreamResponse, StreamEvent
+from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
+from core.file import FileTransferMethod
+
+
+class _FakeSession:
+    def __init__(self, row):
+        self._row = row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, *_args, **_kwargs):
+        class _Result:
+            def __init__(self, row):
+                self._row = row
+
+            def first(self):
+                return self._row
+
+        return _Result(self._row)
+
+
+@pytest.fixture
+def manager():
+    # minimal generate entity for MessageCycleManager
+    application_generate_entity = SimpleNamespace(task_id="task-1")
+    task_state = SimpleNamespace()
+    return MessageCycleManager(
+        application_generate_entity=application_generate_entity,
+        task_state=task_state,
+    )
+
+
+def _build_message_file(
+    *,
+    id: str = "mf-1",
+    type: str = "document",
+    belongs_to: str | None = None,
+    url: str = "http://host/toolfileid.pptx",
+    upload_file_id: str = "tf-1",
+    transfer_method: FileTransferMethod = FileTransferMethod.TOOL_FILE,
+):
+    return SimpleNamespace(
+        id=id,
+        type=type,
+        belongs_to=belongs_to,
+        url=url,
+        upload_file_id=upload_file_id,
+        transfer_method=transfer_method,
+    )
+
+
+def _build_tool_file(
+    *,
+    id: str = "tf-1",
+    mimetype: str = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    name: str = "slides.pptx",
+    size: int = 1234,
+):
+    return SimpleNamespace(id=id, mimetype=mimetype, name=name, size=size)
+
+
+def test_message_file_tool_file_http_url(manager, monkeypatch):
+    """
+    TOOL_FILE with http url should keep url unchanged and include ToolFile metadata.
+    """
+    message_file = _build_message_file(url="http://host/toolfileid.pptx")
+    tool_file = _build_tool_file()
+
+    # patch db.engine to avoid Flask app context requirement
+    monkeypatch.setattr(
+        "core.app.task_pipeline.message_cycle_manager.db",
+        SimpleNamespace(engine=object()),
+    )
+    # patch Session (context manager) to return our tuple row
+    monkeypatch.setattr(
+        "core.app.task_pipeline.message_cycle_manager.Session",
+        lambda *_args, **_kwargs: _FakeSession((message_file, tool_file)),
+    )
+
+    event = Mock(spec=QueueMessageFileEvent)
+    event.message_file_id = message_file.id
+
+    resp = manager.message_file_to_stream_response(event)
+
+    assert isinstance(resp, MessageFileStreamResponse)
+    assert resp.event == StreamEvent.MESSAGE_FILE
+    assert resp.id == message_file.id
+    # default belongs_to to user when None
+    assert resp.belongs_to == "user"
+    # keep original http url
+    assert resp.url == message_file.url
+    assert resp.upload_file_id == message_file.upload_file_id
+    assert resp.transfer_method == message_file.transfer_method
+    assert resp.mime_type == tool_file.mimetype
+    assert resp.filename == tool_file.name
+    assert resp.size == tool_file.size
+    assert resp.related_id == tool_file.id
+    assert resp.extension == ".pptx"
+
+
+def test_message_file_non_tool_file_sign_and_fallbacks(manager, monkeypatch):
+    """
+    Non TOOL_FILE should ignore ToolFile and sign local url; fallbacks applied.
+    """
+    # local file style url without scheme should be signed
+    message_file = _build_message_file(
+        url="toolfileid.pdf",
+        transfer_method=FileTransferMethod.LOCAL_FILE,
+        belongs_to="assistant",
+    )
+    # even provided, should be ignored for non TOOL_FILE
+    tool_file = _build_tool_file(
+        mimetype="application/pdf",
+        name="doc.pdf",
+        size=42,
+    )
+
+    # patch db.engine to avoid Flask app context requirement
+    monkeypatch.setattr(
+        "core.app.task_pipeline.message_cycle_manager.db",
+        SimpleNamespace(engine=object()),
+    )
+    # patch Session to return our row
+    monkeypatch.setattr(
+        "core.app.task_pipeline.message_cycle_manager.Session",
+        lambda *_args, **_kwargs: _FakeSession((message_file, tool_file)),
+    )
+
+    # patch signer
+    with patch(
+        "core.app.task_pipeline.message_cycle_manager.sign_tool_file",
+        return_value="http://signed/toolfileid.pdf",
+    ) as sign_mock:
+        event = Mock(spec=QueueMessageFileEvent)
+        event.message_file_id = message_file.id
+
+        resp = manager.message_file_to_stream_response(event)
+
+        assert isinstance(resp, MessageFileStreamResponse)
+        assert resp.belongs_to == "assistant"
+        # should be signed since not an http url
+        assert resp.url == "http://signed/toolfileid.pdf"
+        # fallbacks when ToolFile ignored
+        assert resp.mime_type == "application/octet-stream"
+        assert resp.filename == ""
+        assert resp.size == 0
+        assert resp.related_id is None
+        assert resp.extension == ".pdf"
+        sign_mock.assert_called_once()

--- a/api/tests/unit_tests/core/tools/test_tool_engine_binary_link.py
+++ b/api/tests/unit_tests/core/tools/test_tool_engine_binary_link.py
@@ -1,0 +1,45 @@
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool_engine import ToolEngine
+
+
+def test_extract_binary_link_with_mime_type_yields():
+    url = "http://example.com/file.bin"
+    msg = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.BINARY_LINK,
+        message=ToolInvokeMessage.TextMessage(text=url),
+        meta={"mime_type": "application/pdf"},
+    )
+
+    out = list(ToolEngine._extract_tool_response_binary_and_text([msg]))
+
+    assert len(out) == 1
+    assert out[0].mimetype == "application/pdf"
+    assert out[0].url == url
+
+
+def test_extract_binary_link_without_mime_type_skips():
+    url = "http://example.com/file.bin"
+    msg = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.BINARY_LINK,
+        message=ToolInvokeMessage.TextMessage(text=url),
+        meta=None,
+    )
+
+    out = list(ToolEngine._extract_tool_response_binary_and_text([msg]))
+
+    assert out == []
+
+
+def test_convert_to_str_includes_binary_link_hint():
+    url = "http://example.com/file.bin"
+    msgs: list[ToolInvokeMessage] = [
+        ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.BINARY_LINK,
+            message=ToolInvokeMessage.TextMessage(text=url),
+            meta={"mime_type": "application/octet-stream"},
+        )
+    ]
+
+    s = ToolEngine._convert_tool_response_to_str(msgs)
+
+    assert "file link" in s.lower()

--- a/web/types/app.ts
+++ b/web/types/app.ts
@@ -446,6 +446,11 @@ export type VisionFile = {
   url: string
   upload_file_id: string
   belongs_to?: string
+  mime_type?: string
+  filename?: string
+  size?: number
+  related_id?: string
+  extension?: string
 }
 
 export type RetrievalConfig = {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #30795

- This PR delivers a minimal viable improvement to surface non-image files produced by tools during agent runs.
- On the web, to minimize impact, I intentionally reuse and extend the existing `VisionFile` shape instead of introducing a new type. In the future, we can unify on `FileResponse` for a cleaner model and broader refactor.

### Changes:
- Backend:
    - Enrich `message_file` stream events with additional metadata (upload_file_id, transfer_method, mime_type, filename, size, related_id, extension) to support non-image files.
    - Extend tool engine handling for `BINARY_LINK` so non-image outputs with mime types are captured and persisted as `MessageFile` entries.
- Frontend:
    - Extend `VisionFile` with optional fields (mime_type, filename, size, related_id, extension) to consume the enriched stream event with minimal Web impact.
### Compatibility:
- The `message_file` event remains unchanged in shape for existing consumers; new fields are additive and optional on the frontend.
- Preserves historical data paths: when `ToolFile `metadata is unavailable, sensible defaults are provided, ensuring the UI continues to function.
### Testing:
- Verified single-file and multi-file scenarios, including historical messages, to ensure no regressions.
- Confirmed streaming behavior and rendering work for non-image files (e.g., .pptx, .docx, .pdf) and that image handling remains unaffected.
### Future Work:
- Consider unifying frontend file handling on `FileResponse` to reduce duplication and improve consistency across views.


## Screenshots

| Before | After |
|--------|-------|
| <img width="282" height="196" alt="before" src="https://github.com/user-attachments/assets/490088f8-6083-41f7-a146-1fc1595a0141" />| <img width="330" height="200" alt="after" src="https://github.com/user-attachments/assets/1e57c393-0b73-44d8-952e-63098e6c5216" />
|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
