### PR TITLE
fix(workflow): Fixed workflow execution status update logic and added support for secure storage mode.

### DIFF
--- a/api/tasks/workflow_execution_tasks.py
+++ b/api/tasks/workflow_execution_tasks.py
@@ -4,13 +4,14 @@ Celery tasks for asynchronous workflow execution storage operations.
 These tasks provide asynchronous storage capabilities for workflow execution data,
 improving performance by offloading storage operations to background workers.
 """
+
 import json
 import logging
 
 from celery import shared_task
 from sqlalchemy import select
-from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
 
 from core.workflow.entities.workflow_execution import WorkflowExecution
 from core.workflow.workflow_type_encoder import WorkflowRuntimeTypeConverter
@@ -79,7 +80,7 @@ def save_workflow_execution_task(
                 # This case is rare. Let Celery's retry mechanism handle it.
                 logger.warning(
                     "IntegrityError on insert but record with id %s not found after rollback. Task will be retried.",
-                    execution.id_
+                    execution.id_,
                 )
                 raise
 

--- a/api/tasks/workflow_execution_tasks.py
+++ b/api/tasks/workflow_execution_tasks.py
@@ -12,7 +12,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import IntegrityError
 
-from core.security.ctx import set_mode
 from core.workflow.entities.workflow_execution import WorkflowExecution
 from core.workflow.workflow_type_encoder import WorkflowRuntimeTypeConverter
 from extensions.ext_database import db
@@ -52,7 +51,6 @@ def save_workflow_execution_task(
         session_factory = sessionmaker(bind=db.engine, expire_on_commit=False)
 
         with session_factory() as session:
-            set_mode(security_store_mode or None)
             execution = WorkflowExecution.model_validate(execution_data)
             existing_run = session.scalar(select(WorkflowRun).where(WorkflowRun.id == execution.id_))
             if existing_run:

--- a/api/tasks/workflow_node_execution_tasks.py
+++ b/api/tasks/workflow_node_execution_tasks.py
@@ -10,8 +10,8 @@ import logging
 
 from celery import shared_task
 from sqlalchemy import select
-from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
 
 from core.workflow.entities.workflow_node_execution import (
     WorkflowNodeExecution,
@@ -86,7 +86,7 @@ def save_workflow_node_execution_task(
                 # This case is rare. Let Celery's retry mechanism handle it.
                 logger.warning(
                     "IntegrityError on insert but record with id %s not found after rollback. Task will be retried.",
-                    execution.id
+                    execution.id,
                 )
                 raise
 

--- a/api/tasks/workflow_node_execution_tasks.py
+++ b/api/tasks/workflow_node_execution_tasks.py
@@ -13,7 +13,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import IntegrityError
 
-from core.security.ctx import set_mode
 from core.workflow.entities.workflow_node_execution import (
     WorkflowNodeExecution,
 )
@@ -55,7 +54,6 @@ def save_workflow_node_execution_task(
         session_factory = sessionmaker(bind=db.engine, expire_on_commit=False)
 
         with session_factory() as session:
-            set_mode(security_store_mode or None)
             execution = WorkflowNodeExecution.model_validate(execution_data)
             existing_execution = session.scalar(
                 select(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id == execution.id)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

### Proposed Solution

I have implemented a fix that addresses both issues:

1.  **Atomic "Insert or Update" Strategy**:
    Wrap the `insert` operation in a `try...except IntegrityError` block. If an insertion fails due to a duplicate key, strictly rollback and fallback to the `update` logic.

2.  **State Machine Guard**:
    Enforce a unidirectional state transition policy in the update logic.

**Code Snippet (Fix Implementation Pattern):**

```python
# Applied to both save_workflow_node_execution_task and save_workflow_execution_task

try:
    session.add(new_record)
    session.commit()
    return True
except IntegrityError:
    # Handle race condition: another worker inserted the record concurrently
    session.rollback()
    existing_record = session.scalar(select(Model).where(Model.id == record_id))
    if existing_record:
        _update_from_domain(existing_record, execution_data)
        session.commit()
        return True
    # Retry insert if somehow still missing
    session.add(new_record)
    session.commit()
    return True
```

And the state guard:

```python
def _update_from_domain(db_record, domain_data):
    terminal = {"succeeded", "failed", "stopped", "exception", "partial-succeeded"}
    if db_record.status in terminal and domain_data.status.value not in terminal:
        # Ignore status update to prevent regression
        # Update other fields (outputs, etc.) if necessary
        db_record.finished_at = db_record.finished_at or domain_data.finished_at
        return
    # ... normal update
```

#31222



## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
