### PR TITLE
[Extension] AgentMesh Trust Layer - Cryptographic Identity for Dify Agents

### DIFF
--- a/api/extensions/agentmesh/README.md
+++ b/api/extensions/agentmesh/README.md
@@ -1,0 +1,151 @@
+# AgentMesh Trust Extension for Dify
+
+Cryptographic identity and trust verification for Dify agents and workflows.
+
+## Overview
+
+This extension adds a trust layer to Dify, enabling:
+
+- **Cryptographic Identity** - Ed25519-based agent identities with DIDs
+- **Trust Verification** - Verify agent identity before workflow execution
+- **Trust Scoring** - Dynamic trust scores based on behavioral history
+- **Audit Logging** - Track all trust decisions for compliance
+
+## Installation
+
+The extension is included in the Dify API. To enable it:
+
+```python
+from extensions.agentmesh import TrustMiddleware, CMVKIdentity
+
+# Initialize with an identity
+identity = CMVKIdentity.generate(
+    name="dify-workflow-engine",
+    capabilities=["workflow:*", "llm:*", "tool:*"],
+    tenant_id="your-tenant-id",
+)
+
+TrustMiddleware.initialize(identity=identity, min_trust_score=0.5)
+```
+
+## Usage
+
+### Protecting API Endpoints
+
+```python
+from extensions.agentmesh import trust_required
+
+@app.route("/api/v1/workflows/<workflow_id>/run", methods=["POST"])
+@trust_required(min_score=0.6, capabilities=["workflow:execute"])
+def run_workflow(workflow_id):
+    # Request is verified - peer has sufficient trust
+    # Access verification result via g.trust_verification
+    return execute_workflow(workflow_id)
+```
+
+### Verifying Workflow Steps
+
+```python
+from extensions.agentmesh import TrustMiddleware
+
+trust_manager = TrustMiddleware.get_trust_manager()
+
+# Before executing a workflow step
+result = trust_manager.verify_workflow_step(
+    workflow_id="wf-123",
+    step_id="step-1",
+    step_type="llm",
+    required_capability="llm:gpt-4",
+)
+
+if result.verified:
+    # Execute the step
+    pass
+else:
+    # Log and handle failure
+    logger.warning(f"Step blocked: {result.reason}")
+```
+
+### Agent-to-Agent Communication
+
+When Dify agents communicate with external agents:
+
+```python
+from extensions.agentmesh import TrustMiddleware, CMVKIdentity
+
+trust_manager = TrustMiddleware.get_trust_manager()
+
+# Verify external agent before interaction
+result = trust_manager.verify_peer(
+    peer_did="did:cmvk:external-agent",
+    peer_public_key="base64-encoded-key",
+    required_capabilities=["data:read"],
+    peer_capabilities=["data:read", "data:write"],
+)
+
+if result.verified:
+    # Safe to interact
+    response = call_external_agent(peer_did, request)
+    trust_manager.record_success(peer_did)
+else:
+    logger.warning(f"Peer verification failed: {result.reason}")
+```
+
+## HTTP Headers
+
+When trust is enabled, agents should include these headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-Agent-DID` | Agent's decentralized identifier |
+| `X-Agent-Public-Key` | Base64-encoded Ed25519 public key |
+| `X-Agent-Capabilities` | Comma-separated list of capabilities |
+| `X-Agent-Signature` | Signature of request body (optional) |
+
+## Trust Score Calculation
+
+Trust scores range from 0.0 to 1.0:
+
+- **0.0 - 0.3**: Untrusted (blocked by default)
+- **0.3 - 0.5**: Low trust (limited operations)
+- **0.5 - 0.7**: Moderate trust (standard operations)
+- **0.7 - 0.9**: High trust (extended permissions)
+- **0.9 - 1.0**: Trusted (full access)
+
+Scores adjust based on:
+- Successful interactions (+0.01)
+- Failed interactions (-0.1 to -0.5 based on severity)
+- Time decay (gradual decrease without activity)
+
+## Audit Log
+
+All trust decisions are logged for compliance:
+
+```python
+audit_log = trust_manager.get_audit_log(limit=100)
+
+# Each entry contains:
+# {
+#     "timestamp": "2026-02-06T22:30:00Z",
+#     "action": "verify_peer",
+#     "target": "did:cmvk:peer123",
+#     "success": true,
+#     "trust_score": 0.72,
+#     "identity_did": "did:cmvk:local",
+# }
+```
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTMESH_ENABLED` | `false` | Enable trust verification |
+| `AGENTMESH_MIN_TRUST` | `0.5` | Minimum trust score |
+| `AGENTMESH_CACHE_TTL` | `900` | Cache TTL in seconds |
+
+## Related
+
+- [AgentMesh](https://github.com/imran-siddique/agent-mesh) - Trust mesh platform
+- [Agent-OS](https://github.com/imran-siddique/agent-os) - Governance kernel

--- a/api/extensions/agentmesh/README.md
+++ b/api/extensions/agentmesh/README.md
@@ -115,7 +115,7 @@ Trust scores range from 0.0 to 1.0:
 Scores adjust based on:
 - Successful interactions (+0.01)
 - Failed interactions (-0.1 to -0.5 based on severity)
-- Time decay (gradual decrease without activity)
+- Time decay (TODO: not yet implemented)
 
 ## Audit Log
 
@@ -137,7 +137,7 @@ audit_log = trust_manager.get_audit_log(limit=100)
 
 ## Configuration
 
-Environment variables:
+Environment variables (TODO: not yet wired up - currently require programmatic initialization):
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/api/extensions/agentmesh/README.md
+++ b/api/extensions/agentmesh/README.md
@@ -137,6 +137,8 @@ audit_log = trust_manager.get_audit_log(limit=100)
 # }
 ```
 
+> **Note:** Audit logs, trust scores, and verification caches are stored in in-memory process state. In multi-worker deployments (e.g., gunicorn with multiple workers), this data will not be shared across workers and will be lost on restart. For production deployments requiring persistent audit trails, consider extending the `TrustManager` to persist to an external store (Redis, PostgreSQL, etc.).
+
 ## Configuration
 
 Environment variables (TODO: not yet wired up - currently require programmatic initialization):

--- a/api/extensions/agentmesh/README.md
+++ b/api/extensions/agentmesh/README.md
@@ -100,7 +100,9 @@ When trust is enabled, agents should include these headers:
 | `X-Agent-DID` | Agent's decentralized identifier |
 | `X-Agent-Public-Key` | Base64-encoded Ed25519 public key |
 | `X-Agent-Capabilities` | Comma-separated list of capabilities |
-| `X-Agent-Signature` | Signature of request body (optional) |
+| `X-Agent-Signature` | Signature of request body (TODO: not yet verified by middleware) |
+
+> **Note:** Request body signature verification (`X-Agent-Signature`) is documented for future implementation but is not currently enforced by the middleware. The current trust layer verifies identity presence and capabilities but does not cryptographically bind requests to the claimed identity.
 
 ## Trust Score Calculation
 

--- a/api/extensions/agentmesh/__init__.py
+++ b/api/extensions/agentmesh/__init__.py
@@ -6,7 +6,7 @@ Provides cryptographic identity and trust verification for Dify agents and workf
 
 from extensions.agentmesh.identity import CMVKIdentity, CMVKSignature
 from extensions.agentmesh.trust import TrustManager, TrustVerificationResult
-from extensions.agentmesh.middleware import TrustMiddleware
+from extensions.agentmesh.middleware import TrustMiddleware, trust_required
 
 __all__ = [
     "CMVKIdentity",
@@ -14,4 +14,5 @@ __all__ = [
     "TrustManager",
     "TrustVerificationResult",
     "TrustMiddleware",
+    "trust_required",
 ]

--- a/api/extensions/agentmesh/__init__.py
+++ b/api/extensions/agentmesh/__init__.py
@@ -4,7 +4,7 @@ AgentMesh Trust Extension for Dify.
 Provides cryptographic identity and trust verification for Dify agents and workflows.
 """
 
-from extensions.agentmesh.identity import CMVKIdentity, CMVKSignature
+from extensions.agentmesh.identity import CMVKIdentity, CMVKSignature, capability_matches
 from extensions.agentmesh.trust import TrustManager, TrustVerificationResult
 from extensions.agentmesh.middleware import TrustMiddleware, trust_required
 
@@ -15,4 +15,5 @@ __all__ = [
     "TrustVerificationResult",
     "TrustMiddleware",
     "trust_required",
+    "capability_matches",
 ]

--- a/api/extensions/agentmesh/__init__.py
+++ b/api/extensions/agentmesh/__init__.py
@@ -1,0 +1,17 @@
+"""
+AgentMesh Trust Extension for Dify.
+
+Provides cryptographic identity and trust verification for Dify agents and workflows.
+"""
+
+from extensions.agentmesh.identity import CMVKIdentity, CMVKSignature
+from extensions.agentmesh.trust import TrustManager, TrustVerificationResult
+from extensions.agentmesh.middleware import TrustMiddleware
+
+__all__ = [
+    "CMVKIdentity",
+    "CMVKSignature",
+    "TrustManager",
+    "TrustVerificationResult",
+    "TrustMiddleware",
+]

--- a/api/extensions/agentmesh/identity.py
+++ b/api/extensions/agentmesh/identity.py
@@ -1,0 +1,172 @@
+"""CMVK Identity for Dify agents."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+# Try to import real cryptography
+try:
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+    from cryptography.exceptions import InvalidSignature
+    CRYPTO_AVAILABLE = True
+except ImportError:
+    CRYPTO_AVAILABLE = False
+
+
+@dataclass
+class CMVKSignature:
+    """Cryptographic signature from a CMVK identity."""
+    
+    public_key: str
+    signature: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "public_key": self.public_key,
+            "signature": self.signature,
+            "timestamp": self.timestamp.isoformat(),
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CMVKSignature":
+        timestamp = data.get("timestamp")
+        if isinstance(timestamp, str):
+            timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        elif timestamp is None:
+            timestamp = datetime.now(timezone.utc)
+        
+        return cls(
+            public_key=data.get("public_key", ""),
+            signature=data.get("signature", ""),
+            timestamp=timestamp,
+        )
+
+
+@dataclass
+class CMVKIdentity:
+    """Cryptographic identity for a Dify agent/workflow using CMVK (Ed25519)."""
+    
+    did: str
+    name: str
+    public_key: str
+    private_key: Optional[str] = None
+    capabilities: List[str] = field(default_factory=list)
+    tenant_id: Optional[str] = None  # Dify workspace binding
+    app_id: Optional[str] = None     # Dify app binding
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    
+    @classmethod
+    def generate(
+        cls,
+        name: str,
+        capabilities: Optional[List[str]] = None,
+        tenant_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+    ) -> "CMVKIdentity":
+        """Generate a new CMVK identity."""
+        seed = f"{name}:{tenant_id or ''}:{app_id or ''}:{time.time_ns()}"
+        did_hash = hashlib.sha256(seed.encode()).hexdigest()[:32]
+        did = f"did:cmvk:{did_hash}"
+        
+        if CRYPTO_AVAILABLE:
+            private_key_obj = ed25519.Ed25519PrivateKey.generate()
+            public_key_obj = private_key_obj.public_key()
+            
+            private_key_b64 = base64.b64encode(
+                private_key_obj.private_bytes_raw()
+            ).decode('ascii')
+            public_key_b64 = base64.b64encode(
+                public_key_obj.public_bytes_raw()
+            ).decode('ascii')
+        else:
+            key_seed = hashlib.sha256(f"{did}:key".encode()).hexdigest()
+            private_key_b64 = base64.b64encode(key_seed[:32].encode()).decode('ascii')
+            public_key_b64 = base64.b64encode(key_seed[32:].encode()).decode('ascii')
+        
+        return cls(
+            did=did,
+            name=name,
+            public_key=public_key_b64,
+            private_key=private_key_b64,
+            capabilities=capabilities or [],
+            tenant_id=tenant_id,
+            app_id=app_id,
+        )
+    
+    def sign(self, data: str) -> CMVKSignature:
+        """Sign data with this identity's private key."""
+        if not self.private_key:
+            raise ValueError("Cannot sign without private key")
+        
+        if CRYPTO_AVAILABLE:
+            private_key_bytes = base64.b64decode(self.private_key)
+            private_key_obj = ed25519.Ed25519PrivateKey.from_private_bytes(private_key_bytes)
+            signature_bytes = private_key_obj.sign(data.encode('utf-8'))
+            signature_b64 = base64.b64encode(signature_bytes).decode('ascii')
+        else:
+            sig_input = f"{self.private_key}:{data}"
+            signature_b64 = base64.b64encode(
+                hashlib.sha256(sig_input.encode()).digest()
+            ).decode('ascii')
+        
+        return CMVKSignature(public_key=self.public_key, signature=signature_b64)
+    
+    def verify_signature(self, data: str, signature: CMVKSignature) -> bool:
+        """Verify a signature."""
+        if signature.public_key != self.public_key:
+            return False
+        
+        if CRYPTO_AVAILABLE:
+            try:
+                public_key_bytes = base64.b64decode(self.public_key)
+                public_key_obj = ed25519.Ed25519PublicKey.from_public_bytes(public_key_bytes)
+                signature_bytes = base64.b64decode(signature.signature)
+                public_key_obj.verify(signature_bytes, data.encode('utf-8'))
+                return True
+            except (InvalidSignature, ValueError, Exception):
+                return False
+        return True
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary (excludes private key)."""
+        return {
+            "did": self.did,
+            "name": self.name,
+            "public_key": self.public_key,
+            "capabilities": self.capabilities,
+            "tenant_id": self.tenant_id,
+            "app_id": self.app_id,
+            "created_at": self.created_at.isoformat(),
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CMVKIdentity":
+        """Create from dictionary."""
+        created_at = data.get("created_at")
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        elif created_at is None:
+            created_at = datetime.now(timezone.utc)
+        
+        return cls(
+            did=data.get("did", ""),
+            name=data.get("name", ""),
+            public_key=data.get("public_key", ""),
+            private_key=data.get("private_key"),
+            capabilities=data.get("capabilities", []),
+            tenant_id=data.get("tenant_id"),
+            app_id=data.get("app_id"),
+            created_at=created_at,
+        )
+    
+    def has_capability(self, capability: str) -> bool:
+        """Check if identity has a capability."""
+        if "*" in self.capabilities:
+            return True
+        return capability in self.capabilities

--- a/api/extensions/agentmesh/middleware.py
+++ b/api/extensions/agentmesh/middleware.py
@@ -1,0 +1,129 @@
+"""Trust middleware for Dify API requests."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional
+import logging
+
+from flask import request, g, jsonify
+
+from extensions.agentmesh.identity import CMVKIdentity
+from extensions.agentmesh.trust import TrustManager
+
+logger = logging.getLogger(__name__)
+
+
+class TrustMiddleware:
+    """Middleware for trust verification in Dify API endpoints."""
+    
+    _instance: Optional["TrustMiddleware"] = None
+    _trust_manager: Optional[TrustManager] = None
+    
+    def __new__(cls) -> "TrustMiddleware":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+    
+    @classmethod
+    def initialize(
+        cls,
+        identity: Optional[CMVKIdentity] = None,
+        min_trust_score: float = 0.5,
+    ) -> "TrustMiddleware":
+        """Initialize the trust middleware."""
+        instance = cls()
+        instance._trust_manager = TrustManager(
+            identity=identity,
+            min_trust_score=min_trust_score,
+        )
+        logger.info("TrustMiddleware initialized")
+        return instance
+    
+    @classmethod
+    def get_trust_manager(cls) -> Optional[TrustManager]:
+        """Get the trust manager instance."""
+        instance = cls()
+        return instance._trust_manager
+    
+    @classmethod
+    def require_trust(
+        cls,
+        min_score: float = 0.5,
+        required_capabilities: Optional[List[str]] = None,
+    ) -> Callable:
+        """Decorator to require trust verification for an endpoint."""
+        def decorator(f: Callable) -> Callable:
+            @wraps(f)
+            def decorated_function(*args: Any, **kwargs: Any) -> Any:
+                trust_manager = cls.get_trust_manager()
+                
+                if not trust_manager:
+                    # Trust not configured, allow through
+                    return f(*args, **kwargs)
+                
+                # Extract trust headers
+                peer_did = request.headers.get("X-Agent-DID")
+                peer_public_key = request.headers.get("X-Agent-Public-Key")
+                peer_capabilities = request.headers.get("X-Agent-Capabilities", "").split(",")
+                peer_capabilities = [c.strip() for c in peer_capabilities if c.strip()]
+                
+                if not peer_did:
+                    # No trust headers, allow through (backward compatible)
+                    return f(*args, **kwargs)
+                
+                # Verify trust
+                result = trust_manager.verify_peer(
+                    peer_did=peer_did,
+                    peer_public_key=peer_public_key or "",
+                    required_capabilities=required_capabilities,
+                    peer_capabilities=peer_capabilities,
+                )
+                
+                if not result.verified:
+                    return jsonify({
+                        "error": "Trust verification failed",
+                        "reason": result.reason,
+                        "trust_score": result.trust_score,
+                    }), 403
+                
+                if result.trust_score < min_score:
+                    return jsonify({
+                        "error": "Insufficient trust score",
+                        "required": min_score,
+                        "actual": result.trust_score,
+                    }), 403
+                
+                # Store verification result in request context
+                g.trust_verification = result
+                g.peer_did = peer_did
+                
+                return f(*args, **kwargs)
+            
+            return decorated_function
+        return decorator
+    
+    @classmethod
+    def add_trust_headers(cls, response_headers: Dict[str, str]) -> Dict[str, str]:
+        """Add trust headers to outgoing response."""
+        trust_manager = cls.get_trust_manager()
+        
+        if trust_manager and trust_manager.identity:
+            response_headers["X-Agent-DID"] = trust_manager.identity.did
+            response_headers["X-Agent-Public-Key"] = trust_manager.identity.public_key
+            response_headers["X-Agent-Capabilities"] = ",".join(
+                trust_manager.identity.capabilities
+            )
+        
+        return response_headers
+
+
+def trust_required(
+    min_score: float = 0.5,
+    capabilities: Optional[List[str]] = None,
+) -> Callable:
+    """Convenience decorator for trust verification."""
+    return TrustMiddleware.require_trust(
+        min_score=min_score,
+        required_capabilities=capabilities,
+    )

--- a/api/extensions/agentmesh/trust.py
+++ b/api/extensions/agentmesh/trust.py
@@ -8,7 +8,7 @@ import threading
 from typing import Any, Dict, List, Optional, Tuple
 import logging
 
-from extensions.agentmesh.identity import CMVKIdentity
+from extensions.agentmesh.identity import CMVKIdentity, capability_matches
 
 logger = logging.getLogger(__name__)
 
@@ -175,17 +175,8 @@ class TrustManager:
     def _peer_has_capability(self, peer_caps: List[str], required: str) -> bool:
         """Check if peer has a required capability (supports wildcards)."""
         for cap in peer_caps:
-            # Universal wildcard
-            if cap == "*":
+            if capability_matches(cap, required):
                 return True
-            # Exact match
-            if cap == required:
-                return True
-            # Prefix wildcard (e.g., "workflow:*" matches "workflow:execute")
-            if cap.endswith(":*"):
-                prefix = cap[:-1]  # "workflow:"
-                if required.startswith(prefix):
-                    return True
         return False
     
     def _calculate_trust_score(self, peer_did: str, peer_public_key: str) -> float:

--- a/api/extensions/agentmesh/trust.py
+++ b/api/extensions/agentmesh/trust.py
@@ -1,0 +1,232 @@
+"""Trust management for Dify agents and workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+import logging
+
+from extensions.agentmesh.identity import CMVKIdentity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrustVerificationResult:
+    """Result of trust verification."""
+    
+    verified: bool
+    trust_score: float = 0.0
+    peer_did: str = ""
+    reason: str = ""
+    verified_capabilities: List[str] = field(default_factory=list)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verified": self.verified,
+            "trust_score": self.trust_score,
+            "peer_did": self.peer_did,
+            "reason": self.reason,
+            "verified_capabilities": self.verified_capabilities,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+class TrustManager:
+    """Manages trust verification for Dify workflows and agents."""
+    
+    def __init__(
+        self,
+        identity: Optional[CMVKIdentity] = None,
+        cache_ttl_seconds: int = 900,
+        min_trust_score: float = 0.5,
+    ):
+        self.identity = identity
+        self.cache_ttl = timedelta(seconds=cache_ttl_seconds)
+        self.min_trust_score = min_trust_score
+        self._verified_peers: Dict[str, Tuple[TrustVerificationResult, datetime]] = {}
+        self._trust_scores: Dict[str, float] = {}  # DID -> score
+        self._audit_log: List[Dict[str, Any]] = []
+    
+    def set_identity(self, identity: CMVKIdentity) -> None:
+        """Set or update the local identity."""
+        self.identity = identity
+        logger.info(f"Trust identity set: {identity.did}")
+    
+    def verify_peer(
+        self,
+        peer_did: str,
+        peer_public_key: str,
+        required_capabilities: Optional[List[str]] = None,
+        peer_capabilities: Optional[List[str]] = None,
+    ) -> TrustVerificationResult:
+        """Verify a peer agent's identity and capabilities."""
+        # Check cache
+        cached = self._get_cached(peer_did)
+        if cached is not None:
+            return cached
+        
+        # Basic validation
+        if not peer_did or not peer_public_key:
+            return self._fail("Missing DID or public key", peer_did)
+        
+        # Check capabilities
+        if required_capabilities and peer_capabilities:
+            missing = [c for c in required_capabilities if c not in peer_capabilities]
+            if missing:
+                return self._fail(f"Missing capabilities: {missing}", peer_did)
+        
+        # Calculate trust score
+        trust_score = self._calculate_trust_score(peer_did, peer_public_key)
+        
+        if trust_score < self.min_trust_score:
+            return self._fail(
+                f"Trust score {trust_score:.2f} below minimum {self.min_trust_score}",
+                peer_did,
+                trust_score=trust_score
+            )
+        
+        # Success
+        result = TrustVerificationResult(
+            verified=True,
+            trust_score=trust_score,
+            peer_did=peer_did,
+            reason="Verification successful",
+            verified_capabilities=peer_capabilities or [],
+        )
+        
+        self._cache(peer_did, result)
+        self._log_audit("verify_peer", peer_did, True, trust_score)
+        
+        return result
+    
+    def verify_workflow_step(
+        self,
+        workflow_id: str,
+        step_id: str,
+        step_type: str,
+        required_capability: Optional[str] = None,
+    ) -> TrustVerificationResult:
+        """Verify trust for a workflow step execution."""
+        if not self.identity:
+            return self._fail("No identity configured", f"{workflow_id}:{step_id}")
+        
+        # Check capability for step type
+        capability = required_capability or f"workflow:{step_type}"
+        if not self.identity.has_capability(capability) and not self.identity.has_capability("*"):
+            return self._fail(
+                f"Missing capability: {capability}",
+                f"{workflow_id}:{step_id}"
+            )
+        
+        trust_score = self._trust_scores.get(self.identity.did, 0.7)
+        
+        result = TrustVerificationResult(
+            verified=True,
+            trust_score=trust_score,
+            peer_did=self.identity.did,
+            reason=f"Step {step_type} authorized",
+            verified_capabilities=[capability],
+        )
+        
+        self._log_audit("verify_step", f"{workflow_id}:{step_id}", True, trust_score)
+        return result
+    
+    def record_success(self, did: str) -> None:
+        """Record successful interaction, increasing trust."""
+        current = self._trust_scores.get(did, 0.5)
+        self._trust_scores[did] = min(1.0, current + 0.01)
+        self._log_audit("record_success", did, True, self._trust_scores[did])
+    
+    def record_failure(self, did: str, severity: float = 0.1) -> None:
+        """Record failed interaction, decreasing trust."""
+        current = self._trust_scores.get(did, 0.5)
+        self._trust_scores[did] = max(0.0, current - severity)
+        self._log_audit("record_failure", did, False, self._trust_scores[did])
+    
+    def get_trust_score(self, did: str) -> float:
+        """Get current trust score for a DID."""
+        return self._trust_scores.get(did, 0.5)
+    
+    def get_audit_log(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Get recent audit log entries."""
+        return self._audit_log[-limit:]
+    
+    def clear_cache(self) -> None:
+        """Clear verification cache."""
+        self._verified_peers.clear()
+    
+    def _calculate_trust_score(self, peer_did: str, peer_public_key: str) -> float:
+        """Calculate trust score for a peer."""
+        # Check if we have historical score
+        if peer_did in self._trust_scores:
+            return self._trust_scores[peer_did]
+        
+        # Base score for new peers
+        score = 0.5
+        
+        # Bonus for having public key
+        if peer_public_key:
+            score += 0.1
+        
+        # Store for future
+        self._trust_scores[peer_did] = score
+        return score
+    
+    def _get_cached(self, peer_did: str) -> Optional[TrustVerificationResult]:
+        """Get cached result if valid."""
+        if peer_did not in self._verified_peers:
+            return None
+        
+        result, cached_at = self._verified_peers[peer_did]
+        if datetime.now(timezone.utc) - cached_at > self.cache_ttl:
+            del self._verified_peers[peer_did]
+            return None
+        
+        return result
+    
+    def _cache(self, peer_did: str, result: TrustVerificationResult) -> None:
+        """Cache a verification result."""
+        self._verified_peers[peer_did] = (result, datetime.now(timezone.utc))
+    
+    def _fail(
+        self,
+        reason: str,
+        peer_did: str,
+        trust_score: float = 0.0
+    ) -> TrustVerificationResult:
+        """Create a failed verification result."""
+        result = TrustVerificationResult(
+            verified=False,
+            trust_score=trust_score,
+            peer_did=peer_did,
+            reason=reason,
+        )
+        self._log_audit("verify_fail", peer_did, False, trust_score, reason)
+        return result
+    
+    def _log_audit(
+        self,
+        action: str,
+        target: str,
+        success: bool,
+        trust_score: float,
+        reason: str = ""
+    ) -> None:
+        """Log an audit entry."""
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            "target": target,
+            "success": success,
+            "trust_score": trust_score,
+            "reason": reason,
+            "identity_did": self.identity.did if self.identity else None,
+        }
+        self._audit_log.append(entry)
+        
+        # Keep log bounded
+        if len(self._audit_log) > 10000:
+            self._audit_log = self._audit_log[-5000:]


### PR DESCRIPTION
Adds a trust layer extension for Dify with cryptographic identity and trust verification.

**Features:**
- Ed25519-based agent identities with DIDs
- Peer verification and trust scoring (0.0-1.0)
- Flask middleware with @trust_required decorator
- Audit logging for compliance

**HTTP Headers:** X-Agent-DID, X-Agent-Public-Key, X-Agent-Capabilities

**Backward compatible** - trust is optional, no breaking changes.

See api/extensions/agentmesh/README.md for full documentation.