### PR TITLE
fix: increase name length limit in ExternalDatasetCreatePayload

### DIFF
--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -81,7 +81,7 @@ class ExternalKnowledgeApiPayload(BaseModel):
 class ExternalDatasetCreatePayload(BaseModel):
     external_knowledge_api_id: str
     external_knowledge_id: str
-    name: str = Field(..., min_length=1, max_length=40)
+    name: str = Field(..., min_length=1, max_length=100)
     description: str | None = Field(None, max_length=400)
     external_retrieval_model: dict[str, object] | None = None
 

--- a/api/tests/unit_tests/controllers/console/datasets/__init__.py
+++ b/api/tests/unit_tests/controllers/console/datasets/__init__.py
@@ -1,2 +1,1 @@
 """Unit tests for `controllers.console.datasets` controllers."""
-

--- a/api/tests/unit_tests/controllers/console/datasets/__init__.py
+++ b/api/tests/unit_tests/controllers/console/datasets/__init__.py
@@ -1,0 +1,2 @@
+"""Unit tests for `controllers.console.datasets` controllers."""
+

--- a/api/tests/unit_tests/controllers/console/datasets/test_external_dataset_payload.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_external_dataset_payload.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""
+Unit tests for the external dataset controller payload schemas.
+
+These tests focus on Pydantic validation rules so we can catch regressions
+in request constraints (e.g. max length changes) without exercising the
+full Flask/RESTX request stack.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from controllers.console.datasets.external import ExternalDatasetCreatePayload
+
+
+def test_external_dataset_create_payload_allows_name_length_100() -> None:
+    """Ensure the `name` field accepts up to 100 characters (inclusive)."""
+
+    # Build a request payload with a boundary-length name value.
+    name_100: str = "a" * 100
+    payload: dict[str, object] = {
+        "external_knowledge_api_id": "ek-api-1",
+        "external_knowledge_id": "ek-1",
+        "name": name_100,
+    }
+
+    model = ExternalDatasetCreatePayload.model_validate(payload)
+    assert model.name == name_100
+
+
+def test_external_dataset_create_payload_rejects_name_length_101() -> None:
+    """Ensure the `name` field rejects values longer than 100 characters."""
+
+    # Build a request payload that exceeds the max length by 1.
+    name_101: str = "a" * 101
+    payload: dict[str, object] = {
+        "external_knowledge_api_id": "ek-api-1",
+        "external_knowledge_id": "ek-1",
+        "name": name_101,
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        ExternalDatasetCreatePayload.model_validate(payload)
+
+    errors = exc_info.value.errors()
+    assert errors[0]["loc"] == ("name",)
+    assert errors[0]["type"] == "string_too_long"
+    assert errors[0]["ctx"]["max_length"] == 100
+

--- a/api/tests/unit_tests/controllers/console/datasets/test_external_dataset_payload.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_external_dataset_payload.py
@@ -19,7 +19,7 @@ def test_external_dataset_create_payload_allows_name_length_100() -> None:
 
     # Build a request payload with a boundary-length name value.
     name_100: str = "a" * 100
-    payload: dict[str, object] = {
+    payload = {
         "external_knowledge_api_id": "ek-api-1",
         "external_knowledge_id": "ek-1",
         "name": name_100,

--- a/api/tests/unit_tests/controllers/console/datasets/test_external_dataset_payload.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_external_dataset_payload.py
@@ -47,4 +47,3 @@ def test_external_dataset_create_payload_rejects_name_length_101() -> None:
     assert errors[0]["loc"] == ("name",)
     assert errors[0]["type"] == "string_too_long"
     assert errors[0]["ctx"]["max_length"] == 100
-


### PR DESCRIPTION
## Description
ExternalDatasetCreatePayload.name have be wrongly set to max_length=40

## Copilot Summary

This pull request updates the validation rules for the `name` field in the `ExternalDatasetCreatePayload` schema and adds unit tests to ensure these rules are enforced. The main change increases the maximum allowed length of the `name` field from 40 to 100 characters, and new tests verify both acceptance and rejection at the boundary.

Validation rule update:

* Increased the maximum length of the `name` field in `ExternalDatasetCreatePayload` from 40 to 100 characters to allow longer dataset names.

Testing improvements:

* Added unit tests in `test_external_dataset_payload.py` to confirm that the `name` field accepts up to 100 characters and rejects values longer than 100 characters, ensuring the new validation rule is properly enforced.
* Added a test module docstring to `__init__.py` for clarity and documentation of the unit tests.