### PR TITLE
feat: add filtering and lookup for workflow node executions

### DIFF
--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -155,6 +155,38 @@ console_ns.schema_model(
 )
 
 
+class WorkflowNodeExecutionQuery(BaseModel):
+    """Query parameters for filtering workflow node executions."""
+
+    node_id: str | None = Field(default=None, description="Filter by node ID")
+    node_type: str | None = Field(default=None, description="Filter by node type (e.g., http-request, llm)")
+    status: Literal["pending", "running", "succeeded", "failed", "exception", "stopped", "paused"] | None = Field(
+        default=None, description="Filter by execution status"
+    )
+
+    @field_validator("node_id")
+    @classmethod
+    def validate_node_id(cls, value: str | None) -> str | None:
+        """Validate node_id is not empty if provided."""
+        if value is not None and not value.strip():
+            raise ValueError("node_id cannot be empty")
+        return value.strip() if value else None
+
+    @field_validator("node_type")
+    @classmethod
+    def validate_node_type(cls, value: str | None) -> str | None:
+        """Validate node_type is not empty if provided."""
+        if value is not None and not value.strip():
+            raise ValueError("node_type cannot be empty")
+        return value.strip() if value else None
+
+
+console_ns.schema_model(
+    WorkflowNodeExecutionQuery.__name__,
+    WorkflowNodeExecutionQuery.model_json_schema(ref_template=DEFAULT_REF_TEMPLATE_SWAGGER_2_0),
+)
+
+
 @console_ns.route("/apps/<uuid:app_id>/advanced-chat/workflow-runs")
 class AdvancedChatAppWorkflowRunListApi(Resource):
     @console_ns.doc("get_advanced_chat_workflow_runs")
@@ -418,6 +450,14 @@ class WorkflowRunNodeExecutionListApi(Resource):
     @console_ns.doc("get_workflow_run_node_executions")
     @console_ns.doc(description="Get workflow run node execution list")
     @console_ns.doc(params={"app_id": "Application ID", "run_id": "Workflow run ID"})
+    @console_ns.doc(
+        params={
+            "node_id": "Filter by node ID (optional)",
+            "node_type": "Filter by node type (optional): e.g., http-request, llm, code",
+            "status": "Filter by status (optional): pending, running, succeeded, failed, exception, stopped, paused",
+        }
+    )
+    @console_ns.expect(console_ns.models[WorkflowNodeExecutionQuery.__name__])
     @console_ns.response(200, "Node executions retrieved successfully", workflow_run_node_execution_list_model)
     @console_ns.response(404, "Workflow run not found")
     @setup_required
@@ -427,9 +467,13 @@ class WorkflowRunNodeExecutionListApi(Resource):
     @marshal_with(workflow_run_node_execution_list_model)
     def get(self, app_model: App, run_id):
         """
-        Get workflow run node execution list
+        Get workflow run node execution list with optional filtering.
         """
         run_id = str(run_id)
+
+        # Parse query parameters
+        query_model = WorkflowNodeExecutionQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
+        filters = query_model.model_dump(exclude_none=True)
 
         workflow_run_service = WorkflowRunService()
         user = cast("Account | EndUser", current_user)
@@ -437,6 +481,43 @@ class WorkflowRunNodeExecutionListApi(Resource):
             app_model=app_model,
             run_id=run_id,
             user=user,
+            node_id=filters.get("node_id"),
+            node_type=filters.get("node_type"),
+            status=filters.get("status"),
         )
 
         return {"data": node_executions}
