### PR TITLE
fix: ui-inconsistecy issue

### DIFF
--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -197,7 +197,7 @@ const List = () => {
           </div>
         )}
 
-        <div className="no-sticky sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
+        <div className="sticky-no-border sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
           <TabSliderNew
             value={activeTab}
             onChange={setActiveTab}

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -197,7 +197,7 @@ const List = () => {
           </div>
         )}
 
-        <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
+        <div className="no-sticky sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
           <TabSliderNew
             value={activeTab}
             onChange={setActiveTab}

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -218,7 +218,7 @@ export default function AccountSetting({
             <div className="system-2xs-medium-uppercase mt-1 text-text-tertiary">ESC</div>
           </div>
           <div ref={scrollRef} className="w-full overflow-y-auto bg-components-panel-bg pb-4">
-            <div className={cn('no-sticky sticky top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-b border-divider-regular')}>
+            <div className={cn('sticky-no-border sticky top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-b border-divider-regular')}>
               <div className="title-2xl-semi-bold shrink-0 text-text-primary">
                 {activeItem?.name}
                 {activeItem?.description && (

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -218,7 +218,7 @@ export default function AccountSetting({
             <div className="system-2xs-medium-uppercase mt-1 text-text-tertiary">ESC</div>
           </div>
           <div ref={scrollRef} className="w-full overflow-y-auto bg-components-panel-bg pb-4">
-            <div className={cn('sticky top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-b border-divider-regular')}>
+            <div className={cn('no-sticky sticky top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-b border-divider-regular')}>
               <div className="title-2xl-semi-bold shrink-0 text-text-primary">
                 {activeItem?.name}
                 {activeItem?.description && (

--- a/web/app/components/plugins/marketplace/sticky-search-and-switch-wrapper.tsx
+++ b/web/app/components/plugins/marketplace/sticky-search-and-switch-wrapper.tsx
@@ -17,7 +17,7 @@ const StickySearchAndSwitchWrapper = ({
     <div
       className={cn(
         'mt-4 bg-background-body',
-        hasCustomTopClass && 'sticky z-10',
+        hasCustomTopClass && 'z-10',
         pluginTypeSwitchClassName,
       )}
     >

--- a/web/app/components/plugins/plugin-page/plugins-panel.tsx
+++ b/web/app/components/plugins/plugin-page/plugins-panel.tsx
@@ -93,7 +93,6 @@ const PluginsPanel = () => {
   return (
     <>
       <div className="flex flex-col items-start justify-center gap-3 self-stretch px-12 pb-3 pt-1">
-        <div className="h-px self-stretch bg-divider-subtle"></div>
         <FilterManagement
           onFilterChange={handleFilterChange}
         />

--- a/web/app/styles/monaco-sticky-fix.css
+++ b/web/app/styles/monaco-sticky-fix.css
@@ -14,3 +14,7 @@ html[data-theme="dark"] .sticky, html[data-theme="dark"] .is-sticky {
   background-color: var(--color-components-sticky-header-bg) !important;
   border-bottom: 1px solid var(--color-components-sticky-header-border) !important;
 }
+html[data-theme="dark"] .no-sticky,
+html[data-theme="dark"] .is-no-sticky {
+  border-bottom: none !important;
+}

--- a/web/app/styles/monaco-sticky-fix.css
+++ b/web/app/styles/monaco-sticky-fix.css
@@ -14,7 +14,7 @@ html[data-theme="dark"] .sticky, html[data-theme="dark"] .is-sticky {
   background-color: var(--color-components-sticky-header-bg) !important;
   border-bottom: 1px solid var(--color-components-sticky-header-border) !important;
 }
-html[data-theme="dark"] .no-sticky,
-html[data-theme="dark"] .is-no-sticky {
-  border-bottom: none !important;
+html[data-theme="dark"] .sticky-no-border,
+html[data-theme="dark"] .is-sticky-no-border {
+  border-bottom: none;
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
 fixes #31137

fixed ui behaviour with unnecessary borders and background-color

## Screenshots

| 
<img width="1366" height="65" alt="image" src="https://github.com/user-attachments/assets/bb78f751-ede3-457b-9ded-0afdba46241b" />
 | <img width="1899" height="97" alt="Captura de tela 2026-01-19 153821" src="https://github.com/user-attachments/assets/88653f93-7346-4cdf-9850-590bceba5e8b" />

<img width="1919" height="122" alt="image" src="https://github.com/user-attachments/assets/78e67201-ff92-4c39-86d7-2fd9699a57e1" /> | 
<img width="1919" height="121" alt="image" src="https://github.com/user-attachments/assets/d8a36991-dbee-45d4-a491-e1d37cf1ce4f" />

<img width="1878" height="88" alt="image" src="https://github.com/user-attachments/assets/c2935bb8-7e13-4ba1-849b-8952ea611671" /> | 
<img width="1887" height="74" alt="image" src="https://github.com/user-attachments/assets/e0d9b87c-2822-466f-9da8-6a5e54a6be81" />

<img width="1657" height="212" alt="image" src="https://github.com/user-attachments/assets/0f552794-3a06-4176-8781-bbd249f52cfa" /> | 
<img width="1803" height="197" alt="image" src="https://github.com/user-attachments/assets/121d7184-458f-47b1-a3f9-53536f2686d4" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
