### PR TITLE
fix: use query params instead of request body for decode_plugin_from_identifier

### DIFF
--- a/api/core/plugin/impl/plugin.py
+++ b/api/core/plugin/impl/plugin.py
@@ -209,8 +209,7 @@ class PluginInstaller(BasePluginClient):
             "GET",
             f"plugin/{tenant_id}/management/decode/from_identifier",
             PluginDecodeResponse,
-            data={"plugin_unique_identifier": plugin_unique_identifier},
-            headers={"Content-Type": "application/json"},
+            params={"plugin_unique_identifier": plugin_unique_identifier},
         )
 
     def fetch_plugin_installation_by_ids(


### PR DESCRIPTION
## Summary

- Changed `decode_plugin_from_identifier` to use query parameters (`params=`) instead of request body (`data=`)
- Removed unnecessary `Content-Type: application/json` header

## Problem

The `decode_plugin_from_identifier` endpoint was sending `plugin_unique_identifier` in the request body with a GET request. This causes issues with HTTP intermediaries like **Google Cloud Run's frontend**, which rejects GET requests with a body as malformed (returning 400 Bad Request before the request reaches the container).

## Solution

Changed from `data=` (request body) to `params=` (query parameters), which is:
- Consistent with similar GET endpoints (`fetch_plugin_manifest`, `fetch_plugin_by_identifier`)
- Compliant with HTTP standards
- Compatible with Cloud Run and other HTTP proxies/load balancers

## Related PR

This change requires a corresponding change in dify-plugin-daemon to accept the parameter from query string instead of JSON body:
- https://github.com/langgenius/dify-plugin-daemon/pull/593