### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,14 +16,14 @@ jobs:
 
       - name: Check Docker Compose inputs
         id: docker-compose-changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             docker/generate_docker_compose
             docker/.env.example
             docker/docker-compose-template.yaml
             docker/docker-compose.yaml
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -112,7 +112,7 @@ jobs:
             context: "web"
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.context }}-*

--- a/.github/workflows/deploy-agent-dev.yml
+++ b/.github/workflows/deploy-agent-dev.yml
@@ -19,7 +19,7 @@ jobs:
       github.event.workflow_run.head_branch == 'deploy/agent-dev'
     steps:
       - name: Deploy to server
-        uses: appleboy/ssh-action@v0.1.8
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.AGENT_DEV_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,7 +16,7 @@ jobs:
       github.event.workflow_run.head_branch == 'deploy/dev'
     steps:
       - name: Deploy to server
-        uses: appleboy/ssh-action@v0.1.8
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/deploy-hitl.yml
+++ b/.github/workflows/deploy-hitl.yml
@@ -20,7 +20,7 @@ jobs:
       )
     steps:
       - name: Deploy to server
-        uses: appleboy/ssh-action@v0.1.8
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.HITL_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 15
           days-before-issue-close: 3

--- a/.github/workflows/trigger-i18n-sync.yml
+++ b/.github/workflows/trigger-i18n-sync.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## [!IMPORTANT]
1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
2. Ensure there is an associated issue and you have been assigned to it
3. Use the correct syntax to link this PR: Fixes: https://github.com/langgenius/dify/issues/31115

## Summary
This PR updates outdated GitHub Action versions to ensure compatibility with the latest workflows. The changes include:
- Updating `actions/stale` from `v5` to `v10` in `.github/workflows/stale.yml`
- Updating `appleboy/ssh-action` from `v0.1.8` to `v1` in `.github/workflows/deploy-agent-dev.yml` and `.github/workflows/deploy-dev.yml`
- Updating `tj-actions/changed-files` from `v46` to `v47` in `.github/workflows/autofix.yml`
- Updating `actions/download-artifact` from `v4` to `v7` in `.github/workflows/build-push.yml`
- Updating `actions/checkout` from `v4` to `v6` in `.github/workflows/trigger-i18n-sync.yml`
- Updating `actions/setup-python` from `v5` to `v6` in `.github/workflows/autofix.yml`

## Screenshots
| Before | After |
|--------|-----|
| ... | ... |

## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

## PR Title
Update GitHub Action versions

## PR Description
This PR updates outdated GitHub Action versions to ensure compatibility with the latest workflows. The changes include:
- `actions/stale` from `v5` to `v10`
- `appleboy/ssh-action` from `v0.1.8` to `v1` in multiple workflows
- `tj-actions/changed-files` from `v46` to `v47`
- `actions/download-artifact` from `v4` to `v7`
- `actions/checkout` from `v4` to `v6`
- `actions/setup-python` from `v5` to `v6`

The changes will be tested in the CI pipeline of the pull request.
