### PR TITLE
chore: remove server_default from UUID columns in model definitions

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -620,7 +620,7 @@ class TrialApp(Base):
         sa.UniqueConstraint("app_id", name="unique_trail_app_id"),
     )
 
-    id = mapped_column(StringUUID, server_default=sa.text("uuid_generate_v4()"))
+    id = mapped_column(StringUUID, default=lambda: str(uuid4()))
     app_id = mapped_column(StringUUID, nullable=False)
     tenant_id = mapped_column(StringUUID, nullable=False)
     created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
@@ -640,7 +640,7 @@ class AccountTrialAppRecord(Base):
         sa.Index("account_trial_app_record_app_id_idx", "app_id"),
         sa.UniqueConstraint("account_id", "app_id", name="unique_account_trial_app_record"),
     )
-    id = mapped_column(StringUUID, server_default=sa.text("uuid_generate_v4()"))
+    id = mapped_column(StringUUID, default=lambda: str(uuid4()))
     account_id = mapped_column(StringUUID, nullable=False)
     app_id = mapped_column(StringUUID, nullable=False)
     count = mapped_column(sa.Integer, nullable=False, default=0)
@@ -660,7 +660,7 @@ class AccountTrialAppRecord(Base):
 class ExporleBanner(TypeBase):
     __tablename__ = "exporle_banners"
     __table_args__ = (sa.PrimaryKeyConstraint("id", name="exporler_banner_pkey"),)
-    id: Mapped[str] = mapped_column(StringUUID, server_default=sa.text("uuid_generate_v4()"), init=False)
+    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()), init=False)
     content: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
     link: Mapped[str] = mapped_column(String(255), nullable=False)
     sort: Mapped[int] = mapped_column(sa.Integer, nullable=False)


### PR DESCRIPTION
## Summary
- Remove server_default from UUID column definitions in TrialApp, AccountTrialAppRecord, and ExporleBanner models
- Replace with default=lambda: str(uuid4()) to handle UUID generation at the application layer
- Aligns these models with the existing convention used by all other models in the file

## Motivation
As described in #29314, the server_default parameter with uuid_generate_v4() is PostgreSQL-specific and causes confusion for new model definitions. The application layer should handle database-agnostic UUID generation using Python uuid4(), which is the established pattern throughout the codebase.

Migration files are intentionally left unchanged as they reflect the actual database state at the time of creation.

## Test plan
- [x] Verified all pre-commit checks pass (Ruff linter, ESLint, TypeScript type-check)
- [x] Confirmed uuid4 is already imported at the top of the file (from uuid import uuid4)
- [x] Confirmed the change follows the same pattern as other models in the same file (e.g., App, InstalledApp, RecommendedApp)

Closes #29314