### PR TITLE
refactor: migrate tag list API query parameters to Pydantic

### DIFF
--- a/api/controllers/console/tag/tags.py
+++ b/api/controllers/console/tag/tags.py
@@ -30,6 +30,11 @@ class TagBindingRemovePayload(BaseModel):
     type: Literal["knowledge", "app"] | None = Field(default=None, description="Tag type")
 
 
+class TagListQueryParam(BaseModel):
+    type: str = Field("", description="Tag type filter")
+    keyword: str | None = Field(None, description="Search keyword")
+
+
 register_schema_models(
     console_ns,
     TagBasePayload,
@@ -46,9 +51,9 @@ class TagListApi(Resource):
     @marshal_with(dataset_tag_fields)
     def get(self):
         _, current_tenant_id = current_account_with_tenant()
-        tag_type = request.args.get("type", type=str, default="")
-        keyword = request.args.get("keyword", default=None, type=str)
-        tags = TagService.get_tags(tag_type, current_tenant_id, keyword)
+        raw_args = request.args.to_dict()
+        param = TagListQueryParam.model_validate(raw_args)
+        tags = TagService.get_tags(param.type, current_tenant_id, param.keyword)
 
         return tags, 200
 

--- a/api/controllers/console/tag/tags.py
+++ b/api/controllers/console/tag/tags.py
@@ -31,7 +31,7 @@ class TagBindingRemovePayload(BaseModel):
 
 
 class TagListQueryParam(BaseModel):
-    type: str = Field("", description="Tag type filter")
+    type: Literal["knowledge", "app", ""] = Field("", description="Tag type filter")
     keyword: str | None = Field(None, description="Search keyword")
 
 
@@ -48,6 +48,9 @@ class TagListApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
+    @console_ns.doc(
+        params={"type": 'Tag type filter. Can be "knowledge" or "app".', "keyword": "Search keyword for tag name."}
+    )
     @marshal_with(dataset_tag_fields)
     def get(self):
         _, current_tenant_id = current_account_with_tenant()


### PR DESCRIPTION
## Summary

Migrate the tag list API endpoint from using `request.args.get()` to Pydantic BaseModel validation.

## Why

- Issue #31077 requests migrating all `request.args.get(default=None, type=str)` patterns to Pydantic BaseModel
- Improves type safety and validation
- Follows the pattern established in #30870
- Makes code more maintainable and enables automatic API documentation

## Changes

- Added `TagListQueryParam` BaseModel to define query parameters
- Replaced `request.args.get()` calls with `model_validate()`
- Maintains backward compatibility with existing API contracts

## Test plan

- [x] `make type-check` passes (0 errors)
- [x] `make lint` passes
- [x] All unit tests pass (4958 passed)

Part of #31077