### PR TITLE
refactor: api/controllers/console/feature.py resolve compatibility issues

### DIFF
--- a/api/controllers/console/feature.py
+++ b/api/controllers/console/feature.py
@@ -1,60 +1,54 @@
-from flask_restx import Resource, fields
 from werkzeug.exceptions import Unauthorized
 
+from controllers.fastopenapi import console_router
 from libs.login import current_account_with_tenant, current_user, login_required
-from services.feature_service import FeatureService
+from services.feature_service import FeatureModel, FeatureService, SystemFeatureModel
 
-from . import console_ns
 from .wraps import account_initialization_required, cloud_utm_record, setup_required
 
 
-@console_ns.route("/features")
-class FeatureApi(Resource):
-    @console_ns.doc("get_tenant_features")
-    @console_ns.doc(description="Get feature configuration for current tenant")
-    @console_ns.response(
-        200,
-        "Success",
-        console_ns.model("FeatureResponse", {"features": fields.Raw(description="Feature configuration object")}),
-    )
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @cloud_utm_record
-    def get(self):
-        """Get feature configuration for current tenant"""
-        _, current_tenant_id = current_account_with_tenant()
-
-        return FeatureService.get_features(current_tenant_id).model_dump()
+# NOTE: The original feature.py Swagger documentation incorrectly specified a wrapped format
+# {"features": ...}, but the actual implementation returned a flat FeatureModel.
+# The frontend has always used the flat format, so we maintain backward compatibility here.
 
 
-@console_ns.route("/system-features")
-class SystemFeatureApi(Resource):
-    @console_ns.doc("get_system_features")
-    @console_ns.doc(description="Get system-wide feature configuration")
-    @console_ns.response(
-        200,
-        "Success",
-        console_ns.model(
-            "SystemFeatureResponse", {"features": fields.Raw(description="System feature configuration object")}
-        ),
-    )
-    def get(self):
-        """Get system-wide feature configuration
+@console_router.get(
+    "/features",
+    response_model=FeatureModel,
+    tags=["console"],
+)
+@setup_required
+@login_required
+@account_initialization_required
+@cloud_utm_record
+def get_tenant_features() -> FeatureModel:
+    """Get feature configuration for current tenant."""
+    _, current_tenant_id = current_account_with_tenant()
 
-        NOTE: This endpoint is unauthenticated by design, as it provides system features
-        data required for dashboard initialization.
+    return FeatureService.get_features(current_tenant_id)
 
-        Authentication would create circular dependency (can't login without dashboard loading).
 
-        Only non-sensitive configuration data should be returned by this endpoint.
-        """
-        # NOTE(QuantumGhost): ideally we should access `current_user.is_authenticated`
-        # without a try-catch. However, due to the implementation of user loader (the `load_user_from_request`
-        # in api/extensions/ext_login.py), accessing `current_user.is_authenticated` will
-        # raise `Unauthorized` exception if authentication token is not provided.
-        try:
-            is_authenticated = current_user.is_authenticated
-        except Unauthorized:
-            is_authenticated = False
-        return FeatureService.get_system_features(is_authenticated=is_authenticated).model_dump()
+@console_router.get(
+    "/system-features",
+    response_model=SystemFeatureModel,
+    tags=["console"],
+)
+def get_system_features() -> SystemFeatureModel:
+    """Get system-wide feature configuration
+
+    NOTE: This endpoint is unauthenticated by design, as it provides system features
+    data required for dashboard initialization.
+
+    Authentication would create circular dependency (can't login without dashboard loading).
+
+    Only non-sensitive configuration data should be returned by this endpoint.
+    """
+    # NOTE(QuantumGhost): ideally we should access `current_user.is_authenticated`
+    # without a try-catch. However, due to the implementation of user loader (the `load_user_from_request`
+    # in api/extensions/ext_login.py), accessing `current_user.is_authenticated` will
+    # raise `Unauthorized` exception if authentication token is not provided.
+    try:
+        is_authenticated = current_user.is_authenticated
+    except Unauthorized:
+        is_authenticated = False
+    return FeatureService.get_system_features(is_authenticated=is_authenticated)

--- a/api/controllers/console/feature.py
+++ b/api/controllers/console/feature.py
@@ -6,7 +6,6 @@ from services.feature_service import FeatureModel, FeatureService, SystemFeature
 
 from .wraps import account_initialization_required, cloud_utm_record, setup_required
 
-
 # NOTE: The original feature.py Swagger documentation incorrectly specified a wrapped format
 # {"features": ...}, but the actual implementation returned a flat FeatureModel.
 # The frontend has always used the flat format, so we maintain backward compatibility here.

--- a/api/extensions/ext_fastopenapi.py
+++ b/api/extensions/ext_fastopenapi.py
@@ -29,10 +29,11 @@ def init_app(app: DifyApp) -> None:
     # Ensure route decorators are evaluated.
     import controllers.console.init_validate as init_validate_module
     import controllers.console.ping as ping_module
-    from controllers.console import remote_files, setup
+    from controllers.console import feature, remote_files, setup
 
     _ = init_validate_module
     _ = ping_module
+    _ = feature
     _ = remote_files
     _ = setup
 

