### PR TITLE
refactor: decouple workflow knowledge access via repository injection

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -50,7 +50,6 @@ ignore_imports =
     core.workflow.nodes.agent.agent_node -> extensions.ext_database
     core.workflow.nodes.datasource.datasource_node -> extensions.ext_database
     core.workflow.nodes.knowledge_index.knowledge_index_node -> extensions.ext_database
-    core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> extensions.ext_database
     core.workflow.nodes.llm.file_saver -> extensions.ext_database
     core.workflow.nodes.llm.llm_utils -> extensions.ext_database
     core.workflow.nodes.llm.node -> extensions.ext_database
@@ -124,7 +123,6 @@ ignore_imports =
     core.workflow.nodes.knowledge_index.knowledge_index_node -> core.rag.index_processor.index_processor_factory
     core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> core.rag.datasource.retrieval_service
     core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> core.rag.retrieval.dataset_retrieval
-    core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> models.dataset
     core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> services.feature_service
     core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> core.model_runtime.model_providers.__base.large_language_model
     core.workflow.nodes.llm.llm_utils -> configs
@@ -287,7 +285,6 @@ ignore_imports =
     core.workflow.nodes.agent.agent_node -> extensions.ext_database
     core.workflow.nodes.datasource.datasource_node -> extensions.ext_database
     core.workflow.nodes.knowledge_index.knowledge_index_node -> extensions.ext_database
-    core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> extensions.ext_database
     core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node -> extensions.ext_redis
     core.workflow.nodes.llm.file_saver -> extensions.ext_database
     core.workflow.nodes.llm.llm_utils -> extensions.ext_database

