### PR TITLE
chore(ty): Bootstrap ty type checking for api

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -47,13 +47,9 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: uv run --directory api --dev lint-imports
 
-      - name: Run Basedpyright Checks
+      - name: Run Type Checks
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: dev/basedpyright-check
-
-      - name: Run Mypy Type Checks
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: uv --directory api run mypy --exclude-gitignore --exclude 'tests/' --exclude 'migrations/' --check-untyped-defs --disable-error-code=import-untyped .
+        run: make type-check
 
       - name: Dotenv check
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,11 @@ lint:
 	@echo "✅ Linting complete"
 
 type-check:
-	@echo "📝 Running type check with basedpyright..."
-	@uv run --directory api --dev basedpyright
-	@echo "✅ Type check complete"
+	@echo "📝 Running type checks (basedpyright + mypy + ty)..."
+	@./dev/basedpyright-check $(PATH_TO_CHECK)
+	@uv --directory api run mypy --exclude-gitignore --exclude 'tests/' --exclude 'migrations/' --check-untyped-defs --disable-error-code=import-untyped .
+	@cd api && uv run ty check
+	@echo "✅ Type checks complete"
 
 test:
 	@echo "🧪 Running backend unit tests..."
@@ -130,7 +132,7 @@ help:
 	@echo "  make format         - Format code with ruff"
 	@echo "  make check          - Check code with ruff"
 	@echo "  make lint           - Format, fix, and lint code (ruff, imports, dotenv)"
-	@echo "  make type-check     - Run type checking with basedpyright"
+	@echo "  make type-check     - Run type checks (basedpyright, mypy, ty)"
 	@echo "  make test           - Run backend unit tests (or TARGET_TESTS=./api/tests/<target_tests>)"
 	@echo ""
 	@echo "Docker Build Targets:"

--- a/api/ty.toml
+++ b/api/ty.toml
@@ -1,11 +1,33 @@
 [src]
 exclude = [
-    # TODO: enable when violations fixed
+    # deps groups (A1/A2/B/C/D/E)
+    # A1: foundational runtime typing / provider plumbing
+    "core/mcp/session",
+    "core/model_runtime/model_providers",
+    "core/workflow/nodes/protocols.py",
+    "libs/gmpy2_pkcs10aep_cipher.py",
+    # A2: workflow engine/nodes
+    "core/workflow",
+    "core/app/workflow",
+    "core/helper/code_executor",
+    # B: app runner + prompt
+    "core/prompt",
+    "core/app/apps/base_app_runner.py",
     "core/app/apps/workflow_app_runner.py",
+    # C: services/controllers/fields/libs
+    "services",
     "controllers/console/app",
     "controllers/console/explore",
     "controllers/console/datasets",
     "controllers/console/workspace",
+    "controllers/service_api/wraps.py",
+    "fields/conversation_fields.py",
+    "libs/external_api.py",
+    # D: observability + integrations
+    "core/ops",
+    "extensions",
+    # E: vector DB integrations
+    "core/rag/datasource/vdb",
     # non-producition or generated code
     "migrations",
     "tests",


### PR DESCRIPTION
Implements PR0 from #31680 by wiring `ty` into `make type-check` and CI style workflow, with an initial `api/ty.toml` exclusion list to allow incremental rollout.

- CI: style workflow runs `make type-check`
- Makefile: `type-check` runs basedpyright + mypy + ty
- api: add `api/ty.toml` exclusions (to be reduced in follow-up PRs)