### PR TITLE
fix: NextStep crash when target node is missing

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/next-step/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/next-step/index.tsx
@@ -44,11 +44,19 @@ const NextStep = ({
   const connectedEdges = getConnectedEdges([selectedNode] as Node[], edges).filter(edge => edge.source === selectedNode!.id)
 
   const list = useMemo(() => {
+    const resolveNextNodes = (connected: typeof connectedEdges) => {
+      return connected.reduce<Node[]>((acc, edge) => {
+        const nextNode = outgoers.find(outgoer => outgoer.id === edge.target)
+        if (nextNode)
+          acc.push(nextNode)
+        return acc
+      }, [])
+    }
     let items = []
     if (branches?.length) {
       items = branches.map((branch, index) => {
         const connected = connectedEdges.filter(edge => edge.sourceHandle === branch.id)
-        const nextNodes = connected.map(edge => outgoers.find(outgoer => outgoer.id === edge.target)!)
+        const nextNodes = resolveNextNodes(connected)
 
         return {
           branch: {
@@ -61,7 +69,7 @@ const NextStep = ({
     }
     else {
       const connected = connectedEdges.filter(edge => edge.sourceHandle === 'source')
-      const nextNodes = connected.map(edge => outgoers.find(outgoer => outgoer.id === edge.target)!)
+      const nextNodes = resolveNextNodes(connected)
 
       items = [{
         branch: {
@@ -73,7 +81,7 @@ const NextStep = ({
 
       if (data.error_strategy === ErrorHandleTypeEnum.failBranch && hasErrorHandleNode(data.type)) {
         const connected = connectedEdges.filter(edge => edge.sourceHandle === ErrorHandleTypeEnum.failBranch)
-        const nextNodes = connected.map(edge => outgoers.find(outgoer => outgoer.id === edge.target)!)
+        const nextNodes = resolveNextNodes(connected)
 
         items.push({
           branch: {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Prevents NextStep from crashing by skipping edges whose target nodes are unavailable.

### Issue

The next.js throw client error when I try to set an LLM node to use structured output, the error reports is:
```
## Error Type
Runtime TypeError

## Error Message
can't access property "id", nextNode is undefined


    at Container/<.children< (app/components/workflow/nodes/_base/components/next-step/container.tsx:49:13)
    at Container (app/components/workflow/nodes/_base/components/next-step/container.tsx:46:19)
    at NextStep/<.children<.children< (app/components/workflow/nodes/_base/components/next-step/index.tsx:106:15)
    at NextStep (app/components/workflow/nodes/_base/components/next-step/index.tsx:104:16)
    at BasePanel (app/components/workflow/nodes/_base/components/workflow-panel/index.tsx:650:19)
    at _c1< (app/components/workflow/nodes/index.tsx:49:7)
    at Panel (app/components/workflow/panel/index.tsx:134:26)
    at WorkflowPanel (app/components/workflow-app/components/workflow-panel.tsx:129:5)
    at WorkflowChildren (app/components/workflow-app/components/workflow-children.tsx:192:7)
    at WorkflowMain (app/components/workflow-app/components/workflow-main.tsx:186:7)
    at WorkflowAppWithAdditionalContext (app/components/workflow-app/index.tsx:203:9)
    at WorkflowAppWrapper (app/components/workflow-app/index.tsx:218:7)
    at Page (app/(commonLayout)/app/(appDetailLayout)/[appId]/workflow/page.tsx:6:7)

## Code Frame
  47 |           <Item
  48 |             key={nextNode.id}
> 49 |             nodeId={nextNode.id}
     |             ^
  50 |             data={nextNode.data}
  51 |             sourceHandle="source"
  52 |           />

Next.js version: 16.1.4 (Turbopack)
```

### Cause
 
The crash happens because the UI assumes every outgoing edge’s target node exists. When an edge points to a node that isn’t in the current outgoers list (e.g., deleted, filtered, or not yet loaded), outgoers.find(...) returns undefined, but the code still tries to read nextNode.id. That throws TypeError: can't access property "id", nextNode is undefined.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
