### PR TITLE
fix: metadata batch edit silently fails due to split transactions and swallowed exceptions

### DIFF
--- a/web/app/components/datasets/metadata/hooks/use-batch-edit-document-metadata.ts
+++ b/web/app/components/datasets/metadata/hooks/use-batch-edit-document-metadata.ts
@@ -71,6 +71,13 @@ const useBatchEditDocumentMetadata = ({
     return res
   }, [metaDataList])
 
+  const toCleanMetadataItem = (item: MetadataItemWithValue | MetadataItemWithEdit | MetadataItemInBatchEdit): MetadataItemWithValue => ({
+    id: item.id,
+    name: item.name,
+    type: item.type,
+    value: item.value ?? null,
+  })
+
   const formateToBackendList = (editedList: MetadataItemWithEdit[], addedList: MetadataItemInBatchEdit[], isApplyToAllSelectDocument: boolean) => {
     const updatedList = editedList.filter((editedItem) => {
       return editedItem.updateType === UpdateType.changeValue
@@ -92,24 +99,19 @@ const useBatchEditDocumentMetadata = ({
         .filter((item) => {
           return !removedList.find(removedItem => removedItem.id === item.id)
         })
-        .map(item => ({
-          id: item.id,
-          name: item.name,
-          type: item.type,
-          value: item.value,
-        }))
+        .map(toCleanMetadataItem)
       if (isApplyToAllSelectDocument) {
         // add missing metadata item
         updatedList.forEach((editedItem) => {
           if (!newMetadataList.find(i => i.id === editedItem.id) && !editedItem.isMultipleValue)
-            newMetadataList.push(editedItem)
+            newMetadataList.push(toCleanMetadataItem(editedItem))
         })
       }
 
       newMetadataList = newMetadataList.map((item) => {
         const editedItem = updatedList.find(i => i.id === item.id)
         if (editedItem)
-          return editedItem
+          return toCleanMetadataItem(editedItem)
         return item
       })
 


### PR DESCRIPTION
## Summary

Fixes #31964 - Metadata batch edit doesn't work. When batch editing document metadata, nothing happens because the backend silently succeeds even when the update actually fails.

**Root causes identified:**

- **Split transaction in backend**: The `update_documents_metadata` method committed `doc_metadata` JSON update and metadata binding management in two separate `db.session.commit()` calls. If the second commit failed (e.g., database error), the bindings were lost while the JSON was already committed, leaving data inconsistent -- `doc_metadata_details` (which joins via bindings) returned nothing even though the JSON had values.
- **Silent exception swallowing**: The `except Exception` clause caught all errors and only logged them, while the API still returned `{"result": "success"}`. The frontend showed a success toast, but nothing was actually updated.
- **Unclean frontend payload**: The frontend sent extra frontend-only fields (`updateType`, `isUpdated`, `isMultipleValue`) to the backend and could send `undefined` values instead of `null`.

**Changes:**

- Combine `doc_metadata` JSON update and binding management into a single atomic transaction so they succeed or fail together
- Add `db.session.rollback()` in the except block and re-raise exceptions so errors propagate to the API response (500) instead of being silently swallowed
- Sanitize metadata items sent to the backend to only include `id`, `name`, `type`, `value` (with `undefined` coerced to `null`)

close #32094
close #32113
close #32225

## Test plan

- [x] All existing backend unit tests pass (`test_metadata_partial_update.py` -- 3 tests)
- [x] All existing frontend unit tests pass (`use-batch-edit-document-metadata.spec.ts` -- 25 tests)
- [x] All batch edit modal component tests pass (132 tests across 7 spec files)
- [x] ESLint, Ruff, and TypeScript type-check pass
- [x] Manual test: select multiple documents, batch edit metadata values, verify changes persist
- [x] Manual test: verify error toast appears when batch edit actually fails (instead of false success)

