### PR TITLE
fix: validation error when uploading images with None URL values

### DIFF
--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -115,7 +115,18 @@ def build_from_mappings(
     # TODO(QuantumGhost): Performance concern - each mapping triggers a separate database query.
     # Implement batch processing to reduce database load when handling multiple files.
     # Filter out None/empty mappings to avoid errors
-    valid_mappings = [m for m in mappings if m and m.get("transfer_method")]
+    def is_valid_mapping(m: Mapping[str, Any]) -> bool:
+        if not m or not m.get("transfer_method"):
+            return False
+        # For REMOTE_URL transfer method, ensure url or remote_url is provided and not None
+        transfer_method = m.get("transfer_method")
+        if transfer_method == FileTransferMethod.REMOTE_URL.value or transfer_method == FileTransferMethod.REMOTE_URL:
+            url = m.get("url") or m.get("remote_url")
+            if not url:
+                return False
+        return True
+
+    valid_mappings = [m for m in mappings if is_valid_mapping(m)]
     files = [
         build_from_mapping(
             mapping=mapping,

--- a/api/factories/file_factory.py
+++ b/api/factories/file_factory.py
@@ -120,7 +120,7 @@ def build_from_mappings(
             return False
         # For REMOTE_URL transfer method, ensure url or remote_url is provided and not None
         transfer_method = m.get("transfer_method")
-        if transfer_method == FileTransferMethod.REMOTE_URL.value or transfer_method == FileTransferMethod.REMOTE_URL:
+        if transfer_method == FileTransferMethod.REMOTE_URL:
             url = m.get("url") or m.get("remote_url")
             if not url:
                 return False


### PR DESCRIPTION
Fixes #30996

When users upload images using URL links in workflows, they get an "Invalid file url" validation error if the URL field is None. This happens because the code wasn't checking for None values before passing them to the File model validator.

This PR adds a simple validation check in build_from_mappings() to filter out mappings where the URL is None for remote_url transfers. Other transfer methods like local_file and tool_file aren't affected since they don't need URLs.

The validation just checks:
- Is there a transfer_method?
- If it's remote_url, is the url/remote_url field actually provided and not None?

If those checks fail, the mapping gets filtered out early instead of causing an error later.

Tested with various scenarios (None URLs, valid URLs, mixed mappings) and they all work as expected.

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501