### PR TITLE
fix(web): fill workflow tool output descriptions from schema

### DIFF
--- a/web/app/components/tools/workflow-tool/utils.test.ts
+++ b/web/app/components/tools/workflow-tool/utils.test.ts
@@ -13,6 +13,54 @@ describe('buildWorkflowOutputParameters', () => {
     expect(result).toBe(params)
   })
 
+  it('fills missing output description and type from schema when array input exists', () => {
+    const params: WorkflowToolProviderOutputParameter[] = [
+      { name: 'answer', description: '', type: undefined },
+      { name: 'files', description: 'keep this description', type: VarType.arrayFile },
+    ]
+    const schema: WorkflowToolProviderOutputSchema = {
+      type: 'object',
+      properties: {
+        answer: {
+          type: VarType.string,
+          description: 'Generated answer',
+        },
+        files: {
+          type: VarType.arrayFile,
+          description: 'Schema files description',
+        },
+      },
+    }
+
+    const result = buildWorkflowOutputParameters(params, schema)
+
+    expect(result).toEqual([
+      { name: 'answer', description: 'Generated answer', type: VarType.string },
+      { name: 'files', description: 'keep this description', type: VarType.arrayFile },
+    ])
+  })
+
+  it('falls back to empty description when both payload and schema descriptions are missing', () => {
+    const params: WorkflowToolProviderOutputParameter[] = [
+      { name: 'missing_desc', description: '', type: undefined },
+    ]
+    const schema: WorkflowToolProviderOutputSchema = {
+      type: 'object',
+      properties: {
+        other_field: {
+          type: VarType.string,
+          description: 'Other',
+        },
+      },
+    }
+
+    const result = buildWorkflowOutputParameters(params, schema)
+
+    expect(result).toEqual([
+      { name: 'missing_desc', description: '', type: undefined },
+    ])
+  })
+
   it('derives parameters from schema when explicit array missing', () => {
     const schema: WorkflowToolProviderOutputSchema = {
       type: 'object',
@@ -43,5 +91,40 @@ describe('buildWorkflowOutputParameters', () => {
 
   it('returns empty array when no source information is provided', () => {
     expect(buildWorkflowOutputParameters(null, null)).toEqual([])
+  })
+
+  it('derives parameters from schema when explicit array is empty', () => {
+    const schema: WorkflowToolProviderOutputSchema = {
+      type: 'object',
+      properties: {
+        output_text: {
+          type: VarType.string,
+          description: 'Output text',
+        },
+      },
+    }
+
+    const result = buildWorkflowOutputParameters([], schema)
+
+    expect(result).toEqual([
+      { name: 'output_text', description: 'Output text', type: VarType.string },
+    ])
+  })
+
+  it('returns undefined type when schema output type is missing', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        answer: {
+          description: 'Answer without type',
+        },
+      },
+    } as unknown as WorkflowToolProviderOutputSchema
+
+    const result = buildWorkflowOutputParameters(undefined, schema)
+
+    expect(result).toEqual([
+      { name: 'answer', description: 'Answer without type', type: undefined },
+    ])
   })
 })

--- a/web/app/components/tools/workflow-tool/utils.test.ts
+++ b/web/app/components/tools/workflow-tool/utils.test.ts
@@ -127,4 +127,21 @@ describe('buildWorkflowOutputParameters', () => {
       { name: 'answer', description: 'Answer without type', type: undefined },
     ])
   })
+
+  it('falls back to empty description when schema-derived description is missing', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        answer: {
+          type: VarType.string,
+        },
+      },
+    } as unknown as WorkflowToolProviderOutputSchema
+
+    const result = buildWorkflowOutputParameters(undefined, schema)
+
+    expect(result).toEqual([
+      { name: 'answer', description: '', type: VarType.string },
+    ])
+  })
 })

--- a/web/app/components/tools/workflow-tool/utils.ts
+++ b/web/app/components/tools/workflow-tool/utils.ts
@@ -35,7 +35,7 @@ export const buildWorkflowOutputParameters = (
 
   return Object.entries(schemaProperties).map(([name, schema]) => ({
     name,
-    description: schema.description,
+    description: schema.description || '',
     type: normalizeVarType(schema.type),
   }))
 }

--- a/web/app/components/tools/workflow-tool/utils.ts
+++ b/web/app/components/tools/workflow-tool/utils.ts
@@ -14,13 +14,26 @@ export const buildWorkflowOutputParameters = (
   outputParameters: WorkflowToolProviderOutputParameter[] | null | undefined,
   outputSchema?: WorkflowToolProviderOutputSchema | null,
 ): WorkflowToolProviderOutputParameter[] => {
-  if (Array.isArray(outputParameters))
-    return outputParameters
+  const schemaProperties = outputSchema?.properties
 
-  if (!outputSchema?.properties)
+  if (Array.isArray(outputParameters) && outputParameters.length > 0) {
+    if (!schemaProperties)
+      return outputParameters
+
+    return outputParameters.map((item) => {
+      const schema = schemaProperties[item.name]
+      return {
+        ...item,
+        description: item.description || schema?.description || '',
+        type: normalizeVarType(item.type || schema?.type),
+      }
+    })
+  }
+
+  if (!schemaProperties)
     return []
 
-  return Object.entries(outputSchema.properties).map(([name, schema]) => ({
+  return Object.entries(schemaProperties).map(([name, schema]) => ({
     name,
     description: schema.description,
     type: normalizeVarType(schema.type),


### PR DESCRIPTION
## Summary
Fixes #32093.

When configuring a published workflow tool, output field descriptions can appear empty in the Tool Output section even though descriptions exist in `tool.output_schema`.

## Root cause
`buildWorkflowOutputParameters` returned `outputParameters` as-is whenever an array was provided, without using `output_schema` to fill missing description/type fields.

## Changes
- Updated `buildWorkflowOutputParameters` to:
  - keep existing behavior when there is no schema;
  - fill missing `description`/`type` from `output_schema` when array items are incomplete;
  - derive from schema when explicit output parameter array is empty.
- Added/updated unit tests for:
  - fallback description/type merge from schema;
  - empty-description fallback when both payload and schema lack description;
  - deriving from schema when explicit array is empty;
  - missing schema type handling.

## Testing
Executed locally in `web/`:
- `corepack pnpm lint app/components/tools/workflow-tool/utils.ts app/components/tools/workflow-tool/utils.test.ts`
- `corepack pnpm test app/components/tools/workflow-tool/utils.test.ts`
- `corepack pnpm test:coverage app/components/tools/workflow-tool/utils.test.ts`
- `corepack pnpm run type-check`

Coverage for touched module in this run:
- `app/components/tools/workflow-tool/utils.ts`
  - statements: 100%
  - branches: 100%
  - functions: 100%
  - lines: 100%
