### PR TITLE
fix: resolve file validation failure on file return for workflow-as-tool

### DIFF
--- a/api/core/tools/__base/tool.py
+++ b/api/core/tools/__base/tool.py
@@ -171,7 +171,7 @@ class Tool(ABC):
     def create_file_message(self, file: File) -> ToolInvokeMessage:
         return ToolInvokeMessage(
             type=ToolInvokeMessage.MessageType.FILE,
-            message=ToolInvokeMessage.FileMessage(),
+            message=ToolInvokeMessage.FileMessage(file_marker="file_marker"),
             meta={"file": file},
         )
 


### PR DESCRIPTION
Fixes #32112

## Summary
### Bug
When a workflow is released as a tool and used elsewhere, it always raise validation error if the return value contains files.

### Root Cause
The returned files are created via
https://github.com/langgenius/dify/blob/0428ac5f3aca02ebaeb3bedad866eb7957adf5a7/api/core/tools/__base/tool.py#L171-L176

While the class `FileMessage` has an attribute `file_marker` which would be validated **before** the model is instantiated and the default value assigned.
https://github.com/langgenius/dify/blob/0428ac5f3aca02ebaeb3bedad866eb7957adf5a7/api/core/tools/entities/tool_entities.py#L146-L154

### Solution
I fix it by simply pass in the default parameter value explicitly.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| <img width="2673" height="1008" alt="bug2" src="https://github.com/user-attachments/assets/fe80cc07-70be-49f9-81e2-f5846390c1bc" /> | <img width="2669" height="1026" alt="fixed" src="https://github.com/user-attachments/assets/f776ed85-62bf-4fd9-ae7a-be9003fafaf7" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
