### PR TITLE
fix(web): correct systemFeatures contract output type to match API response

### DIFF
--- a/web/context/global-public-context.tsx
+++ b/web/context/global-public-context.tsx
@@ -22,10 +22,10 @@ const systemFeaturesQueryKey = ['systemFeatures'] as const
 const setupStatusQueryKey = ['setupStatus'] as const
 
 async function fetchSystemFeatures() {
-  const data = await consoleClient.systemFeatures()
+  const { features } = await consoleClient.systemFeatures()
   const { setSystemFeatures } = useGlobalPublicStore.getState()
-  setSystemFeatures({ ...defaultSystemFeatures, ...data })
-  return data
+  setSystemFeatures({ ...defaultSystemFeatures, ...features })
+  return features
 }
 
 export function useSystemFeaturesQuery() {

--- a/web/contract/console/system.ts
+++ b/web/contract/console/system.ts
@@ -8,4 +8,4 @@ export const systemFeaturesContract = base
     method: 'GET',
   })
   .input(type<unknown>())
-  .output(type<SystemFeatures>())
+  .output(type<{ features: SystemFeatures }>())


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #31820

The oRPC contract for `/system-features` was expecting `SystemFeatures` directly, but the backend API returns `{ features: SystemFeatures }`. This mismatch caused the login page to show "No authentication method configured" even when authentication methods were properly enabled in `.env`.

<img width="1553" height="792" alt="image" src="https://github.com/user-attachments/assets/cd9f4de3-7256-4358-b100-e083b5399c34" />

**Root cause:**
In PR #30885 (oRPC contract migration), the contract output type was defined incorrectly:

```typescript
// Before (incorrect)
.output(type<SystemFeatures>())

// After (correct)
.output(type<{ features: SystemFeatures }>())
```

**Changes:**
- Update contract output type to `{ features: SystemFeatures }`
- Update `fetchSystemFeatures` to destructure `features` from response

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/login-error-before.png) Login shows "No authentication method configured" | ![after](https://github.com/user-attachments/assets/login-form-after.png) Login form displays correctly |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods