### PR TITLE
refactor(model): Refactor plugin model schema cache to be process-global to prevent redundant Daemon API calls

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -242,10 +242,10 @@ class PluginConfig(BaseSettings):
         description="Maximum allowed size for plugin bundles in bytes",
         default=15728640 * 12,
     )
-    
+
     PLUGIN_MODEL_SCHEMA_CACHE_TTL: PositiveInt = Field(
-    description="TTL in seconds for caching plugin model schemas in Redis",
-    default=24 * 60 * 60,
+        description="TTL in seconds for caching plugin model schemas in Redis",
+        default=24 * 60 * 60,
     )
 
 

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -242,6 +242,11 @@ class PluginConfig(BaseSettings):
         description="Maximum allowed size for plugin bundles in bytes",
         default=15728640 * 12,
     )
+    
+    PLUGIN_MODEL_SCHEMA_CACHE_TTL: PositiveInt = Field(
+    description="TTL in seconds for caching plugin model schemas in Redis",
+    default=24 * 60 * 60,
+    )
 
 
 class MarketplaceConfig(BaseSettings):

--- a/api/contexts/__init__.py
+++ b/api/contexts/__init__.py
@@ -6,7 +6,6 @@ from contexts.wrapper import RecyclableContextVar
 
 if TYPE_CHECKING:
     from core.datasource.__base.datasource_provider import DatasourcePluginProviderController
-    from core.model_runtime.entities.model_entities import AIModelEntity
     from core.plugin.entities.plugin_daemon import PluginModelProviderEntity
     from core.tools.plugin_tool.provider import PluginToolProviderController
     from core.trigger.provider import PluginTriggerProviderController
