### PR TITLE
refactor(web): migrate appDetail from Zustand to TanStack Query

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -1,7 +1,6 @@
 'use client'
 import type { FC } from 'react'
 import type { NavIcon } from '@/app/components/app-sidebar/navLink'
-import type { App } from '@/types/app'
 import {
   RiDashboard2Fill,
   RiDashboard2Line,
@@ -12,13 +11,11 @@ import {
   RiTerminalWindowFill,
   RiTerminalWindowLine,
 } from '@remixicon/react'
-import { useUnmount } from 'ahooks'
 import dynamic from 'next/dynamic'
 import { usePathname, useRouter } from 'next/navigation'
 import * as React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useShallow } from 'zustand/react/shallow'
 import AppSideBar from '@/app/components/app-sidebar'
 import { useStore } from '@/app/components/app/store'
 import Loading from '@/app/components/base/loading'
@@ -26,7 +23,7 @@ import { useStore as useTagStore } from '@/app/components/base/tag-management/st
 import { useAppContext } from '@/context/app-context'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import useDocumentTitle from '@/hooks/use-document-title'
-import { fetchAppDetailDirect } from '@/service/apps'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 import { cn } from '@/utils/classnames'
 import s from './style.module.css'
@@ -41,47 +38,41 @@ export type IAppDetailLayoutProps = {
 }
 
 const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
-  const {
-    children,
-    appId, // get appId in path
-  } = props
+  const { children, appId } = props
   const { t } = useTranslation()
   const router = useRouter()
   const pathname = usePathname()
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
-  const { isCurrentWorkspaceEditor, isLoadingCurrentWorkspace, currentWorkspace } = useAppContext()
-  const { appDetail, setAppDetail, setAppSidebarExpand } = useStore(useShallow(state => ({
-    appDetail: state.appDetail,
-    setAppDetail: state.setAppDetail,
-    setAppSidebarExpand: state.setAppSidebarExpand,
-  })))
-  const showTagManagementModal = useTagStore(s => s.showTagManagementModal)
-  const [isLoadingAppDetail, setIsLoadingAppDetail] = useState(false)
-  const [appDetailRes, setAppDetailRes] = useState<App | null>(null)
-  const [navigation, setNavigation] = useState<Array<{
-    name: string
-    href: string
-    icon: NavIcon
-    selectedIcon: NavIcon
-  }>>([])
 
-  const getNavigationConfig = useCallback((appId: string, isCurrentWorkspaceEditor: boolean, mode: AppModeEnum) => {
-    const navConfig = [
+  const { isCurrentWorkspaceEditor, isLoadingCurrentWorkspace } = useAppContext()
+  const setAppSidebarExpand = useStore(s => s.setAppSidebarExpand)
+  const showTagManagementModal = useTagStore(s => s.showTagManagementModal)
+
+  const { data: appDetail, isPending, error } = useAppDetail(appId)
+
+  const navigation = useMemo(() => {
+    if (!appDetail)
+      return []
+
+    const mode = appDetail.mode
+    const isWorkflowMode = mode === AppModeEnum.WORKFLOW || mode === AppModeEnum.ADVANCED_CHAT
+
+    return [
       ...(isCurrentWorkspaceEditor
         ? [{
             name: t('appMenus.promptEng', { ns: 'common' }),
-            href: `/app/${appId}/${(mode === AppModeEnum.WORKFLOW || mode === AppModeEnum.ADVANCED_CHAT) ? 'workflow' : 'configuration'}`,
-            icon: RiTerminalWindowLine,
-            selectedIcon: RiTerminalWindowFill,
+            href: `/app/${appId}/${isWorkflowMode ? 'workflow' : 'configuration'}`,
+            icon: RiTerminalWindowLine as NavIcon,
+            selectedIcon: RiTerminalWindowFill as NavIcon,
           }]
         : []
       ),
       {
         name: t('appMenus.apiAccess', { ns: 'common' }),
         href: `/app/${appId}/develop`,
-        icon: RiTerminalBoxLine,
-        selectedIcon: RiTerminalBoxFill,
+        icon: RiTerminalBoxLine as NavIcon,
+        selectedIcon: RiTerminalBoxFill as NavIcon,
       },
       ...(isCurrentWorkspaceEditor
         ? [{
@@ -89,74 +80,64 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
               ? t('appMenus.logAndAnn', { ns: 'common' })
               : t('appMenus.logs', { ns: 'common' }),
             href: `/app/${appId}/logs`,
-            icon: RiFileList3Line,
-            selectedIcon: RiFileList3Fill,
+            icon: RiFileList3Line as NavIcon,
+            selectedIcon: RiFileList3Fill as NavIcon,
           }]
         : []
       ),
       {
         name: t('appMenus.overview', { ns: 'common' }),
         href: `/app/${appId}/overview`,
-        icon: RiDashboard2Line,
-        selectedIcon: RiDashboard2Fill,
+        icon: RiDashboard2Line as NavIcon,
+        selectedIcon: RiDashboard2Fill as NavIcon,
       },
     ]
-    return navConfig
-  }, [t])
+  }, [appDetail, appId, isCurrentWorkspaceEditor, t])
 
   useDocumentTitle(appDetail?.name || t('menus.appDetail', { ns: 'common' }))
 
   useEffect(() => {
-    if (appDetail) {
-      const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
-      const mode = isMobile ? 'collapse' : 'expand'
-      setAppSidebarExpand(isMobile ? mode : localeMode)
-      // TODO: consider screen size and mode
-      // if ((appDetail.mode === AppModeEnum.ADVANCED_CHAT || appDetail.mode === 'workflow') && (pathname).endsWith('workflow'))
-      //   setAppSidebarExpand('collapse')
-    }
-  }, [appDetail, isMobile])
+    if (!appDetail)
+      return
+    const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
+    setAppSidebarExpand(localeMode)
+  }, [appDetail, setAppSidebarExpand])
 
   useEffect(() => {
-    setAppDetail()
-    setIsLoadingAppDetail(true)
-    fetchAppDetailDirect({ url: '/apps', id: appId }).then((res: App) => {
-      setAppDetailRes(res)
-    }).catch((e: any) => {
-      if (e.status === 404)
-        router.replace('/apps')
-    }).finally(() => {
-      setIsLoadingAppDetail(false)
-    })
-  }, [appId, pathname])
+    if (isMobile)
+      setAppSidebarExpand('collapse')
+  }, [isMobile, setAppSidebarExpand])
 
   useEffect(() => {
-    if (!appDetailRes || !currentWorkspace.id || isLoadingCurrentWorkspace || isLoadingAppDetail)
+    if (!appDetail || isLoadingCurrentWorkspace)
       return
-    const res = appDetailRes
-    // redirection
-    const canIEditApp = isCurrentWorkspaceEditor
-    if (!canIEditApp && (pathname.endsWith('configuration') || pathname.endsWith('workflow') || pathname.endsWith('logs'))) {
-      router.replace(`/app/${appId}/overview`)
-      return
+
+    const mode = appDetail.mode
+    const isWorkflowMode = mode === AppModeEnum.WORKFLOW || mode === AppModeEnum.ADVANCED_CHAT
+
+    if (!isCurrentWorkspaceEditor) {
+      const restrictedPaths = ['configuration', 'workflow', 'logs']
+      if (restrictedPaths.some(p => pathname.endsWith(p))) {
+        router.replace(`/app/${appId}/overview`)
+        return
+      }
     }
-    if ((res.mode === AppModeEnum.WORKFLOW || res.mode === AppModeEnum.ADVANCED_CHAT) && (pathname).endsWith('configuration')) {
+
+    if (isWorkflowMode && pathname.endsWith('configuration'))
       router.replace(`/app/${appId}/workflow`)
-    }
-    else if ((res.mode !== AppModeEnum.WORKFLOW && res.mode !== AppModeEnum.ADVANCED_CHAT) && (pathname).endsWith('workflow')) {
+    else if (!isWorkflowMode && pathname.endsWith('workflow'))
       router.replace(`/app/${appId}/configuration`)
-    }
-    else {
-      setAppDetail({ ...res, enable_sso: false })
-      setNavigation(getNavigationConfig(appId, isCurrentWorkspaceEditor, res.mode))
-    }
-  }, [appDetailRes, isCurrentWorkspaceEditor, isLoadingAppDetail, isLoadingCurrentWorkspace])
+  }, [appDetail, isCurrentWorkspaceEditor, isLoadingCurrentWorkspace, pathname, appId, router])
 
-  useUnmount(() => {
-    setAppDetail()
-  })
+  useEffect(() => {
+    if (error) {
+      const httpError = error as { status?: number }
+      if (httpError.status === 404)
+        router.replace('/apps')
+    }
+  }, [error, router])
 
