### PR TITLE
fix(console): keep conversation updated_at unchanged when marking read

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -599,7 +599,12 @@ def _get_conversation(app_model, conversation_id):
     db.session.execute(
         sa.update(Conversation)
         .where(Conversation.id == conversation_id, Conversation.read_at.is_(None))
-        .values(read_at=naive_utc_now(), read_account_id=current_user.id)
+        # Keep updated_at unchanged when only marking a conversation as read.
+        .values(
+            read_at=naive_utc_now(),
+            read_account_id=current_user.id,
+            updated_at=Conversation.updated_at,
+        )
     )
     db.session.commit()
     db.session.refresh(conversation)

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from controllers.console.app.conversation import _get_conversation
+
+
+def test_get_conversation_mark_read_keeps_updated_at_unchanged():
+    app_model = SimpleNamespace(id="app-id")
+    account = SimpleNamespace(id="account-id")
+    conversation = MagicMock()
+    conversation.id = "conversation-id"
+
+    with (
+        patch("controllers.console.app.conversation.current_account_with_tenant", return_value=(account, None)),
+        patch("controllers.console.app.conversation.naive_utc_now", return_value=datetime(2026, 2, 9, 0, 0, 0)),
+        patch("controllers.console.app.conversation.db.session") as mock_session,
+    ):
+        mock_session.query.return_value.where.return_value.first.return_value = conversation
+
+        _get_conversation(app_model, "conversation-id")
+
+        statement = mock_session.execute.call_args[0][0]
+        sql_text = str(statement).lower()
+
+        assert "updated_at=current_timestamp" not in sql_text
+        assert "updated_at=conversations.updated_at" in sql_text
+        assert "read_at" in sql_text
+        assert "read_account_id" in sql_text

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py
@@ -21,9 +21,14 @@ def test_get_conversation_mark_read_keeps_updated_at_unchanged():
         _get_conversation(app_model, "conversation-id")
 
         statement = mock_session.execute.call_args[0][0]
-        sql_text = str(statement).lower()
+        compiled = statement.compile()
+        sql_text = str(compiled).lower()
+        compact_sql_text = sql_text.replace(" ", "")
+        params = compiled.params
 
-        assert "updated_at=current_timestamp" not in sql_text
-        assert "updated_at=conversations.updated_at" in sql_text
-        assert "read_at" in sql_text
-        assert "read_account_id" in sql_text
+        assert "updated_at=current_timestamp" not in compact_sql_text
+        assert "updated_at=conversations.updated_at" in compact_sql_text
+        assert "read_at=:read_at" in compact_sql_text
+        assert "read_account_id=:read_account_id" in compact_sql_text
+        assert params["read_at"] == datetime(2026, 2, 9, 0, 0, 0)
+        assert params["read_account_id"] == "account-id"


### PR DESCRIPTION
## Summary
Fixes #32125.
close #32136
Viewing a conversation in Logs & Annotations marks it as read (`read_at`/`read_account_id`). This read-only action should not change `updated_at`, but SQLAlchemy `onupdate` was auto-updating it.

This PR keeps `updated_at` unchanged during the mark-as-read update by explicitly setting `updated_at=Conversation.updated_at`.

## Changes
- `api/controllers/console/app/conversation.py`
  - Preserve `updated_at` when setting `read_at` and `read_account_id` in `_get_conversation`.
- `api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py`
  - Add regression test ensuring the generated UPDATE statement does not set `updated_at=CURRENT_TIMESTAMP`.

## Testing
- `uv run --project api --group dev ruff check api/controllers/console/app/conversation.py api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py`
- `uv run --project api --group dev pytest api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py -q`

## Impact
- Prevents read operations from polluting conversation "Updated Time" sorting/filtering.
