### PR TITLE
chore: drop slow lint rules

### DIFF
--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -81,11 +81,6 @@
       "count": 1
     }
   },
-  "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/svg-attribute-error-reproduction.spec.tsx": {
     "no-console": {
       "count": 19
@@ -95,9 +90,6 @@
     }
   },
   "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-panel.tsx": {
-    "react-hooks/static-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -129,11 +121,6 @@
   },
   "app/account/(commonLayout)/account-page/index.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/account/(commonLayout)/delete-account/components/feed-back.tsx": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
   },
@@ -253,9 +240,6 @@
     }
   },
   "app/components/app/app-publisher/features-wrapper.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 19
-    },
     "ts/no-explicit-any": {
       "count": 4
     }
@@ -280,11 +264,6 @@
   },
   "app/components/app/configuration/config-prompt/index.spec.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/app/configuration/config-prompt/prompt-editor-height-resize-wrap.tsx": {
-    "react-hooks/use-memo": {
       "count": 1
     }
   },
@@ -322,9 +301,6 @@
     }
   },
   "app/components/app/configuration/config/agent/agent-tools/index.spec.tsx": {
-    "react-hooks/globals": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 5
     }
@@ -375,11 +351,6 @@
       "count": 1
     }
   },
-  "app/components/app/configuration/config/automatic/version-selector.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/app/configuration/config/code-generator/get-code-generator-res.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 4
@@ -415,11 +386,6 @@
   },
   "app/components/app/configuration/dataset-config/index.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/app/configuration/dataset-config/params-config/config-content.tsx": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
   },
@@ -485,9 +451,6 @@
     }
   },
   "app/components/app/configuration/debug/hooks.tsx": {
-    "react-hooks/refs": {
-      "count": 7
-    },
     "ts/no-explicit-any": {
       "count": 3
     }
@@ -567,9 +530,6 @@
   "app/components/app/log/list.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 6
-    },
-    "react-hooks/refs": {
-      "count": 2
     },
     "style/multiline-ternary": {
       "count": 2
@@ -779,9 +739,6 @@
     }
   },
   "app/components/base/chat/chat-with-history/chat-wrapper.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 6
     }
@@ -864,9 +821,6 @@
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
     },
-    "react-hooks/refs": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 15
     }
@@ -890,9 +844,6 @@
     }
   },
   "app/components/base/chat/embedded-chatbot/chat-wrapper.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 6
     }
@@ -905,9 +856,6 @@
   "app/components/base/chat/embedded-chatbot/hooks.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 6
-    },
-    "react-hooks/refs": {
-      "count": 5
     },
     "ts/no-explicit-any": {
       "count": 16
@@ -957,17 +905,11 @@
   "app/components/base/date-and-time-picker/date-picker/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 4
-    },
-    "react-hooks/refs": {
-      "count": 5
     }
   },
   "app/components/base/date-and-time-picker/time-picker/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 3
     }
   },
   "app/components/base/dialog/index.stories.tsx": {
@@ -982,11 +924,6 @@
   },
   "app/components/base/error-boundary/index.tsx": {
     "ts/no-explicit-any": {
-      "count": 2
-    }
-  },
-  "app/components/base/features/context.tsx": {
-    "react-hooks/refs": {
       "count": 2
     }
   },
@@ -1005,11 +942,6 @@
       "count": 2
     }
   },
-  "app/components/base/features/new-feature-panel/conversation-opener/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/base/features/new-feature-panel/conversation-opener/modal.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
@@ -1026,9 +958,6 @@
     }
   },
   "app/components/base/features/new-feature-panel/moderation/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -1059,16 +988,8 @@
     }
   },
   "app/components/base/file-uploader/hooks.ts": {
-    "react-hooks/use-memo": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 3
-    }
-  },
-  "app/components/base/file-uploader/store.tsx": {
-    "react-hooks/refs": {
-      "count": 2
     }
   },
   "app/components/base/file-uploader/utils.spec.ts": {
@@ -1085,17 +1006,11 @@
     }
   },
   "app/components/base/form/components/base/base-field.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 3
     }
   },
   "app/components/base/form/components/base/base-form.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 6
     }
@@ -1159,9 +1074,6 @@
     }
   },
   "app/components/base/form/hooks/use-get-validators.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 3
     }
@@ -1251,9 +1163,6 @@
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 10
     },
-    "react-hooks/refs": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 9
     }
@@ -1336,9 +1245,6 @@
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 7
     },
-    "react-hooks/purity": {
-      "count": 1
-    },
     "regexp/no-super-linear-backtracking": {
       "count": 3
     },
@@ -1406,15 +1312,9 @@
   "app/components/base/notion-page-selector/page-selector/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
-    },
-    "react-hooks/immutability": {
-      "count": 1
     }
   },
   "app/components/base/pagination/index.tsx": {
-    "react-hooks/refs": {
-      "count": 2
-    },
     "unicorn/prefer-number-properties": {
       "count": 1
     }
@@ -1430,12 +1330,6 @@
     }
   },
   "app/components/base/portal-to-follow-elem/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
-    "react-hooks/refs": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -1450,11 +1344,6 @@
   },
   "app/components/base/prompt-editor/index.tsx": {
     "ts/no-explicit-any": {
-      "count": 2
-    }
-  },
-  "app/components/base/prompt-editor/plugins/component-picker-block/hooks.tsx": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 2
     }
   },
@@ -1489,9 +1378,6 @@
     }
   },
   "app/components/base/prompt-editor/plugins/workflow-variable-block/workflow-variable-block-replacement-block.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -1534,11 +1420,6 @@
       "count": 1
     }
   },
-  "app/components/base/search-input/index.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    }
-  },
   "app/components/base/select/index.stories.tsx": {
     "no-console": {
       "count": 4
@@ -1556,11 +1437,6 @@
     },
     "ts/no-explicit-any": {
       "count": 1
-    }
-  },
-  "app/components/base/select/pure.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
     }
   },
   "app/components/base/slider/index.stories.tsx": {
@@ -1629,15 +1505,7 @@
     "no-console": {
       "count": 2
     },
-    "react-hooks/purity": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/base/voice-input/index.tsx": {
-    "react-hooks/immutability": {
       "count": 1
     }
   },
@@ -1716,11 +1584,6 @@
       "count": 1
     }
   },
