### PR TITLE
feat: add fallback method to extract content from docx

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -4,6 +4,8 @@ import json
 import logging
 import os
 import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -82,6 +84,7 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
             else:
                 raise DocumentExtractorError(f"Unsupported variable type: {type(value)}")
         except DocumentExtractorError as e:
+            logger.error(e, exc_info=True)
             return NodeRunResult(
                 status=WorkflowNodeExecutionStatus.FAILED,
                 error=str(e),
@@ -401,8 +404,41 @@ def _extract_text_from_docx(file_content: bytes) -> str:
 
         return "\n".join(text)
 
+    except KeyError as e:
+        error_msg = str(e)
+        error_msg_lower = error_msg.lower()
+        if "word/media" in error_msg_lower or "word/" in error_msg_lower:
+            logger.warning("DOCX file contains missing media references: %s. Using XML parsing fallback.", e)
+            return _extract_text_from_docx_xml_fallback(file_content)
+        raise TextExtractionError(f"Failed to extract text from DOCX: {str(e)}") from e
     except Exception as e:
         raise TextExtractionError(f"Failed to extract text from DOCX: {str(e)}") from e
+
+
+def _extract_text_from_docx_xml_fallback(file_content: bytes) -> str:
+    """
+    Extract text from corrupted DOCX by parsing XML directly.
+    This handles cases where the DOCX references missing media files.
+    """
+    text_content = []
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(file_content), "r") as z:
+            # Try to read document.xml directly
+            try:
+                xml_content = z.read("word/document.xml")
+                root = ET.fromstring(xml_content)
+
+                # Extract all text elements
+                for elem in root.iter("{http://schemas.openxmlformats.org/wordprocessingml/2006/main}t"):
+                    if elem.text:
+                        text_content.append(elem.text)
+            except KeyError:
+                raise TextExtractionError("Invalid DOCX structure: word/document.xml not found")
+    except Exception as e:
+        raise TextExtractionError(f"Failed to extract text from corrupted DOCX: {str(e)}") from e
+
+    return "\n".join(text_content)
 
 
 def _download_file_content(file: File) -> bytes:

--- a/api/tests/unit_tests/core/workflow/nodes/test_document_extractor_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_document_extractor_node.py
@@ -14,8 +14,10 @@ from core.workflow.entities import GraphInitParams
 from core.workflow.enums import NodeType, WorkflowNodeExecutionStatus
 from core.workflow.node_events import NodeRunResult
 from core.workflow.nodes.document_extractor import DocumentExtractorNode, DocumentExtractorNodeData
+from core.workflow.nodes.document_extractor.exc import TextExtractionError
 from core.workflow.nodes.document_extractor.node import (
     _extract_text_from_docx,
+    _extract_text_from_docx_xml_fallback,
     _extract_text_from_excel,
     _extract_text_from_pdf,
     _extract_text_from_plain_text,
@@ -211,6 +213,101 @@ def test_extract_text_from_docx(mock_document):
     mock_document.return_value.element = mock_element
     text = _extract_text_from_docx(b"PK\x03\x04")
     assert text == "Paragraph 1\nParagraph 2"
+
+
+def test_extract_text_from_docx_xml_fallback():
+    """Test extracting text from corrupted DOCX using XML parsing fallback."""
+    # Minimal DOCX document.xml content with text
+    document_xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+    <w:body>
+        <w:p>
+            <w:r>
+                <w:t>Hello World</w:t>
+            </w:r>
+        </w:p>
+        <w:p>
+            <w:r>
+                <w:t>This is a test</w:t>
+            </w:r>
+        </w:p>
+    </w:body>
+</w:document>"""
+
+    # Create a mock ZIP file structure
+    mock_zip = Mock()
+
+    def mock_read(path):
+        if path == "word/document.xml":
+            return document_xml
+        raise KeyError(f"File not found: {path}")
+
+    mock_zip.read.side_effect = mock_read
+    mock_zip.__enter__ = Mock(return_value=mock_zip)
+    mock_zip.__exit__ = Mock(return_value=False)
+
+    with patch("zipfile.ZipFile", return_value=mock_zip):
+        result = _extract_text_from_docx_xml_fallback(b"fake_docx_content")
+
+    # The function should extract text from <w:t> elements
+    assert "Hello World" in result
+    assert "This is a test" in result
+
+
+def test_extract_text_from_docx_xml_fallback_missing_document_xml():
+    """Test XML fallback when word/document.xml is missing."""
+    mock_zip = Mock()
+
+    def mock_read(path):
+        raise KeyError(f"File not found: {path}")
+
+    mock_zip.read.side_effect = mock_read
+    mock_zip.__enter__ = Mock(return_value=mock_zip)
+    mock_zip.__exit__ = Mock(return_value=False)
+
+    with patch("zipfile.ZipFile", return_value=mock_zip):
+        with pytest.raises(TextExtractionError) as exc_info:
+            _extract_text_from_docx_xml_fallback(b"fake_docx_content")
+
+    assert "Invalid DOCX structure" in str(exc_info.value)
+
+
+def test_extract_text_from_docx_xml_fallback_empty_text():
+    """Test XML fallback with empty text elements."""
+    # Document.xml with empty text elements
+    document_xml = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+    <w:body>
+        <w:p>
+            <w:r>
+                <w:t></w:t>
+            </w:r>
+        </w:p>
+        <w:p>
+            <w:r>
+                <w:t>Only this text</w:t>
+            </w:r>
+        </w:p>
+    </w:body>
+</w:document>"""
+
+    mock_zip = Mock()
+
+    def mock_read(path):
+        if path == "word/document.xml":
+            return document_xml
+        raise KeyError(f"File not found: {path}")
+
+    mock_zip.read.side_effect = mock_read
+    mock_zip.__enter__ = Mock(return_value=mock_zip)
+    mock_zip.__exit__ = Mock(return_value=False)
+
+    with patch("zipfile.ZipFile", return_value=mock_zip):
+        result = _extract_text_from_docx_xml_fallback(b"fake_docx_content")
+
+    # Should only contain non-empty text
+    assert "Only this text" in result
+    assert result.strip() == "Only this text"
 
 
 def test_node_type(document_extractor_node):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #31885

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

before


https://github.com/user-attachments/assets/8ff0d920-8121-4a35-aa9d-febd12c13c78



after


https://github.com/user-attachments/assets/daf606d8-a885-4151-9bec-e3d6031ef33e



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
