### PR TITLE
fix(web): remove inconsistent bottom border from apps page header

### DIFF
--- a/web/app/components/header/header-wrapper.tsx
+++ b/web/app/components/header/header-wrapper.tsx
@@ -14,7 +14,7 @@ const HeaderWrapper = ({
   children,
 }: HeaderWrapperProps) => {
   const pathname = usePathname()
-  const isBordered = ['/apps', '/datasets/create', '/tools'].includes(pathname)
+  const isBordered = ['/datasets/create', '/tools'].includes(pathname)
   // Check if the current path is a workflow canvas & fullscreen
   const inWorkflowCanvas = pathname.endsWith('/workflow')
   const isPipelineCanvas = pathname.endsWith('/pipeline')


### PR DESCRIPTION
## Summary

- Removes `/apps` from the `isBordered` paths in `header-wrapper.tsx` to make the apps page header consistent with the plugins page
- This addresses the dark mode UI inconsistency where the apps page shows a prominent bottom border that is not present on other similar pages

## Changes

**Before:** Apps page (`/apps`) had a bottom border on the header (`border-b border-divider-regular`)  
**After:** Apps page header matches the plugin list page (no bottom border)

This is a minimal fix addressing **screenshot 1** from issue #31137 (the border below tabs on the apps page).

## Related Issue

Fixes #31137 (partially - addresses the apps page header border inconsistency)

## Test Plan

- [ ] Navigate to `/apps` in dark mode - verify no bottom border on header
- [ ] Navigate to `/plugins` in dark mode - verify consistent appearance with apps page
- [ ] Navigate to `/tools` and `/datasets/create` - verify they still have the bottom border as intended