### PR TITLE
fix(i18n): improve Chinese translation of Max Tokens

### DIFF
--- a/api/core/model_runtime/entities/defaults.py
+++ b/api/core/model_runtime/entities/defaults.py
@@ -88,7 +88,7 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
     DefaultParameterName.MAX_TOKENS: {
         "label": {
             "en_US": "Max Tokens",
-            "zh_Hans": "最大标记",
+            "zh_Hans": "最大 Token 数",
         },
         "type": "int",
         "help": {

--- a/web/utils/completion-params.spec.ts
+++ b/web/utils/completion-params.spec.ts
@@ -21,7 +21,7 @@ describe('completion-params', () => {
 
     it('validates int type parameter within range', () => {
       const rules: ModelParameterRule[] = [
-        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大标记' }, required: false },
+        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大 Token 数' }, required: false },
       ]
       const oldParams: FormValue = { max_tokens: 100 }
       const result = mergeValidCompletionParams(oldParams, rules)
@@ -32,7 +32,7 @@ describe('completion-params', () => {
 
     it('removes int parameter below minimum', () => {
       const rules: ModelParameterRule[] = [
-        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大标记' }, required: false },
+        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大 Token 数' }, required: false },
       ]
       const oldParams: FormValue = { max_tokens: 0 }
       const result = mergeValidCompletionParams(oldParams, rules)
@@ -43,7 +43,7 @@ describe('completion-params', () => {
 
     it('removes int parameter above maximum', () => {
       const rules: ModelParameterRule[] = [
-        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大标记' }, required: false },
+        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大 Token 数' }, required: false },
       ]
       const oldParams: FormValue = { max_tokens: 5000 }
       const result = mergeValidCompletionParams(oldParams, rules)
@@ -54,7 +54,7 @@ describe('completion-params', () => {
 
     it('removes int parameter with invalid type', () => {
       const rules: ModelParameterRule[] = [
-        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大标记' }, required: false },
+        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大 Token 数' }, required: false },
       ]
       const oldParams: FormValue = { max_tokens: 'not a number' as any }
       const result = mergeValidCompletionParams(oldParams, rules)
@@ -184,7 +184,7 @@ describe('completion-params', () => {
     it('handles multiple parameters with mixed validity', () => {
       const rules: ModelParameterRule[] = [
         { name: 'temperature', type: 'float', min: 0, max: 2, label: { en_US: 'Temperature', zh_Hans: '温度' }, required: false },
-        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大标记' }, required: false },
+        { name: 'max_tokens', type: 'int', min: 1, max: 4096, label: { en_US: 'Max Tokens', zh_Hans: '最大 Token 数' }, required: false },
         { name: 'model', type: 'string', options: ['gpt-4'], label: { en_US: 'Model', zh_Hans: '模型' }, required: false },
       ]
       const oldParams: FormValue = {


### PR DESCRIPTION
## Summary

- Change Chinese translation of 'Max Tokens' from '最大标记' to '最大 Token 数'
- The term 'Token' is more widely recognized in AI/ML context
- '标记' (marks/labels) is a literal but confusing translation

Fixes #31236

## Screenshots

N/A - Text translation update

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods