### PR TITLE
refactor(contract): restructure console contracts with nested billing module

### DIFF
--- a/web/app/components/billing/pricing/plans/cloud-plan-item/index.spec.tsx
+++ b/web/app/components/billing/pricing/plans/cloud-plan-item/index.spec.tsx
@@ -27,7 +27,9 @@ vi.mock('@/service/billing', () => ({
 
 vi.mock('@/service/client', () => ({
   consoleClient: {
-    billingUrl: vi.fn(),
+    billing: {
+      invoices: vi.fn(),
+    },
   },
 }))
 
@@ -43,7 +45,7 @@ vi.mock('../../assets', () => ({
 
 const mockUseAppContext = useAppContext as Mock
 const mockUseAsyncWindowOpen = useAsyncWindowOpen as Mock
-const mockBillingUrl = consoleClient.billingUrl as Mock
+const mockBillingInvoices = consoleClient.billing.invoices as Mock
 const mockFetchSubscriptionUrls = fetchSubscriptionUrls as Mock
 const mockToastNotify = Toast.notify as Mock
 
@@ -75,7 +77,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockUseAppContext.mockReturnValue({ isCurrentWorkspaceManager: true })
   mockUseAsyncWindowOpen.mockReturnValue(vi.fn(async open => await open()))
-  mockBillingUrl.mockResolvedValue({ url: 'https://billing.example' })
+  mockBillingInvoices.mockResolvedValue({ url: 'https://billing.example' })
   mockFetchSubscriptionUrls.mockResolvedValue({ url: 'https://subscription.example' })
   assignedHref = ''
 })
@@ -149,7 +151,7 @@ describe('CloudPlanItem', () => {
         type: 'error',
         message: 'billing.buyPermissionDeniedTip',
       }))
-      expect(mockBillingUrl).not.toHaveBeenCalled()
+      expect(mockBillingInvoices).not.toHaveBeenCalled()
     })
 
     it('should open billing portal when upgrading current paid plan', async () => {
@@ -168,7 +170,7 @@ describe('CloudPlanItem', () => {
       fireEvent.click(screen.getByRole('button', { name: 'billing.plansCommon.currentPlan' }))
 
       await waitFor(() => {
-        expect(mockBillingUrl).toHaveBeenCalledTimes(1)
+        expect(mockBillingInvoices).toHaveBeenCalledTimes(1)
       })
       expect(openWindow).toHaveBeenCalledTimes(1)
     })

--- a/web/app/components/billing/pricing/plans/cloud-plan-item/index.tsx
+++ b/web/app/components/billing/pricing/plans/cloud-plan-item/index.tsx
@@ -77,7 +77,7 @@ const CloudPlanItem: FC<CloudPlanItemProps> = ({
     try {
       if (isCurrentPaidPlan) {
         await openAsyncWindow(async () => {
-          const res = await consoleClient.billingUrl()
+          const res = await consoleClient.billing.invoices()
           if (res.url)
             return res.url
           throw new Error('Failed to open billing page')

--- a/web/contract/console/billing.ts
+++ b/web/contract/console/billing.ts
@@ -1,16 +1,7 @@
-import type { SystemFeatures } from '@/types/feature'
 import { type } from '@orpc/contract'
-import { base } from './base'
+import { base } from '../base'
 
-export const systemFeaturesContract = base
-  .route({
-    path: '/system-features',
-    method: 'GET',
-  })
-  .input(type<unknown>())
-  .output(type<SystemFeatures>())
-
-export const billingUrlContract = base
+export const invoicesContract = base
   .route({
     path: '/billing/invoices',
     method: 'GET',

--- a/web/contract/console/system.ts
+++ b/web/contract/console/system.ts
@@ -1,0 +1,11 @@
+import type { SystemFeatures } from '@/types/feature'
+import { type } from '@orpc/contract'
+import { base } from '../base'
+
+export const systemFeaturesContract = base
+  .route({
+    path: '/system-features',
+    method: 'GET',
+  })
+  .input(type<unknown>())
+  .output(type<SystemFeatures>())

--- a/web/contract/router.ts
+++ b/web/contract/router.ts
@@ -1,5 +1,6 @@
 import type { InferContractRouterInputs } from '@orpc/contract'
-import { billingUrlContract, bindPartnerStackContract, systemFeaturesContract } from './console'
+import { bindPartnerStackContract, invoicesContract } from './console/billing'
+import { systemFeaturesContract } from './console/system'
 import { collectionPluginsContract, collectionsContract, searchAdvancedContract } from './marketplace'
 
 export const marketplaceRouterContract = {
@@ -12,8 +13,10 @@ export type MarketPlaceInputs = InferContractRouterInputs<typeof marketplaceRout
 
 export const consoleRouterContract = {
   systemFeatures: systemFeaturesContract,
-  billingUrl: billingUrlContract,
-  bindPartnerStack: bindPartnerStackContract,
+  billing: {
+    invoices: invoicesContract,
+    bindPartnerStack: bindPartnerStackContract,
+  },
 }
 
 export type ConsoleInputs = InferContractRouterInputs<typeof consoleRouterContract>

--- a/web/service/use-billing.ts
+++ b/web/service/use-billing.ts
@@ -3,8 +3,8 @@ import { consoleClient, consoleQuery } from '@/service/client'
 
 export const useBindPartnerStackInfo = () => {
   return useMutation({
-    mutationKey: consoleQuery.bindPartnerStack.mutationKey(),
-    mutationFn: (data: { partnerKey: string, clickId: string }) => consoleClient.bindPartnerStack({
+    mutationKey: consoleQuery.billing.bindPartnerStack.mutationKey(),
+    mutationFn: (data: { partnerKey: string, clickId: string }) => consoleClient.billing.bindPartnerStack({
       params: { partnerKey: data.partnerKey },
       body: { click_id: data.clickId },
     }),
@@ -13,10 +13,10 @@ export const useBindPartnerStackInfo = () => {
 
 export const useBillingUrl = (enabled: boolean) => {
   return useQuery({
-    queryKey: consoleQuery.billingUrl.queryKey(),
+    queryKey: consoleQuery.billing.invoices.queryKey(),
     enabled,
     queryFn: async () => {
-      const res = await consoleClient.billingUrl()
+      const res = await consoleClient.billing.invoices()
       return res.url
     },
   })


### PR DESCRIPTION
## Summary
- Reorganize oRPC console contracts to follow best practices from the architecture guide
- Split `console.ts` into `console/system.ts` and `console/billing.ts` for better modularity
- Nest billing contracts under `billing` key in router for proper API prefix grouping
- Rename `billingUrlContract` to `invoicesContract` for semantic clarity

## Test plan
- [x] TypeScript type-check passes
- [x] Unit tests pass for billing components
- [x] ESLint passes