--- a/api/core/repositories/sqlalchemy_knowledge_repository.py
+++ b/api/core/repositories/sqlalchemy_knowledge_repository.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any, cast
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.rag.entities.metadata_entities import MetadataCondition
+from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
+from core.workflow.repositories.knowledge_repository import (
+    DatasetEntity,
+    DatasetMetadataEntity,
+    DocumentEntity,
+    KnowledgeRepository,
+)
+from models.dataset import Dataset, DatasetMetadata, Document, RateLimitLog
+
+
+class SQLAlchemyKnowledgeRepository(KnowledgeRepository):
+    """
+    SQLAlchemy implementation of KnowledgeRepository.
+
+    Sessions are created per method call to avoid shared state across concurrent
+    node executions. `close_session()` is therefore a no-op.
+    """
+
+    _session_factory: sessionmaker[Session]
+
+    def __init__(self, session_factory: sessionmaker[Session] | Engine):
+        if isinstance(session_factory, Engine):
+            self._session_factory = sessionmaker(bind=session_factory, expire_on_commit=False)
+        elif isinstance(session_factory, sessionmaker):
+            self._session_factory = session_factory
+        else:
+            raise ValueError(
+                f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
+            )
+
+    def get_datasets_with_available_documents(
+        self, tenant_id: str, dataset_ids: Sequence[str]
+    ) -> Sequence[DatasetEntity]:
+        """
+        Fetch datasets that have available documents (or are external providers).
+        """
+        if not dataset_ids:
+            return []
+
+        with self._session_factory() as session:
+            subquery = (
+                select(Document.dataset_id, func.count(Document.id).label("available_document_count"))
+                .where(
+                    Document.tenant_id == tenant_id,
+                    Document.indexing_status == "completed",
+                    Document.enabled.is_(True),
+                    Document.archived.is_(False),
+                    Document.dataset_id.in_(dataset_ids),
+                )
+                .group_by(Document.dataset_id)
+                .having(func.count(Document.id) > 0)
+                .subquery()
+            )
+
+            stmt = (
+                select(Dataset)
+                .outerjoin(subquery, Dataset.id == subquery.c.dataset_id)
+                .where(
+                    Dataset.tenant_id == tenant_id,
+                    Dataset.id.in_(dataset_ids),
+                    (subquery.c.available_document_count > 0) | (Dataset.provider == "external"),
+                )
+            )
+            return cast(Sequence[DatasetEntity], session.scalars(stmt).all())
+
+    def get_document(self, tenant_id: str, document_id: str) -> DocumentEntity | None:
+        stmt = select(Document).where(
+            Document.id == document_id,
+            Document.tenant_id == tenant_id,
+            Document.enabled.is_(True),
+            Document.archived.is_(False),
+        )
+        with self._session_factory() as session:
+            return cast(DocumentEntity | None, session.scalar(stmt))
+
+    def get_metadata_fields(self, tenant_id: str, dataset_ids: Sequence[str]) -> Sequence[DatasetMetadataEntity]:
+        if not dataset_ids:
+            return []
+
+        stmt = (
+            select(DatasetMetadata)
+            .join(Dataset, DatasetMetadata.dataset_id == Dataset.id)
+            .where(
+                DatasetMetadata.dataset_id.in_(dataset_ids),
+                Dataset.tenant_id == tenant_id,
+            )
+        )
+        with self._session_factory() as session:
+            return cast(Sequence[DatasetMetadataEntity], session.scalars(stmt).all())
+
+    def add_rate_limit_log(self, tenant_id: str, subscription_plan: str, operation: str) -> None:
+        # Use a separate transaction for logging to ensure it persists even if main transaction fails.
+        with self._session_factory.begin() as session:
+            rate_limit_log = RateLimitLog(
+                tenant_id=tenant_id,
+                subscription_plan=subscription_plan,
+                operation=operation,
+            )
+            session.add(rate_limit_log)
+
+    def get_documents_by_dataset_ids(self, tenant_id: str, dataset_ids: Sequence[str]) -> Sequence[DocumentEntity]:
+        if not dataset_ids:
+            return []
+
+        stmt = select(Document).where(
+            Document.dataset_id.in_(dataset_ids),
+            Document.tenant_id == tenant_id,
+            Document.indexing_status == "completed",
+            Document.enabled.is_(True),
+            Document.archived.is_(False),
+        )
+        with self._session_factory() as session:
+            return cast(Sequence[DocumentEntity], session.scalars(stmt).all())
+
+    def get_dataset(self, tenant_id: str, dataset_id: str) -> DatasetEntity | None:
+        stmt = select(Dataset).where(
+            Dataset.id == dataset_id,
+            Dataset.tenant_id == tenant_id,
+        )
+        with self._session_factory() as session:
+            return cast(DatasetEntity | None, session.scalar(stmt))
+
+    def get_document_ids_by_filtering(
+        self, tenant_id: str, dataset_ids: Sequence[str], filters: MetadataCondition | None
+    ) -> dict[str, list[str]] | None:
+        if not dataset_ids:
+            return None
+
+        stmt = select(Document.id, Document.dataset_id).where(
+            Document.dataset_id.in_(dataset_ids),
+            Document.tenant_id == tenant_id,
+            Document.indexing_status == "completed",
+            Document.enabled.is_(True),
+            Document.archived.is_(False),
+        )
+
+        compiled_filters: list[Any] = []
+        if filters and filters.conditions:
+            for sequence, condition in enumerate(filters.conditions):
+                DatasetRetrieval.process_metadata_filter_func(
+                    sequence,
+                    condition.comparison_operator,
+                    condition.name,
+                    condition.value,
+                    compiled_filters,
+                )
+
+            if compiled_filters:
+                if filters.logical_operator == "and":
+                    stmt = stmt.where(and_(*compiled_filters))
+                else:
+                    stmt = stmt.where(or_(*compiled_filters))
+
+        with self._session_factory() as session:
+            results = session.execute(stmt).all()
+
+        if not results:
+            return None
+
+        metadata_filter_document_ids: dict[str, list[str]] = defaultdict(list)
+        for row in results:
+            metadata_filter_document_ids[row.dataset_id].append(row.id)
+
+        return dict(metadata_filter_document_ids)
+
+    def close_session(self) -> None:
+        return

