### PR TITLE
fix: add IME-safe onPressEnter prop to base Input component

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
@@ -145,10 +145,7 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
             value={password}
             onChange={e => setPassword(e.target.value)}
             id="password"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter')
-                handleEmailPasswordLogin()
-            }}
+            onPressEnter={() => handleEmailPasswordLogin()}
             type={showPassword ? 'text' : 'password'}
             autoComplete="current-password"
             placeholder={t('passwordPlaceholder', { ns: 'login' }) || ''}

--- a/web/app/components/base/input/index.tsx
+++ b/web/app/components/base/input/index.tsx
@@ -54,19 +54,23 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
   onChange = noop,
   onBlur = noop,
   onKeyDown,
+  onCompositionStart,
+  onCompositionEnd,
   onPressEnter,
   unit,
   ...props
 }, ref) => {
   const { t } = useTranslation()
   const isComposingRef = React.useRef(false)
-  const handleCompositionStart = () => {
+  const handleCompositionStart: React.CompositionEventHandler<HTMLInputElement> = (e) => {
     isComposingRef.current = true
+    onCompositionStart?.(e)
   }
-  const handleCompositionEnd = () => {
+  const handleCompositionEnd: React.CompositionEventHandler<HTMLInputElement> = (e) => {
     setTimeout(() => {
       isComposingRef.current = false
     }, 50)
+    onCompositionEnd?.(e)
   }
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (onPressEnter && e.key === 'Enter' && !e.nativeEvent.isComposing && !isComposingRef.current)

--- a/web/app/components/base/pagination/index.tsx
+++ b/web/app/components/base/pagination/index.tsx
@@ -71,12 +71,12 @@ const CustomizedPagination: FC<Props> = ({
     setShowInput(false)
   }
 
+  const handleInputPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.preventDefault()
+    handleInputConfirm()
+  }
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      handleInputConfirm()
-    }
-    else if (e.key === 'Escape') {
+    if (e.key === 'Escape') {
       e.preventDefault()
       setInputValue(current + 1)
       setShowInput(false)
@@ -132,6 +132,7 @@ const CustomizedPagination: FC<Props> = ({
             autoFocus
             value={inputValue}
             onChange={handleInputChange}
+            onPressEnter={handleInputPressEnter}
             onKeyDown={handleInputKeyDown}
             onBlur={handleInputBlur}
           />

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -319,22 +319,17 @@ const GotoAnything: FC<Props> = ({
                     if (!e.target.value.startsWith('@') && !e.target.value.startsWith('/'))
                       clearSelection()
                   }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      const query = searchQuery.trim()
-                      // Check if it's a complete slash command
-                      if (query.startsWith('/')) {
-                        const commandName = query.substring(1).split(' ')[0]
-                        const handler = slashCommandRegistry.findCommand(commandName)
-
-                        // If it's a direct mode command, execute immediately
-                        const isAvailable = handler?.isAvailable?.() ?? true
-                        if (handler?.mode === 'direct' && handler.execute && isAvailable) {
-                          e.preventDefault()
-                          handler.execute()
-                          setShow(false)
-                          setSearchQuery('')
-                        }
+                  onPressEnter={(e) => {
+                    const query = searchQuery.trim()
+                    if (query.startsWith('/')) {
+                      const commandName = query.substring(1).split(' ')[0]
+                      const handler = slashCommandRegistry.findCommand(commandName)
+                      const isAvailable = handler?.isAvailable?.() ?? true
+                      if (handler?.mode === 'direct' && handler.execute && isAvailable) {
+                        e.preventDefault()
+                        handler.execute()
+                        setShow(false)
+                        setSearchQuery('')
                       }
                     }
                   }}

--- a/web/app/signin/components/mail-and-password-auth.tsx
+++ b/web/app/signin/components/mail-and-password-auth.tsx
@@ -139,10 +139,7 @@ export default function MailAndPasswordAuth({ isInvite, isEmailSetup, allowRegis
             id="password"
             value={password}
             onChange={e => setPassword(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter')
-                handleEmailPasswordLogin()
-            }}
+            onPressEnter={() => handleEmailPasswordLogin()}
             type={showPassword ? 'text' : 'password'}
             autoComplete="current-password"
             placeholder={t('passwordPlaceholder', { ns: 'login' }) || ''}

--- a/web/app/signin/invite-settings/page.tsx
+++ b/web/app/signin/invite-settings/page.tsx
@@ -103,12 +103,10 @@ export default function InviteSettingsPage() {
               value={name}
               onChange={e => setName(e.target.value)}
               placeholder={t('namePlaceholder', { ns: 'login' }) || ''}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  handleActivate()
-                }
+              onPressEnter={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                handleActivate()
               }}
             />
           </div>

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -182,11 +182,6 @@
       "count": 1
     }
   },
-  "app/components/app/annotation/add-annotation-modal/edit-item/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/app/annotation/batch-add-annotation-modal/csv-downloader.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 2
@@ -196,18 +191,12 @@
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
     },
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 2
     }
   },
   "app/components/app/annotation/edit-annotation-modal/edit-item/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    },
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -263,11 +252,6 @@
   "app/components/app/app-publisher/index.tsx": {
     "ts/no-explicit-any": {
       "count": 6
-    }
-  },
-  "app/components/app/configuration/base/var-highlight/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/app/configuration/config-prompt/advanced-prompt-input.tsx": {
@@ -440,11 +424,6 @@
       "count": 6
     }
   },
-  "app/components/app/configuration/debug/debug-with-multiple-model/context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/app/configuration/debug/debug-with-multiple-model/index.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 5
@@ -527,11 +506,6 @@
       "count": 1
     }
   },
-  "app/components/app/create-app-dialog/app-list/sidebar.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/app/create-app-modal/index.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 7
@@ -548,14 +522,6 @@
   "app/components/app/create-from-dsl-modal/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
-    },
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "app/components/app/log/filter.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/app/log/index.tsx": {
@@ -624,9 +590,6 @@
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 3
     },
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 4
     }
