### PR TITLE
refactor(workflow-tool): update types and improve modal handling

### DIFF
--- a/web/app/components/tools/provider/detail.tsx
+++ b/web/app/components/tools/provider/detail.tsx
@@ -1,6 +1,5 @@
 'use client'
 import type { Collection, CustomCollectionBackend, Tool, WorkflowToolProviderRequest, WorkflowToolProviderResponse } from '../types'
-import type { WorkflowToolModalPayload } from '@/app/components/tools/workflow-tool'
 import {
   RiCloseLine,
 } from '@remixicon/react'
@@ -411,9 +410,9 @@ const ProviderDetail = ({
             onRemove={onClickCustomToolDelete}
           />
         )}
-        {isShowEditWorkflowToolModal && (
+        {isShowEditWorkflowToolModal && customCollection && (
           <WorkflowToolModal
-            payload={customCollection as unknown as WorkflowToolModalPayload}
+            payload={customCollection as WorkflowToolProviderResponse & { parameters: { name: string, description: string, form: string, required?: boolean, type?: string }[], labels: string[] }}
             onHide={() => setIsShowEditWorkflowToolModal(false)}
             onRemove={onClickWorkflowToolDelete}
             onSave={updateWorkflowToolProvider}

--- a/web/app/components/tools/types.ts
+++ b/web/app/components/tools/types.ts
@@ -52,7 +52,7 @@ export type Collection = {
   icon_dark?: string | Emoji
   label: TypeWithI18N
   type: CollectionType | string
-  team_credentials: Record<string, any>
+  team_credentials: Record<string, unknown>
   is_team_authorization: boolean
   allow_delete: boolean
   labels: string[]
@@ -124,6 +124,7 @@ export type Event = {
   description: TypeWithI18N
   parameters: TriggerParameter[]
   labels: string[]
+  // eslint-disable-next-line ts/no-explicit-any
   output_schema: Record<string, any>
 }
 
@@ -131,9 +132,10 @@ export type Tool = {
   name: string
   author: string
   label: TypeWithI18N
-  description: any
+  description: TypeWithI18N
   parameters: ToolParameter[]
   labels: string[]
+  // eslint-disable-next-line ts/no-explicit-any
   output_schema: Record<string, any>
 }
 
@@ -215,6 +217,7 @@ export type WorkflowToolProviderOutputSchema = {
 
 export type WorkflowToolProviderRequest = {
   name: string
+  label: string
   icon: Emoji
   description: string
   parameters: WorkflowToolProviderParameter[]

--- a/web/app/components/tools/workflow-tool/components/tool-input-table.tsx
+++ b/web/app/components/tools/workflow-tool/components/tool-input-table.tsx
@@ -1,0 +1,105 @@
+'use client'
+import type { FC } from 'react'
+import type { WorkflowToolProviderParameter } from '@/app/components/tools/types'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '@/utils/classnames'
+import MethodSelector from '../method-selector'
+
+type ToolInputTableProps = {
+  parameters: WorkflowToolProviderParameter[]
+  onParameterChange: (key: 'description' | 'form', value: string, index: number) => void
+}
+
+type ParameterRowProps = {
+  item: WorkflowToolProviderParameter
+  index: number
+  onParameterChange: (key: 'description' | 'form', value: string, index: number) => void
+}
+
+const ParameterRow: FC<ParameterRowProps> = ({ item, index, onParameterChange }) => {
+  const { t } = useTranslation()
+  const isImageParameter = item.name === '__image'
+
+  return (
+    <tr className="border-b border-divider-regular last:border-0">
+      <td className="max-w-[156px] p-2 pl-3">
+        <div className="text-[13px] leading-[18px]">
+          <div title={item.name} className="flex">
+            <span className="truncate font-medium text-text-primary">{item.name}</span>
+            {item.required && (
+              <span className="shrink-0 pl-1 text-xs leading-[18px] text-[#ec4a0a]">
+                {t('createTool.toolInput.required', { ns: 'tools' })}
+              </span>
+            )}
+          </div>
+          <div className="text-text-tertiary">{item.type}</div>
+        </div>
+      </td>
+      <td>
+        {isImageParameter
+          ? (
+              <div className={cn(
+                'flex h-9 min-h-[56px] cursor-default items-center gap-1 bg-transparent px-3 py-2',
+              )}
+              >
+                <div className="grow truncate text-[13px] leading-[18px] text-text-secondary">
+                  {t('createTool.toolInput.methodParameter', { ns: 'tools' })}
+                </div>
+              </div>
+            )
+          : (
+              <MethodSelector
+                value={item.form}
+                onChange={value => onParameterChange('form', value, index)}
+              />
+            )}
+      </td>
+      <td className="w-[236px] p-2 pl-3 text-text-tertiary">
+        <input
+          type="text"
+          className="w-full appearance-none bg-transparent text-[13px] font-normal leading-[18px] text-text-secondary caret-primary-600 outline-none placeholder:text-text-quaternary"
+          placeholder={t('createTool.toolInput.descriptionPlaceholder', { ns: 'tools' })!}
+          value={item.description}
+          onChange={e => onParameterChange('description', e.target.value, index)}
+        />
+      </td>
+    </tr>
+  )
+}
+
+const ToolInputTable: FC<ToolInputTableProps> = ({ parameters, onParameterChange }) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="w-full overflow-x-auto rounded-lg border border-divider-regular">
+      <table className="w-full text-xs font-normal leading-[18px] text-text-secondary">
+        <thead className="uppercase text-text-tertiary">
+          <tr className="border-b border-divider-regular">
+            <th className="w-[156px] p-2 pl-3 font-medium">
+              {t('createTool.toolInput.name', { ns: 'tools' })}
+            </th>
+            <th className="w-[102px] p-2 pl-3 font-medium">
+              {t('createTool.toolInput.method', { ns: 'tools' })}
+            </th>
+            <th className="p-2 pl-3 font-medium">
+              {t('createTool.toolInput.description', { ns: 'tools' })}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {parameters.map((item, index) => (
+            <ParameterRow
+              key={item.name}
+              item={item}
+              index={index}
+              onParameterChange={onParameterChange}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default React.memo(ToolInputTable)

--- a/web/app/components/tools/workflow-tool/components/tool-output-table.tsx
+++ b/web/app/components/tools/workflow-tool/components/tool-output-table.tsx
@@ -1,0 +1,88 @@
+'use client'
+import type { FC } from 'react'
+import type { WorkflowToolProviderOutputParameter } from '@/app/components/tools/types'
+import { RiErrorWarningLine } from '@remixicon/react'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import Tooltip from '@/app/components/base/tooltip'
+
+type ToolOutputTableProps = {
+  parameters: WorkflowToolProviderOutputParameter[]
+  isReserved: (name: string) => boolean
+}
+
+type OutputRowProps = {
+  item: WorkflowToolProviderOutputParameter
+  isReserved: (name: string) => boolean
+}
+
+const OutputRow: FC<OutputRowProps> = ({ item, isReserved }) => {
+  const { t } = useTranslation()
+  const showDuplicateWarning = !item.reserved && isReserved(item.name)
+
+  return (
+    <tr className="border-b border-divider-regular last:border-0">
+      <td className="max-w-[156px] p-2 pl-3">
+        <div className="text-[13px] leading-[18px]">
+          <div title={item.name} className="flex items-center">
+            <span className="truncate font-medium text-text-primary">{item.name}</span>
+            {item.reserved && (
+              <span className="shrink-0 pl-1 text-xs leading-[18px] text-[#ec4a0a]">
+                {t('createTool.toolOutput.reserved', { ns: 'tools' })}
+              </span>
+            )}
+            {showDuplicateWarning && (
+              <Tooltip
+                popupContent={(
+                  <div className="w-[180px]">
+                    {t('createTool.toolOutput.reservedParameterDuplicateTip', { ns: 'tools' })}
+                  </div>
+                )}
+              >
+                <RiErrorWarningLine className="h-3 w-3 text-text-warning-secondary" />
+              </Tooltip>
+            )}
+          </div>
+          <div className="text-text-tertiary">{item.type}</div>
+        </div>
+      </td>
+      <td className="w-[236px] p-2 pl-3 text-text-tertiary">
+        <span className="text-[13px] font-normal leading-[18px] text-text-secondary">
+          {item.description}
+        </span>
+      </td>
+    </tr>
+  )
+}
+
+const ToolOutputTable: FC<ToolOutputTableProps> = ({ parameters, isReserved }) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="w-full overflow-x-auto rounded-lg border border-divider-regular">
+      <table className="w-full text-xs font-normal leading-[18px] text-text-secondary">
+        <thead className="uppercase text-text-tertiary">
+          <tr className="border-b border-divider-regular">
+            <th className="w-[156px] p-2 pl-3 font-medium">
+              {t('createTool.name', { ns: 'tools' })}
+            </th>
+            <th className="p-2 pl-3 font-medium">
+              {t('createTool.toolOutput.description', { ns: 'tools' })}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {parameters.map(item => (
+            <OutputRow
+              key={item.name}
+              item={item}
+              isReserved={isReserved}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default React.memo(ToolOutputTable)

--- a/web/app/components/tools/workflow-tool/configure-button.tsx
+++ b/web/app/components/tools/workflow-tool/configure-button.tsx
@@ -1,22 +1,18 @@
 'use client'
-import type { Emoji, WorkflowToolProviderOutputParameter, WorkflowToolProviderParameter, WorkflowToolProviderRequest, WorkflowToolProviderResponse } from '@/app/components/tools/types'
+import type { Emoji } from '@/app/components/tools/types'
 import type { InputVar, Variable } from '@/app/components/workflow/types'
 import type { PublishWorkflowParams } from '@/types/workflow'
 import { RiArrowRightUpLine, RiHammerLine } from '@remixicon/react'
 import { useRouter } from 'next/navigation'
-import * as React from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
+import Divider from '@/app/components/base/divider'
 import Loading from '@/app/components/base/loading'
-import Toast from '@/app/components/base/toast'
 import Indicator from '@/app/components/header/indicator'
 import WorkflowToolModal from '@/app/components/tools/workflow-tool'
 import { useAppContext } from '@/context/app-context'
-import { createWorkflowToolProvider, fetchWorkflowToolDetailByAppID, saveWorkflowToolProvider } from '@/service/tools'
-import { useInvalidateAllWorkflowTools } from '@/service/use-tools'
 import { cn } from '@/utils/classnames'
-import Divider from '../../base/divider'
+import { useConfigureButton } from './hooks/use-configure-button'
 
 type Props = {
   disabled: boolean
@@ -33,10 +29,103 @@ type Props = {
   disabledReason?: string
 }
 
+type UnpublishedCardProps = {
+  disabled: boolean
+  isManager: boolean
+  onConfigureClick: () => void
+}
+
+const UnpublishedCard = ({ disabled, isManager, onConfigureClick }: UnpublishedCardProps) => {
+  const { t } = useTranslation()
+
+  const handleClick = () => {
+    if (!disabled && isManager)
+      onConfigureClick()
+  }
+
+  return (
+    <div
+      className="flex items-center justify-start gap-2 p-2 pl-2.5"
+      onClick={handleClick}
+    >
+      <RiHammerLine className={cn('relative h-4 w-4 text-text-secondary', !disabled && isManager && 'group-hover:text-text-accent')} />
+      <div
+        title={t('common.workflowAsTool', { ns: 'workflow' }) || ''}
+        className={cn('system-sm-medium shrink grow basis-0 truncate text-text-secondary', !disabled && isManager && 'group-hover:text-text-accent')}
+      >
+        {t('common.workflowAsTool', { ns: 'workflow' })}
+      </div>
+      <span className="system-2xs-medium-uppercase shrink-0 rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 text-text-tertiary">
+        {t('common.configureRequired', { ns: 'workflow' })}
+      </span>
+    </div>
+  )
+}
+
+type NonManagerCardProps = object
+
+const NonManagerCard = (_props: NonManagerCardProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex items-center justify-start gap-2 p-2 pl-2.5">
+      <RiHammerLine className="h-4 w-4 text-text-tertiary" />
+      <div
+        title={t('common.workflowAsTool', { ns: 'workflow' }) || ''}
+        className="system-sm-medium shrink grow basis-0 truncate text-text-tertiary"
+      >
+        {t('common.workflowAsTool', { ns: 'workflow' })}
+      </div>
+    </div>
+  )
+}
+
+type PublishedActionsProps = {
+  disabled: boolean
+  isManager: boolean
+  outdated: boolean
+  onConfigureClick: () => void
+  onManageClick: () => void
+}
+
+const PublishedActions = ({ disabled, isManager, outdated, onConfigureClick, onManageClick }: PublishedActionsProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="border-t-[0.5px] border-divider-regular px-2.5 py-2">
+      <div className="flex justify-between gap-x-2">
+        <Button
+          size="small"
+          className="w-[140px]"
+          onClick={onConfigureClick}
+          disabled={!isManager || disabled}
+        >
+          {t('common.configure', { ns: 'workflow' })}
+          {outdated && <Indicator className="ml-1" color="yellow" />}
+        </Button>
+        <Button
+          size="small"
+          className="w-[140px]"
+          onClick={onManageClick}
+          disabled={disabled}
+        >
+          {t('common.manageInTools', { ns: 'workflow' })}
+          <RiArrowRightUpLine className="ml-1 h-4 w-4" />
+        </Button>
+      </div>
+      {outdated && (
+        <div className="mt-1 text-xs leading-[18px] text-text-warning">
+          {t('common.workflowAsToolTip', { ns: 'workflow' })}
+        </div>
+      )}
+    </div>
+  )
+}
+
 const WorkflowToolConfigureButton = ({
   disabled,
   published,
-  detailNeedUpdate,
+  detailNeedUpdate: _detailNeedUpdate,
   workflowAppId,
   icon,
   name,
@@ -49,229 +138,95 @@ const WorkflowToolConfigureButton = ({
 }: Props) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const [showModal, setShowModal] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
-  const [detail, setDetail] = useState<WorkflowToolProviderResponse>()
   const { isCurrentWorkspaceManager } = useAppContext()
-  const invalidateAllWorkflowTools = useInvalidateAllWorkflowTools()
 
-  const outdated = useMemo(() => {
-    if (!detail)
-      return false
-    if (detail.tool.parameters.length !== inputs?.length) {
-      return true
-    }
-    else {
-      for (const item of inputs || []) {
-        const param = detail.tool.parameters.find(toolParam => toolParam.name === item.variable)
-        if (!param) {
-          return true
-        }
-        else if (param.required !== item.required) {
-          return true
-        }
-        else {
-          if (item.type === 'paragraph' && param.type !== 'string')
-            return true
-          if (item.type === 'text-input' && param.type !== 'string')
-            return true
-        }
-      }
-    }
-    return false
-  }, [detail, inputs])
+  const {
+    showModal,
+    isLoading,
+    outdated,
+    payload,
+    openModal,
+    closeModal,
+    handleCreate,
+    handleUpdate,
+  } = useConfigureButton({
+    published,
+    workflowAppId,
+    icon,
+    name,
+    description,
+    inputs,
+    outputs,
+    handlePublish,
+    onRefreshData,
+  })
 
-  const payload = useMemo(() => {
-    let parameters: WorkflowToolProviderParameter[] = []
-    let outputParameters: WorkflowToolProviderOutputParameter[] = []
+  const handleUnpublishedClick = () => {
+    if (!disabled)
+      openModal()
+  }
+
+  const handleManageClick = () => {
+    router.push('/tools?category=workflow')
+  }
+
+  const cardClassName = cn(
+    'group rounded-lg bg-background-section-burn transition-colors',
+    disabled || !isCurrentWorkspaceManager ? 'cursor-not-allowed opacity-60 shadow-xs' : 'cursor-pointer',
+    !disabled && !published && isCurrentWorkspaceManager && 'hover:bg-state-accent-hover',
+  )
+
+  const renderCardContent = () => {
+    if (!isCurrentWorkspaceManager)
+      return <NonManagerCard />
 
     if (!published) {
-      parameters = (inputs || []).map((item) => {
-        return {
-          name: item.variable,
-          description: '',
-          form: 'llm',
-          required: item.required,
-          type: item.type,
-        }
-      })
-      outputParameters = (outputs || []).map((item) => {
-        return {
-          name: item.variable,
-          description: '',
-          type: item.value_type,
-        }
-      })
+      return (
+        <UnpublishedCard
+          disabled={disabled}
+          isManager={isCurrentWorkspaceManager}
+          onConfigureClick={handleUnpublishedClick}
+        />
+      )
     }
-    else if (detail && detail.tool) {
-      parameters = (inputs || []).map((item) => {
-        return {
-          name: item.variable,
-          required: item.required,
-          type: item.type === 'paragraph' ? 'string' : item.type,
-          description: detail.tool.parameters.find(param => param.name === item.variable)?.llm_description || '',
-          form: detail.tool.parameters.find(param => param.name === item.variable)?.form || 'llm',
-        }
-      })
-      outputParameters = (outputs || []).map((item) => {
-        const found = detail.tool.output_schema?.properties?.[item.variable]
-        return {
-          name: item.variable,
-          description: found ? found.description : '',
-          type: item.value_type,
-        }
-      })
-    }
-    return {
-      icon: detail?.icon || icon,
-      label: detail?.label || name,
-      name: detail?.name || '',
-      description: detail?.description || description,
-      parameters,
-      outputParameters,
-      labels: detail?.tool?.labels || [],
-      privacy_policy: detail?.privacy_policy || '',
-      ...(published
-        ? {
-            workflow_tool_id: detail?.workflow_tool_id,
-          }
-        : {
-            workflow_app_id: workflowAppId,
-          }),
-    }
-  }, [detail, published, workflowAppId, icon, name, description, inputs])
 
-  const getDetail = useCallback(async (workflowAppId: string) => {
-    setIsLoading(true)
-    const res = await fetchWorkflowToolDetailByAppID(workflowAppId)
-    setDetail(res)
-    setIsLoading(false)
-  }, [])
-
-  useEffect(() => {
-    if (published)
-      getDetail(workflowAppId)
-  }, [getDetail, published, workflowAppId])
-
-  useEffect(() => {
-    if (detailNeedUpdate)
-      getDetail(workflowAppId)
-  }, [detailNeedUpdate, getDetail, workflowAppId])
-
-  const createHandle = async (data: WorkflowToolProviderRequest & { workflow_app_id: string }) => {
-    try {
-      await createWorkflowToolProvider(data)
-      invalidateAllWorkflowTools()
-      onRefreshData?.()
-      getDetail(workflowAppId)
-      Toast.notify({
-        type: 'success',
-        message: t('api.actionSuccess', { ns: 'common' }),
-      })
-      setShowModal(false)
-    }
-    catch (e) {
-      Toast.notify({ type: 'error', message: (e as Error).message })
-    }
+    return (
+      <div
+        className="flex items-center justify-start gap-2 p-2 pl-2.5"
+        onClick={openModal}
+      >
+        <RiHammerLine className="relative h-4 w-4 text-text-secondary" />
+        <div
+          title={t('common.workflowAsTool', { ns: 'workflow' }) || ''}
+          className="system-sm-medium shrink grow basis-0 truncate text-text-secondary"
+        >
+          {t('common.workflowAsTool', { ns: 'workflow' })}
+        </div>
+      </div>
+    )
   }
 
-  const updateWorkflowToolProvider = async (data: WorkflowToolProviderRequest & Partial<{
-    workflow_app_id: string
-    workflow_tool_id: string
-  }>) => {
-    try {
-      await handlePublish()
-      await saveWorkflowToolProvider(data)
-      onRefreshData?.()
-      invalidateAllWorkflowTools()
-      getDetail(workflowAppId)
-      Toast.notify({
-        type: 'success',
-        message: t('api.actionSuccess', { ns: 'common' }),
-      })
-      setShowModal(false)
-    }
-    catch (e) {
-      Toast.notify({ type: 'error', message: (e as Error).message })
-    }
-  }
+  const showContent = !published || !isLoading
 
   return (
     <>
       <Divider type="horizontal" className="h-px bg-divider-subtle" />
-      {(!published || !isLoading) && (
-        <div className={cn(
-          'group rounded-lg bg-background-section-burn transition-colors',
-          disabled || !isCurrentWorkspaceManager ? 'cursor-not-allowed opacity-60 shadow-xs' : 'cursor-pointer',
-          !disabled && !published && isCurrentWorkspaceManager && 'hover:bg-state-accent-hover',
-        )}
-        >
-          {isCurrentWorkspaceManager
-            ? (
-                <div
-                  className="flex items-center justify-start gap-2 p-2 pl-2.5"
-                  onClick={() => !disabled && !published && setShowModal(true)}
-                >
-                  <RiHammerLine className={cn('relative h-4 w-4 text-text-secondary', !disabled && !published && 'group-hover:text-text-accent')} />
-                  <div
-                    title={t('common.workflowAsTool', { ns: 'workflow' }) || ''}
-                    className={cn('system-sm-medium shrink grow basis-0 truncate text-text-secondary', !disabled && !published && 'group-hover:text-text-accent')}
-                  >
-                    {t('common.workflowAsTool', { ns: 'workflow' })}
-                  </div>
-                  {!published && (
-                    <span className="system-2xs-medium-uppercase shrink-0 rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 text-text-tertiary">
-                      {t('common.configureRequired', { ns: 'workflow' })}
-                    </span>
-                  )}
-                </div>
-              )
-            : (
-                <div
-                  className="flex items-center justify-start gap-2 p-2 pl-2.5"
-                >
-                  <RiHammerLine className="h-4 w-4 text-text-tertiary" />
-                  <div
-                    title={t('common.workflowAsTool', { ns: 'workflow' }) || ''}
-                    className="system-sm-medium shrink grow basis-0 truncate text-text-tertiary"
-                  >
-                    {t('common.workflowAsTool', { ns: 'workflow' })}
-                  </div>
-                </div>
-              )}
+      {showContent && (
+        <div className={cardClassName}>
+          {renderCardContent()}
           {disabledReason && (
             <div className="mt-1 px-2.5 pb-2 text-xs leading-[18px] text-text-tertiary">
               {disabledReason}
             </div>
           )}
           {published && (
-            <div className="border-t-[0.5px] border-divider-regular px-2.5 py-2">
-              <div className="flex justify-between gap-x-2">
-                <Button
-                  size="small"
-                  className="w-[140px]"
-                  onClick={() => setShowModal(true)}
-                  disabled={!isCurrentWorkspaceManager || disabled}
-                >
-                  {t('common.configure', { ns: 'workflow' })}
-                  {outdated && <Indicator className="ml-1" color="yellow" />}
-                </Button>
-                <Button
-                  size="small"
-                  className="w-[140px]"
-                  onClick={() => router.push('/tools?category=workflow')}
-                  disabled={disabled}
-                >
-                  {t('common.manageInTools', { ns: 'workflow' })}
-                  <RiArrowRightUpLine className="ml-1 h-4 w-4" />
-                </Button>
-              </div>
-              {outdated && (
-                <div className="mt-1 text-xs leading-[18px] text-text-warning">
-                  {t('common.workflowAsToolTip', { ns: 'workflow' })}
-                </div>
-              )}
-            </div>
+            <PublishedActions
+              disabled={disabled}
+              isManager={isCurrentWorkspaceManager}
+              outdated={outdated}
+              onConfigureClick={openModal}
+              onManageClick={handleManageClick}
+            />
           )}
         </div>
       )}
@@ -280,12 +235,13 @@ const WorkflowToolConfigureButton = ({
         <WorkflowToolModal
           isAdd={!published}
           payload={payload}
-          onHide={() => setShowModal(false)}
-          onCreate={createHandle}
-          onSave={updateWorkflowToolProvider}
+          onHide={closeModal}
+          onCreate={handleCreate}
+          onSave={handleUpdate}
         />
       )}
     </>
   )
 }
+
 export default WorkflowToolConfigureButton

--- a/web/app/components/tools/workflow-tool/configure-button.tsx
+++ b/web/app/components/tools/workflow-tool/configure-button.tsx
@@ -62,7 +62,7 @@ const UnpublishedCard = ({ disabled, isManager, onConfigureClick }: UnpublishedC
   )
 }
 
-type NonManagerCardProps = object
+type NonManagerCardProps = Record<string, never>
 
 const NonManagerCard = (_props: NonManagerCardProps) => {
   const { t } = useTranslation()
@@ -125,7 +125,7 @@ const PublishedActions = ({ disabled, isManager, outdated, onConfigureClick, onM
 const WorkflowToolConfigureButton = ({
   disabled,
   published,
-  detailNeedUpdate: _detailNeedUpdate,
+  detailNeedUpdate,
   workflowAppId,
   icon,
   name,
@@ -151,6 +151,7 @@ const WorkflowToolConfigureButton = ({
     handleUpdate,
   } = useConfigureButton({
     published,
+    detailNeedUpdate,
     workflowAppId,
     icon,
     name,

--- a/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
@@ -1,0 +1,213 @@
+'use client'
+import type { Emoji, WorkflowToolProviderParameter, WorkflowToolProviderRequest, WorkflowToolProviderResponse } from '@/app/components/tools/types'
+import type { InputVar, Variable } from '@/app/components/workflow/types'
+import type { PublishWorkflowParams } from '@/types/workflow'
+import { useBoolean } from 'ahooks'
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import Toast from '@/app/components/base/toast'
+import { useInvalidateAllWorkflowTools } from '@/service/use-tools'
+import {
+  useCreateWorkflowTool,
+  useInvalidateWorkflowToolDetail,
+  useUpdateWorkflowTool,
+  useWorkflowToolDetail,
+} from './use-workflow-tool'
+
+export type ConfigureButtonProps = {
+  published: boolean
+  workflowAppId: string
+  icon: Emoji
+  name: string
+  description: string
+  inputs?: InputVar[]
+  outputs?: Variable[]
+  handlePublish: (params?: PublishWorkflowParams) => Promise<void>
+  onRefreshData?: () => void
+}
+
+// Type for parameter building context
+type ParameterBuildContext = {
+  inputs: InputVar[] | undefined
+  outputs: Variable[] | undefined
+  detail: WorkflowToolProviderResponse | undefined
+  published: boolean
+}
+
+/**
+ * Check if tool parameters are outdated compared to workflow inputs
+ */
+function checkOutdated(detail: WorkflowToolProviderResponse | undefined, inputs: InputVar[] | undefined): boolean {
+  if (!detail)
+    return false
+
+  const toolParams = detail.tool.parameters
+  const inputList = inputs ?? []
+
+  if (toolParams.length !== inputList.length)
+    return true
+
+  return inputList.some((item) => {
+    const param = toolParams.find(p => p.name === item.variable)
+    if (!param || param.required !== item.required)
+      return true
+
+    const isTextType = item.type === 'paragraph' || item.type === 'text-input'
+    return isTextType && param.type !== 'string'
+  })
+}
+
+/**
+ * Build input parameters based on context
+ */
+function buildInputParameters(ctx: ParameterBuildContext): WorkflowToolProviderParameter[] {
+  const inputList = ctx.inputs ?? []
+
+  if (!ctx.published || !ctx.detail?.tool) {
+    return inputList.map(item => ({
+      name: item.variable,
+      description: '',
+      form: 'llm',
+      required: item.required,
+      type: item.type,
+    }))
+  }
+
+  const existingParams = ctx.detail.tool.parameters
+  return inputList.map((item) => {
+    const existing = existingParams.find(p => p.name === item.variable)
+    return {
+      name: item.variable,
+      required: item.required,
+      type: item.type === 'paragraph' ? 'string' : item.type,
+      description: existing?.llm_description ?? '',
+      form: existing?.form ?? 'llm',
+    }
+  })
+}
+
+/**
+ * Build output parameters
+ */
+function buildOutputParameters(outputs: Variable[] | undefined, detail?: WorkflowToolProviderResponse) {
+  return (outputs ?? []).map((item) => {
+    const found = detail?.tool.output_schema?.properties?.[item.variable]
+    return {
+      name: item.variable,
+      description: found?.description ?? '',
+      type: item.value_type,
+    }
+  })
+}
+
+/**
+ * Custom hook for managing configure button state and logic
+ */
+export const useConfigureButton = ({
+  published,
+  workflowAppId,
+  icon,
+  name,
+  description,
+  inputs,
+  outputs,
+  handlePublish,
+  onRefreshData,
+}: ConfigureButtonProps) => {
+  const { t } = useTranslation()
+  const [showModal, { setTrue: openModal, setFalse: closeModal }] = useBoolean(false)
+
+  // Data fetching with React Query
+  const {
+    data: detail,
+    isLoading,
+    refetch: refetchDetail,
+  } = useWorkflowToolDetail(workflowAppId, published)
+
+  // Mutations
+  const { mutateAsync: createTool } = useCreateWorkflowTool()
+  const { mutateAsync: updateTool } = useUpdateWorkflowTool()
+  const invalidateAllWorkflowTools = useInvalidateAllWorkflowTools()
+  const invalidateDetail = useInvalidateWorkflowToolDetail()
+
+  // Check if parameters are outdated
+  const outdated = useMemo(
+    () => checkOutdated(detail, inputs),
+    [detail, inputs],
+  )
+
+  // Build payload for modal
+  const payload = useMemo(() => {
+    const ctx: ParameterBuildContext = { inputs, outputs, detail, published }
+    const parameters = buildInputParameters(ctx)
+    const outputParameters = buildOutputParameters(outputs, detail)
+
+    return {
+      icon: detail?.icon ?? icon,
+      label: detail?.label ?? name,
+      name: detail?.name ?? '',
+      description: detail?.description ?? description,
+      parameters,
+      outputParameters,
+      labels: detail?.tool?.labels ?? [],
+      privacy_policy: detail?.privacy_policy ?? '',
+      ...(published
+        ? { workflow_tool_id: detail?.workflow_tool_id }
+        : { workflow_app_id: workflowAppId }),
+    }
+  }, [detail, published, workflowAppId, icon, name, description, inputs, outputs])
+
+  // Common cache invalidation logic
+  const invalidateCaches = useCallback(() => {
+    invalidateAllWorkflowTools()
+    invalidateDetail(workflowAppId)
+    onRefreshData?.()
+    refetchDetail()
+  }, [invalidateAllWorkflowTools, invalidateDetail, workflowAppId, onRefreshData, refetchDetail])
+
+  // Common success handler
+  const handleSuccess = useCallback(() => {
+    Toast.notify({ type: 'success', message: t('api.actionSuccess', { ns: 'common' }) })
+    closeModal()
+  }, [t, closeModal])
+
+  // Handler for creating new workflow tool
+  const handleCreate = useCallback(async (data: WorkflowToolProviderRequest & { workflow_app_id: string }) => {
+    try {
+      await createTool(data)
+      invalidateCaches()
+      handleSuccess()
+    }
+    catch (e) {
+      Toast.notify({ type: 'error', message: (e as Error).message })
+    }
+  }, [createTool, invalidateCaches, handleSuccess])
+
+  // Handler for updating workflow tool
+  const handleUpdate = useCallback(async (data: WorkflowToolProviderRequest & Partial<{
+    workflow_app_id: string
+    workflow_tool_id: string
+  }>) => {
+    try {
+      await handlePublish()
+      await updateTool(data)
+      invalidateCaches()
+      handleSuccess()
+    }
+    catch (e) {
+      Toast.notify({ type: 'error', message: (e as Error).message })
+    }
+  }, [handlePublish, updateTool, invalidateCaches, handleSuccess])
+
+  return {
+    showModal,
+    isLoading,
+    detail,
+    outdated,
+    payload,
+    openModal,
+    closeModal,
+    handleCreate,
+    handleUpdate,
+  }
+}

--- a/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
@@ -3,7 +3,7 @@ import type { Emoji, WorkflowToolProviderParameter, WorkflowToolProviderRequest,
 import type { InputVar, Variable } from '@/app/components/workflow/types'
 import type { PublishWorkflowParams } from '@/types/workflow'
 import { useBoolean } from 'ahooks'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Toast from '@/app/components/base/toast'
 import { useInvalidateAllWorkflowTools } from '@/service/use-tools'
@@ -16,6 +16,7 @@ import {
 
 export type ConfigureButtonProps = {
   published: boolean
+  detailNeedUpdate?: boolean
   workflowAppId: string
   icon: Emoji
   name: string
@@ -105,6 +106,7 @@ function buildOutputParameters(outputs: Variable[] | undefined, detail?: Workflo
  */
 export const useConfigureButton = ({
   published,
+  detailNeedUpdate,
   workflowAppId,
   icon,
   name,
@@ -123,6 +125,12 @@ export const useConfigureButton = ({
     isLoading,
     refetch: refetchDetail,
   } = useWorkflowToolDetail(workflowAppId, published)
+
+  // Refetch detail when external updates occur
+  useEffect(() => {
+    if (detailNeedUpdate)
+      refetchDetail()
+  }, [detailNeedUpdate, refetchDetail])
 
   // Mutations
   const { mutateAsync: createTool } = useCreateWorkflowTool()
@@ -151,6 +159,7 @@ export const useConfigureButton = ({
       outputParameters,
       labels: detail?.tool?.labels ?? [],
       privacy_policy: detail?.privacy_policy ?? '',
+      tool: detail?.tool,
       ...(published
         ? { workflow_tool_id: detail?.workflow_tool_id }
         : { workflow_app_id: workflowAppId }),

--- a/web/app/components/tools/workflow-tool/hooks/use-modal-state.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-modal-state.ts
@@ -1,0 +1,40 @@
+'use client'
+import { useBoolean } from 'ahooks'
+import { useCallback } from 'react'
+
+export type ModalStateResult = {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
+}
+
+/**
+ * Simple hook for managing modal open/close state
+ */
+export const useModalState = (initialState = false): ModalStateResult => {
+  const [isOpen, { setTrue: open, setFalse: close, toggle }] = useBoolean(initialState)
+  return { isOpen, open, close, toggle }
+}
+
+/**
+ * Hook for managing multiple modal states
+ */
+export const useMultiModalState = <T extends string>(modalNames: T[]) => {
+  // Create individual modal states
+  const modals = modalNames.reduce((acc, name) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isOpen, { setTrue: open, setFalse: close }] = useBoolean(false)
+    acc[name] = { isOpen, open, close }
+    return acc
+  }, {} as Record<T, { isOpen: boolean, open: () => void, close: () => void }>)
+
+  // Helper to close all modals
+  const closeAll = useCallback(() => {
+    modalNames.forEach((name) => {
+      modals[name].close()
+    })
+  }, [modals, modalNames])
+
+  return { modals, closeAll }
+}

--- a/web/app/components/tools/workflow-tool/hooks/use-modal-state.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-modal-state.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useBoolean } from 'ahooks'
-import { useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 export type ModalStateResult = {
   isOpen: boolean
@@ -17,24 +17,46 @@ export const useModalState = (initialState = false): ModalStateResult => {
   return { isOpen, open, close, toggle }
 }
 
+type ModalActions = {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
 /**
  * Hook for managing multiple modal states
+ * Uses a single useState to avoid violating Rules of Hooks
  */
 export const useMultiModalState = <T extends string>(modalNames: T[]) => {
-  // Create individual modal states
-  const modals = modalNames.reduce((acc, name) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [isOpen, { setTrue: open, setFalse: close }] = useBoolean(false)
-    acc[name] = { isOpen, open, close }
-    return acc
-  }, {} as Record<T, { isOpen: boolean, open: () => void, close: () => void }>)
+  // Use a single state object to track all modal open states
+  const [openStates, setOpenStates] = useState<Record<T, boolean>>(() =>
+    modalNames.reduce((acc, name) => {
+      acc[name] = false
+      return acc
+    }, {} as Record<T, boolean>),
+  )
+
+  // Create memoized modal accessors with open/close callbacks
+  const modals = useMemo(() => {
+    return modalNames.reduce((acc, name) => {
+      acc[name] = {
+        isOpen: openStates[name] ?? false,
+        open: () => setOpenStates(prev => ({ ...prev, [name]: true })),
+        close: () => setOpenStates(prev => ({ ...prev, [name]: false })),
+      }
+      return acc
+    }, {} as Record<T, ModalActions>)
+  }, [modalNames, openStates])
 
   // Helper to close all modals
   const closeAll = useCallback(() => {
-    modalNames.forEach((name) => {
-      modals[name].close()
-    })
-  }, [modals, modalNames])
+    setOpenStates(prev =>
+      modalNames.reduce((acc, name) => {
+        acc[name] = false
+        return acc
+      }, { ...prev } as Record<T, boolean>),
+    )
+  }, [modalNames])
 
   return { modals, closeAll }
 }

--- a/web/app/components/tools/workflow-tool/hooks/use-workflow-tool-form.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-workflow-tool-form.ts
@@ -1,0 +1,240 @@
+'use client'
+import type { Emoji, WorkflowToolProviderOutputParameter, WorkflowToolProviderOutputSchema, WorkflowToolProviderParameter, WorkflowToolProviderRequest } from '@/app/components/tools/types'
+import { produce } from 'immer'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Toast from '@/app/components/base/toast'
+import { VarType } from '@/app/components/workflow/types'
+import { buildWorkflowOutputParameters } from '../utils'
+
+export type WorkflowToolFormPayload = {
+  icon: Emoji
+  label: string
+  name: string
+  description: string
+  parameters: WorkflowToolProviderParameter[]
+  outputParameters?: WorkflowToolProviderOutputParameter[] | null
+  labels: string[]
+  privacy_policy: string
+  workflow_app_id?: string
+  workflow_tool_id?: string
+  tool?: {
+    output_schema?: WorkflowToolProviderOutputSchema | null
+  }
+}
+
+export type UseWorkflowToolFormProps = {
+  payload: WorkflowToolFormPayload
+  isAdd?: boolean
+  onCreate?: (data: WorkflowToolProviderRequest & { workflow_app_id: string }) => void
+  onSave?: (data: WorkflowToolProviderRequest & Partial<{
+    workflow_app_id: string
+    workflow_tool_id: string
+  }>) => void
+}
+
+type FormState = {
+  emoji: Emoji
+  label: string
+  name: string
+  description: string
+  parameters: WorkflowToolProviderParameter[]
+  labels: string[]
+  privacyPolicy: string
+}
+
+/**
+ * Validate tool name format (alphanumeric and underscores only)
+ */
+const isNameValid = (name: string): boolean => {
+  if (name === '')
+    return true
+  return /^\w+$/.test(name)
+}
+
+/**
+ * Custom hook for managing workflow tool form state and logic
+ */
+export const useWorkflowToolForm = ({
+  payload,
+  isAdd,
+  onCreate,
+  onSave,
+}: UseWorkflowToolFormProps) => {
+  const { t } = useTranslation()
+
+  // Form state
+  const [formState, setFormState] = useState<FormState>({
+    emoji: payload.icon,
+    label: payload.label,
+    name: payload.name,
+    description: payload.description,
+    parameters: payload.parameters,
+    labels: payload.labels,
+    privacyPolicy: payload.privacy_policy,
+  })
+
+  // Computed output parameters (from payload.outputParameters or derived from tool.output_schema)
+  const outputParameters = useMemo<WorkflowToolProviderOutputParameter[]>(
+    () => buildWorkflowOutputParameters(payload.outputParameters ?? null, payload.tool?.output_schema ?? null),
+    [payload.outputParameters, payload.tool?.output_schema],
+  )
+
+  // Reserved output parameters (text, files, json)
+  const reservedOutputParameters = useMemo<WorkflowToolProviderOutputParameter[]>(() => [
+    {
+      name: 'text',
+      description: t('nodes.tool.outputVars.text', { ns: 'workflow' }),
+      type: VarType.string,
+      reserved: true,
+    },
+    {
+      name: 'files',
+      description: t('nodes.tool.outputVars.files.title', { ns: 'workflow' }),
+      type: VarType.arrayFile,
+      reserved: true,
+    },
+    {
+      name: 'json',
+      description: t('nodes.tool.outputVars.json', { ns: 'workflow' }),
+      type: VarType.arrayObject,
+      reserved: true,
+    },
+  ], [t])
+
+  // Check if output parameter name conflicts with reserved names
+  const isOutputParameterReserved = useCallback((name: string) => {
+    return reservedOutputParameters.some(p => p.name === name)
+  }, [reservedOutputParameters])
+
+  // State update handlers
+  const setEmoji = useCallback((emoji: Emoji) => {
+    setFormState(prev => ({ ...prev, emoji }))
+  }, [])
+
+  const setLabel = useCallback((label: string) => {
+    setFormState(prev => ({ ...prev, label }))
+  }, [])
+
+  const setName = useCallback((name: string) => {
+    setFormState(prev => ({ ...prev, name }))
+  }, [])
+
+  const setDescription = useCallback((description: string) => {
+    setFormState(prev => ({ ...prev, description }))
+  }, [])
+
+  const setLabels = useCallback((labels: string[]) => {
+    setFormState(prev => ({ ...prev, labels }))
+  }, [])
+
+  const setPrivacyPolicy = useCallback((privacyPolicy: string) => {
+    setFormState(prev => ({ ...prev, privacyPolicy }))
+  }, [])
+
+  // Handle parameter change (description or form/method)
+  const handleParameterChange = useCallback((key: 'description' | 'form', value: string, index: number) => {
+    setFormState((prev) => {
+      const newParameters = produce(prev.parameters, (draft) => {
+        if (key === 'description')
+          draft[index].description = value
+        else
+          draft[index].form = value
+      })
+      return { ...prev, parameters: newParameters }
+    })
+  }, [])
+
+  // Validate form and show error toast if invalid
+  const validateForm = useCallback((): boolean => {
+    if (!formState.label) {
+      Toast.notify({
+        type: 'error',
+        message: t('errorMsg.fieldRequired', { ns: 'common', field: t('createTool.name', { ns: 'tools' }) }),
+      })
+      return false
+    }
+
+    if (!formState.name) {
+      Toast.notify({
+        type: 'error',
+        message: t('errorMsg.fieldRequired', { ns: 'common', field: t('createTool.nameForToolCall', { ns: 'tools' }) }),
+      })
+      return false
+    }
+
+    if (!isNameValid(formState.name)) {
+      Toast.notify({
+        type: 'error',
+        message: t('createTool.nameForToolCall', { ns: 'tools' }) + t('createTool.nameForToolCallTip', { ns: 'tools' }),
+      })
+      return false
+    }
+
+    return true
+  }, [formState.label, formState.name, t])
+
+  // Build request params for API
+  const buildRequestParams = useCallback((): WorkflowToolProviderRequest => ({
+    name: formState.name,
+    description: formState.description,
+    icon: formState.emoji,
+    label: formState.label,
+    parameters: formState.parameters.map(item => ({
+      name: item.name,
+      description: item.description,
+      form: item.form,
+    })),
+    labels: formState.labels,
+    privacy_policy: formState.privacyPolicy,
+  }), [formState])
+
+  // Submit form
+  const onConfirm = useCallback(() => {
+    if (!validateForm())
+      return
+
+    const requestParams = buildRequestParams()
+
+    if (isAdd) {
+      onCreate?.({
+        ...requestParams,
+        workflow_app_id: payload.workflow_app_id!,
+      })
+    }
+    else {
+      onSave?.({
+        ...requestParams,
+        workflow_tool_id: payload.workflow_tool_id,
+      })
+    }
+  }, [validateForm, buildRequestParams, isAdd, onCreate, onSave, payload.workflow_app_id, payload.workflow_tool_id])
+
+  return {
+    // Form state
+    emoji: formState.emoji,
+    label: formState.label,
+    name: formState.name,
+    description: formState.description,
+    parameters: formState.parameters,
+    labels: formState.labels,
+    privacyPolicy: formState.privacyPolicy,
+
+    // Computed values
+    outputParameters,
+    reservedOutputParameters,
+    allOutputParameters: [...reservedOutputParameters, ...outputParameters],
+    isNameValid: isNameValid(formState.name),
+
+    // Handlers
+    setEmoji,
+    setLabel,
+    setName,
+    setDescription,
+    setLabels,
+    setPrivacyPolicy,
+    handleParameterChange,
+    isOutputParameterReserved,
+    onConfirm,
+  }
+}

--- a/web/app/components/tools/workflow-tool/hooks/use-workflow-tool.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-workflow-tool.ts
@@ -1,0 +1,70 @@
+import type { WorkflowToolProviderRequest, WorkflowToolProviderResponse } from '@/app/components/tools/types'
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { get, post } from '@/service/base'
+
+const NAME_SPACE = 'workflow-tool'
+
+// Query key factory for workflow tool detail
+const workflowToolDetailKey = (appId: string) => [NAME_SPACE, 'detail', appId]
+
+/**
+ * Fetch workflow tool detail by app ID
+ */
+export const useWorkflowToolDetail = (appId: string, enabled = true) => {
+  return useQuery<WorkflowToolProviderResponse>({
+    queryKey: workflowToolDetailKey(appId),
+    queryFn: () => get<WorkflowToolProviderResponse>(`/workspaces/current/tool-provider/workflow/detail?workflow_app_id=${appId}`),
+    enabled: enabled && !!appId,
+  })
+}
+
+/**
+ * Invalidate workflow tool detail cache
+ */
+export const useInvalidateWorkflowToolDetail = () => {
+  const queryClient = useQueryClient()
+  return (appId: string) => {
+    queryClient.invalidateQueries({
+      queryKey: workflowToolDetailKey(appId),
+    })
+  }
+}
+
+type CreateWorkflowToolPayload = WorkflowToolProviderRequest & { workflow_app_id: string }
+
+/**
+ * Create workflow tool provider mutation
+ */
+export const useCreateWorkflowTool = () => {
+  return useMutation({
+    mutationKey: [NAME_SPACE, 'create'],
+    mutationFn: (payload: CreateWorkflowToolPayload) => {
+      return post('/workspaces/current/tool-provider/workflow/create', {
+        body: payload,
+      })
+    },
+  })
+}
+
+type UpdateWorkflowToolPayload = WorkflowToolProviderRequest & Partial<{
+  workflow_app_id: string
+  workflow_tool_id: string
+}>
+
+/**
+ * Update workflow tool provider mutation
+ */
+export const useUpdateWorkflowTool = () => {
+  return useMutation({
+    mutationKey: [NAME_SPACE, 'update'],
+    mutationFn: (payload: UpdateWorkflowToolPayload) => {
+      return post('/workspaces/current/tool-provider/workflow/update', {
+        body: payload,
+      })
+    },
+  })
+}

--- a/web/app/components/tools/workflow-tool/index.spec.tsx
+++ b/web/app/components/tools/workflow-tool/index.spec.tsx
@@ -1,0 +1,2857 @@
+import type { WorkflowToolModalPayload } from './index'
+import type { WorkflowToolProviderResponse } from '@/app/components/tools/types'
+import type { InputVar, Variable } from '@/app/components/workflow/types'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { InputVarType, VarType } from '@/app/components/workflow/types'
+import ToolInputTable from './components/tool-input-table'
+import ToolOutputTable from './components/tool-output-table'
+import WorkflowToolConfigureButton from './configure-button'
+import ConfirmModal from './confirm-modal'
+import { useModalState, useMultiModalState } from './hooks/use-modal-state'
+import { useWorkflowToolForm } from './hooks/use-workflow-tool-form'
+import WorkflowToolAsModal from './index'
+import MethodSelector from './method-selector'
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+// Create a fresh QueryClient for each test
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
+    },
+  })
+
+// Wrapper component for tests that need QueryClientProvider
+const TestWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = createTestQueryClient()
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  )
+}
+
+// Custom render function that wraps with QueryClientProvider
+const renderWithQueryClient = (ui: React.ReactElement) => {
+  return render(ui, { wrapper: TestWrapper })
+}
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Mock Next.js navigation
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/app/workflow-app-id',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+// Mock app context
+const mockIsCurrentWorkspaceManager = vi.fn(() => true)
+vi.mock('@/context/app-context', () => ({
+  useAppContext: () => ({
+    isCurrentWorkspaceManager: mockIsCurrentWorkspaceManager(),
+  }),
+}))
+
+// Mock API services
+const mockFetchWorkflowToolDetailByAppID = vi.fn()
+const mockCreateWorkflowToolProvider = vi.fn()
+const mockSaveWorkflowToolProvider = vi.fn()
+vi.mock('@/service/tools', () => ({
+  fetchWorkflowToolDetailByAppID: (...args: unknown[]) => mockFetchWorkflowToolDetailByAppID(...args),
+  createWorkflowToolProvider: (...args: unknown[]) => mockCreateWorkflowToolProvider(...args),
+  saveWorkflowToolProvider: (...args: unknown[]) => mockSaveWorkflowToolProvider(...args),
+}))
+
+// Mock the workflow tool hooks
+const mockUseWorkflowToolDetail = vi.fn()
+const mockCreateTool = vi.fn()
+const mockUpdateTool = vi.fn()
+vi.mock('./hooks/use-workflow-tool', () => ({
+  useWorkflowToolDetail: (appId: string, enabled: boolean) => mockUseWorkflowToolDetail(appId, enabled),
+  useInvalidateWorkflowToolDetail: () => vi.fn(),
+  useCreateWorkflowTool: () => ({
+    mutateAsync: mockCreateTool,
+  }),
+  useUpdateWorkflowTool: () => ({
+    mutateAsync: mockUpdateTool,
+  }),
+}))
+
+// Mock invalidate workflow tools hook
+const mockInvalidateAllWorkflowTools = vi.fn()
+vi.mock('@/service/use-tools', () => ({
+  useInvalidateAllWorkflowTools: () => mockInvalidateAllWorkflowTools,
+}))
+
+// Mock Toast
+const mockToastNotify = vi.fn()
+vi.mock('@/app/components/base/toast', () => ({
+  default: {
+    notify: (options: { type: string, message: string }) => mockToastNotify(options),
+  },
+}))
+
+// Mock useTags hook
+vi.mock('@/app/components/plugins/hooks', () => ({
+  useTags: () => ({
+    tags: [
+      { name: 'label1', label: 'Label 1' },
+      { name: 'label2', label: 'Label 2' },
+    ],
+  }),
+}))
+
+// Mock Drawer
+vi.mock('@/app/components/base/drawer-plus', () => ({
+  default: ({ isShow, onHide, title, body }: { isShow: boolean, onHide: () => void, title: string, body: React.ReactNode }) => {
+    if (!isShow)
+      return null
+    return (
+      <div data-testid="drawer" role="dialog">
+        <div data-testid="drawer-title">{title}</div>
+        <button data-testid="drawer-close" onClick={onHide}>Close</button>
+        {body}
+      </div>
+    )
+  },
+}))
+
+// Mock EmojiPicker
+vi.mock('@/app/components/base/emoji-picker', () => ({
+  default: ({ onSelect, onClose }: { onSelect: (icon: string, background: string) => void, onClose: () => void }) => (
+    <div data-testid="emoji-picker">
+      <button data-testid="select-emoji" onClick={() => onSelect('🚀', '#f0f0f0')}>Select Emoji</button>
+      <button data-testid="close-emoji-picker" onClick={onClose}>Close</button>
+    </div>
+  ),
+}))
+
+// Mock AppIcon
+vi.mock('@/app/components/base/app-icon', () => ({
+  default: ({ onClick, icon, background }: { onClick?: () => void, icon: string, background: string }) => (
+    <div data-testid="app-icon" onClick={onClick} data-icon={icon} data-background={background}>
+      {icon}
+    </div>
+  ),
+}))
+
+// Mock LabelSelector
+vi.mock('@/app/components/tools/labels/selector', () => ({
+  default: ({ value, onChange }: { value: string[], onChange: (labels: string[]) => void }) => (
+    <div data-testid="label-selector">
+      <span data-testid="label-values">{value.join(',')}</span>
+      <button data-testid="add-label" onClick={() => onChange([...value, 'new-label'])}>Add Label</button>
+      <button data-testid="clear-labels" onClick={() => onChange([])}>Clear</button>
+    </div>
+  ),
+}))
+
+// Mock PortalToFollowElem for dropdown tests
+let mockPortalOpenState = false
+vi.mock('@/app/components/base/portal-to-follow-elem', () => ({
+  PortalToFollowElem: ({ children, open, onOpenChange }: { children: React.ReactNode, open: boolean, onOpenChange: (open: boolean) => void }) => {
+    mockPortalOpenState = open
+    return (
+      <div data-testid="portal-elem" data-open={open} onClick={() => onOpenChange(!open)}>
+        {children}
+      </div>
+    )
+  },
+  PortalToFollowElemTrigger: ({ children, onClick, className }: { children: React.ReactNode, onClick: () => void, className?: string }) => (
+    <div data-testid="portal-trigger" onClick={onClick} className={className}>
+      {children}
+    </div>
+  ),
+  PortalToFollowElemContent: ({ children, className }: { children: React.ReactNode, className?: string }) => {
+    if (!mockPortalOpenState)
+      return null
+    return <div data-testid="portal-content" className={className}>{children}</div>
+  },
+}))
+
+// ============================================================================
+// Test Data Factories
+// ============================================================================
+
+const createMockEmoji = (overrides = {}) => ({
+  content: '🔧',
+  background: '#ffffff',
+  ...overrides,
+})
+
+const createMockInputVar = (overrides: Partial<InputVar> = {}): InputVar => ({
+  variable: 'test_var',
+  label: 'Test Variable',
+  type: InputVarType.textInput,
+  required: true,
+  max_length: 100,
+  options: [],
+  ...overrides,
+} as InputVar)
+
+const createMockVariable = (overrides: Partial<Variable> = {}): Variable => ({
+  variable: 'output_var',
+  value_type: 'string',
+  ...overrides,
+} as Variable)
+
+const createMockWorkflowToolDetail = (overrides: Partial<WorkflowToolProviderResponse> = {}): WorkflowToolProviderResponse => ({
+  workflow_app_id: 'workflow-app-123',
+  workflow_tool_id: 'workflow-tool-456',
+  label: 'Test Tool',
+  name: 'test_tool',
+  icon: createMockEmoji(),
+  description: 'A test workflow tool',
+  synced: true,
+  tool: {
+    author: 'test-author',
+    name: 'test_tool',
+    label: { en_US: 'Test Tool', zh_Hans: '测试工具' },
+    description: { en_US: 'Test description', zh_Hans: '测试描述' },
+    labels: ['label1', 'label2'],
+    parameters: [
+      {
+        name: 'test_var',
+        label: { en_US: 'Test Variable', zh_Hans: '测试变量' },
+        human_description: { en_US: 'A test variable', zh_Hans: '测试变量' },
+        type: 'string',
+        form: 'llm',
+        llm_description: 'Test variable description',
+        required: true,
+        default: '',
+      },
+    ],
+    output_schema: {
+      type: 'object',
+      properties: {
+        output_var: {
+          type: 'string',
+          description: 'Output description',
+        },
+      },
+    },
+  },
+  privacy_policy: 'https://example.com/privacy',
+  ...overrides,
+})
+
+const createDefaultConfigureButtonProps = (overrides = {}) => ({
+  disabled: false,
+  published: false,
+  detailNeedUpdate: false,
+  workflowAppId: 'workflow-app-123',
+  icon: createMockEmoji(),
+  name: 'Test Workflow',
+  description: 'Test workflow description',
+  inputs: [createMockInputVar()],
+  outputs: [createMockVariable()],
+  handlePublish: vi.fn().mockResolvedValue(undefined),
+  onRefreshData: vi.fn(),
+  ...overrides,
+})
+
+const createDefaultModalPayload = (overrides: Partial<WorkflowToolModalPayload> = {}): WorkflowToolModalPayload => ({
+  icon: createMockEmoji(),
+  label: 'Test Tool',
+  name: 'test_tool',
+  description: 'Test description',
+  parameters: [
+    {
+      name: 'param1',
+      description: 'Parameter 1',
+      form: 'llm',
+      required: true,
+      type: 'string',
+    },
+  ],
+  outputParameters: [
+    {
+      name: 'output1',
+      description: 'Output 1',
+    },
+  ],
+  labels: ['label1'],
+  privacy_policy: '',
+  workflow_app_id: 'workflow-app-123',
+  ...overrides,
+})
+
+const createMockWorkflowToolFormPayload = (overrides = {}) => ({
+  icon: createMockEmoji(),
+  label: 'Test Tool',
+  name: 'test_tool',
+  description: 'Test description',
+  parameters: [
+    {
+      name: 'param1',
+      description: 'Parameter 1',
+      form: 'llm',
+      required: true,
+      type: 'string',
+    },
+  ],
+  outputParameters: [],
+  labels: ['label1'],
+  privacy_policy: '',
+  workflow_app_id: 'workflow-app-123',
+  ...overrides,
+})
+
+// ============================================================================
+// useModalState Hook Tests
+// ============================================================================
+describe('useModalState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should initialize with false by default', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useModalState())
+
+      // Assert
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it('should initialize with provided initial state', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useModalState(true))
+
+      // Assert
+      expect(result.current.isOpen).toBe(true)
+    })
+  })
+
+  describe('State Operations', () => {
+    it('should open modal when open is called', () => {
+      // Arrange
+      const { result } = renderHook(() => useModalState(false))
+
+      // Act
+      act(() => {
+        result.current.open()
+      })
+
+      // Assert
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it('should close modal when close is called', () => {
+      // Arrange
+      const { result } = renderHook(() => useModalState(true))
+
+      // Act
+      act(() => {
+        result.current.close()
+      })
+
+      // Assert
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it('should toggle modal state when toggle is called', () => {
+      // Arrange
+      const { result } = renderHook(() => useModalState(false))
+
+      // Act - Toggle on
+      act(() => {
+        result.current.toggle()
+      })
+
+      // Assert
+      expect(result.current.isOpen).toBe(true)
+
+      // Act - Toggle off
+      act(() => {
+        result.current.toggle()
+      })
+
+      // Assert
+      expect(result.current.isOpen).toBe(false)
+    })
+  })
+
+  describe('Memoization', () => {
+    it('should maintain stable callback references', () => {
+      // Arrange
+      const { result, rerender } = renderHook(() => useModalState(false))
+      const initialOpen = result.current.open
+      const initialClose = result.current.close
+      const initialToggle = result.current.toggle
+
+      // Act
+      rerender()
+
+      // Assert - Callbacks should be stable
+      expect(result.current.open).toBe(initialOpen)
+      expect(result.current.close).toBe(initialClose)
+      expect(result.current.toggle).toBe(initialToggle)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle multiple rapid state changes', () => {
+      // Arrange
+      const { result } = renderHook(() => useModalState(false))
+
+      // Act
+      act(() => {
+        result.current.open()
+        result.current.close()
+        result.current.open()
+        result.current.toggle()
+        result.current.toggle()
+      })
+
+      // Assert - Final state should be true (open -> close -> open -> toggle(false) -> toggle(true))
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it('should handle open when already open', () => {
+      // Arrange
+      const { result } = renderHook(() => useModalState(true))
+
+      // Act
+      act(() => {
+        result.current.open()
+      })
+
+      // Assert - Should remain open
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it('should handle close when already closed', () => {
+      // Arrange
+      const { result } = renderHook(() => useModalState(false))
+
+      // Act
+      act(() => {
+        result.current.close()
+      })
+
+      // Assert - Should remain closed
+      expect(result.current.isOpen).toBe(false)
+    })
+  })
+})
+
+// ============================================================================
+// useMultiModalState Hook Tests
+// ============================================================================
+describe('useMultiModalState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should initialize all modals as closed', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useMultiModalState(['modal1', 'modal2', 'modal3']))
+
+      // Assert
+      expect(result.current.modals.modal1.isOpen).toBe(false)
+      expect(result.current.modals.modal2.isOpen).toBe(false)
+      expect(result.current.modals.modal3.isOpen).toBe(false)
+    })
+
+    it('should handle single modal name', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useMultiModalState(['single']))
+
+      // Assert
+      expect(result.current.modals.single.isOpen).toBe(false)
+    })
+  })
+
+  describe('Modal Operations', () => {
+    it('should open specific modal', () => {
+      // Arrange
+      const { result } = renderHook(() => useMultiModalState(['modal1', 'modal2']))
+
+      // Act
+      act(() => {
+        result.current.modals.modal1.open()
+      })
+
+      // Assert
+      expect(result.current.modals.modal1.isOpen).toBe(true)
+      expect(result.current.modals.modal2.isOpen).toBe(false)
+    })
+
+    it('should close specific modal', () => {
+      // Arrange
+      const { result } = renderHook(() => useMultiModalState(['modal1', 'modal2']))
+
+      // Act
+      act(() => {
+        result.current.modals.modal1.open()
+        result.current.modals.modal2.open()
+      })
+
+      act(() => {
+        result.current.modals.modal1.close()
+      })
+
+      // Assert
+      expect(result.current.modals.modal1.isOpen).toBe(false)
+      expect(result.current.modals.modal2.isOpen).toBe(true)
+    })
+
+    it('should close all modals with closeAll', () => {
+      // Arrange
+      const { result } = renderHook(() => useMultiModalState(['modal1', 'modal2', 'modal3']))
+
+      // Act
+      act(() => {
+        result.current.modals.modal1.open()
+        result.current.modals.modal2.open()
+        result.current.modals.modal3.open()
+      })
+
+      act(() => {
+        result.current.closeAll()
+      })
+
+      // Assert
+      expect(result.current.modals.modal1.isOpen).toBe(false)
+      expect(result.current.modals.modal2.isOpen).toBe(false)
+      expect(result.current.modals.modal3.isOpen).toBe(false)
+    })
+  })
+
+  describe('Multiple Modal Management', () => {
+    it('should allow multiple modals to be open simultaneously', () => {
+      // Arrange
+      const { result } = renderHook(() => useMultiModalState(['modal1', 'modal2']))
+
+      // Act
+      act(() => {
+        result.current.modals.modal1.open()
+        result.current.modals.modal2.open()
+      })
+
+      // Assert
+      expect(result.current.modals.modal1.isOpen).toBe(true)
+      expect(result.current.modals.modal2.isOpen).toBe(true)
+    })
+
+    it('should handle opening same modal multiple times', () => {
+      // Arrange
+      const { result } = renderHook(() => useMultiModalState(['modal1']))
+
+      // Act
+      act(() => {
+        result.current.modals.modal1.open()
+        result.current.modals.modal1.open()
+        result.current.modals.modal1.open()
+      })
+
+      // Assert
+      expect(result.current.modals.modal1.isOpen).toBe(true)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty modal names array gracefully', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => useMultiModalState([]))
+
+      // Assert
+      expect(result.current.modals).toEqual({})
+      expect(typeof result.current.closeAll).toBe('function')
+    })
+
+    it('should handle closeAll when all modals are already closed', () => {
+      // Arrange
+      const { result } = renderHook(() => useMultiModalState(['modal1', 'modal2']))
+
+      // Act
+      act(() => {
+        result.current.closeAll()
+      })
+
+      // Assert - Should not throw and all modals should remain closed
+      expect(result.current.modals.modal1.isOpen).toBe(false)
+      expect(result.current.modals.modal2.isOpen).toBe(false)
+    })
+
+    it('should handle modalNames array change with new modal names (fallback to false)', () => {
+      // Arrange - Start with one modal
+      let modalNames = ['modal1']
+      const { result, rerender } = renderHook(
+        ({ names }) => useMultiModalState(names),
+        { initialProps: { names: modalNames } },
+      )
+
+      // Open the initial modal
+      act(() => {
+        result.current.modals.modal1.open()
+      })
+      expect(result.current.modals.modal1.isOpen).toBe(true)
+
+      // Act - Add a new modal name that wasn't in the initial state
+      // This triggers the `openStates[name] ?? false` fallback for 'modal2'
+      modalNames = ['modal1', 'modal2']
+      rerender({ names: modalNames })
+
+      // Assert - The new modal should default to false via the ?? operator
+      expect(result.current.modals.modal2.isOpen).toBe(false)
+      // The existing modal should retain its state
+      expect(result.current.modals.modal1.isOpen).toBe(true)
+    })
+
+    it('should handle removing modal names from array', () => {
+      // Arrange - Start with multiple modals
+      let modalNames: string[] = ['modal1', 'modal2', 'modal3']
+      const { result, rerender } = renderHook(
+        ({ names }) => useMultiModalState(names),
+        { initialProps: { names: modalNames } },
+      )
+
+      // Open all modals
+      act(() => {
+        result.current.modals.modal1.open()
+        result.current.modals.modal2.open()
+        result.current.modals.modal3.open()
+      })
+
+      // Act - Remove a modal name from the array
+      modalNames = ['modal1', 'modal3']
+      rerender({ names: modalNames })
+
+      // Assert - Remaining modals should work correctly
+      expect(result.current.modals.modal1.isOpen).toBe(true)
+      expect(result.current.modals.modal3.isOpen).toBe(true)
+      // modal2 should no longer be in the modals object
+      expect(result.current.modals.modal2).toBeUndefined()
+    })
+
+    it('should handle completely replacing modal names array', () => {
+      // Arrange - Start with initial modals
+      let modalNames = ['modalA', 'modalB']
+      const { result, rerender } = renderHook(
+        ({ names }) => useMultiModalState(names),
+        { initialProps: { names: modalNames } },
+      )
+
+      // Open one modal
+      act(() => {
+        result.current.modals.modalA.open()
+      })
+
+      // Act - Completely replace with different modal names
+      modalNames = ['modalX', 'modalY']
+      rerender({ names: modalNames })
+
+      // Assert - New modals should default to closed via ?? false fallback
+      expect(result.current.modals.modalX.isOpen).toBe(false)
+      expect(result.current.modals.modalY.isOpen).toBe(false)
+      // Old modals should no longer exist
+      expect(result.current.modals.modalA).toBeUndefined()
+      expect(result.current.modals.modalB).toBeUndefined()
+    })
+
+    it('should handle rapid modalNames array changes', () => {
+      // Arrange
+      let modalNames = ['modal1']
+      const { result, rerender } = renderHook(
+        ({ names }) => useMultiModalState(names),
+        { initialProps: { names: modalNames } },
+      )
+
+      // Act - Rapidly change modal names
+      modalNames = ['modal1', 'modal2']
+      rerender({ names: modalNames })
+      modalNames = ['modal2', 'modal3']
+      rerender({ names: modalNames })
+      modalNames = ['modal3', 'modal4', 'modal5']
+      rerender({ names: modalNames })
+
+      // Assert - Final state should have the correct modals with fallback values
+      expect(result.current.modals.modal3.isOpen).toBe(false)
+      expect(result.current.modals.modal4.isOpen).toBe(false)
+      expect(result.current.modals.modal5.isOpen).toBe(false)
+    })
+  })
+})
+
+// ============================================================================
+// useWorkflowToolForm Hook Tests
+// ============================================================================
+describe('useWorkflowToolForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should initialize form state from payload', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({
+        label: 'Custom Label',
+        name: 'custom_name',
+        description: 'Custom description',
+      })
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.label).toBe('Custom Label')
+      expect(result.current.name).toBe('custom_name')
+      expect(result.current.description).toBe('Custom description')
+    })
+
+    it('should initialize emoji from payload', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({
+        icon: { content: '🎯', background: '#ff0000' },
+      })
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.emoji.content).toBe('🎯')
+      expect(result.current.emoji.background).toBe('#ff0000')
+    })
+
+    it('should initialize parameters from payload', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({
+        parameters: [
+          { name: 'param1', description: 'Desc 1', form: 'llm', required: true, type: 'string' },
+          { name: 'param2', description: 'Desc 2', form: 'form', required: false, type: 'number' },
+        ],
+      })
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.parameters).toHaveLength(2)
+      expect(result.current.parameters[0].name).toBe('param1')
+      expect(result.current.parameters[1].name).toBe('param2')
+    })
+  })
+
+  describe('State Setters', () => {
+    it('should update label state', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setLabel('New Label')
+      })
+
+      // Assert
+      expect(result.current.label).toBe('New Label')
+    })
+
+    it('should update name state', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setName('new_name')
+      })
+
+      // Assert
+      expect(result.current.name).toBe('new_name')
+    })
+
+    it('should update description state', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setDescription('New description')
+      })
+
+      // Assert
+      expect(result.current.description).toBe('New description')
+    })
+
+    it('should update emoji state', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setEmoji({ content: '🚀', background: '#00ff00' })
+      })
+
+      // Assert
+      expect(result.current.emoji.content).toBe('🚀')
+      expect(result.current.emoji.background).toBe('#00ff00')
+    })
+
+    it('should update labels state', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setLabels(['tag1', 'tag2', 'tag3'])
+      })
+
+      // Assert
+      expect(result.current.labels).toEqual(['tag1', 'tag2', 'tag3'])
+    })
+
+    it('should update privacy policy state', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setPrivacyPolicy('https://new-policy.com')
+      })
+
+      // Assert
+      expect(result.current.privacyPolicy).toBe('https://new-policy.com')
+    })
+  })
+
+  describe('Parameter Change Handler', () => {
+    it('should update parameter description', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: true, type: 'string' },
+        ],
+      })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.handleParameterChange('description', 'New description', 0)
+      })
+
+      // Assert
+      expect(result.current.parameters[0].description).toBe('New description')
+    })
+
+    it('should update parameter form', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: true, type: 'string' },
+        ],
+      })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.handleParameterChange('form', 'form', 0)
+      })
+
+      // Assert
+      expect(result.current.parameters[0].form).toBe('form')
+    })
+
+    it('should update only the targeted parameter index', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({
+        parameters: [
+          { name: 'param1', description: 'Desc 1', form: 'llm', required: true, type: 'string' },
+          { name: 'param2', description: 'Desc 2', form: 'llm', required: false, type: 'string' },
+        ],
+      })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.handleParameterChange('description', 'Updated', 1)
+      })
+
+      // Assert
+      expect(result.current.parameters[0].description).toBe('Desc 1') // Unchanged
+      expect(result.current.parameters[1].description).toBe('Updated')
+    })
+  })
+
+  describe('Name Validation', () => {
+    it('should return true for valid alphanumeric name', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({ name: 'valid_name_123' })
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.isNameValid).toBe(true)
+    })
+
+    it('should return false for name with spaces', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({ name: '' })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setName('invalid name')
+      })
+
+      // Assert
+      expect(result.current.isNameValid).toBe(false)
+    })
+
+    it('should return false for name with special characters', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({ name: '' })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setName('invalid-name!')
+      })
+
+      // Assert
+      expect(result.current.isNameValid).toBe(false)
+    })
+
+    it('should return true for empty name', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload({ name: '' })
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.isNameValid).toBe(true)
+    })
+  })
+
+  describe('Reserved Output Parameters', () => {
+    it('should include text, files, and json as reserved', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.reservedOutputParameters).toHaveLength(3)
+      expect(result.current.reservedOutputParameters.map(p => p.name)).toContain('text')
+      expect(result.current.reservedOutputParameters.map(p => p.name)).toContain('files')
+      expect(result.current.reservedOutputParameters.map(p => p.name)).toContain('json')
+    })
+
+    it('should detect reserved parameter name collision', () => {
+      // Arrange
+      const payload = createMockWorkflowToolFormPayload()
+
+      // Act
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+      }))
+
+      // Assert
+      expect(result.current.isOutputParameterReserved('text')).toBe(true)
+      expect(result.current.isOutputParameterReserved('files')).toBe(true)
+      expect(result.current.isOutputParameterReserved('json')).toBe(true)
+      expect(result.current.isOutputParameterReserved('custom_param')).toBe(false)
+    })
+  })
+
+  describe('onConfirm', () => {
+    it('should call onCreate in add mode with valid form', () => {
+      // Arrange
+      const onCreate = vi.fn()
+      const payload = createMockWorkflowToolFormPayload()
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+        onCreate,
+      }))
+
+      // Act
+      act(() => {
+        result.current.onConfirm()
+      })
+
+      // Assert
+      expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'test_tool',
+        workflow_app_id: 'workflow-app-123',
+      }))
+    })
+
+    it('should call onSave in edit mode with valid form', () => {
+      // Arrange
+      const onSave = vi.fn()
+      const payload = createMockWorkflowToolFormPayload({ workflow_tool_id: 'tool-123' })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: false,
+        onSave,
+      }))
+
+      // Act
+      act(() => {
+        result.current.onConfirm()
+      })
+
+      // Assert
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+        workflow_tool_id: 'tool-123',
+      }))
+    })
+
+    it('should show error toast when label is empty', () => {
+      // Arrange
+      const onCreate = vi.fn()
+      const payload = createMockWorkflowToolFormPayload({ label: '' })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+        onCreate,
+      }))
+
+      // Act
+      act(() => {
+        result.current.onConfirm()
+      })
+
+      // Assert
+      expect(mockToastNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: expect.any(String),
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('should show error toast when name is empty', () => {
+      // Arrange
+      const onCreate = vi.fn()
+      const payload = createMockWorkflowToolFormPayload({ name: '' })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+        onCreate,
+      }))
+
+      // Act
+      act(() => {
+        result.current.onConfirm()
+      })
+
+      // Assert
+      expect(mockToastNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: expect.any(String),
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('should show error toast for invalid name format', () => {
+      // Arrange
+      const onCreate = vi.fn()
+      const payload = createMockWorkflowToolFormPayload({ name: '' })
+      const { result } = renderHook(() => useWorkflowToolForm({
+        payload,
+        isAdd: true,
+        onCreate,
+      }))
+
+      // Act
+      act(() => {
+        result.current.setName('invalid name')
+        result.current.onConfirm()
+      })
+
+      // Assert
+      expect(mockToastNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: expect.any(String),
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ============================================================================
+// ToolInputTable Component Tests
+// ============================================================================
+describe('ToolInputTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPortalOpenState = false
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      // Arrange
+      const props = {
+        parameters: [],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolInput.name')).toBeInTheDocument()
+      expect(screen.getByText('tools.createTool.toolInput.method')).toBeInTheDocument()
+      expect(screen.getByText('tools.createTool.toolInput.description')).toBeInTheDocument()
+    })
+
+    it('should render table headers correctly', () => {
+      // Arrange
+      const props = {
+        parameters: [],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3)
+    })
+
+    it('should render parameter rows', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'param1', description: 'Desc 1', form: 'llm', required: true, type: 'string' },
+          { name: 'param2', description: 'Desc 2', form: 'form', required: false, type: 'number' },
+        ],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('param1')).toBeInTheDocument()
+      expect(screen.getByText('param2')).toBeInTheDocument()
+    })
+
+    it('should render required indicator for required parameters', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: true, type: 'string' },
+        ],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolInput.required')).toBeInTheDocument()
+    })
+
+    it('should not render required indicator for optional parameters', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: false, type: 'string' },
+        ],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.queryByText('tools.createTool.toolInput.required')).not.toBeInTheDocument()
+    })
+
+    it('should render parameter type', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: false, type: 'string' },
+        ],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('string')).toBeInTheDocument()
+    })
+  })
+
+  describe('Special Parameter Handling', () => {
+    it('should render __image parameter without method selector', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: '__image', description: 'Image input', form: 'llm', required: true, type: 'file' },
+        ],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('__image')).toBeInTheDocument()
+      expect(screen.getByText('tools.createTool.toolInput.methodParameter')).toBeInTheDocument()
+      // Should not have portal trigger for __image
+      expect(screen.queryByTestId('portal-trigger')).not.toBeInTheDocument()
+    })
+
+    it('should render regular parameters with method selector', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'regular_param', description: '', form: 'llm', required: false, type: 'string' },
+        ],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByTestId('portal-trigger')).toBeInTheDocument()
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onParameterChange when description is changed', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onParameterChange = vi.fn()
+      const props = {
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: false, type: 'string' },
+        ],
+        onParameterChange,
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+      const input = screen.getByPlaceholderText('tools.createTool.toolInput.descriptionPlaceholder')
+      await user.type(input, 'New description')
+
+      // Assert
+      expect(onParameterChange).toHaveBeenCalledWith('description', expect.any(String), 0)
+    })
+
+    it('should call onParameterChange when method is changed', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onParameterChange = vi.fn()
+      const props = {
+        parameters: [
+          { name: 'param1', description: '', form: 'llm', required: false, type: 'string' },
+        ],
+        onParameterChange,
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Open dropdown
+      await user.click(screen.getByTestId('portal-trigger'))
+
+      // Select form option
+      const formOption = screen.getByText('tools.createTool.toolInput.methodSetting')
+      await user.click(formOption)
+
+      // Assert
+      expect(onParameterChange).toHaveBeenCalledWith('form', 'form', 0)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty parameters array', () => {
+      // Arrange
+      const props = {
+        parameters: [],
+        onParameterChange: vi.fn(),
+      }
+
+      // Act & Assert
+      expect(() => render(<ToolInputTable {...props} />)).not.toThrow()
+    })
+
+    it('should handle many parameters', () => {
+      // Arrange
+      const props = {
+        parameters: Array.from({ length: 10 }, (_, i) => ({
+          name: `param${i}`,
+          description: `Desc ${i}`,
+          form: 'llm',
+          required: i % 2 === 0,
+          type: 'string',
+        })),
+        onParameterChange: vi.fn(),
+      }
+
+      // Act
+      render(<ToolInputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('param0')).toBeInTheDocument()
+      expect(screen.getByText('param9')).toBeInTheDocument()
+    })
+  })
+
+  describe('Memoization', () => {
+    it('should not re-render when props are the same', () => {
+      // Arrange
+      const parameters = [
+        { name: 'param1', description: '', form: 'llm', required: false, type: 'string' },
+      ]
+      const onParameterChange = vi.fn()
+
+      // Act
+      const { rerender } = render(
+        <ToolInputTable parameters={parameters} onParameterChange={onParameterChange} />,
+      )
+
+      // Rerender with same props reference
+      rerender(
+        <ToolInputTable parameters={parameters} onParameterChange={onParameterChange} />,
+      )
+
+      // Assert - Component should still render correctly
+      expect(screen.getByText('param1')).toBeInTheDocument()
+    })
+  })
+})
+
+// ============================================================================
+// ToolOutputTable Component Tests
+// ============================================================================
+describe('ToolOutputTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      // Arrange
+      const props = {
+        parameters: [],
+        isReserved: () => false,
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.name')).toBeInTheDocument()
+      expect(screen.getByText('tools.createTool.toolOutput.description')).toBeInTheDocument()
+    })
+
+    it('should render table headers correctly', () => {
+      // Arrange
+      const props = {
+        parameters: [],
+        isReserved: () => false,
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.getAllByRole('columnheader')).toHaveLength(2)
+    })
+
+    it('should render output parameter rows', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'output1', description: 'Output 1 description', type: VarType.string },
+          { name: 'output2', description: 'Output 2 description', type: VarType.number },
+        ],
+        isReserved: () => false,
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('output1')).toBeInTheDocument()
+      expect(screen.getByText('output2')).toBeInTheDocument()
+      expect(screen.getByText('Output 1 description')).toBeInTheDocument()
+      expect(screen.getByText('Output 2 description')).toBeInTheDocument()
+    })
+
+    it('should render reserved indicator for reserved parameters', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'text', description: 'Reserved text output', type: VarType.string, reserved: true },
+        ],
+        isReserved: () => false,
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolOutput.reserved')).toBeInTheDocument()
+    })
+
+    it('should render parameter type', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'output1', description: '', type: VarType.arrayFile },
+        ],
+        isReserved: () => false,
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert
+      expect(screen.getByText(VarType.arrayFile)).toBeInTheDocument()
+    })
+  })
+
+  describe('Reserved Parameter Warning', () => {
+    it('should show warning tooltip for duplicate reserved name', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'text', description: 'Custom text output', type: VarType.string }, // Not marked as reserved
+        ],
+        isReserved: (name: string) => name === 'text',
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert - Warning icon should be present for collision
+      const warningIcon = document.querySelector('.text-text-warning-secondary')
+      expect(warningIcon).toBeInTheDocument()
+    })
+
+    it('should not show warning for non-colliding names', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'custom_output', description: 'Custom output', type: VarType.string },
+        ],
+        isReserved: (name: string) => ['text', 'files', 'json'].includes(name),
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert
+      const warningIcon = document.querySelector('.text-text-warning-secondary')
+      expect(warningIcon).not.toBeInTheDocument()
+    })
+
+    it('should not show warning for reserved parameters marked as reserved', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'text', description: 'Reserved', type: VarType.string, reserved: true },
+        ],
+        isReserved: (name: string) => name === 'text',
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert - Should show reserved badge, not warning
+      expect(screen.getByText('tools.createTool.toolOutput.reserved')).toBeInTheDocument()
+      const warningIcon = document.querySelector('.text-text-warning-secondary')
+      expect(warningIcon).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty parameters array', () => {
+      // Arrange
+      const props = {
+        parameters: [],
+        isReserved: () => false,
+      }
+
+      // Act & Assert
+      expect(() => render(<ToolOutputTable {...props} />)).not.toThrow()
+    })
+
+    it('should handle undefined type gracefully', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'output1', description: 'No type specified' },
+        ],
+        isReserved: () => false,
+      }
+
+      // Act & Assert
+      expect(() => render(<ToolOutputTable {...props} />)).not.toThrow()
+    })
+
+    it('should handle long parameter names with truncation', () => {
+      // Arrange
+      const props = {
+        parameters: [
+          { name: 'very_long_parameter_name_that_should_be_truncated', description: 'Long name', type: VarType.string },
+        ],
+        isReserved: () => false,
+      }
+
+      // Act
+      render(<ToolOutputTable {...props} />)
+
+      // Assert - Should render with truncate class
+      const nameElement = screen.getByText('very_long_parameter_name_that_should_be_truncated')
+      expect(nameElement).toHaveClass('truncate')
+    })
+  })
+
+  describe('Memoization', () => {
+    it('should be memoized', () => {
+      // Arrange
+      const parameters = [
+        { name: 'output1', description: 'Output 1', type: VarType.string },
+      ]
+      const isReserved = vi.fn(() => false)
+
+      // Act
+      const { rerender } = render(
+        <ToolOutputTable parameters={parameters} isReserved={isReserved} />,
+      )
+
+      rerender(
+        <ToolOutputTable parameters={parameters} isReserved={isReserved} />,
+      )
+
+      // Assert - Component should still render correctly
+      expect(screen.getByText('output1')).toBeInTheDocument()
+    })
+  })
+})
+
+// ============================================================================
+// MethodSelector Component Tests
+// ============================================================================
+describe('MethodSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPortalOpenState = false
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      // Arrange
+      const props = {
+        value: 'llm',
+        onChange: vi.fn(),
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+
+      // Assert
+      expect(screen.getByTestId('portal-trigger')).toBeInTheDocument()
+    })
+
+    it('should display parameter method text when value is llm', () => {
+      // Arrange
+      const props = {
+        value: 'llm',
+        onChange: vi.fn(),
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolInput.methodParameter')).toBeInTheDocument()
+    })
+
+    it('should display setting method text when value is form', () => {
+      // Arrange
+      const props = {
+        value: 'form',
+        onChange: vi.fn(),
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolInput.methodSetting')).toBeInTheDocument()
+    })
+
+    it('should display setting method text when value is undefined', () => {
+      // Arrange
+      const props = {
+        value: undefined,
+        onChange: vi.fn(),
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolInput.methodSetting')).toBeInTheDocument()
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should open dropdown on trigger click', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        value: 'llm',
+        onChange: vi.fn(),
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+      await user.click(screen.getByTestId('portal-trigger'))
+
+      // Assert
+      expect(screen.getByTestId('portal-content')).toBeInTheDocument()
+    })
+
+    it('should call onChange with llm when parameter option clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const props = {
+        value: 'form',
+        onChange,
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+      await user.click(screen.getByTestId('portal-trigger'))
+
+      const paramOption = screen.getAllByText('tools.createTool.toolInput.methodParameter')[0]
+      await user.click(paramOption)
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith('llm')
+    })
+
+    it('should call onChange with form when setting option clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const props = {
+        value: 'llm',
+        onChange,
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+      await user.click(screen.getByTestId('portal-trigger'))
+
+      const settingOption = screen.getByText('tools.createTool.toolInput.methodSetting')
+      await user.click(settingOption)
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith('form')
+    })
+
+    it('should toggle dropdown state on multiple clicks', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        value: 'llm',
+        onChange: vi.fn(),
+      }
+
+      // Act
+      render(<MethodSelector {...props} />)
+
+      // First click - open
+      await user.click(screen.getByTestId('portal-trigger'))
+      expect(screen.getByTestId('portal-content')).toBeInTheDocument()
+
+      // Second click - close
+      await user.click(screen.getByTestId('portal-trigger'))
+      expect(screen.queryByTestId('portal-content')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle rapid value changes', async () => {
+      // Arrange
+      const onChange = vi.fn()
+      const props = {
+        value: 'llm',
+        onChange,
+      }
+
+      // Act
+      const { rerender } = render(<MethodSelector {...props} />)
+      rerender(<MethodSelector {...props} value="form" />)
+      rerender(<MethodSelector {...props} value="llm" />)
+      rerender(<MethodSelector {...props} value="form" />)
+
+      // Assert - should not crash
+      expect(screen.getByText('tools.createTool.toolInput.methodSetting')).toBeInTheDocument()
+    })
+
+    it('should handle empty string value', () => {
+      // Arrange
+      const props = {
+        value: '',
+        onChange: vi.fn(),
+      }
+
+      // Act & Assert
+      expect(() => render(<MethodSelector {...props} />)).not.toThrow()
+    })
+  })
+})
+
+// ============================================================================
+// WorkflowToolAsModal Integration Tests
+// ============================================================================
+describe('WorkflowToolAsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPortalOpenState = false
+  })
+
+  describe('Rendering', () => {
+    it('should render drawer with correct title', () => {
+      // Arrange
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Assert
+      expect(screen.getByTestId('drawer-title')).toHaveTextContent('workflow.common.workflowAsTool')
+    })
+
+    it('should render all form fields', () => {
+      // Arrange
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Assert
+      expect(screen.getByPlaceholderText('tools.createTool.toolNamePlaceHolder')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('tools.createTool.descriptionPlaceholder')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('tools.createTool.privacyPolicyPlaceholder')).toBeInTheDocument()
+    })
+
+    it('should render reserved output parameters', () => {
+      // Arrange
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Assert
+      expect(screen.getByText('text')).toBeInTheDocument()
+      expect(screen.getByText('files')).toBeInTheDocument()
+      expect(screen.getByText('json')).toBeInTheDocument()
+    })
+
+    it('should render delete button when editing and onRemove provided', () => {
+      // Arrange
+      const props = {
+        isAdd: false,
+        payload: createDefaultModalPayload({ workflow_tool_id: 'tool-123' }),
+        onHide: vi.fn(),
+        onRemove: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Assert
+      expect(screen.getByText('common.operation.delete')).toBeInTheDocument()
+    })
+
+    it('should not render delete button when adding', () => {
+      // Arrange
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+        onRemove: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Assert
+      expect(screen.queryByText('common.operation.delete')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Form State Management', () => {
+    it('should update label state on input change', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({ label: '' }),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      const labelInput = screen.getByPlaceholderText('tools.createTool.toolNamePlaceHolder')
+      await user.type(labelInput, 'New Label')
+
+      // Assert
+      expect(labelInput).toHaveValue('New Label')
+    })
+
+    it('should show emoji picker on icon click', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      const iconButton = screen.getByTestId('app-icon')
+      await user.click(iconButton)
+
+      // Assert
+      expect(screen.getByTestId('emoji-picker')).toBeInTheDocument()
+    })
+
+    it('should update emoji on selection', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByTestId('app-icon'))
+      await user.click(screen.getByTestId('select-emoji'))
+
+      // Assert
+      const updatedIcon = screen.getByTestId('app-icon')
+      expect(updatedIcon).toHaveAttribute('data-icon', '🚀')
+      expect(updatedIcon).toHaveAttribute('data-background', '#f0f0f0')
+    })
+
+    it('should show validation error for invalid name format', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({ name: '' }),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      const nameInput = screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')
+      await user.type(nameInput, 'invalid name with spaces')
+
+      // Assert
+      expect(screen.getByText('tools.createTool.nameForToolCallTip')).toBeInTheDocument()
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onHide when cancel button clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onHide = vi.fn()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.cancel'))
+
+      // Assert
+      expect(onHide).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onCreate when save clicked in add mode', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onCreate = vi.fn()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload(),
+        onHide: vi.fn(),
+        onCreate,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'test_tool',
+        workflow_app_id: 'workflow-app-123',
+      }))
+    })
+
+    it('should show confirm modal when save clicked in edit mode', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        isAdd: false,
+        payload: createDefaultModalPayload({ workflow_tool_id: 'tool-123' }),
+        onHide: vi.fn(),
+        onSave: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      expect(screen.getByText('tools.createTool.confirmTitle')).toBeInTheDocument()
+    })
+
+    it('should call onSave after confirm in edit mode', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onSave = vi.fn()
+      const props = {
+        isAdd: false,
+        payload: createDefaultModalPayload({ workflow_tool_id: 'tool-123' }),
+        onHide: vi.fn(),
+        onSave,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.save'))
+      await user.click(screen.getByText('common.operation.confirm'))
+
+      // Assert
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+        workflow_tool_id: 'tool-123',
+      }))
+    })
+
+    it('should call onRemove when delete button clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onRemove = vi.fn()
+      const props = {
+        isAdd: false,
+        payload: createDefaultModalPayload({ workflow_tool_id: 'tool-123' }),
+        onHide: vi.fn(),
+        onRemove,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.delete'))
+
+      // Assert
+      expect(onRemove).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty parameters array', () => {
+      // Arrange
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({ parameters: [] }),
+        onHide: vi.fn(),
+      }
+
+      // Act & Assert
+      expect(() => render(<WorkflowToolAsModal {...props} />)).not.toThrow()
+    })
+
+    it('should handle parameter with __image name specially', () => {
+      // Arrange
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({
+          parameters: [{
+            name: '__image',
+            description: 'Image parameter',
+            form: 'llm',
+            required: true,
+            type: 'file',
+          }],
+        }),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.toolInput.methodParameter')).toBeInTheDocument()
+    })
+
+    it('should handle undefined onSave gracefully', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = {
+        isAdd: false,
+        payload: createDefaultModalPayload({ workflow_tool_id: 'tool-123' }),
+        onHide: vi.fn(),
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('tools.createTool.confirmTitle')).toBeInTheDocument()
+      })
+
+      // Assert - should not crash
+      await user.click(screen.getByText('common.operation.confirm'))
+    })
+  })
+
+  describe('Memoization', () => {
+    it('should be memoized', () => {
+      // Arrange
+      const payload = createDefaultModalPayload()
+      const onHide = vi.fn()
+
+      // Act
+      const { rerender } = render(
+        <WorkflowToolAsModal isAdd={true} payload={payload} onHide={onHide} />,
+      )
+
+      rerender(
+        <WorkflowToolAsModal isAdd={true} payload={payload} onHide={onHide} />,
+      )
+
+      // Assert - Component should still render correctly
+      expect(screen.getByTestId('drawer')).toBeInTheDocument()
+    })
+  })
+})
+
+// ============================================================================
+// WorkflowToolConfigureButton Integration Tests
+// ============================================================================
+describe('WorkflowToolConfigureButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPortalOpenState = false
+    mockIsCurrentWorkspaceManager.mockReturnValue(true)
+    mockFetchWorkflowToolDetailByAppID.mockResolvedValue(createMockWorkflowToolDetail())
+    mockUseWorkflowToolDetail.mockReturnValue({
+      data: createMockWorkflowToolDetail(),
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockCreateTool.mockResolvedValue({})
+    mockUpdateTool.mockResolvedValue({})
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      // Arrange
+      const props = createDefaultConfigureButtonProps()
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      expect(screen.getByText('workflow.common.workflowAsTool')).toBeInTheDocument()
+    })
+
+    it('should render configure required badge when not published', () => {
+      // Arrange
+      const props = createDefaultConfigureButtonProps({ published: false })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      expect(screen.getByText('workflow.common.configureRequired')).toBeInTheDocument()
+    })
+
+    it('should render configure and manage buttons when published', async () => {
+      // Arrange
+      const props = createDefaultConfigureButtonProps({ published: true })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText('workflow.common.configure')).toBeInTheDocument()
+        expect(screen.getByText('workflow.common.manageInTools')).toBeInTheDocument()
+      })
+    })
+
+    it('should render disabled state correctly', () => {
+      // Arrange
+      const props = createDefaultConfigureButtonProps({ disabled: true })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      const container = document.querySelector('.cursor-not-allowed')
+      expect(container).toBeInTheDocument()
+    })
+
+    it('should render disabledReason when provided', () => {
+      // Arrange
+      const props = createDefaultConfigureButtonProps({
+        disabledReason: 'Please save the workflow first',
+      })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      expect(screen.getByText('Please save the workflow first')).toBeInTheDocument()
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should open modal when card clicked (unpublished)', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = createDefaultConfigureButtonProps()
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+      const triggerArea = screen.getByText('workflow.common.workflowAsTool').closest('.flex')
+      await user.click(triggerArea!)
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByTestId('drawer')).toBeInTheDocument()
+      })
+    })
+
+    it('should not open modal when disabled', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = createDefaultConfigureButtonProps({ disabled: true })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+      const triggerArea = screen.getByText('workflow.common.workflowAsTool').closest('.flex')
+      await user.click(triggerArea!)
+
+      // Assert
+      expect(screen.queryByTestId('drawer')).not.toBeInTheDocument()
+    })
+
+    it('should navigate to tools page when manage button clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const props = createDefaultConfigureButtonProps({ published: true })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('workflow.common.manageInTools')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('workflow.common.manageInTools'))
+
+      // Assert
+      expect(mockPush).toHaveBeenCalledWith('/tools?category=workflow')
+    })
+  })
+
+  describe('Outdated Detection', () => {
+    it('should detect outdated when parameter count differs', async () => {
+      // Arrange - detail has 1 parameter but inputs have 2
+      const detail = createMockWorkflowToolDetail()
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: detail,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const props = createDefaultConfigureButtonProps({
+        published: true,
+        inputs: [
+          createMockInputVar({ variable: 'test_var' }),
+          createMockInputVar({ variable: 'extra_var' }),
+        ],
+      })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert - The outdated indicator should show
+      await waitFor(() => {
+        expect(screen.getByText('workflow.common.workflowAsToolTip')).toBeInTheDocument()
+      })
+    })
+
+    it('should not show outdated when parameters match', async () => {
+      // Arrange - detail and inputs both have 1 matching parameter
+      const detail = createMockWorkflowToolDetail()
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: detail,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const props = createDefaultConfigureButtonProps({
+        published: true,
+        inputs: [createMockInputVar({ variable: 'test_var', required: true, type: InputVarType.textInput })],
+      })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText('workflow.common.configure')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('workflow.common.workflowAsToolTip')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('API Integration', () => {
+    it('should create workflow tool provider on first publish', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      mockCreateTool.mockResolvedValue({})
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const props = createDefaultConfigureButtonProps()
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      const triggerArea = screen.getByText('workflow.common.workflowAsTool').closest('.flex')
+      await user.click(triggerArea!)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('drawer')).toBeInTheDocument()
+      })
+
+      const nameInput = screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')
+      await user.type(nameInput, 'my_tool')
+
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      await waitFor(() => {
+        expect(mockCreateTool).toHaveBeenCalled()
+      })
+    })
+
+    it('should show success toast after creating workflow tool', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      mockCreateTool.mockResolvedValue({})
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const props = createDefaultConfigureButtonProps()
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      const triggerArea = screen.getByText('workflow.common.workflowAsTool').closest('.flex')
+      await user.click(triggerArea!)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('drawer')).toBeInTheDocument()
+      })
+
+      const nameInput = screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')
+      await user.type(nameInput, 'my_tool')
+
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      await waitFor(() => {
+        expect(mockToastNotify).toHaveBeenCalledWith({
+          type: 'success',
+          message: 'common.api.actionSuccess',
+        })
+      })
+    })
+
+    it('should show error toast when create fails', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      mockCreateTool.mockRejectedValue(new Error('Create failed'))
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const props = createDefaultConfigureButtonProps()
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      const triggerArea = screen.getByText('workflow.common.workflowAsTool').closest('.flex')
+      await user.click(triggerArea!)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('drawer')).toBeInTheDocument()
+      })
+
+      const nameInput = screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')
+      await user.type(nameInput, 'my_tool')
+
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      await waitFor(() => {
+        expect(mockToastNotify).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'Create failed',
+        })
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle API returning undefined', async () => {
+      // Arrange
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const props = createDefaultConfigureButtonProps({ published: true })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Assert
+      expect(screen.getByText('workflow.common.workflowAsTool')).toBeInTheDocument()
+    })
+
+    it('should handle rapid publish/unpublish state changes', async () => {
+      // Arrange
+      const props = createDefaultConfigureButtonProps({ published: false })
+
+      // Act
+      const { rerender } = renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      await act(async () => {
+        rerender(
+          <TestWrapper>
+            <WorkflowToolConfigureButton {...props} published={true} />
+          </TestWrapper>,
+        )
+      })
+      await act(async () => {
+        rerender(
+          <TestWrapper>
+            <WorkflowToolConfigureButton {...props} published={false} />
+          </TestWrapper>,
+        )
+      })
+
+      // Assert - should not crash
+      expect(screen.getByText('workflow.common.workflowAsTool')).toBeInTheDocument()
+    })
+  })
+})
+
+// ============================================================================
+// ConfirmModal Integration Tests
+// ============================================================================
+describe('ConfirmModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render when show is true', () => {
+      // Arrange & Act
+      render(<ConfirmModal show={true} onClose={vi.fn()} />)
+
+      // Assert
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('should not render when show is false', () => {
+      // Arrange & Act
+      render(<ConfirmModal show={false} onClose={vi.fn()} />)
+
+      // Assert
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('should render title and description', () => {
+      // Arrange & Act
+      render(<ConfirmModal show={true} onClose={vi.fn()} />)
+
+      // Assert
+      expect(screen.getByText('tools.createTool.confirmTitle')).toBeInTheDocument()
+      expect(screen.getByText('tools.createTool.confirmTip')).toBeInTheDocument()
+    })
+
+    it('should render action buttons', () => {
+      // Arrange & Act
+      render(<ConfirmModal show={true} onClose={vi.fn()} />)
+
+      // Assert
+      expect(screen.getByText('common.operation.cancel')).toBeInTheDocument()
+      expect(screen.getByText('common.operation.confirm')).toBeInTheDocument()
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onClose when cancel clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<ConfirmModal show={true} onClose={onClose} />)
+
+      // Act
+      await user.click(screen.getByText('common.operation.cancel'))
+
+      // Assert
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onConfirm when confirm clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onConfirm = vi.fn()
+      render(<ConfirmModal show={true} onClose={vi.fn()} onConfirm={onConfirm} />)
+
+      // Act
+      await user.click(screen.getByText('common.operation.confirm'))
+
+      // Assert
+      expect(onConfirm).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onClose when close button clicked', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<ConfirmModal show={true} onClose={onClose} />)
+
+      // Act
+      const closeButton = document.querySelector('.cursor-pointer')
+      await user.click(closeButton!)
+
+      // Assert
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle missing onConfirm gracefully', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      render(<ConfirmModal show={true} onClose={vi.fn()} />)
+
+      // Act & Assert - should not throw
+      await user.click(screen.getByText('common.operation.confirm'))
+    })
+
+    it('should handle rapid show/hide toggling', async () => {
+      // Arrange
+      const { rerender } = render(<ConfirmModal show={false} onClose={vi.fn()} />)
+
+      // Assert - Initially not shown
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+      // Act - Show modal
+      await act(async () => {
+        rerender(<ConfirmModal show={true} onClose={vi.fn()} />)
+      })
+
+      // Assert - Now shown
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+      // Act - Hide modal again
+      await act(async () => {
+        rerender(<ConfirmModal show={false} onClose={vi.fn()} />)
+      })
+
+      // Assert - Hidden again
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      })
+    })
+  })
+})
+
+// ============================================================================
+// Complete Integration Tests
+// ============================================================================
+describe('Complete Integration Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPortalOpenState = false
+    mockIsCurrentWorkspaceManager.mockReturnValue(true)
+    mockFetchWorkflowToolDetailByAppID.mockResolvedValue(createMockWorkflowToolDetail())
+    mockUseWorkflowToolDetail.mockReturnValue({
+      data: createMockWorkflowToolDetail(),
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockCreateTool.mockResolvedValue({})
+    mockUpdateTool.mockResolvedValue({})
+  })
+
+  describe('Full Create Workflow', () => {
+    it('should complete full create workflow', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      mockCreateTool.mockResolvedValue({})
+      mockUseWorkflowToolDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      const onRefreshData = vi.fn()
+      const props = createDefaultConfigureButtonProps({ onRefreshData })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Open modal
+      const triggerArea = screen.getByText('workflow.common.workflowAsTool').closest('.flex')
+      await user.click(triggerArea!)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('drawer')).toBeInTheDocument()
+      })
+
+      // Fill form
+      const labelInput = screen.getByPlaceholderText('tools.createTool.toolNamePlaceHolder')
+      await user.clear(labelInput)
+      await user.type(labelInput, 'My Custom Tool')
+
+      const nameInput = screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')
+      await user.type(nameInput, 'my_custom_tool')
+
+      const descInput = screen.getByPlaceholderText('tools.createTool.descriptionPlaceholder')
+      await user.clear(descInput)
+      await user.type(descInput, 'A custom tool for testing')
+
+      // Save
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      await waitFor(() => {
+        expect(mockCreateTool).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'my_custom_tool',
+            label: 'My Custom Tool',
+            description: 'A custom tool for testing',
+          }),
+        )
+      })
+
+      await waitFor(() => {
+        expect(onRefreshData).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Full Update Workflow', () => {
+    it('should complete full update workflow', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const handlePublish = vi.fn().mockResolvedValue(undefined)
+      mockUpdateTool.mockResolvedValue({})
+      const props = createDefaultConfigureButtonProps({
+        published: true,
+        handlePublish,
+      })
+
+      // Act
+      renderWithQueryClient(<WorkflowToolConfigureButton {...props} />)
+
+      // Wait for detail to load
+      await waitFor(() => {
+        expect(screen.getByText('workflow.common.configure')).toBeInTheDocument()
+      })
+
+      // Open modal
+      await user.click(screen.getByText('workflow.common.configure'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('drawer')).toBeInTheDocument()
+      })
+
+      // Modify description
+      const descInput = screen.getByPlaceholderText('tools.createTool.descriptionPlaceholder')
+      await user.clear(descInput)
+      await user.type(descInput, 'Updated description')
+
+      // Save
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Confirm
+      await waitFor(() => {
+        expect(screen.getByText('tools.createTool.confirmTitle')).toBeInTheDocument()
+      })
+      await user.click(screen.getByText('common.operation.confirm'))
+
+      // Assert
+      await waitFor(() => {
+        expect(handlePublish).toHaveBeenCalled()
+        expect(mockUpdateTool).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Form Validation Flow', () => {
+    it('should prevent save with empty required fields', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onCreate = vi.fn()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({ label: '', name: '' }),
+        onHide: vi.fn(),
+        onCreate,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      expect(mockToastNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: expect.any(String),
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('should allow save after filling required fields', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onCreate = vi.fn()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({ label: '', name: '' }),
+        onHide: vi.fn(),
+        onCreate,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Fill required fields
+      const labelInput = screen.getByPlaceholderText('tools.createTool.toolNamePlaceHolder')
+      await user.type(labelInput, 'My Tool')
+
+      const nameInput = screen.getByPlaceholderText('tools.createTool.nameForToolCallPlaceHolder')
+      await user.type(nameInput, 'my_tool')
+
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      expect(onCreate).toHaveBeenCalled()
+    })
+  })
+
+  describe('Parameter Management Flow', () => {
+    it('should handle parameter description updates through the full flow', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onCreate = vi.fn()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({
+          parameters: [{
+            name: 'test_param',
+            description: '',
+            form: 'llm',
+            required: true,
+            type: 'string',
+          }],
+        }),
+        onHide: vi.fn(),
+        onCreate,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Update parameter description
+      const descInput = screen.getByPlaceholderText('tools.createTool.toolInput.descriptionPlaceholder')
+      await user.type(descInput, 'Test parameter description')
+
+      // Save
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'test_param',
+              description: 'Test parameter description',
+            }),
+          ]),
+        }),
+      )
+    })
+
+    it('should handle method selector changes through the full flow', async () => {
+      // Arrange
+      const user = userEvent.setup()
+      const onCreate = vi.fn()
+      const props = {
+        isAdd: true,
+        payload: createDefaultModalPayload({
+          parameters: [{
+            name: 'test_param',
+            description: 'Test',
+            form: 'llm',
+            required: false,
+            type: 'string',
+          }],
+        }),
+        onHide: vi.fn(),
+        onCreate,
+      }
+
+      // Act
+      render(<WorkflowToolAsModal {...props} />)
+
+      // Change method to form - use getAllByTestId since there might be multiple portal triggers
+      const portalTriggers = screen.getAllByTestId('portal-trigger')
+      // The method selector trigger should be within the tool input table
+      await user.click(portalTriggers[portalTriggers.length - 1])
+      const formOption = screen.getByText('tools.createTool.toolInput.methodSetting')
+      await user.click(formOption)
+
+      // Save
+      await user.click(screen.getByText('common.operation.save'))
+
+      // Assert
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'test_param',
+              form: 'form',
+            }),
+          ]),
+        }),
+      )
+    })
+  })
+})

