### PR TITLE
fix(tools): fix ToolInvokeMessage Union type parsing issue

### DIFF
--- a/api/core/workflow/nodes/datasource/datasource_node.py
+++ b/api/core/workflow/nodes/datasource/datasource_node.py
@@ -301,7 +301,7 @@ class DatasourceNode(Node[DatasourceNodeData]):
 
         text = ""
         files: list[File] = []
-        json: list[dict] = []
+        json: list[dict | list] = []
 
         variables: dict[str, Any] = {}
 

--- a/api/core/workflow/nodes/tool/tool_node.py
+++ b/api/core/workflow/nodes/tool/tool_node.py
@@ -244,7 +244,7 @@ class ToolNode(Node[ToolNodeData]):
 
         text = ""
         files: list[File] = []
-        json: list[dict] = []
+        json: list[dict | list] = []
 
         variables: dict[str, Any] = {}
 
@@ -400,7 +400,7 @@ class ToolNode(Node[ToolNodeData]):
                         message.message.metadata = dict_metadata
 
         # Add agent_logs to outputs['json'] to ensure frontend can access thinking process
-        json_output: list[dict[str, Any]] = []
+        json_output: list[dict[str, Any] | list[Any]] = []
 
         # Step 2: normalize JSON into {"data": [...]}.change json to list[dict]
         if json:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes https://github.com/langgenius/dify/issues/31451

Fix `ToolInvokeMessage` Union type parsing issue where JSON data returned by plugins was incorrectly parsed as `FileMessage` instead of `JsonMessage`.

**Problem**: When a plugin returns JSON data:
```json
{
  "type": "json",
  "message": {"json_object": [{"cid": 9551, "summary": "..."}]},
  "meta": null
}
```

It was incorrectly parsed as `FileMessage`, causing assertions like `isinstance(message.message, ToolInvokeMessage.JsonMessage)` to fail.

**Root Cause**:
- `FileMessage` was an empty class (`pass`) that could match any dict during Pydantic Union type resolution
- `JsonMessage.json_object` only supported `dict`, but plugins often return `list`

**Changes**:
- Add `file_marker` field and validator to `FileMessage` to prevent false matches with arbitrary dictionaries
- Modify `decode_blob_message` to enforce correct message type based on the `"type"` field
- Change `JsonMessage.json_object` type from `dict` to `dict | list` to support both arrays and objects

## Screenshots

| Before | After |
|--------|-------|
| JSON data parsed as `FileMessage` (incorrect) | JSON data parsed as `JsonMessage` (correct) |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
