### PR TITLE
fix: include doc_type for image hit-testing

### DIFF
--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -38,7 +38,7 @@ class AbstractVectorFactory(ABC):
 class Vector:
     def __init__(self, dataset: Dataset, attributes: list | None = None):
         if attributes is None:
-            attributes = ["doc_id", "dataset_id", "document_id", "doc_hash"]
+            attributes = ["doc_id", "dataset_id", "document_id", "doc_hash", "doc_type"]
         self._dataset = dataset
         self._embeddings = self._get_embeddings()
         self._attributes = attributes


### PR DESCRIPTION
## Summary
- include `doc_type` in default vector attributes for image hit-testing
- ensure image results map back to segments for retrieval

I've been facing the issue of not being able to do a retrieval by passing an image. I found this to be the reason.