### PR TITLE
fix(web): redirect to OAuth authorize page after login instead of /apps

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,7 +1,24 @@
-import Link from 'next/link'
-import Loading from '@/app/components/base/loading'
+'use client'
 
-const Home = async () => {
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import Loading from '@/app/components/base/loading'
+import { OAUTH_AUTHORIZE_PENDING_KEY } from '@/app/account/oauth/authorize/constants'
+import { getOAuthPendingRedirect } from '@/app/signin/utils/post-login-redirect'
+
+const Home = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    const pendingRedirect = getOAuthPendingRedirect(OAUTH_AUTHORIZE_PENDING_KEY)
+    if (pendingRedirect) {
+      router.replace(pendingRedirect)
+      return
+    }
+    router.replace('/apps')
+  }, [router])
+
   return (
     <div className="flex min-h-screen flex-col justify-center py-12 sm:px-6 lg:px-8">
 

--- a/web/app/signin/utils/post-login-redirect.ts
+++ b/web/app/signin/utils/post-login-redirect.ts
@@ -2,7 +2,7 @@ import type { ReadonlyURLSearchParams } from 'next/navigation'
 import dayjs from 'dayjs'
 import { OAUTH_AUTHORIZE_PENDING_KEY, REDIRECT_URL_KEY } from '@/app/account/oauth/authorize/constants'
 
-function getItemWithExpiry(key: string): string | null {
+export function getOAuthPendingRedirect(key: string): string | null {
   const itemStr = localStorage.getItem(key)
   if (!itemStr)
     return null
@@ -33,5 +33,5 @@ export const resolvePostLoginRedirect = (searchParams: ReadonlyURLSearchParams) 
     }
   }
 
-  return getItemWithExpiry(OAUTH_AUTHORIZE_PENDING_KEY)
+  return getOAuthPendingRedirect(OAUTH_AUTHORIZE_PENDING_KEY)
 }


### PR DESCRIPTION
After social auth (GitHub/Google), the backend redirects to the root page `/` which was a static server component showing only a loading spinner. The pending OAuth authorize URL stored in localStorage was never consumed, causing users to get stuck instead of returning to the OAuth authorization flow.

Convert root page to a client component that checks localStorage for a pending OAuth redirect on mount and navigates accordingly.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