--- a/web/app/components/tools/workflow-tool/index.tsx
+++ b/web/app/components/tools/workflow-tool/index.tsx
@@ -1,10 +1,8 @@
 'use client'
 import type { FC } from 'react'
 import type { Emoji, WorkflowToolProviderOutputParameter, WorkflowToolProviderOutputSchema, WorkflowToolProviderParameter, WorkflowToolProviderRequest } from '../types'
-import { RiErrorWarningLine } from '@remixicon/react'
-import { produce } from 'immer'
+import type { WorkflowToolFormPayload } from './hooks/use-workflow-tool-form'
 import * as React from 'react'
-import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
 import Button from '@/app/components/base/button'
@@ -12,14 +10,14 @@ import Drawer from '@/app/components/base/drawer-plus'
 import EmojiPicker from '@/app/components/base/emoji-picker'
 import Input from '@/app/components/base/input'
 import Textarea from '@/app/components/base/textarea'
-import Toast from '@/app/components/base/toast'
 import Tooltip from '@/app/components/base/tooltip'
 import LabelSelector from '@/app/components/tools/labels/selector'
 import ConfirmModal from '@/app/components/tools/workflow-tool/confirm-modal'
-import MethodSelector from '@/app/components/tools/workflow-tool/method-selector'
-import { VarType } from '@/app/components/workflow/types'
 import { cn } from '@/utils/classnames'
