### PR TITLE
docs(api): clarity SystemFeatureApi for webapp is unauthenticated by design

### DIFF
--- a/api/controllers/web/feature.py
+++ b/api/controllers/web/feature.py
@@ -19,7 +19,7 @@ class SystemFeatureApi(Resource):
             dict: System feature configuration object
 
         This endpoint is akin to the `SystemFeatureApi` endpoint in api/controllers/console/feature.py,
-        except it is intended for use by the web app, instead of the console dashboard..
+        except it is intended for use by the web app, instead of the console dashboard.
 
         NOTE: This endpoint is unauthenticated by design, as it provides system features
         data required for webapp initialization.

--- a/api/controllers/web/feature.py
+++ b/api/controllers/web/feature.py
@@ -17,5 +17,15 @@ class SystemFeatureApi(Resource):
 
         Returns:
             dict: System feature configuration object
+
+        This endpoint is akin to the `SystemFeatureApi` endpoint in api/controllers/console/feature.py,
+        except it is intended for use by the web app, instead of the console dashboard..
+
+        NOTE: This endpoint is unauthenticated by design, as it provides system features
+        data required for webapp initialization.
+
+        Authentication would create circular dependency (can't authenticate without webapp loading).
+
+        Only non-sensitive configuration data should be returned by this endpoint.
         """
         return FeatureService.get_system_features().model_dump()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The `/api/system-features` is required for the web app initialization.
Authentication would create circular dependency (can't authenticate without web app loading).

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
