### PR TITLE
fix!: modify console API `/workspaces/current/tools/mcp` to return provider ID

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1145,8 +1145,8 @@ class ToolMCPListAllApi(Resource):
 
         with Session(db.engine) as session, session.begin():
             service = MCPToolManageService(session=session)
-            # Skip sensitive data decryption for list view to improve performance
-            tools = service.list_providers(tenant_id=tenant_id, include_sensitive=False)
+            # for_list=True so "id" is the provider UUID, usable for detail/update/delete APIs
+            tools = service.list_providers(tenant_id=tenant_id, for_list=True, include_sensitive=False)
 
             return [tool.to_dict() for tool in tools]
 


### PR DESCRIPTION
## Summary
Fixes #31763

The `id` field in each MCP server entry from `/console/api/workspaces/current/tools/mcp` API should be the provider ID.

Currently the `id` and `server_identifier` fields are effectively duplicated.
We have no way of obtaining the provider ID without removing and re-adding MCP servers. 
  As such we cannot easily make use of related APIs that requires provider ID as argument.


## Checklist
- ~This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)~
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
