### PR TITLE
fix: correct i18n for stepOne.uploader.tip

### DIFF
--- a/web/i18n/de-DE/dataset-creation.json
+++ b/web/i18n/de-DE/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Abbrechen",
   "stepOne.uploader.change": "Ändern",
   "stepOne.uploader.failed": "Hochladen fehlgeschlagen",
-  "stepOne.uploader.tip": "Unterstützt {{supportTypes}}. Maximal {{size}}MB pro Datei.",
+  "stepOne.uploader.tip": "Unterstützt {{supportTypes}}. Maximal {{batchCount}} Dateien pro Batch und {{size}} MB pro Datei. Insgesamt maximal {{totalCount}} Dateien.",
   "stepOne.uploader.title": "Textdatei hochladen",
   "stepOne.uploader.validation.count": "Mehrere Dateien nicht unterstützt",
   "stepOne.uploader.validation.filesNumber": "Sie haben das Limit für die Stapelverarbeitung von {{filesNumber}} erreicht.",

--- a/web/i18n/es-ES/dataset-creation.json
+++ b/web/i18n/es-ES/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Cancelar",
   "stepOne.uploader.change": "Cambiar",
   "stepOne.uploader.failed": "Error al cargar",
-  "stepOne.uploader.tip": "Soporta {{supportTypes}}. Máximo {{size}}MB cada uno.",
+  "stepOne.uploader.tip": "Soporta {{supportTypes}}. Máximo {{batchCount}} archivos por lote y {{size}} MB cada uno. Total máximo de {{totalCount}} archivos.",
   "stepOne.uploader.title": "Cargar archivo",
   "stepOne.uploader.validation.count": "No se admiten varios archivos",
   "stepOne.uploader.validation.filesNumber": "Has alcanzado el límite de carga por lotes de {{filesNumber}}.",

--- a/web/i18n/fa-IR/dataset-creation.json
+++ b/web/i18n/fa-IR/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "لغو",
   "stepOne.uploader.change": "تغییر",
   "stepOne.uploader.failed": "بارگذاری ناموفق بود",
-  "stepOne.uploader.tip": "پشتیبانی از {{supportTypes}}. حداکثر {{size}}MB هر کدام.",
+  "stepOne.uploader.tip": "پشتیبانی از {{supportTypes}}. حداکثر {{batchCount}} فایل در هر دسته و {{size}} مگابایت برای هر فایل. حداکثر کل {{totalCount}} فایل.",
   "stepOne.uploader.title": "بارگذاری فایل",
   "stepOne.uploader.validation.count": "چندین فایل پشتیبانی نمیشود",
   "stepOne.uploader.validation.filesNumber": "شما به حد مجاز بارگذاری دستهای {{filesNumber}} رسیدهاید.",

--- a/web/i18n/fr-FR/dataset-creation.json
+++ b/web/i18n/fr-FR/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Annuler",
   "stepOne.uploader.change": "Changer",
   "stepOne.uploader.failed": "Le téléchargement a échoué",
-  "stepOne.uploader.tip": "Prend en charge {{supportTypes}}. Max {{size}}MB chacun.",
+  "stepOne.uploader.tip": "Prend en charge {{supportTypes}}. Maximum {{batchCount}} fichiers par lot et {{size}} MB chacun. Maximum total de {{totalCount}} fichiers.",
   "stepOne.uploader.title": "Télécharger le fichier texte",
   "stepOne.uploader.validation.count": "Plusieurs fichiers non pris en charge",
   "stepOne.uploader.validation.filesNumber": "Vous avez atteint la limite de téléchargement par lot de {{filesNumber}}.",

--- a/web/i18n/hi-IN/dataset-creation.json
+++ b/web/i18n/hi-IN/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "रद्द करें",
   "stepOne.uploader.change": "बदलें",
   "stepOne.uploader.failed": "अपलोड विफल रहा",