-  if (!appDetail) {
+  if (isPending) {
     return (
       <div className="flex h-full items-center justify-center bg-background-body">
         <Loading />
@@ -164,13 +145,12 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     )
   }
 
+  if (!appDetail)
+    return null
+
   return (
     <div className={cn(s.app, 'relative flex', 'overflow-hidden')}>
-      {appDetail && (
-        <AppSideBar
-          navigation={navigation}
-        />
-      )}
+      <AppSideBar navigation={navigation} />
       <div className="grow overflow-hidden bg-components-panel-bg">
         {children}
       </div>
@@ -180,4 +160,5 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     </div>
   )
 }
+
 export default React.memo(AppDetailLayout)

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -99,14 +99,14 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
   useEffect(() => {
     if (!appDetail)
       return
-    const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
-    setAppSidebarExpand(localeMode)
-  }, [appDetail, setAppSidebarExpand])
-
-  useEffect(() => {
-    if (isMobile)
+    if (isMobile) {
       setAppSidebarExpand('collapse')
-  }, [isMobile, setAppSidebarExpand])
+    }
+    else {
+      const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
+      setAppSidebarExpand(localeMode)
+    }
+  }, [appDetail, isMobile, setAppSidebarExpand])
 
   useEffect(() => {
     if (!appDetail || isLoadingCurrentWorkspace)

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chart-view.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chart-view.tsx
@@ -8,8 +8,8 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TIME_PERIOD_MAPPING as LONG_TIME_PERIOD_MAPPING } from '@/app/components/app/log/filter'
 import { AvgResponseTime, AvgSessionInteractions, AvgUserInteractions, ConversationsChart, CostChart, EndUsersChart, MessagesChart, TokenPerSecond, UserSatisfactionRate, WorkflowCostChart, WorkflowDailyTerminalsChart, WorkflowMessagesChart } from '@/app/components/app/overview/app-chart'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { IS_CLOUD_EDITION } from '@/config'
+import { useAppDetail } from '@/service/use-apps'
 import LongTimeRangePicker from './long-time-range-picker'
 import TimeRangePicker from './time-range-picker'
 
@@ -34,7 +34,7 @@ export type IChartViewProps = {
 
 export default function ChartView({ appId, headerRight }: IChartViewProps) {
   const { t } = useTranslation()
-  const appDetail = useAppStore(state => state.appDetail)
+  const { data: appDetail } = useAppDetail(appId)
   const isChatApp = appDetail?.mode !== 'completion' && appDetail?.mode !== 'workflow'
   const isWorkflow = appDetail?.mode === 'workflow'
   const [period, setPeriod] = useState<PeriodParams>(IS_CLOUD_EDITION

--- a/web/app/components/app-sidebar/app-info.tsx
+++ b/web/app/components/app-sidebar/app-info.tsx
@@ -11,7 +11,6 @@ import {
   RiFileDownloadLine,
   RiFileUploadLine,
 } from '@remixicon/react'
-import { useQueryClient } from '@tanstack/react-query'
 import dynamic from 'next/dynamic'
 import { useParams, useRouter } from 'next/navigation'
 import * as React from 'react'
@@ -26,7 +25,7 @@ import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { useProviderContext } from '@/context/provider-context'
 import { copyApp, deleteApp, exportAppConfig, updateAppInfo } from '@/service/apps'
-import { useAppDetail, useInvalidateAppList } from '@/service/use-apps'
+import { useAppDetail, useInvalidateAppDetail, useInvalidateAppList } from '@/service/use-apps'
 import { fetchWorkflowDraft } from '@/service/workflow'
 import { AppModeEnum } from '@/types/app'
 import { getRedirection } from '@/utils/app-redirection'
@@ -65,9 +64,9 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
   const { notify } = useContext(ToastContext)
   const { replace } = useRouter()
   const { appId } = useParams()
-  const queryClient = useQueryClient()
   const { onPlanInfoChanged } = useProviderContext()
   const { data: appDetail } = useAppDetail(appId as string)
+  const invalidateAppDetail = useInvalidateAppDetail()
   const invalidateAppList = useInvalidateAppList()
   const [open, setOpen] = useState(openState)
   const [showEditModal, setShowEditModal] = useState(false)
@@ -77,10 +76,6 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
   const [showImportDSLModal, setShowImportDSLModal] = useState<boolean>(false)
   const [secretEnvList, setSecretEnvList] = useState<EnvironmentVariable[]>([])
   const [showExportWarning, setShowExportWarning] = useState(false)
-
-  const invalidateAppDetail = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ['apps', 'detail', appId] })
-  }, [queryClient, appId])
 
   const onEdit: CreateAppModalProps['onConfirm'] = useCallback(async ({
     name,
@@ -109,12 +104,12 @@ const AppInfo = ({ expand, onlyShowDetail = false, openState = false, onDetailEx
         type: 'success',
         message: t('editDone', { ns: 'app' }),
       })
-      invalidateAppDetail()
+      invalidateAppDetail(appId as string)
     }
     catch {
       notify({ type: 'error', message: t('editFailed', { ns: 'app' }) })
     }
-  }, [appDetail, notify, invalidateAppDetail, t])
+  }, [appDetail, notify, invalidateAppDetail, appId, t])
 
   const onCopy: DuplicateAppModalProps['onConfirm'] = async ({ name, icon_type, icon, icon_background }) => {
     if (!appDetail)

--- a/web/app/components/app-sidebar/app-sidebar-dropdown.tsx
+++ b/web/app/components/app-sidebar/app-sidebar-dropdown.tsx
@@ -3,16 +3,17 @@ import {
   RiEqualizer2Line,
   RiMenuLine,
 } from '@remixicon/react'
+import { useParams } from 'next/navigation'
 import * as React from 'react'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import {
   PortalToFollowElem,
   PortalToFollowElemContent,
   PortalToFollowElemTrigger,
 } from '@/app/components/base/portal-to-follow-elem'
 import { useAppContext } from '@/context/app-context'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 import { cn } from '@/utils/classnames'
 import AppIcon from '../base/app-icon'
@@ -31,8 +32,9 @@ type Props = {
 
 const AppSidebarDropdown = ({ navigation }: Props) => {
   const { t } = useTranslation()
+  const { appId } = useParams()
   const { isCurrentWorkspaceEditor } = useAppContext()
-  const appDetail = useAppStore(state => state.appDetail)
+  const { data: appDetail } = useAppDetail(appId as string)
   const [detailExpand, setDetailExpand] = useState(false)
 
   const [open, doSetOpen] = useState(false)

--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -144,7 +144,6 @@ const AppPublisher = ({
   const [published, setPublished] = useState(false)
   const [open, setOpen] = useState(false)
   const [showAppAccessControl, setShowAppAccessControl] = useState(false)
-  const [isAppAccessSet, setIsAppAccessSet] = useState(true)
   const [embeddingModalOpen, setEmbeddingModalOpen] = useState(false)
 
   const { data: appDetail } = useAppDetail(appId as string)
@@ -178,16 +177,12 @@ const AppPublisher = ({
       refetch()
   }, [open, appDetail, refetch, systemFeatures])
 
-  useEffect(() => {
-    if (appDetail && appAccessSubjects) {
-      if (appDetail.access_mode === AccessMode.SPECIFIC_GROUPS_MEMBERS && appAccessSubjects.groups?.length === 0 && appAccessSubjects.members?.length === 0)
-        setIsAppAccessSet(false)
-      else
-        setIsAppAccessSet(true)
-    }
-    else {
-      setIsAppAccessSet(true)
-    }
+  const isAppAccessSet = useMemo(() => {
+    if (!appDetail || !appAccessSubjects)
+      return true
+    if (appDetail.access_mode === AccessMode.SPECIFIC_GROUPS_MEMBERS && appAccessSubjects.groups?.length === 0 && appAccessSubjects.members?.length === 0)
+      return false
+    return true
   }, [appAccessSubjects, appDetail])
 
   const handlePublish = useCallback(async (params?: ModelAndParameter | PublishWorkflowParams) => {

--- a/web/app/components/app/configuration/config-var/config-modal/index.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/index.tsx
@@ -4,11 +4,11 @@ import type { Item as SelectItem } from './type-select'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { InputVar, MoreInfo, UploadFileSetting } from '@/app/components/workflow/types'
 import { produce } from 'immer'
+import { useParams } from 'next/navigation'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useContext } from 'use-context-selector'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Checkbox from '@/app/components/base/checkbox'
 import { FileUploaderInAttachmentWrapper } from '@/app/components/base/file-uploader'
 import Input from '@/app/components/base/input'
@@ -22,6 +22,7 @@ import FileUploadSetting from '@/app/components/workflow/nodes/_base/components/
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import { ChangeType, InputVarType, SupportUploadFileTypes } from '@/app/components/workflow/types'
 import ConfigContext from '@/context/debug-configuration'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum, TransferMethod } from '@/types/app'
 import { checkKeys, getNewVarInWorkflow, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 import ConfigSelect from '../config-select'
@@ -72,10 +73,11 @@ const ConfigModal: FC<IConfigModalProps> = ({
 }) => {
   const { modelConfig } = useContext(ConfigContext)
   const { t } = useTranslation()
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const [tempPayload, setTempPayload] = useState<InputVar>(() => normalizeSelectDefaultValue(payload || getNewVarInWorkflow('') as any))
   const { type, label, variable, options, max_length } = tempPayload
   const modalRef = useRef<HTMLDivElement>(null)
-  const appDetail = useAppStore(state => state.appDetail)
   const isBasicApp = appDetail?.mode !== AppModeEnum.ADVANCED_CHAT && appDetail?.mode !== AppModeEnum.WORKFLOW
   const jsonSchemaStr = useMemo(() => {
     const isJsonObject = type === InputVarType.jsonObject

--- a/web/app/components/app/configuration/config-var/index.spec.tsx
+++ b/web/app/components/app/configuration/config-var/index.spec.tsx
@@ -2,11 +2,13 @@ import type { ReactNode } from 'react'
 import type { IConfigVarProps } from './index'
 import type { ExternalDataTool } from '@/models/common'
 import type { PromptVariable } from '@/models/debug'
+import type { App } from '@/types/app'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import * as React from 'react'
 import { vi } from 'vitest'
 import Toast from '@/app/components/base/toast'
 import DebugConfigurationContext from '@/context/debug-configuration'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 
 import ConfigVar, { ADD_EXTERNAL_DATA_TOOL } from './index'
@@ -37,6 +39,15 @@ vi.mock('@/context/modal-context', () => ({
     setShowExternalDataToolModal,
   }),
 }))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({
+    appId: 'test-app-id',
+  }),
+}))
+
+vi.mock('@/service/use-apps')
+const mockUseAppDetail = vi.mocked(useAppDetail)
 
 type SortableItem = {
   id: string
@@ -83,6 +94,18 @@ const createPromptVariable = (overrides: Partial<PromptVariable> = {}): PromptVa
     required: false,
     ...overrides,
   }
+}
+
+function setupUseAppDetailMock() {
+  mockUseAppDetail.mockReturnValue({
+    data: {
+      id: 'test-app-id',
+      mode: AppModeEnum.CHAT,
+    } as App,
+    isLoading: false,
+    isPending: false,
+    error: null,
+  } as ReturnType<typeof useAppDetail>)
 }
 
 const renderConfigVar = (props: Partial<IConfigVarProps> = {}, debugOverrides: Partial<DebugConfigurationState> = {}) => {
@@ -219,6 +242,7 @@ describe('ConfigVar', () => {
       subscriptionCallback = null
       variableIndex = 0
       notifySpy.mockClear()
+      setupUseAppDetailMock()
     })
 
     it('should save updates when editing a basic variable', async () => {

--- a/web/app/components/app/log-annotation/index.spec.tsx
+++ b/web/app/components/app/log-annotation/index.spec.tsx
@@ -1,15 +1,21 @@
 import type { App, AppIconType } from '@/types/app'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { PageType } from '@/app/components/base/features/new-feature-panel/annotation-reply/type'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 import LogAnnotation from './index'
+
+vi.mock('@/service/use-apps')
+const mockUseAppDetail = vi.mocked(useAppDetail)
 
 const mockRouterPush = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockRouterPush,
+  }),
+  useParams: () => ({
+    appId: 'app-123',
   }),
 }))
 
@@ -61,17 +67,25 @@ const createMockApp = (overrides: Partial<App> = {}): App => ({
   ...overrides,
 })
 
+function mockAppDetailReturn(app: App | undefined) {
+  mockUseAppDetail.mockReturnValue({
+    data: app,
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useAppDetail>)
+}
+
 describe('LogAnnotation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    useAppStore.setState({ appDetail: createMockApp() })
+    mockAppDetailReturn(createMockApp())
   })
 
   // Rendering behavior
   describe('Rendering', () => {
     it('should render loading state when app detail is missing', () => {
       // Arrange
-      useAppStore.setState({ appDetail: undefined })
+      mockAppDetailReturn(undefined)
 
       // Act
       render(<LogAnnotation pageType={PageType.log} />)
@@ -82,7 +96,7 @@ describe('LogAnnotation', () => {
 
     it('should render log and annotation tabs for non-completion apps', () => {
       // Arrange
-      useAppStore.setState({ appDetail: createMockApp({ mode: AppModeEnum.CHAT }) })
+      mockAppDetailReturn(createMockApp({ mode: AppModeEnum.CHAT }))
 
       // Act
       render(<LogAnnotation pageType={PageType.log} />)
@@ -94,7 +108,7 @@ describe('LogAnnotation', () => {
 
     it('should render only log tab for completion apps', () => {
       // Arrange
-      useAppStore.setState({ appDetail: createMockApp({ mode: AppModeEnum.COMPLETION }) })
+      mockAppDetailReturn(createMockApp({ mode: AppModeEnum.COMPLETION }))
 
       // Act
       render(<LogAnnotation pageType={PageType.log} />)
@@ -106,7 +120,7 @@ describe('LogAnnotation', () => {
 
     it('should hide tabs and render workflow log in workflow mode', () => {
       // Arrange
-      useAppStore.setState({ appDetail: createMockApp({ mode: AppModeEnum.WORKFLOW }) })
+      mockAppDetailReturn(createMockApp({ mode: AppModeEnum.WORKFLOW }))
 
       // Act
       render(<LogAnnotation pageType={PageType.log} />)
@@ -121,7 +135,7 @@ describe('LogAnnotation', () => {
   describe('Props', () => {
     it('should render log content when page type is log', () => {
       // Arrange
-      useAppStore.setState({ appDetail: createMockApp({ mode: AppModeEnum.CHAT }) })
+      mockAppDetailReturn(createMockApp({ mode: AppModeEnum.CHAT }))
 
       // Act
       render(<LogAnnotation pageType={PageType.log} />)
@@ -133,7 +147,7 @@ describe('LogAnnotation', () => {
 
     it('should render annotation content when page type is annotation', () => {
       // Arrange
-      useAppStore.setState({ appDetail: createMockApp({ mode: AppModeEnum.CHAT }) })
+      mockAppDetailReturn(createMockApp({ mode: AppModeEnum.CHAT }))
 
       // Act
       render(<LogAnnotation pageType={PageType.annotation} />)

--- a/web/app/components/app/log-annotation/index.tsx
+++ b/web/app/components/app/log-annotation/index.tsx
@@ -1,16 +1,16 @@
 'use client'
 import type { FC } from 'react'
-import { useRouter } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import * as React from 'react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Annotation from '@/app/components/app/annotation'
 import Log from '@/app/components/app/log'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import WorkflowLog from '@/app/components/app/workflow-log'
 import { PageType } from '@/app/components/base/features/new-feature-panel/annotation-reply/type'
 import Loading from '@/app/components/base/loading'
 import TabSlider from '@/app/components/base/tab-slider-plain'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 import { cn } from '@/utils/classnames'
 
@@ -23,7 +23,8 @@ const LogAnnotation: FC<Props> = ({
 }) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const appDetail = useAppStore(state => state.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
 
   const options = useMemo(() => {
     if (appDetail?.mode === AppModeEnum.COMPLETION)

--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -14,7 +14,6 @@ import {
   RiVerifiedBadgeLine,
   RiWindowLine,
 } from '@remixicon/react'
-import { useQueryClient } from '@tanstack/react-query'
 import { usePathname, useRouter } from 'next/navigation'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -35,7 +34,7 @@ import { useGlobalPublicStore } from '@/context/global-public-context'
 import { useDocLink } from '@/context/i18n'
 import { AccessMode } from '@/models/access-control'
 import { useAppWhiteListSubjects } from '@/service/access-control'
-import { useAppDetail } from '@/service/use-apps'
+import { useAppDetail, useInvalidateAppDetail } from '@/service/use-apps'
 import { useAppWorkflow } from '@/service/use-workflow'
 import { AppModeEnum } from '@/types/app'
 import { asyncRunSafe } from '@/utils'
@@ -73,7 +72,7 @@ function AppCard({
 }: IAppCardProps) {
   const router = useRouter()
   const pathname = usePathname()
-  const queryClient = useQueryClient()
+  const invalidateAppDetail = useInvalidateAppDetail()
   const { isCurrentWorkspaceManager, isCurrentWorkspaceEditor } = useAppContext()
   const { data: currentWorkflow } = useAppWorkflow(appInfo.mode === AppModeEnum.WORKFLOW ? appInfo.id : '')
   const docLink = useDocLink()
@@ -178,10 +177,10 @@ function AppCard({
       return
     setShowAccessControl(true)
   }, [appDetail])
-  const handleAccessControlUpdate = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: ['apps', 'detail', appInfo.id] })
+  const handleAccessControlUpdate = useCallback(() => {
+    invalidateAppDetail(appInfo.id)
     setShowAccessControl(false)
-  }, [queryClient, appInfo.id])
+  }, [invalidateAppDetail, appInfo.id])
 
   return (
     <div

--- a/web/app/components/app/store.ts
+++ b/web/app/components/app/store.ts
@@ -1,9 +1,7 @@
 import type { IChatItem } from '@/app/components/base/chat/chat/type'
-import type { App, AppSSO } from '@/types/app'
 import { create } from 'zustand'
 
 type State = {
-  appDetail?: App & Partial<AppSSO>
   appSidebarExpand: string
   currentLogItem?: IChatItem
   currentLogModalActiveTab: string
@@ -14,7 +12,6 @@ type State = {
 }
 
 type Action = {
-  setAppDetail: (appDetail?: App & Partial<AppSSO>) => void
   setAppSidebarExpand: (state: string) => void
   setCurrentLogItem: (item?: IChatItem) => void
   setCurrentLogModalActiveTab: (tab: string) => void
@@ -25,8 +22,6 @@ type Action = {
 }
 
 export const useStore = create<State & Action>(set => ({
-  appDetail: undefined,
-  setAppDetail: appDetail => set(() => ({ appDetail })),
   appSidebarExpand: '',
   setAppSidebarExpand: appSidebarExpand => set(() => ({ appSidebarExpand })),
   currentLogItem: undefined,

--- a/web/app/components/app/switch-app-modal/index.spec.tsx
+++ b/web/app/components/app/switch-app-modal/index.spec.tsx
@@ -15,11 +15,12 @@ vi.mock('next/navigation', () => ({
     push: mockPush,
     replace: mockReplace,
   }),
+  useParams: () => ({ appId: 'app-123' }),
 }))
 
-const mockSetAppDetail = vi.fn()
-vi.mock('@/app/components/app/store', () => ({
-  useStore: (selector: (state: any) => unknown) => selector({ setAppDetail: mockSetAppDetail }),
+const mockInvalidateAppDetail = vi.fn()
+vi.mock('@/service/use-apps', () => ({
+  useInvalidateAppDetail: () => mockInvalidateAppDetail,
 }))
 
 const mockSwitchApp = vi.fn()
@@ -275,7 +276,7 @@ describe('SwitchAppModal', () => {
       })
       expect(mockReplace).toHaveBeenCalledWith('/app/new-app-002/workflow')
       expect(mockPush).not.toHaveBeenCalled()
-      expect(mockSetAppDetail).toHaveBeenCalledTimes(1)
+      expect(mockInvalidateAppDetail).toHaveBeenCalledTimes(1)
     })
 
     it('should notify error when switch app fails', async () => {

--- a/web/app/components/app/switch-app-modal/index.tsx
+++ b/web/app/components/app/switch-app-modal/index.tsx
@@ -3,11 +3,10 @@
 import type { App } from '@/types/app'
 import { RiCloseLine } from '@remixicon/react'
 import { noop } from 'es-toolkit/function'
-import { useRouter } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useContext } from 'use-context-selector'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import AppIcon from '@/app/components/base/app-icon'
 import Button from '@/app/components/base/button'
 import Checkbox from '@/app/components/base/checkbox'
@@ -21,6 +20,7 @@ import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { useProviderContext } from '@/context/provider-context'
 import { deleteApp, switchApp } from '@/service/apps'
+import { useInvalidateAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 import { getRedirection } from '@/utils/app-redirection'
 import { cn } from '@/utils/classnames'
@@ -38,7 +38,8 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
   const { push, replace } = useRouter()
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
-  const setAppDetail = useAppStore(s => s.setAppDetail)
+  const { appId } = useParams()
+  const invalidateAppDetail = useInvalidateAppDetail()
 
   const { isCurrentWorkspaceEditor } = useAppContext()
   const { plan, enableBilling } = useProviderContext()
@@ -70,7 +71,7 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
         onClose()
       notify({ type: 'success', message: t('newApp.appCreated', { ns: 'app' }) })
       if (inAppDetail)
-        setAppDetail()
+        invalidateAppDetail(appId as string)
       if (removeOriginal)
         await deleteApp(appDetail.id)
       localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')

--- a/web/app/components/app/workflow-log/detail.spec.tsx
+++ b/web/app/components/app/workflow-log/detail.spec.tsx
@@ -11,17 +11,23 @@
 import type { App, AppIconType, AppModeEnum } from '@/types/app'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useStore as useAppStore } from '@/app/components/app/store'
+import { useAppDetail } from '@/service/use-apps'
 import DetailPanel from './detail'
 
 // ============================================================================
 // Mocks
 // ============================================================================
 
+vi.mock('@/service/use-apps')
+const mockUseAppDetail = vi.mocked(useAppDetail)
+
 const mockRouterPush = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockRouterPush,
+  }),
+  useParams: () => ({
+    appId: 'test-app-id',
   }),
 }))
 
@@ -89,6 +95,18 @@ const createMockApp = (overrides: Partial<App> = {}): App => ({
 })
 
 // ============================================================================
+// Helper Functions
+// ============================================================================
+
+function mockAppDetailReturn(app: App | undefined) {
+  mockUseAppDetail.mockReturnValue({
+    data: app,
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useAppDetail>)
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -97,7 +115,7 @@ describe('DetailPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    useAppStore.setState({ appDetail: createMockApp() })
+    mockAppDetailReturn(createMockApp())
   })
 
   // --------------------------------------------------------------------------
@@ -125,7 +143,7 @@ describe('DetailPanel', () => {
     })
 
     it('should render Run component with correct URLs', () => {
-      useAppStore.setState({ appDetail: createMockApp({ id: 'app-456' }) })
+      mockAppDetailReturn(createMockApp({ id: 'app-456' }))
 
       render(<DetailPanel runID="run-789" onClose={defaultOnClose} />)
 
@@ -185,7 +203,7 @@ describe('DetailPanel', () => {
 
     it('should navigate to workflow page with replayRunId when replay button is clicked', async () => {
       const user = userEvent.setup()
-      useAppStore.setState({ appDetail: createMockApp({ id: 'app-replay-test' }) })
+      mockAppDetailReturn(createMockApp({ id: 'app-replay-test' }))
 
       render(<DetailPanel runID="run-to-replay" onClose={defaultOnClose} canReplay={true} />)
 
@@ -197,7 +215,7 @@ describe('DetailPanel', () => {
 
     it('should not navigate when replay clicked but appDetail is missing', async () => {
       const user = userEvent.setup()
-      useAppStore.setState({ appDetail: undefined })
+      mockAppDetailReturn(undefined)
 
       render(<DetailPanel runID="run-123" onClose={defaultOnClose} canReplay={true} />)
 
@@ -213,7 +231,7 @@ describe('DetailPanel', () => {
   // --------------------------------------------------------------------------
   describe('URL Generation', () => {
     it('should generate correct run detail URL', () => {
-      useAppStore.setState({ appDetail: createMockApp({ id: 'my-app' }) })
+      mockAppDetailReturn(createMockApp({ id: 'my-app' }))
 
       render(<DetailPanel runID="my-run" onClose={defaultOnClose} />)
 
@@ -221,7 +239,7 @@ describe('DetailPanel', () => {
     })
 
     it('should generate correct tracing list URL', () => {
-      useAppStore.setState({ appDetail: createMockApp({ id: 'my-app' }) })
+      mockAppDetailReturn(createMockApp({ id: 'my-app' }))
 
       render(<DetailPanel runID="my-run" onClose={defaultOnClose} />)
 
@@ -229,7 +247,7 @@ describe('DetailPanel', () => {
     })
 
     it('should handle special characters in runID', () => {
-      useAppStore.setState({ appDetail: createMockApp({ id: 'app-id' }) })
+      mockAppDetailReturn(createMockApp({ id: 'app-id' }))
 
       render(<DetailPanel runID="run-with-special-123" onClose={defaultOnClose} />)
 
@@ -242,7 +260,7 @@ describe('DetailPanel', () => {
   // --------------------------------------------------------------------------
   describe('Store Integration', () => {
     it('should read appDetail from store', () => {
-      useAppStore.setState({ appDetail: createMockApp({ id: 'store-app-id' }) })
+      mockAppDetailReturn(createMockApp({ id: 'store-app-id' }))
 
       render(<DetailPanel runID="run-123" onClose={defaultOnClose} />)
 
@@ -250,7 +268,7 @@ describe('DetailPanel', () => {
     })
 
     it('should handle undefined appDetail from store gracefully', () => {
-      useAppStore.setState({ appDetail: undefined })
+      mockAppDetailReturn(undefined)
 
       render(<DetailPanel runID="run-123" onClose={defaultOnClose} />)
 
@@ -272,7 +290,7 @@ describe('DetailPanel', () => {
 
     it('should handle very long runID', () => {
       const longRunId = 'a'.repeat(100)
-      useAppStore.setState({ appDetail: createMockApp({ id: 'app-id' }) })
+      mockAppDetailReturn(createMockApp({ id: 'app-id' }))
 
       render(<DetailPanel runID={longRunId} onClose={defaultOnClose} />)
 

--- a/web/app/components/app/workflow-log/detail.tsx
+++ b/web/app/components/app/workflow-log/detail.tsx
@@ -1,12 +1,12 @@
 'use client'
 import type { FC } from 'react'
 import { RiCloseLine, RiPlayLargeLine } from '@remixicon/react'
-import { useRouter } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
-import { useStore } from '@/app/components/app/store'
 import TooltipPlus from '@/app/components/base/tooltip'
 import { WorkflowContextProvider } from '@/app/components/workflow/context'
 import Run from '@/app/components/workflow/run'
+import { useAppDetail } from '@/service/use-apps'
 
 type ILogDetail = {
   runID: string
@@ -16,7 +16,8 @@ type ILogDetail = {
 
 const DetailPanel: FC<ILogDetail> = ({ runID, onClose, canReplay = false }) => {
   const { t } = useTranslation()
-  const appDetail = useStore(state => state.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const router = useRouter()
 
   const handleReplay = () => {

--- a/web/app/components/app/workflow-log/index.spec.tsx
+++ b/web/app/components/app/workflow-log/index.spec.tsx
@@ -34,6 +34,18 @@ import Logs from './index'
 
 vi.mock('@/service/use-log')
 
+vi.mock('@/service/use-apps', () => ({
+  useAppDetail: () => ({
+    data: {
+      id: 'test-app-id',
+      name: 'Test App',
+      mode: 'workflow',
+    },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
 vi.mock('ahooks', () => ({
   useDebounce: <T,>(value: T) => value,
   useDebounceFn: (fn: (value: string) => void) => ({ run: fn }),
@@ -50,6 +62,9 @@ vi.mock('ahooks', () => ({
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
+  }),
+  useParams: () => ({
+    appId: 'test-app-id',
   }),
 }))
 

--- a/web/app/components/base/agent-log-modal/detail.tsx
+++ b/web/app/components/base/agent-log-modal/detail.tsx
@@ -4,14 +4,15 @@ import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import type { AgentIteration, AgentLogDetailResponse } from '@/models/log'
 import { uniq } from 'es-toolkit/array'
 import { flatten } from 'es-toolkit/compat'
+import { useParams } from 'next/navigation'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useContext } from 'use-context-selector'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Loading from '@/app/components/base/loading'
 import { ToastContext } from '@/app/components/base/toast'
 import { fetchAgentLogDetail } from '@/service/log'
+import { useAppDetail } from '@/service/use-apps'
 import { cn } from '@/utils/classnames'
 import ResultPanel from './result'
 import TracingPanel from './tracing'
@@ -32,7 +33,8 @@ const AgentLogDetail: FC<AgentLogDetailProps> = ({
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
   const [currentTab, setCurrentTab] = useState<string>(activeTab)
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const [loading, setLoading] = useState<boolean>(true)
   const [runDetail, setRunDetail] = useState<AgentLogDetailResponse>()
   const [list, setList] = useState<AgentIteration[]>([])

--- a/web/app/components/base/message-log-modal/index.tsx
+++ b/web/app/components/base/message-log-modal/index.tsx
@@ -2,10 +2,11 @@ import type { FC } from 'react'
 import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import { RiCloseLine } from '@remixicon/react'
 import { useClickAway } from 'ahooks'
+import { useParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore } from '@/app/components/app/store'
 import Run from '@/app/components/workflow/run'
+import { useAppDetail } from '@/service/use-apps'
 import { cn } from '@/utils/classnames'
 
 type MessageLogModalProps = {
@@ -25,7 +26,8 @@ const MessageLogModal: FC<MessageLogModalProps> = ({
   const { t } = useTranslation()
   const ref = useRef(null)
   const [mounted, setMounted] = useState(false)
-  const appDetail = useStore(state => state.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
 
   useClickAway(() => {
     if (mounted)

--- a/web/app/components/develop/index.tsx
+++ b/web/app/components/develop/index.tsx
@@ -1,17 +1,17 @@
 'use client'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Loading from '@/app/components/base/loading'
 import ApiServer from '@/app/components/develop/ApiServer'
 import Doc from '@/app/components/develop/doc'
+import { useAppDetail } from '@/service/use-apps'
 
 type IDevelopMainProps = {
   appId: string
 }
 
 const DevelopMain = ({ appId }: IDevelopMainProps) => {
-  const appDetail = useAppStore(state => state.appDetail)
+  const { data: appDetail, isPending } = useAppDetail(appId)
 
-  if (!appDetail) {
+  if (isPending || !appDetail) {
     return (
       <div className="flex h-full items-center justify-center bg-background-default">
         <Loading />

--- a/web/app/components/header/nav/index.tsx
+++ b/web/app/components/header/nav/index.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import { useSelectedLayoutSegment } from 'next/navigation'
 import * as React from 'react'
 import { useState } from 'react'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { ArrowNarrowLeft } from '@/app/components/base/icons/src/vender/line/arrows'
 import { cn } from '@/utils/classnames'
 import NavSelector from './nav-selector'
@@ -33,7 +32,6 @@ const Nav = ({
   isLoadingMore,
   isApp,
 }: INavProps) => {
-  const setAppDetail = useAppStore(state => state.setAppDetail)
   const [hovered, setHovered] = useState(false)
   const segment = useSelectedLayoutSegment()
   const isActivated = Array.isArray(activeSegment) ? activeSegment.includes(segment!) : segment === activeSegment
@@ -47,12 +45,6 @@ const Nav = ({
     >
       <Link href={link}>
         <div
-          onClick={(e) => {
-            // Don't clear state if opening in new tab/window
-            if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0)
-              return
-            setAppDetail()
-          }}
           className={cn('flex h-7 cursor-pointer items-center rounded-[10px] px-2.5', isActivated ? 'text-components-main-nav-nav-button-text-active' : 'text-components-main-nav-nav-button-text', curNav && isActivated && 'hover:bg-components-main-nav-nav-button-bg-active-hover')}
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}

--- a/web/app/components/header/nav/nav-selector/index.tsx
+++ b/web/app/components/header/nav/nav-selector/index.tsx
@@ -10,7 +10,6 @@ import { debounce } from 'es-toolkit/compat'
 import { useRouter } from 'next/navigation'
 import { Fragment, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { AppTypeIcon } from '@/app/components/app/type-selector'
 import AppIcon from '@/app/components/base/app-icon'
 import { FileArrow01, FilePlus01, FilePlus02 } from '@/app/components/base/icons/src/vender/line/files'
@@ -42,7 +41,6 @@ const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onL
   const { t } = useTranslation()
   const router = useRouter()
   const { isCurrentWorkspaceEditor } = useAppContext()
-  const setAppDetail = useAppStore(state => state.setAppDetail)
 
   const handleScroll = useCallback(debounce((e) => {
     if (typeof onLoadMore === 'function') {
@@ -84,7 +82,6 @@ const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onL
                       onClick={() => {
                         if (curNav?.id === nav.id)
                           return
-                        setAppDetail()
                         router.push(nav.link)
                       }}
                       title={nav.name}

--- a/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@/app/components/workflow/types'
 import type { PublishWorkflowParams } from '@/types/workflow'
 import { RiApps2AddLine } from '@remixicon/react'
+import { useParams } from 'next/navigation'
 import {
   memo,
   useCallback,
@@ -14,7 +15,6 @@ import {
 import { useTranslation } from 'react-i18next'
 import { useEdges } from 'reactflow'
 import AppPublisher from '@/app/components/app/app-publisher'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Button from '@/app/components/base/button'
 import { useFeatures } from '@/app/components/base/features/hooks'
 import { useToastContext } from '@/app/components/base/toast'
@@ -39,7 +39,7 @@ import {
 } from '@/app/components/workflow/types'
 import { useProviderContext } from '@/context/provider-context'
 import useTheme from '@/hooks/use-theme'
-import { fetchAppDetail } from '@/service/apps'
+import { useInvalidateAppDetail } from '@/service/use-apps'
 import { useInvalidateAppTriggers } from '@/service/use-tools'
 import { useInvalidateAppWorkflow, usePublishWorkflow, useResetWorkflowVersionHistory } from '@/service/use-workflow'
 import { cn } from '@/utils/classnames'
@@ -49,9 +49,9 @@ const FeaturesTrigger = () => {
   const { theme } = useTheme()
   const isChatMode = useIsChatMode()
   const workflowStore = useWorkflowStore()
-  const appDetail = useAppStore(s => s.appDetail)
-  const appID = appDetail?.id
-  const setAppDetail = useAppStore(s => s.setAppDetail)
+  const { appId } = useParams()
+  const appID = appId as string
+  const invalidateAppDetail = useInvalidateAppDetail()
   const { nodesReadOnly, getNodesReadOnly } = useNodesReadOnly()
   const { plan, isFetchedPlan } = useProviderContext()
   const publishedAt = useStore(s => s.publishedAt)
@@ -125,15 +125,9 @@ const FeaturesTrigger = () => {
     setShowFeaturesPanel(!showFeaturesPanel)
   }, [workflowStore, getNodesReadOnly])
 
-  const updateAppDetail = useCallback(async () => {
-    try {
-      const res = await fetchAppDetail({ url: '/apps', id: appID! })
-      setAppDetail({ ...res })
-    }
-    catch (error) {
-      console.error(error)
-    }
-  }, [appID, setAppDetail])
+  const updateAppDetail = useCallback(() => {
+    invalidateAppDetail(appID)
+  }, [appID, invalidateAppDetail])
 
   const { mutateAsync: publishWorkflow } = usePublishWorkflow()
   // const { validateBeforeRun } = useWorkflowRunValidation()

--- a/web/app/components/workflow-app/components/workflow-header/index.spec.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/index.spec.tsx
@@ -4,10 +4,10 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { AppModeEnum } from '@/types/app'
 import WorkflowHeader from './index'
 
-const mockUseAppStoreSelector = vi.fn()
 const mockSetCurrentLogItem = vi.fn()
 const mockSetShowMessageLogModal = vi.fn()
 const mockResetWorkflowVersionHistory = vi.fn()
+const mockUseAppDetail = vi.fn()
 
 const createMockApp = (overrides: Partial<App> = {}): App => ({
   id: 'app-id',
@@ -39,19 +39,24 @@ const createMockApp = (overrides: Partial<App> = {}): App => ({
   ...overrides,
 })
 
-let appDetail: App
-
 const mockAppStore = (overrides: Partial<App> = {}) => {
-  appDetail = createMockApp(overrides)
-  mockUseAppStoreSelector.mockImplementation(selector => selector({
-    appDetail,
-    setCurrentLogItem: mockSetCurrentLogItem,
-    setShowMessageLogModal: mockSetShowMessageLogModal,
-  }))
+  const appDetail = createMockApp(overrides)
+  mockUseAppDetail.mockReturnValue({ data: appDetail })
 }
 
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ appId: 'app-id' }),
+}))
+
+vi.mock('@/service/use-apps', () => ({
+  useAppDetail: (...args: unknown[]) => mockUseAppDetail(...args),
+}))
+
 vi.mock('@/app/components/app/store', () => ({
-  useStore: (selector: (state: { appDetail?: App, setCurrentLogItem: typeof mockSetCurrentLogItem, setShowMessageLogModal: typeof mockSetShowMessageLogModal }) => unknown) => mockUseAppStoreSelector(selector),
+  useStore: (selector: (state: { setCurrentLogItem: typeof mockSetCurrentLogItem, setShowMessageLogModal: typeof mockSetShowMessageLogModal }) => unknown) => selector({
+    setCurrentLogItem: mockSetCurrentLogItem,
+    setShowMessageLogModal: mockSetShowMessageLogModal,
+  }),
 }))
 
 vi.mock('@/app/components/workflow/header', () => ({

--- a/web/app/components/workflow-app/components/workflow-header/index.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/index.tsx
@@ -1,23 +1,23 @@
 import type { HeaderProps } from '@/app/components/workflow/header'
+import { useParams } from 'next/navigation'
 import {
   memo,
   useCallback,
   useMemo,
 } from 'react'
-import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import Header from '@/app/components/workflow/header'
+import { useAppDetail } from '@/service/use-apps'
 import { useResetWorkflowVersionHistory } from '@/service/use-workflow'
 import { useIsChatMode } from '../../hooks'
 import ChatVariableTrigger from './chat-variable-trigger'
 import FeaturesTrigger from './features-trigger'
 
 const WorkflowHeader = () => {
-  const { appDetail, setCurrentLogItem, setShowMessageLogModal } = useAppStore(useShallow(state => ({
-    appDetail: state.appDetail,
-    setCurrentLogItem: state.setCurrentLogItem,
-    setShowMessageLogModal: state.setShowMessageLogModal,
-  })))
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
+  const setCurrentLogItem = useAppStore(state => state.setCurrentLogItem)
+  const setShowMessageLogModal = useAppStore(state => state.setShowMessageLogModal)
   const resetWorkflowVersionHistory = useResetWorkflowVersionHistory()
   const isChatMode = useIsChatMode()
 

--- a/web/app/components/workflow-app/components/workflow-panel.tsx
+++ b/web/app/components/workflow-app/components/workflow-panel.tsx
@@ -1,5 +1,6 @@
 import type { PanelProps } from '@/app/components/workflow/panel'
 import dynamic from 'next/dynamic'
+import { useParams } from 'next/navigation'
 import {
   memo,
   useMemo,
@@ -8,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import Panel from '@/app/components/workflow/panel'
 import { useStore } from '@/app/components/workflow/store'
+import { useAppDetail } from '@/service/use-apps'
 import {
   useIsChatMode,
 } from '../hooks'
@@ -104,16 +106,16 @@ const WorkflowPanelOnRight = () => {
   )
 }
 const WorkflowPanel = () => {
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const versionHistoryPanelProps = useMemo(() => {
-    const appId = appDetail?.id
     return {
       getVersionListUrl: `/apps/${appId}/workflows`,
       deleteVersionUrl: (versionId: string) => `/apps/${appId}/workflows/${versionId}`,
       updateVersionUrl: (versionId: string) => `/apps/${appId}/workflows/${versionId}`,
       latestVersionId: appDetail?.workflow?.id,
     }
-  }, [appDetail?.id, appDetail?.workflow?.id])
+  }, [appId, appDetail?.workflow?.id])
 
   const panelProps: PanelProps = useMemo(() => {
     return {

--- a/web/app/components/workflow-app/hooks/use-DSL.ts
+++ b/web/app/components/workflow-app/hooks/use-DSL.ts
@@ -1,15 +1,16 @@
+import { useParams } from 'next/navigation'
 import {
   useCallback,
   useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { useToastContext } from '@/app/components/base/toast'
 import {
   DSL_EXPORT_CHECK,
 } from '@/app/components/workflow/constants'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import { exportAppConfig } from '@/service/apps'
+import { useAppDetail } from '@/service/use-apps'
 import { fetchWorkflowDraft } from '@/service/workflow'
 import { useNodesSyncDraft } from './use-nodes-sync-draft'
 
@@ -20,7 +21,8 @@ export const useDSL = () => {
   const [exporting, setExporting] = useState(false)
   const { doSyncWorkflowDraft } = useNodesSyncDraft()
 
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
 
   const handleExportDSL = useCallback(async (include = false, workflowId?: string) => {
     if (!appDetail)

--- a/web/app/components/workflow-app/hooks/use-is-chat-mode.ts
+++ b/web/app/components/workflow-app/hooks/use-is-chat-mode.ts
@@ -1,8 +1,10 @@
-import { useStore as useAppStore } from '@/app/components/app/store'
+import { useParams } from 'next/navigation'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 
 export const useIsChatMode = () => {
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
 
   return appDetail?.mode === AppModeEnum.ADVANCED_CHAT
 }

--- a/web/app/components/workflow-app/index.tsx
+++ b/web/app/components/workflow-app/index.tsx
@@ -2,12 +2,11 @@
 
 import type { Features as FeaturesData } from '@/app/components/base/features/types'
 import type { InjectWorkflowStoreSliceFn } from '@/app/components/workflow/store'
-import { useSearchParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import {
   useEffect,
   useMemo,
 } from 'react'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { FeaturesProvider } from '@/app/components/base/features'
 import Loading from '@/app/components/base/loading'
 import { FILE_EXTS } from '@/app/components/base/prompt-editor/constants'
@@ -26,6 +25,7 @@ import {
 } from '@/app/components/workflow/utils'
 import { useAppContext } from '@/context/app-context'
 import { fetchRunDetail } from '@/service/log'
+import { useAppDetail } from '@/service/use-apps'
 import { useAppTriggers } from '@/service/use-tools'
 import { AppModeEnum } from '@/types/app'
 import WorkflowAppMain from './components/workflow-main'
@@ -47,10 +47,10 @@ const WorkflowAppWithAdditionalContext = () => {
 
   // Initialize trigger status at application level
   const { setTriggerStatuses } = useTriggerStatusStore()
-  const appDetail = useAppStore(s => s.appDetail)
-  const appId = appDetail?.id
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const isWorkflowMode = appDetail?.mode === AppModeEnum.WORKFLOW
-  const { data: triggersResponse } = useAppTriggers(isWorkflowMode ? appId : undefined, {
+  const { data: triggersResponse } = useAppTriggers(isWorkflowMode ? appId as string : undefined, {
     staleTime: 5 * 60 * 1000, // 5 minutes cache
     refetchOnWindowFocus: false,
   })

--- a/web/app/components/workflow/header/view-workflow-history.tsx
+++ b/web/app/components/workflow/header/view-workflow-history.tsx
@@ -44,7 +44,6 @@ const ViewWorkflowHistory = () => {
 
   const { nodesReadOnly } = useNodesReadOnly()
   const { setCurrentLogItem, setShowMessageLogModal } = useAppStore(useShallow(state => ({
-    appDetail: state.appDetail,
     setCurrentLogItem: state.setCurrentLogItem,
     setShowMessageLogModal: state.setShowMessageLogModal,
   })))

--- a/web/app/components/workflow/hooks/use-auto-generate-webhook-url.ts
+++ b/web/app/components/workflow/hooks/use-auto-generate-webhook-url.ts
@@ -1,15 +1,15 @@
 import { produce } from 'immer'
+import { useParams } from 'next/navigation'
 import { useCallback } from 'react'
 import { useStoreApi } from 'reactflow'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { fetchWebhookUrl } from '@/service/apps'
 
 export const useAutoGenerateWebhookUrl = () => {
   const reactFlowStore = useStoreApi()
+  const { appId } = useParams()
 
   return useCallback(async (nodeId: string) => {
-    const appId = useAppStore.getState().appDetail?.id
     if (!appId)
       return
 
@@ -22,7 +22,7 @@ export const useAutoGenerateWebhookUrl = () => {
       return
 
     try {
-      const response = await fetchWebhookUrl({ appId, nodeId })
+      const response = await fetchWebhookUrl({ appId: appId as string, nodeId })
       const { getNodes: getLatestNodes, setNodes } = reactFlowStore.getState()
       let hasUpdated = false
       const updatedNodes = produce(getLatestNodes(), (draft) => {
@@ -44,5 +44,5 @@ export const useAutoGenerateWebhookUrl = () => {
     catch (error: unknown) {
       console.error('Failed to auto-generate webhook URL:', error)
     }
-  }, [reactFlowStore])
+  }, [reactFlowStore, appId])
 }

--- a/web/app/components/workflow/hooks/use-checklist.ts
+++ b/web/app/components/workflow/hooks/use-checklist.ts
@@ -14,6 +14,7 @@ import type {
 import type { Emoji } from '@/app/components/tools/types'
 import type { DataSet } from '@/models/datasets'
 import type { I18nKeysWithPrefix } from '@/types/i18n'
+import { useParams } from 'next/navigation'
 import {
   useCallback,
   useMemo,
@@ -21,7 +22,6 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEdges, useStoreApi } from 'reactflow'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { useToastContext } from '@/app/components/base/toast'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useModelList } from '@/app/components/header/account-setting/model-provider-page/hooks'
@@ -29,6 +29,7 @@ import useNodes from '@/app/components/workflow/store/workflow/use-nodes'
 import { MAX_TREE_DEPTH } from '@/config'
 import { useGetLanguage } from '@/context/i18n'
 import { fetchDatasets } from '@/service/datasets'
+import { useAppDetail } from '@/service/use-apps'
 import { useStrategyProviders } from '@/service/use-strategy'
 import {
   useAllBuiltInTools,
@@ -96,7 +97,9 @@ export const useChecklist = (nodes: Node[], edges: Edge[]) => {
   const { data: triggerPlugins } = useAllTriggerPlugins()
   const datasetsDetail = useDatasetsDetailStore(s => s.datasetsDetail)
   const getToolIcon = useGetToolIcon()
-  const appMode = useAppStore.getState().appDetail?.mode
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
+  const appMode = appDetail?.mode
   const shouldCheckStartNode = appMode === AppModeEnum.WORKFLOW || appMode === AppModeEnum.ADVANCED_CHAT
 
   const map = useNodesAvailableVarList(nodes)
@@ -249,7 +252,7 @@ export const useChecklist = (nodes: Node[], edges: Edge[]) => {
     })
 
     return list
-  }, [nodes, nodesExtraData, edges, buildInTools, customTools, workflowTools, language, dataSourceList, getToolIcon, strategyProviders, getCheckData, t, map, shouldCheckStartNode])
+  }, [nodes, nodesExtraData, edges, buildInTools, customTools, workflowTools, language, dataSourceList, getToolIcon, strategyProviders, triggerPlugins, getCheckData, t, map, shouldCheckStartNode])
 
   return needWarningNodes
 }
@@ -270,7 +273,9 @@ export const useChecklistBeforePublish = () => {
   const { data: buildInTools } = useAllBuiltInTools()
   const { data: customTools } = useAllCustomTools()
   const { data: workflowTools } = useAllWorkflowTools()
-  const appMode = useAppStore.getState().appDetail?.mode
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
+  const appMode = appDetail?.mode
   const shouldCheckStartNode = appMode === AppModeEnum.WORKFLOW || appMode === AppModeEnum.ADVANCED_CHAT
 
   const getCheckData = useCallback((data: CommonNodeType<{}>, datasets: DataSet[]) => {
@@ -419,7 +424,7 @@ export const useChecklistBeforePublish = () => {
     }
 
     return true
-  }, [store, notify, t, language, nodesExtraData, strategyProviders, updateDatasetsDetail, getCheckData, workflowStore, buildInTools, customTools, workflowTools, shouldCheckStartNode])
+  }, [store, notify, t, language, nodesExtraData, strategyProviders, updateDatasetsDetail, getCheckData, workflowStore, buildInTools, customTools, workflowTools, shouldCheckStartNode, getNodesAvailableVarList])
 
   return {
     handleCheckBeforePublish,

--- a/web/app/components/workflow/hooks/use-workflow.ts
+++ b/web/app/components/workflow/hooks/use-workflow.ts
@@ -10,6 +10,7 @@ import type {
   ValueSelector,
 } from '../types'
 import { uniqBy } from 'es-toolkit/compat'
+import { useParams } from 'next/navigation'
 import {
   useCallback,
 } from 'react'
@@ -18,9 +19,9 @@ import {
   getOutgoers,
   useStoreApi,
 } from 'reactflow'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import { CUSTOM_ITERATION_START_NODE } from '@/app/components/workflow/nodes/iteration-start/constants'
 import { CUSTOM_LOOP_START_NODE } from '@/app/components/workflow/nodes/loop-start/constants'
+import { useAppDetail } from '@/service/use-apps'
 import { AppModeEnum } from '@/types/app'
 import { useNodesMetaData } from '.'
 import {
@@ -43,7 +44,8 @@ import {
 import { useAvailableBlocks } from './use-available-blocks'
 
 export const useIsChatMode = () => {
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
 
   return appDetail?.mode === AppModeEnum.ADVANCED_CHAT
 }

--- a/web/app/components/workflow/nodes/_base/components/workflow-panel/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/workflow-panel/index.tsx
@@ -7,6 +7,7 @@ import {
   RiPlayLargeLine,
 } from '@remixicon/react'
 import { debounce } from 'es-toolkit/compat'
+import { useParams } from 'next/navigation'
 import * as React from 'react'
 import {
   cloneElement,
@@ -60,6 +61,7 @@ import {
   isSupportCustomRunForm,
 } from '@/app/components/workflow/utils'
 import { useModalContext } from '@/context/modal-context'
+import { useAppDetail } from '@/service/use-apps'
 import { useAllBuiltInTools } from '@/service/use-tools'
 import { useAllTriggerPlugins } from '@/service/use-triggers'
 import { FlowType } from '@/types/common'
@@ -109,6 +111,8 @@ const BasePanel: FC<BasePanelProps> = ({
 }) => {
   const { t } = useTranslation()
   const language = useLanguage()
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const { showMessageLogModal } = useAppStore(useShallow(state => ({
     showMessageLogModal: state.showMessageLogModal,
   })))
@@ -196,7 +200,6 @@ const BasePanel: FC<BasePanelProps> = ({
 
   const isChildNode = !!(data.isInIteration || data.isInLoop)
   const isSupportSingleRun = canRunBySingle(data.type, isChildNode)
-  const appDetail = useAppStore(state => state.appDetail)
 
   const hasClickRunning = useRef(false)
   const [isPaused, setIsPaused] = useState(false)

--- a/web/app/components/workflow/nodes/trigger-webhook/use-config.ts
+++ b/web/app/components/workflow/nodes/trigger-webhook/use-config.ts
@@ -1,10 +1,10 @@
 import type { HttpMethod, WebhookHeader, WebhookParameter, WebhookTriggerNodeType } from './types'
 import type { Variable } from '@/app/components/workflow/types'
 import { produce } from 'immer'
+import { useParams } from 'next/navigation'
 import { useCallback } from 'react'
 
 import { useTranslation } from 'react-i18next'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Toast from '@/app/components/base/toast'
 import { useNodesReadOnly, useWorkflow } from '@/app/components/workflow/hooks'
 import useNodeCrud from '@/app/components/workflow/nodes/_base/hooks/use-node-crud'
@@ -17,7 +17,7 @@ const useConfig = (id: string, payload: WebhookTriggerNodeType) => {
   const { t } = useTranslation()
   const { nodesReadOnly: readOnly } = useNodesReadOnly()
   const { inputs, setInputs } = useNodeCrud<WebhookTriggerNodeType>(id, payload)
-  const appId = useAppStore.getState().appDetail?.id
+  const { appId } = useParams()
   const { isVarUsedInNodes, removeUsedVarInNodes } = useWorkflow()
 
   const handleMethodChange = useCallback((method: HttpMethod) => {
@@ -217,7 +217,7 @@ const useConfig = (id: string, payload: WebhookTriggerNodeType) => {
 
     try {
       // Call backend to generate or fetch webhook url for this node
-      const response = await fetchWebhookUrl({ appId, nodeId: id })
+      const response = await fetchWebhookUrl({ appId: appId as string, nodeId: id })
 
       const newInputs = produce(inputs, (draft) => {
         draft.webhook_url = response.webhook_url

--- a/web/app/components/workflow/panel/chat-record/index.tsx
+++ b/web/app/components/workflow/panel/chat-record/index.tsx
@@ -1,18 +1,19 @@
 import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import type { ChatItem, ChatItemInTree } from '@/app/components/base/chat/types'
 import { RiCloseLine } from '@remixicon/react'
+import { useParams } from 'next/navigation'
 import {
   memo,
   useCallback,
   useEffect,
   useState,
 } from 'react'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Chat from '@/app/components/base/chat/chat'
 import { buildChatItemTree, getThreadMessages } from '@/app/components/base/chat/utils'
 import { getProcessedFilesFromResponse } from '@/app/components/base/file-uploader/utils'
 import Loading from '@/app/components/base/loading'
 import { fetchConversationMessages } from '@/service/debug'
+import { useAppDetail } from '@/service/use-apps'
 import { useWorkflowRun } from '../../hooks'
 import {
   useStore,
@@ -51,7 +52,8 @@ const ChatRecord = () => {
   const [fetched, setFetched] = useState(false)
   const [chatItemTree, setChatItemTree] = useState<ChatItemInTree[]>([])
   const [threadChatItems, setThreadChatItems] = useState<IChatItem[]>([])
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const workflowStore = useWorkflowStore()
   const { handleLoadBackupDraft } = useWorkflowRun()
   const historyWorkflowData = useStore(s => s.historyWorkflowData)

--- a/web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx
@@ -2,9 +2,9 @@ import type { StartNodeType } from '../../nodes/start/types'
 import type { ChatWrapperRefType } from './index'
 import type { ChatItem, OnSend } from '@/app/components/base/chat/types'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
+import { useParams } from 'next/navigation'
 import { memo, useCallback, useEffect, useImperativeHandle, useMemo } from 'react'
 import { useNodes } from 'reactflow'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Chat from '@/app/components/base/chat/chat'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
 import { useFeatures } from '@/app/components/base/features/hooks'
@@ -14,6 +14,7 @@ import {
   fetchSuggestedQuestions,
   stopChatMessageResponding,
 } from '@/service/debug'
+import { useAppDetail } from '@/service/use-apps'
 import {
   useStore,
   useWorkflowStore,
@@ -45,7 +46,8 @@ const ChatWrapper = (
   const nodes = useNodes<StartNodeType>()
   const startNode = nodes.find(node => node.data.type === BlockEnum.Start)
   const startVariables = startNode?.data.variables
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const workflowStore = useWorkflowStore()
   const inputs = useStore(s => s.inputs)
   const setInputs = useStore(s => s.setInputs)

--- a/web/app/components/workflow/update-dsl-modal.tsx
+++ b/web/app/components/workflow/update-dsl-modal.tsx
@@ -11,6 +11,7 @@ import {
   RiFileDownloadLine,
 } from '@remixicon/react'
 import { load as yamlLoad } from 'js-yaml'
+import { useParams } from 'next/navigation'
 import {
   memo,
   useCallback,
@@ -20,7 +21,6 @@ import {
 import { useTranslation } from 'react-i18next'
 import { useContext } from 'use-context-selector'
 import Uploader from '@/app/components/app/create-from-dsl-modal/uploader'
-import { useStore as useAppStore } from '@/app/components/app/store'
 import Button from '@/app/components/base/button'
 import Modal from '@/app/components/base/modal'
 import { FILE_EXTS } from '@/app/components/base/prompt-editor/constants'
@@ -35,6 +35,7 @@ import {
   importDSL,
   importDSLConfirm,
 } from '@/service/apps'
+import { useAppDetail } from '@/service/use-apps'
 import { fetchWorkflowDraft } from '@/service/workflow'
 import { AppModeEnum } from '@/types/app'
 import { WORKFLOW_DATA_UPDATE } from './constants'
@@ -60,7 +61,8 @@ const UpdateDSLModal = ({
 }: UpdateDSLModalProps) => {
   const { t } = useTranslation()
   const { notify } = useContext(ToastContext)
-  const appDetail = useAppStore(s => s.appDetail)
+  const { appId } = useParams()
+  const { data: appDetail } = useAppDetail(appId as string)
   const [currentFile, setDSLFile] = useState<File>()
   const [fileContent, setFileContent] = useState<string>()
   const [loading, setLoading] = useState(false)

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -253,9 +253,6 @@
     }
   },
   "app/components/app/app-publisher/index.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
       "count": 6
     }

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -608,11 +608,6 @@
       "count": 1
     }
   },
-  "app/components/app/switch-app-modal/index.spec.tsx": {
-    "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
   "app/components/app/switch-app-modal/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -73,19 +73,6 @@
       "count": 1
     }
   },
-  "app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
-    },
-    "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/svg-attribute-error-reproduction.spec.tsx": {
     "no-console": {
       "count": 19
@@ -2184,19 +2171,6 @@
   "app/components/header/account-setting/plugin-page/utils.ts": {
     "ts/no-explicit-any": {
       "count": 4
-    }
-  },
-  "app/components/header/app-nav/index.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
-    },
-    "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/header/dataset-nav/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 6
     }
   },
   "app/components/header/header-wrapper.tsx": {

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -73,14 +73,6 @@
       "count": 1
     }
   },
-  "app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
-    },
-    "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
   "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx": {
     "react-hooks/preserve-manual-memoization": {
       "count": 1
@@ -700,9 +692,6 @@
   },
   "app/components/base/agent-log-modal/index.stories.tsx": {
     "no-console": {
-      "count": 1
-    },
-    "ts/no-explicit-any": {
       "count": 1
     }
   },
@@ -2439,14 +2428,6 @@
   "app/components/header/account-setting/plugin-page/utils.ts": {
     "ts/no-explicit-any": {
       "count": 4
-    }
-  },
-  "app/components/header/app-nav/index.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
-    },
-    "ts/no-explicit-any": {
-      "count": 1
     }
   },
   "app/components/header/dataset-nav/index.tsx": {

--- a/web/service/use-apps.ts
+++ b/web/service/use-apps.ts
@@ -94,6 +94,17 @@ export const useAppDetail = (appID: string) => {
   })
 }
 
+export const useInvalidateAppDetail = () => {
+  const queryClient = useQueryClient()
+  return (appId?: string) => {
+    if (!appId)
+      return
+    queryClient.invalidateQueries({
+      queryKey: [NAME_SPACE, 'detail', appId],
+    })
+  }
+}
+
 export const useAppList = (params: AppListParams, options?: { enabled?: boolean }) => {
   const normalizedParams = normalizeAppListParams(params)
   return useQuery<AppListResponse>({


### PR DESCRIPTION
## Summary
- Migrate `appDetail` state management from Zustand store to TanStack Query
- Remove `appDetail` and `setAppDetail` from Zustand store
- Update all components to use the new TanStack Query pattern
- Update all tests to mock query functions

Closes #31181
Closes #31171