### PR TITLE
chore(typing): reduce ty excludes for A1

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from celery import Celery
+
     celery: Celery
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
 import sys
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from celery import Celery
+    celery: Celery
 
 
 def is_db_command() -> bool:
@@ -23,7 +30,7 @@ else:
     from app_factory import create_app
 
     app = create_app()
-    celery = app.extensions["celery"]
+    celery = cast("Celery", app.extensions["celery"])
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5001)

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -149,7 +149,7 @@ def initialize_extensions(app: DifyApp):
             logger.info("Loaded %s (%s ms)", short_name, round((end_time - start_time) * 1000, 2))
 
 
-def create_migrations_app():
+def create_migrations_app() -> DifyApp:
     app = create_flask_app_with_configs()
     from extensions import ext_database, ext_migrate
 

--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -68,7 +68,7 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         request_id: RequestId,
         request_meta: RequestParams.Meta | None,
         request: ReceiveRequestT,
-        session: """BaseSession[SendRequestT, SendNotificationT, SendResultT, ReceiveRequestT, ReceiveNotificationT]""",
+        session: Any,
         on_complete: Callable[["RequestResponder[ReceiveRequestT, SendResultT]"], Any],
     ):
         self.request_id = request_id
@@ -145,7 +145,7 @@ class BaseSession(
 
     _response_streams: dict[RequestId, queue.Queue[JSONRPCResponse | JSONRPCError | HTTPStatusError]]
     _request_id: int
-    _in_flight: dict[RequestId, RequestResponder[ReceiveRequestT, SendResultT]]
+    _in_flight: dict[RequestId, RequestResponder[Any, Any]]
     _receive_request_type: type[ReceiveRequestT]
     _receive_notification_type: type[ReceiveNotificationT]
 

--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -68,7 +68,7 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         request_id: RequestId,
         request_meta: RequestParams.Meta | None,
         request: ReceiveRequestT,
-        session: Any,
+        session: """BaseSession[SendRequestT, SendNotificationT, SendResultT, ReceiveRequestT, ReceiveNotificationT]""",
         on_complete: Callable[["RequestResponder[ReceiveRequestT, SendResultT]"], Any],
     ):
         self.request_id = request_id
