### PR TITLE
fix: correct API Extension documentation link

### DIFF
--- a/web/app/components/header/account-setting/api-based-extension-page/modal.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/modal.tsx
@@ -30,7 +30,7 @@ const ApiBasedExtensionModal: FC<ApiBasedExtensionModalProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation()
-  const docLink = useDocLink()
+  const docLink = useDocLink('https://docs.dify.ai/versions/3-0-x')
   const [localeData, setLocaleData] = useState(data)
   const [loading, setLoading] = useState(false)
   const { notify } = useToastContext()
@@ -102,7 +102,7 @@ const ApiBasedExtensionModal: FC<ApiBasedExtensionModalProps> = ({
         <div className="flex h-9 items-center justify-between text-sm font-medium text-text-primary">
           {t('apiBasedExtension.modal.apiEndpoint.title', { ns: 'common' })}
           <a
-            href={docLink('/guides/extension/api-based-extension/README')}
+            href={docLink('/user-guide/extension/api-based-extension/README#api-based-extension')}
             target="_blank"
             rel="noopener noreferrer"
             className="group flex items-center text-xs font-normal text-text-accent"


### PR DESCRIPTION
## Summary
- Fixes the broken documentation link on the API Extension settings page
- The old link `/guides/extension/api-based-extension/README` was redirecting to an unrelated getting-started page
- Updated to point to the correct documentation URL

Fixes #30946

## Test plan
- [ ] Navigate to Settings > API Extension
- [ ] Click "Learn how to develop your own API Extension" link
- [ ] Verify it opens the correct API-based extension documentation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)