### PR TITLE
feat: pre-cache all the plugin manifests before checking updates

### DIFF
--- a/api/core/helper/marketplace.py
+++ b/api/core/helper/marketplace.py
@@ -6,7 +6,7 @@ from yarl import URL
 
 from configs import dify_config
 from core.helper.download import download_with_size_limit
-from core.plugin.entities.marketplace import MarketplacePluginDeclaration, MarketplacePluginSnapshot
+from core.plugin.entities.marketplace import MarketplacePluginDeclaration
 
 marketplace_api_url = URL(str(dify_config.MARKETPLACE_API_URL))
 logger = logging.getLogger(__name__)

--- a/api/core/helper/marketplace.py
+++ b/api/core/helper/marketplace.py
@@ -43,27 +43,6 @@ def batch_fetch_plugin_by_ids(plugin_ids: list[str]) -> list[dict]:
     return data.get("data", {}).get("plugins", [])
 
 
-def batch_fetch_plugin_manifests_ignore_deserialization_error(
-    plugin_ids: list[str],
-) -> Sequence[MarketplacePluginSnapshot]:
-    if len(plugin_ids) == 0:
-        return []
-
-    url = str(marketplace_api_url / "api/v1/plugins/batch")
-    response = httpx.post(url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version})
-    response.raise_for_status()
-    result: list[MarketplacePluginSnapshot] = []
-    for plugin in response.json()["data"]["plugins"]:
-        try:
-            result.append(MarketplacePluginSnapshot.model_validate(plugin))
-        except Exception:
-            logger.exception(
-                "Failed to deserialize marketplace plugin manifest for %s", plugin.get("plugin_id", "unknown")
-            )
-
-    return result
-
-
 def record_install_plugin_event(plugin_unique_identifier: str):
     url = str(marketplace_api_url / "api/v1/stats/plugins/install_count")
     response = httpx.post(url, json={"unique_identifier": plugin_unique_identifier})

--- a/api/core/helper/marketplace.py
+++ b/api/core/helper/marketplace.py
@@ -6,7 +6,8 @@ from yarl import URL
 
 from configs import dify_config
 from core.helper.download import download_with_size_limit
-from core.plugin.entities.marketplace import MarketplacePluginDeclaration
+from core.plugin.entities.marketplace import MarketplacePluginDeclaration, MarketplacePluginSnapshot
+from extensions.ext_redis import redis_client
 
 marketplace_api_url = URL(str(dify_config.MARKETPLACE_API_URL))
 logger = logging.getLogger(__name__)
@@ -47,3 +48,33 @@ def record_install_plugin_event(plugin_unique_identifier: str):
     url = str(marketplace_api_url / "api/v1/stats/plugins/install_count")
     response = httpx.post(url, json={"unique_identifier": plugin_unique_identifier})
     response.raise_for_status()
+
+
+def fetch_global_plugin_manifest(cache_key_prefix: str, cache_ttl: int) -> None:
+    """
+    Fetch all plugin manifests from marketplace and cache them in Redis.
+    This should be called once per check cycle to populate the instance-level cache.
+
+    Args:
+        cache_key_prefix: Redis key prefix for caching plugin manifests
+        cache_ttl: Cache TTL in seconds
+
+    Raises:
+        httpx.HTTPError: If the HTTP request fails
+        Exception: If any other error occurs during fetching or caching
+    """
+    url = str(marketplace_api_url / "api/v1/dist/plugins/manifest.json")
+    response = httpx.get(url, headers={"X-Dify-Version": dify_config.project.version}, timeout=30)
+    response.raise_for_status()
+
+    raw_json = response.json()
+    plugins_data = raw_json.get("plugins", [])
+
+    # Parse and cache all plugin snapshots
+    for plugin_data in plugins_data:
+        plugin_snapshot = MarketplacePluginSnapshot.model_validate(plugin_data)
+        redis_client.setex(
+            name=f"{cache_key_prefix}{plugin_snapshot.plugin_id}",
+            time=cache_ttl,
+            value=plugin_snapshot.model_dump_json(),
+        )

--- a/api/core/helper/marketplace.py
+++ b/api/core/helper/marketplace.py
@@ -6,7 +6,7 @@ from yarl import URL
 
 from configs import dify_config
 from core.helper.download import download_with_size_limit
