### PR TITLE
fix(api): serialize pipeline file-upload created_at

### DIFF
--- a/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
@@ -239,5 +239,5 @@ class KnowledgebasePipelineFileUploadApi(DatasetApiResource):
             "extension": upload_file.extension,
             "mime_type": upload_file.mime_type,
             "created_by": upload_file.created_by,
-            "created_at": upload_file.created_at,
+            "created_at": upload_file.created_at.isoformat() if upload_file.created_at else None,
         }, 201

--- a/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
@@ -11,6 +11,7 @@ import services
 from controllers.common.errors import FilenameNotExistsError, NoFileUploadedError, TooManyFilesError
 from controllers.common.schema import register_schema_model
 from controllers.service_api import service_api_ns
+from controllers.service_api.dataset.rag_pipeline.serializers import serialize_upload_file
 from controllers.service_api.dataset.error import PipelineRunError
 from controllers.service_api.wraps import DatasetApiResource
 from core.app.apps.pipeline.pipeline_generator import PipelineGenerator
@@ -232,12 +233,4 @@ class KnowledgebasePipelineFileUploadApi(DatasetApiResource):
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError()
 
-        return {
-            "id": upload_file.id,
-            "name": upload_file.name,
-            "size": upload_file.size,
-            "extension": upload_file.extension,
-            "mime_type": upload_file.mime_type,
-            "created_by": upload_file.created_by,
-            "created_at": upload_file.created_at.isoformat() if upload_file.created_at else None,
-        }, 201
+        return serialize_upload_file(upload_file), 201

--- a/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
@@ -11,8 +11,8 @@ import services
 from controllers.common.errors import FilenameNotExistsError, NoFileUploadedError, TooManyFilesError
 from controllers.common.schema import register_schema_model
 from controllers.service_api import service_api_ns
-from controllers.service_api.dataset.rag_pipeline.serializers import serialize_upload_file
 from controllers.service_api.dataset.error import PipelineRunError
+from controllers.service_api.dataset.rag_pipeline.serializers import serialize_upload_file
 from controllers.service_api.wraps import DatasetApiResource
 from core.app.apps.pipeline.pipeline_generator import PipelineGenerator
 from core.app.entities.app_invoke_entities import InvokeFrom

--- a/api/controllers/service_api/dataset/rag_pipeline/serializers.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/serializers.py
@@ -13,7 +13,7 @@ class UploadFileLike(Protocol):
     name: str
     size: int
     extension: str
-    mime_type: str
+    mime_type: str | None
     created_by: str
     created_at: datetime | None
 
@@ -28,4 +28,3 @@ def serialize_upload_file(upload_file: UploadFileLike) -> dict[str, Any]:
         "created_by": upload_file.created_by,
         "created_at": upload_file.created_at.isoformat() if upload_file.created_at else None,
     }
-

