### PR TITLE
chore(web): disable Serwist dev logs

### DIFF
--- a/web/app/sw.ts
+++ b/web/app/sw.ts
@@ -21,6 +21,7 @@ const offlineUrl = `${basePath}/_offline.html`
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true,
+  disableDevLogs: true,
   clientsClaim: true,
   navigationPreload: true,
   runtimeCaching: [


### PR DESCRIPTION
## Summary
- Add `disableDevLogs: true` option to Serwist configuration to suppress verbose development logging output in the service worker

## Test plan
- [ ] Verify service worker still functions correctly in development mode
- [ ] Confirm development logs are no longer output to console