-from core.plugin.entities.marketplace import MarketplacePluginDeclaration
+from core.plugin.entities.marketplace import MarketplacePluginDeclaration, MarketplacePluginSnapshot
 
 marketplace_api_url = URL(str(dify_config.MARKETPLACE_API_URL))
 logger = logging.getLogger(__name__)
@@ -45,17 +45,17 @@ def batch_fetch_plugin_by_ids(plugin_ids: list[str]) -> list[dict]:
 
 def batch_fetch_plugin_manifests_ignore_deserialization_error(
     plugin_ids: list[str],
-) -> Sequence[MarketplacePluginDeclaration]:
+) -> Sequence[MarketplacePluginSnapshot]:
     if len(plugin_ids) == 0:
         return []
 
     url = str(marketplace_api_url / "api/v1/plugins/batch")
     response = httpx.post(url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version})
     response.raise_for_status()
-    result: list[MarketplacePluginDeclaration] = []
+    result: list[MarketplacePluginSnapshot] = []
     for plugin in response.json()["data"]["plugins"]:
         try:
-            result.append(MarketplacePluginDeclaration.model_validate(plugin))
+            result.append(MarketplacePluginSnapshot.model_validate(plugin))
         except Exception:
             logger.exception(
                 "Failed to deserialize marketplace plugin manifest for %s", plugin.get("plugin_id", "unknown")

--- a/api/core/plugin/entities/marketplace.py
+++ b/api/core/plugin/entities/marketplace.py
@@ -58,6 +58,5 @@ class MarketplacePluginSnapshot(BaseModel):
     latest_package_url: str
 
     @computed_field
-    @property
     def plugin_id(self) -> str:
         return f"{self.org}/{self.name}"

--- a/api/core/plugin/entities/marketplace.py
+++ b/api/core/plugin/entities/marketplace.py
@@ -60,4 +60,4 @@ class MarketplacePluginSnapshot(BaseModel):
     @computed_field
     @property
     def plugin_id(self) -> str:
-        return self.latest_package_identifier.split(":")[0]
+        return f"{self.org}/{self.name}"

--- a/api/core/plugin/entities/marketplace.py
+++ b/api/core/plugin/entities/marketplace.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 from core.model_runtime.entities.provider_entities import ProviderEntity
 from core.plugin.entities.endpoint import EndpointProviderDeclaration
@@ -48,3 +48,16 @@ class MarketplacePluginDeclaration(BaseModel):
         if "tool" in data and not data["tool"]:
             del data["tool"]
         return data
+
+
+class MarketplacePluginSnapshot(BaseModel):
+    org: str
+    name: str
+    latest_version: str
+    latest_package_identifier: str
+    latest_package_url: str
+
+    @computed_field
+    @property
+    def plugin_id(self) -> str:
+        return self.latest_package_identifier.split(":")[0]

--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -1,16 +1,23 @@
+import logging
 import math
 import time
 
 import click
 
 import app
+from core.helper.marketplace import fetch_global_plugin_manifest
 from extensions.ext_database import db
 from models.account import TenantPluginAutoUpgradeStrategy
 from tasks import process_tenant_plugin_autoupgrade_check_task as check_task
-from tasks.process_tenant_plugin_autoupgrade_check_task import fetch_global_plugin_manifest
+
+logger = logging.getLogger(__name__)
 
 AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL = 15 * 60  # 15 minutes
 MAX_CONCURRENT_CHECK_TASKS = 20
+
+# Import cache constants from the task module
+CACHE_REDIS_KEY_PREFIX = check_task.CACHE_REDIS_KEY_PREFIX
+CACHE_REDIS_TTL = check_task.CACHE_REDIS_TTL
 
 
 @app.celery.task(queue="plugin")
@@ -42,15 +49,19 @@ def check_upgradable_plugin_task():
     batch_interval_time = (AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL / batch_chunk_count) if batch_chunk_count > 0 else 0
 
     if total_strategies == 0:
-        click.echo(click.style("No strategies to process, skipping plugin manifest fetch.", fg="green"))
+        click.echo(click.style("no strategies to process, skipping plugin manifest fetch.", fg="green"))
         return
+
     # Fetch and cache all plugin manifests before processing tenants
     # This reduces load on marketplace from 300k requests to 1 request per check cycle
+    logger.info("fetching global plugin manifest from marketplace")
     try:
-        fetch_global_plugin_manifest()
+        fetch_global_plugin_manifest(CACHE_REDIS_KEY_PREFIX, CACHE_REDIS_TTL)
+        logger.info("successfully fetched and cached global plugin manifest")
     except Exception as e:
-        click.echo(click.style(f"Failed to fetch global plugin manifest: {e}", fg="red"))
-        click.echo(click.style("Skipping plugin upgrade check for this cycle", fg="yellow"))
+        logger.exception("failed to fetch global plugin manifest")
+        click.echo(click.style(f"failed to fetch global plugin manifest: {e}", fg="red"))
+        click.echo(click.style("skipping plugin upgrade check for this cycle", fg="yellow"))
         return
 
     for i in range(0, total_strategies, MAX_CONCURRENT_CHECK_TASKS):

--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -7,6 +7,7 @@ import app
 from extensions.ext_database import db
 from models.account import TenantPluginAutoUpgradeStrategy
 from tasks import process_tenant_plugin_autoupgrade_check_task as check_task
+from tasks.process_tenant_plugin_autoupgrade_check_task import fetch_global_plugin_manifest
 
 AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL = 15 * 60  # 15 minutes
 MAX_CONCURRENT_CHECK_TASKS = 20
@@ -39,6 +40,8 @@ def check_upgradable_plugin_task():
         total_strategies / MAX_CONCURRENT_CHECK_TASKS
     )  # make sure all strategies are checked in this interval
     batch_interval_time = (AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL / batch_chunk_count) if batch_chunk_count > 0 else 0