--- a/api/core/workflow/entities/graph_init_params.py
+++ b/api/core/workflow/entities/graph_init_params.py
@@ -1,7 +1,9 @@
 from collections.abc import Mapping
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, SkipValidation
+
+from core.workflow.entities.repositories import Repositories
 
 
 class GraphInitParams(BaseModel):
@@ -18,3 +20,6 @@ class GraphInitParams(BaseModel):
         ..., description="invoke from, service-api, web-app, explore or debugger"
     )  # Should be InvokeFrom enum: 'service-api' | 'web-app' | 'explore' | 'debugger'
     call_depth: int = Field(..., description="call depth")
+    repositories: SkipValidation[Repositories] | None = Field(default=None, description="repositories for data access")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/api/core/workflow/entities/repositories.py
+++ b/api/core/workflow/entities/repositories.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from core.workflow.repositories.knowledge_repository import KnowledgeRepository
+
+if TYPE_CHECKING:
+    from core.workflow.repositories.workflow_execution_repository import WorkflowExecutionRepository
+else:  # pragma: no cover - runtime fallbacks to avoid import cycles
+    WorkflowExecutionRepository = object  # type: ignore[assignment]
+
+
+@dataclass
+class Repositories:
+    """
+    Container for all repositories injected into the workflow execution context.
+    Methods/Nodes can access specific repositories from this container.
+    """
+
+    knowledge_repo: KnowledgeRepository
+    workflow_execution_repo: WorkflowExecutionRepository | None = None

--- a/api/core/workflow/nodes/iteration/iteration_node.py
+++ b/api/core/workflow/nodes/iteration/iteration_node.py
@@ -605,6 +605,7 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
             user_from=self.user_from.value,
             invoke_from=self.invoke_from.value,
             call_depth=self.workflow_call_depth,
+            repositories=self.graph_init_params.repositories,
         )
         # Create a deep copy of the variable pool for each iteration
         variable_pool_copy = self.graph_runtime_state.variable_pool.model_copy(deep=True)

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -252,9 +252,6 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
         # Subquery: Count the number of available documents for each dataset
         results = knowledge_repo.get_datasets_with_available_documents(self.tenant_id, dataset_ids)
 
-        # avoid blocking at retrieval
-        knowledge_repo.close_session()
-
         for dataset in results:
             # pass if dataset is not available
             if not dataset:

--- a/api/core/workflow/nodes/loop/loop_node.py
+++ b/api/core/workflow/nodes/loop/loop_node.py
@@ -430,6 +430,7 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             user_from=self.user_from.value,
             invoke_from=self.invoke_from.value,
             call_depth=self.workflow_call_depth,
+            repositories=self.graph_init_params.repositories,
         )
 
         # Create a new GraphRuntimeState for this iteration