-  "app/components/datasets/common/document-status-with-action/auto-disabled-document.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 5
-    }
-  },
   "app/components/datasets/common/image-previewer/index.tsx": {
     "no-irregular-whitespace": {
       "count": 1
@@ -1729,11 +1592,6 @@
   "app/components/datasets/common/image-uploader/hooks/use-upload.ts": {
     "ts/no-explicit-any": {
       "count": 3
-    }
-  },
-  "app/components/datasets/common/image-uploader/store.tsx": {
-    "react-hooks/refs": {
-      "count": 2
     }
   },
   "app/components/datasets/common/image-uploader/utils.ts": {
@@ -1746,20 +1604,12 @@
       "count": 1
     }
   },
-  "app/components/datasets/common/retrieval-param-config/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/datasets/create/file-preview/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
     }
   },
   "app/components/datasets/create/file-uploader/index.tsx": {
-    "react-hooks/immutability": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 3
     }
@@ -1873,9 +1723,6 @@
   "app/components/datasets/documents/create-from-pipeline/data-source/online-documents/page-selector/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
-    },
-    "react-hooks/immutability": {
-      "count": 1
     }
   },
   "app/components/datasets/documents/create-from-pipeline/data-source/online-drive/connect/index.spec.tsx": {
@@ -1905,11 +1752,6 @@
   },
   "app/components/datasets/documents/create-from-pipeline/data-source/online-drive/utils.ts": {
     "ts/no-explicit-any": {
-      "count": 2
-    }
-  },
-  "app/components/datasets/documents/create-from-pipeline/data-source/store/provider.tsx": {
-    "react-hooks/refs": {
       "count": 2
     }
   },
@@ -1953,18 +1795,8 @@
       "count": 1
     }
   },
-  "app/components/datasets/documents/detail/completed/child-segment-list.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    }
-  },
   "app/components/datasets/documents/detail/completed/common/chunk-content.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/documents/detail/completed/common/regeneration-modal.tsx": {
-    "react-hooks/purity": {
       "count": 1
     }
   },
@@ -1977,9 +1809,6 @@
     }
   },
   "app/components/datasets/documents/detail/completed/new-child-segment.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -1987,14 +1816,6 @@
   "app/components/datasets/documents/detail/context.ts": {
     "ts/no-explicit-any": {
       "count": 1
-    }
-  },
-  "app/components/datasets/documents/detail/embedding/index.tsx": {
-    "react-hooks/immutability": {
-      "count": 1
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
     }
   },
   "app/components/datasets/documents/detail/index.tsx": {
@@ -2011,22 +1832,11 @@
     }
   },
   "app/components/datasets/documents/detail/new-segment.tsx": {
-    "react-hooks/purity": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
   },
-  "app/components/datasets/documents/detail/settings/document-settings.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/datasets/documents/detail/settings/pipeline-settings/index.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 6
     }
@@ -2061,21 +1871,6 @@
       "count": 1
     }
   },
-  "app/components/datasets/extra-info/service-api/card.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/formatted-text/flavours/edit-slice.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/formatted-text/flavours/preview-slice.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    }
-  },
   "app/components/datasets/formatted-text/flavours/type.ts": {
     "ts/no-empty-object-type": {
       "count": 1
@@ -2086,18 +1881,8 @@
       "count": 1
     }
   },
-  "app/components/datasets/hit-testing/index.tsx": {
-    "react-hooks/purity": {
-      "count": 1
-    }
-  },
   "app/components/datasets/list/dataset-card/hooks/use-dataset-card-state.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/metadata/base/date-picker.tsx": {
-    "react-hooks/purity": {
       "count": 1
     }
   },
@@ -2123,11 +1908,6 @@
   },
   "app/components/datasets/metadata/metadata-dataset/create-metadata-modal.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx": {
-    "react-hooks/static-components": {
       "count": 1
     }
   },
@@ -2234,15 +2014,9 @@
   "app/components/goto-anything/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 9
     }
   },
   "app/components/header/account-setting/data-source-page-new/card.tsx": {
-    "react-hooks/immutability": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 2
     }
@@ -2262,20 +2036,12 @@
       "count": 1
     }
   },
-  "app/components/header/account-setting/data-source-page-new/operator.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/header/account-setting/data-source-page-new/types.ts": {
     "ts/no-explicit-any": {
       "count": 2
     }
   },
   "app/components/header/account-setting/data-source-page/data-source-website/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -2297,9 +2063,6 @@
   },
   "app/components/header/account-setting/members-page/invite-modal/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 3
-    },
-    "react-hooks/preserve-manual-memoization": {
       "count": 3
     }
   },
@@ -2367,9 +2130,6 @@
     }
   },
   "app/components/header/account-setting/model-provider-page/model-modal/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 5
     }
@@ -2392,18 +2152,9 @@
   "app/components/header/account-setting/model-provider-page/provider-added-card/cooldown-timer.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
-    },
-    "react-hooks/immutability": {
-      "count": 1
-    },
-    "react-hooks/purity": {
-      "count": 1
     }
   },
   "app/components/header/account-setting/model-provider-page/provider-added-card/credential-panel.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -2444,18 +2195,8 @@
       "count": 1
     }
   },
-  "app/components/header/dataset-nav/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 6
-    }
-  },
   "app/components/header/header-wrapper.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/header/nav/nav-selector/index.tsx": {
-    "react-hooks/use-memo": {
       "count": 1
     }
   },
@@ -2475,11 +2216,6 @@
     },
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/plugins/install-plugin/install-bundle/steps/install.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     }
   },
   "app/components/plugins/install-plugin/install-from-github/index.tsx": {
@@ -2585,11 +2321,6 @@
       "count": 1
     }
   },
-  "app/components/plugins/plugin-detail-panel/detail-header.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/plugins/plugin-detail-panel/endpoint-card.tsx": {
     "ts/no-explicit-any": {
       "count": 2
@@ -2638,21 +2369,8 @@
       "count": 2
     }
   },
-  "app/components/plugins/plugin-detail-panel/subscription-list/create/common-modal.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/plugins/plugin-detail-panel/subscription-list/create/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/plugins/plugin-detail-panel/subscription-list/create/oauth-client.tsx": {
-    "react-hooks/immutability": {
       "count": 1
     }
   },
@@ -2786,11 +2504,6 @@
       "count": 1
     }
   },
-  "app/components/rag-pipeline/components/panel/input-field/field-list/hooks.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 3
-    }
-  },
   "app/components/rag-pipeline/components/panel/input-field/field-list/index.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 1
@@ -2798,16 +2511,6 @@
   },
   "app/components/rag-pipeline/components/panel/input-field/hooks.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    }
-  },
-  "app/components/rag-pipeline/components/panel/input-field/index.tsx": {
-    "react-hooks/refs": {
-      "count": 3
-    }
-  },
-  "app/components/rag-pipeline/components/panel/test-run/header.tsx": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
   },
