### PR TITLE
fix: use fastopenapi decorators should either return data (dicts, lis…

### DIFF
--- a/api/libs/login.py
+++ b/api/libs/login.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from flask import current_app, g, has_request_context, request
 from flask_login.config import EXEMPT_METHODS
+from werkzeug.exceptions import Unauthorized
 from werkzeug.local import LocalProxy
 
 from configs import dify_config
@@ -42,7 +43,7 @@ def login_required(func: Callable[P, R]):
     """
     If you decorate a view with this, it will ensure that the current user is
     logged in and authenticated before calling the actual view. (If they are
-    not, it calls the :attr:`LoginManager.unauthorized` callback.) For
+    not, it raises an Unauthorized exception.) For
     example::
 
         @app.route('/post')
@@ -54,7 +55,7 @@ def login_required(func: Callable[P, R]):
     logged in, you can do so with::
 
         if not current_user.is_authenticated:
-            return current_app.login_manager.unauthorized()
+            raise Unauthorized("Unauthorized.")
 
     ...which is essentially the code that this function adds to your views.
 
@@ -77,7 +78,7 @@ def login_required(func: Callable[P, R]):
         if request.method in EXEMPT_METHODS or dify_config.LOGIN_DISABLED:
             pass
         elif current_user is not None and not current_user.is_authenticated:
-            return current_app.login_manager.unauthorized()  # type: ignore
+            raise Unauthorized("Unauthorized.")
         # we put csrf validation here for less conflicts
         # TODO: maybe find a better place for it.
         check_csrf_token(request, current_user.id)


### PR DESCRIPTION
…ts, Pydantic models) or raise exceptions - not return Response objects directly

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #31871

use fastopenapi decorators should either return data (dicts, lists, Pydantic models) or raise exceptions - not return Response objects directly

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