--- a/api/core/workflow/repositories/__init__.py
+++ b/api/core/workflow/repositories/__init__.py
@@ -6,9 +6,31 @@ for accessing and manipulating data, regardless of the underlying
 storage mechanism.
 """
 
-from core.workflow.repositories.workflow_node_execution_repository import OrderConfig, WorkflowNodeExecutionRepository
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.workflow.repositories.workflow_node_execution_repository import (
+        OrderConfig,
+        WorkflowNodeExecutionRepository,
+    )
 
 __all__ = [
     "OrderConfig",
     "WorkflowNodeExecutionRepository",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"OrderConfig", "WorkflowNodeExecutionRepository"}:
+        from core.workflow.repositories.workflow_node_execution_repository import (
+            OrderConfig,
+            WorkflowNodeExecutionRepository,
+        )
+
+        return {
+            "OrderConfig": OrderConfig,
+            "WorkflowNodeExecutionRepository": WorkflowNodeExecutionRepository,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/api/core/workflow/repositories/knowledge_repository.py
+++ b/api/core/workflow/repositories/knowledge_repository.py
@@ -1,0 +1,119 @@
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
+
+from core.rag.entities.metadata_entities import MetadataCondition
+
+
+class DatasetEntity(Protocol):
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def tenant_id(self) -> str: ...
+
+    @property
+    def provider(self) -> str: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def description(self) -> str | None: ...
+
+    @property
+    def indexing_technique(self) -> str | None: ...
+
+    @property
+    def retrieval_model(self) -> Mapping[str, Any] | None: ...
+
+
+class DocumentEntity(Protocol):
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def tenant_id(self) -> str: ...
+
+    @property
+    def dataset_id(self) -> str: ...
+
+    @property
+    def indexing_status(self) -> str: ...
+
+    @property
+    def enabled(self) -> bool: ...
+
+    @property
+    def archived(self) -> bool: ...
+
+    @property
+    def doc_metadata(self) -> dict[str, Any] | None: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def data_source_type(self) -> str: ...
+
+
+class DatasetMetadataEntity(Protocol):
+    @property
+    def name(self) -> str: ...
+
+
+class KnowledgeRepository(Protocol):
+    """
+    Repository interface for accessing Knowledge Base data (Datasets, Documents).
+    """
+
+    def get_datasets_with_available_documents(
+        self, tenant_id: str, dataset_ids: Sequence[str]
+    ) -> Sequence[DatasetEntity]:
+        """
+        Fetch datasets that have available documents (or are external providers).
+        """
+        ...
+
+    def get_dataset(self, tenant_id: str, dataset_id: str) -> DatasetEntity | None:
+        """
+        Fetch a dataset by ID.
+        """
+        ...
+
+    def get_document(self, tenant_id: str, document_id: str) -> DocumentEntity | None:
+        """
+        Fetch a single document by ID.
+        """
+        ...
+
+    def get_documents_by_dataset_ids(self, tenant_id: str, dataset_ids: Sequence[str]) -> Sequence[DocumentEntity]:
+        """
+        Fetch documents by dataset IDs.
+        """
+        ...
+
+    def get_metadata_fields(self, tenant_id: str, dataset_ids: Sequence[str]) -> Sequence[DatasetMetadataEntity]:
+        """
+        Fetch metadata fields for the given datasets.
+        """
+        ...
+
+    def get_document_ids_by_filtering(
+        self, tenant_id: str, dataset_ids: Sequence[str], filters: MetadataCondition | None
+    ) -> dict[str, list[str]] | None:
+        """
+        Fetch document IDs grouped by dataset after applying metadata filters.
+        """
+        ...
+
+    def add_rate_limit_log(self, tenant_id: str, subscription_plan: str, operation: str) -> None:
+        """
+        Persist a rate limit log entry.
+        """
+        ...
+
+    def close_session(self) -> None:
+        """
+        Close the database session.
+        """
+        ...

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -12,6 +12,7 @@ from core.app.workflow.node_factory import DifyNodeFactory
 from core.file.models import File
 from core.workflow.constants import ENVIRONMENT_VARIABLE_NODE_ID
 from core.workflow.entities import GraphInitParams
+from core.workflow.entities.repositories import Repositories
 from core.workflow.errors import WorkflowNodeRunFailedError
 from core.workflow.graph import Graph
 from core.workflow.graph_engine import GraphEngine, GraphEngineConfig
@@ -135,6 +136,7 @@ class WorkflowEntry:
         user_inputs: Mapping[str, Any],
         variable_pool: VariablePool,
         variable_loader: VariableLoader = DUMMY_VARIABLE_LOADER,
+        repositories: Repositories | None = None,
     ) -> tuple[Node, Generator[GraphNodeEventBase, None, None]]:
         """
         Single step run workflow node
@@ -142,6 +144,7 @@ class WorkflowEntry:
         :param node_id: node id
         :param user_id: user id
         :param user_inputs: user inputs