@@ -2866,16 +2569,6 @@
       "count": 1
     }
   },
-  "app/components/rag-pipeline/hooks/use-available-nodes-meta-data.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
-  "app/components/rag-pipeline/hooks/use-configs-map.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/rag-pipeline/hooks/use-input-fields.ts": {
     "ts/no-explicit-any": {
       "count": 2
@@ -2892,23 +2585,12 @@
     }
   },
   "app/components/rag-pipeline/hooks/use-pipeline-init.ts": {
-    "react-hooks/immutability": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 2
     }
   },
   "app/components/rag-pipeline/hooks/use-pipeline-run.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/rag-pipeline/hooks/use-pipeline-start-run.tsx": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
   },
@@ -2953,11 +2635,6 @@
       "count": 3
     }
   },
-  "app/components/share/text-generation/run-batch/csv-download/index.spec.tsx": {
-    "react-hooks/globals": {
-      "count": 1
-    }
-  },
   "app/components/share/text-generation/run-batch/csv-reader/index.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 2
@@ -2968,15 +2645,7 @@
       "count": 2
     }
   },
-  "app/components/share/text-generation/run-batch/res-download/index.spec.tsx": {
-    "react-hooks/globals": {
-      "count": 1
-    }
-  },
   "app/components/share/text-generation/run-once/index.spec.tsx": {
-    "react-hooks/globals": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 4
     }
@@ -3022,11 +2691,6 @@
       "count": 3
     }
   },
-  "app/components/tools/mcp/detail/operation-dropdown.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/tools/mcp/mcp-server-modal.tsx": {
     "ts/no-explicit-any": {
       "count": 5
@@ -3060,11 +2724,6 @@
       "count": 1
     }
   },
-  "app/components/tools/provider/custom-create-card.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/tools/provider/empty.tsx": {
     "ts/no-explicit-any": {
       "count": 1
@@ -3085,11 +2744,6 @@
       "count": 15
     }
   },
-  "app/components/tools/workflow-tool/configure-button.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    }
-  },
   "app/components/tools/workflow-tool/index.tsx": {
     "ts/no-explicit-any": {
       "count": 2
@@ -3101,11 +2755,6 @@
     },
     "ts/no-explicit-any": {
       "count": 3
-    }
-  },
-  "app/components/workflow-app/components/workflow-header/features-trigger.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     }
   },
   "app/components/workflow-app/components/workflow-main.tsx": {
@@ -3128,20 +2777,12 @@
       "count": 1
     }
   },
-  "app/components/workflow-app/hooks/use-configs-map.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/workflow-app/hooks/use-nodes-sync-draft.ts": {
     "ts/no-explicit-any": {
       "count": 2
     }
   },
   "app/components/workflow-app/hooks/use-workflow-init.ts": {
-    "react-hooks/immutability": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 3
     }
@@ -3152,9 +2793,6 @@
     }
   },
   "app/components/workflow-app/hooks/use-workflow-run.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 13
     }
@@ -3175,9 +2813,6 @@
     }
   },
   "app/components/workflow/__tests__/trigger-status-sync.test.tsx": {
-    "react-hooks/use-memo": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 2
     }
@@ -3185,11 +2820,6 @@
   "app/components/workflow/block-selector/all-start-blocks.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
-    }
-  },
-  "app/components/workflow/block-selector/data-sources.tsx": {
-    "react-hooks/refs": {
-      "count": 2
     }
   },
   "app/components/workflow/block-selector/featured-tools.tsx": {
@@ -3231,9 +2861,6 @@
   "app/components/workflow/block-selector/tool/tool.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 4
     }
   },
   "app/components/workflow/block-selector/trigger-plugin/action-item.tsx": {
@@ -3259,21 +2886,6 @@
       "count": 2
     }
   },
-  "app/components/workflow/context.tsx": {
-    "react-hooks/refs": {
-      "count": 2
-    }
-  },
-  "app/components/workflow/datasets-detail-store/provider.tsx": {
-    "react-hooks/refs": {
-      "count": 2
-    }
-  },
-  "app/components/workflow/header/header-in-normal.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/workflow/header/run-mode.tsx": {
     "no-console": {
       "count": 1
@@ -3285,11 +2897,6 @@
   "app/components/workflow/header/view-workflow-history.tsx": {
     "ts/no-explicit-any": {
       "count": 1
-    }
-  },
-  "app/components/workflow/hooks-store/provider.tsx": {
-    "react-hooks/refs": {
-      "count": 2
     }
   },
   "app/components/workflow/hooks-store/store.ts": {
@@ -3326,9 +2933,6 @@
     }
   },
   "app/components/workflow/hooks/use-nodes-interactions.ts": {
-    "react-hooks/immutability": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 8
     }
@@ -3440,9 +3044,6 @@
     }
   },
   "app/components/workflow/nodes/_base/components/input-var-type-icon.tsx": {
-    "react-hooks/static-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -3460,11 +3061,6 @@
   "app/components/workflow/nodes/_base/components/mixed-variable-text-input/placeholder.tsx": {
     "ts/no-explicit-any": {
       "count": 1
-    }
-  },
-  "app/components/workflow/nodes/_base/components/next-step/add.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
     }
   },
   "app/components/workflow/nodes/_base/components/node-handle.tsx": {
@@ -3492,29 +3088,14 @@
       "count": 1
     }
   },
-  "app/components/workflow/nodes/_base/components/toggle-expand-btn.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/workflow/nodes/_base/components/variable/match-schema-type.ts": {
     "ts/no-explicit-any": {
       "count": 8
     }
   },
-  "app/components/workflow/nodes/_base/components/variable/output-var-list.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/workflow/nodes/_base/components/variable/utils.ts": {
     "ts/no-explicit-any": {
       "count": 32
-    }
-  },
-  "app/components/workflow/nodes/_base/components/variable/var-list.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     }
   },
   "app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx": {
@@ -3525,22 +3106,9 @@
       "count": 3
     }
   },
-  "app/components/workflow/nodes/_base/components/variable/variable-label/base/variable-icon.tsx": {
-    "react-hooks/static-components": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/nodes/_base/components/variable/variable-label/hooks.ts": {
-    "react-hooks/use-memo": {
-      "count": 2
-    }
-  },
   "app/components/workflow/nodes/_base/components/workflow-panel/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 3
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     },
     "ts/no-explicit-any": {
       "count": 6
@@ -3557,9 +3125,6 @@
   "app/components/workflow/nodes/_base/components/workflow-panel/last-run/use-last-run.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 3
     },
     "ts/no-explicit-any": {
       "count": 7
@@ -3586,9 +3151,6 @@
   "app/components/workflow/nodes/_base/hooks/use-toggle-expend.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
-    },
-    "react-hooks/refs": {
-      "count": 2
     }
   },
   "app/components/workflow/nodes/_base/hooks/use-var-list.ts": {
@@ -3698,15 +3260,7 @@
     }
   },
   "app/components/workflow/nodes/data-source-empty/hooks.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/nodes/data-source-empty/index.tsx": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
   },
