### PR TITLE
chore: remove .codex/skills directory

### DIFF
--- a/.codex/skills/component-refactoring
+++ b/.codex/skills/component-refactoring
@@ -1,1 +1,0 @@
-../../.agents/skills/component-refactoring

--- a/.codex/skills/frontend-code-review
+++ b/.codex/skills/frontend-code-review
@@ -1,1 +1,0 @@
-../../.agents/skills/frontend-code-review

--- a/.codex/skills/frontend-testing
+++ b/.codex/skills/frontend-testing
@@ -1,1 +1,0 @@
-../../.agents/skills/frontend-testing

--- a/.codex/skills/orpc-contract-first
+++ b/.codex/skills/orpc-contract-first
@@ -1,1 +1,0 @@
-../../.agents/skills/orpc-contract-first


### PR DESCRIPTION
## Summary

Removes the `.codex/skills` directory as requested.

## Changes

Deleted the following symlinks from `.codex/skills/`:
- `component-refactoring` → `../../.agents/skills/component-refactoring`
- `frontend-code-review` → `../../.agents/skills/frontend-code-review`
- `frontend-testing` → `../../.agents/skills/frontend-testing`
- `orpc-contract-first` → `../../.agents/skills/orpc-contract-first`

## Context

This directory appears to be auto-generated by Codex AI tooling and should not be committed to the repository. The symlinks reference a `.agents/skills/` directory that may not exist for all contributors.

Reference: https://x.com/embirico/status/2018415923930206718

## Related Issue

Fixes #31988