### PR TITLE
fix: non-auto variable type params of agent node tool are not correctly parsed

### DIFF
--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -235,12 +235,16 @@ class AgentNode(Node[AgentNodeData]):
                                 0,
                             ):
                                 value_param = param.get("value", {})
-                                if value_param.get('type', '') == 'variable':
-                                    variable = variable_pool.get(value_param.get("value"))
-                                    if variable is not None:
-                                        params[key] = variable.value
-                                    else:
-                                        raise AgentVariableNotFoundError(str(value_param.get("value")))
+                                if value_param and value_param.get('type', '') == 'variable':
+                                    variable_selector = value_param.get("value")
+                                    if not variable_selector:
+                                        raise ValueError("Variable selector is missing for a variable-type parameter.")
+
+                                    variable = variable_pool.get(variable_selector)
+                                    if variable is None:
+                                        raise AgentVariableNotFoundError(str(variable_selector))
+
+                                    params[key] = variable.value
                                 else:
                                     params[key] = value_param.get("value", "") if value_param is not None else None
                             else:

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -235,7 +235,7 @@ class AgentNode(Node[AgentNodeData]):
                                 0,
                             ):
                                 value_param = param.get("value", {})
-                                if value_param and value_param.get('type', '') == 'variable':
+                                if value_param and value_param.get("type", "") == "variable":
                                     variable_selector = value_param.get("value")
                                     if not variable_selector:
                                         raise ValueError("Variable selector is missing for a variable-type parameter.")

--- a/api/core/workflow/nodes/agent/agent_node.py
+++ b/api/core/workflow/nodes/agent/agent_node.py
@@ -235,7 +235,14 @@ class AgentNode(Node[AgentNodeData]):
                                 0,
                             ):
                                 value_param = param.get("value", {})
-                                params[key] = value_param.get("value", "") if value_param is not None else None
+                                if value_param.get('type', '') == 'variable':
+                                    variable = variable_pool.get(value_param.get("value"))
+                                    if variable is not None:
+                                        params[key] = variable.value
+                                    else:
+                                        raise AgentVariableNotFoundError(str(value_param.get("value")))
+                                else:
+                                    params[key] = value_param.get("value", "") if value_param is not None else None
                             else:
                                 params[key] = None
                         parameters = params


### PR DESCRIPTION
… correctly parsed

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix: [31127](https://github.com/langgenius/dify/issues/31127)
## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
