### PR TITLE
perf(api): Optimize the response time of AppListApi endpoint

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from datetime import datetime
 from typing import Any, Literal, TypeAlias
@@ -53,6 +54,8 @@ from services.feature_service import FeatureService
 ALLOW_CREATE_APP_MODES = ["chat", "agent-chat", "advanced-chat", "workflow", "completion"]
 
 register_enum_models(console_ns, IconType)
+
+_logger = logging.getLogger(__name__)
 
 
 class AppListQuery(BaseModel):
@@ -511,12 +514,14 @@ class AppListApi(Resource):
                 NodeType.TRIGGER_PLUGIN,
             }
             for workflow in draft_workflows:
+                node_id = None
                 try:
-                    for _, node_data in workflow.walk_nodes():
+                    for node_id, node_data in workflow.walk_nodes():
                         if node_data.get("type") in trigger_node_types:
                             draft_trigger_app_ids.add(str(workflow.app_id))
                             break
                 except Exception:
+                    _logger.exception("error while walking nodes, workflow_id=%s, node_id=%s", workflow.id, node_id)
                     continue
 
         for app in app_pagination.items:

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -499,6 +499,7 @@ class AppListApi(Resource):
                     select(Workflow).where(
                         Workflow.version == Workflow.VERSION_DRAFT,
                         Workflow.app_id.in_(workflow_capable_app_ids),
+                        Workflow.tenant_id == current_tenant_id,
                     )
                 )
                 .scalars()


### PR DESCRIPTION
## Summary

Query workflow with `current_tenant_id` to ensure the index `workflow_version_idx` can be fully utilized.

Closes #31998

## Screenshots

<img width="1147" height="328" alt="image" src="https://github.com/user-attachments/assets/7de98294-7dac-4074-9abe-0a725f079e6d" />

Executed SQL:

```
2026-02-05 10:11:51,221 INFO sqlalchemy.engine.Engine SELECT workflows.id, workflows.tenant_id, workflows.app_id, workflows.type, workflows.version, workflows.marked_name, workflows.marked_comment, workflows.graph, workflows.features, workflows.created_by, workflows.created_at, workflows.updated_by, workflows.updated_at, workflows.environment_variables, workflows.conversation_variables, workflows.rag_pipeline_variables 
FROM workflows 
WHERE workflows.version = %(version_1)s AND workflows.app_id IN (%(app_id_1_1)s::UUID, %(app_id_1_2)s::UUID, %(app_id_1_3)s::UUID, %(app_id_1_4)s::UUID, %(app_id_1_5)s::UUID, %(app_id_1_6)s::UUID, %(app_id_1_7)s::UUID, %(app_id_1_8)s::UUID, %(app_id_1_9)s::UUID, %(app_id_1_10)s::UUID, %(app_id_1_11)s::UUID, %(app_id_1_12)s::UUID, %(app_id_1_13)s::UUID, %(app_id_1_14)s::UUID, %(app_id_1_15)s::UUID, %(app_id_1_16)s::UUID, %(app_id_1_17)s::UUID, %(app_id_1_18)s::UUID, %(app_id_1_19)s::UUID, %(app_id_1_20)s::UUID, %(app_id_1_21)s::UUID, %(app_id_1_22)s::UUID, %(app_id_1_23)s::UUID, %(app_id_1_24)s::UUID, %(app_id_1_25)s::UUID, %(app_id_1_26)s::UUID, %(app_id_1_27)s::UUID) AND workflows.tenant_id = %(tenant_id_1)s::UUID
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