--- a/api/extensions/ext_login.py
+++ b/api/extensions/ext_login.py
@@ -118,7 +118,7 @@ def on_user_logged_in(_sender, user):
 @login_manager.unauthorized_handler
 def unauthorized_handler():
     """Handle unauthorized requests.
-    
+
     For FastOpenAPI routes (no blueprint), we raise Unauthorized exception
     which will be caught and serialized properly by the framework.
     For traditional Blueprint-based routes, we return a Response object.
@@ -127,7 +127,7 @@ def unauthorized_handler():
     if request.blueprint is None and request.path.startswith("/console/api/"):
         # Raise exception - FastOpenAPI will handle serialization
         raise Unauthorized("Unauthorized.")
-    
+
     # Traditional Blueprint routes - return Response object
     return Response(
         json.dumps({"code": "unauthorized", "message": "Unauthorized."}),

--- a/api/extensions/ext_login.py
+++ b/api/extensions/ext_login.py
@@ -48,7 +48,9 @@ def load_user_from_request(request_from_flask_login):
                         account.current_tenant = tenant
                         return account
 
-    if request.blueprint in {"console", "inner_api"}:
+    # Support both Blueprint-based routes and FastOpenAPI routes (which have no blueprint)
+    is_console_api = request.blueprint in {"console", "inner_api"} or request.path.startswith("/console/api/")
+    if is_console_api:
         if not auth_token:
             raise Unauthorized("Invalid Authorization token.")
         decoded = PassportService().verify(auth_token)
@@ -115,7 +117,18 @@ def on_user_logged_in(_sender, user):
 
 @login_manager.unauthorized_handler
 def unauthorized_handler():
-    """Handle unauthorized requests."""
+    """Handle unauthorized requests.
+    
+    For FastOpenAPI routes (no blueprint), we raise Unauthorized exception
+    which will be caught and serialized properly by the framework.
+    For traditional Blueprint-based routes, we return a Response object.
+    """
+    # Check if this is a FastOpenAPI route (no blueprint but console API path)
+    if request.blueprint is None and request.path.startswith("/console/api/"):
+        # Raise exception - FastOpenAPI will handle serialization
+        raise Unauthorized("Unauthorized.")
+    
+    # Traditional Blueprint routes - return Response object
     return Response(
         json.dumps({"code": "unauthorized", "message": "Unauthorized."}),
         status=401,

--- a/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
@@ -28,7 +28,8 @@ def app() -> Flask:
 @pytest.fixture
 def mock_auth():
     """Mocks authentication decorators and user context."""
-    noop = lambda f: f
+    def noop(f):
+        return f
     with (
         patch("controllers.console.wraps.setup_required", side_effect=noop),
         patch("libs.login.login_required", side_effect=noop),

--- a/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
@@ -13,7 +13,6 @@ from extensions import ext_fastopenapi
 from extensions.ext_database import db
 from services.feature_service import FeatureModel, SystemFeatureModel
 
-
 # ------------------------------------------------------------------------------
 # Fixtures
 # ------------------------------------------------------------------------------

--- a/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
@@ -1,7 +1,4 @@
 import builtins
-import contextlib
-import importlib
-import sys
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -13,175 +10,43 @@ from extensions import ext_fastopenapi
 from extensions.ext_database import db
 from services.feature_service import FeatureModel, SystemFeatureModel
 
+if not hasattr(builtins, "MethodView"):
+    builtins.MethodView = MethodView  # type: ignore[attr-defined]
+
 
 @pytest.fixture
-def app():
-    """
-    Creates a Flask application instance configured for testing.
-    """
+def app() -> Flask:
+    """Creates a Flask app configured for testing."""
     app = Flask(__name__)
     app.config["TESTING"] = True
     app.config["SECRET_KEY"] = "test-secret"
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-
-    # Initialize the database with the app
     db.init_app(app)
-
     return app
 
 
-@pytest.fixture(autouse=True)
-def fix_method_view_issue(monkeypatch):
-    """
-    Automatic fixture to patch 'builtins.MethodView'.
-
-    Why this is needed:
-    The official legacy codebase contains a global patch in its initialization logic:
-        if not hasattr(builtins, "MethodView"):
-             builtins.MethodView = MethodView
-
-    Some dependencies (like ext_fastopenapi or older Flask extensions) might implicitly
-    rely on 'MethodView' being available in the global builtins namespace.
-
-    Refactoring Note:
-    While patching builtins is generally discouraged due to global side effects,
-    this fixture reproduces the production environment's state to ensure tests are realistic.
-    We use 'monkeypatch' to ensure that this change is undone after the test finishes,
-    keeping other tests isolated.
-    """
-    if not hasattr(builtins, "MethodView"):
-        # 'raising=False' allows us to set an attribute that doesn't exist yet
-        monkeypatch.setattr(builtins, "MethodView", MethodView, raising=False)
-
-
-# ------------------------------------------------------------------------------
-# Helper Functions for Fixture Complexity Reduction
-# ------------------------------------------------------------------------------
-
-
-def _create_isolated_router():
-    """
-    Creates a fresh, isolated router instance to prevent route pollution.
-    """
-    import controllers.fastopenapi
-
-    # Dynamically get the class type (e.g., FlaskRouter) to avoid hardcoding dependencies
-    RouterClass = type(controllers.fastopenapi.console_router)
-    return RouterClass()
-
-
-@contextlib.contextmanager
-def _patch_auth_and_router(temp_router):
-    """
-    Context manager that applies all necessary patches for:
-    1. The console_router (redirecting to our isolated temp_router)
-    2. Authentication decorators (disabling them with no-ops)
-    3. User/Account loaders (mocking authenticated state)
-    """
-
-    def noop(f):
-        return f
-
-    # We patch the SOURCE of the decorators/functions, not the destination module.
-    # This ensures that when 'controllers.console.feature' imports them, it gets the mocks.
+@pytest.fixture
+def mock_auth():
+    """Mocks authentication decorators and user context."""
+    noop = lambda f: f
     with (
-        patch("controllers.fastopenapi.console_router", temp_router),
-        patch("extensions.ext_fastopenapi.console_router", temp_router),
         patch("controllers.console.wraps.setup_required", side_effect=noop),
         patch("libs.login.login_required", side_effect=noop),
         patch("controllers.console.wraps.account_initialization_required", side_effect=noop),
         patch("controllers.console.wraps.cloud_utm_record", side_effect=noop),
         patch("libs.login.current_account_with_tenant", return_value=(MagicMock(), "tenant-id")),
-        patch("libs.login.current_user", MagicMock(is_authenticated=True)),
+        patch("libs.login.current_user", MagicMock(is_authenticated=True)) as mock_user,
     ):
-        # Explicitly reload ext_fastopenapi to ensure it uses the patched console_router
-        import extensions.ext_fastopenapi
-
-        importlib.reload(extensions.ext_fastopenapi)
-
-        yield
-
-
-def _force_reload_module(target_module: str, alias_module: str):
-    """
-    Forces a reload of the specified module and handles sys.modules aliasing.
-
-    Why reload?
-    Python decorators (like @route, @login_required) run at IMPORT time.
-    To apply our patches (mocks/no-ops) to these decorators, we must re-import
-    the module while the patches are active.
-
-    Why alias?
-    If 'ext_fastopenapi' imports the controller as 'api.controllers...', but we import
-    it as 'controllers...', Python treats them as two separate modules. This causes:
-    1. Double execution of decorators (registering routes twice -> AssertionError).
-    2. Type mismatch errors (Class A from module X is not Class A from module Y).
-
-    This function ensures both names point to the SAME loaded module instance.
-    """
-    # 1. Clean existing entries to force re-import
-    if target_module in sys.modules:
-        del sys.modules[target_module]
-    if alias_module in sys.modules:
-        del sys.modules[alias_module]
-
-    # 2. Import the module (triggering decorators with active patches)
-    module = importlib.import_module(target_module)
-
-    # 3. Alias the module in sys.modules to prevent double loading
-    sys.modules[alias_module] = sys.modules[target_module]
-
-    return module
-
-
-def _cleanup_modules(target_module: str, alias_module: str):
-    """
-    Removes the module and its alias from sys.modules to prevent side effects
-    on other tests.
-    """
-    if target_module in sys.modules:
-        del sys.modules[target_module]
-    if alias_module in sys.modules:
-        del sys.modules[alias_module]
-
-
-@pytest.fixture
-def mock_feature_module_env():
-    """
-    Sets up a mocked environment for the feature module.
-
-    This fixture orchestrates:
-    1. Creating an isolated router.
-    2. Patching authentication and global dependencies.
-    3. Reloading the controller module to apply patches to decorators.
-    4. cleaning up sys.modules afterwards.
-    """
-    target_module = "controllers.console.feature"
-    alias_module = "api.controllers.console.feature"
-
-    # 1. Prepare isolated router
-    temp_router = _create_isolated_router()
-
-    # 2. Apply patches
-    try:
-        with _patch_auth_and_router(temp_router):
-            # 3. Reload module to register routes on the temp_router
-            feature_module = _force_reload_module(target_module, alias_module)
-
-            yield feature_module
-
-    finally:
-        # 4. Teardown: Clean up sys.modules
-        _cleanup_modules(target_module, alias_module)
+        yield mock_user
 
 
 # ------------------------------------------------------------------------------
-# Test Cases
+# Core Feature Endpoint Tests
 # ------------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    ("url", "service_mock_path", "mock_model_instance"),
+    ("url", "service_mock_path", "mock_model"),
     [
         (
             "/console/api/features",
@@ -195,24 +60,15 @@ def mock_feature_module_env():
         ),
     ],
 )
-def test_console_features_success(app, mock_feature_module_env, url, service_mock_path, mock_model_instance):
-    """
-    Tests that the feature APIs return a 200 OK status and correct JSON structure.
-    """
-    # Patch the service layer to return our mock model instance
-    with patch(service_mock_path, return_value=mock_model_instance):
-        # Initialize the API extension
+def test_feature_endpoints_return_200_with_flat_json(app, mock_auth, url, service_mock_path, mock_model):
+    """Tests that feature endpoints return 200 with flat JSON format."""
+    with patch(service_mock_path, return_value=mock_model):
         ext_fastopenapi.init_app(app)
+        response = app.test_client().get(url)
 
-        client = app.test_client()
-        response = client.get(url)
-
-    # Assertions
-    assert response.status_code == 200, f"Request failed with status {response.status_code}: {response.text}"
-
-    # Verify the JSON response matches the Pydantic model dump (flat format, not wrapped)
-    expected_data = mock_model_instance.model_dump(mode="json")
-    assert response.get_json() == expected_data
+    assert response.status_code == 200
+    assert response.get_json() == mock_model.model_dump(mode="json")
+    assert "application/json" in response.content_type
 
 
 @pytest.mark.parametrize(
@@ -222,451 +78,115 @@ def test_console_features_success(app, mock_feature_module_env, url, service_moc
         ("/console/api/system-features", "controllers.console.feature.FeatureService.get_system_features"),
     ],
 )
-def test_console_features_service_error(app, mock_feature_module_env, url, service_mock_path):
-    """
-    Tests how the application handles Service layer errors.
-
-    Note: When an exception occurs in the view, it is typically caught by the framework
-    (Flask or the OpenAPI wrapper) and converted to a 500 error response.
-    This test verifies that the application returns a 500 status code.
-    """
-    # Simulate a service failure
+def test_feature_endpoints_return_500_on_service_error(app, mock_auth, url, service_mock_path):
+    """Tests that service errors return 500."""
     with patch(service_mock_path, side_effect=ValueError("Service Failure")):
         ext_fastopenapi.init_app(app)
-        client = app.test_client()
+        response = app.test_client().get(url)
 
-        # When an exception occurs in the view, it is typically caught by the framework
-        # (Flask or the OpenAPI wrapper) and converted to a 500 error response.
-        response = client.get(url)
-
-        assert response.status_code == 500
-        # Check if the error details are exposed in the response (depends on error handler config)
-        # We accept either generic 500 or the specific error message
-        assert "Service Failure" in response.text or "Internal Server Error" in response.text
+    assert response.status_code == 500
 
 
-def test_system_features_unauthenticated(app, mock_feature_module_env):
-    """
-    Tests that /console/api/system-features endpoint works without authentication.
-
-    This test verifies the try-except block in get_system_features that handles
-    unauthenticated requests by passing is_authenticated=False to the service layer.
-    """
-    feature_module = mock_feature_module_env
-
-    # Override the behavior of the current_user mock
-    # The fixture patched 'libs.login.current_user', so 'controllers.console.feature.current_user'
-    # refers to that same Mock object.
-    mock_user = feature_module.current_user
-
-    # Simulate property access raising Unauthorized
-    # Note: We must reset side_effect if it was set, or set it here.
-    # The fixture initialized it as MagicMock(is_authenticated=True).
-    # We want type(mock_user).is_authenticated to raise Unauthorized.
+def test_system_features_handles_unauthenticated_users(app, mock_auth):
+    """Tests /system-features passes is_authenticated=False when auth fails."""
+    mock_user = mock_auth
     type(mock_user).is_authenticated = PropertyMock(side_effect=Unauthorized)
+    mock_model = SystemFeatureModel(enable_marketplace=True)
 
-    # Patch the service layer for this specific test
-    with patch("controllers.console.feature.FeatureService.get_system_features") as mock_service:
-        # Setup mock service return value
-        mock_model = SystemFeatureModel(enable_marketplace=True)
-        mock_service.return_value = mock_model
-
-        # Initialize app
+    with patch("controllers.console.feature.FeatureService.get_system_features", return_value=mock_model) as svc:
         ext_fastopenapi.init_app(app)
-        client = app.test_client()
+        response = app.test_client().get("/console/api/system-features")
 
-        # Act
-        response = client.get("/console/api/system-features")
+    assert response.status_code == 200
+    svc.assert_called_once_with(is_authenticated=False)
 
-        # Assert
-        assert response.status_code == 200, f"Request failed: {response.text}"
 
-        # Verify service was called with is_authenticated=False
-        mock_service.assert_called_once_with(is_authenticated=False)
+def test_features_endpoint_rejects_post_method(app, mock_auth):
+    """Tests that feature endpoints only accept GET."""
+    with patch("controllers.console.feature.FeatureService.get_features", return_value=FeatureModel()):
+        ext_fastopenapi.init_app(app)
+        response = app.test_client().post("/console/api/features")
 
-        # Verify response body (flat format, not wrapped)
-        expected_data = mock_model.model_dump(mode="json")
-        assert response.get_json() == expected_data
+    assert response.status_code == 405
+
+
+def test_routes_are_registered_correctly(app, mock_auth):
+    """Tests that FastOpenAPI registers routes with correct paths."""
+    ext_fastopenapi.init_app(app)
+    rules = {rule.rule for rule in app.url_map.iter_rules()}
+
+    assert "/console/api/features" in rules
+    assert "/console/api/system-features" in rules
 
 
 # ------------------------------------------------------------------------------
 # FastOpenAPI Authentication Tests
 # ------------------------------------------------------------------------------
-# These tests verify that our fixes for FastOpenAPI routing work correctly:
-# 1. load_user_from_request supports FastOpenAPI routes (no blueprint)
-# 2. unauthorized_handler returns serializable response for FastOpenAPI routes
-# 3. Response format is flat (not wrapped in {"features": ...})
 
 
-class TestFastOpenAPIAuthenticationBehavior:
-    """
-    Tests for FastOpenAPI-specific authentication behavior.
+@pytest.fixture
+def app_with_login_manager():
+    """Creates Flask app with login manager to test auth behavior."""
+    from flask_login import LoginManager
 