-import { buildWorkflowOutputParameters } from './utils'
+import ToolInputTable from './components/tool-input-table'
+import ToolOutputTable from './components/tool-output-table'
+import { useModalState } from './hooks/use-modal-state'
+import { useWorkflowToolForm } from './hooks/use-workflow-tool-form'
 
 export type WorkflowToolModalPayload = {
   icon: Emoji
@@ -39,7 +37,7 @@ export type WorkflowToolModalPayload = {
 
 type Props = {
   isAdd?: boolean
-  payload: WorkflowToolModalPayload
+  payload: WorkflowToolFormPayload
   onHide: () => void
   onRemove?: () => void
   onCreate?: (payload: WorkflowToolProviderRequest & { workflow_app_id: string }) => void
@@ -48,7 +46,64 @@ type Props = {
     workflow_tool_id: string
   }>) => void
 }
-// Add and Edit
+
+// Form field wrapper component
+type FormFieldProps = {
+  label: string
+  required?: boolean
+  tooltip?: string
+  children: React.ReactNode
+}
+
+const FormField: FC<FormFieldProps> = ({ label, required, tooltip, children }) => (
+  <div>
+    <div className="system-sm-medium flex items-center py-2 text-text-primary">
+      {label}
+      {required && <span className="ml-1 text-red-500">*</span>}
+      {tooltip && (
+        <Tooltip popupContent={<div className="w-[180px]">{tooltip}</div>} />
+      )}
+    </div>
+    {children}
+  </div>
+)
+
+// Footer actions component
+type FooterActionsProps = {
+  isAdd?: boolean
+  onRemove?: () => void
+  onHide: () => void
+  onSaveClick: () => void
+}
+
+const FooterActions: FC<FooterActionsProps> = ({ isAdd, onRemove, onHide, onSaveClick }) => {
+  const { t } = useTranslation()
+  const showDeleteButton = !isAdd && onRemove
+
+  return (
+    <div className={cn(
+      showDeleteButton ? 'justify-between' : 'justify-end',
+      'mt-2 flex shrink-0 rounded-b-[10px] border-t border-divider-regular bg-background-section-burn px-6 py-4',
+    )}
+    >
+      {showDeleteButton && (
+        <Button variant="warning" onClick={onRemove}>
+          {t('operation.delete', { ns: 'common' })}
+        </Button>
+      )}
+      <div className="flex space-x-2">
+        <Button onClick={onHide}>
+          {t('operation.cancel', { ns: 'common' })}
+        </Button>
+        <Button variant="primary" onClick={onSaveClick}>
+          {t('operation.save', { ns: 'common' })}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// Main component
 const WorkflowToolAsModal: FC<Props> = ({
   isAdd,
   payload,
@@ -59,108 +114,24 @@ const WorkflowToolAsModal: FC<Props> = ({
 }) => {
   const { t } = useTranslation()
 
-  const [showEmojiPicker, setShowEmojiPicker] = useState<boolean>(false)
-  const [emoji, setEmoji] = useState<Emoji>(payload.icon)
-  const [label, setLabel] = useState<string>(payload.label)
-  const [name, setName] = useState(payload.name)
-  const [description, setDescription] = useState(payload.description)
-  const [parameters, setParameters] = useState<WorkflowToolProviderParameter[]>(payload.parameters)
-  const rawOutputParameters = payload.outputParameters
-  const outputSchema = payload.tool?.output_schema
-  const outputParameters = useMemo<WorkflowToolProviderOutputParameter[]>(() => buildWorkflowOutputParameters(rawOutputParameters, outputSchema), [rawOutputParameters, outputSchema])
-  const reservedOutputParameters: WorkflowToolProviderOutputParameter[] = [
-    {
-      name: 'text',
-      description: t('nodes.tool.outputVars.text', { ns: 'workflow' }),
-      type: VarType.string,
-      reserved: true,
-    },
-    {
-      name: 'files',
-      description: t('nodes.tool.outputVars.files.title', { ns: 'workflow' }),
-      type: VarType.arrayFile,
-      reserved: true,
-    },
-    {
-      name: 'json',
-      description: t('nodes.tool.outputVars.json', { ns: 'workflow' }),
-      type: VarType.arrayObject,
-      reserved: true,
-    },
-  ]
+  // Modal states
+  const emojiPicker = useModalState(false)
+  const confirmModal = useModalState(false)
 
-  const handleParameterChange = (key: string, value: string, index: number) => {
-    const newData = produce(parameters, (draft: WorkflowToolProviderParameter[]) => {
-      if (key === 'description')
-        draft[index].description = value
-      else
-        draft[index].form = value
-    })
-    setParameters(newData)
-  }
-  const [labels, setLabels] = useState<string[]>(payload.labels)
-  const handleLabelSelect = (value: string[]) => {
-    setLabels(value)
-  }
-  const [privacyPolicy, setPrivacyPolicy] = useState(payload.privacy_policy)
-  const [showModal, setShowModal] = useState(false)
+  // Form state and logic
+  const form = useWorkflowToolForm({
+    payload,
+    isAdd,
+    onCreate,
+    onSave,
+  })
 
-  const isNameValid = (name: string) => {
-    // when the user has not input anything, no need for a warning
-    if (name === '')
-      return true
-
-    return /^\w+$/.test(name)
-  }
-
-  const isOutputParameterReserved = (name: string) => {
-    return reservedOutputParameters.find(p => p.name === name)
-  }
-
-  const onConfirm = () => {
-    let errorMessage = ''
-    if (!label)
-      errorMessage = t('errorMsg.fieldRequired', { ns: 'common', field: t('createTool.name', { ns: 'tools' }) })
-
-    if (!name)
-      errorMessage = t('errorMsg.fieldRequired', { ns: 'common', field: t('createTool.nameForToolCall', { ns: 'tools' }) })
-
-    if (!isNameValid(name))
-      errorMessage = t('createTool.nameForToolCall', { ns: 'tools' }) + t('createTool.nameForToolCallTip', { ns: 'tools' })
-
-    if (errorMessage) {
-      Toast.notify({
-        type: 'error',
-        message: errorMessage,
-      })
-      return
-    }
-
-    const requestParams = {
-      name,
-      description,
-      icon: emoji,
-      label,
-      parameters: parameters.map(item => ({
-        name: item.name,
-        description: item.description,
-        form: item.form,
-      })),
-      labels,
-      privacy_policy: privacyPolicy,
-    }
-    if (!isAdd) {
-      onSave?.({
-        ...requestParams,
-        workflow_tool_id: payload.workflow_tool_id!,
-      })
-    }
-    else {
-      onCreate?.({
-        ...requestParams,
-        workflow_app_id: payload.workflow_app_id!,
-      })
-    }
+  // Handle save button click
+  const handleSaveClick = () => {
+    if (isAdd)
+      form.onConfirm()
+    else
+      confirmModal.open()
   }
 
   return (
@@ -176,217 +147,119 @@ const WorkflowToolAsModal: FC<Props> = ({
         body={(
           <div className="flex h-full flex-col">
             <div className="h-0 grow space-y-4 overflow-y-auto px-6 py-3">
-              {/* name & icon */}
-              <div>
-                <div className="system-sm-medium py-2 text-text-primary">
-                  {t('createTool.name', { ns: 'tools' })}
-                  {' '}
-                  <span className="ml-1 text-red-500">*</span>
-                </div>
+              {/* Name & Icon */}
+              <FormField label={t('createTool.name', { ns: 'tools' })} required>
                 <div className="flex items-center justify-between gap-3">
-                  <AppIcon size="large" onClick={() => { setShowEmojiPicker(true) }} className="cursor-pointer" iconType="emoji" icon={emoji.content} background={emoji.background} />
+                  <AppIcon
+                    size="large"
+                    onClick={emojiPicker.open}
+                    className="cursor-pointer"
+                    iconType="emoji"
+                    icon={form.emoji.content}
+                    background={form.emoji.background}
+                  />
                   <Input
                     className="h-10 grow"
                     placeholder={t('createTool.toolNamePlaceHolder', { ns: 'tools' })!}
-                    value={label}
-                    onChange={e => setLabel(e.target.value)}
+                    value={form.label}
+                    onChange={e => form.setLabel(e.target.value)}
                   />
                 </div>
-              </div>
-              {/* name for tool call */}
-              <div>
-                <div className="system-sm-medium flex items-center py-2 text-text-primary">
-                  {t('createTool.nameForToolCall', { ns: 'tools' })}
-                  {' '}
-                  <span className="ml-1 text-red-500">*</span>
-                  <Tooltip
-                    popupContent={(
-                      <div className="w-[180px]">
-                        {t('createTool.nameForToolCallPlaceHolder', { ns: 'tools' })}
-                      </div>
-                    )}
-                  />
-                </div>
+              </FormField>
+
+              {/* Name for Tool Call */}
+              <FormField
+                label={t('createTool.nameForToolCall', { ns: 'tools' })}
+                required
+                tooltip={t('createTool.nameForToolCallPlaceHolder', { ns: 'tools' })}
+              >
                 <Input
                   className="h-10"
                   placeholder={t('createTool.nameForToolCallPlaceHolder', { ns: 'tools' })!}
-                  value={name}
-                  onChange={e => setName(e.target.value)}
+                  value={form.name}
+                  onChange={e => form.setName(e.target.value)}
                 />
-                {!isNameValid(name) && (
-                  <div className="text-xs leading-[18px] text-red-500">{t('createTool.nameForToolCallTip', { ns: 'tools' })}</div>
+                {!form.isNameValid && (
+                  <div className="text-xs leading-[18px] text-red-500">
+                    {t('createTool.nameForToolCallTip', { ns: 'tools' })}
+                  </div>
                 )}
-              </div>
-              {/* description */}
-              <div>
-                <div className="system-sm-medium py-2 text-text-primary">{t('createTool.description', { ns: 'tools' })}</div>
+              </FormField>
+
+              {/* Description */}
+              <FormField label={t('createTool.description', { ns: 'tools' })}>
                 <Textarea
                   placeholder={t('createTool.descriptionPlaceholder', { ns: 'tools' }) || ''}
-                  value={description}
-                  onChange={e => setDescription(e.target.value)}
+                  value={form.description}
+                  onChange={e => form.setDescription(e.target.value)}
                 />
-              </div>
-              {/* Tool Input  */}
-              <div>
-                <div className="system-sm-medium py-2 text-text-primary">{t('createTool.toolInput.title', { ns: 'tools' })}</div>
-                <div className="w-full overflow-x-auto rounded-lg border border-divider-regular">
-                  <table className="w-full text-xs font-normal leading-[18px] text-text-secondary">
-                    <thead className="uppercase text-text-tertiary">
-                      <tr className="border-b border-divider-regular">
-                        <th className="w-[156px] p-2 pl-3 font-medium">{t('createTool.toolInput.name', { ns: 'tools' })}</th>
-                        <th className="w-[102px] p-2 pl-3 font-medium">{t('createTool.toolInput.method', { ns: 'tools' })}</th>
-                        <th className="p-2 pl-3 font-medium">{t('createTool.toolInput.description', { ns: 'tools' })}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {parameters.map((item, index) => (
-                        <tr key={index} className="border-b border-divider-regular last:border-0">
-                          <td className="max-w-[156px] p-2 pl-3">
-                            <div className="text-[13px] leading-[18px]">
-                              <div title={item.name} className="flex">
-                                <span className="truncate font-medium text-text-primary">{item.name}</span>
-                                <span className="shrink-0 pl-1 text-xs leading-[18px] text-[#ec4a0a]">{item.required ? t('createTool.toolInput.required', { ns: 'tools' }) : ''}</span>
-                              </div>
-                              <div className="text-text-tertiary">{item.type}</div>
-                            </div>
-                          </td>
-                          <td>
-                            {item.name === '__image' && (
-                              <div className={cn(
-                                'flex h-9 min-h-[56px] cursor-default items-center gap-1 bg-transparent px-3 py-2',
-                              )}
-                              >
-                                <div className={cn('grow truncate text-[13px] leading-[18px] text-text-secondary')}>
-                                  {t('createTool.toolInput.methodParameter', { ns: 'tools' })}
-                                </div>
-                              </div>
-                            )}
-                            {item.name !== '__image' && (
-                              <MethodSelector value={item.form} onChange={value => handleParameterChange('form', value, index)} />
-                            )}
-                          </td>
-                          <td className="w-[236px] p-2 pl-3 text-text-tertiary">
-                            <input
-                              type="text"
-                              className="w-full appearance-none bg-transparent text-[13px] font-normal leading-[18px] text-text-secondary caret-primary-600 outline-none placeholder:text-text-quaternary"
-                              placeholder={t('createTool.toolInput.descriptionPlaceholder', { ns: 'tools' })!}
-                              value={item.description}
-                              onChange={e => handleParameterChange('description', e.target.value, index)}
-                            />
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-              {/* Tool Output  */}
-              <div>
-                <div className="system-sm-medium py-2 text-text-primary">{t('createTool.toolOutput.title', { ns: 'tools' })}</div>
-                <div className="w-full overflow-x-auto rounded-lg border border-divider-regular">
-                  <table className="w-full text-xs font-normal leading-[18px] text-text-secondary">
-                    <thead className="uppercase text-text-tertiary">
-                      <tr className="border-b border-divider-regular">
-                        <th className="w-[156px] p-2 pl-3 font-medium">{t('createTool.name', { ns: 'tools' })}</th>
-                        <th className="p-2 pl-3 font-medium">{t('createTool.toolOutput.description', { ns: 'tools' })}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {[...reservedOutputParameters, ...outputParameters].map((item, index) => (
-                        <tr key={index} className="border-b border-divider-regular last:border-0">
-                          <td className="max-w-[156px] p-2 pl-3">
-                            <div className="text-[13px] leading-[18px]">
-                              <div title={item.name} className="flex items-center">
-                                <span className="truncate font-medium text-text-primary">{item.name}</span>
-                                <span className="shrink-0 pl-1 text-xs leading-[18px] text-[#ec4a0a]">{item.reserved ? t('createTool.toolOutput.reserved', { ns: 'tools' }) : ''}</span>
-                                {
-                                  !item.reserved && isOutputParameterReserved(item.name)
-                                    ? (
-                                        <Tooltip
-                                          popupContent={(
-                                            <div className="w-[180px]">
-                                              {t('createTool.toolOutput.reservedParameterDuplicateTip', { ns: 'tools' })}
-                                            </div>
-                                          )}
-                                        >
-                                          <RiErrorWarningLine className="h-3 w-3 text-text-warning-secondary" />
-                                        </Tooltip>
-                                      )
-                                    : null
-                                }
-                              </div>
-                              <div className="text-text-tertiary">{item.type}</div>
-                            </div>
-                          </td>
-                          <td className="w-[236px] p-2 pl-3 text-text-tertiary">
-                            <span className="text-[13px] font-normal leading-[18px] text-text-secondary">{item.description}</span>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+              </FormField>
+
+              {/* Tool Input */}
+              <FormField label={t('createTool.toolInput.title', { ns: 'tools' })}>
+                <ToolInputTable
+                  parameters={form.parameters}
+                  onParameterChange={form.handleParameterChange}
+                />
+              </FormField>
+
+              {/* Tool Output */}
+              <FormField label={t('createTool.toolOutput.title', { ns: 'tools' })}>
+                <ToolOutputTable
+                  parameters={form.allOutputParameters}
+                  isReserved={form.isOutputParameterReserved}
+                />
+              </FormField>
+
               {/* Tags */}
-              <div>
-                <div className="system-sm-medium py-2 text-text-primary">{t('createTool.toolInput.label', { ns: 'tools' })}</div>
-                <LabelSelector value={labels} onChange={handleLabelSelect} />
-              </div>
+              <FormField label={t('createTool.toolInput.label', { ns: 'tools' })}>
+                <LabelSelector value={form.labels} onChange={form.setLabels} />
+              </FormField>
+
               {/* Privacy Policy */}
-              <div>
-                <div className="system-sm-medium py-2 text-text-primary">{t('createTool.privacyPolicy', { ns: 'tools' })}</div>
+              <FormField label={t('createTool.privacyPolicy', { ns: 'tools' })}>
                 <Input
                   className="h-10"
-                  value={privacyPolicy}
-                  onChange={e => setPrivacyPolicy(e.target.value)}
+                  value={form.privacyPolicy}
+                  onChange={e => form.setPrivacyPolicy(e.target.value)}
                   placeholder={t('createTool.privacyPolicyPlaceholder', { ns: 'tools' }) || ''}
                 />
-              </div>
+              </FormField>
             </div>
-            <div className={cn((!isAdd && onRemove) ? 'justify-between' : 'justify-end', 'mt-2 flex shrink-0 rounded-b-[10px] border-t border-divider-regular bg-background-section-burn px-6 py-4')}>
-              {!isAdd && onRemove && (
-                <Button variant="warning" onClick={onRemove}>{t('operation.delete', { ns: 'common' })}</Button>
-              )}
-              <div className="flex space-x-2 ">
-                <Button onClick={onHide}>{t('operation.cancel', { ns: 'common' })}</Button>
-                <Button
-                  variant="primary"
-                  onClick={() => {
-                    if (isAdd)
-                      onConfirm()
-                    else
-                      setShowModal(true)
-                  }}
-                >
-                  {t('operation.save', { ns: 'common' })}
-                </Button>
-              </div>
-            </div>
+
+            <FooterActions
+              isAdd={isAdd}
+              onRemove={onRemove}
+              onHide={onHide}
+              onSaveClick={handleSaveClick}
+            />
           </div>
         )}
         isShowMask={true}
         clickOutsideNotOpen={true}
       />
-      {showEmojiPicker && (
+
+      {/* Emoji Picker Modal */}
+      {emojiPicker.isOpen && (
         <EmojiPicker
           onSelect={(icon, icon_background) => {
-            setEmoji({ content: icon, background: icon_background })
-            setShowEmojiPicker(false)
+            form.setEmoji({ content: icon, background: icon_background })
+            emojiPicker.close()
           }}
-          onClose={() => {
-            setShowEmojiPicker(false)
-          }}
+          onClose={emojiPicker.close}
         />
       )}
-      {showModal && (
+
+      {/* Confirm Modal */}
+      {confirmModal.isOpen && (
         <ConfirmModal
-          show={showModal}
-          onClose={() => setShowModal(false)}
-          onConfirm={onConfirm}
+          show={confirmModal.isOpen}
+          onClose={confirmModal.close}
+          onConfirm={form.onConfirm}
         />
       )}
     </>
-
   )
 }
+
 export default React.memo(WorkflowToolAsModal)

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -2683,11 +2683,6 @@
       "count": 3
     }
   },
-  "app/components/tools/types.ts": {
-    "ts/no-explicit-any": {
-      "count": 4
-    }
-  },
   "app/components/tools/utils/to-form-schema.ts": {
     "ts/no-explicit-any": {
       "count": 15

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -2683,11 +2683,6 @@
       "count": 3
     }
   },
-  "app/components/tools/utils/to-form-schema.ts": {
-    "ts/no-explicit-any": {
-      "count": 15
-    }
-  },
   "app/components/workflow-app/components/workflow-children.tsx": {
     "no-console": {
       "count": 1


### PR DESCRIPTION
## Summary

- Removed explicit 'any' types in favor of 'unknown' for better type safety.
- Refactored the WorkflowToolConfigureButton component to utilize a custom hook for managing modal state and logic.
- Introduced new components for input and output tables to streamline the workflow tool configuration process.
- Enhanced the form handling logic with a dedicated hook for managing form state and validation.
- Cleaned up unused imports and improved overall code organization.


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