-  "stepOne.uploader.tip": "समर्थित {{supportTypes}}। प्रत्येक अधिकतम {{size}}MB।",
+  "stepOne.uploader.tip": "{{supportTypes}} समर्थित है। एक बैच में अधिकतम {{batchCount}} फ़ाइलें और प्रत्येक {{size}} MB। कुल अधिकतम {{totalCount}} फ़ाइलें।",
   "stepOne.uploader.title": "फ़ाइल अपलोड करें",
   "stepOne.uploader.validation.count": "एकाधिक फ़ाइलें समर्थित नहीं हैं",
   "stepOne.uploader.validation.filesNumber": "आपने {{filesNumber}} की बैच अपलोड सीमा तक पहुँच गए हैं।",

--- a/web/i18n/it-IT/dataset-creation.json
+++ b/web/i18n/it-IT/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Annulla",
   "stepOne.uploader.change": "Cambia",
   "stepOne.uploader.failed": "Caricamento fallito",
-  "stepOne.uploader.tip": "Supporta {{supportTypes}}. Max {{size}}MB ciascuno.",
+  "stepOne.uploader.tip": "Supporta {{supportTypes}}. Massimo {{batchCount}} file per batch e {{size}} MB ciascuno. Totale massimo {{totalCount}} file.",
   "stepOne.uploader.title": "Carica file",
   "stepOne.uploader.validation.count": "Più file non supportati",
   "stepOne.uploader.validation.filesNumber": "Hai raggiunto il limite di caricamento batch di {{filesNumber}}.",

--- a/web/i18n/ja-JP/dataset-creation.json
+++ b/web/i18n/ja-JP/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "キャンセル",
   "stepOne.uploader.change": "変更",
   "stepOne.uploader.failed": "アップロードに失敗しました",
-  "stepOne.uploader.tip": "{{supportTypes}}をサポートしています。1 つあたりの最大サイズは{{size}}MB です。",
+  "stepOne.uploader.tip": "{{supportTypes}}をサポートしています。1バッチあたり最大{{batchCount}}ファイル、各ファイル{{size}}MB まで。合計最大{{totalCount}}ファイル。",
   "stepOne.uploader.title": "テキストファイルをアップロード",
   "stepOne.uploader.validation.count": "複数のファイルはサポートされていません",
   "stepOne.uploader.validation.filesNumber": "バッチアップロードの制限（{{filesNumber}}個）に達しました。",

--- a/web/i18n/ko-KR/dataset-creation.json
+++ b/web/i18n/ko-KR/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "취소",
   "stepOne.uploader.change": "변경",
   "stepOne.uploader.failed": "업로드에 실패했습니다",
-  "stepOne.uploader.tip": "{{supportTypes}}을 (를) 지원합니다. 파일당 최대 크기는 {{size}}MB 입니다.",
+  "stepOne.uploader.tip": "{{supportTypes}}을(를) 지원합니다. 배치당 최대 {{batchCount}}개 파일, 각 파일당 {{size}}MB까지. 총 최대 {{totalCount}}개 파일.",
   "stepOne.uploader.title": "텍스트 파일 업로드",
   "stepOne.uploader.validation.count": "여러 파일은 지원되지 않습니다",
   "stepOne.uploader.validation.filesNumber": "일괄 업로드 제한 ({{filesNumber}}개) 에 도달했습니다.",

--- a/web/i18n/pl-PL/dataset-creation.json
+++ b/web/i18n/pl-PL/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Anuluj",
   "stepOne.uploader.change": "Zmień",
   "stepOne.uploader.failed": "Przesyłanie nie powiodło się",
-  "stepOne.uploader.tip": "Obsługuje {{supportTypes}}. Maksymalnie {{size}}MB każdy.",
+  "stepOne.uploader.tip": "Obsługuje {{supportTypes}}. Maksymalnie {{batchCount}} plików w partii, każdy do {{size}} MB. Łącznie maksymalnie {{totalCount}} plików.",
   "stepOne.uploader.title": "Prześlij plik tekstowy",
   "stepOne.uploader.validation.count": "Nieobsługiwane przesyłanie wielu plików",
   "stepOne.uploader.validation.filesNumber": "Osiągnąłeś limit przesłania partii {{filesNumber}}.",

--- a/web/i18n/pt-BR/dataset-creation.json
+++ b/web/i18n/pt-BR/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Cancelar",
   "stepOne.uploader.change": "Alterar",
   "stepOne.uploader.failed": "Falha no envio",
