### PR TITLE
fix(docker): improve IRIS data persistence with proper Durable %SYS

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -662,13 +662,14 @@ services:
       - "${IRIS_SUPER_SERVER_PORT:-1972}:1972"
       - "${IRIS_WEB_SERVER_PORT:-52773}:52773"
     volumes:
-      - ./volumes/iris:/opt/iris
+      - ./volumes/iris:/durable
       - ./iris/iris-init.script:/iris-init.script
       - ./iris/docker-entrypoint.sh:/custom-entrypoint.sh
     entrypoint: ["/custom-entrypoint.sh"]
     tty: true
     environment:
       TZ: ${IRIS_TIMEZONE:-UTC}
+      ISC_DATA_DIRECTORY: /durable/iris
 
   # Oracle vector database
   oracle:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1348,13 +1348,14 @@ services:
       - "${IRIS_SUPER_SERVER_PORT:-1972}:1972"
       - "${IRIS_WEB_SERVER_PORT:-52773}:52773"
     volumes:
-      - ./volumes/iris:/opt/iris
+      - ./volumes/iris:/durable
       - ./iris/iris-init.script:/iris-init.script
       - ./iris/docker-entrypoint.sh:/custom-entrypoint.sh
     entrypoint: ["/custom-entrypoint.sh"]
     tty: true
     environment:
       TZ: ${IRIS_TIMEZONE:-UTC}
+      ISC_DATA_DIRECTORY: /durable/iris
 
   # Oracle vector database
   oracle:

--- a/docker/iris/docker-entrypoint.sh
+++ b/docker/iris/docker-entrypoint.sh
@@ -9,7 +9,7 @@ wait_for_iris() {
     echo "Waiting for IRIS to be ready..."
     local max_attempts=30
     local attempt=1
-    while [ $attempt -le $max_attempts ]; do
+    while [ "$attempt" -le "$max_attempts" ]; do
         if iris qlist IRIS 2>/dev/null | grep -q "running"; then
             echo "IRIS is ready."
             return 0

--- a/docker/iris/docker-entrypoint.sh
+++ b/docker/iris/docker-entrypoint.sh
@@ -1,28 +1,56 @@
 #!/bin/bash
 set -e
 
-# Function to configure IRIS (idempotent - safe to run multiple times)
+# IRIS configuration flag file (stored in durable directory to persist with data)
+IRIS_CONFIG_DONE="/durable/.iris-configured"
+
+# Function to wait for IRIS to be ready
+wait_for_iris() {
+    echo "Waiting for IRIS to be ready..."
+    local max_attempts=30
+    local attempt=1
+    while [ $attempt -le $max_attempts ]; do
+        if iris qlist IRIS 2>/dev/null | grep -q "running"; then
+            echo "IRIS is ready."
+            return 0
+        fi
+        echo "Attempt $attempt/$max_attempts: IRIS not ready yet, waiting..."
+        sleep 2
+        attempt=$((attempt + 1))
+    done
+    echo "ERROR: IRIS failed to start within expected time."
+    return 1
+}
+
+# Function to configure IRIS
 configure_iris() {
-    echo "Running IRIS initialization..."
+    echo "Configuring IRIS for first-time setup..."
 
     # Wait for IRIS to be fully started
-    sleep 5
+    wait_for_iris
 
     # Execute the initialization script
     iris session IRIS < /iris-init.script
 
-    echo "IRIS initialization completed."
+    # Mark configuration as done
+    touch "$IRIS_CONFIG_DONE"
+
+    echo "IRIS configuration completed."
 }
 
-# Start IRIS for initialization
-echo "Starting IRIS for initialization..."
-iris start IRIS
+# Start IRIS in background for initial configuration if not already configured
+if [ ! -f "$IRIS_CONFIG_DONE" ]; then
+    echo "First-time IRIS setup detected. Starting IRIS for configuration..."
 
-# Configure IRIS (idempotent)
-configure_iris
+    # Start IRIS
+    iris start IRIS
 
-# Stop IRIS
-iris stop IRIS quietly
+    # Configure IRIS
+    configure_iris
+
+    # Stop IRIS
+    iris stop IRIS quietly
+fi
 
 # Run the original IRIS entrypoint
 exec /iris-main "$@"

--- a/docker/iris/docker-entrypoint.sh
+++ b/docker/iris/docker-entrypoint.sh
@@ -18,7 +18,7 @@ wait_for_iris() {
         sleep 2
         attempt=$((attempt + 1))
     done
-    echo "ERROR: IRIS failed to start within expected time."
+    echo "ERROR: IRIS failed to start within expected time." >&2
     return 1
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

Follow-up fix for #31899 (merged PR had issues identified in review comments)

## Summary

This PR addresses the issues identified in the review of #31899:

### 1. Use ISC_DATA_DIRECTORY for proper Durable %SYS
- Change volume mount from `/opt/iris` to `/durable`
- Set `ISC_DATA_DIRECTORY=/durable/iris` for complete data persistence
- This properly implements InterSystems IRIS Durable %SYS feature

### 2. Restore flag file mechanism to prevent password reset
- Move flag file to `/durable/.iris-configured` (persists with data)
- Only run initialization on first startup
- Prevents security issue where admin password changes were overwritten on restart

### 3. Replace fixed sleep with reliable health check
- Use `iris qlist` to detect when IRIS is ready
- Loop with timeout (max 60 seconds) instead of fixed 5-second sleep
- Prevents race condition on slower systems

## Screenshots

N/A (Docker configuration change only)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods