### PR TITLE
perf(web): use getState() for Zustand setters in callbacks

### DIFF
--- a/.claude/skills/frontend-testing/SKILL.md
+++ b/.claude/skills/frontend-testing/SKILL.md
@@ -83,6 +83,9 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/test',
 }))
 
+// ✅ Zustand stores: Use real stores (auto-mocked globally)
+// Set test state with: useAppStore.setState({ ... })
+
 // Shared state for mocks (if needed)
 let mockSharedState = false
 
@@ -296,7 +299,7 @@ For each test file generated, aim for:
 For more detailed information, refer to:
 
 - `references/workflow.md` - **Incremental testing workflow** (MUST READ for multi-file testing)
-- `references/mocking.md` - Mock patterns and best practices
+- `references/mocking.md` - Mock patterns, Zustand store testing, and best practices
 - `references/async-testing.md` - Async operations and API calls
 - `references/domain-components.md` - Workflow, Dataset, Configuration testing
 - `references/common-patterns.md` - Frequently used testing patterns

--- a/.claude/skills/frontend-testing/references/mocking.md
+++ b/.claude/skills/frontend-testing/references/mocking.md
@@ -37,15 +37,35 @@ Only mock these categories:
 1. **Third-party libraries with side effects** - `next/navigation`, external SDKs
 1. **i18n** - Always mock to return keys
 