-    Unlike the tests above that mock authentication decorators,
-    these tests verify the actual authentication flow works correctly
-    for FastOpenAPI routes where request.blueprint is None.
-    """
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
 
-    @pytest.fixture
-    def app_with_login_manager(self):
-        """
-        Creates a Flask app with login manager configured,
-        simulating the production environment more closely.
-        """
-        from flask_login import LoginManager
+    login_manager = LoginManager()
+    login_manager.init_app(app)
 
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        app.config["SECRET_KEY"] = "test-secret"
-        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    @login_manager.request_loader
+    def load_user(request):
+        if request.headers.get("Authorization") == "Bearer valid-token":
+            user = MagicMock()
+            user.is_authenticated = True
+            return user
+        return None
 
-        # Initialize database
-        db.init_app(app)
-
-        # Initialize login manager with unauthorized handler that matches our fix
-        login_manager = LoginManager()
-        login_manager.init_app(app)
-
-        @login_manager.unauthorized_handler
-        def test_unauthorized_handler():
-            """Simulates our fixed unauthorized_handler behavior."""
-            from flask import request
-
-            # For FastOpenAPI routes, raise exception (serializable by orjson)
-            if request.blueprint is None and request.path.startswith("/console/api/"):
-                raise Unauthorized("Unauthorized.")
-            # For Blueprint routes, return Response (legacy behavior)
-            import json
-
-            from flask import Response
-
-            return Response(
-                json.dumps({"code": "unauthorized", "message": "Unauthorized."}),
-                status=401,
-                content_type="application/json",
-            )
-
-        return app
-
-    def test_fastopenapi_route_has_no_blueprint(self, app_with_login_manager, fix_method_view_issue):
-        """
-        Verify that FastOpenAPI routes have request.blueprint == None.
-
-        This is the core assumption our authentication fix relies on.
-        """
-        captured_blueprint = {}
-
-        # Create a simple test route to capture request.blueprint
-        @app_with_login_manager.route("/console/api/test-blueprint")
-        def test_route():
-            from flask import request
-
-            captured_blueprint["value"] = request.blueprint
-            return {"status": "ok"}
-
-        client = app_with_login_manager.test_client()
-        response = client.get("/console/api/test-blueprint")
-
-        assert response.status_code == 200
-        # FastOpenAPI routes registered directly on app have no blueprint
-        assert captured_blueprint["value"] is None
-
-    def test_unauthorized_response_is_serializable_json(self, app_with_login_manager, fix_method_view_issue):
-        """
-        Verify that unauthorized response for FastOpenAPI routes is valid JSON.
-
-        When unauthorized_handler raises Unauthorized exception for FastOpenAPI routes,
-        Flask/Werkzeug converts it to a proper HTTP 401 response that is serializable.
-        """
-
-        @app_with_login_manager.route("/console/api/protected")
-        def protected_route():
-            # Simulate login_required behavior when user is not authenticated
+    @login_manager.unauthorized_handler
+    def unauthorized():
+        from flask import request
+        # FastOpenAPI routes: raise exception (serializable)
+        if request.blueprint is None and request.path.startswith("/console/api/"):
             raise Unauthorized("Unauthorized.")
+        # Blueprint routes: return Response
+        from flask import Response
+        import json
+        return Response(json.dumps({"code": "unauthorized"}), status=401, content_type="application/json")
 
-        client = app_with_login_manager.test_client()
-        response = client.get("/console/api/protected")
+    return app
 
-        assert response.status_code == 401
-        # Response should be valid (either JSON or HTML error page, but not a serialization error)
-        assert response.data is not None
-        # Should not be a TypeError from orjson trying to serialize Response object
-        assert b"TypeError" not in response.data
 
-    def test_response_format_is_flat_not_wrapped(self, app, mock_feature_module_env):
-        """
-        Explicitly verify that response format is flat FeatureModel,
-        not wrapped in {"features": {...}}.
+def test_fastopenapi_route_has_no_blueprint(app_with_login_manager):
+    """Verifies FastOpenAPI routes have request.blueprint == None."""
+    captured = {}
 
