### PR TITLE
fix(web): preserve HTTP method in ORPC fetchCompat mode

### DIFF
--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -127,8 +127,7 @@ export const getBaseOptions = (): RequestInit => ({
 })
 
 async function base<T>(url: string, options: FetchOptionType = {}, otherOptions: IOtherOptions = {}): Promise<T> {
-  // In fetchCompat mode, skip baseOptions to avoid overriding Request object's
-  // method, headers,
+  // In fetchCompat mode, skip baseOptions to avoid overriding Request object's method, headers,
   const baseOptions = otherOptions.fetchCompat
     ? {
         mode: 'cors',

--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -127,7 +127,14 @@ export const getBaseOptions = (): RequestInit => ({
 })
 
 async function base<T>(url: string, options: FetchOptionType = {}, otherOptions: IOtherOptions = {}): Promise<T> {
-  const baseOptions = getBaseOptions()
+  const baseOptions = otherOptions.fetchCompat
+    ? {
+        mode: 'cors' as RequestMode,
+        credentials: 'include' as RequestCredentials,
+        headers: new Headers(),
+        redirect: 'follow' as RequestRedirect,
+      }
+    : getBaseOptions()
   const { params, body, headers, ...init } = Object.assign({}, baseOptions, options)
   const {
     isPublicAPI = false,


### PR DESCRIPTION
## Summary
- Fix HTTP method being ignored in ORPC `fetchCompat` mode, causing "Request with GET/HEAD method cannot have body" errors for POST/PUT/DELETE requests
- Skip `getBaseOptions()` entirely when `fetchCompat` is enabled, since `OpenAPILink` already provides complete Request configuration
- Fixes a bug introduced in #30885 that affected `bindPartnerStack` (PUT) and any future non-GET ORPC contracts

## Background
When `OpenAPILink` creates a `Request` object, the HTTP method, headers, and other config are stored inside the Request. However, `fetch.ts`'s `base` function was merging options with `getBaseOptions()` which defaults to `method: 'GET'`, `mode: 'cors'`, etc. Since the `init` parameter from OpenAPILink doesn't include these values separately, all requests fell back to the defaults (e.g., GET method).

## Solution
In `fetchCompat` mode, skip `getBaseOptions()` entirely to avoid polluting the Request object's configuration:

```typescript
const baseOptions = otherOptions.fetchCompat ? {} : getBaseOptions()
```

## Test plan
- [ ] Verify `bindPartnerStack` (PUT request with body) works correctly
- [ ] Verify any POST/PUT/DELETE ORPC contracts function properly