@@ -28,9 +27,6 @@ plugin_model_providers: RecyclableContextVar[list["PluginModelProviderEntity"] |
 plugin_model_providers_lock: RecyclableContextVar[Lock] = RecyclableContextVar(
     ContextVar("plugin_model_providers_lock")
 )
-
-plugin_model_schema_lock: Lock = Lock()
-plugin_model_schemas: dict[str, "AIModelEntity"] = {}
 
 datasource_plugin_providers: RecyclableContextVar[dict[str, "DatasourcePluginProviderController"]] = (
     RecyclableContextVar(ContextVar("datasource_plugin_providers"))

--- a/api/contexts/__init__.py
+++ b/api/contexts/__init__.py
@@ -29,11 +29,8 @@ plugin_model_providers_lock: RecyclableContextVar[Lock] = RecyclableContextVar(
     ContextVar("plugin_model_providers_lock")
 )
 
-plugin_model_schema_lock: RecyclableContextVar[Lock] = RecyclableContextVar(ContextVar("plugin_model_schema_lock"))
-
-plugin_model_schemas: RecyclableContextVar[dict[str, "AIModelEntity"]] = RecyclableContextVar(
-    ContextVar("plugin_model_schemas")
-)
+plugin_model_schema_lock: Lock = Lock()
+plugin_model_schemas: dict[str, "AIModelEntity"] = {}
 
 datasource_plugin_providers: RecyclableContextVar[dict[str, "DatasourcePluginProviderController"]] = (
     RecyclableContextVar(ContextVar("datasource_plugin_providers"))

--- a/api/core/model_runtime/model_providers/__base/ai_model.py
+++ b/api/core/model_runtime/model_providers/__base/ai_model.py
@@ -170,7 +170,7 @@ class AIModel(BaseModel):
         if schema:
             redis_client.setex(cache_key, dify_config.PLUGIN_MODEL_SCHEMA_CACHE_TTL, schema.model_dump_json())
 
-            return schema
+        return schema
 
     def get_customizable_model_schema_from_credentials(self, model: str, credentials: dict) -> AIModelEntity | None:
         """

--- a/api/core/model_runtime/model_providers/__base/ai_model.py
+++ b/api/core/model_runtime/model_providers/__base/ai_model.py
@@ -5,7 +5,6 @@ import logging
 from pydantic import BaseModel, ConfigDict, Field
 
 from configs import dify_config
-
 from core.model_runtime.entities.common_entities import I18nObject
 from core.model_runtime.entities.defaults import PARAMETER_RULE_TEMPLATE
 from core.model_runtime.entities.model_entities import (
@@ -16,7 +15,6 @@ from core.model_runtime.entities.model_entities import (
     PriceInfo,
     PriceType,
 )
-from extensions.ext_redis import redis_client
 from core.model_runtime.errors.invoke import (
     InvokeAuthorizationError,
     InvokeBadRequestError,
@@ -26,6 +24,7 @@ from core.model_runtime.errors.invoke import (
     InvokeServerUnavailableError,
 )
 from core.plugin.entities.plugin_daemon import PluginModelProviderEntity
+from extensions.ext_redis import redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -148,9 +147,9 @@ class AIModel(BaseModel):
 
         plugin_model_manager = PluginModelClient()
         cache_key = (
-                    f"plugin_model_schema:{self.tenant_id}:{self.plugin_id}:"
-                    f"{self.provider_name}:{self.model_type.value}:{model}"
-                )        # sort credentials
+            f"plugin_model_schema:{self.tenant_id}:{self.plugin_id}:"
+            f"{self.provider_name}:{self.model_type.value}:{model}"
+        )  # sort credentials
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 

--- a/api/core/model_runtime/model_providers/__base/ai_model.py
+++ b/api/core/model_runtime/model_providers/__base/ai_model.py
@@ -147,10 +147,7 @@ class AIModel(BaseModel):
         from core.plugin.impl.model import PluginModelClient
 
         plugin_model_manager = PluginModelClient()
-        cache_key = (
-                    f"plugin_model_schema:{self.tenant_id}:{self.plugin_id}:"
-                    f"{self.provider_name}:{self.model_type.value}:{model}"
-                )        # sort credentials
+        cache_key = f"{self.tenant_id}:{self.plugin_id}:{self.provider_name}:{self.model_type.value}:{model}"       # sort credentials
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 

--- a/api/core/model_runtime/model_providers/__base/ai_model.py
+++ b/api/core/model_runtime/model_providers/__base/ai_model.py
@@ -146,7 +146,7 @@ class AIModel(BaseModel):
         from core.plugin.impl.model import PluginModelClient
 
         plugin_model_manager = PluginModelClient()
-        cache_key = f"{self.tenant_id}:{self.plugin_id}:{self.provider_name}:{self.model_type.value}:{model}"       # sort credentials
+        cache_key = f"{self.tenant_id}:{self.plugin_id}:{self.provider_name}:{self.model_type.value}:{model}"
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -176,8 +176,10 @@ class ModelProviderFactory:
         Get model schema
         """
         plugin_id, provider_name = self.get_plugin_id_and_provider_name_from_provider(provider)
-        cache_key = f"plugin_model_schema:{self.tenant_id}:{plugin_id}:{provider_name}:{model_type.value}:{model}"
-        # sort credentials
+        cache_key = (
+                    f"plugin_model_schema:{self.tenant_id}:{plugin_id}:"
+                    f"{provider_name}:{model_type.value}:{model}"
+                )        # sort credentials
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 
@@ -186,7 +188,7 @@ class ModelProviderFactory:
             try:
                 return AIModelEntity.model_validate_json(cached_schema_json)
             except Exception:
-                pass
+                logger.warning("Failed to validate cached plugin model schema for model %s", model)
 
         schema = self.plugin_model_manager.get_model_schema(
             tenant_id=self.tenant_id,

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -7,7 +7,6 @@ from threading import Lock
 
 import contexts
 from configs import dify_config
-from extensions.ext_redis import redis_client
 from core.model_runtime.entities.model_entities import AIModelEntity, ModelType
 from core.model_runtime.entities.provider_entities import ProviderConfig, ProviderEntity, SimpleProviderEntity
 from core.model_runtime.model_providers.__base.ai_model import AIModel
@@ -20,6 +19,7 @@ from core.model_runtime.model_providers.__base.tts_model import TTSModel
 from core.model_runtime.schema_validators.model_credential_schema_validator import ModelCredentialSchemaValidator
 from core.model_runtime.schema_validators.provider_credential_schema_validator import ProviderCredentialSchemaValidator
 from core.plugin.entities.plugin_daemon import PluginModelProviderEntity
+from extensions.ext_redis import redis_client
 from models.provider_ids import ModelProviderID
 
 logger = logging.getLogger(__name__)
@@ -177,9 +177,9 @@ class ModelProviderFactory:
         """
         plugin_id, provider_name = self.get_plugin_id_and_provider_name_from_provider(provider)
         cache_key = (
-                    f"plugin_model_schema:{self.tenant_id}:{plugin_id}:"
-                    f"{provider_name}:{model_type.value}:{model}"
-                )        # sort credentials
+            f"plugin_model_schema:{self.tenant_id}:{plugin_id}:"
+            f"{provider_name}:{model_type.value}:{model}"
+        )  # sort credentials
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -200,7 +200,7 @@ class ModelProviderFactory:
         if schema:
             redis_client.setex(cache_key, dify_config.PLUGIN_MODEL_SCHEMA_CACHE_TTL, schema.model_dump_json())
 
-            return schema
+        return schema
 
     def get_models(
         self,

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -5,6 +5,9 @@ import logging
 from collections.abc import Sequence
 from threading import Lock
 
+from pydantic import ValidationError
+from redis import RedisError
+
 import contexts
 from configs import dify_config
 from core.model_runtime.entities.model_entities import AIModelEntity, ModelType
@@ -180,12 +183,34 @@ class ModelProviderFactory:
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 
-        cached_schema_json = redis_client.get(cache_key)
+        cached_schema_json = None
+        try:
+            cached_schema_json = redis_client.get(cache_key)
+        except (RedisError, RuntimeError) as exc:
+            logger.warning(
+                "Failed to read plugin model schema cache for model %s: %s",
+                model,
+                str(exc),
+                exc_info=True,
+            )
         if cached_schema_json:
             try:
                 return AIModelEntity.model_validate_json(cached_schema_json)
-            except Exception:
-                logger.warning("Failed to validate cached plugin model schema for model %s", model)
+            except ValidationError:
+                logger.warning(
+                    "Failed to validate cached plugin model schema for model %s",
+                    model,
+                    exc_info=True,
+                )
+                try:
+                    redis_client.delete(cache_key)
+                except (RedisError, RuntimeError) as exc:
+                    logger.warning(
+                        "Failed to delete invalid plugin model schema cache for model %s: %s",
+                        model,
+                        str(exc),
+                        exc_info=True,
+                    )
 
         schema = self.plugin_model_manager.get_model_schema(
             tenant_id=self.tenant_id,
@@ -198,7 +223,15 @@ class ModelProviderFactory:
         )
 
         if schema:
-            redis_client.setex(cache_key, dify_config.PLUGIN_MODEL_SCHEMA_CACHE_TTL, schema.model_dump_json())
+            try:
+                redis_client.setex(cache_key, dify_config.PLUGIN_MODEL_SCHEMA_CACHE_TTL, schema.model_dump_json())
+            except (RedisError, RuntimeError) as exc:
+                logger.warning(
+                    "Failed to write plugin model schema cache for model %s: %s",
+                    model,
+                    str(exc),
+                    exc_info=True,
+                )
 
         return schema
 

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -176,7 +176,7 @@ class ModelProviderFactory:
         Get model schema
         """
         plugin_id, provider_name = self.get_plugin_id_and_provider_name_from_provider(provider)
-        cache_key = f"{self.tenant_id}:{plugin_id}:{provider_name}:{model_type.value}:{model}"        # sort credentials
+        cache_key = f"{self.tenant_id}:{plugin_id}:{provider_name}:{model_type.value}:{model}"
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -176,10 +176,7 @@ class ModelProviderFactory:
         Get model schema
         """
         plugin_id, provider_name = self.get_plugin_id_and_provider_name_from_provider(provider)
-        cache_key = (
-                    f"plugin_model_schema:{self.tenant_id}:{plugin_id}:"
-                    f"{provider_name}:{model_type.value}:{model}"
-                )        # sort credentials
+        cache_key = f"{self.tenant_id}:{plugin_id}:{provider_name}:{model_type.value}:{model}"        # sort credentials
         sorted_credentials = sorted(credentials.items()) if credentials else []
         cache_key += ":".join([hashlib.md5(f"{k}:{v}".encode()).hexdigest() for k, v in sorted_credentials])
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Currently, `plugin_model_schemas` is implemented using `RecyclableContextVar`. This causes the cache to be reset with every request (or thread recycle), rendering it ineffective for cross-request caching. As a result, the system re-fetches the model schema from the Plugin Daemon for every single API request, leading to unnecessary network overhead and latency.

This refactor transitions the plugin_model_schemas caching mechanism to a distributed Redis-based storage. By leveraging Redis, model schemas are now cached across multiple processes and instances, persisting according to a configurable Time-To-Live (TTL) which defaults to 24 hours. This significantly reduces redundant internal Plugin Daemon API calls and enhances the system's scalability.

## Screenshots

| Before | After |
|--------|-------|
| <img width="400" height="200" alt="Clipboard_Screenshot_1769569761" src="https://github.com/user-attachments/assets/83babe77-9b9c-4fe9-a6c9-aa65c44765c4" /> | <img width="400" height="200" alt="Clipboard_Screenshot_1769570075" src="https://github.com/user-attachments/assets/630118da-9187-4a7c-be19-6b6bffcfb023" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

#31627