### PR TITLE
fix: include locale in appList query key for localization support inuseExploreAppList

### DIFF
--- a/web/service/use-explore.ts
+++ b/web/service/use-explore.ts
@@ -1,6 +1,7 @@
 import type { App, AppCategory } from '@/models/explore'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useGlobalPublicStore } from '@/context/global-public-context'
+import { useLocale } from '@/context/i18n'
 import { AccessMode } from '@/models/access-control'
 import { fetchAppList, fetchBanners, fetchInstalledAppList, getAppAccessModeByAppId, uninstallApp, updatePinStatus } from './explore'
 import { AppSourceType, fetchAppMeta, fetchAppParams } from './share'
@@ -13,8 +14,9 @@ type ExploreAppListData = {
 }
 
 export const useExploreAppList = () => {
+  const locale = useLocale()
   return useQuery<ExploreAppListData>({
-    queryKey: [NAME_SPACE, 'appList'],
+    queryKey: [NAME_SPACE, 'appList', locale],
     queryFn: async () => {
       const { categories, recommended_apps } = await fetchAppList()
       return {


### PR DESCRIPTION
## Summary

fix: include locale in appList query key for localization support inuseExploreAppList


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