-        This ensures backward compatibility with frontend expectations.
-        """
-        mock_model = FeatureModel(can_replace_logo=True)
+    @app_with_login_manager.route("/console/api/test")
+    def test_route():
+        from flask import request
+        captured["blueprint"] = request.blueprint
+        return {"ok": True}
 
-        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
-            ext_fastopenapi.init_app(app)
-            client = app.test_client()
-            response = client.get("/console/api/features")
+    response = app_with_login_manager.test_client().get("/console/api/test")
 
-        assert response.status_code == 200
-        json_data = response.get_json()
+    assert response.status_code == 200
+    assert captured["blueprint"] is None
 
-        # Should NOT be wrapped format
-        assert "features" not in json_data or not isinstance(json_data.get("features"), dict)
 
-        # Should be flat format - top level keys are FeatureModel fields
-        assert "can_replace_logo" in json_data
+def test_protected_route_returns_401_without_auth(app_with_login_manager):
+    """Tests that protected routes return 401 without authentication."""
+    from flask_login import login_required
 
+    @app_with_login_manager.route("/console/api/protected")
+    @login_required
+    def protected():
+        return {"status": "ok"}
 
-# ------------------------------------------------------------------------------
-# Response Format and Content-Type Tests
-# ------------------------------------------------------------------------------
-# These tests verify OpenAPI v3 migration requirements for response handling
+    client = app_with_login_manager.test_client()
 
+    # Without auth
+    assert client.get("/console/api/protected").status_code == 401
 
-class TestResponseFormatValidation:
-    """
-    Tests for response format validation.
-
-    Ensures FastOpenAPI produces correct Content-Type headers and JSON format
-    that matches OpenAPI 3.0 specification requirements.
-    """
-
-    def test_response_content_type_is_json(self, app, mock_feature_module_env):
-        """
-        Verify response Content-Type is application/json.
-
-        FastOpenAPI uses orjson for serialization, must produce correct Content-Type.
-        """
-        mock_model = FeatureModel(can_replace_logo=True)
-
-        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
-            ext_fastopenapi.init_app(app)
-            client = app.test_client()
-            response = client.get("/console/api/features")
-
-        assert response.status_code == 200
-        # Content-Type should be JSON
-        assert "application/json" in response.content_type
-
-    def test_system_features_content_type_is_json(self, app, mock_feature_module_env):
-        """
-        Verify /system-features response Content-Type is application/json.
-        """
-        mock_model = SystemFeatureModel(enable_marketplace=True)
-
-        with patch("controllers.console.feature.FeatureService.get_system_features", return_value=mock_model):
-            ext_fastopenapi.init_app(app)
-            client = app.test_client()
-            response = client.get("/console/api/system-features")
-
-        assert response.status_code == 200
-        assert "application/json" in response.content_type
-
-    def test_feature_model_all_fields_serialized(self, app, mock_feature_module_env):
-        """
-        Verify all FeatureModel fields are serialized in response.
-
-        This ensures Pydantic model dump is complete for OpenAPI schema compliance.
-        """
-        mock_model = FeatureModel(
-            can_replace_logo=True,
-            model_load_balancing_enabled=True,
-        )
-
-        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
-            ext_fastopenapi.init_app(app)
-            client = app.test_client()
-            response = client.get("/console/api/features")
-
-        assert response.status_code == 200
-        json_data = response.get_json()
-
-        # Verify key fields are present
-        assert "can_replace_logo" in json_data
-        assert json_data["can_replace_logo"] is True
-        assert "model_load_balancing_enabled" in json_data
-        assert json_data["model_load_balancing_enabled"] is True
-
-
-# ------------------------------------------------------------------------------
-# Authentication Behavior Tests with Realistic Mocking
-# ------------------------------------------------------------------------------
-# These tests use more realistic mocking to verify authentication behavior
-
-
-class TestAuthenticationWithRealisticMocking:
-    """
-    Tests authentication behavior with more realistic mocking.
-
-    Unlike tests that completely bypass decorators, these tests mock
-    at the user/account level to verify decorator behavior.
-    """
-
-    @pytest.fixture
-    def app_with_real_decorators(self, monkeypatch):
-        """
-        Creates a Flask app where decorators execute but dependencies are mocked.
-
-        This provides a middle ground between:
-        - Full integration tests (require database setup)
-        - Tests that completely bypass decorators (don't test auth flow)
-        """
-        from flask import Flask
-        from flask_login import LoginManager
-
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        app.config["SECRET_KEY"] = "test-secret"
-        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-
-        # Initialize database
-        db.init_app(app)
-
-        # Initialize login manager
-        login_manager = LoginManager()
-        login_manager.init_app(app)
-
-        # Mock request loader to return None (unauthenticated)
-        @login_manager.request_loader
-        def mock_load_user(request):
-            # Check for test auth header
-            auth_header = request.headers.get("Authorization")
-            if auth_header and auth_header.startswith("Bearer test-valid-token"):
-                # Return a mock user
-                mock_user = MagicMock()
-                mock_user.is_authenticated = True
-                mock_user.current_tenant_id = "test-tenant-id"
-                return mock_user
-            return None
-
-        @login_manager.unauthorized_handler
-        def handle_unauthorized():
-            """Simulates production unauthorized_handler for FastOpenAPI routes."""
-            from flask import request
-
-            if request.blueprint is None and request.path.startswith("/console/api/"):
-                raise Unauthorized("Unauthorized.")
-            import json
-
-            from flask import Response
-
-            return Response(
-                json.dumps({"code": "unauthorized", "message": "Unauthorized."}),
-                status=401,
-                content_type="application/json",
-            )
-
-        return app
-
-    def test_features_endpoint_requires_authentication_concept(self, app_with_real_decorators, fix_method_view_issue):
-        """
-        Conceptual test: verify that a protected route would return 401 without auth.
-
-        Note: This test creates a simple protected route to verify the auth flow,
-        since the actual feature.py module loading is complex.
-        """
-        from flask_login import login_required as flask_login_required
-
-        @app_with_real_decorators.route("/console/api/test-protected")
-        @flask_login_required
-        def protected_test_route():
-            return {"status": "authenticated"}
-
-        client = app_with_real_decorators.test_client()
-
-        # Without authentication - should return 401
-        response = client.get("/console/api/test-protected")
-        assert response.status_code == 401
-
-        # With valid test token - should return 200
-        response_with_auth = client.get(
-            "/console/api/test-protected", headers={"Authorization": "Bearer test-valid-token"}
-        )
-        assert response_with_auth.status_code == 200
-
-    def test_system_features_no_auth_decorator_concept(self, app_with_real_decorators, fix_method_view_issue):
-        """
-        Conceptual test: verify that an unprotected route works without auth.
-
-        This mirrors /system-features behavior which has no @login_required.
-        """
-
-        @app_with_real_decorators.route("/console/api/test-public")
-        def public_test_route():
-            return {"status": "public"}
-
-        client = app_with_real_decorators.test_client()
-
-        # Without authentication - should still work
-        response = client.get("/console/api/test-public")
-        assert response.status_code == 200
-        assert response.get_json()["status"] == "public"
-
-
-# ------------------------------------------------------------------------------
-# OpenAPI Schema Compliance Tests
-# ------------------------------------------------------------------------------
-# These tests verify the generated OpenAPI schema meets requirements
-
-
-class TestOpenAPISchemaCompliance:
-    """
-    Tests for OpenAPI 3.0 schema compliance.
-
-    Verifies that FastOpenAPI generates correct schema for endpoints.
-    """
-
-    def test_fastopenapi_registers_routes_correctly(self, app, mock_feature_module_env):
-        """
-        Verify that FastOpenAPI registers routes with correct paths.
-        """
-        ext_fastopenapi.init_app(app)
-
-        # Check that routes are registered
-        rules = {rule.rule for rule in app.url_map.iter_rules()}
-
-        # Feature endpoints should be registered
-        assert "/console/api/features" in rules
-        assert "/console/api/system-features" in rules
-
-    def test_fastopenapi_routes_use_get_method(self, app, mock_feature_module_env):
-        """
-        Verify that feature endpoints only accept GET method.
-        """
-        mock_model = FeatureModel(can_replace_logo=True)
-
-        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
-            ext_fastopenapi.init_app(app)
-            client = app.test_client()
-
-            # GET should work
-            response_get = client.get("/console/api/features")
-            assert response_get.status_code == 200
-
-            # POST should return 405 Method Not Allowed
-            response_post = client.post("/console/api/features")
-            assert response_post.status_code == 405
-
-    def test_system_features_handles_both_auth_states(self, app, mock_feature_module_env):
-        """
-        Verify /system-features correctly handles both authenticated and unauthenticated states.
-
-        This is a critical test for the is_authenticated try-catch logic.
-        """
-        feature_module = mock_feature_module_env
-
-        # Test 1: When user is authenticated
-        with patch("controllers.console.feature.FeatureService.get_system_features") as mock_service:
-            mock_model = SystemFeatureModel(enable_marketplace=True)
-            mock_service.return_value = mock_model
-
-            # Reset mock to authenticated state
-            type(feature_module.current_user).is_authenticated = PropertyMock(return_value=True)
-
-            ext_fastopenapi.init_app(app)
-            client = app.test_client()
-            response = client.get("/console/api/system-features")
-
-            assert response.status_code == 200
-            # Service should be called with is_authenticated=True
-            mock_service.assert_called_with(is_authenticated=True)
+    # With valid token
+    assert client.get("/console/api/protected", headers={"Authorization": "Bearer valid-token"}).status_code == 200

--- a/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
@@ -28,8 +28,10 @@ def app() -> Flask:
 @pytest.fixture
 def mock_auth():
     """Mocks authentication decorators and user context."""
+
     def noop(f):
         return f
+
     with (
         patch("controllers.console.wraps.setup_required", side_effect=noop),
         patch("libs.login.login_required", side_effect=noop),
@@ -148,12 +150,15 @@ def app_with_login_manager():
     @login_manager.unauthorized_handler
     def unauthorized():
         from flask import request
+
         # FastOpenAPI routes: raise exception (serializable)
         if request.blueprint is None and request.path.startswith("/console/api/"):
             raise Unauthorized("Unauthorized.")
         # Blueprint routes: return Response
-        from flask import Response
         import json
+
+        from flask import Response
+
         return Response(json.dumps({"code": "unauthorized"}), status=401, content_type="application/json")
 
     return app
@@ -166,6 +171,7 @@ def test_fastopenapi_route_has_no_blueprint(app_with_login_manager):
     @app_with_login_manager.route("/console/api/test")
     def test_route():
         from flask import request
+
         captured["blueprint"] = request.blueprint
         return {"ok": True}
 

--- a/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
@@ -400,7 +400,7 @@ class TestFastOpenAPIAuthenticationBehavior:
 
         This ensures backward compatibility with frontend expectations.
         """
-        mock_model = FeatureModel(can_replace_logo=True, billing=None)
+        mock_model = FeatureModel(can_replace_logo=True)
 
         with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
             ext_fastopenapi.init_app(app)

--- a/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_fastopenapi_feature.py
@@ -1,0 +1,664 @@
+import builtins
+import contextlib
+import importlib
+import sys
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from flask import Flask
+from flask.views import MethodView
+from werkzeug.exceptions import Unauthorized
+
+from extensions import ext_fastopenapi
+from extensions.ext_database import db
+from services.feature_service import FeatureModel, SystemFeatureModel
+
+
+@pytest.fixture
+def app():
+    """
+    Creates a Flask application instance configured for testing.
+    """
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+    # Initialize the database with the app
+    db.init_app(app)
+
+    return app
+
+
+@pytest.fixture(autouse=True)
+def fix_method_view_issue(monkeypatch):
+    """
+    Automatic fixture to patch 'builtins.MethodView'.
+
+    Why this is needed:
+    The official legacy codebase contains a global patch in its initialization logic:
+        if not hasattr(builtins, "MethodView"):
+             builtins.MethodView = MethodView
+
+    Some dependencies (like ext_fastopenapi or older Flask extensions) might implicitly
+    rely on 'MethodView' being available in the global builtins namespace.
+
+    Refactoring Note:
+    While patching builtins is generally discouraged due to global side effects,
+    this fixture reproduces the production environment's state to ensure tests are realistic.
+    We use 'monkeypatch' to ensure that this change is undone after the test finishes,
+    keeping other tests isolated.
+    """
+    if not hasattr(builtins, "MethodView"):
+        # 'raising=False' allows us to set an attribute that doesn't exist yet
+        monkeypatch.setattr(builtins, "MethodView", MethodView, raising=False)
+
+
+# ------------------------------------------------------------------------------
+# Helper Functions for Fixture Complexity Reduction
+# ------------------------------------------------------------------------------
+
+
+def _create_isolated_router():
+    """
+    Creates a fresh, isolated router instance to prevent route pollution.
+    """
+    import controllers.fastopenapi
+
+    # Dynamically get the class type (e.g., FlaskRouter) to avoid hardcoding dependencies
+    RouterClass = type(controllers.fastopenapi.console_router)
+    return RouterClass()
+
+
+@contextlib.contextmanager
+def _patch_auth_and_router(temp_router):
+    """
+    Context manager that applies all necessary patches for:
+    1. The console_router (redirecting to our isolated temp_router)
+    2. Authentication decorators (disabling them with no-ops)
+    3. User/Account loaders (mocking authenticated state)
+    """
+
+    def noop(f):
+        return f
+
+    # We patch the SOURCE of the decorators/functions, not the destination module.
+    # This ensures that when 'controllers.console.feature' imports them, it gets the mocks.
+    with (
+        patch("controllers.fastopenapi.console_router", temp_router),
+        patch("extensions.ext_fastopenapi.console_router", temp_router),
+        patch("controllers.console.wraps.setup_required", side_effect=noop),
+        patch("libs.login.login_required", side_effect=noop),
+        patch("controllers.console.wraps.account_initialization_required", side_effect=noop),
+        patch("controllers.console.wraps.cloud_utm_record", side_effect=noop),
+        patch("libs.login.current_account_with_tenant", return_value=(MagicMock(), "tenant-id")),
+        patch("libs.login.current_user", MagicMock(is_authenticated=True)),
+    ):
+        # Explicitly reload ext_fastopenapi to ensure it uses the patched console_router
+        import extensions.ext_fastopenapi
+
+        importlib.reload(extensions.ext_fastopenapi)
+
+        yield
+
+
+def _force_reload_module(target_module: str, alias_module: str):
+    """
+    Forces a reload of the specified module and handles sys.modules aliasing.
+
+    Why reload?
+    Python decorators (like @route, @login_required) run at IMPORT time.
+    To apply our patches (mocks/no-ops) to these decorators, we must re-import
+    the module while the patches are active.
+
+    Why alias?
+    If 'ext_fastopenapi' imports the controller as 'api.controllers...', but we import
+    it as 'controllers...', Python treats them as two separate modules. This causes:
+    1. Double execution of decorators (registering routes twice -> AssertionError).
+    2. Type mismatch errors (Class A from module X is not Class A from module Y).
+
+    This function ensures both names point to the SAME loaded module instance.
+    """
+    # 1. Clean existing entries to force re-import
+    if target_module in sys.modules:
+        del sys.modules[target_module]
+    if alias_module in sys.modules:
+        del sys.modules[alias_module]
+
+    # 2. Import the module (triggering decorators with active patches)
+    module = importlib.import_module(target_module)
+
+    # 3. Alias the module in sys.modules to prevent double loading
+    sys.modules[alias_module] = sys.modules[target_module]
+
+    return module
+
+
+def _cleanup_modules(target_module: str, alias_module: str):
+    """
+    Removes the module and its alias from sys.modules to prevent side effects
+    on other tests.
+    """
+    if target_module in sys.modules:
+        del sys.modules[target_module]
+    if alias_module in sys.modules:
+        del sys.modules[alias_module]
+
+
+@pytest.fixture
+def mock_feature_module_env():
+    """
+    Sets up a mocked environment for the feature module.
+
+    This fixture orchestrates:
+    1. Creating an isolated router.
+    2. Patching authentication and global dependencies.
+    3. Reloading the controller module to apply patches to decorators.
+    4. cleaning up sys.modules afterwards.
+    """
+    target_module = "controllers.console.feature"
+    alias_module = "api.controllers.console.feature"
+
+    # 1. Prepare isolated router
+    temp_router = _create_isolated_router()
+
+    # 2. Apply patches
+    try:
+        with _patch_auth_and_router(temp_router):
+            # 3. Reload module to register routes on the temp_router
+            feature_module = _force_reload_module(target_module, alias_module)
+
+            yield feature_module
+
+    finally:
+        # 4. Teardown: Clean up sys.modules
+        _cleanup_modules(target_module, alias_module)
+
+
+# ------------------------------------------------------------------------------
+# Test Cases
+# ------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "service_mock_path", "mock_model_instance"),
+    [
+        (
+            "/console/api/features",
+            "controllers.console.feature.FeatureService.get_features",
+            FeatureModel(can_replace_logo=True),
+        ),
+        (
+            "/console/api/system-features",
+            "controllers.console.feature.FeatureService.get_system_features",
+            SystemFeatureModel(enable_marketplace=True),
+        ),
+    ],
+)
+def test_console_features_success(app, mock_feature_module_env, url, service_mock_path, mock_model_instance):
+    """
+    Tests that the feature APIs return a 200 OK status and correct JSON structure.
+    """
+    # Patch the service layer to return our mock model instance
+    with patch(service_mock_path, return_value=mock_model_instance):
+        # Initialize the API extension
+        ext_fastopenapi.init_app(app)
+
+        client = app.test_client()
+        response = client.get(url)
+
+    # Assertions
+    assert response.status_code == 200, f"Request failed with status {response.status_code}: {response.text}"
+
+    # Verify the JSON response matches the Pydantic model dump (flat format, not wrapped)
+    expected_data = mock_model_instance.model_dump(mode="json")
+    assert response.get_json() == expected_data
+
+
+@pytest.mark.parametrize(
+    ("url", "service_mock_path"),
+    [
+        ("/console/api/features", "controllers.console.feature.FeatureService.get_features"),
+        ("/console/api/system-features", "controllers.console.feature.FeatureService.get_system_features"),
+    ],
+)
+def test_console_features_service_error(app, mock_feature_module_env, url, service_mock_path):
+    """
+    Tests how the application handles Service layer errors.
+
+    Note: When an exception occurs in the view, it is typically caught by the framework
+    (Flask or the OpenAPI wrapper) and converted to a 500 error response.
+    This test verifies that the application returns a 500 status code.
+    """
+    # Simulate a service failure
+    with patch(service_mock_path, side_effect=ValueError("Service Failure")):
+        ext_fastopenapi.init_app(app)
+        client = app.test_client()
+
+        # When an exception occurs in the view, it is typically caught by the framework
+        # (Flask or the OpenAPI wrapper) and converted to a 500 error response.
+        response = client.get(url)
+
+        assert response.status_code == 500
+        # Check if the error details are exposed in the response (depends on error handler config)
+        # We accept either generic 500 or the specific error message
+        assert "Service Failure" in response.text or "Internal Server Error" in response.text
+
+
+def test_system_features_unauthenticated(app, mock_feature_module_env):
+    """
+    Tests that /console/api/system-features endpoint works without authentication.
+
+    This test verifies the try-except block in get_system_features that handles
+    unauthenticated requests by passing is_authenticated=False to the service layer.
+    """
+    feature_module = mock_feature_module_env
+
+    # Override the behavior of the current_user mock
+    # The fixture patched 'libs.login.current_user', so 'controllers.console.feature.current_user'
+    # refers to that same Mock object.
+    mock_user = feature_module.current_user
+
+    # Simulate property access raising Unauthorized
+    # Note: We must reset side_effect if it was set, or set it here.
+    # The fixture initialized it as MagicMock(is_authenticated=True).
+    # We want type(mock_user).is_authenticated to raise Unauthorized.
+    type(mock_user).is_authenticated = PropertyMock(side_effect=Unauthorized)
+
+    # Patch the service layer for this specific test
+    with patch("controllers.console.feature.FeatureService.get_system_features") as mock_service:
+        # Setup mock service return value
+        mock_model = SystemFeatureModel(enable_marketplace=True)
+        mock_service.return_value = mock_model
+
+        # Initialize app
+        ext_fastopenapi.init_app(app)
+        client = app.test_client()
+
+        # Act
+        response = client.get("/console/api/system-features")
+
+        # Assert
+        assert response.status_code == 200, f"Request failed: {response.text}"
+
+        # Verify service was called with is_authenticated=False
+        mock_service.assert_called_once_with(is_authenticated=False)
+
+        # Verify response body (flat format, not wrapped)
+        expected_data = mock_model.model_dump(mode="json")
+        assert response.get_json() == expected_data
+
+
+# ------------------------------------------------------------------------------
+# FastOpenAPI Authentication Tests
+# ------------------------------------------------------------------------------
+# These tests verify that our fixes for FastOpenAPI routing work correctly:
+# 1. load_user_from_request supports FastOpenAPI routes (no blueprint)
+# 2. unauthorized_handler returns serializable response for FastOpenAPI routes
+# 3. Response format is flat (not wrapped in {"features": ...})
+
+
+class TestFastOpenAPIAuthenticationBehavior:
+    """
+    Tests for FastOpenAPI-specific authentication behavior.
+    
+    Unlike the tests above that mock authentication decorators,
+    these tests verify the actual authentication flow works correctly
+    for FastOpenAPI routes where request.blueprint is None.
+    """
+
+    @pytest.fixture
+    def app_with_login_manager(self):
+        """
+        Creates a Flask app with login manager configured,
+        simulating the production environment more closely.
+        """
+        from flask_login import LoginManager
+        
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret"
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        
+        # Initialize database
+        db.init_app(app)
+        
+        # Initialize login manager with unauthorized handler that matches our fix
+        login_manager = LoginManager()
+        login_manager.init_app(app)
+        
+        @login_manager.unauthorized_handler
+        def test_unauthorized_handler():
+            """Simulates our fixed unauthorized_handler behavior."""
+            from flask import request
+            # For FastOpenAPI routes, raise exception (serializable by orjson)
+            if request.blueprint is None and request.path.startswith("/console/api/"):
+                raise Unauthorized("Unauthorized.")
+            # For Blueprint routes, return Response (legacy behavior)
+            from flask import Response
+            import json
+            return Response(
+                json.dumps({"code": "unauthorized", "message": "Unauthorized."}),
+                status=401,
+                content_type="application/json",
+            )
+        
+        return app
+
+    def test_fastopenapi_route_has_no_blueprint(self, app_with_login_manager, fix_method_view_issue):
+        """
+        Verify that FastOpenAPI routes have request.blueprint == None.
+        
+        This is the core assumption our authentication fix relies on.
+        """
+        captured_blueprint = {}
+        
+        # Create a simple test route to capture request.blueprint
+        @app_with_login_manager.route("/console/api/test-blueprint")
+        def test_route():
+            from flask import request
+            captured_blueprint["value"] = request.blueprint
+            return {"status": "ok"}
+        
+        client = app_with_login_manager.test_client()
+        response = client.get("/console/api/test-blueprint")
+        
+        assert response.status_code == 200
+        # FastOpenAPI routes registered directly on app have no blueprint
+        assert captured_blueprint["value"] is None
+
+    def test_unauthorized_response_is_serializable_json(self, app_with_login_manager, fix_method_view_issue):
+        """
+        Verify that unauthorized response for FastOpenAPI routes is valid JSON.
+        
+        When unauthorized_handler raises Unauthorized exception for FastOpenAPI routes,
+        Flask/Werkzeug converts it to a proper HTTP 401 response that is serializable.
+        """
+        @app_with_login_manager.route("/console/api/protected")
+        def protected_route():
+            # Simulate login_required behavior when user is not authenticated
+            raise Unauthorized("Unauthorized.")
+        
+        client = app_with_login_manager.test_client()
+        response = client.get("/console/api/protected")
+        
+        assert response.status_code == 401
+        # Response should be valid (either JSON or HTML error page, but not a serialization error)
+        assert response.data is not None
+        # Should not be a TypeError from orjson trying to serialize Response object
+        assert b"TypeError" not in response.data
+
+    def test_response_format_is_flat_not_wrapped(self, app, mock_feature_module_env):
+        """
+        Explicitly verify that response format is flat FeatureModel,
+        not wrapped in {"features": {...}}.
+        
+        This ensures backward compatibility with frontend expectations.
+        """
+        mock_model = FeatureModel(can_replace_logo=True, billing=None)
+        
+        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
+            ext_fastopenapi.init_app(app)
+            client = app.test_client()
+            response = client.get("/console/api/features")
+        
+        assert response.status_code == 200
+        json_data = response.get_json()
+        
+        # Should NOT be wrapped format
+        assert "features" not in json_data or not isinstance(json_data.get("features"), dict)
+        
+        # Should be flat format - top level keys are FeatureModel fields
+        assert "can_replace_logo" in json_data
+
+
+# ------------------------------------------------------------------------------
+# Response Format and Content-Type Tests
+# ------------------------------------------------------------------------------
+# These tests verify OpenAPI v3 migration requirements for response handling
+
+
+class TestResponseFormatValidation:
+    """
+    Tests for response format validation.
+    
+    Ensures FastOpenAPI produces correct Content-Type headers and JSON format
+    that matches OpenAPI 3.0 specification requirements.
+    """
+
+    def test_response_content_type_is_json(self, app, mock_feature_module_env):
+        """
+        Verify response Content-Type is application/json.
+        
+        FastOpenAPI uses orjson for serialization, must produce correct Content-Type.
+        """
+        mock_model = FeatureModel(can_replace_logo=True)
+        
+        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
+            ext_fastopenapi.init_app(app)
+            client = app.test_client()
+            response = client.get("/console/api/features")
+        
+        assert response.status_code == 200
+        # Content-Type should be JSON
+        assert "application/json" in response.content_type
+
+    def test_system_features_content_type_is_json(self, app, mock_feature_module_env):
+        """
+        Verify /system-features response Content-Type is application/json.
+        """
+        mock_model = SystemFeatureModel(enable_marketplace=True)
+        
+        with patch("controllers.console.feature.FeatureService.get_system_features", return_value=mock_model):
+            ext_fastopenapi.init_app(app)
+            client = app.test_client()
+            response = client.get("/console/api/system-features")
+        
+        assert response.status_code == 200
+        assert "application/json" in response.content_type
+
+    def test_feature_model_all_fields_serialized(self, app, mock_feature_module_env):
+        """
+        Verify all FeatureModel fields are serialized in response.
+        
+        This ensures Pydantic model dump is complete for OpenAPI schema compliance.
+        """
+        mock_model = FeatureModel(
+            can_replace_logo=True,
+            model_load_balancing_enabled=True,
+        )
+        
+        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
+            ext_fastopenapi.init_app(app)
+            client = app.test_client()
+            response = client.get("/console/api/features")
+        
+        assert response.status_code == 200
+        json_data = response.get_json()
+        
+        # Verify key fields are present
+        assert "can_replace_logo" in json_data
+        assert json_data["can_replace_logo"] is True
+        assert "model_load_balancing_enabled" in json_data
+        assert json_data["model_load_balancing_enabled"] is True
+
+
+# ------------------------------------------------------------------------------
+# Authentication Behavior Tests with Realistic Mocking
+# ------------------------------------------------------------------------------
+# These tests use more realistic mocking to verify authentication behavior
+
+
+class TestAuthenticationWithRealisticMocking:
+    """
+    Tests authentication behavior with more realistic mocking.
+    
+    Unlike tests that completely bypass decorators, these tests mock
+    at the user/account level to verify decorator behavior.
+    """
+
+    @pytest.fixture
+    def app_with_real_decorators(self, monkeypatch):
+        """
+        Creates a Flask app where decorators execute but dependencies are mocked.
+        
+        This provides a middle ground between:
+        - Full integration tests (require database setup)
+        - Tests that completely bypass decorators (don't test auth flow)
+        """
+        from flask import Flask
+        from flask_login import LoginManager
+        
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret"
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        
+        # Initialize database
+        db.init_app(app)
+        
+        # Initialize login manager
+        login_manager = LoginManager()
+        login_manager.init_app(app)
+        
+        # Mock request loader to return None (unauthenticated)
+        @login_manager.request_loader
+        def mock_load_user(request):
+            # Check for test auth header
+            auth_header = request.headers.get("Authorization")
+            if auth_header and auth_header.startswith("Bearer test-valid-token"):
+                # Return a mock user
+                mock_user = MagicMock()
+                mock_user.is_authenticated = True
+                mock_user.current_tenant_id = "test-tenant-id"
+                return mock_user
+            return None
+        
+        @login_manager.unauthorized_handler
+        def handle_unauthorized():
+            """Simulates production unauthorized_handler for FastOpenAPI routes."""
+            from flask import request
+            if request.blueprint is None and request.path.startswith("/console/api/"):
+                raise Unauthorized("Unauthorized.")
+            from flask import Response
+            import json
+            return Response(
+                json.dumps({"code": "unauthorized", "message": "Unauthorized."}),
+                status=401,
+                content_type="application/json",
+            )
+        
+        return app
+
+    def test_features_endpoint_requires_authentication_concept(self, app_with_real_decorators, fix_method_view_issue):
+        """
+        Conceptual test: verify that a protected route would return 401 without auth.
+        
+        Note: This test creates a simple protected route to verify the auth flow,
+        since the actual feature.py module loading is complex.
+        """
+        from flask_login import login_required as flask_login_required
+        
+        @app_with_real_decorators.route("/console/api/test-protected")
+        @flask_login_required
+        def protected_test_route():
+            return {"status": "authenticated"}
+        
+        client = app_with_real_decorators.test_client()
+        
+        # Without authentication - should return 401
+        response = client.get("/console/api/test-protected")
+        assert response.status_code == 401
+        
+        # With valid test token - should return 200
+        response_with_auth = client.get(
+            "/console/api/test-protected",
+            headers={"Authorization": "Bearer test-valid-token"}
+        )
+        assert response_with_auth.status_code == 200
+
+    def test_system_features_no_auth_decorator_concept(self, app_with_real_decorators, fix_method_view_issue):
+        """
+        Conceptual test: verify that an unprotected route works without auth.
+        
+        This mirrors /system-features behavior which has no @login_required.
+        """
+        @app_with_real_decorators.route("/console/api/test-public")
+        def public_test_route():
+            return {"status": "public"}
+        
+        client = app_with_real_decorators.test_client()
+        
+        # Without authentication - should still work
+        response = client.get("/console/api/test-public")
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "public"
+
+
+# ------------------------------------------------------------------------------
+# OpenAPI Schema Compliance Tests
+# ------------------------------------------------------------------------------
+# These tests verify the generated OpenAPI schema meets requirements
+
+
+class TestOpenAPISchemaCompliance:
+    """
+    Tests for OpenAPI 3.0 schema compliance.
+    
+    Verifies that FastOpenAPI generates correct schema for endpoints.
+    """
+
+    def test_fastopenapi_registers_routes_correctly(self, app, mock_feature_module_env):
+        """
+        Verify that FastOpenAPI registers routes with correct paths.
+        """
+        ext_fastopenapi.init_app(app)
+        
+        # Check that routes are registered
+        rules = {rule.rule for rule in app.url_map.iter_rules()}
+        
+        # Feature endpoints should be registered
+        assert "/console/api/features" in rules
+        assert "/console/api/system-features" in rules
+
+    def test_fastopenapi_routes_use_get_method(self, app, mock_feature_module_env):
+        """
+        Verify that feature endpoints only accept GET method.
+        """
+        mock_model = FeatureModel(can_replace_logo=True)
+        
+        with patch("controllers.console.feature.FeatureService.get_features", return_value=mock_model):
+            ext_fastopenapi.init_app(app)
+            client = app.test_client()
+            
+            # GET should work
+            response_get = client.get("/console/api/features")
+            assert response_get.status_code == 200
+            
+            # POST should return 405 Method Not Allowed
+            response_post = client.post("/console/api/features")
+            assert response_post.status_code == 405
+
+    def test_system_features_handles_both_auth_states(self, app, mock_feature_module_env):
+        """
+        Verify /system-features correctly handles both authenticated and unauthenticated states.
+        
+        This is a critical test for the is_authenticated try-catch logic.
+        """
+        feature_module = mock_feature_module_env
+        
+        # Test 1: When user is authenticated
+        with patch("controllers.console.feature.FeatureService.get_system_features") as mock_service:
+            mock_model = SystemFeatureModel(enable_marketplace=True)
+            mock_service.return_value = mock_model
+            
+            # Reset mock to authenticated state
+            type(feature_module.current_user).is_authenticated = PropertyMock(return_value=True)
+            
+            ext_fastopenapi.init_app(app)
+            client = app.test_client()
+            response = client.get("/console/api/system-features")
+            
+            assert response.status_code == 200
+            # Service should be called with is_authenticated=True
+            mock_service.assert_called_with(is_authenticated=True)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Update load_user_from_request to support FastOpenAPI routes

