### PR TITLE
feat(qdrant): implement full-text search with multi-keyword support

### DIFF
--- a/api/core/rag/datasource/vdb/qdrant/qdrant_vector.py
+++ b/api/core/rag/datasource/vdb/qdrant/qdrant_vector.py
@@ -391,46 +391,79 @@ class QdrantVector(BaseVector):
         return docs
 
     def search_by_full_text(self, query: str, **kwargs: Any) -> list[Document]:
-        """Return docs most similar by bm25.
+        """Return docs most similar by full-text search.
+
+        Searches each keyword separately and merges results to ensure documents
+        matching ANY keyword are returned. This guarantees that results for each
+        keyword are included, regardless of Qdrant's scroll ordering.
+
+        Note: Total results may exceed top_k when multiple keywords are searched,
+        as each keyword search returns up to top_k results.
+
+        Args:
+            query: Search query text (each keyword searched separately)
+            **kwargs: Additional search parameters (top_k, document_ids_filter)
+
         Returns:
-            List of documents most similar to the query text and distance for each.
+            List of unique documents matching any of the query keywords.
         """
         from qdrant_client.http import models
 
-        scroll_filter = models.Filter(
-            must=[
-                models.FieldCondition(
-                    key="group_id",
-                    match=models.MatchValue(value=self._group_id),
-                ),
-                models.FieldCondition(
-                    key="page_content",
-                    match=models.MatchText(text=query),
-                ),
-            ]
-        )
+        # Build base must conditions (AND logic) for metadata filters
+        base_must_conditions: list = [
+            models.FieldCondition(
+                key="group_id",
+                match=models.MatchValue(value=self._group_id),
+            ),
+        ]
+
         document_ids_filter = kwargs.get("document_ids_filter")
         if document_ids_filter:
-            if scroll_filter.must:
-                scroll_filter.must.append(
-                    models.FieldCondition(
-                        key="metadata.document_id",
-                        match=models.MatchAny(any=document_ids_filter),
-                    )
+            base_must_conditions.append(
+                models.FieldCondition(
+                    key="metadata.document_id",
+                    match=models.MatchAny(any=document_ids_filter),
                 )
-        response = self._client.scroll(
-            collection_name=self._collection_name,
-            scroll_filter=scroll_filter,
-            limit=kwargs.get("top_k", 2),
-            with_payload=True,
-            with_vectors=True,
-        )
-        results = response[0]
-        documents = []
-        for result in results:
-            if result:
-                document = self._document_from_scored_point(result, Field.CONTENT_KEY, Field.METADATA_KEY)
-                documents.append(document)
+            )
+
+        # Split query into keywords
+        keywords = [kw.strip() for kw in query.strip().split() if kw.strip()]
+
+        if not keywords:
+            return []
+
+        top_k = kwargs.get("top_k", 2)
+        seen_ids: set[str | int] = set()
+        documents: list[Document] = []
+
+        # Search each keyword separately and merge results.
+        # This ensures each keyword gets its own search, preventing one keyword's
+        # results from completely overshadowing another's due to scroll ordering.
+        for keyword in keywords:
+            scroll_filter = models.Filter(
+                must=[
+                    *base_must_conditions,
+                    models.FieldCondition(
+                        key="page_content",
+                        match=models.MatchText(text=keyword),
+                    ),
+                ]
+            )
+
+            response = self._client.scroll(
+                collection_name=self._collection_name,
+                scroll_filter=scroll_filter,
+                limit=top_k,
+                with_payload=True,
+                with_vectors=True,
+            )
+            results = response[0]
+
+            for result in results:
+                if result and result.id not in seen_ids:
+                    seen_ids.add(result.id)
+                    document = self._document_from_scored_point(result, Field.CONTENT_KEY, Field.METADATA_KEY)
+                    documents.append(document)
 
         return documents
 

--- a/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
+++ b/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
@@ -61,13 +61,7 @@ class QdrantVectorTest(AbstractVectorTest):
         self.vector.add_texts(documents=documents, embeddings=embeddings)
 
     def search_by_full_text_multi_keyword(self):
-        """Test that multi-keyword search returns documents matching ANY keyword.
-
-        Verifies OR logic: searching for 'apple banana' should return:
-        - Document with 'apple' only
-        - Document with 'banana' only
-        - Document with both 'apple and banana'
-        """
+        """Test multi-keyword search returns docs matching ANY keyword (OR logic)."""
         # First verify single keyword searches work correctly
         hits_apple = self.vector.search_by_full_text(query="apple", top_k=10)
         apple_ids = {doc.metadata["doc_id"] for doc in hits_apple}
@@ -86,6 +80,7 @@ class QdrantVectorTest(AbstractVectorTest):
         assert self.doc_apple_id in doc_ids, "Document with 'apple' should be found in multi-keyword search"
         assert self.doc_banana_id in doc_ids, "Document with 'banana' should be found in multi-keyword search"
         assert self.doc_both_id in doc_ids, "Document with both keywords should be found"
+        # Expect 3 results: doc_apple (apple only), doc_banana (banana only), doc_both (contains both)
         assert len(hits) == 3, f"Expected 3 documents, got {len(hits)}"
 
         # Test keyword order independence

--- a/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
+++ b/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
@@ -106,9 +106,7 @@ class QdrantVectorTest(AbstractVectorTest):
         # Multi-keyword search tests
         self.setup_multi_keyword_documents()
         self.search_by_full_text_multi_keyword()
-        # Cleanup
-        added_doc_ids = self.add_texts()
-        self.delete_by_ids(added_doc_ids)
+        # Cleanup - delete_vector() removes the entire collection
         self.delete_vector()
 
 

--- a/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
+++ b/api/tests/integration_tests/vdb/qdrant/test_qdrant.py
@@ -1,3 +1,5 @@
+import uuid
+
 from core.rag.datasource.vdb.qdrant.qdrant_vector import QdrantConfig, QdrantVector
 from core.rag.models.document import Document
 from tests.integration_tests.vdb.test_vector_store import (
@@ -18,6 +20,10 @@ class QdrantVectorTest(AbstractVectorTest):
                 api_key="difyai123456",
             ),
         )
+        # Additional doc IDs for multi-keyword search tests
+        self.doc_apple_id = ""
+        self.doc_banana_id = ""
+        self.doc_both_id = ""
 
     def search_by_vector(self):
         super().search_by_vector()
@@ -26,6 +32,84 @@ class QdrantVectorTest(AbstractVectorTest):
             query_vector=self.example_embedding, score_threshold=1
         )
         assert len(hits_by_vector) == 0
+
+    def _create_document(self, content: str, doc_id: str) -> Document:
+        """Create a document with the given content and doc_id."""
+        return Document(
+            page_content=content,
+            metadata={
+                "doc_id": doc_id,
+                "doc_hash": doc_id,
+                "document_id": doc_id,
+                "dataset_id": self.dataset_id,
+            },
+        )
+
+    def setup_multi_keyword_documents(self):
+        """Create test documents with different keyword combinations for multi-keyword search tests."""
+        self.doc_apple_id = str(uuid.uuid4())
+        self.doc_banana_id = str(uuid.uuid4())
+        self.doc_both_id = str(uuid.uuid4())
+
+        documents = [
+            self._create_document("This document contains apple only", self.doc_apple_id),
+            self._create_document("This document contains banana only", self.doc_banana_id),
+            self._create_document("This document contains both apple and banana", self.doc_both_id),
+        ]
+        embeddings = [self.example_embedding] * len(documents)
+
+        self.vector.add_texts(documents=documents, embeddings=embeddings)
+
+    def search_by_full_text_multi_keyword(self):
+        """Test that multi-keyword search returns documents matching ANY keyword.
+
+        Verifies OR logic: searching for 'apple banana' should return:
+        - Document with 'apple' only
+        - Document with 'banana' only
+        - Document with both 'apple and banana'
+        """
+        # First verify single keyword searches work correctly
+        hits_apple = self.vector.search_by_full_text(query="apple", top_k=10)
+        apple_ids = {doc.metadata["doc_id"] for doc in hits_apple}
+        assert self.doc_apple_id in apple_ids, "Document with 'apple' should be found"
+        assert self.doc_both_id in apple_ids, "Document with 'apple and banana' should be found"
+
+        hits_banana = self.vector.search_by_full_text(query="banana", top_k=10)
+        banana_ids = {doc.metadata["doc_id"] for doc in hits_banana}
+        assert self.doc_banana_id in banana_ids, "Document with 'banana' should be found"
+        assert self.doc_both_id in banana_ids, "Document with 'apple and banana' should be found"
+
+        # Test multi-keyword search returns all matching documents
+        hits = self.vector.search_by_full_text(query="apple banana", top_k=10)
+        doc_ids = {doc.metadata["doc_id"] for doc in hits}
+
+        assert self.doc_apple_id in doc_ids, "Document with 'apple' should be found in multi-keyword search"
+        assert self.doc_banana_id in doc_ids, "Document with 'banana' should be found in multi-keyword search"
+        assert self.doc_both_id in doc_ids, "Document with both keywords should be found"
+        assert len(hits) == 3, f"Expected 3 documents, got {len(hits)}"
+
+        # Test keyword order independence
+        hits_ba = self.vector.search_by_full_text(query="banana apple", top_k=10)
+        ids_ba = {doc.metadata["doc_id"] for doc in hits_ba}
+        assert doc_ids == ids_ba, "Keyword order should not affect search results"
+
+        # Test no duplicates in results
+        doc_id_list = [doc.metadata["doc_id"] for doc in hits]
+        assert len(doc_id_list) == len(set(doc_id_list)), "Search results should not contain duplicates"
+
+    def run_all_tests(self):
+        self.create_vector()
+        self.search_by_vector()
+        self.search_by_full_text()
+        self.text_exists()
+        self.get_ids_by_metadata_field()
+        # Multi-keyword search tests
+        self.setup_multi_keyword_documents()
+        self.search_by_full_text_multi_keyword()
+        # Cleanup
+        added_doc_ids = self.add_texts()
+        self.delete_by_ids(added_doc_ids)
+        self.delete_vector()
 
 
 def test_qdrant_vector(setup_mock_redis):


### PR DESCRIPTION
Resolve #31657

## Summary

When using Qdrant's search_by_full_text method with multiple keywords (e.g., "apple banana"), the search only returns documents containing all keywords instead of documents containing any keyword.

For example:

Searching "apple" returns documents A (with "apple")
Searching "banana" returns documents B (with "banana")
Searching "apple banana" only returns documents containing both keywords, missing A and B

This happens because Qdrant's MatchText uses AND logic by default, unlike Elasticsearch/OpenSearch which use OR logic for multi-word match queries.

#### Root Cause:

Qdrant's MatchText with multiple words uses AND logic (all words must match)

The original docstring incorrectly stated "BM25" - Qdrant < 1.10 doesn't support native BM25

Current  Qdrant image is `langgenius/qdrant:v1.8.3`

### Solution:

Search each keyword separately and merge results with deduplication

This aligns with the behavior of other vector databases (ES/OpenSearch)

## Screenshots

`uv run --project api pytest api/tests/integration_tests/vdb/qdrant/test_qdrant.py `

| Before | After |
|--------|-------|
| Test fail: Searching "apple banana" returns only docs with both keywords | Test success: Searching "apple banana" returns docs with any keyword (union of results) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
