### PR TITLE
fix: fix tool_response is omitted

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -480,9 +480,13 @@ class BaseAgentRunner(AppRunner):
                                     ),
                                 )
                             )
+
+                            tool_response_content = tool_responses.get(tool, agent_thought.observation)
+                            if not tool_response_content:
+                                tool_response_content = "No results returned from the tool."
                             tool_call_response.append(
                                 ToolPromptMessage(
-                                    content=tool_responses.get(tool, agent_thought.observation),
+                                    content=str(tool_response_content),
                                     name=tool,
                                     tool_call_id=tool_call_id,
                                 )

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -268,14 +268,17 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                     }
 
                 tool_responses.append(tool_response)
-                if tool_response["tool_response"] is not None:
-                    self._current_thoughts.append(
-                        ToolPromptMessage(
-                            content=str(tool_response["tool_response"]),
-                            tool_call_id=tool_call_id,
-                            name=tool_call_name,
-                        )
+
+                tool_response_text = tool_response["tool_response"]
+                if not tool_response_text:
+                    tool_response_text = "No results returned from the tool."
+                self._current_thoughts.append(
+                    ToolPromptMessage(
+                        content=str(tool_response_text),
+                        tool_call_id=tool_call_id,
+                        name=tool_call_name,
                     )
+                )
 
             if len(tool_responses) > 0:
                 # save agent thought


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #31741

```
2026-02-02 10:46:07,984 ERROR [base.py:305] 4238db1a49 Error in stream
 response for plugin {'code': -500, 'message': 
'{"message":"{\\"args\\":{\\"description\\":\\"[models] Error: API 
request failed with status code 400: 
{\\\\\\"error\\\\\\":{\\\\\\"message\\\\\\":\\\\\\"An assistant 
message with \'tool_calls\' must be followed by tool messages 
responding to each \'tool_call_id\'. (insufficient tool messages 
following tool_calls message)\\\\\\",\\\\\\"type\\\\\\":\\\\\\"invalid
_request_error\\\\\\",\\\\\\"param\\\\\\":null,\\\\\\"code\\\\\\":\\\\
\\"invalid_request_error\\\\\\"}}\\"},\\"error_type\\":\\"InvokeError\
\",\\"message\\":\\"[models] Error: API request failed with status 
code 400: {\\\\\\"error\\\\\\":{\\\\\\"message\\\\\\":\\\\\\"An 
assistant message with \'tool_calls\' must be followed by tool 
messages responding to each \'tool_call_id\'. (insufficient tool 
messages following tool_calls 
message)\\\\\\",\\\\\\"type\\\\\\":\\\\\\"invalid_request_error\\\\\\"
,\\\\\\"param\\\\\\":null,\\\\\\"code\\\\\\":\\\\\\"invalid_request_er
ror\\\\\\"}}\\"}","error_type":"PluginInvokeError","args":null}', 
'data': None}
```

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

after

<img width="1102" height="910" alt="image" src="https://github.com/user-attachments/assets/be74d009-95aa-474d-aabf-aa999c3ee69f" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