+
+
+@console_ns.route("/apps/<uuid:app_id>/workflow-runs/<uuid:run_id>/node-executions/<string:node_id>")
+class WorkflowRunNodeExecutionDetailApi(Resource):
+    @console_ns.doc("get_workflow_run_node_execution")
+    @console_ns.doc(description="Get a specific node execution by node ID")
+    @console_ns.doc(params={"app_id": "Application ID", "run_id": "Workflow run ID", "node_id": "Node ID"})
+    @console_ns.response(200, "Node execution retrieved successfully", workflow_run_node_execution_model)
+    @console_ns.response(404, "Node execution not found")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
+    @marshal_with(workflow_run_node_execution_model)
+    def get(self, app_model: App, run_id, node_id):
+        """
+        Get a specific node execution by node ID for a workflow run.
+        """
+        run_id = str(run_id)
+        node_id = str(node_id)
+
+        workflow_run_service = WorkflowRunService()
+        user = cast("Account | EndUser", current_user)
+        node_execution = workflow_run_service.get_workflow_run_node_execution_by_node_id(
+            app_model=app_model,
+            run_id=run_id,
+            node_id=node_id,
+            user=user,
+        )
+
+        if not node_execution:
+            return {"code": "node_execution_not_found", "message": "Node execution not found"}, 404
+
+        return node_execution

--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -156,7 +156,15 @@ console_ns.schema_model(
 
 
 class WorkflowNodeExecutionQuery(BaseModel):
-    """Query parameters for filtering workflow node executions."""
+    """
+    Query parameters for filtering workflow node executions.
+    
+    Why this is important:
+    - When debugging workflows, you often need to find specific nodes (like a payment API call that failed)
+    - Instead of loading ALL nodes and searching through them, you can filter directly
+    - This saves time and makes debugging much faster
+    - Example: Find all failed HTTP requests in a workflow run to see what went wrong
+    """
 
     node_id: str | None = Field(default=None, description="Filter by node ID")
     node_type: str | None = Field(default=None, description="Filter by node type (e.g., http-request, llm)")
@@ -468,6 +476,14 @@ class WorkflowRunNodeExecutionListApi(Resource):
     def get(self, app_model: App, run_id):
         """
         Get workflow run node execution list with optional filtering.
+        
+        Why filtering is important:
+        - Workflows can have many nodes (10, 20, or even 100+)
+        - Loading all nodes takes time and uses bandwidth
+        - With filters, you can quickly find what you need:
+          * All failed nodes to debug errors
+          * All HTTP request nodes to check API calls
+          * A specific node by ID to see its details
         """
         run_id = str(run_id)
 
@@ -504,6 +520,12 @@ class WorkflowRunNodeExecutionDetailApi(Resource):
     def get(self, app_model: App, run_id, node_id):
         """
         Get a specific node execution by node ID for a workflow run.
+        
+        Why this endpoint is important:
+        - Sometimes you only need details for ONE specific node (like a payment API call)
+        - Instead of loading all nodes and finding the one you want, you can get it directly
+        - This is much faster and uses less data
+        - Perfect for debugging a specific step in a workflow
         """
         run_id = str(run_id)
         node_id = str(node_id)

--- a/api/repositories/api_workflow_node_execution_repository.py
+++ b/api/repositories/api_workflow_node_execution_repository.py
@@ -69,6 +69,9 @@ class DifyAPIWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository, Pr
         tenant_id: str,
         app_id: str,
         workflow_run_id: str,
+        node_id: str | None = None,
+        node_type: str | None = None,
+        status: str | None = None,
     ) -> Sequence[WorkflowNodeExecutionModel]:
         """
         Get all node executions for a specific workflow run.
@@ -80,9 +83,36 @@ class DifyAPIWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository, Pr
             tenant_id: The tenant identifier
             app_id: The application identifier
             workflow_run_id: The workflow run identifier
+            node_id: Optional filter by node ID
+            node_type: Optional filter by node type
+            status: Optional filter by execution status
 
         Returns:
             A sequence of WorkflowNodeExecutionModel instances ordered by index (desc)
+        """
+        ...
+
+    def get_execution_by_node_id(
+        self,
+        tenant_id: str,
+        app_id: str,
+        workflow_run_id: str,
+        node_id: str,
+    ) -> WorkflowNodeExecutionModel | None:
+        """
+        Get a specific node execution by node ID for a workflow run.
+
+        This method retrieves a specific node execution within a workflow run
+        by its node ID. Returns the most recent execution if multiple exist.
+
+        Args:
+            tenant_id: The tenant identifier
+            app_id: The application identifier
+            workflow_run_id: The workflow run identifier
+            node_id: The node identifier
+
+        Returns:
+            The WorkflowNodeExecutionModel if found, or None if not found
         """
         ...
 

