### PR TITLE
chore(web): upgrade pnpm to 10.28.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "1.11.2",
   "private": true,
-  "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a",
+  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
   "imports": {
     "#i18n": {
       "react-server": "./i18n-config/lib.server.ts",


### PR DESCRIPTION
## Summary
- Upgrade pnpm package manager from 10.27.0 to 10.28.0 using `corepack use pnpm@latest`

## Test plan
- [x] Lockfile validation passed
- [x] Pre-commit hooks passed

Closes #30804