### PR TITLE
fix: refresh tool lists after custom and workflow provider changes

### DIFF
--- a/web/app/components/tools/mcp/create-card.spec.tsx
+++ b/web/app/components/tools/mcp/create-card.spec.tsx
@@ -13,6 +13,7 @@ vi.mock('@/service/use-tools', () => ({
   useCreateMCP: () => ({
     mutateAsync: mockCreateMCP,
   }),
+  useInvalidateAllMCPTools: () => vi.fn(),
 }))
 
 // Mock the MCP Modal

--- a/web/app/components/tools/mcp/create-card.tsx
+++ b/web/app/components/tools/mcp/create-card.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppContext } from '@/context/app-context'
 import { useDocLink } from '@/context/i18n'
-import { useCreateMCP } from '@/service/use-tools'
+import { useCreateMCP, useInvalidateAllMCPTools } from '@/service/use-tools'
 import MCPModal from './modal'
 
 type Props = {
@@ -22,10 +22,12 @@ const NewMCPCard = ({ handleCreate }: Props) => {
   const { isCurrentWorkspaceManager } = useAppContext()
 
   const { mutateAsync: createMCP } = useCreateMCP()
+  const invalidateAllMCPTools = useInvalidateAllMCPTools()
 
   const create = async (info: any) => {
     const provider = await createMCP(info)
     handleCreate(provider)
+    invalidateAllMCPTools()
   }
 
   const linkUrl = useMemo(() => docLink('/use-dify/build/mcp'), [docLink])

--- a/web/app/components/tools/mcp/detail/content.spec.tsx
+++ b/web/app/components/tools/mcp/detail/content.spec.tsx
@@ -33,6 +33,7 @@ vi.mock('@/service/use-tools', () => ({
     isFetching: mockIsFetching,
   }),
   useInvalidateMCPTools: () => mockInvalidateMCPTools,
+  useInvalidateAllMCPTools: () => vi.fn(),
   useUpdateMCPTools: () => ({
     mutateAsync: mockUpdateTools,
     isPending: mockIsUpdating,

--- a/web/app/components/tools/mcp/detail/content.tsx
+++ b/web/app/components/tools/mcp/detail/content.tsx
@@ -23,6 +23,7 @@ import {
   useAuthorizeMCP,
   useDeleteMCP,
   useInvalidateMCPTools,
+  useInvalidateAllMCPTools,
   useMCPTools,
   useUpdateMCP,
   useUpdateMCPTools,
@@ -53,6 +54,7 @@ const MCPDetailContent: FC<Props> = ({
 
   const { data, isFetching: isGettingTools } = useMCPTools(detail.is_team_authorization ? detail.id : '')
   const invalidateMCPTools = useInvalidateMCPTools()
+  const invalidateAllMCPTools = useInvalidateAllMCPTools()
   const { mutateAsync: updateTools, isPending: isUpdating } = useUpdateMCPTools()
   const { mutateAsync: authorizeMcp, isPending: isAuthorizing } = useAuthorizeMCP()
   const toolList = data?.tools || []
@@ -68,8 +70,9 @@ const MCPDetailContent: FC<Props> = ({
       return
     await updateTools(detail.id)
     invalidateMCPTools(detail.id)
+    invalidateAllMCPTools()
     onUpdate()
-  }, [detail, hideUpdateConfirm, invalidateMCPTools, onUpdate, updateTools])
+  }, [detail, hideUpdateConfirm, invalidateMCPTools, invalidateAllMCPTools, onUpdate, updateTools])
 
   const { mutateAsync: updateMCP } = useUpdateMCP({})
   const { mutateAsync: deleteMCP } = useDeleteMCP({})
@@ -122,10 +125,11 @@ const MCPDetailContent: FC<Props> = ({
     })
     if ((res as any)?.result === 'success') {
       hideUpdateModal()
+      invalidateAllMCPTools()
       onUpdate()
       handleAuthorize()
     }
-  }, [detail, updateMCP, hideUpdateModal, onUpdate, handleAuthorize])
+  }, [detail, updateMCP, hideUpdateModal, onUpdate, handleAuthorize, invalidateAllMCPTools])
 
   const handleDelete = useCallback(async () => {
     if (!detail)
@@ -135,9 +139,10 @@ const MCPDetailContent: FC<Props> = ({
     hideDeleting()
     if ((res as any)?.result === 'success') {
       hideDeleteConfirm()
+      invalidateAllMCPTools()
       onUpdate(true)
     }
-  }, [detail, showDeleting, deleteMCP, hideDeleting, hideDeleteConfirm, onUpdate])
+  }, [detail, showDeleting, deleteMCP, hideDeleting, hideDeleteConfirm, onUpdate, invalidateAllMCPTools])
 
   useEffect(() => {
     if (isTriggerAuthorize)

--- a/web/app/components/tools/provider/custom-create-card.spec.tsx
+++ b/web/app/components/tools/provider/custom-create-card.spec.tsx
@@ -1,5 +1,8 @@
+import type { ReactNode } from 'react'
 import type { CustomCollectionBackend } from '../types'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthType } from '../types'
 import CustomCreateCard from './custom-create-card'
@@ -78,6 +81,17 @@ vi.mock('@/app/components/base/toast', () => ({
   },
 }))
 
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(ui, { wrapper: createWrapper() })
+
 describe('CustomCreateCard', () => {
   const mockOnRefreshData = vi.fn()
 
@@ -93,7 +107,7 @@ describe('CustomCreateCard', () => {
     it('should render card when user is workspace manager', () => {
       mockIsWorkspaceManager = true
 
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Card should be visible with create text
       expect(screen.getByText(/createCustomTool/i)).toBeInTheDocument()
@@ -102,7 +116,7 @@ describe('CustomCreateCard', () => {
     it('should not render anything when user is not workspace manager', () => {
       mockIsWorkspaceManager = false
 
-      const { container } = render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      const { container } = renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Container should be empty (firstChild is null when nothing renders)
       expect(container.firstChild).toBeNull()
@@ -112,13 +126,13 @@ describe('CustomCreateCard', () => {
   // Tests for card rendering and styling
   describe('Card Rendering', () => {
     it('should render without crashing', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       expect(screen.getByText(/createCustomTool/i)).toBeInTheDocument()
     })
 
     it('should render add icon', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // RiAddCircleFill icon should be present
       const iconContainer = document.querySelector('.h-10.w-10')
@@ -126,7 +140,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should have proper card styling', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       const card = document.querySelector('.min-h-\\[135px\\]')
       expect(card).toBeInTheDocument()
@@ -137,7 +151,7 @@ describe('CustomCreateCard', () => {
   // Tests for modal interaction
   describe('Modal Interaction', () => {
     it('should open modal when card is clicked', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Click on the card area (the group div)
       const cardClickArea = document.querySelector('.group.grow')
@@ -148,7 +162,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should pass null payload to modal', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       const cardClickArea = document.querySelector('.group.grow')
       fireEvent.click(cardClickArea!)
@@ -157,7 +171,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should close modal when onHide is called', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -173,7 +187,7 @@ describe('CustomCreateCard', () => {
   // Tests for custom collection creation
   describe('Custom Collection Creation', () => {
     it('should call createCustomCollection when form is submitted', async () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -188,7 +202,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should show success toast after successful creation', async () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -206,7 +220,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should close modal after successful creation', async () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -222,7 +236,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should call onRefreshData after successful creation', async () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -237,7 +251,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should pass correct data to createCustomCollection', async () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -262,7 +276,7 @@ describe('CustomCreateCard', () => {
     it('should call createCustomCollection and handle successful response', async () => {
       mockCreateCustomCollection.mockResolvedValue({ success: true })
 
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -283,7 +297,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should not call onRefreshData if modal is just closed without submitting', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       // Open modal
       const cardClickArea = document.querySelector('.group.grow')
@@ -296,7 +310,7 @@ describe('CustomCreateCard', () => {
     })
 
     it('should handle rapid open/close of modal', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       const cardClickArea = document.querySelector('.group.grow')
 
@@ -312,14 +326,14 @@ describe('CustomCreateCard', () => {
   // Tests for hover styling
   describe('Hover Styling', () => {
     it('should have hover styles on card', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       const card = document.querySelector('.transition-all.duration-200')
       expect(card).toBeInTheDocument()
     })
 
     it('should have group hover styles on icon container', () => {
-      render(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
+      renderWithProvider(<CustomCreateCard onRefreshData={mockOnRefreshData} />)
 
       const iconContainer = document.querySelector('.group-hover\\:border-state-accent-hover-alt')
       expect(iconContainer).toBeInTheDocument()

--- a/web/app/components/tools/provider/custom-create-card.tsx
+++ b/web/app/components/tools/provider/custom-create-card.tsx
@@ -9,6 +9,7 @@ import Toast from '@/app/components/base/toast'
 import EditCustomToolModal from '@/app/components/tools/edit-custom-collection-modal'
 import { useAppContext } from '@/context/app-context'
 import { createCustomCollection } from '@/service/tools'
+import { useInvalidateAllCustomTools } from '@/service/use-tools'
 
 type Props = {
   onRefreshData: () => void
@@ -17,6 +18,7 @@ type Props = {
 const Contribute = ({ onRefreshData }: Props) => {
   const { t } = useTranslation()
   const { isCurrentWorkspaceManager } = useAppContext()
+  const invalidateCustomTools = useInvalidateAllCustomTools()
 
   const [isShowEditCollectionToolModal, setIsShowEditCustomCollectionModal] = useState(false)
   const doCreateCustomToolCollection = async (data: CustomCollectionBackend) => {
@@ -27,6 +29,7 @@ const Contribute = ({ onRefreshData }: Props) => {
     })
     setIsShowEditCustomCollectionModal(false)
     onRefreshData()
+    invalidateCustomTools()
   }
 
   return (

--- a/web/app/components/tools/provider/custom-create-card.tsx
+++ b/web/app/components/tools/provider/custom-create-card.tsx
@@ -28,8 +28,8 @@ const Contribute = ({ onRefreshData }: Props) => {
       message: t('api.actionSuccess', { ns: 'common' }),
     })
     setIsShowEditCustomCollectionModal(false)
-    onRefreshData()
     invalidateCustomTools()
+    onRefreshData()
   }
 
   return (

--- a/web/app/components/tools/provider/detail.tsx
+++ b/web/app/components/tools/provider/detail.tsx
@@ -42,7 +42,10 @@ import {
   updateBuiltInToolCredential,
   updateCustomCollection,
 } from '@/service/tools'
-import { useInvalidateAllWorkflowTools } from '@/service/use-tools'
+import {
+  useInvalidateAllCustomTools,
+  useInvalidateAllWorkflowTools,
+} from '@/service/use-tools'
 import { cn } from '@/utils/classnames'
 import { basePath } from '@/utils/var'
 import { AuthHeaderPrefix, AuthType, CollectionType } from '../types'
@@ -69,6 +72,7 @@ const ProviderDetail = ({
   const isModel = collection.type === CollectionType.model
   const { isCurrentWorkspaceManager } = useAppContext()
   const invalidateAllWorkflowTools = useInvalidateAllWorkflowTools()
+  const invalidateCustomTools = useInvalidateAllCustomTools()
   const [isDetailLoading, setIsDetailLoading] = useState(false)
 
   // built in provider
@@ -118,6 +122,7 @@ const ProviderDetail = ({
 
   const doUpdateCustomToolCollection = async (data: CustomCollectionBackend) => {
     await updateCustomCollection(data)
+    invalidateCustomTools()
     onRefreshData()
     await getCustomProvider()
     // Use fresh data from form submission to avoid race condition with collection.labels
@@ -130,6 +135,7 @@ const ProviderDetail = ({
   }
   const doRemoveCustomToolCollection = async () => {
     await removeCustomCollection(collection?.name as string)
+    invalidateCustomTools()
     onRefreshData()
     Toast.notify({
       type: 'success',
@@ -160,6 +166,7 @@ const ProviderDetail = ({
   }, [collection.id])
   const removeWorkflowToolProvider = async () => {
     await deleteWorkflowTool(collection.id)
+    invalidateAllWorkflowTools()
     onRefreshData()
     Toast.notify({
       type: 'success',


### PR DESCRIPTION
## Summary

Fixes [#31372](https://github.com/langgenius/dify/issues/31372)

refresh tool lists after custom and workflow provider changes

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