@@ -634,11 +597,6 @@
   "app/components/app/text-generate/item/result-tab.tsx": {
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/app/workflow-log/filter.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/app/workflow-log/list.spec.tsx": {
@@ -692,11 +650,6 @@
       "count": 1
     }
   },
-  "app/components/base/action-button/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/base/agent-log-modal/detail.tsx": {
     "ts/no-explicit-any": {
       "count": 1
@@ -723,11 +676,6 @@
   "app/components/base/agent-log-modal/tool-call.tsx": {
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/base/amplitude/AmplitudeProvider.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/base/amplitude/utils.ts": {
@@ -778,9 +726,6 @@
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
     },
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "react/no-nested-component-definitions": {
       "count": 1
     }
@@ -790,18 +735,8 @@
       "count": 1
     }
   },
-  "app/components/base/button/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/base/button/sync-button.stories.tsx": {
     "no-console": {
-      "count": 1
-    }
-  },
-  "app/components/base/carousel/index.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -889,11 +824,6 @@
       "count": 3
     },
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/base/chat/chat/context.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -1000,16 +930,8 @@
     }
   },
   "app/components/base/error-boundary/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/base/features/context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/base/features/new-feature-panel/annotation-reply/index.tsx": {
@@ -1075,11 +997,6 @@
   "app/components/base/file-uploader/hooks.ts": {
     "ts/no-explicit-any": {
       "count": 3
-    }
-  },
-  "app/components/base/file-uploader/store.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 4
     }
   },
   "app/components/base/file-uploader/utils.spec.ts": {
@@ -1178,11 +1095,6 @@
       "count": 2
     }
   },
-  "app/components/base/ga/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/base/icons/utils.ts": {
     "ts/no-explicit-any": {
       "count": 3
@@ -1232,11 +1144,6 @@
     },
     "ts/no-explicit-any": {
       "count": 1
-    }
-  },
-  "app/components/base/logo/dify-logo.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
     }
   },
   "app/components/base/markdown-blocks/audio-block.tsx": {
@@ -1389,11 +1296,6 @@
       "count": 1
     }
   },
-  "app/components/base/node-status/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/base/notion-connector/index.stories.tsx": {
     "no-console": {
       "count": 1
@@ -1425,9 +1327,6 @@
     }
   },
   "app/components/base/portal-to-follow-elem/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -1609,16 +1508,6 @@
       "count": 1
     }
   },
