### PR TITLE
fix: ui in dark mode

### DIFF
--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -197,7 +197,7 @@ const List = () => {
           </div>
         )}
 
-        <div className="sticky border-b-0 top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
+        <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
           <TabSliderNew
             value={activeTab}
             onChange={setActiveTab}

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -197,7 +197,7 @@ const List = () => {
           </div>
         )}
 
-        <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
+        <div className="sticky border-b-0 top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pb-5 pt-7">
           <TabSliderNew
             value={activeTab}
             onChange={setActiveTab}

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -218,7 +218,7 @@ export default function AccountSetting({
             <div className="system-2xs-medium-uppercase mt-1 text-text-tertiary">ESC</div>
           </div>
           <div ref={scrollRef} className="w-full overflow-y-auto bg-components-panel-bg pb-4">
-            <div className={cn('sticky top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-b border-divider-regular')}>
+            <div className={cn('sticky border-b-0 top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-divider-regular')}>
               <div className="title-2xl-semi-bold shrink-0 text-text-primary">
                 {activeItem?.name}
                 {activeItem?.description && (

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -218,7 +218,7 @@ export default function AccountSetting({
             <div className="system-2xs-medium-uppercase mt-1 text-text-tertiary">ESC</div>
           </div>
           <div ref={scrollRef} className="w-full overflow-y-auto bg-components-panel-bg pb-4">
-            <div className={cn('sticky border-b-0 top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-divider-regular')}>
+            <div className={cn('sticky top-0 z-20 mx-8 mb-[18px] flex items-center bg-components-panel-bg pb-2 pt-[27px]', scrolled && 'border-divider-regular')}>
               <div className="title-2xl-semi-bold shrink-0 text-text-primary">
                 {activeItem?.name}
                 {activeItem?.description && (

--- a/web/app/components/plugins/marketplace/sticky-search-and-switch-wrapper.tsx
+++ b/web/app/components/plugins/marketplace/sticky-search-and-switch-wrapper.tsx
@@ -17,7 +17,7 @@ const StickySearchAndSwitchWrapper = ({
     <div
       className={cn(
         'mt-4 bg-background-body',
-        hasCustomTopClass && 'sticky z-10',
+        hasCustomTopClass && 'z-10',
         pluginTypeSwitchClassName,
       )}
     >

--- a/web/app/components/plugins/plugin-page/plugins-panel.tsx
+++ b/web/app/components/plugins/plugin-page/plugins-panel.tsx
@@ -93,7 +93,6 @@ const PluginsPanel = () => {
   return (
     <>
       <div className="flex flex-col items-start justify-center gap-3 self-stretch px-12 pb-3 pt-1">
-        <div className="h-px hidden self-stretch bg-divider-subtle"></div>
         <FilterManagement
           onFilterChange={handleFilterChange}
         />

--- a/web/app/components/plugins/plugin-page/plugins-panel.tsx
+++ b/web/app/components/plugins/plugin-page/plugins-panel.tsx
@@ -93,7 +93,7 @@ const PluginsPanel = () => {
   return (
     <>
       <div className="flex flex-col items-start justify-center gap-3 self-stretch px-12 pb-3 pt-1">
-        <div className="h-px self-stretch bg-divider-subtle"></div>
+        <div className="h-px hidden self-stretch bg-divider-subtle"></div>
         <FilterManagement
           onFilterChange={handleFilterChange}
         />

--- a/web/app/styles/monaco-sticky-fix.css
+++ b/web/app/styles/monaco-sticky-fix.css
@@ -17,5 +17,5 @@ html[data-theme="dark"] .sticky, html[data-theme="dark"] .is-sticky {
 /* Remove border-bottom from AccountSetting and Apps List sticky headers */
 html[data-theme="dark"] .mx-8.sticky.top-0.z-20,
 html[data-theme="dark"] .sticky.top-0.z-10.flex.flex-wrap {
-  border-bottom: none !important;
+  border-bottom: none;
 }

--- a/web/app/styles/monaco-sticky-fix.css
+++ b/web/app/styles/monaco-sticky-fix.css
@@ -14,3 +14,8 @@ html[data-theme="dark"] .sticky, html[data-theme="dark"] .is-sticky {
   background-color: var(--color-components-sticky-header-bg) !important;
   border-bottom: 1px solid var(--color-components-sticky-header-border) !important;
 }
+/* Remove border-bottom from AccountSetting and Apps List sticky headers */
+html[data-theme="dark"] .mx-8.sticky.top-0.z-20,
+html[data-theme="dark"] .sticky.top-0.z-10.flex.flex-wrap {
+  border-bottom: none !important;
+}


### PR DESCRIPTION
## Summary
fixes #31137

fixed ui behaviour with unnecessary borders and background-color
## Screenshots

<img width="1899" height="97" alt="Captura de tela 2026-01-19 153821" src="https://github.com/user-attachments/assets/b96134f2-2db5-48e9-a6d7-f9fde67c565d" />
<img width="1366" height="65" alt="Captura de tela 2026-01-19 154032" src="https://github.com/user-attachments/assets/0785348a-237c-4b77-8527-f7a8194a3c74" />
<img width="1919" height="122" alt="Captura de tela 2026-01-19 154153" src="https://github.com/user-attachments/assets/7c273f57-9a02-4a5b-8caa-235fc0305181" />
<img width="1919" height="121" alt="Captura de tela 2026-01-19 154239" src="https://github.com/user-attachments/assets/5999f9fe-dd7b-4f55-8cf9-a71e4db73502" />
<img width="1878" height="88" alt="Captura de tela 2026-01-19 154414" src="https://github.com/user-attachments/assets/9c00e00a-ac0c-418b-89b6-13dcddf246c7" />
<img width="1887" height="74" alt="Captura de tela 2026-01-19 154614" src="https://github.com/user-attachments/assets/100d1a93-c97d-4f00-a047-e6101c0c7486" />
<img width="1657" height="212" alt="Captura de tela 2026-01-19 154700" src="https://github.com/user-attachments/assets/ffc48c5c-095a-41ba-9c86-4d2e9c1d60a9" />
<img width="1803" height="197" alt="Captura de tela 2026-01-19 154741" src="https://github.com/user-attachments/assets/f6442bd4-89a4-4540-9c2f-f7e6ffd2e3a1" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