-  "stepOne.uploader.tip": "Suporta {{supportTypes}}. Máximo de {{size}}MB cada.",
+  "stepOne.uploader.tip": "Suporta {{supportTypes}}. Máximo de {{batchCount}} arquivos por lote e {{size}} MB cada. Total máximo de {{totalCount}} arquivos.",
   "stepOne.uploader.title": "Enviar arquivo de texto",
   "stepOne.uploader.validation.count": "Vários arquivos não suportados",
   "stepOne.uploader.validation.filesNumber": "Limite de upload em massa {{filesNumber}}.",

--- a/web/i18n/ro-RO/dataset-creation.json
+++ b/web/i18n/ro-RO/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Anulează",
   "stepOne.uploader.change": "Schimbă",
   "stepOne.uploader.failed": "Încărcarea a eșuat",
-  "stepOne.uploader.tip": "Acceptă {{supportTypes}}. Maxim {{size}}MB fiecare.",
+  "stepOne.uploader.tip": "Acceptă {{supportTypes}}. Maxim {{batchCount}} fișiere pe lot și {{size}} MB fiecare. Total maxim {{totalCount}} fișiere.",
   "stepOne.uploader.title": "Încărcați fișier text",
   "stepOne.uploader.validation.count": "Nu se acceptă mai multe fișiere",
   "stepOne.uploader.validation.filesNumber": "Ați atins limita de încărcare în lot de {{filesNumber}} fișiere.",

--- a/web/i18n/ru-RU/dataset-creation.json
+++ b/web/i18n/ru-RU/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Отмена",
   "stepOne.uploader.change": "Изменить",
   "stepOne.uploader.failed": "Ошибка загрузки",
-  "stepOne.uploader.tip": "Поддерживаются {{supportTypes}}. Максимум {{size}} МБ каждый.",
+  "stepOne.uploader.tip": "Поддерживаются {{supportTypes}}. Максимум {{batchCount}} файлов за раз, каждый до {{size}} МБ. Всего максимум {{totalCount}} файлов.",
   "stepOne.uploader.title": "Загрузить файл",
   "stepOne.uploader.validation.count": "Несколько файлов не поддерживаются",
   "stepOne.uploader.validation.filesNumber": "Вы достигли лимита пакетной загрузки {{filesNumber}} файлов.",

--- a/web/i18n/sl-SI/dataset-creation.json
+++ b/web/i18n/sl-SI/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Prekliči",
   "stepOne.uploader.change": "Zamenjaj",
   "stepOne.uploader.failed": "Nalaganje ni uspelo",
-  "stepOne.uploader.tip": "Podprti tipi datotek: {{supportTypes}}. Največ {{size}}MB na datoteko.",
+  "stepOne.uploader.tip": "Podpira {{supportTypes}}. Največje število datotek v seriji: {{batchCount}}, vsaka do {{size}} MB. Skupaj največ {{totalCount}} datotek.",
   "stepOne.uploader.title": "Naloži datoteko",
   "stepOne.uploader.validation.count": "Podprta je le ena datoteka",
   "stepOne.uploader.validation.filesNumber": "Dosegli ste omejitev za pošiljanje {{filesNumber}} datotek.",

--- a/web/i18n/th-TH/dataset-creation.json
+++ b/web/i18n/th-TH/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "ยกเลิก",
   "stepOne.uploader.change": "เปลี่ยน",
   "stepOne.uploader.failed": "อัปโหลดล้มเหลว",
-  "stepOne.uploader.tip": "รองรับ {{supportTypes}} สูงสุด {{size}}MB แต่ละตัว",
+  "stepOne.uploader.tip": "รองรับ {{supportTypes}} สูงสุด {{batchCount}} ไฟล์ต่อชุดและ {{size}} MB แต่ละไฟล์ รวมสูงสุด {{totalCount}} ไฟล์",
   "stepOne.uploader.title": "อัปโหลดไฟล์",
   "stepOne.uploader.validation.count": "ไม่รองรับหลายไฟล์",
   "stepOne.uploader.validation.filesNumber": "คุณถึงขีดจํากัดการอัปโหลดเป็นชุดของ {{filesNumber}} แล้ว",

--- a/web/i18n/tr-TR/dataset-creation.json
+++ b/web/i18n/tr-TR/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "İptal",
   "stepOne.uploader.change": "Değiştir",
   "stepOne.uploader.failed": "Yükleme başarısız",
