### PR TITLE
fix: align callback return types with base class

### DIFF
--- a/api/core/model_runtime/callbacks/base_callback.py
+++ b/api/core/model_runtime/callbacks/base_callback.py
@@ -34,7 +34,7 @@ class Callback(ABC):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         Before invoke callback
 
@@ -63,7 +63,7 @@ class Callback(ABC):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         On new chunk callback
 
@@ -93,7 +93,7 @@ class Callback(ABC):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         After invoke callback
 
@@ -123,7 +123,7 @@ class Callback(ABC):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         Invoke error callback
 

--- a/api/core/model_runtime/callbacks/logging_callback.py
+++ b/api/core/model_runtime/callbacks/logging_callback.py
@@ -24,7 +24,7 @@ class LoggingCallback(Callback):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         Before invoke callback
 
@@ -80,7 +80,7 @@ class LoggingCallback(Callback):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         On new chunk callback
 
@@ -110,7 +110,7 @@ class LoggingCallback(Callback):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         After invoke callback
 
@@ -151,7 +151,7 @@ class LoggingCallback(Callback):
         stop: Sequence[str] | None = None,
         stream: bool = True,
         user: str | None = None,
-    ):
+    ) -> None:
         """
         Invoke error callback
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Explicitly annotate both the base method and all overrides with -> None in their signatures

Fixes - #30853 

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
