### PR TITLE
fix: move segment operations inside Redis lock scope

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -2799,39 +2799,39 @@ class SegmentService:
                     segment_document.word_count += len(args["answer"])
                     segment_document.answer = args["answer"]
 
-            db.session.add(segment_document)
-            # update document word count
-            assert document.word_count is not None
-            document.word_count += segment_document.word_count
-            db.session.add(document)
-            db.session.commit()
-
-            if args["attachment_ids"]:
-                for attachment_id in args["attachment_ids"]:
-                    binding = SegmentAttachmentBinding(
-                        tenant_id=current_user.current_tenant_id,
-                        dataset_id=document.dataset_id,
-                        document_id=document.id,
-                        segment_id=segment_document.id,
-                        attachment_id=attachment_id,
-                    )
-                    db.session.add(binding)
+                db.session.add(segment_document)
+                # update document word count
+                assert document.word_count is not None
+                document.word_count += segment_document.word_count
+                db.session.add(document)
                 db.session.commit()
 
-            # save vector index
-            try:
-                keywords = args.get("keywords")
-                keywords_list = [keywords] if keywords is not None else None
-                VectorService.create_segments_vector(keywords_list, [segment_document], dataset, document.doc_form)
-            except Exception as e:
-                logger.exception("create segment index failed")
-                segment_document.enabled = False
-                segment_document.disabled_at = naive_utc_now()
-                segment_document.status = "error"
-                segment_document.error = str(e)
-                db.session.commit()
-            segment = db.session.query(DocumentSegment).where(DocumentSegment.id == segment_document.id).first()
-            return segment
+                if args["attachment_ids"]:
+                    for attachment_id in args["attachment_ids"]:
+                        binding = SegmentAttachmentBinding(
+                            tenant_id=current_user.current_tenant_id,
+                            dataset_id=document.dataset_id,
+                            document_id=document.id,
+                            segment_id=segment_document.id,
+                            attachment_id=attachment_id,
+                        )
+                        db.session.add(binding)
+                    db.session.commit()
+
+                # save vector index
+                try:
+                    keywords = args.get("keywords")
+                    keywords_list = [keywords] if keywords is not None else None
+                    VectorService.create_segments_vector(keywords_list, [segment_document], dataset, document.doc_form)
+                except Exception as e:
+                    logger.exception("create segment index failed")
+                    segment_document.enabled = False
+                    segment_document.disabled_at = naive_utc_now()
+                    segment_document.status = "error"
+                    segment_document.error = str(e)
+                    db.session.commit()
+                segment = db.session.query(DocumentSegment).where(DocumentSegment.id == segment_document.id).first()
+                return segment
         except LockNotOwnedError:
             pass
 


### PR DESCRIPTION
# fix: trigger subscription OAuth refresh fails with encrypted credentials

## Summary
This PR fixes two issues in the trigger subscription refresh mechanism that prevented OAuth tokens and subscriptions from being refreshed correctly.

## Problems & Fixes

### 1) OAuth token refresh fails with encrypted credentials
**Symptom**  
When the Celery worker refreshes OAuth tokens for trigger subscriptions, it fails with:
- `AADSTS9002313: Invalid request. Request is malformed or invalid.`

**Root cause**  
In `refresh_oauth_token()`, the code used `create_provider_encrypter()` with `get_oauth_client_schema()` (schema for `client_id` / `client_secret`).  
However, subscription credentials contain `access_tokens` / `refresh_token`, which require the schema from `get_credentials_schema()`.

Because of this mismatch, decryption fails and encrypted (e.g., `HYBRID`-prefixed) tokens are passed to the OAuth provider.

**Fix**  
Use `create_trigger_provider_encrypter_for_subscription()` so the correct credential schema is applied when decrypting subscription credentials.

---

### 2) Subscription refresh is always skipped before expiration
**Symptom**  
Subscriptions were never proactively refreshed, even when approaching expiration.

**Root cause**  
In `refresh_subscription()`, the skip condition was:
```python
if subscription.expires_at == -1 or int(subscription.expires_at) > now_ts:
    return {"result": "skipped", ...}
This skips refresh for any subscription that has not expired yet.

But the caller (trigger_provider_refresh_task) already filters subscriptions using a refresh threshold (e.g., within 24 hours before expiration).
The service method should not duplicate this check.

Fix
Only skip when expires_at == -1 (no expiration). Threshold handling remains in the calling task.

Changes
api/services/trigger/trigger_provider_service.py

refresh_oauth_token(): Use the correct encrypter for subscription credentials

refresh_subscription(): Remove premature skip condition that prevented proactive refresh

Testing
Tested with Microsoft Teams Chat Trigger plugin:

OAuth token auto-refresh: ✅ Working

Subscription auto-refresh: ✅ Working

Teams message → Dify workflow trigger: ✅ Working