-  "stepOne.uploader.tip": "Destekler {{supportTypes}}. Her biri en fazla {{size}}MB.",
+  "stepOne.uploader.tip": "{{supportTypes}} destekler. Parti başına en fazla {{batchCount}} dosya ve her biri {{size}} MB. Toplam en fazla {{totalCount}} dosya.",
   "stepOne.uploader.title": "Dosya yükle",
   "stepOne.uploader.validation.count": "Birden fazla dosya desteklenmiyor",
   "stepOne.uploader.validation.filesNumber": "Toplu yükleme sınırına ulaştınız, {{filesNumber}} dosya.",

--- a/web/i18n/uk-UA/dataset-creation.json
+++ b/web/i18n/uk-UA/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Скасувати",
   "stepOne.uploader.change": "Змінити",
   "stepOne.uploader.failed": "Завантаження не вдалося",
-  "stepOne.uploader.tip": "Підтримуються {{supportTypes}}. Максимум {{size}} МБ кожен.",
+  "stepOne.uploader.tip": "Підтримуються {{supportTypes}}. Максимум {{batchCount}} файлів за раз, кожен до {{size}} МБ. Загалом максимум {{totalCount}} файлів.",
   "stepOne.uploader.title": "Завантажити текстовий файл",
   "stepOne.uploader.validation.count": "Не підтримується завантаження кількох файлів",
   "stepOne.uploader.validation.filesNumber": "Ліміт масового завантаження {{filesNumber}}.",

--- a/web/i18n/vi-VN/dataset-creation.json
+++ b/web/i18n/vi-VN/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "Hủy",
   "stepOne.uploader.change": "Thay đổi",
   "stepOne.uploader.failed": "Tải lên thất bại",
-  "stepOne.uploader.tip": "Hỗ trợ {{supportTypes}}. Tối đa {{size}}MB mỗi tệp.",
+  "stepOne.uploader.tip": "Hỗ trợ {{supportTypes}}. Tối đa {{batchCount}} tệp trong một lô và {{size}} MB mỗi tệp. Tổng tối đa {{totalCount}} tệp.",
   "stepOne.uploader.title": "Tải lên tệp văn bản",
   "stepOne.uploader.validation.count": "Không hỗ trợ tải lên nhiều tệp",
   "stepOne.uploader.validation.filesNumber": "Bạn đã đạt đến giới hạn tải lên lô của {{filesNumber}} tệp.",

--- a/web/i18n/zh-Hant/dataset-creation.json
+++ b/web/i18n/zh-Hant/dataset-creation.json
@@ -35,7 +35,7 @@
   "stepOne.uploader.cancel": "取消",
   "stepOne.uploader.change": "更改檔案",
   "stepOne.uploader.failed": "上傳失敗",
-  "stepOne.uploader.tip": "已支援 {{supportTypes}}，每個檔案不超過 {{size}}MB。",
+  "stepOne.uploader.tip": "支援 {{supportTypes}}。每批最多 {{batchCount}} 個檔案，每個檔案不超過 {{size}} MB，總數不超過 {{totalCount}} 個檔案。",
   "stepOne.uploader.title": "上傳文字檔案",
   "stepOne.uploader.validation.count": "暫不支援多個檔案",
   "stepOne.uploader.validation.filesNumber": "批次上傳限制 {{filesNumber}}。",


### PR DESCRIPTION
## Summary

This PR modifies the `stepOne.uploader.tip` for each language to include both `batchCount` and `totalCount`.
Closes #31173 

## Screenshots

| Before | After |
|--------|-------|
| <img width="1140" height="421" alt="image" src="https://github.com/user-attachments/assets/0cce7d94-814c-4980-8e84-fa0954aa52b3" /><img width="1150" height="432" alt="image" src="https://github.com/user-attachments/assets/2b19691d-cd14-4db4-9c3b-a29d26c868aa" /> | <img width="1145" height="419" alt="image" src="https://github.com/user-attachments/assets/70c01d45-24c0-44db-a712-d0e4d4c5ba25" /><img width="1147" height="429" alt="image" src="https://github.com/user-attachments/assets/0c9886ff-78bc-48d5-bc20-02b6b837b635" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