--- a/api/controllers/service_api/dataset/rag_pipeline/serializers.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/serializers.py
@@ -1,0 +1,31 @@
+"""
+Serialization helpers for Service API knowledge pipeline endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Protocol
+
+
+class UploadFileLike(Protocol):
+    id: Any
+    name: str
+    size: int
+    extension: str
+    mime_type: str
+    created_by: str
+    created_at: datetime | None
+
+
+def serialize_upload_file(upload_file: UploadFileLike) -> dict[str, Any]:
+    return {
+        "id": upload_file.id,
+        "name": upload_file.name,
+        "size": upload_file.size,
+        "extension": upload_file.extension,
+        "mime_type": upload_file.mime_type,
+        "created_by": upload_file.created_by,
+        "created_at": upload_file.created_at.isoformat() if upload_file.created_at else None,
+    }
+

--- a/api/controllers/service_api/dataset/rag_pipeline/serializers.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/serializers.py
@@ -4,21 +4,13 @@ Serialization helpers for Service API knowledge pipeline endpoints.
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from models.model import UploadFile
 
 
-class UploadFileLike(Protocol):
-    id: Any
-    name: str
-    size: int
-    extension: str
-    mime_type: str | None
-    created_by: str
-    created_at: datetime | None
-
-
-def serialize_upload_file(upload_file: UploadFileLike) -> dict[str, Any]:
+def serialize_upload_file(upload_file: UploadFile) -> dict[str, Any]:
     return {
         "id": upload_file.id,
         "name": upload_file.name,

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for Service API knowledge pipeline file-upload serialization.
+"""
+
+import ast
+from pathlib import Path
+
+
+def test_file_upload_created_at_is_isoformat_string():
+    api_dir = Path(__file__).resolve().parents[5]
+    rag_pipeline_workflow = (
+        api_dir / "controllers" / "service_api" / "dataset" / "rag_pipeline" / "rag_pipeline_workflow.py"
+    )
+
+    tree = ast.parse(rag_pipeline_workflow.read_text(encoding="utf-8"))
+    created_at_expr = None
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if node.name != "KnowledgebasePipelineFileUploadApi":
+            continue
+        for body_node in node.body:
+            if not isinstance(body_node, ast.FunctionDef):
+                continue
+            if body_node.name != "post":
+                continue
+            for inner in ast.walk(body_node):
+                if not isinstance(inner, ast.Return):
+                    continue
+                if not isinstance(inner.value, ast.Tuple) or not inner.value.elts:
+                    continue
+                response_dict = inner.value.elts[0]
+                if not isinstance(response_dict, ast.Dict):
+                    continue
+                for key, value in zip(response_dict.keys, response_dict.values, strict=False):
+                    if isinstance(key, ast.Constant) and key.value == "created_at":
+                        created_at_expr = value
+
+    assert created_at_expr is not None
+
+    isoformat_call = created_at_expr.body if isinstance(created_at_expr, ast.IfExp) else created_at_expr
+    assert isinstance(isoformat_call, ast.Call)
+    assert isinstance(isoformat_call.func, ast.Attribute)
+    assert isoformat_call.func.attr == "isoformat"
+

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
@@ -22,7 +22,8 @@ def _load_serialize_upload_file():
     serializers_path = api_dir / "controllers" / "service_api" / "dataset" / "rag_pipeline" / "serializers.py"
 
     spec = importlib.util.spec_from_file_location("rag_pipeline_serializers", serializers_path)
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore[attr-defined]
     return module.serialize_upload_file
@@ -59,4 +60,3 @@ def test_file_upload_created_at_none_serializes_to_null():
 
     result = serialize_upload_file(upload_file)
     assert result["created_at"] is None
-

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
@@ -3,7 +3,7 @@ Unit tests for Service API knowledge pipeline file-upload serialization.
 """
 
 import importlib.util
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -32,7 +32,7 @@ def _load_serialize_upload_file():
 def test_file_upload_created_at_is_isoformat_string():
     serialize_upload_file = _load_serialize_upload_file()
 
-    created_at = datetime(2026, 2, 8, 12, 0, 0, tzinfo=timezone.utc)
+    created_at = datetime(2026, 2, 8, 12, 0, 0, tzinfo=UTC)
     upload_file = FakeUploadFile()
     upload_file.id = "file-1"
     upload_file.name = "test.pdf"


### PR DESCRIPTION
Fixes #32100

## Summary
- Fix `POST /v1/datasets/pipeline/file-upload` 500s by serializing `created_at` to an ISO-8601 string.
- Add a small serializer helper + unit tests to verify the JSON-safe output.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Verification
```bash
# Upload
curl -i -X POST -H "Authorization: Bearer $DIFY_API_KEY" \
  -F "file=@/path/to/file.pdf" \
  "$DIFY_BASE_URL/v1/datasets/pipeline/file-upload"
# -> 201 and JSON where created_at is a string

# No file
curl -i -X POST -H "Authorization: Bearer $DIFY_API_KEY" \
  "$DIFY_BASE_URL/v1/datasets/pipeline/file-upload"
# -> 400 {"code":"no_file_uploaded",...}
```

## Tests
- `make test TARGET_TESTS=api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py`

## Checklist
- [ ] This change requires a documentation update, included: https://github.com/langgenius/dify-docs
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

> Note: As an external contributor I can’t self-assign to issues; please assign if needed.