@@ -145,7 +145,7 @@ class BaseSession(
 
     _response_streams: dict[RequestId, queue.Queue[JSONRPCResponse | JSONRPCError | HTTPStatusError]]
     _request_id: int
-    _in_flight: dict[RequestId, RequestResponder[Any, Any]]
+    _in_flight: dict[RequestId, RequestResponder[ReceiveRequestT, SendResultT]]
     _receive_request_type: type[ReceiveRequestT]
     _receive_notification_type: type[ReceiveNotificationT]
 
@@ -347,7 +347,7 @@ class BaseSession(
                         message.message.root.model_dump(by_alias=True, mode="json", exclude_none=True)
                     )
 
-                    responder = RequestResponder(
+                    responder = RequestResponder[ReceiveRequestT, SendResultT](
                         request_id=message.message.root.id,
                         request_meta=validated_request.root.params.meta if validated_request.root.params else None,
                         request=validated_request,

--- a/api/core/model_runtime/model_providers/__base/large_language_model.py
+++ b/api/core/model_runtime/model_providers/__base/large_language_model.py
@@ -2,7 +2,7 @@ import logging
 import time
 import uuid
 from collections.abc import Callable, Generator, Iterator, Sequence
-from typing import Any, Union
+from typing import Union
 
 from pydantic import ConfigDict
 
@@ -283,7 +283,7 @@ class LargeLanguageModel(AIModel):
             # TODO
             raise self._transform_invoke_error(e)
 
-        if stream and isinstance(result, Generator) and not isinstance(result, LLMResult):
+        if stream and not isinstance(result, LLMResult):
             return self._invoke_result_generator(
                 model=model,
                 result=result,
@@ -319,7 +319,7 @@ class LargeLanguageModel(AIModel):
     def _invoke_result_generator(
         self,
         model: str,
-        result: Generator[Any, None, None],
+        result: Generator[LLMResultChunk, None, None],
         credentials: dict,
         prompt_messages: Sequence[PromptMessage],
         model_parameters: dict,
@@ -353,8 +353,6 @@ class LargeLanguageModel(AIModel):
 
         try:
             for chunk in result:
-                if not isinstance(chunk, LLMResultChunk):
-                    raise NotImplementedError("unsupported invoke result type", type(chunk))
                 # Following https://github.com/langgenius/dify/issues/17799,
                 # we removed the prompt_messages from the chunk on the plugin daemon side.
                 # To ensure compatibility, we add the prompt_messages back here.

--- a/api/core/model_runtime/model_providers/model_provider_factory.py
+++ b/api/core/model_runtime/model_providers/model_provider_factory.py
@@ -314,6 +314,8 @@ class ModelProviderFactory:
         elif model_type == ModelType.TTS:
             return TTSModel.model_validate(init_params)
 
+        raise ValueError(f"Unsupported model type: {model_type}")
+
     def get_provider_icon(self, provider: str, icon_type: str, lang: str) -> tuple[bytes, str]:
         """
         Get provider icon

--- a/api/core/workflow/nodes/protocols.py
+++ b/api/core/workflow/nodes/protocols.py
@@ -1,10 +1,11 @@
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import httpx
 
 from core.file import File
 
 
+@runtime_checkable
 class HttpClientProtocol(Protocol):
     @property
     def max_retries_exceeded_error(self) -> type[Exception]: ...
@@ -25,5 +26,6 @@ class HttpClientProtocol(Protocol):
     def patch(self, url: str, max_retries: int = ..., **kwargs: object) -> httpx.Response: ...
 
 
+@runtime_checkable
 class FileManagerProtocol(Protocol):
     def download(self, f: File, /) -> bytes: ...

--- a/api/core/workflow/nodes/protocols.py
+++ b/api/core/workflow/nodes/protocols.py
@@ -1,11 +1,10 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 import httpx
 
 from core.file import File
 
 
-@runtime_checkable
 class HttpClientProtocol(Protocol):
     @property
     def max_retries_exceeded_error(self) -> type[Exception]: ...
@@ -26,6 +25,5 @@ class HttpClientProtocol(Protocol):
     def patch(self, url: str, max_retries: int = ..., **kwargs: object) -> httpx.Response: ...
 
 
-@runtime_checkable
 class FileManagerProtocol(Protocol):
     def download(self, f: File, /) -> bytes: ...

--- a/api/libs/gmpy2_pkcs10aep_cipher.py
+++ b/api/libs/gmpy2_pkcs10aep_cipher.py
@@ -136,7 +136,11 @@ class PKCS1OAepCipher:
         # Step 3a (OS2IP)
         em_int = bytes_to_long(em)
         # Step 3b (RSAEP)
-        m_int = gmpy2.powmod(em_int, self._key.e, self._key.n)
+        powmod = getattr(gmpy2, "powmod", None)
+        if callable(powmod):
+            m_int = powmod(em_int, self._key.e, self._key.n)
+        else:
+            m_int = pow(em_int, self._key.e, self._key.n)
         # Step 3c (I2OSP)
         c = long_to_bytes(m_int, k)
         return c
@@ -169,7 +173,11 @@ class PKCS1OAepCipher:
         ct_int = bytes_to_long(ciphertext)
         # Step 2b (RSADP)
         # m_int = self._key._decrypt(ct_int)
-        m_int = gmpy2.powmod(ct_int, self._key.d, self._key.n)
+        powmod = getattr(gmpy2, "powmod", None)
+        if callable(powmod):
+            m_int = powmod(ct_int, self._key.d, self._key.n)
+        else:
+            m_int = pow(ct_int, self._key.d, self._key.n)
         # Complete step 2c (I2OSP)
         em = long_to_bytes(m_int, k)
         # Step 3a

--- a/api/libs/gmpy2_pkcs10aep_cipher.py
+++ b/api/libs/gmpy2_pkcs10aep_cipher.py
@@ -136,11 +136,7 @@ class PKCS1OAepCipher:
         # Step 3a (OS2IP)
         em_int = bytes_to_long(em)
         # Step 3b (RSAEP)
-        powmod = getattr(gmpy2, "powmod", None)
-        if callable(powmod):
-            m_int = powmod(em_int, self._key.e, self._key.n)
-        else:
-            m_int = pow(em_int, self._key.e, self._key.n)
+        m_int: int = gmpy2.powmod(em_int, self._key.e, self._key.n)  # type: ignore[attr-defined]
         # Step 3c (I2OSP)
         c = long_to_bytes(m_int, k)
         return c
@@ -173,11 +169,7 @@ class PKCS1OAepCipher:
         ct_int = bytes_to_long(ciphertext)
         # Step 2b (RSADP)
         # m_int = self._key._decrypt(ct_int)
-        powmod = getattr(gmpy2, "powmod", None)
-        if callable(powmod):
-            m_int = powmod(ct_int, self._key.d, self._key.n)
-        else:
-            m_int = pow(ct_int, self._key.d, self._key.n)
+        m_int: int = gmpy2.powmod(ct_int, self._key.d, self._key.n)  # type: ignore[attr-defined]
         # Complete step 2c (I2OSP)
         em = long_to_bytes(m_int, k)
         # Step 3a

--- a/api/ty.toml
+++ b/api/ty.toml
@@ -1,11 +1,6 @@
 [src]
 exclude = [
     # deps groups (A1/A2/B/C/D/E)
-    # A1: foundational runtime typing / provider plumbing
-    "core/mcp/session",
-    "core/model_runtime/model_providers",
-    "core/workflow/nodes/protocols.py",
-    "libs/gmpy2_pkcs10aep_cipher.py",
     # A2: workflow engine/nodes
     "core/workflow",
     "core/app/workflow",
@@ -33,6 +28,3 @@ exclude = [
     "tests",
 ]
 
-[rules]
-missing-argument = "ignore" # TODO: restore when **args for constructor is supported properly
-possibly-unbound-attribute = "ignore"


### PR DESCRIPTION
Relates to #31680.

- Fix ty typing issues in foundational API modules (A1).
- Remove A1 paths from `api/ty.toml` excludes and drop temporary ignore rules.