+
+    fetch_global_plugin_manifest()
 
     for i in range(0, total_strategies, MAX_CONCURRENT_CHECK_TASKS):
         batch_strategies = strategies[i : i + MAX_CONCURRENT_CHECK_TASKS]

--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -41,6 +41,9 @@ def check_upgradable_plugin_task():
     )  # make sure all strategies are checked in this interval
     batch_interval_time = (AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL / batch_chunk_count) if batch_chunk_count > 0 else 0
 
+    if total_strategies == 0:
+        click.echo(click.style("No strategies to process, skipping plugin manifest fetch.", fg="green"))
+        return
     # Fetch and cache all plugin manifests before processing tenants
     # This reduces load on marketplace from 300k requests to 1 request per check cycle
     try:

--- a/api/tasks/process_tenant_plugin_autoupgrade_check_task.py
+++ b/api/tasks/process_tenant_plugin_autoupgrade_check_task.py
@@ -62,7 +62,8 @@ def marketplace_batch_fetch_plugin_manifests(
     # Check Redis cache for each plugin
     for plugin_id in plugin_ids_plain_list:
         cached_result = _get_cached_manifest(plugin_id)
-        if cached_result is False or cached_result is None:
+        if not isinstance(cached_result, MarketplacePluginSnapshot):
+            # cached_result is False (not in cache) or None (cached as not found)
             logger.warning("plugin %s not found in cache, skipping", plugin_id)
             continue
 

--- a/api/tasks/process_tenant_plugin_autoupgrade_check_task.py
+++ b/api/tasks/process_tenant_plugin_autoupgrade_check_task.py
@@ -119,6 +119,7 @@ def marketplace_batch_fetch_plugin_manifests(
 
     return result
 
+
 def fetch_global_plugin_manifest():
     url = str(marketplace_api_url / "api/v1/dist/plugins/manifest.json")
     response = httpx.get(url, headers={"X-Dify-Version": dify_config.project.version}, timeout=30)
@@ -131,6 +132,7 @@ def fetch_global_plugin_manifest():
             time=CACHE_REDIS_TTL,
             value=plugin_snapshot.model_dump_json(),
         )
+
 
 @shared_task(queue="plugin")
 def process_tenant_plugin_autoupgrade_check_task(

--- a/api/tasks/process_tenant_plugin_autoupgrade_check_task.py
+++ b/api/tasks/process_tenant_plugin_autoupgrade_check_task.py
@@ -72,7 +72,7 @@ def marketplace_batch_fetch_plugin_manifests(
             # Cached as None - plugin was not found in marketplace
             logger.debug("Plugin %s was cached as not found in marketplace", plugin_id)
             continue
-        else:
+        elif isinstance(cached_result, MarketplacePluginSnapshot):
             # Found valid manifest in cache
             result.append(cached_result)
 


### PR DESCRIPTION
## Summary

Pre-cache all the plugin manifests before checking updates.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