+        :param repositories: Optional repository container for dependency injection
         :return:
         """
         node_config = workflow.get_node_config_by_id(node_id)
@@ -149,6 +152,8 @@ class WorkflowEntry:
 
         # Get node type
         node_type = NodeType(node_config_data["type"])
+
+        # init repositories for nodes that require data access
 
         # init graph init params and runtime state
         graph_init_params = GraphInitParams(
@@ -160,6 +165,7 @@ class WorkflowEntry:
             user_from=UserFrom.ACCOUNT,
             invoke_from=InvokeFrom.DEBUGGER,
             call_depth=0,
+            repositories=repositories,
         )
         graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.perf_counter())
 

--- a/api/services/rag_pipeline/rag_pipeline.py
+++ b/api/services/rag_pipeline/rag_pipeline.py
@@ -35,8 +35,10 @@ from core.rag.entities.event import (
     DatasourceProcessingEvent,
 )
 from core.repositories.factory import DifyCoreRepositoryFactory
+from core.repositories.sqlalchemy_knowledge_repository import SQLAlchemyKnowledgeRepository
 from core.repositories.sqlalchemy_workflow_node_execution_repository import SQLAlchemyWorkflowNodeExecutionRepository
 from core.variables.variables import VariableBase
+from core.workflow.entities.repositories import Repositories
 from core.workflow.entities.workflow_node_execution import (
     WorkflowNodeExecution,
     WorkflowNodeExecutionStatus,
@@ -429,6 +431,10 @@ class RagPipelineService:
         else:
             enclosing_node_id = None
 
+        repositories = Repositories(
+            knowledge_repo=SQLAlchemyKnowledgeRepository(db.engine),
+        )
+
         workflow_node_execution = self._handle_node_run_result(
             getter=lambda: WorkflowEntry.single_step_run(
                 workflow=draft_workflow,
@@ -447,6 +453,7 @@ class RagPipelineService:
                     app_id=pipeline.id,
                     tenant_id=pipeline.tenant_id,
                 ),
+                repositories=repositories,
             ),
             start_at=start_at,
             tenant_id=pipeline.tenant_id,
@@ -1189,6 +1196,10 @@ class RagPipelineService:
         else:
             enclosing_node_id = None
 
+        repositories = Repositories(
+            knowledge_repo=SQLAlchemyKnowledgeRepository(db.engine),
+        )
+
         system_inputs = SystemVariable(
             datasource_type=args.get("datasource_type", "online_document"),
             datasource_info=args.get("datasource_info", {}),
@@ -1212,6 +1223,7 @@ class RagPipelineService:
                     app_id=pipeline.id,
                     tenant_id=pipeline.tenant_id,
                 ),
+                repositories=repositories,
             ),
             start_at=start_at,
             tenant_id=pipeline.tenant_id,

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -13,9 +13,11 @@ from core.app.apps.advanced_chat.app_config_manager import AdvancedChatAppConfig
 from core.app.apps.workflow.app_config_manager import WorkflowAppConfigManager
 from core.file import File
 from core.repositories import DifyCoreRepositoryFactory
+from core.repositories.sqlalchemy_knowledge_repository import SQLAlchemyKnowledgeRepository
 from core.variables import VariableBase
 from core.variables.variables import Variable
 from core.workflow.entities import WorkflowNodeExecution
+from core.workflow.entities.repositories import Repositories
 from core.workflow.enums import ErrorStrategy, WorkflowNodeExecutionMetadataKey, WorkflowNodeExecutionStatus
 from core.workflow.errors import WorkflowNodeRunFailedError
 from core.workflow.graph_events import GraphNodeEventBase, NodeRunFailedEvent, NodeRunSucceededEvent
@@ -693,6 +695,10 @@ class WorkflowService:
         else:
             enclosing_node_id = None
 
+        repositories = Repositories(
+            knowledge_repo=SQLAlchemyKnowledgeRepository(db.engine),
+        )
+
         run = WorkflowEntry.single_step_run(
             workflow=draft_workflow,
             node_id=node_id,
@@ -700,6 +706,7 @@ class WorkflowService:
             user_id=account.id,
             variable_pool=variable_pool,
             variable_loader=variable_loader,
+            repositories=repositories,
         )
 
         # run draft workflow node

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
@@ -98,6 +98,7 @@ def test_run_uses_single_node_execution_branch(
         workflow=workflow,
         single_iteration_run=single_iteration_run,
         single_loop_run=single_loop_run,
+        repositories=None,
     )
     init_graph.assert_not_called()
 

--- a/api/tests/unit_tests/core/workflow/nodes/knowledge_retrieval/test_retrieval_node_mock.py
+++ b/api/tests/unit_tests/core/workflow/nodes/knowledge_retrieval/test_retrieval_node_mock.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.model_runtime.entities.llm_entities import LLMUsage
+from core.variables import StringSegment
+from core.workflow.entities.graph_init_params import GraphInitParams
+from core.workflow.entities.repositories import Repositories
+from core.workflow.enums import WorkflowNodeExecutionStatus
+from core.workflow.nodes.knowledge_retrieval.exc import KnowledgeRetrievalNodeError
+from core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node import KnowledgeRetrievalNode
+from core.workflow.repositories.knowledge_repository import KnowledgeRepository
+
+
+def _build_graph_runtime_state(query_text: str) -> MagicMock:
+    graph_runtime_state = MagicMock()
+    variable_pool = MagicMock()
+    variable_pool.get.return_value = StringSegment(
+        value=query_text,
+        name="text",
+        created_by_role="user",
+        created_by_node_id="start",
+    )
+    graph_runtime_state.variable_pool = variable_pool
+    return graph_runtime_state
+
+
+def test_knowledge_retrieval_node_uses_repository() -> None:
+    knowledge_repo = MagicMock(spec=KnowledgeRepository)
+    repositories = Repositories(knowledge_repo=knowledge_repo)
+
+    graph_init_params = GraphInitParams(
+        tenant_id="tenant_1",
+        app_id="app_1",
+        workflow_id="workflow_1",
+        graph_config={},
+        user_id="user_1",
+        user_from="account",
+        invoke_from="service-api",
+        call_depth=0,
+        repositories=repositories,
+    )
+
+    knowledge_repo.get_datasets_with_available_documents.return_value = [
+        SimpleNamespace(
+            id="ds1",
+            provider="dify",
+            name="Dataset 1",
+            description=None,
+            indexing_technique="high_quality",
+            retrieval_model=None,
+            tenant_id="tenant_1",
+        )
+    ]
+    knowledge_repo.get_dataset.return_value = SimpleNamespace(id="ds1", name="Dataset 1")
+    knowledge_repo.get_document.return_value = SimpleNamespace(
+        id="doc1",
+        name="Doc 1",
+        data_source_type="upload",
+        doc_metadata={},
+    )
+
+    config = {
+        "id": "node_1",
+        "data": {
+            "title": "Knowledge Retrieval",
+            "dataset_ids": ["ds1"],
+            "retrieval_mode": "single",
+            "single_retrieval_config": {
+                "model": {
+                    "provider": "openai",
+                    "name": "gpt-4",
+                    "mode": "chat",
+                    "completion_params": {},
+                }
+            },
+            "query_variable_selector": ["query_node", "text"],
+        },
+    }
+
+    graph_runtime_state = _build_graph_runtime_state("search query")
+
+    node = KnowledgeRetrievalNode(
+        id="node_1",
+        config=config,
+        graph_init_params=graph_init_params,
+        graph_runtime_state=graph_runtime_state,
+    )
+
+    model_type_instance = MagicMock()
+    model_type_instance.get_model_schema.return_value = SimpleNamespace(features=None)
+    model_config = SimpleNamespace(
+        provider_model_bundle=SimpleNamespace(model_type_instance=model_type_instance),
+        model="gpt-4",
+        credentials={},
+    )
+
+    with (
+        patch("services.feature_service.FeatureService.get_knowledge_rate_limit") as mock_rate_limit,
+        patch("core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node.DatasetRetrieval") as mock_dr_cls,
+        patch.object(node, "get_model_config", return_value=(MagicMock(), model_config)),
+        patch("core.workflow.nodes.knowledge_retrieval.knowledge_retrieval_node.RetrievalService") as mock_rs,
+    ):
+        mock_rate_limit.return_value = SimpleNamespace(enabled=False)
+
+        mock_dr_instance = mock_dr_cls.return_value
+        mock_retrieved_doc = SimpleNamespace(
+            provider="dify",
+            metadata={
+                "dataset_id": "ds1",
+                "document_id": "doc1",
+                "score": 0.9,
+                "title": "Doc 1",
+            },
+        )
+        mock_dr_instance.single_retrieve.return_value = [mock_retrieved_doc]
+        mock_dr_instance.llm_usage = LLMUsage.empty_usage()
+
+        segment = SimpleNamespace(
+            id="seg1",
+            dataset_id="ds1",
+            document_id="doc1",
+            hit_count=1,
+            word_count=10,
+            position=0,
+            index_node_hash="hash",
+            answer=None,
+            get_sign_content=lambda: "content",
+        )
+        mock_rs.format_retrieval_documents.return_value = [
+            SimpleNamespace(
+                segment=segment,
+                score=0.9,
+                child_chunks=[],
+                files=None,
+                summary=None,
+            )
+        ]
+
+        result = node._run()
+
+    knowledge_repo.get_datasets_with_available_documents.assert_called_once_with("tenant_1", ["ds1"])
+    knowledge_repo.get_dataset.assert_called_once_with("tenant_1", "ds1")
+    knowledge_repo.get_document.assert_called_once_with("tenant_1", "doc1")
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+
+
+def test_knowledge_retrieval_node_without_repository_fails_fast() -> None:
+    graph_init_params = GraphInitParams(
+        tenant_id="tenant_1",
+        app_id="app_1",
+        workflow_id="workflow_1",
+        graph_config={},
+        user_id="user_1",
+        user_from="account",
+        invoke_from="service-api",
+        call_depth=0,
+        repositories=None,
+    )
+
+    config = {
+        "id": "node_1",
+        "data": {
+            "title": "Knowledge Retrieval",
+            "dataset_ids": ["ds1"],
+            "retrieval_mode": "single",
+            "single_retrieval_config": {
+                "model": {
+                    "provider": "openai",
+                    "name": "gpt-4",
+                    "mode": "chat",
+                    "completion_params": {},
+                }
+            },
+            "query_variable_selector": ["query_node", "text"],
+        },
+    }
+
+    graph_runtime_state = _build_graph_runtime_state("search query")
+
+    node = KnowledgeRetrievalNode(
+        id="node_1",
+        config=config,
+        graph_init_params=graph_init_params,
+        graph_runtime_state=graph_runtime_state,
+    )
+
+    with pytest.raises(KnowledgeRetrievalNodeError):
+        node._run()


### PR DESCRIPTION
## Summary
- Introduce a knowledge repository protocol with a SQLAlchemy implementation that is tenant-scoped and uses per-call sessions.
- Inject repositories into workflow and pipeline execution paths, including single-step runs and sub-graph execution.
- Refactor KnowledgeRetrievalNode to use repository access and add focused unit coverage.

## Testing
- make lint
- uv run --directory api --dev -- basedpyright --threads 8
- uv --directory api run mypy --exclude-gitignore --exclude 'tests/' --exclude 'migrations/' --check-untyped-defs --disable-error-code=import-untyped .
- uv --directory api run ty check
- uv run --project api pytest api/tests/unit_tests/core/workflow api/tests/unit_tests/core/app/apps -q

### Related Issue
Part of #30269.
Implements the Repository pattern to decouple the Graph Engine from Flask-SQLAlchemy, setting the stage for the FastAPI migration.
