### PR TITLE
chore: remove non-ASCII characters in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -397,7 +397,7 @@ WEB_API_CORS_ALLOW_ORIGINS=*
 # Specifies the allowed origins for cross-origin requests to the console API,
 # e.g. https://cloud.dify.ai or * for all origins.
 CONSOLE_CORS_ALLOW_ORIGINS=*
-# When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site’s top-level domain (e.g., `example.com`). Leading dots are optional.
+# When the frontend and backend run on different subdomains, set COOKIE_DOMAIN to the site's top-level domain (e.g., `example.com`). Leading dots are optional.
 COOKIE_DOMAIN=
 # When the frontend and backend run on different subdomains, set NEXT_PUBLIC_COOKIE_DOMAIN=1.
 NEXT_PUBLIC_COOKIE_DOMAIN=
@@ -1080,7 +1080,7 @@ ALIYUN_SLS_ENDPOINT=
 ALIYUN_SLS_REGION=
 # Aliyun SLS Project Name
 ALIYUN_SLS_PROJECT_NAME=
-# Number of days to retain workflow run logs (default: 365 days， 3650 for permanent storage)
+# Number of days to retain workflow run logs (default: 365 days, 3650 for permanent storage)
 ALIYUN_SLS_LOGSTORE_TTL=365
 # Enable dual-write to both SLS LogStore and SQL database (default: false)
 LOGSTORE_DUAL_WRITE_ENABLED=false

--- a/docker/generate_docker_compose
+++ b/docker/generate_docker_compose
@@ -9,7 +9,7 @@ def parse_env_example(file_path):
     Parses the .env.example file and returns a dictionary with variable names as keys and default values as values.
     """
     env_vars = {}
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         for line_number, line in enumerate(f, 1):
             line = line.strip()
             # Ignore empty lines and comments
@@ -55,7 +55,7 @@ def insert_shared_env(template_path, output_path, shared_env_block, header_comme
     Inserts the shared environment variables block and header comments into the template file,
     removing any existing x-shared-env anchors, and generates the final docker-compose.yaml file.
     """
-    with open(template_path, "r") as f:
+    with open(template_path, "r", encoding="utf-8") as f:
         template_content = f.read()
 
     # Remove existing x-shared-env: &shared-api-worker-env lines
@@ -69,7 +69,7 @@ def insert_shared_env(template_path, output_path, shared_env_block, header_comme
     # Prepare the final content with header comments and shared env block
     final_content = f"{header_comments}\n{shared_env_block}\n\n{template_content}"
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(final_content)
     print(f"Generated {output_path}")
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The file .env.example contains non-ASCII characters in its comments. This causes a UnicodeDecodeError when executing generate_docker_compose in some environments.

Fixes #31351

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