-  "app/components/base/textarea/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "app/components/base/toast/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    }
-  },
   "app/components/base/video-gallery/VideoPlayer.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
@@ -1660,16 +1549,6 @@
   "app/components/billing/plan/index.tsx": {
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/billing/pricing/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "app/components/billing/pricing/plan-switcher/plan-range-switcher.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/billing/pricing/plans/cloud-plan-item/index.spec.tsx": {
@@ -1722,11 +1601,6 @@
       "count": 3
     }
   },
-  "app/components/datasets/common/image-uploader/store.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 4
-    }
-  },
   "app/components/datasets/common/image-uploader/utils.ts": {
     "ts/no-explicit-any": {
       "count": 2
@@ -1734,16 +1608,6 @@
   },
   "app/components/datasets/common/retrieval-method-config/index.spec.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/common/retrieval-method-info/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/index.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -1775,11 +1639,6 @@
   "app/components/datasets/create/step-two/hooks/use-indexing-config.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 3
-    }
-  },
-  "app/components/datasets/create/step-two/preview-item/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/datasets/create/stop-embedding-modal/index.spec.tsx": {
@@ -1838,9 +1697,6 @@
   "app/components/datasets/documents/components/list.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
-    },
-    "react-refresh/only-export-components": {
-      "count": 1
     },
     "ts/no-explicit-any": {
       "count": 2
@@ -1906,11 +1762,6 @@
       "count": 2
     }
   },
-  "app/components/datasets/documents/create-from-pipeline/data-source/store/provider.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/datasets/documents/create-from-pipeline/data-source/store/slices/online-drive.ts": {
     "ts/no-explicit-any": {
       "count": 4
@@ -1956,11 +1807,6 @@
       "count": 1
     }
   },
-  "app/components/datasets/documents/detail/completed/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/datasets/documents/detail/completed/new-child-segment.tsx": {
     "ts/no-explicit-any": {
       "count": 1
@@ -1981,11 +1827,6 @@
   },
   "app/components/datasets/documents/detail/new-segment.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/datasets/documents/detail/segment-add/index.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -2129,11 +1970,6 @@
       "count": 1
     }
   },
-  "app/components/explore/try-app/tab.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/goto-anything/actions/commands/command-bus.ts": {
     "ts/no-explicit-any": {
       "count": 2
@@ -2145,9 +1981,6 @@
     }
   },
   "app/components/goto-anything/actions/commands/slash.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -2165,9 +1998,6 @@
   "app/components/goto-anything/context.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 4
-    },
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/goto-anything/index.spec.tsx": {
@@ -2364,11 +2194,6 @@
       "count": 4
     }
   },
-  "app/components/plugins/install-plugin/install-bundle/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/plugins/install-plugin/install-bundle/item/github-item.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
@@ -2443,11 +2268,6 @@
   "app/components/plugins/plugin-auth/hooks/use-plugin-auth-action.ts": {
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/plugins/plugin-auth/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 3
     }
   },
   "app/components/plugins/plugin-auth/plugin-auth-in-agent.tsx": {
@@ -2534,9 +2354,6 @@
     }
   },
   "app/components/plugins/plugin-detail-panel/subscription-list/create/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -2577,9 +2394,6 @@
     }
   },
   "app/components/plugins/plugin-page/context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -2944,11 +2758,6 @@
       "count": 1
     }
   },
-  "app/components/workflow/block-selector/constants.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/workflow/block-selector/featured-tools.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
@@ -2967,11 +2776,6 @@
   },
   "app/components/workflow/block-selector/hooks.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/block-selector/index-bar.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -3013,24 +2817,9 @@
       "count": 1
     }
   },
-  "app/components/workflow/block-selector/view-type-select.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/workflow/candidate-node-main.tsx": {
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/components/workflow/context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/datasets-detail-store/provider.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/workflow/header/run-mode.tsx": {
@@ -3041,18 +2830,8 @@
       "count": 1
     }
   },
