### PR TITLE
fix: metadata batch edit silently fails by swallowing exceptions

### DIFF
--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -220,7 +220,7 @@ class MetadataService:
                     doc_metadata[BuiltInField.source] = MetadataDataSource[document.data_source_type]
                 document.doc_metadata = doc_metadata
                 db.session.add(document)
-                db.session.commit()
+
                 # deal metadata binding
                 if not operation.partial_update:
                     db.session.query(DatasetMetadataBinding).filter_by(document_id=operation.document_id).delete()
@@ -247,7 +247,9 @@ class MetadataService:
                     db.session.add(dataset_metadata_binding)
                 db.session.commit()
             except Exception:
+                db.session.rollback()
                 logger.exception("Update documents metadata failed")
+                raise
             finally:
                 redis_client.delete(lock_key)
 


### PR DESCRIPTION
## Summary
- Fixes a bug where batch metadata edits appeared to succeed but silently failed, with no changes actually persisted.
- The `update_documents_metadata` method caught all exceptions with a bare `except` clause and only logged them, always returning `{"result": "success"}` to the API caller regardless of whether the update actually succeeded.
- Additionally, the method had two separate `db.session.commit()` calls which could leave the database in an inconsistent state if the second commit failed (doc_metadata JSON updated but metadata bindings not created/updated).

## Root Cause
In `MetadataService.update_documents_metadata()`:

```python
try:
    # ... update doc_metadata ...
    db.session.commit()       # <-- first commit: doc_metadata updated
    # ... update bindings ...
    db.session.commit()       # <-- second commit: bindings updated
except Exception:
    logger.exception("Update documents metadata failed")  # silently swallowed!
```

Any exception (lock conflicts, DB errors, validation errors) was silently caught and logged. The API endpoint always returned 200 success, and the frontend showed a success toast even though nothing was saved.

## Fix
1. **Consolidate into a single `db.session.commit()`** for atomicity -- both doc_metadata and bindings are committed together or not at all
2. **Add `db.session.rollback()` on exception** to clean up the session state
3. **Re-raise the exception** so the API endpoint returns a proper error response to the frontend

## Test plan
- [x] Ruff linting passes
- [ ] Verify batch metadata edit now shows error when backend fails
- [ ] Verify batch metadata edit succeeds when backend processes correctly

Closes #31964