### PR TITLE
fix(api): return provider ID instead of server_identifier in MCP list API

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1146,7 +1146,7 @@ class ToolMCPListAllApi(Resource):
         with Session(db.engine) as session, session.begin():
             service = MCPToolManageService(session=session)
             # Skip sensitive data decryption for list view to improve performance
-            tools = service.list_providers(tenant_id=tenant_id, include_sensitive=False)
+            tools = service.list_providers(tenant_id=tenant_id, include_sensitive=False, for_list=True)
 
             return [tool.to_dict() for tool in tools]
 


### PR DESCRIPTION
## Summary

- Fix bug where `/console/api/workspaces/current/tools/mcp` returned `server_identifier` in the `id` field instead of the actual provider ID
- Add `for_list=True` parameter to `list_providers` call to ensure the `id` field contains the provider ID

Fixes #31763

## Screenshots

N/A - Backend API fix

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods