### PR TITLE
fix: fix access token is still valid after logout

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -29,6 +29,14 @@ class SecurityConfig(BaseSettings):
         default="",
     )
 
+    SESSION_REVOCATION_STORAGE: str = Field(
+        description=(
+            "Session revocation storage backend for JWT jti revocation checks. "
+            "Options: 'null' (default, disabled) or 'redis' (use configured Redis)."
+        ),
+        default="null",
+    )
+
     RESET_PASSWORD_TOKEN_EXPIRY_MINUTES: PositiveInt = Field(
         description="Duration in minutes for which a password reset token remains valid",
         default=5,

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -37,6 +37,7 @@ from libs.token import (
     clear_access_token_from_cookie,
     clear_csrf_token_from_cookie,
     clear_refresh_token_from_cookie,
+    extract_access_token,
     extract_refresh_token,
     set_access_token_to_cookie,
     set_csrf_token_to_cookie,
@@ -157,7 +158,9 @@ class LogoutApi(Resource):
         if isinstance(account, flask_login.AnonymousUserMixin):
             response = make_response({"result": "success"})
         else:
-            AccountService.logout(account=account)
+            # Extract access_token from request to revoke it
+            access_token = extract_access_token(request)
+            AccountService.logout(account=account, access_token=access_token)
             flask_login.logout_user()
             response = make_response({"result": "success"})
 

--- a/api/libs/passport.py
+++ b/api/libs/passport.py
@@ -1,19 +1,73 @@
+import time
+import uuid
+
 import jwt
 from werkzeug.exceptions import Unauthorized
 
 from configs import dify_config
+from extensions.ext_redis import redis_client
+
+
+def _get_blacklist_key(jti: str) -> str:
+    """Generate Redis key for token blacklist using JWT ID."""
+    return f"passport:blacklist:jti:{jti}"
 
 
 class PassportService:
     def __init__(self):
         self.sk = dify_config.SECRET_KEY
 
+    @classmethod
+    def _get_blacklist_key(cls, jti: str) -> str:
+        """Instance-accessible helper for tests and internal use."""
+        return _get_blacklist_key(jti)
+
     def issue(self, payload):
-        return jwt.encode(payload, self.sk, algorithm="HS256")
+        # Add jti (JWT ID) if not present for token revocation support
+        payload_to_encode = dict(payload)
+        if "jti" not in payload_to_encode:
+            payload_to_encode["jti"] = str(uuid.uuid4())
+        return jwt.encode(payload_to_encode, self.sk, algorithm="HS256")
+
+    @classmethod
+    def revoke(cls, token: str) -> bool:
+        """Add token to blacklist until its expiration using JWT ID (jti).
+
+        Returns False if the token is invalid, missing exp/jti, or already expired.
+        """
+        try:
+            payload = jwt.decode(token, options={"verify_signature": False})
+        except jwt.PyJWTError:
+            # Invalid/garbled token: treat as non-revocable
+            return False
+
+        jti = payload.get("jti")
+        if not jti:
+            # Fallback for tokens without jti (old format)
+            # Use the full token as key for backward compatibility
+            jti = token
+
+        exp = payload.get("exp")
+        if not exp:
+            return False
+
+        ttl = int(exp - time.time())
+        if ttl <= 0:
+            return False
+
+        redis_client.setex(cls._get_blacklist_key(jti), ttl, "1")
+        return True
 
     def verify(self, token):
+        """Verify a JWT and then enforce revocation via Redis blacklist.
+
+        The signature and standard claims are verified first to avoid any processing
+        of untrusted data (including Redis lookups) for invalid tokens. Only after a
+        successful verification do we consult the blacklist using the token's `jti`.
+        """
+        # 1) Verify signature/claims first
         try:
-            return jwt.decode(token, self.sk, algorithms=["HS256"])
+            verified_payload = jwt.decode(token, self.sk, algorithms=["HS256"])
         except jwt.ExpiredSignatureError:
             raise Unauthorized("Token has expired.")
         except jwt.InvalidSignatureError:
@@ -22,3 +76,15 @@ class PassportService:
             raise Unauthorized("Invalid token.")
         except jwt.PyJWTError:  # Catch-all for other JWT errors
             raise Unauthorized("Invalid token.")
+
+        # 2) Enforce revocation via blacklist using jti (if present)
+        jti = verified_payload.get("jti")
+        if jti:
+            if redis_client.exists(self._get_blacklist_key(jti)):
+                raise Unauthorized("Token has been revoked.")
+        else:
+            # Fallback for old tokens without jti
+            if redis_client.exists(self._get_blacklist_key(token)):
+                raise Unauthorized("Token has been revoked.")
+
+        return verified_payload

--- a/api/libs/passport.py
+++ b/api/libs/passport.py
@@ -1,15 +1,15 @@
 import time
 import uuid
+from datetime import UTC, datetime
 
 import jwt
 from werkzeug.exceptions import Unauthorized
 
 from configs import dify_config
-from extensions.ext_redis import redis_client
+from libs.session_revocation_storage import get_session_revocation_storage
 
 
 def _get_blacklist_key(jti: str) -> str:
-    """Generate Redis key for token blacklist using JWT ID."""
     return f"passport:blacklist:jti:{jti}"
 
 
@@ -31,22 +31,13 @@ class PassportService:
 
     @classmethod
     def revoke(cls, token: str) -> bool:
-        """Add token to blacklist until its expiration using JWT ID (jti).
-
-        Returns False if the token is invalid, missing exp/jti, or already expired.
-        """
         try:
             payload = jwt.decode(token, options={"verify_signature": False})
         except jwt.PyJWTError:
             # Invalid/garbled token: treat as non-revocable
             return False
 
-        jti = payload.get("jti")
-        if not jti:
-            # Fallback for tokens without jti (old format)
-            # Use the full token as key for backward compatibility
-            jti = token
-
+        token_id = payload.get("jti") or token
         exp = payload.get("exp")
         if not exp:
             return False
@@ -55,15 +46,16 @@ class PassportService:
         if ttl <= 0:
             return False
 
-        redis_client.setex(cls._get_blacklist_key(jti), ttl, "1")
+        storage = get_session_revocation_storage()
+        storage.revoke(token_id, datetime.fromtimestamp(exp, tz=UTC))
         return True
 
     def verify(self, token):
-        """Verify a JWT and then enforce revocation via Redis blacklist.
+        """Verify a JWT and then enforce revocation via SessionRevocationStorage.
 
         The signature and standard claims are verified first to avoid any processing
-        of untrusted data (including Redis lookups) for invalid tokens. Only after a
-        successful verification do we consult the blacklist using the token's `jti`.
+        of untrusted data for invalid tokens. After successful verification we consult
+        the configured revocation storage using the token's `jti` when present.
         """
         # 1) Verify signature/claims first
         try:
@@ -77,14 +69,10 @@ class PassportService:
         except jwt.PyJWTError:  # Catch-all for other JWT errors
             raise Unauthorized("Invalid token.")
 
-        # 2) Enforce revocation via blacklist using jti (if present)
-        jti = verified_payload.get("jti")
-        if jti:
-            if redis_client.exists(self._get_blacklist_key(jti)):
-                raise Unauthorized("Token has been revoked.")
-        else:
-            # Fallback for old tokens without jti
-            if redis_client.exists(self._get_blacklist_key(token)):
-                raise Unauthorized("Token has been revoked.")
+        # 2) Enforce revocation using storage (supports old tokens without jti)
+        storage = get_session_revocation_storage()
+        token_id = verified_payload.get("jti") or token
+        if storage.is_revoked(token_id):
+            raise Unauthorized("Token has been revoked.")
 
         return verified_payload

--- a/api/libs/session_revocation_storage.py
+++ b/api/libs/session_revocation_storage.py
@@ -29,7 +29,6 @@ class NullSessionRevocationStorage(SessionRevocationStorage):
 
 
 class RedisSessionRevocationStorage(SessionRevocationStorage):
-
     def __init__(self, key_prefix: str = "passport:blacklist:jti:") -> None:
         self.key_prefix = key_prefix
 

--- a/api/libs/session_revocation_storage.py
+++ b/api/libs/session_revocation_storage.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
+
+from configs import dify_config
+from extensions.ext_redis import redis_client
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SessionRevocationStorage(Protocol):
+    def revoke(self, token_id: str, expiration_time: datetime) -> None: ...
+    def is_revoked(self, token_id: str) -> bool: ...
+    def expunge(self) -> None: ...
+
+
+class NullSessionRevocationStorage(SessionRevocationStorage):
+    def revoke(self, token_id: str, expiration_time: datetime) -> None:
+        return None
+
+    def is_revoked(self, token_id: str) -> bool:
+        return False
+
+    def expunge(self) -> None:
+        return None
+
+
+class RedisSessionRevocationStorage(SessionRevocationStorage):
+
+    def __init__(self, key_prefix: str = "passport:blacklist:jti:") -> None:
+        self.key_prefix = key_prefix
+
+    def _key(self, token_id: str) -> str:
+        return f"{self.key_prefix}{token_id}"
+
+    def revoke(self, token_id: str, expiration_time: datetime) -> None:
+        # Compute remaining lifetime in seconds
+        now_ts = datetime.now(UTC).timestamp()
+        ttl = int(expiration_time.timestamp() - now_ts)
+        if ttl <= 0:
+            return None
+        redis_client.setex(self._key(token_id), ttl, b"1")
+        return None
+
+    def is_revoked(self, token_id: str) -> bool:
+        return bool(redis_client.exists(self._key(token_id)))
+
+    def expunge(self) -> None:
+        return None
+
+
+_singleton: SessionRevocationStorage | None = None
+
+
+def get_session_revocation_storage() -> SessionRevocationStorage:
+    global _singleton
+    if _singleton is not None:
+        return _singleton
+
+    backend = (dify_config.SESSION_REVOCATION_STORAGE or "null").strip().lower()
+    if backend in ("", "null", "disabled", "off"):
+        _singleton = NullSessionRevocationStorage()
+    elif backend == "redis":
+        _singleton = RedisSessionRevocationStorage()
+    else:
+        logger.warning(
+            "Unknown SESSION_REVOCATION_STORAGE '%s'; falling back to 'null' (disabled).",
+            backend,
+        )
+        _singleton = NullSessionRevocationStorage()
+    return _singleton

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -440,7 +440,12 @@ class AccountService:
         return TokenPair(access_token=access_token, refresh_token=refresh_token, csrf_token=csrf_token)
 
     @staticmethod
-    def logout(*, account: Account):
+    def logout(*, account: Account, access_token: str | None = None):
+        # Revoke access_token if provided
+        if access_token:
+            PassportService.revoke(access_token)
+
+        # Delete refresh_token
         refresh_token = redis_client.get(AccountService._get_account_refresh_token_key(account.id))
         if refresh_token:
             AccountService._delete_refresh_token(refresh_token.decode("utf-8"), account.id)

--- a/api/tests/unit_tests/libs/test_passport.py
+++ b/api/tests/unit_tests/libs/test_passport.py
@@ -229,9 +229,12 @@ class TestPassportService:
         # Mock redis_client (via storage layer) and force storage backend to redis
         mock_redis = MagicMock()
         import libs.session_revocation_storage as srs
+
         srs._singleton = None
-        with patch("libs.session_revocation_storage.dify_config") as s_cfg, \
-             patch("libs.session_revocation_storage.redis_client", mock_redis):
+        with (
+            patch("libs.session_revocation_storage.dify_config") as s_cfg,
+            patch("libs.session_revocation_storage.redis_client", mock_redis),
+        ):
             s_cfg.SESSION_REVOCATION_STORAGE = "redis"
             result = passport_service.revoke(token)
 
@@ -256,9 +259,12 @@ class TestPassportService:
 
         mock_redis = MagicMock()
         import libs.session_revocation_storage as srs
+
         srs._singleton = None
-        with patch("libs.session_revocation_storage.dify_config") as s_cfg, \
-             patch("libs.session_revocation_storage.redis_client", mock_redis):
+        with (
+            patch("libs.session_revocation_storage.dify_config") as s_cfg,
+            patch("libs.session_revocation_storage.redis_client", mock_redis),
+        ):
             s_cfg.SESSION_REVOCATION_STORAGE = "redis"
             result = passport_service.revoke(token)
 
@@ -280,6 +286,7 @@ class TestPassportService:
 
         with patch("libs.session_revocation_storage.redis_client", mock_redis):
             import libs.session_revocation_storage as srs
+
             srs._singleton = None
             with patch("libs.session_revocation_storage.dify_config") as s_cfg:
                 s_cfg.SESSION_REVOCATION_STORAGE = "redis"
@@ -305,6 +312,7 @@ class TestPassportService:
 
         with patch("libs.session_revocation_storage.redis_client", mock_redis):
             import libs.session_revocation_storage as srs
+
             srs._singleton = None
             with patch("libs.session_revocation_storage.dify_config") as s_cfg:
                 s_cfg.SESSION_REVOCATION_STORAGE = "redis"
@@ -320,9 +328,12 @@ class TestPassportService:
 
         mock_redis = MagicMock()
         import libs.session_revocation_storage as srs
+
         srs._singleton = None
-        with patch("libs.session_revocation_storage.dify_config") as s_cfg, \
-             patch("libs.session_revocation_storage.redis_client", mock_redis):
+        with (
+            patch("libs.session_revocation_storage.dify_config") as s_cfg,
+            patch("libs.session_revocation_storage.redis_client", mock_redis),
+        ):
             s_cfg.SESSION_REVOCATION_STORAGE = "redis"
             result = passport_service.revoke(invalid_token)
 

--- a/api/tests/unit_tests/libs/test_passport.py
+++ b/api/tests/unit_tests/libs/test_passport.py
@@ -226,9 +226,13 @@ class TestPassportService:
             mock_config.SECRET_KEY = "test-secret-key-for-testing"
             token = jwt.encode(payload, mock_config.SECRET_KEY, algorithm="HS256")
 
-        # Mock redis_client
+        # Mock redis_client (via storage layer) and force storage backend to redis
         mock_redis = MagicMock()
-        with patch("libs.passport.redis_client", mock_redis):
+        import libs.session_revocation_storage as srs
+        srs._singleton = None
+        with patch("libs.session_revocation_storage.dify_config") as s_cfg, \
+             patch("libs.session_revocation_storage.redis_client", mock_redis):
+            s_cfg.SESSION_REVOCATION_STORAGE = "redis"
             result = passport_service.revoke(token)
 
         assert result is True
@@ -250,9 +254,12 @@ class TestPassportService:
             mock_config.SECRET_KEY = "test-secret-key-for-testing"
             token = jwt.encode(payload, mock_config.SECRET_KEY, algorithm="HS256")
 
-        # Mock redis_client
         mock_redis = MagicMock()
-        with patch("libs.passport.redis_client", mock_redis):
+        import libs.session_revocation_storage as srs
+        srs._singleton = None
+        with patch("libs.session_revocation_storage.dify_config") as s_cfg, \
+             patch("libs.session_revocation_storage.redis_client", mock_redis):
+            s_cfg.SESSION_REVOCATION_STORAGE = "redis"
             result = passport_service.revoke(token)
 
         assert result is False
@@ -271,9 +278,13 @@ class TestPassportService:
         mock_redis = MagicMock()
         mock_redis.exists.return_value = True
 
-        with patch("libs.passport.redis_client", mock_redis):
-            with pytest.raises(Unauthorized) as exc_info:
-                passport_service.verify(token)
+        with patch("libs.session_revocation_storage.redis_client", mock_redis):
+            import libs.session_revocation_storage as srs
+            srs._singleton = None
+            with patch("libs.session_revocation_storage.dify_config") as s_cfg:
+                s_cfg.SESSION_REVOCATION_STORAGE = "redis"
+                with pytest.raises(Unauthorized) as exc_info:
+                    passport_service.verify(token)
 
         assert "revoked" in str(exc_info.value).lower()
         # Verify that jti was used to check blacklist
@@ -292,8 +303,12 @@ class TestPassportService:
         mock_redis = MagicMock()
         mock_redis.exists.return_value = False
 
-        with patch("libs.passport.redis_client", mock_redis):
-            decoded = passport_service.verify(token)
+        with patch("libs.session_revocation_storage.redis_client", mock_redis):
+            import libs.session_revocation_storage as srs
+            srs._singleton = None
+            with patch("libs.session_revocation_storage.dify_config") as s_cfg:
+                s_cfg.SESSION_REVOCATION_STORAGE = "redis"
+                decoded = passport_service.verify(token)
 
         assert decoded["user_id"] == payload["user_id"]
         assert "jti" in decoded
@@ -303,9 +318,12 @@ class TestPassportService:
         """Test that revoke handles invalid tokens gracefully"""
         invalid_token = "invalid.token.here"
 
-        # Mock redis_client
         mock_redis = MagicMock()
-        with patch("libs.passport.redis_client", mock_redis):
+        import libs.session_revocation_storage as srs
+        srs._singleton = None
+        with patch("libs.session_revocation_storage.dify_config") as s_cfg, \
+             patch("libs.session_revocation_storage.redis_client", mock_redis):
+            s_cfg.SESSION_REVOCATION_STORAGE = "redis"
             result = passport_service.revoke(invalid_token)
 
         assert result is False

--- a/api/tests/unit_tests/libs/test_session_revocation_storage.py
+++ b/api/tests/unit_tests/libs/test_session_revocation_storage.py
@@ -47,4 +47,3 @@ class TestSessionRevocationStorage:
             cfg.SESSION_REVOCATION_STORAGE = "redis"
             inst = get_session_revocation_storage()
             assert isinstance(inst, RedisSessionRevocationStorage)
-

--- a/api/tests/unit_tests/libs/test_session_revocation_storage.py
+++ b/api/tests/unit_tests/libs/test_session_revocation_storage.py
@@ -1,0 +1,50 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from libs.session_revocation_storage import (
+    NullSessionRevocationStorage,
+    RedisSessionRevocationStorage,
+    get_session_revocation_storage,
+)
+
+
+class TestSessionRevocationStorage:
+    def test_null_storage_behaviour(self):
+        s = NullSessionRevocationStorage()
+        s.revoke("any", datetime.now(UTC) + timedelta(hours=1))
+        assert s.is_revoked("any") is False
+        s.expunge()
+
+    def test_redis_storage_revoke_sets_ttl_and_is_revoked_true(self):
+        mock_redis = MagicMock()
+        storage = RedisSessionRevocationStorage()
+
+        token_id = "jti-abc"
+        exp = datetime.now(UTC) + timedelta(hours=1)
+
+        with patch("libs.session_revocation_storage.redis_client", mock_redis):
+            storage.revoke(token_id, exp)
+            assert mock_redis.setex.called
+            key, ttl, value = mock_redis.setex.call_args[0]
+            assert key == f"passport:blacklist:jti:{token_id}"
+            assert 3500 <= int(ttl) <= 3600
+            assert value in (b"1", "1")
+
+            mock_redis.exists.return_value = True
+            assert storage.is_revoked(token_id) is True
+
+    def test_factory_returns_null_by_default_and_redis_when_configured(self):
+        import libs.session_revocation_storage as srs
+
+        srs._singleton = None
+        with patch("libs.session_revocation_storage.dify_config") as cfg:
+            cfg.SESSION_REVOCATION_STORAGE = ""
+            inst = get_session_revocation_storage()
+            assert isinstance(inst, NullSessionRevocationStorage)
+
+        srs._singleton = None
+        with patch("libs.session_revocation_storage.dify_config") as cfg:
+            cfg.SESSION_REVOCATION_STORAGE = "redis"
+            inst = get_session_revocation_storage()
+            assert isinstance(inst, RedisSessionRevocationStorage)
+


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #31793

save jti in jwt payload, when logout save jti in blacklist, when use access token visit api check the jti is in blacklist or not


it only delete the refresh_token, so the access token is still valid

here we set a access token blacklist, after logout, we add it to blacklist and set access token  valid ttl, when use it after logout, it will reject with error

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