+### Zustand Stores - DO NOT Mock Manually
+
+**Zustand is globally mocked** in `web/vitest.setup.ts`. Use real stores with `setState()`:
+
+```typescript
+// ✅ CORRECT: Use real store, set test state
+import { useAppStore } from '@/app/components/app/store'
+
+useAppStore.setState({ appDetail: { id: 'test', name: 'Test' } })
+render(<MyComponent />)
+
+// ❌ WRONG: Don't mock the store module
+vi.mock('@/app/components/app/store', () => ({ ... }))
+```
+
+See [Zustand Store Testing](#zustand-store-testing) section for full details.
+
 ## Mock Placement
 
 | Location | Purpose |
 |----------|---------|
-| `web/vitest.setup.ts` | Global mocks shared by all tests (for example `react-i18next`, `next/image`) |
+| `web/vitest.setup.ts` | Global mocks shared by all tests (`react-i18next`, `next/image`, `zustand`) |
+| `web/__mocks__/zustand.ts` | Zustand mock implementation (auto-resets stores after each test) |
 | `web/__mocks__/` | Reusable mock factories shared across multiple test files |
 | Test file | Test-specific mocks, inline with `vi.mock()` |
 
 Modules are not mocked automatically. Use `vi.mock` in test files, or add global mocks in `web/vitest.setup.ts`.
+
+**Note**: Zustand is special - it's globally mocked but you should NOT mock store modules manually. See [Zustand Store Testing](#zustand-store-testing).
 
 ## Essential Mocks
 
@@ -276,6 +296,7 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
 
 1. **Use real base components** - Import from `@/app/components/base/` directly
 1. **Use real project components** - Prefer importing over mocking
+1. **Use real Zustand stores** - Set test state via `store.setState()`
 1. **Reset mocks in `beforeEach`**, not `afterEach`
 1. **Match actual component behavior** in mocks (when mocking is necessary)
 1. **Use factory functions** for complex mock data
@@ -285,6 +306,7 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
 ### ❌ DON'T
 
 1. **Don't mock base components** (`Loading`, `Button`, `Tooltip`, etc.)
+1. **Don't mock Zustand store modules** - Use real stores with `setState()`
 1. Don't mock components you can import directly
 1. Don't create overly simplified mocks that miss conditional logic
 1. Don't forget to clean up nock after each test
@@ -308,8 +330,149 @@ Need to use a component in test?
 ├─ Is it a third-party lib with side effects?
 │  └─ YES → Mock it (next/navigation, external SDKs)
 │
+├─ Is it a Zustand store?
+│  └─ YES → DO NOT mock the module!
+│           Use real store + setState() to set test state
+│           (Global mock handles auto-reset)
+│
 └─ Is it i18n?
    └─ YES → Uses shared mock (auto-loaded). Override only for custom translations
+```
+
+## Zustand Store Testing
+
+### Global Zustand Mock (Auto-loaded)
+
+Zustand is globally mocked in `web/vitest.setup.ts` following the [official Zustand testing guide](https://zustand.docs.pmnd.rs/guides/testing). The mock in `web/__mocks__/zustand.ts` provides:
+
+- Real store behavior with `getState()`, `setState()`, `subscribe()` methods
+- Automatic store reset after each test via `afterEach`
+- Proper test isolation between tests
+
+### ✅ Recommended: Use Real Stores (Official Best Practice)
+
+**DO NOT mock store modules manually.** Import and use the real store, then use `setState()` to set test state:
+
+```typescript
+// ✅ CORRECT: Use real store with setState
+import { useAppStore } from '@/app/components/app/store'
+
+describe('MyComponent', () => {
+  it('should render app details', () => {
+    // Arrange: Set test state via setState
+    useAppStore.setState({
+      appDetail: {
+        id: 'test-app',
+        name: 'Test App',
+        mode: 'chat',
+      },
+    })
+
+    // Act
+    render(<MyComponent />)
+
+    // Assert
+    expect(screen.getByText('Test App')).toBeInTheDocument()
+    // Can also verify store state directly
+    expect(useAppStore.getState().appDetail?.name).toBe('Test App')
+  })
+
+  // No cleanup needed - global mock auto-resets after each test
+})
+```
+
+### ❌ Avoid: Manual Store Module Mocking
+
+Manual mocking conflicts with the global Zustand mock and loses store functionality:
+
+```typescript
+// ❌ WRONG: Don't mock the store module
+vi.mock('@/app/components/app/store', () => ({
+  useStore: (selector) => mockSelector(selector),  // Missing getState, setState!
+}))
+
+// ❌ WRONG: This conflicts with global zustand mock
+vi.mock('@/app/components/workflow/store', () => ({
+  useWorkflowStore: vi.fn(() => mockState),
+}))
+```
+
+**Problems with manual mocking:**
+
+1. Loses `getState()`, `setState()`, `subscribe()` methods
+2. Conflicts with global Zustand mock behavior
+3. Requires manual maintenance of store API
+4. Tests don't reflect actual store behavior
+
+### When Manual Store Mocking is Necessary
+
+In rare cases where the store has complex initialization or side effects, you can mock it, but ensure you provide the full store API:
+
+```typescript
+// If you MUST mock (rare), include full store API
+const mockStore = {
+  appDetail: { id: 'test', name: 'Test' },
+  setAppDetail: vi.fn(),
+}
+
+vi.mock('@/app/components/app/store', () => ({
+  useStore: Object.assign(
+    (selector: (state: typeof mockStore) => unknown) => selector(mockStore),
+    {
+      getState: () => mockStore,
+      setState: vi.fn(),
+      subscribe: vi.fn(),
+    },
+  ),
+}))
+```
+
+### Store Testing Decision Tree
+
+```
+Need to test a component using Zustand store?
+│
+├─ Can you use the real store?
+│  └─ YES → Use real store + setState (RECOMMENDED)
+│           useAppStore.setState({ ... })
+│
+├─ Does the store have complex initialization/side effects?
+│  └─ YES → Consider mocking, but include full API
+│           (getState, setState, subscribe)
+│
+└─ Are you testing the store itself (not a component)?
+   └─ YES → Test store directly with getState/setState
+            const store = useMyStore
+            store.setState({ count: 0 })
+            store.getState().increment()
+            expect(store.getState().count).toBe(1)
+```
+
+### Example: Testing Store Actions
+
+```typescript
+import { useCounterStore } from '@/stores/counter'
+
+describe('Counter Store', () => {
+  it('should increment count', () => {
+    // Initial state (auto-reset by global mock)
+    expect(useCounterStore.getState().count).toBe(0)
+
+    // Call action
+    useCounterStore.getState().increment()
+
+    // Verify state change
+    expect(useCounterStore.getState().count).toBe(1)
+  })
+
+  it('should reset to initial state', () => {
+    // Set some state
+    useCounterStore.setState({ count: 100 })
+    expect(useCounterStore.getState().count).toBe(100)
+
+    // After this test, global mock will reset to initial state
+  })
+})
 ```
 
 ## Factory Function Pattern

--- a/.claude/skills/frontend-testing/references/mocking.md
+++ b/.claude/skills/frontend-testing/references/mocking.md
@@ -400,9 +400,9 @@ vi.mock('@/app/components/workflow/store', () => ({
 **Problems with manual mocking:**
 
 1. Loses `getState()`, `setState()`, `subscribe()` methods
-2. Conflicts with global Zustand mock behavior
-3. Requires manual maintenance of store API
-4. Tests don't reflect actual store behavior
+1. Conflicts with global Zustand mock behavior
+1. Requires manual maintenance of store API
+1. Tests don't reflect actual store behavior
 
 ### When Manual Store Mocking is Necessary
 

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/card-view.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/card-view.tsx
@@ -39,7 +39,6 @@ const CardView: FC<ICardViewProps> = ({ appId, isInPanel, className }) => {
   const docLink = useDocLink()
   const { notify } = useContext(ToastContext)
   const appDetail = useAppStore(state => state.appDetail)
-  const setAppDetail = useAppStore(state => state.setAppDetail)
 
   const isWorkflowApp = appDetail?.mode === AppModeEnum.WORKFLOW
   const showMCPCard = isInPanel
@@ -92,7 +91,7 @@ const CardView: FC<ICardViewProps> = ({ appId, isInPanel, className }) => {
   const updateAppDetail = async () => {
     try {
       const res = await fetchAppDetail({ url: '/apps', id: appId })
-      setAppDetail({ ...res })
+      useAppStore.getState().setAppDetail({ ...res })
     }
     catch (error) { console.error(error) }
   }

--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
@@ -107,13 +107,11 @@ const DatasetDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
 
   useDocumentTitle(datasetRes?.name || t('menus.datasets', { ns: 'common' }))
 
-  const setAppSidebarExpand = useStore(state => state.setAppSidebarExpand)
-
   useEffect(() => {
     const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
     const mode = isMobile ? 'collapse' : 'expand'
-    setAppSidebarExpand(isMobile ? mode : localeMode)
-  }, [isMobile, setAppSidebarExpand])
+    useStore.getState().setAppSidebarExpand(isMobile ? mode : localeMode)
+  }, [isMobile])
 
   if (!datasetRes && !error)
     return <Loading type="app" />

--- a/web/app/account/(commonLayout)/delete-account/state.tsx
+++ b/web/app/account/(commonLayout)/delete-account/state.tsx
@@ -13,13 +13,12 @@ export const useAccountDeleteStore = create<State>(set => ({
 }))
 
 export function useSendDeleteAccountEmail() {
-  const updateEmailToken = useAccountDeleteStore(state => state.setSendEmailToken)
   return useMutation({
     mutationKey: ['delete-account'],
     mutationFn: sendDeleteAccountCode,
     onSuccess: (ret) => {
       if (ret.result === 'success')
-        updateEmailToken(ret.data)
+        useAccountDeleteStore.getState().setSendEmailToken(ret.data)
     },
   })
 }

--- a/web/app/components/app-sidebar/app-info.tsx
+++ b/web/app/components/app-sidebar/app-info.tsx
@@ -66,7 +66,6 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
   const { replace } = useRouter()
   const { onPlanInfoChanged } = useProviderContext()
   const appDetail = useAppStore(state => state.appDetail)
-  const setAppDetail = useAppStore(state => state.setAppDetail)
   const invalidateAppList = useInvalidateAppList()
   const [open, setOpen] = useState(openState)
   const [showEditModal, setShowEditModal] = useState(false)
@@ -104,12 +103,12 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
         type: 'success',
         message: t('editDone', { ns: 'app' }),
       })
-      setAppDetail(app)
+      useAppStore.getState().setAppDetail(app)
     }
     catch {
       notify({ type: 'error', message: t('editFailed', { ns: 'app' }) })
     }
-  }, [appDetail, notify, setAppDetail, t])
+  }, [appDetail, notify, t])
 
   const onCopy: DuplicateAppModalProps['onConfirm'] = async ({ name, icon_type, icon, icon_background }) => {
     if (!appDetail)
@@ -195,7 +194,7 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
       notify({ type: 'success', message: t('appDeleted', { ns: 'app' }) })
       invalidateAppList()
       onPlanInfoChanged()
-      setAppDetail()
+      useAppStore.getState().setAppDetail()
       replace('/apps')
     }
     catch (e: any) {
@@ -205,7 +204,7 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
       })
     }
     setShowConfirmDelete(false)
-  }, [appDetail, invalidateAppList, notify, onPlanInfoChanged, replace, setAppDetail, t])
+  }, [appDetail, invalidateAppList, notify, onPlanInfoChanged, replace, t])
 
   const { isCurrentWorkspaceEditor } = useAppContext()
 

--- a/web/app/components/app/app-access-control/access-control-item.tsx
+++ b/web/app/components/app/app-access-control/access-control-item.tsx
@@ -9,14 +9,13 @@ type AccessControlItemProps = PropsWithChildren<{
 
 const AccessControlItem: FC<AccessControlItemProps> = ({ type, children }) => {
   const currentMenu = useAccessControlStore(s => s.currentMenu)
-  const setCurrentMenu = useAccessControlStore(s => s.setCurrentMenu)
   if (currentMenu !== type) {
     return (
       <div
         className="cursor-pointer rounded-[10px] border-[1px]
       border-components-option-card-option-border bg-components-option-card-option-bg
       hover:border-components-option-card-option-border-hover hover:bg-components-option-card-option-bg-hover"
-        onClick={() => setCurrentMenu(type)}
+        onClick={() => useAccessControlStore.getState().setCurrentMenu(type)}
       >
         {children}
       </div>

--- a/web/app/components/app/app-access-control/add-member-or-group-pop.tsx
+++ b/web/app/components/app/app-access-control/add-member-or-group-pop.tsx
@@ -103,16 +103,15 @@ function renderGroupOrMember(data: GroupOrMemberData) {
 
 function SelectedGroupsBreadCrumb() {
   const selectedGroupsForBreadcrumb = useAccessControlStore(s => s.selectedGroupsForBreadcrumb)
-  const setSelectedGroupsForBreadcrumb = useAccessControlStore(s => s.setSelectedGroupsForBreadcrumb)
   const { t } = useTranslation()
 
   const handleBreadCrumbClick = useCallback((index: number) => {
     const newGroups = selectedGroupsForBreadcrumb.slice(0, index + 1)
-    setSelectedGroupsForBreadcrumb(newGroups)
-  }, [setSelectedGroupsForBreadcrumb, selectedGroupsForBreadcrumb])
+    useAccessControlStore.getState().setSelectedGroupsForBreadcrumb(newGroups)
+  }, [selectedGroupsForBreadcrumb])
   const handleReset = useCallback(() => {
-    setSelectedGroupsForBreadcrumb([])
-  }, [setSelectedGroupsForBreadcrumb])
+    useAccessControlStore.getState().setSelectedGroupsForBreadcrumb([])
+  }, [])
   return (
     <div className="flex h-7 items-center gap-x-0.5 px-2 py-0.5">
       <span className={cn('system-xs-regular text-text-tertiary', selectedGroupsForBreadcrumb.length > 0 && 'cursor-pointer text-text-accent')} onClick={handleReset}>{t('accessControlDialog.operateGroupAndMember.allMembers', { ns: 'app' })}</span>
@@ -134,24 +133,22 @@ type GroupItemProps = {
 function GroupItem({ group }: GroupItemProps) {
   const { t } = useTranslation()
   const specificGroups = useAccessControlStore(s => s.specificGroups)
-  const setSpecificGroups = useAccessControlStore(s => s.setSpecificGroups)
   const selectedGroupsForBreadcrumb = useAccessControlStore(s => s.selectedGroupsForBreadcrumb)
-  const setSelectedGroupsForBreadcrumb = useAccessControlStore(s => s.setSelectedGroupsForBreadcrumb)
   const isChecked = specificGroups.some(g => g.id === group.id)
   const handleCheckChange = useCallback(() => {
     if (!isChecked) {
       const newGroups = [...specificGroups, group]
-      setSpecificGroups(newGroups)
+      useAccessControlStore.getState().setSpecificGroups(newGroups)
     }
     else {
       const newGroups = specificGroups.filter(g => g.id !== group.id)
-      setSpecificGroups(newGroups)
+      useAccessControlStore.getState().setSpecificGroups(newGroups)
     }
-  }, [specificGroups, setSpecificGroups, group, isChecked])
+  }, [specificGroups, group, isChecked])
 
   const handleExpandClick = useCallback(() => {
-    setSelectedGroupsForBreadcrumb([...selectedGroupsForBreadcrumb, group])
-  }, [selectedGroupsForBreadcrumb, setSelectedGroupsForBreadcrumb, group])
+    useAccessControlStore.getState().setSelectedGroupsForBreadcrumb([...selectedGroupsForBreadcrumb, group])
+  }, [selectedGroupsForBreadcrumb, group])
   return (
     <BaseItem>
       <Checkbox checked={isChecked} className="h-4 w-4 shrink-0" onCheck={handleCheckChange} />
@@ -185,18 +182,17 @@ function MemberItem({ member }: MemberItemProps) {
   const currentUser = useSelector(s => s.userProfile)
   const { t } = useTranslation()
   const specificMembers = useAccessControlStore(s => s.specificMembers)
-  const setSpecificMembers = useAccessControlStore(s => s.setSpecificMembers)
   const isChecked = specificMembers.some(m => m.id === member.id)
   const handleCheckChange = useCallback(() => {
     if (!isChecked) {
       const newMembers = [...specificMembers, member]
-      setSpecificMembers(newMembers)
+      useAccessControlStore.getState().setSpecificMembers(newMembers)
     }
     else {
       const newMembers = specificMembers.filter(m => m.id !== member.id)
-      setSpecificMembers(newMembers)
+      useAccessControlStore.getState().setSpecificMembers(newMembers)
     }
-  }, [specificMembers, setSpecificMembers, member, isChecked])
+  }, [specificMembers, member, isChecked])
   return (
     <BaseItem className="pr-3">
       <Checkbox checked={isChecked} className="h-4 w-4 shrink-0" onCheck={handleCheckChange} />

--- a/web/app/components/app/app-access-control/index.tsx
+++ b/web/app/components/app/app-access-control/index.tsx
@@ -25,20 +25,19 @@ export default function AccessControl(props: AccessControlProps) {
   const { app, onClose, onConfirm } = props
   const { t } = useTranslation()
   const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
-  const setAppId = useAccessControlStore(s => s.setAppId)
   const specificGroups = useAccessControlStore(s => s.specificGroups)
   const specificMembers = useAccessControlStore(s => s.specificMembers)
   const currentMenu = useAccessControlStore(s => s.currentMenu)
-  const setCurrentMenu = useAccessControlStore(s => s.setCurrentMenu)
   const hideTip = systemFeatures.webapp_auth.enabled
     && (systemFeatures.webapp_auth.allow_sso
       || systemFeatures.webapp_auth.allow_email_password_login
       || systemFeatures.webapp_auth.allow_email_code_login)
 
   useEffect(() => {
+    const { setAppId, setCurrentMenu } = useAccessControlStore.getState()
     setAppId(app.id)
     setCurrentMenu(app.access_mode ?? AccessMode.SPECIFIC_GROUPS_MEMBERS)
-  }, [app, setAppId, setCurrentMenu])
+  }, [app])
 
   const { isPending, mutateAsync: updateAccessMode } = useUpdateAccessMode()
   const handleConfirm = useCallback(async () => {

--- a/web/app/components/app/app-access-control/specific-groups-or-members.tsx
+++ b/web/app/components/app/app-access-control/specific-groups-or-members.tsx
@@ -14,15 +14,14 @@ import AddMemberOrGroupDialog from './add-member-or-group-pop'
 export default function SpecificGroupsOrMembers() {
   const currentMenu = useAccessControlStore(s => s.currentMenu)
   const appId = useAccessControlStore(s => s.appId)
-  const setSpecificGroups = useAccessControlStore(s => s.setSpecificGroups)
-  const setSpecificMembers = useAccessControlStore(s => s.setSpecificMembers)
   const { t } = useTranslation()
 
   const { isPending, data } = useAppWhiteListSubjects(appId, Boolean(appId) && currentMenu === AccessMode.SPECIFIC_GROUPS_MEMBERS)
   useEffect(() => {
+    const { setSpecificGroups, setSpecificMembers } = useAccessControlStore.getState()
     setSpecificGroups(data?.groups ?? [])
     setSpecificMembers(data?.members ?? [])
-  }, [data, setSpecificGroups, setSpecificMembers])
+  }, [data])
 
   if (currentMenu !== AccessMode.SPECIFIC_GROUPS_MEMBERS) {
     return (
@@ -80,10 +79,9 @@ type GroupItemProps = {
 }
 function GroupItem({ group }: GroupItemProps) {
   const specificGroups = useAccessControlStore(s => s.specificGroups)
-  const setSpecificGroups = useAccessControlStore(s => s.setSpecificGroups)
   const handleRemoveGroup = useCallback(() => {
-    setSpecificGroups(specificGroups.filter(g => g.id !== group.id))
-  }, [group, setSpecificGroups, specificGroups])
+    useAccessControlStore.getState().setSpecificGroups(specificGroups.filter(g => g.id !== group.id))
+  }, [group, specificGroups])
   return (
     <BaseItem
       icon={<RiOrganizationChart className="h-[14px] w-[14px] text-components-avatar-shape-fill-stop-0" />}
@@ -100,10 +98,9 @@ type MemberItemProps = {
 }
 function MemberItem({ member }: MemberItemProps) {
   const specificMembers = useAccessControlStore(s => s.specificMembers)
-  const setSpecificMembers = useAccessControlStore(s => s.setSpecificMembers)
   const handleRemoveMember = useCallback(() => {
-    setSpecificMembers(specificMembers.filter(m => m.id !== member.id))
-  }, [member, setSpecificMembers, specificMembers])
+    useAccessControlStore.getState().setSpecificMembers(specificMembers.filter(m => m.id !== member.id))
+  }, [member, specificMembers])
   return (
     <BaseItem
       icon={<Avatar className="h-[14px] w-[14px]" textClassName="text-[12px]" avatar={null} name={member.name} />}

--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -147,7 +147,6 @@ const AppPublisher = ({
   const [embeddingModalOpen, setEmbeddingModalOpen] = useState(false)
 
   const appDetail = useAppStore(state => state.appDetail)
-  const setAppDetail = useAppStore(s => s.setAppDetail)
   const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
   const { formatTimeFromNow } = useFormatTimeFromNow()
   const { app_base_url: appBaseURL = '', access_token: accessToken = '' } = appDetail?.site ?? {}
@@ -243,12 +242,12 @@ const AppPublisher = ({
       return
     try {
       const res = await fetchAppDetailDirect({ url: '/apps', id: appDetail.id })
-      setAppDetail(res)
+      useAppStore.getState().setAppDetail(res)
     }
     finally {
       setShowAppAccessControl(false)
     }
-  }, [appDetail, setAppDetail])
+  }, [appDetail])
 
   useKeyPress(`${getKeyboardKeyCodeBySystem('ctrl')}.shift.p`, (e) => {
     e.preventDefault()

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/index.spec.tsx
@@ -7,6 +7,7 @@ import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { Inputs, ModelConfig } from '@/models/debug'
 import type { PromptVariable } from '@/types/app'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { useStore as useAppStore } from '@/app/components/app/store'
 import { DEFAULT_AGENT_SETTING, DEFAULT_CHAT_PROMPT_CONFIG, DEFAULT_COMPLETION_PROMPT_CONFIG } from '@/config'
 import { AppModeEnum, ModelModeType, Resolution, TransferMethod } from '@/types/app'
 import { APP_CHAT_WITH_MULTIPLE_MODEL } from '../types'
@@ -21,9 +22,7 @@ type PromptVariableWithMeta = Omit<PromptVariable, 'type' | 'required'> & {
 const mockUseDebugConfigurationContext = vi.fn()
 const mockUseFeaturesSelector = vi.fn()
 const mockUseEventEmitterContext = vi.fn()
-const mockUseAppStoreSelector = vi.fn()
 const mockEventEmitter = { emit: vi.fn() }
-const mockSetShowAppConfigureFeaturesModal = vi.fn()
 let capturedChatInputProps: MockChatInputAreaProps | null = null
 let modelIdCounter = 0
 let featureState: FeatureStoreState
@@ -61,10 +60,6 @@ vi.mock('@/app/components/base/features/hooks', () => ({
 
 vi.mock('@/context/event-emitter', () => ({
   useEventEmitterContextContext: () => mockUseEventEmitterContext(),
-}))
-
-vi.mock('@/app/components/app/store', () => ({
-  useStore: (selector: (state: { setShowAppConfigureFeaturesModal: typeof mockSetShowAppConfigureFeaturesModal }) => unknown) => mockUseAppStoreSelector(selector),
 }))
 
 vi.mock('./debug-item', () => ({
@@ -191,7 +186,6 @@ describe('DebugWithMultipleModel', () => {
     featureState = createFeatureState()
     mockUseFeaturesSelector.mockImplementation(selector => selector(featureState))
     mockUseEventEmitterContext.mockReturnValue({ eventEmitter: mockEventEmitter })
-    mockUseAppStoreSelector.mockImplementation(selector => selector({ setShowAppConfigureFeaturesModal: mockSetShowAppConfigureFeaturesModal }))
     mockUseDebugConfigurationContext.mockReturnValue(createDebugConfiguration())
   })
 
@@ -438,7 +432,7 @@ describe('DebugWithMultipleModel', () => {
       expect(capturedChatInputProps?.showFileUpload).toBe(false)
       expect(capturedChatInputProps?.speechToTextConfig).toEqual(featureState.features.speech2text)
       expect(capturedChatInputProps?.visionConfig).toEqual(featureState.features.file)
-      expect(mockSetShowAppConfigureFeaturesModal).toHaveBeenCalledWith(true)
+      expect(useAppStore.getState().showAppConfigureFeaturesModal).toBe(true)
     })
 
     it('should render chat input in agent chat mode', () => {

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/index.tsx
@@ -99,7 +99,6 @@ const DebugWithMultipleModel = () => {
     }
   }, [twoLine, threeLine, fourLine])
 
-  const setShowAppConfigureFeaturesModal = useAppStore(s => s.setShowAppConfigureFeaturesModal)
   const inputsForm = modelConfig.configs.prompt_variables
     .filter(item => item.type !== 'api')
     .map(item => ({
@@ -145,7 +144,7 @@ const DebugWithMultipleModel = () => {
             botName="Bot"
             showFeatureBar
             showFileUpload={false}
-            onFeatureBarClick={setShowAppConfigureFeaturesModal}
+            onFeatureBarClick={state => useAppStore.getState().setShowAppConfigureFeaturesModal(state)}
             onSend={handleSend}
             speechToTextConfig={speech2text as any}
             visionConfig={file}

--- a/web/app/components/app/configuration/debug/debug-with-single-model/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/index.spec.tsx
@@ -7,6 +7,7 @@ import type { ProviderContextState } from '@/context/provider-context'
 import type { DatasetConfigs, ModelConfig } from '@/models/debug'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createRef } from 'react'
+import { useStore as useAppStore } from '@/app/components/app/store'
 import { ConfigurationMethodEnum, ModelFeatureEnum, ModelStatusEnum, ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { CollectionType } from '@/app/components/tools/types'
 import { PromptMode } from '@/models/debug'
@@ -376,15 +377,7 @@ vi.mock('../hooks', () => ({
   useFormattingChangedSubscription: mockUseFormattingChangedSubscription,
 }))
 
-const mockSetShowAppConfigureFeaturesModal = vi.fn()
-
-vi.mock('@/app/components/app/store', () => ({
-  useStore: vi.fn((selector?: (state: { setShowAppConfigureFeaturesModal: typeof mockSetShowAppConfigureFeaturesModal }) => unknown) => {
-    if (typeof selector === 'function')
-      return selector({ setShowAppConfigureFeaturesModal: mockSetShowAppConfigureFeaturesModal })
-    return mockSetShowAppConfigureFeaturesModal
-  }),
-}))
+// Use real store - global zustand mock will auto-reset between tests
 
 // Mock event emitter context
 vi.mock('@/context/event-emitter', () => ({
@@ -659,7 +652,7 @@ describe('DebugWithSingleModel', () => {
 
       fireEvent.click(screen.getByTestId('feature-bar-button'))
 
-      expect(mockSetShowAppConfigureFeaturesModal).toHaveBeenCalledWith(true)
+      expect(useAppStore.getState().showAppConfigureFeaturesModal).toBe(true)
     })
   })
 

--- a/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
@@ -146,8 +146,6 @@ const DebugWithSingleModel = (
     }
   }, [handleRestart])
 
-  const setShowAppConfigureFeaturesModal = useAppStore(s => s.setShowAppConfigureFeaturesModal)
-
   return (
     <Chat
       config={config}
@@ -157,7 +155,7 @@ const DebugWithSingleModel = (
       chatFooterClassName="px-3 pt-10 pb-0"
       showFeatureBar
       showFileUpload={false}
-      onFeatureBarClick={setShowAppConfigureFeaturesModal}
+      onFeatureBarClick={state => useAppStore.getState().setShowAppConfigureFeaturesModal(state)}
       suggestedQuestions={suggestedQuestions}
       onSend={doSend}
       inputs={inputs}

--- a/web/app/components/app/configuration/prompt-value-panel/index.spec.tsx
+++ b/web/app/components/app/configuration/prompt-value-panel/index.spec.tsx
@@ -2,14 +2,11 @@ import type { IPromptValuePanelProps } from './index'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useStore } from '@/app/components/app/store'
 import ConfigContext from '@/context/debug-configuration'
 import { AppModeEnum, ModelModeType, Resolution } from '@/types/app'
 import PromptValuePanel from './index'
 
-vi.mock('@/app/components/app/store', () => ({
-  useStore: vi.fn(),
-}))
+// Use real store - global zustand mock will auto-reset between tests
 vi.mock('@/app/components/base/features/new-feature-panel/feature-bar', () => ({
   default: ({ onFeatureBarClick }: { onFeatureBarClick: () => void }) => (
     <button type="button" onClick={onFeatureBarClick}>
@@ -18,8 +15,6 @@ vi.mock('@/app/components/base/features/new-feature-panel/feature-bar', () => ({
   ),
 }))
 
-const mockSetShowAppConfigureFeaturesModal = vi.fn()
-const mockUseStore = vi.mocked(useStore)
 const mockSetInputs = vi.fn()
 const mockOnSend = vi.fn()
 
@@ -69,20 +64,9 @@ const renderPanel = (options: {
 
 describe('PromptValuePanel', () => {
   beforeEach(() => {
-    mockUseStore.mockImplementation(selector => selector({
-      setShowAppConfigureFeaturesModal: mockSetShowAppConfigureFeaturesModal,
-      appSidebarExpand: '',
-      currentLogModalActiveTab: 'prompt',
-      showPromptLogModal: false,
-      showAgentLogModal: false,
-      setShowPromptLogModal: vi.fn(),
-      setShowAgentLogModal: vi.fn(),
-      showMessageLogModal: false,
-      showAppConfigureFeaturesModal: false,
-    } as any))
+    vi.clearAllMocks()
     mockSetInputs.mockClear()
     mockOnSend.mockClear()
-    mockSetShowAppConfigureFeaturesModal.mockClear()
   })
 
   it('updates inputs, clears values, and triggers run when ready', async () => {

--- a/web/app/components/app/configuration/prompt-value-panel/index.tsx
+++ b/web/app/components/app/configuration/prompt-value-panel/index.tsx
@@ -105,8 +105,6 @@ const PromptValuePanel: FC<IPromptValuePanelProps> = ({
     setInputs(newInputs)
   }
 
-  const setShowAppConfigureFeaturesModal = useAppStore(s => s.setShowAppConfigureFeaturesModal)
-
   return (
     <>
       <div className="relative z-[1] mx-3 rounded-xl border-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg shadow-md">
@@ -236,7 +234,7 @@ const PromptValuePanel: FC<IPromptValuePanelProps> = ({
         <FeatureBar
           showFileUpload={false}
           isChatMode={appType !== AppModeEnum.COMPLETION}
-          onFeatureBarClick={setShowAppConfigureFeaturesModal}
+          onFeatureBarClick={state => useAppStore.getState().setShowAppConfigureFeaturesModal(state)}
         />
       </div>
     </>

--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -77,7 +77,6 @@ function AppCard({
   const { data: currentWorkflow } = useAppWorkflow(appInfo.mode === AppModeEnum.WORKFLOW ? appInfo.id : '')
   const docLink = useDocLink()
   const appDetail = useAppStore(state => state.appDetail)
-  const setAppDetail = useAppStore(state => state.setAppDetail)
   const [showSettingsModal, setShowSettingsModal] = useState(false)
   const [showEmbedded, setShowEmbedded] = useState(false)
   const [showCustomizeModal, setShowCustomizeModal] = useState(false)
@@ -181,13 +180,13 @@ function AppCard({
   const handleAccessControlUpdate = useCallback(async () => {
     try {
       const res = await fetchAppDetailDirect({ url: '/apps', id: appDetail!.id })
-      setAppDetail(res)
+      useAppStore.getState().setAppDetail(res)
       setShowAccessControl(false)
     }
     catch (error) {
       console.error('Failed to fetch app detail:', error)
     }
-  }, [appDetail, setAppDetail])
+  }, [appDetail])
 
   return (
     <div

--- a/web/app/components/app/store.ts
+++ b/web/app/components/app/store.ts
@@ -24,7 +24,7 @@ type Action = {
   setShowAppConfigureFeaturesModal: (showAppConfigureFeaturesModal: boolean) => void
 }
 
-export const useStore = create<State & Action>(set => ({
+export const useStore = create<State & Action>()(set => ({
   appDetail: undefined,
   setAppDetail: appDetail => set(() => ({ appDetail })),
   appSidebarExpand: '',

--- a/web/app/components/app/switch-app-modal/index.spec.tsx
+++ b/web/app/components/app/switch-app-modal/index.spec.tsx
@@ -2,6 +2,7 @@ import type { App } from '@/types/app'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
+import { useStore as useAppStore } from '@/app/components/app/store'
 import { ToastContext } from '@/app/components/base/toast'
 import { Plan } from '@/app/components/billing/type'
 import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
@@ -17,10 +18,7 @@ vi.mock('next/navigation', () => ({
   }),
 }))
 
-const mockSetAppDetail = vi.fn()
-vi.mock('@/app/components/app/store', () => ({
-  useStore: (selector: (state: any) => unknown) => selector({ setAppDetail: mockSetAppDetail }),
-}))
+// Use real store - global zustand mock will auto-reset between tests
 
 const mockSwitchApp = vi.fn()
 const mockDeleteApp = vi.fn()
@@ -137,9 +135,17 @@ const renderComponent = (overrides: Partial<React.ComponentProps<typeof SwitchAp
   }
 }
 
+const setAppDetailSpy = vi.fn()
+
 describe('SwitchAppModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Spy on setAppDetail
+    const originalSetAppDetail = useAppStore.getState().setAppDetail
+    setAppDetailSpy.mockImplementation((...args: Parameters<typeof originalSetAppDetail>) => {
+      originalSetAppDetail(...args)
+    })
+    useAppStore.setState({ setAppDetail: setAppDetailSpy as typeof originalSetAppDetail })
     mockIsEditor = true
     mockEnableBilling = false
     mockPlan = {
@@ -275,7 +281,7 @@ describe('SwitchAppModal', () => {
       })
       expect(mockReplace).toHaveBeenCalledWith('/app/new-app-002/workflow')
       expect(mockPush).not.toHaveBeenCalled()
-      expect(mockSetAppDetail).toHaveBeenCalledTimes(1)
+      expect(setAppDetailSpy).toHaveBeenCalledTimes(1)
     })
 
     it('should notify error when switch app fails', async () => {

--- a/web/app/components/app/switch-app-modal/index.tsx
+++ b/web/app/components/app/switch-app-modal/index.tsx
@@ -38,7 +38,6 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
   const { push, replace } = useRouter()
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
-  const setAppDetail = useAppStore(s => s.setAppDetail)
 
   const { isCurrentWorkspaceEditor } = useAppContext()
   const { plan, enableBilling } = useProviderContext()
@@ -70,7 +69,7 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
         onClose()
       notify({ type: 'success', message: t('newApp.appCreated', { ns: 'app' }) })
       if (inAppDetail)
-        setAppDetail()
+        useAppStore.getState().setAppDetail()
       if (removeOriginal)
         await deleteApp(appDetail.id)
       localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')

--- a/web/app/components/app/text-generate/item/index.tsx
+++ b/web/app/components/app/text-generate/item/index.tsx
@@ -109,9 +109,6 @@ const GenerationItem: FC<IGenerationItemProps> = ({
     config,
   } = useChatContext()
 
-  const setCurrentLogItem = useAppStore(s => s.setCurrentLogItem)
-  const setShowPromptLogModal = useAppStore(s => s.setShowPromptLogModal)
-
   const handleFeedback = async (childFeedback: FeedbackType) => {
     await updateFeedback({ url: `/messages/${childMessageId}/feedbacks`, body: { rating: childFeedback.rating } }, isInstalledApp, installedAppId)
     setChildFeedback(childFeedback)
@@ -196,6 +193,7 @@ const GenerationItem: FC<IGenerationItemProps> = ({
               }
             : data.message],
         }
+    const { setCurrentLogItem, setShowPromptLogModal } = useAppStore.getState()
     setCurrentLogItem(logItem)
     setShowPromptLogModal(true)
   }

--- a/web/app/components/apps/list.spec.tsx
+++ b/web/app/components/apps/list.spec.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import * as React from 'react'
+import { useStore as useTagStore } from '@/app/components/base/tag-management/store'
 import { AppModeEnum } from '@/types/app'
 
 // Import after mocks
@@ -123,18 +124,7 @@ vi.mock('@/service/use-apps', () => ({
   }),
 }))
 
-// Mock tag store
-vi.mock('@/app/components/base/tag-management/store', () => ({
-  useStore: (selector: (state: { tagList: any[], setTagList: any, showTagManagementModal: boolean, setShowTagManagementModal: any }) => any) => {
-    const state = {
-      tagList: [{ id: 'tag-1', name: 'Test Tag', type: 'app' }],
-      setTagList: vi.fn(),
-      showTagManagementModal: false,
-      setShowTagManagementModal: vi.fn(),
-    }
-    return selector(state)
-  },
-}))
+// Use real tag store - global zustand mock will auto-reset between tests
 
 // Mock tag service to avoid API calls in TagFilter
 vi.mock('@/service/tag', () => ({
@@ -247,6 +237,11 @@ beforeAll(() => {
 describe('List', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Set up tag store state
+    useTagStore.setState({
+      tagList: [{ id: 'tag-1', name: 'Test Tag', type: 'app', binding_count: 0 }],
+      showTagManagementModal: false,
+    })
     mockIsCurrentWorkspaceEditor.mockReturnValue(true)
     mockIsCurrentWorkspaceDatasetOperator.mockReturnValue(false)
     mockDragging = false

--- a/web/app/components/base/agent-log-modal/index.stories.tsx
+++ b/web/app/components/base/agent-log-modal/index.stories.tsx
@@ -70,10 +70,9 @@ const AgentLogModalDemo = ({
   width?: number
 }) => {
   const originalFetchRef = useRef<typeof globalThis.fetch>(null)
-  const setAppDetail = useAppStore(state => state.setAppDetail)
 
   useEffect(() => {
-    setAppDetail({
+    useAppStore.getState().setAppDetail({
       id: 'app-1',
       name: 'Analytics Agent',
       mode: 'agent-chat',
@@ -104,9 +103,9 @@ const AgentLogModalDemo = ({
     return () => {
       if (originalFetchRef.current)
         globalThis.fetch = originalFetchRef.current
-      setAppDetail(undefined)
+      useAppStore.getState().setAppDetail(undefined)
     }
-  }, [setAppDetail])
+  }, [])
 
   return (
     <ToastProvider>

--- a/web/app/components/base/chat/chat/log/index.tsx
+++ b/web/app/components/base/chat/chat/log/index.tsx
@@ -7,30 +7,30 @@ import ActionButton from '@/app/components/base/action-button'
 type LogProps = {
   logItem: IChatItem
 }
+
 const Log: FC<LogProps> = ({
   logItem,
 }) => {
-  const setCurrentLogItem = useAppStore(s => s.setCurrentLogItem)
-  const setShowPromptLogModal = useAppStore(s => s.setShowPromptLogModal)
-  const setShowAgentLogModal = useAppStore(s => s.setShowAgentLogModal)
-  const setShowMessageLogModal = useAppStore(s => s.setShowMessageLogModal)
   const { workflow_run_id: runID, agent_thoughts } = logItem
   const isAgent = agent_thoughts && agent_thoughts.length > 0
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const { setCurrentLogItem, setShowPromptLogModal, setShowAgentLogModal, setShowMessageLogModal } = useAppStore.getState()
+    e.stopPropagation()
+    e.nativeEvent.stopImmediatePropagation()
+    setCurrentLogItem(logItem)
+    if (runID)
+      setShowMessageLogModal(true)
+    else if (isAgent)
+      setShowAgentLogModal(true)
+    else
+      setShowPromptLogModal(true)
+  }
 
   return (
     <div
       className="ml-1 flex items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-sm"
-      onClick={(e) => {
-        e.stopPropagation()
-        e.nativeEvent.stopImmediatePropagation()
-        setCurrentLogItem(logItem)
-        if (runID)
-          setShowMessageLogModal(true)
-        else if (isAgent)
-          setShowAgentLogModal(true)
-        else
-          setShowPromptLogModal(true)
-      }}
+      onClick={handleClick}
     >
       <ActionButton>
         <RiFileList3Line className="h-4 w-4" />

--- a/web/app/components/base/tag-management/filter.tsx
+++ b/web/app/components/base/tag-management/filter.tsx
@@ -32,8 +32,6 @@ const TagFilter: FC<TagFilterProps> = ({
   const [open, setOpen] = useState(false)
 
   const tagList = useTagStore(s => s.tagList)
-  const setTagList = useTagStore(s => s.setTagList)
-  const setShowTagManagementModal = useTagStore(s => s.setShowTagManagementModal)
 
   const [keywords, setKeywords] = useState('')
   const [searchKeywords, setSearchKeywords] = useState('')
@@ -62,7 +60,7 @@ const TagFilter: FC<TagFilterProps> = ({
 
   useMount(() => {
     fetchTagList(type).then((res) => {
-      setTagList(res)
+      useTagStore.getState().setTagList(res)
     })
   })
 
@@ -146,7 +144,7 @@ const TagFilter: FC<TagFilterProps> = ({
               <div
                 className="flex cursor-pointer select-none items-center gap-2 rounded-lg py-[6px] pl-3 pr-2 hover:bg-state-base-hover"
                 onClick={() => {
-                  setShowTagManagementModal(true)
+                  useTagStore.getState().setShowTagManagementModal(true)
                   setOpen(false)
                 }}
               >

--- a/web/app/components/base/tag-management/index.stories.tsx
+++ b/web/app/components/base/tag-management/index.stories.tsx
@@ -20,14 +20,13 @@ const TagManagementPlayground = ({
 }) => {
   const originalFetchRef = useRef<typeof globalThis.fetch>(null)
   const tagsRef = useRef<Tag[]>(INITIAL_TAGS)
-  const setTagList = useTagStore(s => s.setTagList)
   const showModal = useTagStore(s => s.showTagManagementModal)
-  const setShowModal = useTagStore(s => s.setShowTagManagementModal)
 
   useEffect(() => {
+    const { setTagList, setShowTagManagementModal } = useTagStore.getState()
     setTagList(tagsRef.current)
-    setShowModal(true)
-  }, [setTagList, setShowModal])
+    setShowTagManagementModal(true)
+  }, [])
 
   useEffect(() => {
     originalFetchRef.current = globalThis.fetch?.bind(globalThis)
@@ -56,7 +55,7 @@ const TagManagementPlayground = ({
             binding_count: 0,
           }
           tagsRef.current = [newTag, ...tagsRef.current]
-          setTagList(tagsRef.current)
+          useTagStore.getState().setTagList(tagsRef.current)
           return new Response(JSON.stringify(newTag), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
@@ -83,7 +82,7 @@ const TagManagementPlayground = ({
       if (originalFetchRef.current)
         globalThis.fetch = originalFetchRef.current
     }
-  }, [setTagList])
+  }, [])
 
   return (
     <ToastProvider>
@@ -91,7 +90,7 @@ const TagManagementPlayground = ({
         <button
           type="button"
           className="self-start rounded-md border border-divider-subtle bg-background-default px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-state-base-hover"
-          onClick={() => setShowModal(true)}
+          onClick={() => useTagStore.getState().setShowTagManagementModal(true)}
         >
           Manage tags
         </button>

--- a/web/app/components/base/tag-management/index.tsx
+++ b/web/app/components/base/tag-management/index.tsx
@@ -22,12 +22,10 @@ const TagManagementModal = ({ show, type }: TagManagementModalProps) => {
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
   const tagList = useTagStore(s => s.tagList)
-  const setTagList = useTagStore(s => s.setTagList)
-  const setShowTagManagementModal = useTagStore(s => s.setShowTagManagementModal)
 
   const getTagList = async (type: 'knowledge' | 'app') => {
     const res = await fetchTagList(type)
-    setTagList(res)
+    useTagStore.getState().setTagList(res)
   }
 
   const [pending, setPending] = useState<boolean>(false)
@@ -41,7 +39,7 @@ const TagManagementModal = ({ show, type }: TagManagementModalProps) => {
       setPending(true)
       const newTag = await createTag(name, type)
       notify({ type: 'success', message: t('tag.created', { ns: 'common' }) })
-      setTagList([
+      useTagStore.getState().setTagList([
         newTag,
         ...tagList,
       ])
@@ -62,10 +60,10 @@ const TagManagementModal = ({ show, type }: TagManagementModalProps) => {
     <Modal
       className="!w-[600px] !max-w-[600px] rounded-xl px-8 py-6"
       isShow={show}
-      onClose={() => setShowTagManagementModal(false)}
+      onClose={() => useTagStore.getState().setShowTagManagementModal(false)}
     >
       <div className="relative pb-2 text-xl font-semibold leading-[30px] text-text-primary">{t('tag.manageTags', { ns: 'common' })}</div>
-      <div className="absolute right-4 top-4 cursor-pointer p-2" onClick={() => setShowTagManagementModal(false)}>
+      <div className="absolute right-4 top-4 cursor-pointer p-2" onClick={() => useTagStore.getState().setShowTagManagementModal(false)}>
         <RiCloseLine className="h-4 w-4 text-text-tertiary" />
       </div>
       <div className="mt-3 flex flex-wrap gap-2">

--- a/web/app/components/base/tag-management/panel.tsx
+++ b/web/app/components/base/tag-management/panel.tsx
@@ -24,8 +24,6 @@ const Panel = (props: PanelProps) => {
   const { notify } = useContext(ToastContext)
   const { targetID, type, value, selectedTags, onCacheUpdate, onChange, onCreate } = props
   const tagList = useTagStore(s => s.tagList)
-  const setTagList = useTagStore(s => s.setTagList)
-  const setShowTagManagementModal = useTagStore(s => s.setShowTagManagementModal)
   const [selectedTagIDs, setSelectedTagIDs] = useState<string[]>(value)
   const [keywords, setKeywords] = useState('')
   const handleKeywordsChange = (value: string) => {
@@ -52,7 +50,7 @@ const Panel = (props: PanelProps) => {
       setCreating(true)
       const newTag = await createTag(keywords, type)
       notify({ type: 'success', message: t('tag.created', { ns: 'common' }) })
-      setTagList([
+      useTagStore.getState().setTagList([
         ...tagList,
         newTag,
       ])
@@ -198,7 +196,7 @@ const Panel = (props: PanelProps) => {
       <div className="p-1">
         <div
           className="flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
-          onClick={() => setShowTagManagementModal(true)}
+          onClick={() => useTagStore.getState().setShowTagManagementModal(true)}
         >
           <RiPriceTag3Line className="h-4 w-4 text-text-tertiary" />
           <div className="system-md-regular grow truncate px-1 text-text-secondary">

--- a/web/app/components/base/tag-management/selector.tsx
+++ b/web/app/components/base/tag-management/selector.tsx
@@ -32,12 +32,11 @@ const TagSelector: FC<TagSelectorProps> = ({
   minWidth,
 }) => {
   const tagList = useTagStore(s => s.tagList)
-  const setTagList = useTagStore(s => s.setTagList)
 
   const getTagList = useCallback(async () => {
     const res = await fetchTagList(type)
-    setTagList(res)
-  }, [setTagList, type])
+    useTagStore.getState().setTagList(res)
+  }, [type])
 
   const tags = useMemo(() => {
     if (selectedTags?.length)

--- a/web/app/components/base/tag-management/tag-item-editor.tsx
+++ b/web/app/components/base/tag-management/tag-item-editor.tsx
@@ -27,7 +27,6 @@ const TagItemEditor: FC<TagItemEditorProps> = ({
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
   const tagList = useTagStore(s => s.tagList)
-  const setTagList = useTagStore(s => s.setTagList)
 
   const [isEditing, setIsEditing] = useState(false)
   const [name, setName] = useState(tag.name)
@@ -52,7 +51,7 @@ const TagItemEditor: FC<TagItemEditorProps> = ({
         }
         return tag
       })
-      setTagList([
+      useTagStore.getState().setTagList([
         ...newList,
       ])
       setIsEditing(false)
@@ -72,7 +71,7 @@ const TagItemEditor: FC<TagItemEditorProps> = ({
         }
         return tag
       })
-      setTagList([
+      useTagStore.getState().setTagList([
         ...recoverList,
       ])
       setIsEditing(false)
@@ -88,7 +87,7 @@ const TagItemEditor: FC<TagItemEditorProps> = ({
       await deleteTag(tagID)
       notify({ type: 'success', message: t('actionMsg.modifiedSuccessfully', { ns: 'common' }) })
       const newList = tagList.filter(tag => tag.id !== tagID)
-      setTagList([
+      useTagStore.getState().setTagList([
         ...newList,
       ])
       setPending(false)

--- a/web/app/components/header/nav/index.tsx
+++ b/web/app/components/header/nav/index.tsx
@@ -33,7 +33,6 @@ const Nav = ({
   isLoadingMore,
   isApp,
 }: INavProps) => {
-  const setAppDetail = useAppStore(state => state.setAppDetail)
   const [hovered, setHovered] = useState(false)
   const segment = useSelectedLayoutSegment()
   const isActivated = Array.isArray(activeSegment) ? activeSegment.includes(segment!) : segment === activeSegment
@@ -51,7 +50,7 @@ const Nav = ({
             // Don't clear state if opening in new tab/window
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0)
               return
-            setAppDetail()
+            useAppStore.getState().setAppDetail()
           }}
           className={cn('flex h-7 cursor-pointer items-center rounded-[10px] px-2.5', isActivated ? 'text-components-main-nav-nav-button-text-active' : 'text-components-main-nav-nav-button-text', curNav && isActivated && 'hover:bg-components-main-nav-nav-button-bg-active-hover')}
           onMouseEnter={() => setHovered(true)}

--- a/web/app/components/header/nav/nav-selector/index.tsx
+++ b/web/app/components/header/nav/nav-selector/index.tsx
@@ -42,7 +42,6 @@ const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onL
   const { t } = useTranslation()
   const router = useRouter()
   const { isCurrentWorkspaceEditor } = useAppContext()
-  const setAppDetail = useAppStore(state => state.setAppDetail)
 
   const handleScroll = useCallback(debounce((e) => {
     if (typeof onLoadMore === 'function') {
@@ -84,7 +83,7 @@ const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onL
                       onClick={() => {
                         if (curNav?.id === nav.id)
                           return
-                        setAppDetail()
+                        useAppStore.getState().setAppDetail()
                         router.push(nav.link)
                       }}
                       title={nav.name}

--- a/web/app/components/plugins/readme-panel/index.spec.tsx
+++ b/web/app/components/plugins/readme-panel/index.spec.tsx
@@ -221,7 +221,6 @@ describe('useReadmePanelStore', () => {
 // ReadmeEntrance Component Tests
 // ================================
 describe('ReadmeEntrance', () => {
-
   // ================================
   // Rendering Tests
   // ================================

--- a/web/app/components/rag-pipeline/components/index.spec.tsx
+++ b/web/app/components/rag-pipeline/components/index.spec.tsx
@@ -92,6 +92,9 @@ vi.mock('@/app/components/workflow/store', () => {
     useWorkflowStore: () => ({
       getState: () => ({
         pipelineId: 'test-pipeline-id',
+        setShowInputFieldPanel: mockSetShowInputFieldPanel,
+        setShowEnvPanel: mockSetShowEnvPanel,
+        setShowImportDSLModal: mockSetShowImportDSLModal,
         setIsPreparingDataSource: mockSetIsPreparingDataSource,
         setShowDebugAndPreviewPanel: mockSetShowDebugAndPreviewPanel,
         setPublishedAt: mockSetPublishedAt,

--- a/web/app/components/rag-pipeline/components/panel/input-field/index.spec.tsx
+++ b/web/app/components/rag-pipeline/components/panel/input-field/index.spec.tsx
@@ -49,6 +49,11 @@ vi.mock('@/app/components/workflow/store', () => ({
     }
     return selector(state)
   },
+  useWorkflowStore: () => ({
+    getState: () => ({
+      setRagPipelineVariables: mockSetRagPipelineVariables,
+    }),
+  }),
 }))
 
 // Mock useNodesSyncDraft hook

--- a/web/app/components/rag-pipeline/components/panel/input-field/index.tsx
+++ b/web/app/components/rag-pipeline/components/panel/input-field/index.tsx
@@ -15,7 +15,7 @@ import Divider from '@/app/components/base/divider'
 import Tooltip from '@/app/components/base/tooltip'
 import { useInputFieldPanel } from '@/app/components/rag-pipeline/hooks'
 import { useNodesSyncDraft } from '@/app/components/workflow/hooks'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { cn } from '@/utils/classnames'
 import FieldList from './field-list'
@@ -32,8 +32,8 @@ const InputFieldPanel = () => {
     isPreviewing,
     isEditing,
   } = useInputFieldPanel()
+  const workflowStore = useWorkflowStore()
   const ragPipelineVariables = useStore(state => state.ragPipelineVariables)
-  const setRagPipelineVariables = useStore(state => state.setRagPipelineVariables)
 
   const getInputFieldsMap = () => {
     const inputFieldsMap: Record<string, InputVar[]> = {}
@@ -83,9 +83,9 @@ const InputFieldPanel = () => {
     })
     // Datasource node input fields come first, then global input fields
     const newRagPipelineVariables = [...datasourceNodeInputFields, ...globalInputFields]
-    setRagPipelineVariables?.(newRagPipelineVariables)
+    workflowStore.getState().setRagPipelineVariables?.(newRagPipelineVariables)
     handleSyncWorkflowDraft()
-  }, [setRagPipelineVariables, handleSyncWorkflowDraft])
+  }, [workflowStore, handleSyncWorkflowDraft])
 
   const closePanel = useCallback(() => {
     closeAllInputFieldPanels()

--- a/web/app/components/rag-pipeline/components/publish-as-knowledge-pipeline-modal.tsx
+++ b/web/app/components/rag-pipeline/components/publish-as-knowledge-pipeline-modal.tsx
@@ -11,7 +11,7 @@ import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
 import Modal from '@/app/components/base/modal'
 import Textarea from '@/app/components/base/textarea'
-import { useStore } from '@/app/components/workflow/store'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 
 type PublishAsKnowledgePipelineModalProps = {
   confirmDisabled?: boolean
@@ -28,10 +28,9 @@ const PublishAsKnowledgePipelineModal = ({
   onConfirm,
 }: PublishAsKnowledgePipelineModalProps) => {
   const { t } = useTranslation()
-  const knowledgeName = useStore(s => s.knowledgeName)
-  const knowledgeIcon = useStore(s => s.knowledgeIcon)
-  const [pipelineName, setPipelineName] = useState(knowledgeName!)
-  const [pipelineIcon, setPipelineIcon] = useState(knowledgeIcon!)
+  const workflowStore = useWorkflowStore()
+  const [pipelineName, setPipelineName] = useState(() => workflowStore.getState().knowledgeName!)
+  const [pipelineIcon, setPipelineIcon] = useState(() => workflowStore.getState().knowledgeIcon!)
   const [description, setDescription] = useState('')
   const [showAppIconPicker, setShowAppIconPicker] = useState(false)
 

--- a/web/app/components/rag-pipeline/components/rag-pipeline-children.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-children.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/app/components/workflow/hooks'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import PluginDependency from '../../workflow/plugin-dependency'
-import { useStore } from '../../workflow/store'
+import { useStore, useWorkflowStore } from '../../workflow/store'
 import { useRagPipelineSearch } from '../hooks/use-rag-pipeline-search'
 import RagPipelinePanel from './panel'
 import PublishToast from './publish-toast'
@@ -21,8 +21,8 @@ import UpdateDSLModal from './update-dsl-modal'
 const RagPipelineChildren = () => {
   const { eventEmitter } = useEventEmitterContextContext()
   const [secretEnvList, setSecretEnvList] = useState<EnvironmentVariable[]>([])
+  const workflowStore = useWorkflowStore()
   const showImportDSLModal = useStore(s => s.showImportDSLModal)
-  const setShowImportDSLModal = useStore(s => s.setShowImportDSLModal)
   const {
     handlePaneContextmenuCancel,
   } = usePanelInteractions()
@@ -45,7 +45,7 @@ const RagPipelineChildren = () => {
       {
         showImportDSLModal && (
           <UpdateDSLModal
-            onCancel={() => setShowImportDSLModal(false)}
+            onCancel={() => workflowStore.getState().setShowImportDSLModal(false)}
             onBackup={exportCheck!}
             onImport={handlePaneContextmenuCancel}
           />

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/index.spec.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/index.spec.tsx
@@ -42,6 +42,8 @@ vi.mock('@/app/components/workflow/store', () => ({
   useStore: (selector: (state: typeof mockStoreState) => unknown) => selector(mockStoreState),
   useWorkflowStore: () => ({
     getState: () => ({
+      setShowInputFieldPanel: mockSetShowInputFieldPanel,
+      setShowEnvPanel: mockSetShowEnvPanel,
       setIsPreparingDataSource: mockSetIsPreparingDataSource,
       setShowDebugAndPreviewPanel: mockSetShowDebugAndPreviewPanel,
       setPublishedAt: mockSetPublishedAt,

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/index.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/index.tsx
@@ -3,7 +3,6 @@ import {
   memo,
   useMemo,
 } from 'react'
-import { useTranslation } from 'react-i18next'
 import Header from '@/app/components/workflow/header'
 import {
   useStore,
@@ -13,9 +12,7 @@ import Publisher from './publisher'
 import RunMode from './run-mode'
 
 const RagPipelineHeader = () => {
-  const { t } = useTranslation()
   const pipelineId = useStore(s => s.pipelineId)
-  const showDebugAndPreviewPanel = useStore(s => s.showDebugAndPreviewPanel)
 
   const viewHistoryProps = useMemo(() => {
     return {
@@ -42,7 +39,7 @@ const RagPipelineHeader = () => {
         viewHistoryProps,
       },
     }
-  }, [viewHistoryProps, showDebugAndPreviewPanel, t])
+  }, [viewHistoryProps])
 
   return (
     <Header {...headerProps} />

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/input-field-button.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/input-field-button.tsx
@@ -2,16 +2,16 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import { InputField } from '@/app/components/base/icons/src/vender/pipeline'
-import { useStore } from '@/app/components/workflow/store'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 
 const InputFieldButton = () => {
   const { t } = useTranslation()
-  const setShowInputFieldPanel = useStore(state => state.setShowInputFieldPanel)
-  const setShowEnvPanel = useStore(state => state.setShowEnvPanel)
+  const workflowStore = useWorkflowStore()
   const handleClick = useCallback(() => {
+    const { setShowInputFieldPanel, setShowEnvPanel } = workflowStore.getState()
     setShowInputFieldPanel?.(true)
     setShowEnvPanel(false)
-  }, [setShowInputFieldPanel, setShowEnvPanel])
+  }, [workflowStore])
 
   return (
     <Button

--- a/web/app/components/workflow-app/components/workflow-children.tsx
+++ b/web/app/components/workflow-app/components/workflow-children.tsx
@@ -17,7 +17,7 @@ import {
   usePanelInteractions,
 } from '@/app/components/workflow/hooks'
 import { useNodesSyncDraft } from '@/app/components/workflow/hooks/use-nodes-sync-draft'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { generateNewNode } from '@/app/components/workflow/utils'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
@@ -68,13 +68,10 @@ const getTriggerPluginNodeData = (
 const WorkflowChildren = () => {
   const { eventEmitter } = useEventEmitterContextContext()
   const [secretEnvList, setSecretEnvList] = useState<EnvironmentVariable[]>([])
+  const workflowStore = useWorkflowStore()
   const showFeaturesPanel = useStore(s => s.showFeaturesPanel)
   const showImportDSLModal = useStore(s => s.showImportDSLModal)
-  const setShowImportDSLModal = useStore(s => s.setShowImportDSLModal)
   const showOnboarding = useStore(s => s.showOnboarding)
-  const setShowOnboarding = useStore(s => s.setShowOnboarding)
-  const setHasSelectedStartNode = useStore(s => s.setHasSelectedStartNode)
-  const setShouldAutoOpenStartNodeSelector = useStore(s => s.setShouldAutoOpenStartNodeSelector)
   const reactFlowStore = useStoreApi()
   const availableNodesMetaData = useAvailableNodesMetaData()
   const { handleSyncWorkflowDraft } = useNodesSyncDraft()
@@ -140,6 +137,11 @@ const WorkflowChildren = () => {
     setNodes([newNode])
     setEdges([])
 
+    const {
+      setShowOnboarding,
+      setHasSelectedStartNode,
+      setShouldAutoOpenStartNodeSelector,
+    } = workflowStore.getState()
     setShowOnboarding?.(false)
     setHasSelectedStartNode?.(true)
     setShouldAutoOpenStartNodeSelector?.(true)
@@ -153,7 +155,7 @@ const WorkflowChildren = () => {
         console.error('Failed to save node to draft')
       },
     })
-  }, [availableNodesMetaData, setShowOnboarding, setHasSelectedStartNode, reactFlowStore, handleSyncWorkflowDraft])
+  }, [availableNodesMetaData, reactFlowStore, handleSyncWorkflowDraft, workflowStore])
 
   return (
     <>
@@ -173,7 +175,7 @@ const WorkflowChildren = () => {
       {
         showImportDSLModal && (
           <UpdateDSLModal
-            onCancel={() => setShowImportDSLModal(false)}
+            onCancel={() => workflowStore.getState().setShowImportDSLModal(false)}
             onBackup={exportCheck!}
             onImport={handlePaneContextmenuCancel}
           />

--- a/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
@@ -51,7 +51,6 @@ const FeaturesTrigger = () => {
   const workflowStore = useWorkflowStore()
   const appDetail = useAppStore(s => s.appDetail)
   const appID = appDetail?.id
-  const setAppDetail = useAppStore(s => s.setAppDetail)
   const { nodesReadOnly, getNodesReadOnly } = useNodesReadOnly()
   const { plan, isFetchedPlan } = useProviderContext()
   const publishedAt = useStore(s => s.publishedAt)
@@ -128,12 +127,12 @@ const FeaturesTrigger = () => {
   const updateAppDetail = useCallback(async () => {
     try {
       const res = await fetchAppDetail({ url: '/apps', id: appID! })
-      setAppDetail({ ...res })
+      useAppStore.getState().setAppDetail({ ...res })
     }
     catch (error) {
       console.error(error)
     }
-  }, [appID, setAppDetail])
+  }, [appID])
 
   const { mutateAsync: publishWorkflow } = usePublishWorkflow()
   // const { validateBeforeRun } = useWorkflowRunValidation()

--- a/web/app/components/workflow-app/hooks/use-workflow-init.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-init.ts
@@ -7,10 +7,7 @@ import {
   useState,
 } from 'react'
 import { useStore as useAppStore } from '@/app/components/app/store'
-import {
-  useStore,
-  useWorkflowStore,
-} from '@/app/components/workflow/store'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { useWorkflowConfig } from '@/service/use-workflow'
 import {
@@ -39,7 +36,6 @@ export const useWorkflowInit = () => {
     edges: edgesTemplate,
   } = useWorkflowTemplate()
   const appDetail = useAppStore(state => state.appDetail)!
-  const setSyncWorkflowDraftHash = useStore(s => s.setSyncWorkflowDraftHash)
   const [data, setData] = useState<FetchWorkflowDraftResponse>()
   const [isLoading, setIsLoading] = useState(true)
   useEffect(() => {
@@ -68,7 +64,7 @@ export const useWorkflowInit = () => {
         conversationVariables: res.conversation_variables || [],
         isWorkflowDataLoaded: true,
       })
-      setSyncWorkflowDraftHash(res.hash)
+      workflowStore.getState().setSyncWorkflowDraftHash(res.hash)
       setIsLoading(false)
     }
     catch (error: any) {
@@ -106,7 +102,7 @@ export const useWorkflowInit = () => {
         })
       }
     }
-  }, [appDetail, nodesTemplate, edgesTemplate, workflowStore, setSyncWorkflowDraftHash])
+  }, [appDetail, nodesTemplate, edgesTemplate, workflowStore])
 
   useEffect(() => {
     handleGetInitialWorkflowData()

--- a/web/app/components/workflow/features.tsx
+++ b/web/app/components/workflow/features.tsx
@@ -13,11 +13,11 @@ import {
   useNodesSyncDraft,
 } from './hooks'
 import useConfig from './nodes/start/use-config'
-import { useStore } from './store'
+import { useWorkflowStore } from './store'
 import { InputVarType } from './types'
 
 const Features = () => {
-  const setShowFeaturesPanel = useStore(s => s.setShowFeaturesPanel)
+  const workflowStore = useWorkflowStore()
   const isChatMode = useIsChatMode()
   const { nodesReadOnly } = useNodesReadOnly()
   const { handleSyncWorkflowDraft } = useNodesSyncDraft()
@@ -42,8 +42,8 @@ const Features = () => {
 
   const handleFeaturesChange = useCallback(() => {
     handleSyncWorkflowDraft()
-    setShowFeaturesPanel(true)
-  }, [handleSyncWorkflowDraft, setShowFeaturesPanel])
+    workflowStore.getState().setShowFeaturesPanel(true)
+  }, [handleSyncWorkflowDraft, workflowStore])
 
   return (
     <NewFeaturePanel
@@ -51,7 +51,7 @@ const Features = () => {
       isChatMode={isChatMode}
       disabled={nodesReadOnly}
       onChange={handleFeaturesChange}
-      onClose={() => setShowFeaturesPanel(false)}
+      onClose={() => workflowStore.getState().setShowFeaturesPanel(false)}
       onAutoAddPromptVariable={handleAddOpeningStatementVariable}
       workflowVariables={data.variables}
     />

--- a/web/app/components/workflow/header/chat-variable-button.tsx
+++ b/web/app/components/workflow/header/chat-variable-button.tsx
@@ -1,19 +1,16 @@
 import { memo } from 'react'
 import Button from '@/app/components/base/button'
 import { BubbleX } from '@/app/components/base/icons/src/vender/line/others'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import useTheme from '@/hooks/use-theme'
 import { cn } from '@/utils/classnames'
 
 const ChatVariableButton = ({ disabled }: { disabled: boolean }) => {
   const { theme } = useTheme()
+  const workflowStore = useWorkflowStore()
   const showChatVariablePanel = useStore(s => s.showChatVariablePanel)
-  const setShowChatVariablePanel = useStore(s => s.setShowChatVariablePanel)
-  const setShowEnvPanel = useStore(s => s.setShowEnvPanel)
-  const setShowGlobalVariablePanel = useStore(s => s.setShowGlobalVariablePanel)
-  const setShowDebugAndPreviewPanel = useStore(s => s.setShowDebugAndPreviewPanel)
-
   const handleClick = () => {
+    const { setShowChatVariablePanel, setShowEnvPanel, setShowGlobalVariablePanel, setShowDebugAndPreviewPanel } = workflowStore.getState()
     setShowChatVariablePanel(true)
     setShowEnvPanel(false)
     setShowGlobalVariablePanel(false)

--- a/web/app/components/workflow/header/env-button.tsx
+++ b/web/app/components/workflow/header/env-button.tsx
@@ -2,20 +2,17 @@ import { memo } from 'react'
 import Button from '@/app/components/base/button'
 import { Env } from '@/app/components/base/icons/src/vender/line/others'
 import { useInputFieldPanel } from '@/app/components/rag-pipeline/hooks'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import useTheme from '@/hooks/use-theme'
 import { cn } from '@/utils/classnames'
 
 const EnvButton = ({ disabled }: { disabled: boolean }) => {
   const { theme } = useTheme()
-  const setShowChatVariablePanel = useStore(s => s.setShowChatVariablePanel)
+  const workflowStore = useWorkflowStore()
   const showEnvPanel = useStore(s => s.showEnvPanel)
-  const setShowEnvPanel = useStore(s => s.setShowEnvPanel)
-  const setShowGlobalVariablePanel = useStore(s => s.setShowGlobalVariablePanel)
-  const setShowDebugAndPreviewPanel = useStore(s => s.setShowDebugAndPreviewPanel)
   const { closeAllInputFieldPanels } = useInputFieldPanel()
-
   const handleClick = () => {
+    const { setShowChatVariablePanel, setShowEnvPanel, setShowGlobalVariablePanel, setShowDebugAndPreviewPanel } = workflowStore.getState()
     setShowEnvPanel(true)
     setShowChatVariablePanel(false)
     setShowGlobalVariablePanel(false)

--- a/web/app/components/workflow/header/global-variable-button.tsx
+++ b/web/app/components/workflow/header/global-variable-button.tsx
@@ -2,20 +2,18 @@ import { memo } from 'react'
 import Button from '@/app/components/base/button'
 import { GlobalVariable } from '@/app/components/base/icons/src/vender/line/others'
 import { useInputFieldPanel } from '@/app/components/rag-pipeline/hooks'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store/workflow'
 import useTheme from '@/hooks/use-theme'
 import { cn } from '@/utils/classnames'
 
 const GlobalVariableButton = ({ disabled }: { disabled: boolean }) => {
   const { theme } = useTheme()
+  const workflowStore = useWorkflowStore()
   const showGlobalVariablePanel = useStore(s => s.showGlobalVariablePanel)
-  const setShowGlobalVariablePanel = useStore(s => s.setShowGlobalVariablePanel)
-  const setShowEnvPanel = useStore(s => s.setShowEnvPanel)
-  const setShowChatVariablePanel = useStore(s => s.setShowChatVariablePanel)
-  const setShowDebugAndPreviewPanel = useStore(s => s.setShowDebugAndPreviewPanel)
   const { closeAllInputFieldPanels } = useInputFieldPanel()
 
   const handleClick = () => {
+    const { setShowGlobalVariablePanel, setShowEnvPanel, setShowChatVariablePanel, setShowDebugAndPreviewPanel } = workflowStore.getState()
     setShowGlobalVariablePanel(true)
     setShowEnvPanel(false)
     setShowChatVariablePanel(false)

--- a/web/app/components/workflow/header/header-in-normal.tsx
+++ b/web/app/components/workflow/header/header-in-normal.tsx
@@ -11,10 +11,7 @@ import {
   useNodesReadOnly,
   useWorkflowRun,
 } from '../hooks'
-import {
-  useStore,
-  useWorkflowStore,
-} from '../store'
+import { useWorkflowStore } from '../store'
 import EditingTitle from './editing-title'
 import EnvButton from './env-button'
 import GlobalVariableButton from './global-variable-button'
@@ -37,18 +34,20 @@ const HeaderInNormal = ({
   const workflowStore = useWorkflowStore()
   const { nodesReadOnly } = useNodesReadOnly()
   const { handleNodeSelect } = useNodesInteractions()
-  const setShowWorkflowVersionHistoryPanel = useStore(s => s.setShowWorkflowVersionHistoryPanel)
-  const setShowEnvPanel = useStore(s => s.setShowEnvPanel)
-  const setShowDebugAndPreviewPanel = useStore(s => s.setShowDebugAndPreviewPanel)
-  const setShowVariableInspectPanel = useStore(s => s.setShowVariableInspectPanel)
-  const setShowChatVariablePanel = useStore(s => s.setShowChatVariablePanel)
-  const setShowGlobalVariablePanel = useStore(s => s.setShowGlobalVariablePanel)
   const nodes = useNodes<StartNodeType>()
   const selectedNode = nodes.find(node => node.data.selected)
   const { handleBackupDraft } = useWorkflowRun()
   const { closeAllInputFieldPanels } = useInputFieldPanel()
 
   const onStartRestoring = useCallback(() => {
+    const {
+      setShowWorkflowVersionHistoryPanel,
+      setShowEnvPanel,
+      setShowDebugAndPreviewPanel,
+      setShowVariableInspectPanel,
+      setShowChatVariablePanel,
+      setShowGlobalVariablePanel,
+    } = workflowStore.getState()
     workflowStore.setState({ isRestoring: true })
     handleBackupDraft()
     // clear right panel
@@ -61,7 +60,7 @@ const HeaderInNormal = ({
     setShowChatVariablePanel(false)
     setShowGlobalVariablePanel(false)
     closeAllInputFieldPanels()
-  }, [workflowStore, handleBackupDraft, selectedNode, handleNodeSelect, setShowWorkflowVersionHistoryPanel, setShowEnvPanel, setShowDebugAndPreviewPanel, setShowVariableInspectPanel, setShowChatVariablePanel, setShowGlobalVariablePanel])
+  }, [workflowStore, handleBackupDraft, selectedNode, handleNodeSelect, closeAllInputFieldPanels])
 
   return (
     <div className="flex w-full items-center justify-between">

--- a/web/app/components/workflow/header/header-in-restoring.tsx
+++ b/web/app/components/workflow/header/header-in-restoring.tsx
@@ -37,7 +37,6 @@ const HeaderInRestoring = ({
     deleteAllInspectVars,
   } = workflowStore.getState()
   const currentVersion = useStore(s => s.currentVersion)
-  const setShowWorkflowVersionHistoryPanel = useStore(s => s.setShowWorkflowVersionHistoryPanel)
 
   const {
     handleLoadBackupDraft,
@@ -47,11 +46,11 @@ const HeaderInRestoring = ({
   const handleCancelRestore = useCallback(() => {
     handleLoadBackupDraft()
     workflowStore.setState({ isRestoring: false })
-    setShowWorkflowVersionHistoryPanel(false)
-  }, [workflowStore, handleLoadBackupDraft, setShowWorkflowVersionHistoryPanel])
+    workflowStore.getState().setShowWorkflowVersionHistoryPanel(false)
+  }, [workflowStore, handleLoadBackupDraft])
 
   const handleRestore = useCallback(() => {
-    setShowWorkflowVersionHistoryPanel(false)
+    workflowStore.getState().setShowWorkflowVersionHistoryPanel(false)
     workflowStore.setState({ isRestoring: false })
     workflowStore.setState({ backupDraft: undefined })
     handleSyncWorkflowDraft(true, false, {
@@ -73,7 +72,7 @@ const HeaderInRestoring = ({
     })
     deleteAllInspectVars()
     invalidAllLastRun()
-  }, [setShowWorkflowVersionHistoryPanel, workflowStore, handleSyncWorkflowDraft, deleteAllInspectVars, invalidAllLastRun, t, onRestoreSettled])
+  }, [workflowStore, handleSyncWorkflowDraft, deleteAllInspectVars, invalidAllLastRun, t, onRestoreSettled])
 
   return (
     <>

--- a/web/app/components/workflow/header/view-history.tsx
+++ b/web/app/components/workflow/header/view-history.tsx
@@ -58,7 +58,6 @@ const ViewHistory = ({
     handleCancelDebugAndPreviewPanel,
   } = useWorkflowInteractions()
   const workflowStore = useWorkflowStore()
-  const setControlMode = useStore(s => s.setControlMode)
   const historyWorkflowData = useStore(s => s.historyWorkflowData)
   const { handleBackupDraft } = useWorkflowRun()
   const { closeAllInputFieldPanels } = useInputFieldPanel()
@@ -171,7 +170,7 @@ const ViewHistory = ({
                           setOpen(false)
                           handleNodesCancelSelected()
                           handleCancelDebugAndPreviewPanel()
-                          setControlMode(ControlMode.Hand)
+                          workflowStore.getState().setControlMode(ControlMode.Hand)
                         }}
                       >
                         {

--- a/web/app/components/workflow/hooks/use-workflow-interactions.ts
+++ b/web/app/components/workflow/hooks/use-workflow-interactions.ts
@@ -50,7 +50,7 @@ export const useWorkflowInteractions = () => {
 }
 
 export const useWorkflowMoveMode = () => {
-  const setControlMode = useStore(s => s.setControlMode)
+  const workflowStore = useWorkflowStore()
   const {
     getNodesReadOnly,
   } = useNodesReadOnly()
@@ -60,16 +60,16 @@ export const useWorkflowMoveMode = () => {
     if (getNodesReadOnly())
       return
 
-    setControlMode(ControlMode.Pointer)
-  }, [getNodesReadOnly, setControlMode])
+    workflowStore.getState().setControlMode(ControlMode.Pointer)
+  }, [getNodesReadOnly, workflowStore])
 
   const handleModeHand = useCallback(() => {
     if (getNodesReadOnly())
       return
 
-    setControlMode(ControlMode.Hand)
+    workflowStore.getState().setControlMode(ControlMode.Hand)
     handleSelectionCancel()
-  }, [getNodesReadOnly, setControlMode, handleSelectionCancel])
+  }, [getNodesReadOnly, workflowStore, handleSelectionCancel])
 
   return {
     handleModePointer,
@@ -330,9 +330,9 @@ export const useWorkflowUpdate = () => {
 
 export const useWorkflowCanvasMaximize = () => {
   const { eventEmitter } = useEventEmitterContextContext()
+  const workflowStore = useWorkflowStore()
 
   const maximizeCanvas = useStore(s => s.maximizeCanvas)
-  const setMaximizeCanvas = useStore(s => s.setMaximizeCanvas)
   const {
     getNodesReadOnly,
   } = useNodesReadOnly()
@@ -341,13 +341,13 @@ export const useWorkflowCanvasMaximize = () => {
     if (getNodesReadOnly())
       return
 
-    setMaximizeCanvas(!maximizeCanvas)
+    workflowStore.getState().setMaximizeCanvas(!maximizeCanvas)
     localStorage.setItem('workflow-canvas-maximize', String(!maximizeCanvas))
     eventEmitter?.emit({
       type: 'workflow-canvas-maximize',
       payload: !maximizeCanvas,
     } as any)
-  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas])
+  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, workflowStore])
 
   return {
     handleToggleMaximizeCanvas,

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -141,8 +141,6 @@ export const Workflow: FC<WorkflowProps> = memo(({
   const showConfirm = useStore(s => s.showConfirm)
   const workflowCanvasHeight = useStore(s => s.workflowCanvasHeight)
   const bottomPanelHeight = useStore(s => s.bottomPanelHeight)
-  const setWorkflowCanvasWidth = useStore(s => s.setWorkflowCanvasWidth)
-  const setWorkflowCanvasHeight = useStore(s => s.setWorkflowCanvasHeight)
   const controlHeight = useMemo(() => {
     if (!workflowCanvasHeight)
       return '100%'
@@ -155,6 +153,7 @@ export const Workflow: FC<WorkflowProps> = memo(({
       const resizeContainerObserver = new ResizeObserver((entries) => {
         for (const entry of entries) {
           const { inlineSize, blockSize } = entry.borderBoxSize[0]
+          const { setWorkflowCanvasWidth, setWorkflowCanvasHeight } = workflowStore.getState()
           setWorkflowCanvasWidth(inlineSize)
           setWorkflowCanvasHeight(blockSize)
         }
@@ -164,7 +163,7 @@ export const Workflow: FC<WorkflowProps> = memo(({
         resizeContainerObserver.disconnect()
       }
     }
-  }, [setWorkflowCanvasHeight, setWorkflowCanvasWidth])
+  }, [workflowStore])
 
   const {
     setShowConfirm,

--- a/web/app/components/workflow/nodes/_base/components/add-variable-popup-with-position.tsx
+++ b/web/app/components/workflow/nodes/_base/components/add-variable-popup-with-position.tsx
@@ -16,7 +16,7 @@ import {
   useWorkflow,
   useWorkflowVariables,
 } from '../../../hooks'
-import { useStore } from '../../../store'
+import { useStore, useWorkflowStore } from '../../../store'
 import { useVariableAssigner } from '../../variable-assigner/hooks'
 import { filterVar } from '../../variable-assigner/utils'
 import AddVariablePopup from './add-variable-popup'
@@ -31,7 +31,7 @@ const AddVariablePopupWithPosition = ({
 }: AddVariablePopupWithPositionProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const showAssignVariablePopup = useStore(s => s.showAssignVariablePopup)
-  const setShowAssignVariablePopup = useStore(s => s.setShowAssignVariablePopup)
+  const workflowStore = useWorkflowStore()
   const { handleNodeDataUpdate } = useNodeDataUpdate()
   const { handleAddVariableInAddVariablePopupWithPosition } = useVariableAssigner()
   const isChatMode = useIsChatMode()
@@ -91,7 +91,7 @@ const AddVariablePopupWithPosition = ({
           _showAddVariablePopup: false,
         },
       })
-      setShowAssignVariablePopup(undefined)
+      workflowStore.getState().setShowAssignVariablePopup(undefined)
     }
   }, ref)
 

--- a/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next'
 import { Variable02 } from '@/app/components/base/icons/src/vender/solid/development'
 import PromptEditor from '@/app/components/base/prompt-editor'
 import Tooltip from '@/app/components/base/tooltip'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { cn } from '@/utils/classnames'
 
@@ -57,8 +57,8 @@ const Editor: FC<Props> = ({
     onFocusChange?.(isFocus)
   }, [isFocus])
 
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
 
   return (
     <div className={cn(className, 'relative')}>
@@ -108,7 +108,7 @@ const Editor: FC<Props> = ({
               return acc
             }, {} as any),
             showManageInputField: !!pipelineId,
-            onManageInputField: () => setShowInputFieldPanel?.(true),
+            onManageInputField: () => workflowStore.getState().setShowInputFieldPanel?.(true),
           }}
           onChange={onChange}
           editable={!readOnly}

--- a/web/app/components/workflow/nodes/_base/components/node-handle.tsx
+++ b/web/app/components/workflow/nodes/_base/components/node-handle.tsx
@@ -129,8 +129,6 @@ export const NodeSourceHandle = memo(({
 }: NodeHandleProps) => {
   const { t } = useTranslation()
   const shouldAutoOpenStartNodeSelector = useStore(s => s.shouldAutoOpenStartNodeSelector)
-  const setShouldAutoOpenStartNodeSelector = useStore(s => s.setShouldAutoOpenStartNodeSelector)
-  const setHasSelectedStartNode = useStore(s => s.setHasSelectedStartNode)
   const workflowStoreApi = useWorkflowStore()
   const [open, setOpen] = useState(false)
   const { handleNodeAdd } = useNodesInteractions()
@@ -165,23 +163,16 @@ export const NodeSourceHandle = memo(({
       return
 
     if (isChatMode) {
-      setShouldAutoOpenStartNodeSelector?.(false)
+      workflowStoreApi.getState().setShouldAutoOpenStartNodeSelector?.(false)
       return
     }
 
     if (data.type === BlockEnum.Start || data.type === BlockEnum.TriggerSchedule || data.type === BlockEnum.TriggerWebhook || data.type === BlockEnum.TriggerPlugin) {
       setOpen(true)
-      if (setShouldAutoOpenStartNodeSelector)
-        setShouldAutoOpenStartNodeSelector(false)
-      else
-        workflowStoreApi?.setState?.({ shouldAutoOpenStartNodeSelector: false })
-
-      if (setHasSelectedStartNode)
-        setHasSelectedStartNode(false)
-      else
-        workflowStoreApi?.setState?.({ hasSelectedStartNode: false })
+      workflowStoreApi.getState().setShouldAutoOpenStartNodeSelector?.(false)
+      workflowStoreApi.getState().setHasSelectedStartNode?.(false)
     }
-  }, [shouldAutoOpenStartNodeSelector, data.type, isChatMode, setShouldAutoOpenStartNodeSelector, setHasSelectedStartNode, workflowStoreApi])
+  }, [shouldAutoOpenStartNodeSelector, data.type, isChatMode, workflowStoreApi])
 
   return (
     <Handle

--- a/web/app/components/workflow/nodes/_base/components/prompt/editor.tsx
+++ b/web/app/components/workflow/nodes/_base/components/prompt/editor.tsx
@@ -30,7 +30,7 @@ import { useWorkflowVariableType } from '@/app/components/workflow/hooks'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor/editor-support-vars'
 import ToggleExpandBtn from '@/app/components/workflow/nodes/_base/components/toggle-expand-btn'
 import useToggleExpend from '@/app/components/workflow/nodes/_base/hooks/use-toggle-expend'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import { cn } from '@/utils/classnames'
 import { BlockEnum, EditionType } from '../../../../types'
@@ -151,8 +151,8 @@ const Editor: FC<Props> = ({
   }
 
   const getVarType = useWorkflowVariableType()
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
 
   return (
     <Wrap className={cn(className, wrapClassName)} style={wrapStyle} isInNode isExpand={isExpand}>
@@ -288,7 +288,7 @@ const Editor: FC<Props> = ({
                           return acc
                         }, {} as any),
                         showManageInputField: !!pipelineId,
-                        onManageInputField: () => setShowInputFieldPanel?.(true),
+                        onManageInputField: () => workflowStore.getState().setShowInputFieldPanel?.(true),
                       }}
                       onChange={onChange}
                       onBlur={setBlur}

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-popup.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-popup.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ListEmpty from '@/app/components/base/list-empty'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { useDocLink } from '@/context/i18n'
 import VarReferenceVars from './var-reference-vars'
 
@@ -28,9 +28,9 @@ const VarReferencePopup: FC<Props> = ({
   preferSchemaType,
 }) => {
   const { t } = useTranslation()
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
   const showManageRagInputFields = useMemo(() => !!pipelineId, [pipelineId])
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
   const docLink = useDocLink()
   // max-h-[300px] overflow-y-auto todo: use portal to handle long list
   return (
@@ -82,7 +82,7 @@ const VarReferencePopup: FC<Props> = ({
               isSupportFileVar={isSupportFileVar}
               zIndex={zIndex}
               showManageInputField={showManageRagInputFields}
-              onManageInputField={() => setShowInputFieldPanel?.(true)}
+              onManageInputField={() => workflowStore.getState().setShowInputFieldPanel?.(true)}
               preferSchemaType={preferSchemaType}
             />
           )}

--- a/web/app/components/workflow/nodes/_base/components/workflow-panel/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/workflow-panel/index.tsx
@@ -51,7 +51,7 @@ import DataSourceBeforeRunForm from '@/app/components/workflow/nodes/data-source
 import { DataSourceClassification } from '@/app/components/workflow/nodes/data-source/types'
 import { useLogs } from '@/app/components/workflow/run/hooks'
 import SpecialResultPanel from '@/app/components/workflow/run/special-result-panel'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum, NodeRunningStatus } from '@/app/components/workflow/types'
 import {
   canRunBySingle,
@@ -113,14 +113,13 @@ const BasePanel: FC<BasePanelProps> = ({
     showMessageLogModal: state.showMessageLogModal,
   })))
   const isSingleRunning = data._singleRunningStatus === NodeRunningStatus.Running
+  const workflowStore = useWorkflowStore()
 
   const showSingleRunPanel = useStore(s => s.showSingleRunPanel)
   const workflowCanvasWidth = useStore(s => s.workflowCanvasWidth)
   const nodePanelWidth = useStore(s => s.nodePanelWidth)
   const otherPanelWidth = useStore(s => s.otherPanelWidth)
-  const setNodePanelWidth = useStore(s => s.setNodePanelWidth)
   const pendingSingleRun = useStore(s => s.pendingSingleRun)
-  const setPendingSingleRun = useStore(s => s.setPendingSingleRun)
 
   const reservedCanvasWidth = 400 // Reserve the minimum visible width for the canvas
 
@@ -139,8 +138,8 @@ const BasePanel: FC<BasePanelProps> = ({
     if (source === 'user')
       localStorage.setItem('workflow-node-panel-width', `${newValue}`)
 
-    setNodePanelWidth(newValue)
-  }, [maxNodePanelWidth, setNodePanelWidth])
+    workflowStore.getState().setNodePanelWidth(newValue)
+  }, [maxNodePanelWidth, workflowStore])
 
   const handleResize = useCallback((width: number) => {
     updateNodePanelWidth(width, 'user')
@@ -276,8 +275,8 @@ const BasePanel: FC<BasePanelProps> = ({
     else
       handleStop()
 
-    setPendingSingleRun(undefined)
-  }, [pendingSingleRun, id, handleSingleRun, handleStop, setPendingSingleRun])
+    workflowStore.getState().setPendingSingleRun(undefined)
+  }, [pendingSingleRun, id, handleSingleRun, handleStop, workflowStore])
 
   const logParams = useLogs()
   const passedLogParams = useMemo(() => [BlockEnum.Tool, BlockEnum.Agent, BlockEnum.Iteration, BlockEnum.Loop].includes(data.type) ? logParams : {}, [data.type, logParams])

--- a/web/app/components/workflow/nodes/agent/panel.tsx
+++ b/web/app/components/workflow/nodes/agent/panel.tsx
@@ -7,7 +7,7 @@ import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toType } from '@/app/components/tools/utils/to-form-schema'
 import { isSupportMCP } from '@/utils/plugin-version-feature'
-import { useStore } from '../../store'
+import { useWorkflowStore } from '../../store'
 import { AgentStrategy } from '../_base/components/agent-strategy'
 import Field from '../_base/components/field'
 import { MCPToolAvailabilityProvider } from '../_base/components/mcp-tool-availability'
@@ -46,7 +46,7 @@ const AgentPanel: FC<NodePanelProps<AgentNodeType>> = (props) => {
   const { t } = useTranslation()
   const isMCPVersionSupported = isSupportMCP(inputs.meta?.version)
 
-  const resetEditor = useStore(s => s.setControlPromptEditorRerenderKey)
+  const workflowStore = useWorkflowStore()
   return (
     <div className="my-2">
       <Field
@@ -77,7 +77,7 @@ const AgentPanel: FC<NodePanelProps<AgentNodeType>> = (props) => {
                 plugin_unique_identifier: strategy!.plugin_unique_identifier,
                 meta: strategy?.meta,
               })
-              resetEditor(Date.now())
+              workflowStore.getState().setControlPromptEditorRerenderKey(Date.now())
             }}
             formSchema={currentStrategy?.parameters?.map(strategyParamToCredientialForm) || []}
             formValue={formData}

--- a/web/app/components/workflow/nodes/data-source/panel.tsx
+++ b/web/app/components/workflow/nodes/data-source/panel.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/app/components/workflow/nodes/_base/components/layout'
 import OutputVars, { VarItem } from '@/app/components/workflow/nodes/_base/components/output-vars'
 import StructureOutputItem from '@/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/show'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { wrapStructuredVarItem } from '@/app/components/workflow/utils/tool'
 import useMatchSchemaType, { getMatchedSchemaType } from '../_base/components/variable/use-match-schema-type'
 import ToolForm from '../tool/components/tool-form'
@@ -48,8 +48,8 @@ const Panel: FC<NodePanelProps<DataSourceNodeType>> = ({ id, data }) => {
     return currentDataSourceItem ? toolParametersToFormSchemas(currentDataSourceItem.parameters) : []
   }, [currentDataSourceItem])
 
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
   const { schemaTypeDefinitions } = useMatchSchemaType()
   return (
     <div>
@@ -76,7 +76,7 @@ const Panel: FC<NodePanelProps<DataSourceNodeType>> = ({ id, data }) => {
                 currentProvider={currentDataSource}
                 currentTool={currentDataSourceItem}
                 showManageInputField={!!pipelineId}
-                onManageInputField={() => setShowInputFieldPanel?.(true)}
+                onManageInputField={() => workflowStore.getState().setShowInputFieldPanel?.(true)}
               />
             )}
           </BoxGroupField>

--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-input.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-input.tsx
@@ -4,7 +4,7 @@ import type {
 } from '@/app/components/workflow/types'
 import { useTranslation } from 'react-i18next'
 import PromptEditor from '@/app/components/base/prompt-editor'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 
 type ConditionInputProps = {
@@ -23,8 +23,8 @@ const ConditionInput = ({
 }: ConditionInputProps) => {
   const { t } = useTranslation()
   const controlPromptEditorRerenderKey = useStore(s => s.controlPromptEditorRerenderKey)
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
 
   return (
     <PromptEditor
@@ -52,7 +52,7 @@ const ConditionInput = ({
           return acc
         }, {} as any),
         showManageInputField: !!pipelineId,
-        onManageInputField: () => setShowInputFieldPanel?.(true),
+        onManageInputField: () => workflowStore.getState().setShowInputFieldPanel?.(true),
       }}
       onChange={onChange}
       editable={!disabled}

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-config.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-config.tsx
@@ -24,7 +24,7 @@ import JsonSchemaGenerator from './json-schema-generator'
 import SchemaEditor from './schema-editor'
 import VisualEditor from './visual-editor'
 import { MittProvider, useMittContext, VisualEditorContextProvider } from './visual-editor/context'
-import { useVisualEditorStore } from './visual-editor/store'
+import { useVisualEditorStore, useVisualEditorStoreApi } from './visual-editor/store'
 
 type JsonSchemaConfigProps = {
   defaultSchema?: SchemaRoot
@@ -62,11 +62,9 @@ const JsonSchemaConfig: FC<JsonSchemaConfigProps> = ({
   const [btnWidth, setBtnWidth] = useState(0)
   const [parseError, setParseError] = useState<Error | null>(null)
   const [validationError, setValidationError] = useState<string>('')
+  const visualEditorStore = useVisualEditorStoreApi()
   const advancedEditing = useVisualEditorStore(state => state.advancedEditing)
-  const setAdvancedEditing = useVisualEditorStore(state => state.setAdvancedEditing)
   const isAddingNewField = useVisualEditorStore(state => state.isAddingNewField)
-  const setIsAddingNewField = useVisualEditorStore(state => state.setIsAddingNewField)
-  const setHoveringProperty = useVisualEditorStore(state => state.setHoveringProperty)
   const { emit } = useMittContext()
 
   const updateBtnWidth = useCallback((width: number) => {
@@ -142,15 +140,15 @@ const JsonSchemaConfig: FC<JsonSchemaConfigProps> = ({
 
   const handleResetDefaults = useCallback(() => {
     if (currentTab === SchemaView.VisualEditor) {
-      setHoveringProperty(null)
+      visualEditorStore.getState().setHoveringProperty(null)
       if (advancedEditing)
-        setAdvancedEditing(false)
+        visualEditorStore.getState().setAdvancedEditing(false)
       if (isAddingNewField)
-        setIsAddingNewField(false)
+        visualEditorStore.getState().setIsAddingNewField(false)
     }
     setJsonSchema(DEFAULT_SCHEMA)
     setJson(JSON.stringify(DEFAULT_SCHEMA, null, 2))
-  }, [currentTab, advancedEditing, isAddingNewField, setAdvancedEditing, setIsAddingNewField, setHoveringProperty])
+  }, [currentTab, advancedEditing, isAddingNewField, visualEditorStore])
 
   const handleCancel = useCallback(() => {
     onClose()

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/add-field.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/add-field.tsx
@@ -4,20 +4,20 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import { useMittContext } from './context'
-import { useVisualEditorStore } from './store'
+import { useVisualEditorStoreApi } from './store'
 
 const AddField = () => {
   const { t } = useTranslation()
-  const setIsAddingNewField = useVisualEditorStore(state => state.setIsAddingNewField)
+  const visualEditorStore = useVisualEditorStoreApi()
   const { emit } = useMittContext()
 
   const handleAddField = useCallback(() => {
-    setIsAddingNewField(true)
+    visualEditorStore.getState().setIsAddingNewField(true)
     // fix: when user change the last property type, the 'hoveringProperty' value will be reset by 'setHoveringPropertyDebounced(null)', that cause the EditCard not showing
     setTimeout(() => {
       emit('addField', { path: [] })
     }, 100)
-  }, [setIsAddingNewField, emit])
+  }, [visualEditorStore, emit])
 
   return (
     <div className="py-2 pl-5">

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/index.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/index.tsx
@@ -11,7 +11,7 @@ import { JSON_SCHEMA_MAX_DEPTH } from '@/config'
 import { cn } from '@/utils/classnames'
 import { ArrayType, Type } from '../../../../types'
 import { useMittContext } from '../context'
-import { useVisualEditorStore } from '../store'
+import { useVisualEditorStore, useVisualEditorStoreApi } from '../store'
 import Actions from './actions'
 import AdvancedActions from './advanced-actions'
 import AdvancedOptions from './advanced-options'
@@ -66,10 +66,9 @@ const EditCard: FC<EditCardProps> = ({
   const { t } = useTranslation()
   const [currentFields, setCurrentFields] = useState(fields)
   const [backupFields, setBackupFields] = useState<EditData | null>(null)
+  const visualEditorStore = useVisualEditorStoreApi()
   const isAddingNewField = useVisualEditorStore(state => state.isAddingNewField)
-  const setIsAddingNewField = useVisualEditorStore(state => state.setIsAddingNewField)
   const advancedEditing = useVisualEditorStore(state => state.advancedEditing)
-  const setAdvancedEditing = useVisualEditorStore(state => state.setAdvancedEditing)
   const { emit, useSubscribe } = useMittContext()
   const blurWithActions = useRef(false)
 
@@ -91,9 +90,9 @@ const EditCard: FC<EditCardProps> = ({
 
   useSubscribe('fieldChangeSuccess', () => {
     if (isAddingNewField)
-      setIsAddingNewField(false)
+      visualEditorStore.getState().setIsAddingNewField(false)
     if (advancedEditing)
-      setAdvancedEditing(false)
+      visualEditorStore.getState().setAdvancedEditing(false)
   })
 
   const emitPropertyNameChange = useCallback(() => {
@@ -184,8 +183,8 @@ const EditCard: FC<EditCardProps> = ({
 
   const handleAdvancedEdit = useCallback(() => {
     setBackupFields({ ...currentFields })
-    setAdvancedEditing(true)
-  }, [currentFields, setAdvancedEditing])
+    visualEditorStore.getState().setAdvancedEditing(true)
+  }, [currentFields, visualEditorStore])
 
   const handleAddChildField = useCallback(() => {
     blurWithActions.current = true
@@ -200,15 +199,15 @@ const EditCard: FC<EditCardProps> = ({
     if (isAddingNewField) {
       blurWithActions.current = true
       emit('restoreSchema')
-      setIsAddingNewField(false)
+      visualEditorStore.getState().setIsAddingNewField(false)
       return
     }
     if (backupFields) {
       setCurrentFields(backupFields)
       setBackupFields(null)
     }
-    setAdvancedEditing(false)
-  }, [isAddingNewField, emit, setIsAddingNewField, setAdvancedEditing, backupFields])
+    visualEditorStore.getState().setAdvancedEditing(false)
+  }, [isAddingNewField, emit, backupFields, visualEditorStore])
 
   useUnmount(() => {
     if (isAdvancedEditing || blurWithActions.current)

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/schema-node.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/schema-node.tsx
@@ -12,7 +12,7 @@ import { getFieldType, getHasChildren } from '../../../utils'
 import AddField from './add-field'
 import Card from './card'
 import EditCard from './edit-card'
-import { useVisualEditorStore } from './store'
+import { useVisualEditorStore, useVisualEditorStoreApi } from './store'
 
 type SchemaNodeProps = {
   name: string
@@ -63,13 +63,13 @@ const SchemaNode: FC<SchemaNodeProps> = ({
   readOnly,
 }) => {
   const [isExpanded, setIsExpanded] = useState(true)
+  const visualEditorStore = useVisualEditorStoreApi()
   const hoveringProperty = useVisualEditorStore(state => state.hoveringProperty)
-  const setHoveringProperty = useVisualEditorStore(state => state.setHoveringProperty)
   const isAddingNewField = useVisualEditorStore(state => state.isAddingNewField)
   const advancedEditing = useVisualEditorStore(state => state.advancedEditing)
 
   const { run: setHoveringPropertyDebounced } = useDebounceFn((path: string | null) => {
-    setHoveringProperty(path)
+    visualEditorStore.getState().setHoveringProperty(path)
   }, { wait: 50 })
 
   const hasChildren = useMemo(() => getHasChildren(schema), [schema])

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/store.ts
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/store.ts
@@ -32,3 +32,11 @@ export const useVisualEditorStore = <T>(selector: (state: VisualEditorStore) => 
 
   return useStore(store, selector)
 }
+
+export const useVisualEditorStoreApi = () => {
+  const store = useContext(VisualEditorContext)
+  if (!store)
+    throw new Error('Missing VisualEditorContext.Provider in the tree')
+
+  return store
+}

--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-input.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-input.tsx
@@ -3,7 +3,7 @@ import type {
 } from '@/app/components/workflow/types'
 import { useTranslation } from 'react-i18next'
 import PromptEditor from '@/app/components/base/prompt-editor'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 
 type ConditionInputProps = {
@@ -20,8 +20,8 @@ const ConditionInput = ({
 }: ConditionInputProps) => {
   const { t } = useTranslation()
   const controlPromptEditorRerenderKey = useStore(s => s.controlPromptEditorRerenderKey)
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
 
   return (
     <PromptEditor
@@ -46,7 +46,7 @@ const ConditionInput = ({
           return acc
         }, {} as any),
         showManageInputField: !!pipelineId,
-        onManageInputField: () => setShowInputFieldPanel?.(true),
+        onManageInputField: () => workflowStore.getState().setShowInputFieldPanel?.(true),
       }}
       onChange={onChange}
       editable={!disabled}

--- a/web/app/components/workflow/nodes/tool/panel.tsx
+++ b/web/app/components/workflow/nodes/tool/panel.tsx
@@ -7,7 +7,7 @@ import Loading from '@/app/components/base/loading'
 import Field from '@/app/components/workflow/nodes/_base/components/field'
 import OutputVars, { VarItem } from '@/app/components/workflow/nodes/_base/components/output-vars'
 import StructureOutputItem from '@/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/show'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { wrapStructuredVarItem } from '@/app/components/workflow/utils/tool'
 import Split from '../_base/components/split'
 import useMatchSchemaType, { getMatchedSchemaType } from '../_base/components/variable/use-match-schema-type'
@@ -38,8 +38,8 @@ const Panel: FC<NodePanelProps<ToolNodeType>> = ({
   } = useConfig(id, data)
 
   const [collapsed, setCollapsed] = React.useState(false)
+  const workflowStore = useWorkflowStore()
   const pipelineId = useStore(s => s.pipelineId)
-  const setShowInputFieldPanel = useStore(s => s.setShowInputFieldPanel)
   const { schemaTypeDefinitions } = useMatchSchemaType()
 
   if (isLoading) {
@@ -68,7 +68,7 @@ const Panel: FC<NodePanelProps<ToolNodeType>> = ({
                 currentProvider={currCollection}
                 currentTool={currTool}
                 showManageInputField={!!pipelineId}
-                onManageInputField={() => setShowInputFieldPanel?.(true)}
+                onManageInputField={() => workflowStore.getState().setShowInputFieldPanel?.(true)}
               />
             </Field>
           )}

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
@@ -20,7 +20,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import { cn } from '@/utils/classnames'
-import { useStore } from '../../store'
+import { useNoteEditorStore, useStore } from '../../store'
 import { useLink } from './hooks'
 
 type LinkEditorComponentProps = {
@@ -34,11 +34,10 @@ const LinkEditorComponent = ({
     handleSaveLink,
     handleUnlink,
   } = useLink()
+  const noteEditorStore = useNoteEditorStore()
   const selectedLinkUrl = useStore(s => s.selectedLinkUrl)
   const linkAnchorElement = useStore(s => s.linkAnchorElement)
   const linkOperatorShow = useStore(s => s.linkOperatorShow)
-  const setLinkAnchorElement = useStore(s => s.setLinkAnchorElement)
-  const setLinkOperatorShow = useStore(s => s.setLinkOperatorShow)
   const [url, setUrl] = useState(selectedLinkUrl)
   const { refs, floatingStyles, elements } = useFloating({
     placement: 'top',
@@ -50,7 +49,7 @@ const LinkEditorComponent = ({
   })
 
   useClickAway(() => {
-    setLinkAnchorElement()
+    noteEditorStore.getState().setLinkAnchorElement()
   }, linkAnchorElement)
 
   useEffect(() => {
@@ -122,7 +121,7 @@ const LinkEditorComponent = ({
                       className="mr-0.5 flex h-6 cursor-pointer items-center rounded-md px-2 hover:bg-state-base-hover"
                       onClick={(e) => {
                         e.stopPropagation()
-                        setLinkOperatorShow(false)
+                        noteEditorStore.getState().setLinkOperatorShow(false)
                       }}
                     >
                       <RiEditLine className="mr-1 h-3 w-3" />

--- a/web/app/components/workflow/operator/index.tsx
+++ b/web/app/components/workflow/operator/index.tsx
@@ -2,7 +2,7 @@ import type { Node } from 'reactflow'
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { MiniMap } from 'reactflow'
 import UndoRedo from '../header/undo-redo'
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 import VariableInspectPanel from '../variable-inspect'
 import VariableTrigger from '../variable-inspect/trigger'
 import ZoomInOut from './zoom-in-out'
@@ -14,10 +14,9 @@ export type OperatorProps = {
 
 const Operator = ({ handleUndo, handleRedo }: OperatorProps) => {
   const bottomPanelRef = useRef<HTMLDivElement>(null)
+  const workflowStore = useWorkflowStore()
   const workflowCanvasWidth = useStore(s => s.workflowCanvasWidth)
   const rightPanelWidth = useStore(s => s.rightPanelWidth)
-  const setBottomPanelWidth = useStore(s => s.setBottomPanelWidth)
-  const setBottomPanelHeight = useStore(s => s.setBottomPanelHeight)
 
   const bottomPanelWidth = useMemo(() => {
     if (!workflowCanvasWidth || !rightPanelWidth)
@@ -37,6 +36,7 @@ const Operator = ({ handleUndo, handleRedo }: OperatorProps) => {
       const resizeContainerObserver = new ResizeObserver((entries) => {
         for (const entry of entries) {
           const { inlineSize, blockSize } = entry.borderBoxSize[0]
+          const { setBottomPanelWidth, setBottomPanelHeight } = workflowStore.getState()
           setBottomPanelWidth(inlineSize)
           setBottomPanelHeight(blockSize)
         }
@@ -46,7 +46,7 @@ const Operator = ({ handleUndo, handleRedo }: OperatorProps) => {
         resizeContainerObserver.disconnect()
       }
     }
-  }, [setBottomPanelHeight, setBottomPanelWidth])
+  }, [workflowStore])
 
   return (
     <div

--- a/web/app/components/workflow/panel-contextmenu.tsx
+++ b/web/app/components/workflow/panel-contextmenu.tsx
@@ -16,14 +16,14 @@ import {
 import AddBlock from './operator/add-block'
 import { useOperator } from './operator/hooks'
 import ShortcutsName from './shortcuts-name'
-import { useStore } from './store'
+import { useStore, useWorkflowStore } from './store'
 
 const PanelContextmenu = () => {
   const { t } = useTranslation()
   const ref = useRef(null)
   const panelMenu = useStore(s => s.panelMenu)
   const clipboardElements = useStore(s => s.clipboardElements)
-  const setShowImportDSLModal = useStore(s => s.setShowImportDSLModal)
+  const workflowStore = useWorkflowStore()
   const { handleNodesPaste } = useNodesInteractions()
   const { handlePaneContextmenuCancel, handleNodeContextmenuCancel } = usePanelInteractions()
   const { handleStartWorkflowRun } = useWorkflowStartRun()
@@ -118,7 +118,7 @@ const PanelContextmenu = () => {
         </div>
         <div
           className="flex h-8 cursor-pointer items-center justify-between rounded-lg px-3 text-sm text-text-secondary hover:bg-state-base-hover"
-          onClick={() => setShowImportDSLModal(true)}
+          onClick={() => workflowStore.getState().setShowImportDSLModal(true)}
         >
           {t('common.importDSL', { ns: 'workflow' })}
         </div>

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.tsx
@@ -22,7 +22,7 @@ import {
   arrayStringPlaceholder,
   objectPlaceholder,
 } from '@/app/components/workflow/panel/chat-variable-panel/utils'
-import { useStore } from '@/app/components/workflow/store'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 import { cn } from '@/utils/classnames'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 import ArrayBoolList from './array-bool-list'
@@ -58,7 +58,7 @@ const ChatVariableModal = ({
 }: ModalPropsType) => {
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
-  const varList = useStore(s => s.conversationVariables)
+  const workflowStore = useWorkflowStore()
   const [name, setName] = React.useState('')
   const [type, setType] = React.useState<ChatVarType>(ChatVarType.String)
   const [value, setValue] = React.useState<any>()
@@ -234,6 +234,7 @@ const ChatVariableModal = ({
   const handleSave = () => {
     if (!checkVariableName(name))
       return
+    const varList = workflowStore.getState().conversationVariables
     if (!chatVar && varList.some(chatVar => chatVar.name === name))
       return notify({ type: 'error', message: 'name is existed' })
     // if (type !== ChatVarType.Object && !value)

--- a/web/app/components/workflow/panel/chat-variable-panel/index.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/index.tsx
@@ -19,7 +19,7 @@ import RemoveEffectVarConfirm from '@/app/components/workflow/nodes/_base/compon
 import { findUsedVarNodes, updateNodeVars } from '@/app/components/workflow/nodes/_base/components/variable/utils'
 import VariableItem from '@/app/components/workflow/panel/chat-variable-panel/components/variable-item'
 import VariableModalTrigger from '@/app/components/workflow/panel/chat-variable-panel/components/variable-modal-trigger'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { useDocLink } from '@/context/i18n'
 import { cn } from '@/utils/classnames'
@@ -29,9 +29,8 @@ const ChatVariablePanel = () => {
   const { t } = useTranslation()
   const docLink = useDocLink()
   const store = useStoreApi()
-  const setShowChatVariablePanel = useStore(s => s.setShowChatVariablePanel)
+  const workflowStore = useWorkflowStore()
   const varList = useStore(s => s.conversationVariables) as ConversationVariable[]
-  const updateChatVarList = useStore(s => s.setConversationVariables)
   const { doSyncWorkflowDraft } = useNodesSyncDraft()
   const {
     invalidateConversationVarValues,
@@ -79,11 +78,11 @@ const ChatVariablePanel = () => {
 
   const handleDelete = useCallback((chatVar: ConversationVariable) => {
     removeUsedVarInNodes(chatVar)
-    updateChatVarList(varList.filter(v => v.id !== chatVar.id))
+    workflowStore.getState().setConversationVariables(varList.filter(v => v.id !== chatVar.id))
     setCacheForDelete(undefined)
     setShowRemoveConfirm(false)
     handleVarChanged()
-  }, [handleVarChanged, removeUsedVarInNodes, updateChatVarList, varList])
+  }, [handleVarChanged, removeUsedVarInNodes, workflowStore, varList])
 
   const deleteCheck = useCallback((chatVar: ConversationVariable) => {
     const effectedNodes = getEffectedNodes(chatVar)
@@ -100,13 +99,13 @@ const ChatVariablePanel = () => {
     // add chatVar
     if (!currentVar) {
       const newList = [chatVar, ...varList]
-      updateChatVarList(newList)
+      workflowStore.getState().setConversationVariables(newList)
       handleVarChanged()
       return
     }
     // edit chatVar
     const newList = varList.map(v => v.id === currentVar.id ? chatVar : v)
-    updateChatVarList(newList)
+    workflowStore.getState().setConversationVariables(newList)
     // side effects of rename env
     if (currentVar.name !== chatVar.name) {
       const { getNodes, setNodes } = store.getState()
@@ -120,7 +119,7 @@ const ChatVariablePanel = () => {
       setNodes(newNodes)
     }
     handleVarChanged()
-  }, [currentVar, getEffectedNodes, handleVarChanged, store, updateChatVarList, varList])
+  }, [currentVar, getEffectedNodes, handleVarChanged, store, workflowStore, varList])
 
   return (
     <div
@@ -136,7 +135,7 @@ const ChatVariablePanel = () => {
           </ActionButton>
           <div
             className="flex h-6 w-6 cursor-pointer items-center justify-center"
-            onClick={() => setShowChatVariablePanel(false)}
+            onClick={() => workflowStore.getState().setShowChatVariablePanel(false)}
           >
             <RiCloseLine className="h-4 w-4 text-text-tertiary" />
           </div>

--- a/web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx
@@ -48,7 +48,6 @@ const ChatWrapper = (
   const appDetail = useAppStore(s => s.appDetail)
   const workflowStore = useWorkflowStore()
   const inputs = useStore(s => s.inputs)
-  const setInputs = useStore(s => s.setInputs)
 
   const initialInputs = useMemo(() => {
     const initInputs: Record<string, any> = {}
@@ -74,7 +73,6 @@ const ChatWrapper = (
       file_upload: features.file,
     }
   }, [features.opening, features.suggested, features.text2speech, features.speech2text, features.citation, features.moderation, features.file])
-  const setShowFeaturesPanel = useStore(s => s.setShowFeaturesPanel)
 
   const {
     conversationId,
@@ -97,8 +95,8 @@ const ChatWrapper = (
 
   const handleRestartChat = useCallback(() => {
     handleRestart()
-    setInputs(initialInputs)
-  }, [handleRestart, setInputs, initialInputs])
+    workflowStore.getState().setInputs(initialInputs)
+  }, [handleRestart, workflowStore, initialInputs])
 
   const doSend: OnSend = useCallback((message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
     handleSend(
@@ -135,7 +133,7 @@ const ChatWrapper = (
 
   useEffect(() => {
     if (Object.keys(initialInputs).length > 0) {
-      setInputs({
+      workflowStore.getState().setInputs({
         ...initialInputs,
         ...inputs,
       })
@@ -162,7 +160,7 @@ const ChatWrapper = (
         chatFooterInnerClassName="pb-0"
         showFileUpload
         showFeatureBar
-        onFeatureBarClick={setShowFeaturesPanel}
+        onFeatureBarClick={state => workflowStore.getState().setShowFeaturesPanel(state)}
         onSend={doSend}
         inputs={inputs}
         inputsForm={(startVariables || []) as any}

--- a/web/app/components/workflow/panel/debug-and-preview/index.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/index.tsx
@@ -17,7 +17,7 @@ import { RefreshCcw01 } from '@/app/components/base/icons/src/vender/line/arrows
 import Tooltip from '@/app/components/base/tooltip'
 import { useEdgesInteractionsWithoutSync } from '@/app/components/workflow/hooks/use-edges-interactions-without-sync'
 import { useNodesInteractionsWithoutSync } from '@/app/components/workflow/hooks/use-nodes-interactions-without-sync'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { cn } from '@/utils/classnames'
 import {
   useWorkflowInteractions,
@@ -37,6 +37,7 @@ const DebugAndPreview = () => {
   const { handleEdgeCancelRunningStatus } = useEdgesInteractionsWithoutSync()
   const [expanded, setExpanded] = useState(true)
   const nodes = useNodes<StartNodeType>()
+  const workflowStore = useWorkflowStore()
   const selectedNode = nodes.find(node => node.data.selected)
   const startNode = nodes.find(node => node.data.type === BlockEnum.Start)
   const variables = startNode?.data.variables || []
@@ -53,12 +54,11 @@ const DebugAndPreview = () => {
   const workflowCanvasWidth = useStore(s => s.workflowCanvasWidth)
   const nodePanelWidth = useStore(s => s.nodePanelWidth)
   const panelWidth = useStore(s => s.previewPanelWidth)
-  const setPanelWidth = useStore(s => s.setPreviewPanelWidth)
   const handleResize = useCallback((width: number, source: 'user' | 'system' = 'user') => {
     if (source === 'user')
       localStorage.setItem('debug-and-preview-panel-width', `${width}`)
-    setPanelWidth(width)
-  }, [setPanelWidth])
+    workflowStore.getState().setPreviewPanelWidth(width)
+  }, [workflowStore])
   const maxPanelWidth = useMemo(() => {
     if (!workflowCanvasWidth)
       return 720

--- a/web/app/components/workflow/panel/env-panel/index.tsx
+++ b/web/app/components/workflow/panel/env-panel/index.tsx
@@ -16,13 +16,13 @@ import RemoveEffectVarConfirm from '@/app/components/workflow/nodes/_base/compon
 import { findUsedVarNodes, updateNodeVars } from '@/app/components/workflow/nodes/_base/components/variable/utils'
 import EnvItem from '@/app/components/workflow/panel/env-panel/env-item'
 import VariableTrigger from '@/app/components/workflow/panel/env-panel/variable-trigger'
-import { useStore } from '@/app/components/workflow/store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { cn } from '@/utils/classnames'
 
 const EnvPanel = () => {
   const { t } = useTranslation()
   const store = useStoreApi()
-  const setShowEnvPanel = useStore(s => s.setShowEnvPanel)
+  const workflowStore = useWorkflowStore()
   const envList = useStore(s => s.environmentVariables) as EnvironmentVariable[]
   const envSecrets = useStore(s => s.envSecrets)
   const updateEnvList = useStore(s => s.setEnvironmentVariables)
@@ -157,7 +157,7 @@ const EnvPanel = () => {
         <div className="flex items-center">
           <div
             className="flex h-6 w-6 cursor-pointer items-center justify-center"
-            onClick={() => setShowEnvPanel(false)}
+            onClick={() => workflowStore.getState().setShowEnvPanel(false)}
           >
             <RiCloseLine className="h-4 w-4 text-text-tertiary" />
           </div>

--- a/web/app/components/workflow/panel/env-panel/variable-modal.tsx
+++ b/web/app/components/workflow/panel/env-panel/variable-modal.tsx
@@ -9,7 +9,7 @@ import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
 import { ToastContext } from '@/app/components/base/toast'
 import Tooltip from '@/app/components/base/tooltip'
-import { useStore } from '@/app/components/workflow/store'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 import { cn } from '@/utils/classnames'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 
@@ -25,8 +25,7 @@ const VariableModal = ({
 }: ModalPropsType) => {
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
-  const envList = useStore(s => s.environmentVariables)
-  const envSecrets = useStore(s => s.envSecrets)
+  const workflowStore = useWorkflowStore()
   const [type, setType] = React.useState<'string' | 'number' | 'secret'>('string')
   const [name, setName] = React.useState('')
   const [value, setValue] = React.useState<any>()
@@ -58,6 +57,7 @@ const VariableModal = ({
       return notify({ type: 'error', message: 'value can not be empty' })
 
     // Add check for duplicate name when editing
+    const envList = workflowStore.getState().environmentVariables
     if (env && env.name !== name && envList.some(e => e.name === name))
       return notify({ type: 'error', message: 'name is existed' })
     // Original check for create new variable
@@ -78,10 +78,11 @@ const VariableModal = ({
     if (env) {
       setType(env.value_type)
       setName(env.name)
+      const envSecrets = workflowStore.getState().envSecrets
       setValue(env.value_type === 'secret' ? envSecrets[env.id] : env.value)
       setDescription(env.description)
     }
-  }, [env, envSecrets])
+  }, [env, workflowStore])
 
   return (
     <div

--- a/web/app/components/workflow/panel/global-variable-panel/index.tsx
+++ b/web/app/components/workflow/panel/global-variable-panel/index.tsx
@@ -5,7 +5,7 @@ import {
   memo,
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore } from '@/app/components/workflow/store'
+import { useWorkflowStore } from '@/app/components/workflow/store'
 
 import { cn } from '@/utils/classnames'
 import { isInWorkflowPage } from '../../constants'
@@ -15,7 +15,7 @@ import Item from './item'
 const Panel = () => {
   const { t } = useTranslation()
   const isChatMode = useIsChatMode()
-  const setShowPanel = useStore(s => s.setShowGlobalVariablePanel)
+  const workflowStore = useWorkflowStore()
   const isWorkflowPage = isInWorkflowPage()
 
   const globalVariableList: GlobalVariable[] = [
@@ -71,7 +71,7 @@ const Panel = () => {
         <div className="flex items-center">
           <div
             className="flex h-6 w-6 cursor-pointer items-center justify-center"
-            onClick={() => setShowPanel(false)}
+            onClick={() => workflowStore.getState().setShowGlobalVariablePanel(false)}
           >
             <RiCloseLine className="h-4 w-4 text-text-tertiary" />
           </div>

--- a/web/app/components/workflow/panel/index.tsx
+++ b/web/app/components/workflow/panel/index.tsx
@@ -6,7 +6,7 @@ import { useStore as useReactflow } from 'reactflow'
 import { useShallow } from 'zustand/react/shallow'
 import { cn } from '@/utils/classnames'
 import { Panel as NodePanel } from '../nodes'
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 import EnvPanel from './env-panel'
 
 const VersionHistoryPanel = dynamic(() => import('@/app/components/workflow/panel/version-history-panel'), {
@@ -85,11 +85,11 @@ const Panel: FC<PanelProps> = ({
   const showEnvPanel = useStore(s => s.showEnvPanel)
   const isRestoring = useStore(s => s.isRestoring)
   const showWorkflowVersionHistoryPanel = useStore(s => s.showWorkflowVersionHistoryPanel)
+  const workflowStore = useWorkflowStore()
 
   // widths used for adaptive layout
   const workflowCanvasWidth = useStore(s => s.workflowCanvasWidth)
   const previewPanelWidth = useStore(s => s.previewPanelWidth)
-  const setPreviewPanelWidth = useStore(s => s.setPreviewPanelWidth)
 
   // When a node is selected and the NodePanel appears, if the current width
   // of preview/otherPanel is too large, it may result in the total width of
@@ -107,20 +107,25 @@ const Panel: FC<PanelProps> = ({
     const maxAllowed = Math.max(workflowCanvasWidth - reservedCanvasWidth - minNodePanelWidth, 400)
 
     if (previewPanelWidth > maxAllowed)
-      setPreviewPanelWidth(maxAllowed)
-  }, [selectedNode, workflowCanvasWidth, previewPanelWidth, setPreviewPanelWidth])
+      workflowStore.getState().setPreviewPanelWidth(maxAllowed)
+  }, [selectedNode, workflowCanvasWidth, previewPanelWidth, workflowStore])
 
-  const setRightPanelWidth = useStore(s => s.setRightPanelWidth)
-  const setOtherPanelWidth = useStore(s => s.setOtherPanelWidth)
+  const handleRightPanelResize = useCallback((width: number) => {
+    workflowStore.getState().setRightPanelWidth(width)
+  }, [workflowStore])
+
+  const handleOtherPanelResize = useCallback((width: number) => {
+    workflowStore.getState().setOtherPanelWidth(width)
+  }, [workflowStore])
 
   const rightPanelRef = useResizeObserver(
-    setRightPanelWidth,
-    [setRightPanelWidth, selectedNode, showEnvPanel, showWorkflowVersionHistoryPanel],
+    handleRightPanelResize,
+    [handleRightPanelResize, selectedNode, showEnvPanel, showWorkflowVersionHistoryPanel],
   )
 
   const otherPanelRef = useResizeObserver(
-    setOtherPanelWidth,
-    [setOtherPanelWidth, showEnvPanel, showWorkflowVersionHistoryPanel],
+    handleOtherPanelResize,
+    [handleOtherPanelResize, showEnvPanel, showWorkflowVersionHistoryPanel],
   )
 
   return (

--- a/web/app/components/workflow/panel/version-history-panel/index.spec.tsx
+++ b/web/app/components/workflow/panel/version-history-panel/index.spec.tsx
@@ -97,6 +97,8 @@ vi.mock('../../store', () => ({
   useWorkflowStore: () => ({
     getState: () => ({
       deleteAllInspectVars: vi.fn(),
+      setShowWorkflowVersionHistoryPanel: vi.fn(),
+      setCurrentVersion: mockSetCurrentVersion,
     }),
     setState: vi.fn(),
   }),

--- a/web/app/components/workflow/panel/version-history-panel/index.tsx
+++ b/web/app/components/workflow/panel/version-history-panel/index.tsx
@@ -46,9 +46,7 @@ export const VersionHistoryPanel = ({
   const { handleSyncWorkflowDraft } = useNodesSyncDraft()
   const { handleRestoreFromPublishedWorkflow, handleLoadBackupDraft } = useWorkflowRun()
   const { handleExportDSL } = useDSL()
-  const setShowWorkflowVersionHistoryPanel = useStore(s => s.setShowWorkflowVersionHistoryPanel)
   const currentVersion = useStore(s => s.currentVersion)
-  const setCurrentVersion = useStore(s => s.setCurrentVersion)
   const userProfile = useAppContextSelector(s => s.userProfile)
   const configsMap = useHooksStore(s => s.configsMap)
   const invalidAllLastRun = useInvalidAllLastRun(configsMap?.flowType, configsMap?.flowId)
@@ -72,13 +70,13 @@ export const VersionHistoryPanel = ({
 
   const handleVersionClick = useCallback((item: VersionHistory) => {
     if (item.id !== currentVersion?.id) {
-      setCurrentVersion(item)
+      workflowStore.getState().setCurrentVersion(item)
       if (item.version === WorkflowVersion.Draft)
         handleLoadBackupDraft()
       else
         handleRestoreFromPublishedWorkflow(item)
     }
-  }, [currentVersion?.id, setCurrentVersion, handleLoadBackupDraft, handleRestoreFromPublishedWorkflow])
+  }, [currentVersion?.id, handleLoadBackupDraft, handleRestoreFromPublishedWorkflow, workflowStore])
 
   const handleNextPage = () => {
     if (hasNextPage)
@@ -88,7 +86,7 @@ export const VersionHistoryPanel = ({
   const handleClose = () => {
     handleLoadBackupDraft()
     workflowStore.setState({ isRestoring: false })
-    setShowWorkflowVersionHistoryPanel(false)
+    workflowStore.getState().setShowWorkflowVersionHistoryPanel(false)
   }
 
   const handleClickFilterItem = useCallback((value: WorkflowVersionFilterOptions) => {
@@ -146,7 +144,7 @@ export const VersionHistoryPanel = ({
   const resetWorkflowVersionHistory = useResetWorkflowVersionHistory()
 
   const handleRestore = useCallback((item: VersionHistory) => {
-    setShowWorkflowVersionHistoryPanel(false)
+    workflowStore.getState().setShowWorkflowVersionHistoryPanel(false)
     handleRestoreFromPublishedWorkflow(item)
     workflowStore.setState({ isRestoring: false })
     workflowStore.setState({ backupDraft: undefined })
@@ -169,7 +167,7 @@ export const VersionHistoryPanel = ({
         resetWorkflowVersionHistory()
       },
     })
-  }, [setShowWorkflowVersionHistoryPanel, handleRestoreFromPublishedWorkflow, workflowStore, handleSyncWorkflowDraft, deleteAllInspectVars, invalidAllLastRun, t, resetWorkflowVersionHistory])
+  }, [handleRestoreFromPublishedWorkflow, workflowStore, handleSyncWorkflowDraft, deleteAllInspectVars, invalidAllLastRun, t, resetWorkflowVersionHistory])
 
   const { mutateAsync: deleteWorkflow } = useDeleteWorkflow()
 

--- a/web/app/components/workflow/panel/workflow-preview.tsx
+++ b/web/app/components/workflow/panel/workflow-preview.tsx
@@ -20,7 +20,7 @@ import {
 import ResultPanel from '../run/result-panel'
 import ResultText from '../run/result-text'
 import TracingPanel from '../run/tracing-panel'
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 import {
   WorkflowRunningStatus,
 } from '../types'
@@ -30,12 +30,12 @@ import InputsPanel from './inputs-panel'
 const WorkflowPreview = () => {
   const { t } = useTranslation()
   const { handleCancelDebugAndPreviewPanel } = useWorkflowInteractions()
+  const workflowStore = useWorkflowStore()
   const workflowRunningData = useStore(s => s.workflowRunningData)
   const isListening = useStore(s => s.isListening)
   const showInputsPanel = useStore(s => s.showInputsPanel)
   const workflowCanvasWidth = useStore(s => s.workflowCanvasWidth)
   const panelWidth = useStore(s => s.previewPanelWidth)
-  const setPreviewPanelWidth = useStore(s => s.setPreviewPanelWidth)
   const showDebugAndPreviewPanel = useStore(s => s.showDebugAndPreviewPanel)
   const [currentTab, setCurrentTab] = useState<string>(showInputsPanel ? 'INPUT' : 'TRACING')
 
@@ -81,9 +81,9 @@ const WorkflowPreview = () => {
       const maxAllowed = workflowCanvasWidth ? (workflowCanvasWidth - reservedCanvasWidth) : 1024
 
       if (newWidth >= 400 && newWidth <= maxAllowed)
-        setPreviewPanelWidth(newWidth)
+        workflowStore.getState().setPreviewPanelWidth(newWidth)
     }
-  }, [isResizing, workflowCanvasWidth, setPreviewPanelWidth])
+  }, [isResizing, workflowCanvasWidth, workflowStore])
 
   useEffect(() => {
     window.addEventListener('mousemove', resize)

--- a/web/app/components/workflow/variable-inspect/index.tsx
+++ b/web/app/components/workflow/variable-inspect/index.tsx
@@ -6,14 +6,14 @@ import {
 } from 'react'
 import { cn } from '@/utils/classnames'
 import { useResizePanel } from '../nodes/_base/hooks/use-resize-panel'
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 import Panel from './panel'
 
 const VariableInspectPanel: FC = () => {
   const showVariableInspectPanel = useStore(s => s.showVariableInspectPanel)
+  const workflowStore = useWorkflowStore()
   const workflowCanvasHeight = useStore(s => s.workflowCanvasHeight)
   const variableInspectPanelHeight = useStore(s => s.variableInspectPanelHeight)
-  const setVariableInspectPanelHeight = useStore(s => s.setVariableInspectPanelHeight)
 
   const maxHeight = useMemo(() => {
     if (!workflowCanvasHeight)
@@ -23,8 +23,8 @@ const VariableInspectPanel: FC = () => {
 
   const handleResize = useCallback((width: number, height: number) => {
     localStorage.setItem('workflow-variable-inpsect-panel-height', `${height}`)
-    setVariableInspectPanelHeight(height)
-  }, [setVariableInspectPanelHeight])
+    workflowStore.getState().setVariableInspectPanelHeight(height)
+  }, [workflowStore])
 
   const {
     triggerRef,

--- a/web/app/components/workflow/variable-inspect/left.tsx
+++ b/web/app/components/workflow/variable-inspect/left.tsx
@@ -8,9 +8,7 @@ import { VarInInspectType } from '@/types/workflow'
 import { cn } from '@/utils/classnames'
 import useCurrentVars from '../hooks/use-inspect-vars-crud'
 import { useNodesInteractions } from '../hooks/use-nodes-interactions'
-import { useStore } from '../store'
-// import ActionButton from '@/app/components/base/action-button'
-// import Tooltip from '@/app/components/base/tooltip'
+import { useStore, useWorkflowStore } from '../store'
 import Group from './group'
 
 type Props = {
@@ -23,9 +21,8 @@ const Left = ({
   handleVarSelect,
 }: Props) => {
   const { t } = useTranslation()
-
+  const workflowStore = useWorkflowStore()
   const environmentVariables = useStore(s => s.environmentVariables)
-  const setCurrentFocusNodeId = useStore(s => s.setCurrentFocusNodeId)
 
   const {
     conversationVars,
@@ -40,12 +37,12 @@ const Left = ({
 
   const handleClearAll = () => {
     deleteAllInspectorVars()
-    setCurrentFocusNodeId('')
+    workflowStore.getState().setCurrentFocusNodeId('')
   }
 
   const handleClearNode = (nodeId: string) => {
     deleteNodeInspectorVars(nodeId)
-    setCurrentFocusNodeId('')
+    workflowStore.getState().setCurrentFocusNodeId('')
   }
 
   return (

--- a/web/app/components/workflow/variable-inspect/panel.tsx
+++ b/web/app/components/workflow/variable-inspect/panel.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/utils/classnames'
 import useCurrentVars from '../hooks/use-inspect-vars-crud'
 import useMatchSchemaType from '../nodes/_base/components/variable/use-match-schema-type'
 
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 import Empty from './empty'
 import Left from './left'
 import Listening from './listening'
@@ -31,15 +31,13 @@ export type currentVarType = {
 
 const Panel: FC = () => {
   const { t } = useTranslation()
-
+  const workflowStore = useWorkflowStore()
   const bottomPanelWidth = useStore(s => s.bottomPanelWidth)
-  const setShowVariableInspectPanel = useStore(s => s.setShowVariableInspectPanel)
   const [showLeftPanel, setShowLeftPanel] = useState(true)
   const isListening = useStore(s => s.isListening)
 
   const environmentVariables = useStore(s => s.environmentVariables)
   const currentFocusNodeId = useStore(s => s.currentFocusNodeId)
-  const setCurrentFocusNodeId = useStore(s => s.setCurrentFocusNodeId)
   const [currentVarId, setCurrentVarId] = useState('')
 
   const {
@@ -138,9 +136,9 @@ const Panel: FC = () => {
   }, [currentNodeInfo, nodesWithInspectVars])
 
   const handleNodeVarSelect = useCallback((node: currentVarType) => {
-    setCurrentFocusNodeId(node.nodeId)
+    workflowStore.getState().setCurrentFocusNodeId(node.nodeId)
     setCurrentVarId(node.var.id)
-  }, [setCurrentFocusNodeId, setCurrentVarId])
+  }, [workflowStore])
 
   const { isLoading, schemaTypeDefinitions } = useMatchSchemaType()
   const { eventEmitter } = useEventEmitterContextContext()
@@ -148,6 +146,10 @@ const Panel: FC = () => {
   const handleStopListening = useCallback(() => {
     eventEmitter?.emit({ type: EVENT_WORKFLOW_STOP } as any)
   }, [eventEmitter])
+
+  const handleClick = () => {
+    workflowStore.getState().setShowVariableInspectPanel(false)
+  }
 
   useEffect(() => {
     if (currentFocusNodeId && currentVarId && !isLoading) {
@@ -162,7 +164,7 @@ const Panel: FC = () => {
       <div className={cn('flex h-full flex-col')}>
         <div className="flex shrink-0 items-center justify-between pl-4 pr-2 pt-2">
           <div className="system-sm-semibold-uppercase text-text-primary">{t('debug.variableInspect.title', { ns: 'workflow' })}</div>
-          <ActionButton onClick={() => setShowVariableInspectPanel(false)}>
+          <ActionButton onClick={handleClick}>
             <RiCloseLine className="h-4 w-4" />
           </ActionButton>
         </div>
@@ -180,7 +182,7 @@ const Panel: FC = () => {
       <div className={cn('flex h-full flex-col')}>
         <div className="flex shrink-0 items-center justify-between pl-4 pr-2 pt-2">
           <div className="system-sm-semibold-uppercase text-text-primary">{t('debug.variableInspect.title', { ns: 'workflow' })}</div>
-          <ActionButton onClick={() => setShowVariableInspectPanel(false)}>
+          <ActionButton onClick={handleClick}>
             <RiCloseLine className="h-4 w-4" />
           </ActionButton>
         </div>

--- a/web/app/components/workflow/variable-inspect/right.tsx
+++ b/web/app/components/workflow/variable-inspect/right.tsx
@@ -31,7 +31,7 @@ import useCurrentVars from '../hooks/use-inspect-vars-crud'
 import useNodeCrud from '../nodes/_base/hooks/use-node-crud'
 import useNodeInfo from '../nodes/_base/hooks/use-node-info'
 import { CodeLanguage } from '../nodes/code/types'
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 import { BlockEnum } from '../types'
 import Empty from './empty'
 import ValueContent from './value-content'
@@ -50,9 +50,8 @@ const Right = ({
   isValueFetching,
 }: Props) => {
   const { t } = useTranslation()
+  const workflowStore = useWorkflowStore()
   const bottomPanelWidth = useStore(s => s.bottomPanelWidth)
-  const setShowVariableInspectPanel = useStore(s => s.setShowVariableInspectPanel)
-  const setCurrentFocusNodeId = useStore(s => s.setCurrentFocusNodeId)
   const toolIcon = useToolIcon(currentNodeVar?.nodeData)
   const isTruncated = currentNodeVar?.var.is_truncated
   const fullContent = currentNodeVar?.var.full_content
@@ -76,6 +75,7 @@ const Right = ({
   }
 
   const handleClose = () => {
+    const { setShowVariableInspectPanel, setCurrentFocusNodeId } = workflowStore.getState()
     setShowVariableInspectPanel(false)
     setCurrentFocusNodeId('')
   }

--- a/web/app/components/workflow/variable-inspect/trigger.tsx
+++ b/web/app/components/workflow/variable-inspect/trigger.tsx
@@ -11,17 +11,15 @@ import { useEventEmitterContextContext } from '@/context/event-emitter'
 import { cn } from '@/utils/classnames'
 import useCurrentVars from '../hooks/use-inspect-vars-crud'
 import { useNodesReadOnly } from '../hooks/use-workflow'
-import { useStore } from '../store'
+import { useStore, useWorkflowStore } from '../store'
 
 const VariableInspectTrigger: FC = () => {
   const { t } = useTranslation()
   const { eventEmitter } = useEventEmitterContextContext()
-
+  const workflowStore = useWorkflowStore()
   const showVariableInspectPanel = useStore(s => s.showVariableInspectPanel)
-  const setShowVariableInspectPanel = useStore(s => s.setShowVariableInspectPanel)
 
   const environmentVariables = useStore(s => s.environmentVariables)
-  const setCurrentFocusNodeId = useStore(s => s.setCurrentFocusNodeId)
   const {
     conversationVars,
     systemVars,
@@ -54,7 +52,13 @@ const VariableInspectTrigger: FC = () => {
 
   const handleClearAll = () => {
     deleteAllInspectorVars()
-    setCurrentFocusNodeId('')
+    workflowStore.getState().setCurrentFocusNodeId('')
+  }
+
+  const handleClick = () => {
+    if (getNodesReadOnly())
+      return
+    workflowStore.getState().setShowVariableInspectPanel(true)
   }
 
   if (showVariableInspectPanel)
@@ -65,11 +69,7 @@ const VariableInspectTrigger: FC = () => {
       {!isRunning && !currentVars.length && (
         <div
           className={cn('system-2xs-semibold-uppercase flex h-5 cursor-pointer items-center gap-1 rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-2 text-text-tertiary shadow-lg backdrop-blur-sm hover:bg-background-default-hover', nodesReadOnly && 'cursor-not-allowed text-text-disabled hover:bg-transparent hover:text-text-disabled')}
-          onClick={() => {
-            if (getNodesReadOnly())
-              return
-            setShowVariableInspectPanel(true)
-          }}
+          onClick={handleClick}
         >
           {t('debug.variableInspect.trigger.normal', { ns: 'workflow' })}
         </div>
@@ -78,11 +78,7 @@ const VariableInspectTrigger: FC = () => {
         <>
           <div
             className={cn('system-xs-medium flex h-6 cursor-pointer items-center gap-1 rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-2 text-text-accent shadow-lg backdrop-blur-sm hover:bg-components-actionbar-bg-accent', nodesReadOnly && 'cursor-not-allowed text-text-disabled hover:bg-transparent hover:text-text-disabled')}
-            onClick={() => {
-              if (getNodesReadOnly())
-                return
-              setShowVariableInspectPanel(true)
-            }}
+            onClick={handleClick}
           >
             {t('debug.variableInspect.trigger.cached', { ns: 'workflow' })}
           </div>
@@ -102,7 +98,7 @@ const VariableInspectTrigger: FC = () => {
         <>
           <div
             className="system-xs-medium flex h-6 cursor-pointer items-center gap-1 rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-2 text-text-accent shadow-lg backdrop-blur-sm hover:bg-components-actionbar-bg-accent"
-            onClick={() => setShowVariableInspectPanel(true)}
+            onClick={() => workflowStore.getState().setShowVariableInspectPanel(true)}
           >
             <RiLoader2Line className="h-4 w-4 animate-spin" />
             <span className="text-text-accent">{t('debug.variableInspect.trigger.running', { ns: 'workflow' })}</span>

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -518,7 +518,7 @@
   },
   "app/components/app/configuration/prompt-value-panel/index.spec.tsx": {
     "ts/no-explicit-any": {
-      "count": 3
+      "count": 2
     }
   },
   "app/components/app/configuration/prompt-value-panel/utils.ts": {
@@ -619,11 +619,6 @@
       "count": 1
     }
   },
-  "app/components/app/switch-app-modal/index.spec.tsx": {
-    "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
   "app/components/app/switch-app-modal/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
@@ -675,7 +670,7 @@
   },
   "app/components/apps/list.spec.tsx": {
     "ts/no-explicit-any": {
-      "count": 9
+      "count": 5
     }
   },
   "app/components/apps/list.tsx": {
@@ -3272,11 +3267,6 @@
   "app/components/workflow/datasets-detail-store/provider.tsx": {
     "react-hooks/refs": {
       "count": 2
-    }
-  },
-  "app/components/workflow/header/header-in-normal.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     }
   },
   "app/components/workflow/header/run-mode.tsx": {


### PR DESCRIPTION
## Summary
- Replace `useStore(s => s.setXxx)` subscriptions with `store.getState().setXxx()` in callbacks
- Refactor tests to use real Zustand stores with global mock auto-reset
- Add Zustand store testing best practices to frontend-testing skill

## Test plan
- [x] All refactored tests pass (128 tests)
- [x] Lint checks pass

Fixes #31158