### PR TITLE
feat(tools): Add Nory x402 payment provider

### DIFF
--- a/api/core/tools/builtin_tool/providers/nory_x402/_assets/icon.svg
+++ b/api/core/tools/builtin_tool/providers/nory_x402/_assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/>
+  <path d="M12 18V6"/>
+</svg>

--- a/api/core/tools/builtin_tool/providers/nory_x402/nory_x402.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/nory_x402.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from core.tools.builtin_tool.provider import BuiltinToolProviderController
+
+
+class NoryX402Provider(BuiltinToolProviderController):
+    def _validate_credentials(self, user_id: str, credentials: dict[str, Any]):
+        """
+        Validate credentials - API key is optional for Nory
+        """
+        pass

--- a/api/core/tools/builtin_tool/providers/nory_x402/nory_x402.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/nory_x402.py
@@ -1,11 +1,24 @@
 from typing import Any
 
+import requests
+
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
+from core.tools.errors import ToolProviderCredentialValidationError
+
+# Centralized API base URL for all Nory x402 tools
+NORY_API_BASE = "https://noryx402.com"
 
 
 class NoryX402Provider(BuiltinToolProviderController):
     def _validate_credentials(self, user_id: str, credentials: dict[str, Any]):
         """
-        Validate credentials - API key is optional for Nory
+        Validate credentials by checking API health.
+        API key is optional for Nory, but we verify the service is reachable.
         """
-        pass
+        try:
+            response = requests.get(f"{NORY_API_BASE}/api/x402/health", timeout=10)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise ToolProviderCredentialValidationError(
+                f"Failed to connect to Nory x402 service: {e}"
+            )

--- a/api/core/tools/builtin_tool/providers/nory_x402/nory_x402.yaml
+++ b/api/core/tools/builtin_tool/providers/nory_x402/nory_x402.yaml
@@ -1,0 +1,25 @@
+identity:
+  author: Nory
+  name: nory_x402
+  label:
+    en_US: Nory x402 Payments
+    zh_Hans: Nory x402 支付
+  description:
+    en_US: AI agent payment tools using the x402 HTTP protocol. Supports Solana and 7 EVM chains with sub-400ms settlement.
+    zh_Hans: 使用 x402 HTTP 协议的 AI 代理支付工具。支持 Solana 和 7 条 EVM 链，结算时间低于 400ms。
+  icon: icon.svg
+  tags:
+    - finance
+credentials_for_provider:
+  api_key:
+    type: secret-input
+    required: false
+    label:
+      en_US: API Key
+      zh_Hans: API 密钥
+    placeholder:
+      en_US: Enter your Nory API key (optional)
+      zh_Hans: 输入您的 Nory API 密钥（可选）
+    help:
+      en_US: Optional API key for authenticated Nory endpoints
+      zh_Hans: 用于经过身份验证的 Nory 端点的可选 API 密钥

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/get_payment_requirements.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/get_payment_requirements.py
@@ -3,11 +3,10 @@ from typing import Any
 
 import requests
 
+from core.tools.builtin_tool.providers.nory_x402.nory_x402 import NORY_API_BASE
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError
-
-NORY_API_BASE = "https://noryx402.com"
 
 
 class GetPaymentRequirementsTool(BuiltinTool):
@@ -53,5 +52,5 @@ class GetPaymentRequirementsTool(BuiltinTool):
             response.raise_for_status()
 
             yield self.create_text_message(response.text)