@@ -3796,11 +3350,6 @@
       "count": 1
     }
   },
-  "app/components/workflow/nodes/if-else/components/condition-list/condition-item.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/components/workflow/nodes/if-else/default.ts": {
     "ts/no-explicit-any": {
       "count": 1
@@ -3811,11 +3360,6 @@
       "count": 5
     }
   },
-  "app/components/workflow/nodes/index.tsx": {
-    "react-hooks/static-components": {
-      "count": 1
-    }
-  },
   "app/components/workflow/nodes/iteration/default.ts": {
     "ts/no-explicit-any": {
       "count": 1
@@ -3823,11 +3367,6 @@
   },
   "app/components/workflow/nodes/iteration/node.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/nodes/iteration/use-interactions.ts": {
-    "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
   },
@@ -3882,9 +3421,6 @@
     }
   },
   "app/components/workflow/nodes/knowledge-retrieval/use-single-run-form-params.ts": {
-    "react-hooks/refs": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
       "count": 5
     }
@@ -3915,9 +3451,6 @@
     }
   },
   "app/components/workflow/nodes/llm/components/json-schema-config-modal/code-editor.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 4
     }
@@ -3934,11 +3467,6 @@
   },
   "app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
-    }
-  },
-  "app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/context.tsx": {
-    "react-hooks/refs": {
       "count": 2
     }
   },
@@ -3971,9 +3499,6 @@
     }
   },
   "app/components/workflow/nodes/llm/use-single-run-form-params.ts": {
-    "react-hooks/refs": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
       "count": 9
     }
@@ -3994,9 +3519,6 @@
     }
   },
   "app/components/workflow/nodes/loop/components/loop-variables/item.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
       "count": 4
     }
@@ -4040,9 +3562,6 @@
     }
   },
   "app/components/workflow/nodes/parameter-extractor/use-single-run-form-params.ts": {
-    "react-hooks/refs": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 9
     }
@@ -4071,16 +3590,8 @@
     }
   },
   "app/components/workflow/nodes/question-classifier/use-single-run-form-params.ts": {
-    "react-hooks/refs": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 8
-    }
-  },
-  "app/components/workflow/nodes/start/components/var-list.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     }
   },
   "app/components/workflow/nodes/start/panel.tsx": {
@@ -4089,9 +3600,6 @@
     }
   },
   "app/components/workflow/nodes/start/use-config.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -4257,21 +3765,8 @@
       "count": 5
     }
   },
-  "app/components/workflow/note-node/index.tsx": {
-    "react-hooks/refs": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/note-node/note-editor/context.tsx": {
-    "react-hooks/refs": {
-      "count": 2
-    }
-  },
   "app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    },
-    "react-hooks/refs": {
       "count": 1
     }
   },
@@ -4347,9 +3842,6 @@
     }
   },
   "app/components/workflow/panel/debug-and-preview/hooks.ts": {
-    "react-hooks/purity": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 7
     }
@@ -4362,22 +3854,9 @@
       "count": 1
     }
   },
-  "app/components/workflow/panel/index.tsx": {
-    "react-hooks/use-memo": {
-      "count": 1
-    }
-  },
   "app/components/workflow/panel/inputs-panel.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 4
-    }
-  },
-  "app/components/workflow/panel/version-history-panel/context-menu/use-context-menu.ts": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
     }
   },
   "app/components/workflow/panel/version-history-panel/index.spec.tsx": {
@@ -4513,9 +3992,6 @@
     }
   },
   "app/components/workflow/update-dsl-modal.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 2
     }
@@ -4581,9 +4057,6 @@
     }
   },
   "app/components/workflow/variable-inspect/right.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 3
     }
@@ -4614,11 +4087,6 @@
   },
   "app/components/workflow/workflow-preview/components/nodes/constants.ts": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/workflow-preview/components/note-node/index.tsx": {
-    "react-hooks/refs": {
       "count": 1
     }
   },
@@ -4662,11 +4130,6 @@
       "count": 1
     }
   },
-  "app/signin/invite-settings/page.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "app/signin/layout.tsx": {
     "ts/no-explicit-any": {
       "count": 1
@@ -4680,11 +4143,6 @@
   "app/signup/layout.tsx": {
     "ts/no-explicit-any": {
       "count": 1
-    }
-  },
-  "app/signup/set-password/page.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 2
     }
   },
   "context/app-context.tsx": {
@@ -4737,9 +4195,6 @@
   },
   "hooks/use-moderate.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    },
