### PR TITLE
security: prevent exception message disclosure in OAuth error handling

### DIFF
--- a/api/controllers/console/auth/oauth.py
+++ b/api/controllers/console/auth/oauth.py
@@ -134,8 +134,8 @@ class OAuthCallback(Resource):
                 f"{dify_config.CONSOLE_WEB_URL}/signin"
                 "?message=Workspace not found, please contact system admin to invite you to join in a workspace."
             )
-        except AccountRegisterError as e:
-            return redirect(f"{dify_config.CONSOLE_WEB_URL}/signin?message={e.description}")
+        except AccountRegisterError:
+            return redirect(f"{dify_config.CONSOLE_WEB_URL}/signin?message=Account registration failed.")
 
         # Check account status
         if account.status == AccountStatus.BANNED:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -1391,7 +1391,7 @@ class RegisterService:
         except Exception as e:
             db.session.rollback()
             logger.exception("Register failed")
-            raise AccountRegisterError(f"Registration failed: {e}") from e
+            raise AccountRegisterError("Registration failed.") from e
 
         return account
 


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

This potential vulnerability was originally reported through Github Security Advisories on January 6th 2026, as detailed in the SECURITY.md. However, as there has been no acknowledgement or update on this, we are creating this PR in the interest of the community to assist in ensuring this project remains secure.

The finding and PR was generated using [Kolega.dev](https://kolega.dev/)'s AI Agent and manually checked and verified by @FaizanKolega before PR creation.

## Exception Message Disclosure in OAuth Error Handling

## Location
`api/controllers/console/auth/oauth.py:136`

## Description
Exception descriptions from the service layer are directly exposed to users in OAuth callback redirects. Service layer exceptions may contain sensitive information like database errors, API details, or configuration info.

## Analysis Notes
The code passes `e.description` directly to the client via URL redirect. While most AccountRegisterError descriptions are hardcoded safe strings ('Invalid email or password', '30 days unavailable'), there is a dangerous case at services/account_service.py:1350 where `raise AccountRegisterError(f"Registration failed: {e}")` wraps arbitrary exceptions. If the underlying exception contains database errors, connection details, or stack trace information, this will be exposed to the user in the URL. This is a real vulnerability because: (1) The description can contain raw exception messages from unexpected errors. (2) URL parameters are logged in browser history, server logs, and may be visible to intermediaries. (3) The fix is simple: map AccountRegisterError to a generic message or use an error code lookup.

## Fix Applied
Replaced the dynamic `e.description` passthrough in the OAuth callback redirect with a static generic error message ("Account registration failed."), matching the pattern used by other auth controllers (login.py, email_register.py) that catch AccountRegisterError without exposing its description. Also removed the f-string interpolation of arbitrary exception messages in `RegisterService.register()` to prevent sensitive error details from being embedded in AccountRegisterError descriptions at the source.

## Tests/Linters Ran
- `ruff check` on both changed files: All checks passed
- `ruff format --check` on both changed files: Already formatted
- `pytest tests/unit_tests/controllers/console/auth/test_oauth.py --no-cov`: 26 passed
- `pytest tests/unit_tests/services/test_account_service.py --no-cov`: 52 passed
- `pytest tests/unit_tests/controllers/console/auth/ --no-cov`: 103 passed (all auth controller tests)