### PR TITLE
fix: fix mcp output schema is union type frontend crash

### DIFF
--- a/web/app/components/workflow/nodes/tool/use-config.ts
+++ b/web/app/components/workflow/nodes/tool/use-config.ts
@@ -1,6 +1,7 @@
 import type { ToolNodeType, ToolVarInputs } from './types'
 import type { InputVar } from '@/app/components/workflow/types'
 import { useBoolean } from 'ahooks'
+import { capitalize } from 'es-toolkit/string'
 import { produce } from 'immer'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -32,7 +33,7 @@ const formatDisplayType = (output: Record<string, unknown>): string => {
   if (normalizedType === 'Unknown')
     return 'Unknown'
 
-  return normalizedType.slice(0, 1).toLocaleUpperCase() + normalizedType.slice(1)
+  return capitalize(normalizedType)
 }
 
 const useConfig = (id: string, payload: ToolNodeType) => {

--- a/web/app/components/workflow/nodes/tool/use-config.ts
+++ b/web/app/components/workflow/nodes/tool/use-config.ts
@@ -25,6 +25,15 @@ import {
 } from '@/service/use-tools'
 import { canFindTool } from '@/utils'
 import { useWorkflowStore } from '../../store'
+import { normalizeJsonSchemaType } from './output-schema-utils'
+
+const formatDisplayType = (output: Record<string, unknown>): string => {
+  const normalizedType = normalizeJsonSchemaType(output) || 'Unknown'
+  if (normalizedType === 'Unknown')
+    return 'Unknown'
+
+  return normalizedType.slice(0, 1).toLocaleUpperCase() + normalizedType.slice(1)
+}
 
 const useConfig = (id: string, payload: ToolNodeType) => {
   const workflowStore = useWorkflowStore()
@@ -247,20 +256,13 @@ const useConfig = (id: string, payload: ToolNodeType) => {
         })
       }
       else {
+        const normalizedType = normalizeJsonSchemaType(output)
         res.push({
           name: outputKey,
           type:
-            output.type === 'array'
-              ? `Array[${output.items?.type
-                ? output.items.type.slice(0, 1).toLocaleUpperCase()
-                + output.items.type.slice(1)
-                : 'Unknown'
-              }]`
-              : `${output.type
-                ? output.type.slice(0, 1).toLocaleUpperCase()
-                + output.type.slice(1)
-                : 'Unknown'
-              }`,
+            normalizedType === 'array'
+              ? `Array[${output.items ? formatDisplayType(output.items) : 'Unknown'}]`
+              : formatDisplayType(output),
           description: output.description,
         })
       }

--- a/web/app/components/workflow/nodes/tool/use-config.ts
+++ b/web/app/components/workflow/nodes/tool/use-config.ts
@@ -30,9 +30,6 @@ import { normalizeJsonSchemaType } from './output-schema-utils'
 
 const formatDisplayType = (output: Record<string, unknown>): string => {
   const normalizedType = normalizeJsonSchemaType(output) || 'Unknown'
-  if (normalizedType === 'Unknown')
-    return 'Unknown'
-
   return capitalize(normalizedType)
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #31773

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