-        except Exception as e:
-            raise ToolInvokeError(str(e))
+        except requests.exceptions.RequestException as e:
+            raise ToolInvokeError(f"Request failed: {e}")

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/get_payment_requirements.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/get_payment_requirements.py
@@ -1,0 +1,57 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+NORY_API_BASE = "https://noryx402.com"
+
+
+class GetPaymentRequirementsTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Get x402 payment requirements for a resource.
+        """
+        try:
+            resource = tool_parameters.get("resource", "")
+            amount = tool_parameters.get("amount", "")
+            network = tool_parameters.get("network")
+
+            if not resource:
+                yield self.create_text_message("Please provide a resource path")
+                return
+
+            if not amount:
+                yield self.create_text_message("Please provide an amount")
+                return
+
+            params = {"resource": resource, "amount": amount}
+            if network:
+                params["network"] = network
+
+            headers = {}
+            api_key = self.runtime.credentials.get("api_key")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            response = requests.get(
+                f"{NORY_API_BASE}/api/x402/requirements",
+                params=params,
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+
+            yield self.create_text_message(response.text)
+        except Exception as e:
+            raise ToolInvokeError(str(e))

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/get_payment_requirements.yaml
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/get_payment_requirements.yaml
@@ -1,0 +1,73 @@
+identity:
+  name: get_payment_requirements
+  author: Nory
+  label:
+    en_US: Get Payment Requirements
+    zh_Hans: 获取支付要求
+description:
+  human:
+    en_US: Get x402 payment requirements for accessing a paid resource. Use this when you encounter an HTTP 402 Payment Required response.
+    zh_Hans: 获取访问付费资源的 x402 支付要求。当遇到 HTTP 402 Payment Required 响应时使用。
+  llm: Get x402 payment requirements for a resource. Returns amount, supported networks, and wallet address needed to make a payment.
+parameters:
+  - name: resource
+    type: string
+    required: true
+    label:
+      en_US: Resource Path
+      zh_Hans: 资源路径
+    human_description:
+      en_US: The resource path requiring payment (e.g., /api/premium/data)
+      zh_Hans: 需要支付的资源路径（例如 /api/premium/data）
+    llm_description: The resource path requiring payment
+    form: llm
+  - name: amount
+    type: string
+    required: true
+    label:
+      en_US: Amount
+      zh_Hans: 金额
+    human_description:
+      en_US: Amount in human-readable format (e.g., '0.10' for $0.10 USDC)
+      zh_Hans: 人类可读格式的金额（例如 '0.10' 表示 $0.10 USDC）
+    llm_description: Amount in human-readable format (e.g., 0.10 for $0.10 USDC)
+    form: llm
+  - name: network
+    type: select
+    required: false
+    label:
+      en_US: Network
+      zh_Hans: 网络
+    human_description:
+      en_US: Preferred blockchain network
+      zh_Hans: 首选区块链网络
+    llm_description: Preferred blockchain network for payment
+    form: form
+    options:
+      - value: solana-mainnet
+        label:
+          en_US: Solana Mainnet
+      - value: solana-devnet
+        label:
+          en_US: Solana Devnet
+      - value: base-mainnet
+        label:
+          en_US: Base
+      - value: polygon-mainnet
+        label:
+          en_US: Polygon
+      - value: arbitrum-mainnet
+        label:
+          en_US: Arbitrum
+      - value: optimism-mainnet
+        label:
+          en_US: Optimism
+      - value: avalanche-mainnet
+        label:
+          en_US: Avalanche
+      - value: sei-mainnet
+        label:
+          en_US: Sei
+      - value: iotex-mainnet
+        label:
+          en_US: IoTeX

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/health_check.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/health_check.py
@@ -1,0 +1,34 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+NORY_API_BASE = "https://noryx402.com"
+
+
+class HealthCheckTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Check Nory service health.
+        """
+        try:
+            response = requests.get(
+                f"{NORY_API_BASE}/api/x402/health",
+                timeout=30,
+            )
+            response.raise_for_status()
+
+            yield self.create_text_message(response.text)
+        except Exception as e:
+            raise ToolInvokeError(str(e))

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/health_check.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/health_check.py
@@ -3,11 +3,10 @@ from typing import Any
 
 import requests
 
+from core.tools.builtin_tool.providers.nory_x402.nory_x402 import NORY_API_BASE
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError
-
-NORY_API_BASE = "https://noryx402.com"
 
 
 class HealthCheckTool(BuiltinTool):
@@ -30,5 +29,5 @@ class HealthCheckTool(BuiltinTool):
             response.raise_for_status()
 
             yield self.create_text_message(response.text)