-    "react-hooks/refs": {
       "count": 1
     }
   },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -9,6 +9,8 @@ import difyI18n from './eslint-rules/index.js'
 export default antfu(
   {
     react: {
+      // This react compiler rules are pretty slow
+      // We can wait for https://github.com/Rel1cx/eslint-react/issues/1237
       reactCompiler: false,
       overrides: {
         'react/no-context-provider': 'off',
@@ -57,47 +59,8 @@ export default antfu(
   // sonar
   {
     rules: {
-      ...sonar.configs.recommended.rules,
-      // code complexity
-      'sonarjs/cognitive-complexity': 'off',
-      'sonarjs/no-nested-functions': 'warn',
-      'sonarjs/no-nested-conditional': 'warn',
-      'sonarjs/nested-control-flow': 'warn', // 3 levels of nesting
-      'sonarjs/no-small-switch': 'off',
-      'sonarjs/no-nested-template-literals': 'warn',
-      'sonarjs/redundant-type-aliases': 'off',
-      'sonarjs/regex-complexity': 'warn',
-      // maintainability
-      'sonarjs/no-ignored-exceptions': 'off',
-      'sonarjs/no-commented-code': 'warn',
-      'sonarjs/no-unused-vars': 'warn',
-      'sonarjs/prefer-single-boolean-return': 'warn',
-      'sonarjs/duplicates-in-character-class': 'off',
-      'sonarjs/single-char-in-character-classes': 'off',
-      'sonarjs/anchor-precedence': 'warn',
-      'sonarjs/updated-loop-counter': 'off',
-      'sonarjs/no-dead-store': 'error',
-      'sonarjs/no-duplicated-branches': 'warn',
-      'sonarjs/max-lines': 'warn', // max 1000 lines
-      'sonarjs/no-variable-usage-before-declaration': 'error',
-      // security
-
-      'sonarjs/no-hardcoded-passwords': 'off', // detect the wrong code that is not password.
-      'sonarjs/no-hardcoded-secrets': 'off',
-      'sonarjs/pseudo-random': 'off',
-      // performance
-      'sonarjs/slow-regex': 'warn',
-      // others
-      'sonarjs/todo-tag': 'warn',
-      'sonarjs/table-header': 'off',
-
-      // new from this update
-      'sonarjs/unused-import': 'off',
-      'sonarjs/use-type-alias': 'warn',
-      'sonarjs/single-character-alternation': 'warn',
-      'sonarjs/no-os-command-from-path': 'warn',
-      'sonarjs/class-name': 'off',
-      'sonarjs/no-redundant-jump': 'warn',
+      // Manually pick rules that are actually useful and not slow.
+      // Or we can just drop the plugin entirely.
     },
     plugins: {
       sonarjs: sonar,

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -9,7 +9,7 @@ import difyI18n from './eslint-rules/index.js'
 export default antfu(
   {
     react: {
-      reactCompiler: true,
+      reactCompiler: false,
       overrides: {
         'react/no-context-provider': 'off',
         'react/no-forward-ref': 'off',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

close #31200

before 2m37s
disable react compiler rules 2m0s
disable sonarjs 1m13s

after

Perhaps some rules can optimize performance.

Rule                                                 | Time (ms) | Relative
:----------------------------------------------------|----------:|--------:
style/indent                                         |  4623.165 |    14.5%
unused-imports/no-unused-imports                     |  2745.831 |     8.6%
react-hooks/rules-of-hooks                           |  1300.012 |     4.1%
perfectionist/sort-imports                           |   960.617 |     3.0%
style/comma-style                                    |   792.658 |     2.5%
style/space-in-parens                                |   752.510 |     2.4%
unicorn/prefer-dom-node-text-content                 |   690.261 |     2.2%
style/no-extra-parens                                |   658.213 |     2.1%
jsonc/indent                                         |   651.100 |     2.0%
regexp/control-character-escape                      |   533.676 |     1.7%
ts/no-redeclare                                      |   530.908 |     1.7%
style/comma-spacing                                  |   480.865 |     1.5%
style/object-curly-spacing                           |   453.868 |     1.4%
style/keyword-spacing                                |   432.397 |     1.4%
next/no-html-link-for-pages                          |   359.281 |     1.1%
style/comma-dangle                                   |   353.082 |     1.1%
node/no-deprecated-api                               |   334.067 |     1.0%
unused-imports/no-unused-vars                        |   316.862 |     1.0%
unicorn/prefer-string-starts-ends-with               |   276.766 |     0.9%
test/consistent-test-it                              |   271.496 |     0.9%
perfectionist/sort-named-imports                     |   266.457 |     0.8%
unicorn/error-message                                |   261.199 |     0.8%
no-unmodified-loop-condition                         |   259.941 |     0.8%
antfu/consistent-list-newline                        |   257.620 |     0.8%
style/max-statements-per-line                        |   255.336 |     0.8%
unicorn/escape-case                                  |   251.786 |     0.8%
jsonc/no-dupe-keys                                   |   240.646 |     0.8%
react-hooks-extra/no-direct-set-state-in-use-effect  |   232.523 |     0.7%
perfectionist/sort-exports                           |   220.731 |     0.7%
style/jsx-curly-brace-presence                       |   217.139 |     0.7%
unicorn/prefer-node-protocol                         |   211.496 |     0.7%
react/no-missing-key                                 |   186.709 |     0.6%
jsonc/no-unicode-codepoint-escapes                   |   180.893 |     0.6%
dify-i18n/valid-i18n-keys                            |   180.378 |     0.6%
ts/no-use-before-define                              |   177.811 |     0.6%
no-alert                                             |   172.833 |     0.5%
object-shorthand                                     |   168.974 |     0.5%
react/no-nested-component-definitions                |   167.465 |     0.5%
unicorn/prefer-includes                              |   165.823 |     0.5%
no-useless-return                                    |   165.773 |     0.5%
unicorn/new-for-builtins                             |   157.382 |     0.5%
style/no-trailing-spaces                             |   153.555 |     0.5%
style/semi                                           |   145.431 |     0.5%
ts/consistent-type-imports                           |   141.836 |     0.4%
jsonc/no-useless-escape                              |   141.291 |     0.4%
unicorn/throw-new-error                              |   141.267 |     0.4%
style/space-infix-ops                                |   140.880 |     0.4%
style/no-multi-spaces                                |   135.837 |     0.4%
no-restricted-globals                                |   128.327 |     0.4%
style/no-whitespace-before-property                  |   121.552 |     0.4%
test/prefer-hooks-in-order                           |   120.254 |     0.4%
style/operator-linebreak                             |   120.178 |     0.4%
style/type-annotation-spacing                        |   119.440 |     0.4%
style/key-spacing                                    |   117.923 |     0.4%
style/arrow-spacing                                  |   116.001 |     0.4%
unicorn/prefer-number-properties                     |   113.892 |     0.4%
style/spaced-comment                                 |   111.800 |     0.4%
style/jsx-closing-bracket-location                   |   111.140 |     0.3%
array-callback-return                                |   107.440 |     0.3%
one-var                                              |   106.076 |     0.3%
style/quote-props                                    |   103.876 |     0.3%
style/jsx-wrap-multilines                            |   103.032 |     0.3%
no-unused-vars                                       |    98.641 |     0.3%
no-redeclare                                         |    97.349 |     0.3%
unicorn/number-literal-case                          |    96.723 |     0.3%
jsonc/comma-style                                    |    96.195 |     0.3%
@tanstack/query/no-unstable-deps                     |    96.102 |     0.3%
import/newline-after-import                          |    94.521 |     0.3%
no-global-assign                                     |    92.597 |     0.3%
no-misleading-character-class                        |    92.072 |     0.3%
style/jsx-tag-spacing                                |    91.008 |     0.3%
no-extend-native                                     |    90.768 |     0.3%
jsonc/no-octal-escape                                |    89.636 |     0.3%
style/block-spacing                                  |    89.628 |     0.3%
no-unexpected-multiline                              |    88.539 |     0.3%
dify-i18n/no-extra-keys                              |    87.591 |     0.3%
test/no-identical-title                              |    83.712 |     0.3%
style/semi-spacing                                   |    83.078 |     0.3%
ts/no-unused-expressions                             |    82.017 |     0.3%
style/jsx-indent-props                               |    81.410 |     0.3%
no-regex-spaces                                      |    81.297 |     0.3%
style/dot-location                                   |    81.127 |     0.3%
style/member-delimiter-style                         |    80.356 |     0.3%
no-unreachable-loop                                  |    79.319 |     0.2%
antfu/consistent-chaining                            |    77.086 |     0.2%
jsonc/no-parenthesized                               |    76.522 |     0.2%
@tanstack/query/exhaustive-deps                      |    76.252 |     0.2%
style/jsx-one-expression-per-line                    |    75.252 |     0.2%
react/no-create-ref                                  |    75.033 |     0.2%
style/brace-style                                    |    70.404 |     0.2%
style/padded-blocks                                  |    69.596 |     0.2%
regexp/no-legacy-features                            |    68.217 |     0.2%
style/no-multiple-empty-lines                        |    65.117 |     0.2%
node/handle-callback-err                             |    64.281 |     0.2%
regexp/no-useless-dollar-replacements                |    63.938 |     0.2%
react-dom/no-void-elements-with-children             |    62.012 |     0.2%
style/indent-binary-ops                              |    61.863 |     0.2%
no-fallthrough                                       |    61.008 |     0.2%
no-control-regex                                     |    60.730 |     0.2%
no-undef-init                                        |    59.615 |     0.2%
jsonc/no-multi-str                                   |    57.488 |     0.2%
no-irregular-whitespace                              |    56.300 |     0.2%
ts/ban-ts-comment                                    |    56.072 |     0.2%
style/quotes                                         |    56.013 |     0.2%
react-dom/no-render-return-value                     |    55.542 |     0.2%
no-loss-of-precision                                 |    54.384 |     0.2%
react/no-nested-lazy-component-declarations          |    54.380 |     0.2%
unicorn/consistent-empty-array-spread                |    53.753 |     0.2%
no-eval                                              |    53.514 |     0.2%
style/jsx-curly-newline                              |    53.239 |     0.2%
no-restricted-properties                             |    51.870 |     0.2%
jsonc/no-octal                                       |    51.630 |     0.2%
command/command                                      |    51.417 |     0.2%
style/no-tabs                                        |    50.375 |     0.2%
style/jsx-function-call-newline                      |    50.075 |     0.2%
accessor-pairs                                       |    50.023 |     0.2%
no-shadow-restricted-names                           |    49.944 |     0.2%
style/no-mixed-spaces-and-tabs                       |    49.099 |     0.2%
style/jsx-curly-spacing                              |    49.008 |     0.2%
jsonc/no-floating-decimal                            |    48.622 |     0.2%
ts/no-explicit-any                                   |    47.615 |     0.1%
perfectionist/sort-named-exports                     |    46.832 |     0.1%
@tanstack/query/infinite-query-property-order        |    46.681 |     0.1%
use-isnan                                            |    46.681 |     0.1%
style/space-before-blocks                            |    45.639 |     0.1%
style/array-bracket-spacing                          |    44.671 |     0.1%
no-implied-eval                                      |    42.454 |     0.1%
no-multi-str                                         |    41.646 |     0.1%
react-dom/no-render                                  |    41.419 |     0.1%
no-octal-escape                                      |    41.035 |     0.1%
node/no-path-concat                                  |    40.657 |     0.1%
style/computed-property-spacing                      |    40.548 |     0.1%
jsonc/key-spacing                                    |    38.798 |     0.1%
import/no-duplicates                                 |    36.989 |     0.1%
style/jsx-equals-spacing                             |    36.760 |     0.1%
eslint-comments/no-aggregating-enable                |    35.416 |     0.1%
@tanstack/query/mutation-property-order              |    35.086 |     0.1%
style/wrap-iife                                      |    34.821 |     0.1%
no-lone-blocks                                       |    33.257 |     0.1%
react/prefer-namespace-import                        |    32.762 |     0.1%
prefer-template                                      |    32.756 |     0.1%
react/no-access-state-in-setstate                    |    32.750 |     0.1%
import/consistent-type-specifier-style               |    32.707 |     0.1%
jsonc/sort-keys                                      |    31.837 |     0.1%
no-prototype-builtins                                |    31.268 |     0.1%
new-cap                                              |    30.760 |     0.1%
jsonc/object-property-newline                        |    30.242 |     0.1%
prefer-promise-reject-errors                         |    30.033 |     0.1%
test/no-only-tests                                   |    29.394 |     0.1%
style/space-before-function-paren                    |    29.372 |     0.1%
ts/no-array-constructor                              |    29.245 |     0.1%
no-template-curly-in-string                          |    28.680 |     0.1%
ts/no-unnecessary-type-constraint                    |    28.354 |     0.1%
no-useless-call                                      |    26.372 |     0.1%
no-extra-boolean-cast                                |    26.239 |     0.1%
@tanstack/query/no-void-query-fn                     |    25.959 |     0.1%
style/arrow-parens                                   |    25.745 |     0.1%
style/space-unary-ops                                |    25.529 |     0.1%
no-caller                                            |    24.903 |     0.1%
jsonc/quotes                                         |    24.673 |     0.1%
block-scoped-var                                     |    24.658 |     0.1%
style/no-mixed-operators                             |    24.422 |     0.1%
import/first                                         |    24.259 |     0.1%
prefer-spread                                        |    24.048 |     0.1%
unicorn/no-instanceof-builtins                       |    23.994 |     0.1%
style/multiline-ternary                              |    23.832 |     0.1%
no-restricted-syntax                                 |    23.495 |     0.1%
no-iterator                                          |    23.346 |     0.1%
style/jsx-max-props-per-line                         |    23.218 |     0.1%
style/lines-between-class-members                    |    23.073 |     0.1%
ts/no-empty-object-type                              |    22.822 |     0.1%
jsonc/no-numeric-separators                          |    21.827 |     0.1%
prefer-const                                         |    21.421 |     0.1%
jsonc/no-bigint-literals                             |    21.178 |     0.1%
unicorn/no-new-array                                 |    21.066 |     0.1%
dot-notation                                         |    20.969 |     0.1%
prefer-regex-literals                                |    20.506 |     0.1%
node/prefer-global/buffer                            |    20.089 |     0.1%
no-console                                           |    19.905 |     0.1%
no-octal                                             |    19.759 |     0.1%
style/no-floating-decimal                            |    19.723 |     0.1%
next/no-duplicate-head                               |    19.715 |     0.1%
react-dom/no-namespace                               |    19.624 |     0.1%
jsonc/valid-json-number                              |    19.467 |     0.1%
style/type-generic-spacing                           |    19.247 |     0.1%
jsonc/object-curly-newline                           |    19.204 |     0.1%
antfu/curly                                          |    19.054 |     0.1%
no-unsafe-finally                                    |    18.752 |     0.1%
no-useless-computed-key                              |    18.497 |     0.1%
jsonc/no-binary-numeric-literals                     |    18.324 |     0.1%
import/no-mutable-exports                            |    18.315 |     0.1%
next/no-assign-module-variable                       |    17.528 |     0.1%
style/jsx-quotes                                     |    17.371 |     0.1%
jsonc/no-regexp-literals                             |    16.999 |     0.1%
eslint-comments/no-unlimited-disable                 |    16.973 |     0.1%
jsonc/no-hexadecimal-numeric-literals                |    16.812 |     0.1%
next/inline-script-id                                |    16.771 |     0.1%
no-extra-bind                                        |    16.698 |     0.1%
jsonc/no-octal-numeric-literals                      |    16.672 |     0.1%
@tanstack/query/stable-query-client                  |    16.605 |     0.1%
style/template-curly-spacing                         |    16.514 |     0.1%
unicorn/no-new-buffer                                |    16.313 |     0.1%
prefer-exponentiation-operator                       |    16.269 |     0.1%
style/jsx-closing-tag-location                       |    16.158 |     0.1%
style/generator-star-spacing                         |    15.958 |     0.1%
no-proto                                             |    15.938 |     0.0%
jsonc/quote-props                                    |    15.741 |     0.0%
no-useless-rename                                    |    14.825 |     0.0%
react/no-prop-types                                  |    14.736 |     0.0%
ts/prefer-as-const                                   |    14.726 |     0.0%
ts/no-namespace                                      |    14.018 |     0.0%
antfu/no-import-dist                                 |    13.629 |     0.0%
no-cond-assign                                       |    13.429 |     0.0%
ts/no-wrapper-object-types                           |    13.245 |     0.0%
ts/no-require-imports                                |    13.242 |     0.0%
unicorn/prefer-type-error                            |    13.202 |     0.0%
style/jsx-first-prop-new-line                        |    13.153 |     0.0%
ts/prefer-literal-enum-member                        |    13.072 |     0.0%
style/eol-last                                       |    13.042 |     0.0%
ts/no-unsafe-function-type                           |    13.021 |     0.0%
no-self-compare                                      |    12.929 |     0.0%
react/no-component-will-mount                        |    12.826 |     0.0%
react-dom/no-hydrate                                 |    12.823 |     0.0%
react/no-duplicate-key                               |    12.735 |     0.0%
import/no-named-default                              |    12.641 |     0.0%
antfu/import-dedupe                                  |    12.572 |     0.0%
jsonc/comma-dangle                                   |    11.962 |     0.0%
react/no-string-refs                                 |    11.950 |     0.0%
no-empty                                             |    11.788 |     0.0%
react/no-default-props                               |    11.722 |     0.0%
jsonc/no-number-props                                |    11.612 |     0.0%
yoda                                                 |    11.350 |     0.0%
ts/no-this-alias                                     |    11.325 |     0.0%
react-dom/no-use-form-state                          |    11.170 |     0.0%
react-dom/no-dangerously-set-innerhtml-with-children |    11.055 |     0.0%
react/no-redundant-should-component-update           |    10.677 |     0.0%
ts/no-import-type-side-effects                       |    10.667 |     0.0%
antfu/no-import-node-modules-by-path                 |    10.541 |     0.0%
valid-typeof                                         |    10.453 |     0.0%
ts/consistent-type-definitions                       |    10.440 |     0.0%
no-self-assign                                       |     9.813 |     0.0%
jsonc/object-curly-spacing                           |     9.744 |     0.0%
react-dom/no-flush-sync                              |     9.675 |     0.0%
regexp/no-dupe-disjunctions                          |     9.385 |     0.0%
no-var                                               |     9.284 |     0.0%
react-dom/no-find-dom-node                           |     9.103 |     0.0%
next/no-script-component-in-head                     |     9.090 |     0.0%
react/no-direct-mutation-state                       |     9.061 |     0.0%
eqeqeq                                               |     9.056 |     0.0%
ts/no-dupe-class-members                             |     8.969 |     0.0%
no-sparse-arrays                                     |     8.875 |     0.0%
style/rest-spread-spacing                            |     8.863 |     0.0%
prefer-arrow-callback                                |     8.819 |     0.0%
constructor-super                                    |     8.671 |     0.0%
antfu/no-top-level-await                             |     8.452 |     0.0%
react/no-component-will-update                       |     8.409 |     0.0%
react/no-component-will-receive-props                |     8.250 |     0.0%
no-unreachable                                       |     8.143 |     0.0%
no-empty-pattern                                     |     8.084 |     0.0%
no-compare-neg-zero                                  |     7.694 |     0.0%
next/no-sync-scripts                                 |     7.569 |     0.0%
ts/method-signature-style                            |     7.542 |     0.0%
ts/no-duplicate-enum-values                          |     7.169 |     0.0%
no-this-before-super                                 |     7.125 |     0.0%
no-obj-calls                                         |     6.938 |     0.0%
no-new-func                                          |     6.744 |     0.0%
jsonc/no-sparse-arrays                               |     6.688 |     0.0%
jsonc/array-bracket-spacing                          |     6.586 |     0.0%
node/no-exports-assign                               |     6.551 |     0.0%
no-use-before-define                                 |     6.418 |     0.0%
symbol-description                                   |     6.337 |     0.0%
ts/no-unsafe-declaration-merging                     |     6.280 |     0.0%
next/no-document-import-in-page                      |     6.060 |     0.0%
regexp/no-missing-g-flag                             |     6.047 |     0.0%
regexp/match-any                                     |     5.942 |     0.0%
no-unneeded-ternary                                  |     5.854 |     0.0%
unicode-bom                                          |     5.592 |     0.0%
next/no-head-import-in-document                      |     5.224 |     0.0%
ts/no-misused-new                                    |     5.037 |     0.0%
regexp/prefer-d                                      |     4.888 |     0.0%
style/yield-star-spacing                             |     4.628 |     0.0%
no-labels                                            |     4.621 |     0.0%
regexp/negation                                      |     4.613 |     0.0%
style/new-parens                                     |     4.569 |     0.0%
no-sequences                                         |     4.279 |     0.0%
regexp/no-useless-escape                             |     4.277 |     0.0%
style/template-tag-spacing                           |     4.215 |     0.0%
regexp/no-useless-non-capturing-group                |     4.162 |     0.0%
no-duplicate-case                                    |     4.077 |     0.0%
ts/prefer-namespace-keyword                          |     4.011 |     0.0%
ts/no-extra-non-null-assertion                       |     3.985 |     0.0%
antfu/if-newline                                     |     3.922 |     0.0%
ts/no-non-null-asserted-nullish-coalescing           |     3.857 |     0.0%
no-unused-expressions                                |     3.826 |     0.0%
regexp/prefer-range                                  |     3.803 |     0.0%
ts/no-non-null-asserted-optional-chain               |     3.747 |     0.0%
no-delete-var                                        |     3.552 |     0.0%
regexp/no-misleading-unicode-character               |     3.493 |     0.0%
regexp/no-unused-capturing-group                     |     3.407 |     0.0%
regexp/no-empty-capturing-group                      |     3.403 |     0.0%
regexp/sort-flags                                    |     3.400 |     0.0%
regexp/no-useless-assertions                         |     3.351 |     0.0%
no-ex-assign                                         |     3.292 |     0.0%
eslint-comments/no-unused-enable                     |     3.292 |     0.0%
storybook/story-exports                              |     3.245 |     0.0%
regexp/no-super-linear-backtracking                  |     3.238 |     0.0%
regexp/no-useless-backreference                      |     3.218 |     0.0%
regexp/no-obscure-range                              |     3.193 |     0.0%
regexp/no-contradiction-with-assertion               |     3.162 |     0.0%
regexp/no-empty-string-literal                       |     3.161 |     0.0%
regexp/no-empty-group                                |     3.116 |     0.0%
eslint-comments/no-duplicate-disable                 |     3.114 |     0.0%
storybook/await-interactions                         |     3.110 |     0.0%
regexp/prefer-set-operation                          |     3.107 |     0.0%
regexp/no-optional-assertion                         |     3.044 |     0.0%
regexp/no-misleading-capturing-group                 |     2.977 |     0.0%
no-new-native-nonconstructor                         |     2.975 |     0.0%
regexp/no-invalid-regexp                             |     2.921 |     0.0%
regexp/no-invisible-character                        |     2.894 |     0.0%
regexp/no-useless-range                              |     2.818 |     0.0%
regexp/no-empty-lookarounds-assertion                |     2.814 |     0.0%
regexp/no-extra-lookaround-assertions                |     2.814 |     0.0%
regexp/no-useless-quantifier                         |     2.805 |     0.0%
regexp/no-useless-string-literal                     |     2.759 |     0.0%
regexp/no-useless-character-class                    |     2.727 |     0.0%
regexp/no-dupe-characters-character-class            |     2.717 |     0.0%
node/no-new-require                                  |     2.675 |     0.0%
style/type-named-tuple-spacing                       |     2.653 |     0.0%
regexp/no-trivially-nested-quantifier                |     2.640 |     0.0%
regexp/prefer-plus-quantifier                        |     2.638 |     0.0%
regexp/no-non-standard-flag                          |     2.634 |     0.0%
regexp/no-escape-backspace                           |     2.606 |     0.0%
regexp/optimal-quantifier-concatenation              |     2.587 |     0.0%
regexp/prefer-character-class                        |     2.575 |     0.0%
regexp/prefer-star-quantifier                        |     2.574 |     0.0%
regexp/use-ignore-case                               |     2.524 |     0.0%
regexp/simplify-set-operations                       |     2.514 |     0.0%
default-case-last                                    |     2.512 |     0.0%
regexp/no-trivially-nested-assertion                 |     2.509 |     0.0%
prefer-rest-params                                   |     2.473 |     0.0%
no-new-wrappers                                      |     2.470 |     0.0%
regexp/prefer-unicode-codepoint-escapes              |     2.426 |     0.0%
no-case-declarations                                 |     2.376 |     0.0%
no-throw-literal                                     |     2.343 |     0.0%
regexp/prefer-question-quantifier                    |     2.328 |     0.0%
regexp/prefer-predefined-assertion                   |     2.324 |     0.0%
regexp/no-empty-character-class                      |     2.298 |     0.0%
vars-on-top                                          |     2.263 |     0.0%
regexp/no-zero-quantifier                            |     2.246 |     0.0%
no-dupe-keys                                         |     2.188 |     0.0%
no-undef                                             |     2.178 |     0.0%
regexp/no-useless-lazy                               |     2.164 |     0.0%
regexp/strict                                        |     2.152 |     0.0%
regexp/prefer-w                                      |     2.097 |     0.0%
no-new                                               |     2.080 |     0.0%
regexp/no-useless-set-operand                        |     1.915 |     0.0%
no-useless-catch                                     |     1.914 |     0.0%
no-const-assign                                      |     1.853 |     0.0%
regexp/no-useless-two-nums-quantifier                |     1.843 |     0.0%
no-debugger                                          |     1.832 |     0.0%
node/process-exit-as-throw                           |     1.830 |     0.0%
no-unsafe-negation                                   |     1.742 |     0.0%
no-async-promise-executor                            |     1.623 |     0.0%
no-array-constructor                                 |     1.609 |     0.0%
no-dupe-args                                         |     1.535 |     0.0%
no-dupe-class-members                                |     1.530 |     0.0%
jsonc/vue-custom-block/no-parsing-error              |     1.503 |     0.0%
storybook/default-exports                            |     1.452 |     0.0%
no-import-assign                                     |     1.448 |     0.0%
jsonc/space-unary-ops                                |     1.373 |     0.0%
no-func-assign                                       |     1.315 |     0.0%
jsonc/no-plus-sign                                   |     1.198 |     0.0%
no-useless-constructor                               |     1.156 |     0.0%
jsonc/no-binary-expression                           |     1.153 |     0.0%
test/no-import-node-test                             |     1.112 |     0.0%
jsonc/no-escape-sequence-in-identifier               |     1.105 |     0.0%
no-with                                              |     1.013 |     0.0%
storybook/use-storybook-expect                       |     0.983 |     0.0%
storybook/context-in-play-function                   |     0.913 |     0.0%
jsonc/no-template-literals                           |     0.913 |     0.0%
no-class-assign                                      |     0.870 |     0.0%
jsonc/no-infinity                                    |     0.824 |     0.0%
jsonc/no-nan                                         |     0.805 |     0.0%
storybook/no-uninstalled-addons                      |     0.784 |     0.0%
jsonc/no-undefined-value                             |     0.662 |     0.0%
storybook/no-renderer-packages                       |     0.557 |     0.0%
storybook/use-storybook-testing-library              |     0.522 |     0.0%
jsonc/sort-array-values                              |     0.285 |     0.0%

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
