### PR TITLE
fix: remove unexpected scrollbar in KB Retrieval settings

### DIFF
--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -198,7 +198,7 @@ const ConfigContent: FC<Props> = ({
             <div className="system-xs-semibold-uppercase mr-2 shrink-0 text-text-secondary">
               {t('rerankSettings', { ns: 'dataset' })}
             </div>
-            <Divider bgStyle="gradient" className="mx-0 !h-px" />
+            <Divider bgStyle="gradient" className="mx-0 my-0 !h-px" />
           </div>
           {
             selectedDatasetsMode.inconsistentEmbeddingModel

--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -194,8 +194,8 @@ const ConfigContent: FC<Props> = ({
       </div>
       {type === RETRIEVE_TYPE.multiWay && (
         <>
-          <div className="my-2 flex h-6 items-center py-1">
-            <div className="system-xs-semibold-uppercase mr-2 shrink-0 text-text-secondary">
+          <div className="my-2 flex flex-col py-1">
+            <div className="system-xs-semibold-uppercase mb-2 text-text-secondary">
               {t('rerankSettings', { ns: 'dataset' })}
             </div>
             <Divider bgStyle="gradient" className="mx-0 my-0 !h-px" />

--- a/web/app/components/base/divider/index.tsx
+++ b/web/app/components/base/divider/index.tsx
@@ -7,8 +7,8 @@ import { cn } from '@/utils/classnames'
 const dividerVariants = cva('', {
   variants: {
     type: {
-      horizontal: 'w-full h-[0.5px] my-2 ',
-      vertical: 'w-[1px] h-full mx-2',
+      horizontal: 'my-2 h-[0.5px] w-full',
+      vertical: 'mx-2 h-full w-[1px]',
     },
     bgStyle: {
       gradient: 'bg-gradient-to-r from-divider-regular to-background-gradient-mask-transparent',


### PR DESCRIPTION
## Summary
- Fixes the unexpected scrollbar that appears when opening the KB Retrieval settings panel in a workflow node
- The root cause was the gradient `Divider` component inheriting a default `my-2` (16px vertical margin) from its horizontal variant, which caused the panel content to slightly exceed the floating element's `maxHeight` set by floating-ui's `size` middleware, triggering a scrollbar via `overflowY: auto`
- Adding `my-0` to the Divider's className neutralizes the default vertical margin and eliminates the overflow

Closes #31954

## Test plan
- [x] Existing unit tests for `ConfigContent` pass (5/5)
- [ ] Open a workflow, add a KB Retrieval node, select a knowledge base, and open retrieval settings — verify no scrollbar appears
- [ ] Verify the gradient divider still renders correctly between the title and the rerank settings section