-        except Exception as e:
-            raise ToolInvokeError(str(e))
+        except requests.exceptions.RequestException as e:
+            raise ToolInvokeError(f"Request failed: {e}")

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/health_check.yaml
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/health_check.yaml
@@ -1,0 +1,12 @@
+identity:
+  name: health_check
+  author: Nory
+  label:
+    en_US: Health Check
+    zh_Hans: 健康检查
+description:
+  human:
+    en_US: Check Nory service health and see supported networks.
+    zh_Hans: 检查 Nory 服务健康状况并查看支持的网络。
+  llm: Check Nory service health. Verify the payment service is operational and see supported networks.
+parameters: []

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/lookup_transaction.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/lookup_transaction.py
@@ -1,0 +1,52 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+NORY_API_BASE = "https://noryx402.com"
+
+
+class LookupTransactionTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Look up transaction status.
+        """
+        try:
+            transaction_id = tool_parameters.get("transaction_id", "")
+            network = tool_parameters.get("network", "")
+
+            if not transaction_id:
+                yield self.create_text_message("Please provide a transaction ID")
+                return
+
+            if not network:
+                yield self.create_text_message("Please provide a network")
+                return
+
+            headers = {}
+            api_key = self.runtime.credentials.get("api_key")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            response = requests.get(
+                f"{NORY_API_BASE}/api/x402/transactions/{transaction_id}",
+                params={"network": network},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+
+            yield self.create_text_message(response.text)
+        except Exception as e:
+            raise ToolInvokeError(str(e))

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/lookup_transaction.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/lookup_transaction.py
@@ -3,11 +3,10 @@ from typing import Any
 
 import requests
 
+from core.tools.builtin_tool.providers.nory_x402.nory_x402 import NORY_API_BASE
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError
-
-NORY_API_BASE = "https://noryx402.com"
 
 
 class LookupTransactionTool(BuiltinTool):
@@ -48,5 +47,5 @@ class LookupTransactionTool(BuiltinTool):
             response.raise_for_status()
 
             yield self.create_text_message(response.text)
-        except Exception as e:
-            raise ToolInvokeError(str(e))
+        except requests.exceptions.RequestException as e:
+            raise ToolInvokeError(f"Request failed: {e}")

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/lookup_transaction.yaml
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/lookup_transaction.yaml
@@ -1,0 +1,62 @@
+identity:
+  name: lookup_transaction
+  author: Nory
+  label:
+    en_US: Lookup Transaction
+    zh_Hans: 查询交易
+description:
+  human:
+    en_US: Look up the status of a previously submitted payment transaction.
+    zh_Hans: 查询先前提交的支付交易的状态。
+  llm: Look up transaction status. Check the status of a previously submitted payment. Returns transaction details including status and confirmations.
+parameters:
+  - name: transaction_id
+    type: string
+    required: true
+    label:
+      en_US: Transaction ID
+      zh_Hans: 交易 ID
+    human_description:
+      en_US: Transaction ID or signature
+      zh_Hans: 交易 ID 或签名
+    llm_description: Transaction ID or signature to look up
+    form: llm
+  - name: network
+    type: select
+    required: true
+    label:
+      en_US: Network
+      zh_Hans: 网络
+    human_description:
+      en_US: Network where the transaction was submitted
+      zh_Hans: 提交交易的网络
+    llm_description: Network where the transaction was submitted
+    form: llm
+    options:
+      - value: solana-mainnet
+        label:
+          en_US: Solana Mainnet
+      - value: solana-devnet
+        label:
+          en_US: Solana Devnet
+      - value: base-mainnet
+        label:
+          en_US: Base
+      - value: polygon-mainnet
+        label:
+          en_US: Polygon
+      - value: arbitrum-mainnet
+        label:
+          en_US: Arbitrum
+      - value: optimism-mainnet
+        label:
+          en_US: Optimism
+      - value: avalanche-mainnet
+        label:
+          en_US: Avalanche
+      - value: sei-mainnet
+        label:
+          en_US: Sei
+      - value: iotex-mainnet
+        label:
+          en_US: IoTeX

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/settle_payment.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/settle_payment.py
@@ -3,11 +3,10 @@ from typing import Any
 
 import requests
 
+from core.tools.builtin_tool.providers.nory_x402.nory_x402 import NORY_API_BASE
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError
-
-NORY_API_BASE = "https://noryx402.com"
 
 
 class SettlePaymentTool(BuiltinTool):
@@ -43,5 +42,5 @@ class SettlePaymentTool(BuiltinTool):
             response.raise_for_status()
 
             yield self.create_text_message(response.text)
-        except Exception as e:
-            raise ToolInvokeError(str(e))
+        except requests.exceptions.RequestException as e:
+            raise ToolInvokeError(f"Request failed: {e}")

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/settle_payment.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/settle_payment.py
@@ -1,0 +1,47 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+NORY_API_BASE = "https://noryx402.com"
+
+
+class SettlePaymentTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Settle a payment on-chain.
+        """
+        try:
+            payload = tool_parameters.get("payload", "")
+
+            if not payload:
+                yield self.create_text_message("Please provide a payment payload")
+                return
+
+            headers = {"Content-Type": "application/json"}
+            api_key = self.runtime.credentials.get("api_key")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            response = requests.post(
+                f"{NORY_API_BASE}/api/x402/settle",
+                json={"payload": payload},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+
+            yield self.create_text_message(response.text)
+        except Exception as e:
+            raise ToolInvokeError(str(e))

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/settle_payment.yaml
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/settle_payment.yaml
@@ -1,0 +1,23 @@
+identity:
+  name: settle_payment
+  author: Nory
+  label:
+    en_US: Settle Payment
+    zh_Hans: 结算支付
+description:
+  human:
+    en_US: Settle a payment on-chain. Submits a verified payment to the blockchain with ~400ms settlement time.
+    zh_Hans: 在链上结算支付。将已验证的支付提交到区块链，结算时间约 400ms。
+  llm: Settle a payment on-chain. Submits a verified payment transaction to the blockchain. Settlement typically completes in under 400ms.
+parameters:
+  - name: payload
+    type: string
+    required: true
+    label:
+      en_US: Payment Payload
+      zh_Hans: 支付载荷
+    human_description:
+      en_US: Base64-encoded payment payload
+      zh_Hans: Base64 编码的支付载荷
+    llm_description: Base64-encoded payment payload to settle
+    form: llm

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/verify_payment.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/verify_payment.py
@@ -1,0 +1,47 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+NORY_API_BASE = "https://noryx402.com"
+
+
+class VerifyPaymentTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Verify a signed payment transaction before settlement.
+        """
+        try:
+            payload = tool_parameters.get("payload", "")
+
+            if not payload:
+                yield self.create_text_message("Please provide a payment payload")
+                return
+
+            headers = {"Content-Type": "application/json"}
+            api_key = self.runtime.credentials.get("api_key")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            response = requests.post(
+                f"{NORY_API_BASE}/api/x402/verify",
+                json={"payload": payload},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+
+            yield self.create_text_message(response.text)
+        except Exception as e:
+            raise ToolInvokeError(str(e))

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/verify_payment.py
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/verify_payment.py
@@ -3,11 +3,10 @@ from typing import Any
 
 import requests
 
+from core.tools.builtin_tool.providers.nory_x402.nory_x402 import NORY_API_BASE
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.errors import ToolInvokeError
-
-NORY_API_BASE = "https://noryx402.com"
 
 
 class VerifyPaymentTool(BuiltinTool):
@@ -43,5 +42,5 @@ class VerifyPaymentTool(BuiltinTool):
             response.raise_for_status()
 
             yield self.create_text_message(response.text)
-        except Exception as e:
-            raise ToolInvokeError(str(e))
+        except requests.exceptions.RequestException as e:
+            raise ToolInvokeError(f"Request failed: {e}")

--- a/api/core/tools/builtin_tool/providers/nory_x402/tools/verify_payment.yaml
+++ b/api/core/tools/builtin_tool/providers/nory_x402/tools/verify_payment.yaml
@@ -1,0 +1,23 @@
+identity:
+  name: verify_payment
+  author: Nory
+  label:
+    en_US: Verify Payment
+    zh_Hans: 验证支付
+description:
+  human:
+    en_US: Verify a signed payment transaction before settlement. Validates that a payment is correct before submitting to blockchain.
+    zh_Hans: 在结算前验证已签名的支付交易。在提交到区块链之前验证支付是否正确。
+  llm: Verify a signed payment transaction before submitting to blockchain. Returns verification result including validity and payer info.
+parameters:
+  - name: payload
+    type: string
+    required: true
+    label:
+      en_US: Payment Payload
+      zh_Hans: 支付载荷
+    human_description:
+      en_US: Base64-encoded payment payload containing signed transaction
+      zh_Hans: 包含已签名交易的 Base64 编码支付载荷
+    llm_description: Base64-encoded payment payload containing signed transaction
+    form: llm


### PR DESCRIPTION
## Summary

Adds Nory x402 payment tools provider for AI agents to make payments using the x402 HTTP payment protocol.

## New Tools

| Tool | Description |
|------|-------------|
| `get_payment_requirements` | Get payment requirements for a resource (amount, supported networks, wallet address) |
| `verify_payment` | Verify a signed payment transaction before settlement |
| `settle_payment` | Submit a verified payment to the blockchain (~400ms) |
| `lookup_transaction` | Check the status of a previously submitted payment |
| `health_check` | Check Nory service health and supported networks |

## Supported Networks

- Solana (mainnet/devnet)
- Base, Polygon, Arbitrum, Optimism, Avalanche, Sei, IoTeX (all mainnet)

## Use Cases

AI agents can now:
- Pay for premium API access on-the-fly
- Handle HTTP 402 Payment Required responses automatically
- Make micropayments for AI-to-AI services
- Access paid resources without pre-configured subscriptions

## Features

- Optional API key authentication via provider credentials
- Multilingual support (en_US, zh_Hans)
- Network selection dropdown with all supported chains
- SVG icon included

## Documentation

- [x402 Protocol Spec](https://x402.org)
- [Nory API](https://noryx402.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)