### PR TITLE
refactor: remove unnecessary type: async_workflow_service.py

### DIFF
--- a/api/services/async_workflow_service.py
+++ b/api/services/async_workflow_service.py
@@ -155,11 +155,11 @@ class AsyncWorkflowService:
 
         task: AsyncResult[Any] | None = None
         if queue_name == QueuePriority.PROFESSIONAL:
-            task = execute_workflow_professional.delay(task_data_dict)  # type: ignore
+            task = execute_workflow_professional.delay(task_data_dict)
         elif queue_name == QueuePriority.TEAM:
-            task = execute_workflow_team.delay(task_data_dict)  # type: ignore
+            task = execute_workflow_team.delay(task_data_dict)
         else:  # SANDBOX
-            task = execute_workflow_sandbox.delay(task_data_dict)  # type: ignore
+            task = execute_workflow_sandbox.delay(task_data_dict)
 
         # 10. Update trigger log with task info
         trigger_log.status = WorkflowTriggerStatus.QUEUED
@@ -170,7 +170,7 @@ class AsyncWorkflowService:
 
         return AsyncTriggerResponse(
             workflow_trigger_log_id=trigger_log.id,
-            task_id=task.id,  # type: ignore
+            task_id=task.id,
             status="queued",
             queue=queue_name,
         )


### PR DESCRIPTION
## Summary
Remove the unnecessary `# type: ignore` comment from the `api/services/async_workflow_service.py`.

This is a partial fix for https://github.com/langgenius/dify/issues/24494, following the pattern established in https://github.com/langgenius/dify/pull/24649.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
