### PR TITLE
feat: reranking_enable should respect node config and selected dataset

### DIFF
--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -330,6 +330,9 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
             else:
                 reranking_model = None
                 weights = None
+
+            reranking_enable = node_data.multiple_retrieval_config.reranking_enable and len(available_datasets) > 1
+
             all_documents = dataset_retrieval.multiple_retrieve(
                 app_id=self.app_id,
                 tenant_id=self.tenant_id,
@@ -344,7 +347,7 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
                 reranking_mode=node_data.multiple_retrieval_config.reranking_mode,
                 reranking_model=reranking_model,
                 weights=weights,
-                reranking_enable=node_data.multiple_retrieval_config.reranking_enable,
+                reranking_enable=reranking_enable,
                 metadata_filter_document_ids=metadata_filter_document_ids,
                 metadata_condition=metadata_condition,
                 attachment_ids=[attachment.related_id for attachment in attachments] if attachments else None,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #30872

feat: reranking_enable should respect node config and selected dataset

Benefits:

1. Reduced Latency: Skips unnecessary reranking when only one KB is selected
2. Lower Token Consumption: Avoids redundant reranker model calls
3. Preserves Dataset-Level Configuration: The KB's own reranking settings are still respected
4. Multi-Path Only When Needed: Reranking at node level only applies when merging results from multiple KBs

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
