### PR TITLE
chore: follow-up fixes for storybook vite migration

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -1,4 +1,8 @@
 import type { StorybookConfig } from '@storybook/nextjs-vite'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const config: StorybookConfig = {
   stories: ['../app/components/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -16,6 +20,14 @@ const config: StorybookConfig = {
   },
   docs: {
     defaultName: 'Documentation',
+  },
+  viteFinal: async (config) => {
+    config.resolve = config.resolve || {}
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '~@': path.resolve(__dirname, '..'),
+    }
+    return config
   },
 }
 export default config

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -1,8 +1,4 @@
 import type { StorybookConfig } from '@storybook/nextjs-vite'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const config: StorybookConfig = {
   stories: ['../app/components/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -20,14 +16,6 @@ const config: StorybookConfig = {
   },
   docs: {
     defaultName: 'Documentation',
-  },
-  viteFinal: async (config) => {
-    config.resolve = config.resolve || {}
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      '~@': path.resolve(__dirname, '..'),
-    }
-    return config
   },
 }
 export default config

--- a/web/app/components/base/icons/icon-gallery.stories.tsx
+++ b/web/app/components/base/icons/icon-gallery.stories.tsx
@@ -1,9 +1,9 @@
+/// <reference types="vite/client" />
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import * as React from 'react'
 
-declare const require: any
-
 type IconComponent = React.ComponentType<Record<string, unknown>>
+type IconModule = { default: IconComponent }
 
 type IconEntry = {
   name: string
@@ -12,18 +12,16 @@ type IconEntry = {
   Component: IconComponent
 }
 
-const iconContext = require.context('./src', true, /\.tsx$/)
+const iconModules: Record<string, IconModule> = import.meta.glob('./src/**/*.tsx', { eager: true })
 
-const iconEntries: IconEntry[] = iconContext
-  .keys()
-  .filter((key: string) => !key.endsWith('.stories.tsx') && !key.endsWith('.spec.tsx'))
-  .map((key: string) => {
-    const mod = iconContext(key)
-    const Component = mod.default as IconComponent | undefined
+const iconEntries: IconEntry[] = Object.entries(iconModules)
+  .filter(([key]) => !key.endsWith('.stories.tsx') && !key.endsWith('.spec.tsx'))
+  .map(([key, mod]) => {
+    const Component = mod.default
     if (!Component)
       return null
 
-    const relativePath = key.replace(/^\.\//, '')
+    const relativePath = key.replace(/^\.\/src\//, '')
     const path = `app/components/base/icons/src/${relativePath}`
     const parts = relativePath.split('/')
     const fileName = parts.pop() || ''

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -1085,11 +1085,6 @@
       "count": 2
     }
   },
-  "app/components/base/icons/icon-gallery.stories.tsx": {
-    "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
   "app/components/base/icons/utils.ts": {
     "ts/no-explicit-any": {
       "count": 3

--- a/web/package.json
+++ b/web/package.json
@@ -48,7 +48,7 @@
     "analyze-component": "node ./scripts/analyze-component.js",
     "refactor-component": "node ./scripts/refactor-component.js",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "storybook:build": "storybook build",
     "preinstall": "npx only-allow pnpm",
     "analyze": "ANALYZE=true pnpm build",
     "knip": "knip"

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [tsconfigPaths(), react()],
+  resolve: {
+    alias: {
+      '~@': __dirname,
+    },
+  },
+})

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,9 +1,7 @@
-import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
 
-export default defineConfig({
-  plugins: [tsconfigPaths(), react()],
+export default mergeConfig(viteConfig, defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
@@ -13,4 +11,4 @@ export default defineConfig({
       reporter: ['text', 'json', 'json-summary'],
     },
   },
-})
+}))


### PR DESCRIPTION
## Summary

Follow-up to #31536.

- `main.ts`: Add `~@` path alias in Vite config
- `icon-gallery.stories.tsx`: Replace Webpack `require.context` with Vite `import.meta.glob`
- `package.json`: Rename `build-storybook` → `storybook:build`