### PR TITLE
ci: enable ESLint autofix in autofix bot

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -79,6 +79,29 @@ jobs:
           find . -name "*.py" -type f -exec sed -i.bak -E 's/"([^"]+)" \| None/Optional["\1"]/g; s/'"'"'([^'"'"']+)'"'"' \| None/Optional['"'"'\1'"'"']/g' {} \;
           find . -name "*.py.bak" -type f -delete
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: ./web/pnpm-lock.yaml
+
+      - name: Install web dependencies
+        run: |
+          cd web
+          pnpm install --frozen-lockfile
+
+      - name: ESLint autofix
+        run: |
+          cd web
+          pnpm lint:fix || true
+
       # mdformat breaks YAML front matter in markdown files. Add --exclude for directories containing YAML front matter.
       - name: mdformat
         run: |


### PR DESCRIPTION
## Summary
- Added ESLint autofix step to the autofix CI workflow
- Allows auto-fixing linting issues when applying suggestions on the webpage

## Changes
- Install pnpm and Node.js in the autofix workflow
- Run `pnpm lint:fix` for the web directory

## Test plan
- [x] Workflow syntax is valid (YAML)
- [x] Uses same pnpm/Node.js setup patterns as web-tests.yml

Closes #31425