--- a/api/repositories/api_workflow_node_execution_repository.py
+++ b/api/repositories/api_workflow_node_execution_repository.py
@@ -77,7 +77,7 @@ class DifyAPIWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository, Pr
         Get all node executions for a specific workflow run.
 
         This method retrieves all node executions that belong to a specific workflow run,
-        ordered by index in descending order for proper trace visualization.
+        ordered by created_at in ascending order for proper trace visualization.
 
         Args:
             tenant_id: The tenant identifier
@@ -88,7 +88,7 @@ class DifyAPIWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository, Pr
             status: Optional filter by execution status
 
         Returns:
-            A sequence of WorkflowNodeExecutionModel instances ordered by index (desc)
+            A sequence of WorkflowNodeExecutionModel instances ordered by created_at (asc)
         """
         ...
 

--- a/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py
@@ -1,0 +1,199 @@
+"""Unit tests for DifyAPISQLAlchemyWorkflowNodeExecutionRepository filtering and node lookup."""
+
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.workflow import WorkflowNodeExecutionModel
+from repositories.sqlalchemy_api_workflow_node_execution_repository import (
+    DifyAPISQLAlchemyWorkflowNodeExecutionRepository,
+)
+
+
+class TestDifyAPISQLAlchemyWorkflowNodeExecutionRepositoryFiltering:
+    """Test filtering functionality in DifyAPISQLAlchemyWorkflowNodeExecutionRepository."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock session."""
+        return Mock(spec=Session)
+
+    @pytest.fixture
+    def mock_session_maker(self, mock_session):
+        """Create a mock sessionmaker."""
+        session_maker = Mock(spec=sessionmaker)
+
+        context_manager = Mock()
+        context_manager.__enter__ = Mock(return_value=mock_session)
+        context_manager.__exit__ = Mock(return_value=None)
+        session_maker.return_value = context_manager
+
+        mock_session.scalar = Mock()
+        mock_session.execute = Mock()
+        mock_session.scalars = Mock()
+
+        return session_maker
+
+    @pytest.fixture
+    def repository(self, mock_session_maker):
+        """Create repository instance with mocked dependencies."""
+        return DifyAPISQLAlchemyWorkflowNodeExecutionRepository(mock_session_maker)
+
+    @pytest.fixture
+    def sample_node_execution(self):
+        """Create a sample WorkflowNodeExecutionModel."""
+        execution = Mock(spec=WorkflowNodeExecutionModel)
+        execution.id = "execution-123"
+        execution.tenant_id = "tenant-123"
+        execution.app_id = "app-123"
+        execution.workflow_run_id = "run-123"
+        execution.node_id = "node-123"
+        execution.node_type = "http-request"
+        execution.status = "succeeded"
+        execution.created_at = datetime.now()
+        return execution
+
+    def test_get_executions_by_workflow_run_no_filters(self, repository, mock_session, mock_session_maker):
+        """Test getting executions without filters."""
+        # Arrange
+        mock_result = Mock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        # Act
+        result = repository.get_executions_by_workflow_run(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+        )
+
+        # Assert
+        assert result == []
+        mock_session_maker.assert_called_once()
+        mock_session.execute.assert_called_once()
+
+    def test_get_executions_by_workflow_run_with_node_id_filter(
+        self, repository, mock_session, mock_session_maker, sample_node_execution
+    ):
+        """Test getting executions filtered by node_id."""
+        # Arrange
+        mock_result = Mock()
+        mock_result.scalars.return_value.all.return_value = [sample_node_execution]
+        mock_session.execute.return_value = mock_result
+
+        # Act
+        result = repository.get_executions_by_workflow_run(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id="node-123",
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result[0] == sample_node_execution
+        mock_session.execute.assert_called_once()
+
+    def test_get_executions_by_workflow_run_with_node_type_filter(
+        self, repository, mock_session, mock_session_maker, sample_node_execution
+    ):
+        """Test getting executions filtered by node_type."""
+        # Arrange
+        mock_result = Mock()
+        mock_result.scalars.return_value.all.return_value = [sample_node_execution]
+        mock_session.execute.return_value = mock_result
+
+        # Act
+        result = repository.get_executions_by_workflow_run(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_type="http-request",
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result[0] == sample_node_execution
+        mock_session.execute.assert_called_once()
+
+    def test_get_executions_by_workflow_run_with_status_filter(
+        self, repository, mock_session, mock_session_maker, sample_node_execution
+    ):
+        """Test getting executions filtered by status."""
+        # Arrange
+        mock_result = Mock()
+        mock_result.scalars.return_value.all.return_value = [sample_node_execution]
+        mock_session.execute.return_value = mock_result
+
+        # Act
+        result = repository.get_executions_by_workflow_run(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            status="succeeded",
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result[0] == sample_node_execution
+        mock_session.execute.assert_called_once()
+
+    def test_get_executions_by_workflow_run_with_all_filters(
+        self, repository, mock_session, mock_session_maker, sample_node_execution
+    ):
+        """Test getting executions with all filters applied."""
+        # Arrange
+        mock_result = Mock()
+        mock_result.scalars.return_value.all.return_value = [sample_node_execution]
+        mock_session.execute.return_value = mock_result
+
+        # Act
+        result = repository.get_executions_by_workflow_run(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id="node-123",
+            node_type="http-request",
+            status="succeeded",
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result[0] == sample_node_execution
+        mock_session.execute.assert_called_once()
+
+    def test_get_execution_by_node_id_found(self, repository, mock_session, mock_session_maker, sample_node_execution):
+        """Test getting execution by node_id when found."""
+        # Arrange
+        mock_session.scalar.return_value = sample_node_execution
+
+        # Act
+        result = repository.get_execution_by_node_id(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id="node-123",
+        )
+
+        # Assert
+        assert result == sample_node_execution
+        mock_session.scalar.assert_called_once()
+
+    def test_get_execution_by_node_id_not_found(self, repository, mock_session, mock_session_maker):
+        """Test getting execution by node_id when not found."""
+        # Arrange
+        mock_session.scalar.return_value = None
+
+        # Act
+        result = repository.get_execution_by_node_id(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id="node-123",
+        )
+
+        # Assert
+        assert result is None
+        mock_session.scalar.assert_called_once()

--- a/api/tests/unit_tests/services/test_workflow_run_service_node_executions.py
+++ b/api/tests/unit_tests/services/test_workflow_run_service_node_executions.py
@@ -1,0 +1,294 @@
+"""Unit tests for WorkflowRunService node execution filtering and lookup."""
+
+import threading
+from unittest.mock import Mock, patch
+
+import pytest
+
+from models import Account, App, EndUser, WorkflowNodeExecutionModel, WorkflowRun
+from repositories.api_workflow_node_execution_repository import DifyAPIWorkflowNodeExecutionRepository
+from repositories.api_workflow_run_repository import APIWorkflowRunRepository
+from services.workflow_run_service import WorkflowRunService
+
+
+class TestWorkflowRunServiceNodeExecutions:
+    """Test node execution filtering and lookup in WorkflowRunService."""
+
+    @pytest.fixture
+    def mock_node_execution_repo(self):
+        """Create a mock node execution repository."""
+        return Mock(spec=DifyAPIWorkflowNodeExecutionRepository)
+
+    @pytest.fixture
+    def mock_workflow_run_repo(self):
+        """Create a mock workflow run repository."""
+        return Mock(spec=APIWorkflowRunRepository)
+
+    @pytest.fixture
+    def mock_session_factory(self):
+        """Create a mock session factory."""
+        return Mock()
+
+    @pytest.fixture
+    def service(self, mock_node_execution_repo, mock_workflow_run_repo, mock_session_factory):
+        """Create WorkflowRunService with mocked repositories."""
+        with patch("services.workflow_run_service.DifyAPIRepositoryFactory") as mock_factory:
+            mock_factory.create_api_workflow_node_execution_repository.return_value = mock_node_execution_repo
+            mock_factory.create_api_workflow_run_repository.return_value = mock_workflow_run_repo
+
+            service = WorkflowRunService(session_factory=mock_session_factory)
+            service._node_execution_service_repo = mock_node_execution_repo
+            service._workflow_run_repo = mock_workflow_run_repo
+            return service
+
+    @pytest.fixture
+    def mock_app(self):
+        """Create a mock App."""
+        app = Mock(spec=App)
+        app.id = "app-123"
+        app.tenant_id = "tenant-123"
+        return app
+
+    @pytest.fixture
+    def mock_account(self):
+        """Create a mock Account."""
+        account = Mock(spec=Account)
+        account.id = "account-123"
+        account.current_tenant_id = "tenant-123"
+        account.tenant_id = None
+        return account
+
+    @pytest.fixture
+    def mock_end_user(self):
+        """Create a mock EndUser."""
+        end_user = Mock(spec=EndUser)
+        end_user.id = "end-user-123"
+        end_user.tenant_id = "tenant-123"
+        return end_user
+
+    @pytest.fixture
+    def mock_workflow_run(self):
+        """Create a mock WorkflowRun."""
+        workflow_run = Mock(spec=WorkflowRun)
+        workflow_run.id = "run-123"
+        workflow_run.tenant_id = "tenant-123"
+        workflow_run.app_id = "app-123"
+        return workflow_run
+
+    @pytest.fixture
+    def mock_node_execution(self):
+        """Create a mock WorkflowNodeExecutionModel."""
+        execution = Mock(spec=WorkflowNodeExecutionModel)
+        execution.id = "execution-123"
+        execution.node_id = "node-123"
+        execution.node_type = "http-request"
+        execution.status = "succeeded"
+        return execution
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_executions_no_filters(
+        self, mock_contexts, service, mock_app, mock_account, mock_workflow_run, mock_node_execution_repo, mock_node_execution
+    ):
+        """Test getting node executions without filters."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=mock_workflow_run)
+        mock_node_execution_repo.get_executions_by_workflow_run.return_value = [mock_node_execution]
+
+        # Act
+        result = service.get_workflow_run_node_executions(
+            app_model=mock_app,
+            run_id="run-123",
+            user=mock_account,
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result[0] == mock_node_execution
+        mock_node_execution_repo.get_executions_by_workflow_run.assert_called_once_with(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id=None,
+            node_type=None,
+            status=None,
+        )
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_executions_with_filters(
+        self, mock_contexts, service, mock_app, mock_account, mock_workflow_run, mock_node_execution_repo, mock_node_execution
+    ):
+        """Test getting node executions with filters."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=mock_workflow_run)
+        mock_node_execution_repo.get_executions_by_workflow_run.return_value = [mock_node_execution]
+
+        # Act
+        result = service.get_workflow_run_node_executions(
+            app_model=mock_app,
+            run_id="run-123",
+            user=mock_account,
+            node_id="node-123",
+            node_type="http-request",
+            status="succeeded",
+        )
+
+        # Assert
+        assert len(result) == 1
+        mock_node_execution_repo.get_executions_by_workflow_run.assert_called_once_with(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id="node-123",
+            node_type="http-request",
+            status="succeeded",
+        )
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_executions_workflow_run_not_found(
+        self, mock_contexts, service, mock_app, mock_account, mock_node_execution_repo
+    ):
+        """Test getting node executions when workflow run not found."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=None)
+
+        # Act
+        result = service.get_workflow_run_node_executions(
+            app_model=mock_app,
+            run_id="run-123",
+            user=mock_account,
+        )
+
+        # Assert
+        assert result == []
+        mock_node_execution_repo.get_executions_by_workflow_run.assert_not_called()
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_executions_with_end_user(
+        self, mock_contexts, service, mock_app, mock_end_user, mock_workflow_run, mock_node_execution_repo, mock_node_execution
+    ):
+        """Test getting node executions with EndUser."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=mock_workflow_run)
+        mock_node_execution_repo.get_executions_by_workflow_run.return_value = [mock_node_execution]
+
+        # Act
+        result = service.get_workflow_run_node_executions(
+            app_model=mock_app,
+            run_id="run-123",
+            user=mock_end_user,
+        )
+
+        # Assert
+        assert len(result) == 1
+        mock_node_execution_repo.get_executions_by_workflow_run.assert_called_once_with(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id=None,
+            node_type=None,
+            status=None,
+        )
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_execution_by_node_id_found(
+        self, mock_contexts, service, mock_app, mock_account, mock_workflow_run, mock_node_execution_repo, mock_node_execution
+    ):
+        """Test getting node execution by node_id when found."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=mock_workflow_run)
+        mock_node_execution_repo.get_execution_by_node_id.return_value = mock_node_execution
+
+        # Act
+        result = service.get_workflow_run_node_execution_by_node_id(
+            app_model=mock_app,
+            run_id="run-123",
+            node_id="node-123",
+            user=mock_account,
+        )
+
+        # Assert
+        assert result == mock_node_execution
+        mock_node_execution_repo.get_execution_by_node_id.assert_called_once_with(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workflow_run_id="run-123",
+            node_id="node-123",
+        )
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_execution_by_node_id_not_found(
+        self, mock_contexts, service, mock_app, mock_account, mock_workflow_run, mock_node_execution_repo
+    ):
+        """Test getting node execution by node_id when not found."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=mock_workflow_run)
+        mock_node_execution_repo.get_execution_by_node_id.return_value = None
+
+        # Act
+        result = service.get_workflow_run_node_execution_by_node_id(
+            app_model=mock_app,
+            run_id="run-123",
+            node_id="node-123",
+            user=mock_account,
+        )
+
+        # Assert
+        assert result is None
+        mock_node_execution_repo.get_execution_by_node_id.assert_called_once()
+
+    @patch("services.workflow_run_service.contexts")
+    def test_get_workflow_run_node_execution_by_node_id_workflow_run_not_found(
+        self, mock_contexts, service, mock_app, mock_account, mock_node_execution_repo
+    ):
+        """Test getting node execution by node_id when workflow run not found."""
+        # Arrange
+        mock_contexts.plugin_tool_providers.set = Mock()
+        mock_contexts.plugin_tool_providers_lock.set = Mock()
+
+        service.get_workflow_run = Mock(return_value=None)
+
+        # Act
+        result = service.get_workflow_run_node_execution_by_node_id(
+            app_model=mock_app,
+            run_id="run-123",
+            node_id="node-123",
+            user=mock_account,
+        )
+
+        # Assert
+        assert result is None
+        mock_node_execution_repo.get_execution_by_node_id.assert_not_called()
+
+    def test_get_workflow_run_node_executions_raises_error_on_none_tenant_id(
+        self, service, mock_app, mock_account, mock_workflow_run
+    ):
+        """Test that ValueError is raised when tenant_id is None."""
+        # Arrange
+        mock_account.current_tenant_id = None
+        service.get_workflow_run = Mock(return_value=mock_workflow_run)
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="User tenant_id cannot be None"):
+            service.get_workflow_run_node_executions(
+                app_model=mock_app,
+                run_id="run-123",
+                user=mock_account,
+            )


### PR DESCRIPTION
- Introduced `WorkflowNodeExecutionQuery` model for filtering node executions by node ID, type, and status.
- Updated `WorkflowRunNodeExecutionListApi` to support optional filtering in the GET request.
- Enhanced `WorkflowRunService` and repository methods to handle filtering parameters.
- Added new method `get_execution_by_node_id` in repositories for fetching specific node executions.
- Implemented unit tests for filtering functionality in the repository and service layers.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
