### PR TITLE
fix: populate files array in message_end SSE event for vision responses

### DIFF
--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -44,6 +44,8 @@ from core.app.entities.task_entities import (
 from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
 from core.base.tts import AppGeneratorTTSPublisher, AudioTrunk
+from core.file import helpers as file_helpers
+from core.file.enums import FileTransferMethod
 from core.model_manager import ModelInstance
 from core.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from core.model_runtime.entities.message_entities import (
@@ -55,10 +57,11 @@ from core.ops.entities.trace_entity import TraceTaskName
 from core.ops.ops_trace_manager import TraceQueueManager, TraceTask
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
 from core.prompt.utils.prompt_template_parser import PromptTemplateParser
+from core.tools.signature import sign_tool_file
 from events.message_event import message_was_created
 from extensions.ext_database import db
 from libs.datetime_utils import naive_utc_now
-from models.model import AppMode, Conversation, Message, MessageAgentThought
+from models.model import AppMode, Conversation, Message, MessageAgentThought, MessageFile, UploadFile
 
 logger = logging.getLogger(__name__)
 
@@ -451,10 +454,98 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
         """
         self._task_state.metadata.usage = self._task_state.llm_result.usage
         metadata_dict = self._task_state.metadata.model_dump()
+        
+        # Fetch files associated with this message
+        files = None
+        with Session(db.engine, expire_on_commit=False) as session:
+            message_files = session.scalars(
+                select(MessageFile).where(MessageFile.message_id == self._message_id)
+            ).all()
+            
+            if message_files:
+                files_list = []
+                for message_file in message_files:
+                    # Get upload file info if it's a local file
+                    upload_file = None
+                    if message_file.transfer_method == FileTransferMethod.LOCAL_FILE and message_file.upload_file_id:
+                        upload_file = session.scalar(
+                            select(UploadFile).where(UploadFile.id == message_file.upload_file_id)
+                        )
+                    
+                    # Generate URL based on transfer method
+                    url = None
+                    filename = "file"
+                    mime_type = "application/octet-stream"
+                    size = 0
+                    extension = ""
+                    
+                    if message_file.transfer_method == FileTransferMethod.REMOTE_URL:
+                        url = message_file.url
+                        if message_file.url:
+                            filename = message_file.url.split("/")[-1].split("?")[0]  # Remove query params
+                    elif message_file.transfer_method == FileTransferMethod.LOCAL_FILE:
+                        if upload_file:
+                            url = file_helpers.get_signed_file_url(upload_file_id=str(upload_file.id))
+                            filename = upload_file.name
+                            mime_type = upload_file.mime_type or "application/octet-stream"
+                            size = upload_file.size or 0
+                            extension = f".{upload_file.extension}" if upload_file.extension else ""
+                        elif message_file.upload_file_id:
+                            # Fallback: generate URL even if upload_file not found
+                            url = file_helpers.get_signed_file_url(upload_file_id=str(message_file.upload_file_id))
+                    elif message_file.transfer_method == FileTransferMethod.TOOL_FILE and message_file.url:
+                        # For tool files, use URL directly if it's HTTP, otherwise sign it
+                        if message_file.url.startswith("http"):
+                            url = message_file.url
+                            filename = message_file.url.split("/")[-1].split("?")[0]
+                        else:
+                            # Extract tool file id and extension from URL
+                            url_parts = message_file.url.split("/")
+                            if url_parts:
+                                file_part = url_parts[-1]
+                                if "." in file_part:
+                                    tool_file_id = file_part.split(".")[0]
+                                    extension = f".{file_part.split('.')[-1]}"
+                                    if len(extension) > 10:
+                                        extension = ".bin"
+                                else:
+                                    tool_file_id = file_part
+                                    extension = ".bin"
+                                url = sign_tool_file(tool_file_id=tool_file_id, extension=extension)
+                                filename = file_part.split("?")[0]  # Remove query params
+                    
+                    # Format file response according to FileResponse type
+                    transfer_method_value = (
+                        message_file.transfer_method.value
+                        if hasattr(message_file.transfer_method, 'value')
+                        else str(message_file.transfer_method)
+                    )
+                    remote_url = (
+                        message_file.url
+                        if message_file.transfer_method == FileTransferMethod.REMOTE_URL
+                        else None
+                    )
+                    file_dict = {
+                        "related_id": message_file.id,
+                        "extension": extension,
+                        "filename": filename,
+                        "size": size,
+                        "mime_type": mime_type,
+                        "transfer_method": transfer_method_value,
+                        "type": message_file.type,
+                        "url": url or "",
+                        "upload_file_id": message_file.upload_file_id or message_file.id,
+                        "remote_url": remote_url,
+                    }
+                    files_list.append(file_dict)
+                
+                files = files_list or None
+        
         return MessageEndStreamResponse(
             task_id=self._application_generate_entity.task_id,
             id=self._message_id,
             metadata=metadata_dict,
+            files=files,
         )
 
     def _agent_message_to_stream_response(self, answer: str, message_id: str) -> AgentMessageStreamResponse:

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_message_end_files.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_message_end_files.py
@@ -1,0 +1,351 @@
+"""
+Unit tests for EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response method.
+
+This test suite ensures that the files array is correctly populated in the message_end
+SSE event, which is critical for vision/image chat responses to render correctly.
+
+Test Coverage:
+- Files array populated when MessageFile records exist
+- Files array is None when no MessageFile records exist
+- Correct signed URL generation for LOCAL_FILE transfer method
+- Correct URL handling for REMOTE_URL transfer method
+- Correct URL handling for TOOL_FILE transfer method
+- Proper file metadata formatting (filename, mime_type, size, extension)
+"""
+
+import uuid
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from core.app.entities.task_entities import MessageEndStreamResponse
+from core.app.task_pipeline.easy_ui_based_generate_task_pipeline import EasyUIBasedGenerateTaskPipeline
+from core.file.enums import FileTransferMethod
+from models.model import MessageFile, UploadFile
+
+
+class TestMessageEndStreamResponseFiles:
+    """Test suite for files array population in message_end SSE event."""
+
+    @pytest.fixture
+    def mock_pipeline(self):
+        """Create a mock EasyUIBasedGenerateTaskPipeline instance."""
+        pipeline = Mock(spec=EasyUIBasedGenerateTaskPipeline)
+        pipeline._message_id = str(uuid.uuid4())
+        pipeline._task_state = Mock()
+        pipeline._task_state.metadata = Mock()
+        pipeline._task_state.metadata.model_dump = Mock(return_value={"test": "metadata"})
+        pipeline._task_state.llm_result = Mock()
+        pipeline._task_state.llm_result.usage = Mock()
+        pipeline._application_generate_entity = Mock()
+        pipeline._application_generate_entity.task_id = str(uuid.uuid4())
+        return pipeline
+
+    @pytest.fixture
+    def mock_message_file_local(self):
+        """Create a mock MessageFile with LOCAL_FILE transfer method."""
+        message_file = Mock(spec=MessageFile)
+        message_file.id = str(uuid.uuid4())
+        message_file.message_id = str(uuid.uuid4())
+        message_file.transfer_method = FileTransferMethod.LOCAL_FILE
+        message_file.upload_file_id = str(uuid.uuid4())
+        message_file.url = None
+        message_file.type = "image"
+        return message_file
+
+    @pytest.fixture
+    def mock_message_file_remote(self):
+        """Create a mock MessageFile with REMOTE_URL transfer method."""
+        message_file = Mock(spec=MessageFile)
+        message_file.id = str(uuid.uuid4())
+        message_file.message_id = str(uuid.uuid4())
+        message_file.transfer_method = FileTransferMethod.REMOTE_URL
+        message_file.upload_file_id = None
+        message_file.url = "https://example.com/image.jpg"
+        message_file.type = "image"
+        return message_file
+
+    @pytest.fixture
+    def mock_message_file_tool(self):
+        """Create a mock MessageFile with TOOL_FILE transfer method."""
+        message_file = Mock(spec=MessageFile)
+        message_file.id = str(uuid.uuid4())
+        message_file.message_id = str(uuid.uuid4())
+        message_file.transfer_method = FileTransferMethod.TOOL_FILE
+        message_file.upload_file_id = None
+        message_file.url = "tool_file_123.png"
+        message_file.type = "image"
+        return message_file
+
+    @pytest.fixture
+    def mock_upload_file(self):
+        """Create a mock UploadFile."""
+        upload_file = Mock(spec=UploadFile)
+        upload_file.id = str(uuid.uuid4())
+        upload_file.name = "test_image.png"
+        upload_file.mime_type = "image/png"
+        upload_file.size = 1024
+        upload_file.extension = "png"
+        return upload_file
+
+    def test_message_end_with_no_files(self, mock_pipeline):
+        """Test that files array is None when no MessageFile records exist."""
+        # Arrange
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            mock_session.scalars.return_value.all.return_value = []
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is None
+            assert result.id == mock_pipeline._message_id
+            assert result.metadata == {"test": "metadata"}
+
+    def test_message_end_with_local_file(self, mock_pipeline, mock_message_file_local, mock_upload_file):
+        """Test that files array is populated correctly for LOCAL_FILE transfer method."""
+        # Arrange
+        mock_message_file_local.message_id = mock_pipeline._message_id
+
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class, \
+             patch(
+                 "core.app.task_pipeline.easy_ui_based_generate_task_pipeline.file_helpers.get_signed_file_url"
+             ) as mock_get_url:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            
+            # Mock database queries
+            mock_scalars_result = Mock()
+            mock_scalars_result.all.return_value = [mock_message_file_local]
+            mock_session.scalars.return_value = mock_scalars_result
+            
+            mock_session.scalar.return_value = mock_upload_file
+            mock_get_url.return_value = "https://example.com/signed-url?signature=abc123"
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is not None
+            assert len(result.files) == 1
+            
+            file_dict = result.files[0]
+            assert file_dict["related_id"] == mock_message_file_local.id
+            assert file_dict["filename"] == "test_image.png"
+            assert file_dict["mime_type"] == "image/png"
+            assert file_dict["size"] == 1024
+            assert file_dict["extension"] == ".png"
+            assert file_dict["type"] == "image"
+            assert file_dict["transfer_method"] == FileTransferMethod.LOCAL_FILE.value
+            assert "https://example.com/signed-url" in file_dict["url"]
+            assert file_dict["upload_file_id"] == mock_message_file_local.upload_file_id
+            assert file_dict["remote_url"] is None
+
+            # Verify database queries
+            mock_session.scalars.assert_called_once()
+            mock_session.scalar.assert_called_once()
+            mock_get_url.assert_called_once_with(upload_file_id=str(mock_upload_file.id))
+
+    def test_message_end_with_remote_url(self, mock_pipeline, mock_message_file_remote):
+        """Test that files array is populated correctly for REMOTE_URL transfer method."""
+        # Arrange
+        mock_message_file_remote.message_id = mock_pipeline._message_id
+
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            
+            # Mock database queries
+            mock_scalars_result = Mock()
+            mock_scalars_result.all.return_value = [mock_message_file_remote]
+            mock_session.scalars.return_value = mock_scalars_result
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is not None
+            assert len(result.files) == 1
+            
+            file_dict = result.files[0]
+            assert file_dict["related_id"] == mock_message_file_remote.id
+            assert file_dict["filename"] == "image.jpg"
+            assert file_dict["url"] == "https://example.com/image.jpg"
+            assert file_dict["type"] == "image"
+            assert file_dict["transfer_method"] == FileTransferMethod.REMOTE_URL.value
+            assert file_dict["remote_url"] == "https://example.com/image.jpg"
+            assert file_dict["upload_file_id"] == mock_message_file_remote.id
+
+            # Verify no upload_file query for remote URLs
+            mock_session.scalar.assert_not_called()
+
+    def test_message_end_with_tool_file_http(self, mock_pipeline, mock_message_file_tool):
+        """Test that files array is populated correctly for TOOL_FILE with HTTP URL."""
+        # Arrange
+        mock_message_file_tool.message_id = mock_pipeline._message_id
+        mock_message_file_tool.url = "https://example.com/tool_file.png"
+
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            
+            # Mock database queries
+            mock_scalars_result = Mock()
+            mock_scalars_result.all.return_value = [mock_message_file_tool]
+            mock_session.scalars.return_value = mock_scalars_result
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is not None
+            assert len(result.files) == 1
+            
+            file_dict = result.files[0]
+            assert file_dict["url"] == "https://example.com/tool_file.png"
+            assert file_dict["filename"] == "tool_file.png"
+            assert file_dict["transfer_method"] == FileTransferMethod.TOOL_FILE.value
+
+    def test_message_end_with_tool_file_local(self, mock_pipeline, mock_message_file_tool):
+        """Test that files array is populated correctly for TOOL_FILE with local path."""
+        # Arrange
+        mock_message_file_tool.message_id = mock_pipeline._message_id
+        mock_message_file_tool.url = "tool_file_123.png"
+
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.sign_tool_file") as mock_sign_tool:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            
+            # Mock database queries
+            mock_scalars_result = Mock()
+            mock_scalars_result.all.return_value = [mock_message_file_tool]
+            mock_session.scalars.return_value = mock_scalars_result
+            
+            mock_sign_tool.return_value = "https://example.com/signed-tool-file.png?signature=xyz"
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is not None
+            assert len(result.files) == 1
+            
+            file_dict = result.files[0]
+            assert "https://example.com/signed-tool-file.png" in file_dict["url"]
+            assert file_dict["filename"] == "tool_file_123.png"
+            assert file_dict["extension"] == ".png"
+            assert file_dict["transfer_method"] == FileTransferMethod.TOOL_FILE.value
+
+            # Verify tool file signing was called
+            mock_sign_tool.assert_called_once_with(tool_file_id="tool_file_123", extension=".png")
+
+    def test_message_end_with_multiple_files(
+        self, mock_pipeline, mock_message_file_local, mock_message_file_remote, mock_upload_file
+    ):
+        """Test that files array contains all MessageFile records when multiple exist."""
+        # Arrange
+        mock_message_file_local.message_id = mock_pipeline._message_id
+        mock_message_file_remote.message_id = mock_pipeline._message_id
+
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class, \
+             patch(
+                 "core.app.task_pipeline.easy_ui_based_generate_task_pipeline.file_helpers.get_signed_file_url"
+             ) as mock_get_url:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            
+            # Mock database queries
+            mock_scalars_result = Mock()
+            mock_scalars_result.all.return_value = [mock_message_file_local, mock_message_file_remote]
+            mock_session.scalars.return_value = mock_scalars_result
+            
+            mock_session.scalar.return_value = mock_upload_file
+            mock_get_url.return_value = "https://example.com/signed-url?signature=abc123"
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is not None
+            assert len(result.files) == 2
+            
+            # Verify both files are present
+            file_ids = [f["related_id"] for f in result.files]
+            assert mock_message_file_local.id in file_ids
+            assert mock_message_file_remote.id in file_ids
+
+    def test_message_end_with_local_file_no_upload_file(self, mock_pipeline, mock_message_file_local):
+        """Test fallback when UploadFile is not found for LOCAL_FILE."""
+        # Arrange
+        mock_message_file_local.message_id = mock_pipeline._message_id
+
+        with patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db, \
+             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.Session") as mock_session_class, \
+             patch(
+                 "core.app.task_pipeline.easy_ui_based_generate_task_pipeline.file_helpers.get_signed_file_url"
+             ) as mock_get_url:
+            
+            mock_engine = MagicMock()
+            mock_db.engine = mock_engine
+            
+            mock_session = MagicMock(spec=Session)
+            mock_session_class.return_value.__enter__.return_value = mock_session
+            
+            # Mock database queries - UploadFile not found
+            mock_scalars_result = Mock()
+            mock_scalars_result.all.return_value = [mock_message_file_local]
+            mock_session.scalars.return_value = mock_scalars_result
+            
+            mock_session.scalar.return_value = None  # UploadFile not found
+            mock_get_url.return_value = "https://example.com/fallback-url?signature=def456"
+
+            # Act
+            result = EasyUIBasedGenerateTaskPipeline._message_end_to_stream_response(mock_pipeline)
+
+            # Assert
+            assert isinstance(result, MessageEndStreamResponse)
+            assert result.files is not None
+            assert len(result.files) == 1
+            
+            file_dict = result.files[0]
+            assert "https://example.com/fallback-url" in file_dict["url"]
+            # Verify fallback URL was generated using upload_file_id from message_file
+            mock_get_url.assert_called_with(upload_file_id=str(mock_message_file_local.upload_file_id))


### PR DESCRIPTION
- Fetch MessageFile records associated with the message
- Generate signed URLs for local files based on transfer_method
- Support LOCAL_FILE, REMOTE_URL, and TOOL_FILE transfer methods
- Fixes issue where images and text responses were not rendered in chat apps
- Related to vision feature regression from #22552

Fixes: vision responses not rendering in chat apps when images are uploaded

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

# Chat app vision responses not rendering - message_file event handler bug (regression from #22552)

**Related Issue:** #22552 (closed) - The fix in commit `084dcd1a50` has a bug that prevents vision responses from rendering in chat apps.

**Dify Version:** `1.11.2`, `1.11.4`, `hotfix-1.11.4-fix.4` (likely affects `1.12.0` as well)

**Cloud or Self Hosted:** Self Hosted (Kubernetes)

**Description:** When uploading an image to a **chat app** (not workflow), the AI response is completely empty - neither the text answer nor the image are rendered in the chat interface. The HTML container exists but is empty. This is a regression from the fix in #22552.

## Steps to Reproduce

1. Create a chat app with vision model enabled (e.g., GPT-4 Vision, Claude 3.5 Sonnet with vision)
2. Upload an image file (e.g., PNG, JPG) in the chat input
3. Send a message asking about the image (e.g., "explain this image")
4. Wait for AI response
5. Observe the chat interface - response container is empty

**Note:** Check browser DevTools → Network tab to see SSE events are being received, but nothing renders in the UI.

## Expected Behavior

- ✅ AI generates a text response describing the image
- ✅ Image thumbnail is displayed in the chat history
- ✅ Both text answer and image are visible in the chat interface
- ✅ User can see the complete conversation with image context

## Actual Behavior

- ✅ AI generates a text response (confirmed via API logs and SSE events)
- ✅ Image file is uploaded successfully (201 response from `/console/api/files/upload`)
- ✅ File is stored correctly in database and filesystem
- ✅ File preview URL works when accessed directly in browser
- ❌ **Chat interface shows completely empty div container** - no text, no image
- ❌ Frontend receives `message_file` SSE events but doesn't render them
- ❌ `message_end` event has `"files": null` instead of files array
- ❌ HTML structure exists but content is missing (empty `<div class="chat-answer-container">`)

---

## Additional Information

### Technical Analysis

### Backend (API) Behavior

The API correctly:
1. Receives file upload → Returns 201 with `upload_file_id`
2. Processes image → Generates response with correct tokens
3. Sends SSE events:
   - `message_file` events with file data ✅
   - `message_end` event with `"files": null` ❌ (should contain files array)

### Frontend Behavior

The frontend (`web/app/components/base/chat/chat/hooks.ts`):

**Problem 1: `onFile` handler (line 419-422)**
```typescript
onFile(file) {
  const lastThought = responseItem.agent_thoughts?.[responseItem.agent_thoughts?.length - 1]
  if (lastThought)  // ← BUG: Only adds files if agent_thoughts exists!
    responseItem.agent_thoughts![responseItem.agent_thoughts!.length - 1].message_files = [...(lastThought as any).message_files, file]
  // Missing: else clause to add files to responseItem.message_files for chat apps
}
```

**Problem 2: `onMessageEnd` handler (line 477-478)**
```typescript
const processedFilesFromResponse = getProcessedFilesFromResponse(messageEnd.files || [])
responseItem.allFiles = uniqBy([...(responseItem.allFiles || []), ...(processedFilesFromResponse || [])], 'id')
```

But `message_end` event has `"files": null` instead of the files array.

### Root Cause

The fix in commit `084dcd1a50` (issue #22552) has a bug:

**File:** `api/core/app/task_pipeline/message_cycle_manager.py`

**Current (incorrect) code:**
```python
message_file = db.session.query(MessageFile).filter(MessageFile.id == message_id).first()
event_type = StreamEvent.MESSAGE_FILE if message_file else StreamEvent.MESSAGE
```

**Problem:** `message_id` is the **message ID**, not the file ID! The query should check if there are files **associated with** the message, not if a file **is** the message.

**Should be:**
```python
message_file = db.session.query(MessageFile).filter(MessageFile.message_id == message_id).first()
event_type = StreamEvent.MESSAGE_FILE if message_file else StreamEvent.MESSAGE
```

Additionally, the `message_end` event should include the files array, but it's currently `null`.

## Evidence

### SSE Events Received:
```json
data: {"event":"message_file","conversation_id":"...","message_id":"...","answer":"","from_variable_selector":null}
data: {"event":"message_file","conversation_id":"...","message_id":"...","answer":"I","from_variable_selector":null}
... (streaming text chunks)
data: {"event":"message_end","conversation_id":"...","message_id":"...","files":null}  ← Should contain files!
```

### API Response (GET /chat-messages):
```json
{
  "answer": "I'm sorry for the confusion...",
  "message_files": [
    {
      "id": "858106aa-d422-4922-9b7f-f52eed3f0619",
      "filename": "twilio.png",
      "url": "/files/.../file-preview?...",
      ...
    }
  ]
}
```

### Browser DOM:
```html
<div class="chat-answer-container">
  <div class="body-lg-regular">
    <!-- EMPTY - no text, no image -->
  </div>
</div>
```

## Proposed Fix

### Backend Fix:
1. Fix the query in `message_cycle_manager.py`:
   ```python
   message_file = db.session.query(MessageFile).filter(MessageFile.message_id == message_id).first()
   ```

2. Ensure `message_end` event includes files array:
   ```python
   # In message_end_to_stream_response method
   files = db.session.query(MessageFile).filter(MessageFile.message_id == message_id).all()
   return MessageEndStreamResponse(..., files=files)
   ```

### Frontend Fix (if backend fix doesn't solve it):
1. Update `onFile` handler to handle chat apps:
   ```typescript
   onFile(file) {
     const lastThought = responseItem.agent_thoughts?.[responseItem.agent_thoughts?.length - 1]
     if (lastThought) {
       responseItem.agent_thoughts![responseItem.agent_thoughts!.length - 1].message_files = [...(lastThought as any).message_files, file]
     } else {
       // FIX: Add files to message_files for chat apps
       responseItem.message_files = [...(responseItem.message_files || []), file]
     }
     updateCurrentQAOnTree({...})
   }
   ```

## Impact

- **Severity:** High - Vision features completely broken for chat apps
- **Affected Users:** All users trying to use vision/image features in chat apps
- **Workaround:** None - feature is unusable

## Additional Context

- File upload works correctly
- File storage works correctly  
- File preview URLs work when accessed directly
- The issue is specifically in the rendering pipeline between SSE events and DOM