-  "app/components/workflow/header/test-run-menu.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/workflow/header/view-workflow-history.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/hooks-store/provider.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -3176,16 +2955,8 @@
     }
   },
   "app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 6
-    }
-  },
-  "app/components/workflow/nodes/_base/components/entry-node-container.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
     }
   },
   "app/components/workflow/nodes/_base/components/error-handle/default-value.tsx": {
@@ -3210,16 +2981,6 @@
   },
   "app/components/workflow/nodes/_base/components/input-var-type-icon.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/components/workflow/nodes/_base/components/layout/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 7
-    }
-  },
-  "app/components/workflow/nodes/_base/components/mcp-tool-availability.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -3306,9 +3067,6 @@
     }
   },
   "app/components/workflow/nodes/_base/components/workflow-panel/tab.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -3362,9 +3120,6 @@
     }
   },
   "app/components/workflow/nodes/agent/panel.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -3540,9 +3295,6 @@
     }
   },
   "app/components/workflow/nodes/human-input/components/variable-in-markdown.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 8
     }
@@ -3670,11 +3422,6 @@
   "app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2
-    }
-  },
-  "app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 3
     }
   },
   "app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/auto-width-input.tsx": {
@@ -3974,11 +3721,6 @@
       "count": 1
     }
   },
-  "app/components/workflow/note-node/note-editor/toolbar/color-picker.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/workflow/note-node/note-editor/utils.ts": {
     "regexp/no-useless-quantifier": {
       "count": 1
@@ -4015,9 +3757,6 @@
     }
   },
   "app/components/workflow/panel/chat-variable-panel/components/object-value-item.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 5
     },
@@ -4304,11 +4043,6 @@
       "count": 8
     }
   },
-  "app/components/workflow/workflow-history-store.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    }
-  },
   "app/components/workflow/workflow-preview/components/nodes/constants.ts": {
     "ts/no-explicit-any": {
       "count": 1
@@ -4370,45 +4104,12 @@
     }
   },
   "context/app-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
   },
-  "context/datasets-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "context/event-emitter.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "context/external-api-panel-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "context/external-knowledge-api-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "context/global-public-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 4
-    }
-  },
   "context/hooks/use-trigger-events-limit-modal.ts": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 3
-    }
-  },
-  "context/mitt-context.tsx": {
-    "react-refresh/only-export-components": {
       "count": 3
     }
   },
@@ -4418,28 +4119,12 @@
     }
   },
   "context/modal-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 5
     }
   },
   "context/provider-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 3
-    },
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "context/web-app-context.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
-  "context/workspace-context.tsx": {
-    "react-refresh/only-export-components": {
       "count": 1
     }
   },
@@ -4479,9 +4164,6 @@
   "hooks/use-pay.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 4
-    },
-    "react-refresh/only-export-components": {
-      "count": 3
     }
   },
   "i18n-config/README.md": {

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -1234,11 +1234,6 @@
       "count": 1
     }
   },
-  "app/components/base/input/index.tsx": {
-    "react-refresh/only-export-components": {
-      "count": 1
-    }
-  },
   "app/components/base/logo/dify-logo.tsx": {
     "react-refresh/only-export-components": {
       "count": 2


### PR DESCRIPTION
Closes #31757

## Summary

- Add `onPressEnter` prop to the base `Input` component with built-in IME composition detection, preventing CJK input method Enter-to-confirm from triggering form submissions
- Uses `isComposingRef` + `onCompositionStart/End` + `setTimeout(50ms)` for Safari compatibility (same pattern as `chat-input-area`)
- Migrate all 5 call sites from manual `onKeyDown` Enter detection to `onPressEnter`

## Test plan

- [ ] English input: type text, press Enter → triggers `onPressEnter`
- [ ] Chinese IME: type pinyin, press Enter to confirm candidate → does NOT trigger `onPressEnter`
- [ ] Chinese IME: after confirming candidate, press Enter again → triggers `onPressEnter`
- [ ] Safari browser: same behavior as above
- [ ] Sign-in password input (admin + webapp): Enter submits login
- [ ] Invite settings name input: Enter activates account
- [ ] Goto Anything: Enter executes slash command
- [ ] Pagination: Enter confirms page number, Escape cancels