### PR TITLE
refactor(model): Refactor plugin model schema cache to be process-global to prevent redundant Daemon API calls

### DIFF
--- a/api/contexts/__init__.py
+++ b/api/contexts/__init__.py
@@ -29,11 +29,8 @@ plugin_model_providers_lock: RecyclableContextVar[Lock] = RecyclableContextVar(
     ContextVar("plugin_model_providers_lock")
 )
 
-plugin_model_schema_lock: RecyclableContextVar[Lock] = RecyclableContextVar(ContextVar("plugin_model_schema_lock"))
-
-plugin_model_schemas: RecyclableContextVar[dict[str, "AIModelEntity"]] = RecyclableContextVar(
-    ContextVar("plugin_model_schemas")
-)
+plugin_model_schema_lock: Lock = Lock()
+plugin_model_schemas: dict[str, "AIModelEntity"] = {}
 
 datasource_plugin_providers: RecyclableContextVar[dict[str, "DatasourcePluginProviderController"]] = (
     RecyclableContextVar(ContextVar("datasource_plugin_providers"))


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Currently, `plugin_model_schemas` is implemented using `RecyclableContextVar`. This causes the cache to be reset with every request (or thread recycle), rendering it ineffective for cross-request caching. As a result, the system re-fetches the model schema from the Plugin Daemon for every single API request, leading to unnecessary network overhead and latency.

This refactor changes `plugin_model_schemas` and its corresponding lock to be global process-level variables (`dict` and `Lock`). This ensures that once a model schema is fetched, it remains cached in memory for the lifetime of the process, significantly reducing internal API calls.

## Screenshots

| Before | After |
|--------|-------|
| <img width="400" height="200" alt="Clipboard_Screenshot_1769569761" src="https://github.com/user-attachments/assets/83babe77-9b9c-4fe9-a6c9-aa65c44765c4" /> | <img width="400" height="200" alt="Clipboard_Screenshot_1769570075" src="https://github.com/user-attachments/assets/630118da-9187-4a7c-be19-6b6bffcfb023" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

#31627