Change unauthorized_handler to raise exception rather than return Response

Add integration tests to verify authentication flow

Fix return type incompatibility

@asukaminato0721

I have encountered the same issue reported in #31887 and have a proposed solution. I hope this helps.

Here is a detailed description of the problems:

Problem 1: request.blueprint dependency in Authentication Dify's authentication system (at ext_login.py:51) relies on request.blueprint to determine how to load the user. However, for routes registered via FastOpenAPI, request.blueprint is None. As a result, the authentication logic is completely bypassed, and current_user is not loaded.

Problem 2: Incompatible return types in error handling When login_required detects an unauthenticated user (api/libs/login.py:80), the unauthorized_handler (api/extensions/ext_login.py:117-123) returns a standard Flask Response object. Since FastOpenAPI uses orjson for serialization, it fails to serialize the Flask Response object, leading to a TypeError.

The following are the solutions:

Issue 1: Blueprint Registration Issue

In ext_login.py (lines 51-53), the PR adds a path check to support FastOpenAPI routes:
```python
# Before
if request.blueprint in {"console", "inner_api"}:

# After
is_console_api = request.blueprint in {"console", "inner_api"} or request.path.startswith("/console/api/")
if is_console_api:
```

This ensures that even if request.blueprint is None (which is the case for FastOpenAPI routes), the authentication logic will still execute as long as the path starts with /console/api/.

Issue 2: Serialization Error Caused by Authentication Failure

In api/extensions/ext_login.py (lines 127-131), the unauthorized_handler now raises an exception for FastOpenAPI routes instead of returning a Response object:

```python
# FastOpenAPI routes: Raise exception (serializable by orjson)
if request.blueprint is None and request.path.startswith("/console/api/"):
    raise Unauthorized("Unauthorized.")
# Blueprint routes: Return Response (retain original behavior)
return Response(...
```

The system-features endpoint is not decorated with @login_required, so it does not trigger the unauthorized_handler. It handles the authentication check via a try-catch block (lines 49-52). When current_user.is_authenticated raises Unauthorized, the exception is caught, and is_authenticated is set to False.

The workflow is as follows:

- Request without token -> /console/api/system-features

- The endpoint lacks the @login_required decorator, so execution enters the function body directly.

- Accessing current_user.is_authenticated triggers load_user_from_request.

- load_user_from_request raises Unauthorized due to the missing token.

- The endpoint's try-catch block catches the exception and sets is_authenticated=False.

- Returns a streamlined system configuration (excluding sensitive license information).

This aligns with the original design, allowing the frontend login page to successfully retrieve SSO/OAuth configurations.



## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
