### PR TITLE
fix: add distributed lock and fix session persistence for OAuth token refresh

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -278,9 +278,7 @@ class ToolManager:
                         with Session(db.engine) as session:
                             # double-check after acquiring lock: re-read from DB
                             bp = session.get(BuiltinToolProvider, builtin_provider.id)
-                            if bp is not None and bp.expires_at != -1 and (
-                                bp.expires_at - 60
-                            ) < int(time.time()):
+                            if bp is not None and bp.expires_at != -1 and (bp.expires_at - 60) < int(time.time()):
                                 # TODO: circular import
                                 from core.plugin.impl.oauth import OAuthHandler
                                 from services.tools.builtin_tools_manage_service import BuiltinToolManageService
@@ -292,9 +290,7 @@ class ToolManager:
                                     f"{dify_config.CONSOLE_API_URL}/console/api/oauth/plugin/"
                                     f"{provider_id}/tool/callback"
                                 )
-                                system_credentials = BuiltinToolManageService.get_oauth_client(
-                                    tenant_id, provider_id
-                                )
+                                system_credentials = BuiltinToolManageService.get_oauth_client(tenant_id, provider_id)
 
                                 oauth_handler = OAuthHandler()
                                 refreshed_credentials = oauth_handler.refresh_credentials(

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -26,6 +26,7 @@ from core.tools.utils.uuid_utils import is_valid_uuid
 from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
 from core.workflow.runtime.variable_pool import VariablePool
 from extensions.ext_database import db
+from extensions.ext_redis import redis_client
 from models.provider_ids import ToolProviderID
 from services.enterprise.plugin_manager_service import PluginCredentialType
 from services.tools.mcp_tools_manage_service import MCPToolManageService
@@ -267,35 +268,62 @@ class ToolManager:
 
             # check if the credentials is expired
             if builtin_provider.expires_at != -1 and (builtin_provider.expires_at - 60) < int(time.time()):
-                # TODO: circular import
-                from core.plugin.impl.oauth import OAuthHandler
-                from services.tools.builtin_tools_manage_service import BuiltinToolManageService
+                lock_key = f"oauth_token_refresh_lock:{tenant_id}_{provider_id}_{builtin_provider.id}"
+                lock = redis_client.lock(lock_key, timeout=30)
+                if lock.acquire(blocking=False):
+                    try:
+                        # double-check after acquiring lock: another request may have already refreshed
+                        db.session.refresh(builtin_provider)
+                        if builtin_provider.expires_at != -1 and (
+                            builtin_provider.expires_at - 60
+                        ) < int(time.time()):
+                            # TODO: circular import
+                            from core.plugin.impl.oauth import OAuthHandler
+                            from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 
-                # refresh the credentials
-                tool_provider = ToolProviderID(provider_id)
-                provider_name = tool_provider.provider_name
-                redirect_uri = f"{dify_config.CONSOLE_API_URL}/console/api/oauth/plugin/{provider_id}/tool/callback"
-                system_credentials = BuiltinToolManageService.get_oauth_client(tenant_id, provider_id)
+                            # refresh the credentials
+                            tool_provider = ToolProviderID(provider_id)
+                            provider_name = tool_provider.provider_name
+                            redirect_uri = (
+                                f"{dify_config.CONSOLE_API_URL}/console/api/oauth/plugin/"
+                                f"{provider_id}/tool/callback"
+                            )
+                            system_credentials = BuiltinToolManageService.get_oauth_client(tenant_id, provider_id)
 
-                oauth_handler = OAuthHandler()
-                # refresh the credentials
-                refreshed_credentials = oauth_handler.refresh_credentials(
-                    tenant_id=tenant_id,
-                    user_id=builtin_provider.user_id,
-                    plugin_id=tool_provider.plugin_id,
-                    provider=provider_name,
-                    redirect_uri=redirect_uri,
-                    system_credentials=system_credentials or {},
-                    credentials=decrypted_credentials,
-                )
-                # update the credentials
-                builtin_provider.encrypted_credentials = json.dumps(
-                    encrypter.encrypt(refreshed_credentials.credentials)
-                )
-                builtin_provider.expires_at = refreshed_credentials.expires_at
-                db.session.commit()
-                decrypted_credentials = refreshed_credentials.credentials
-                cache.delete()
+                            oauth_handler = OAuthHandler()
+                            refreshed_credentials = oauth_handler.refresh_credentials(
+                                tenant_id=tenant_id,
+                                user_id=builtin_provider.user_id,
+                                plugin_id=tool_provider.plugin_id,
+                                provider=provider_name,
+                                redirect_uri=redirect_uri,
+                                system_credentials=system_credentials or {},
+                                credentials=decrypted_credentials,
+                            )
+                            # update the credentials
+                            builtin_provider.encrypted_credentials = json.dumps(
+                                encrypter.encrypt(refreshed_credentials.credentials)
+                            )
+                            builtin_provider.expires_at = refreshed_credentials.expires_at
+                            db.session.commit()
+                            decrypted_credentials = refreshed_credentials.credentials
+                            cache.delete()
+                        else:
+                            decrypted_credentials = encrypter.decrypt(builtin_provider.credentials)
+                    finally:
+                        lock.release()
+                else:
+                    # another request is refreshing; poll DB until credentials are fresh
+                    backoff = 0.1
+                    for _ in range(5):
+                        time.sleep(backoff)
+                        db.session.refresh(builtin_provider)
+                        if builtin_provider.expires_at != -1 and (
+                            builtin_provider.expires_at - 60
+                        ) >= int(time.time()):
+                            break
+                        backoff = min(backoff * 2, 1.0)
+                    decrypted_credentials = encrypter.decrypt(builtin_provider.credentials)
 
             return builtin_tool.fork_tool_runtime(
                 runtime=ToolRuntime(

--- a/api/services/datasource_provider_service.py
+++ b/api/services/datasource_provider_service.py
@@ -130,9 +130,9 @@ class DatasourceProviderService:
                     with redis_client.lock(lock_key, timeout=30, blocking_timeout=0):
                         # double-check after acquiring lock: another request may have already refreshed
                         session.refresh(datasource_provider)
-                        if datasource_provider.expires_at != -1 and (
-                            datasource_provider.expires_at - 60
-                        ) < int(time.time()):
+                        if datasource_provider.expires_at != -1 and (datasource_provider.expires_at - 60) < int(
+                            time.time()
+                        ):
                             current_user = get_current_user()
                             decrypted_credentials = self.decrypt_datasource_provider_credentials(
                                 tenant_id=tenant_id,
@@ -156,14 +156,12 @@ class DatasourceProviderService:
                                 system_credentials=system_credentials or {},
                                 credentials=decrypted_credentials,
                             )
-                            datasource_provider.encrypted_credentials = (
-                                self.encrypt_datasource_provider_credentials(
-                                    tenant_id=tenant_id,
-                                    raw_credentials=refreshed_credentials.credentials,
-                                    provider=provider,
-                                    plugin_id=plugin_id,
-                                    datasource_provider=datasource_provider,
-                                )
+                            datasource_provider.encrypted_credentials = self.encrypt_datasource_provider_credentials(
+                                tenant_id=tenant_id,
+                                raw_credentials=refreshed_credentials.credentials,
+                                provider=provider,
+                                plugin_id=plugin_id,
+                                datasource_provider=datasource_provider,
                             )
                             datasource_provider.expires_at = refreshed_credentials.expires_at
                             session.commit()

--- a/api/tests/integration_tests/test_oauth_refresh_lock_concurrency.py
+++ b/api/tests/integration_tests/test_oauth_refresh_lock_concurrency.py
@@ -61,12 +61,14 @@ class TokenRotationSimulator:
 
             if incoming_rt != self._current_valid_refresh_token:
                 self.invalid_grant_count += 1
-                self.call_log.append({
-                    "thread": threading.current_thread().name,
-                    "incoming_rt": incoming_rt,
-                    "expected_rt": self._current_valid_refresh_token,
-                    "result": "invalid_grant",
-                })
+                self.call_log.append(
+                    {
+                        "thread": threading.current_thread().name,
+                        "incoming_rt": incoming_rt,
+                        "expected_rt": self._current_valid_refresh_token,
+                        "result": "invalid_grant",
+                    }
+                )
                 raise RuntimeError(
                     f"invalid_grant: refresh_token '{incoming_rt}' has been revoked. "
                     f"Current valid token is '{self._current_valid_refresh_token}'"
@@ -79,13 +81,15 @@ class TokenRotationSimulator:
             self._current_valid_refresh_token = new_rt
             self.success_count += 1
 
-            self.call_log.append({
-                "thread": threading.current_thread().name,
-                "incoming_rt": incoming_rt,
-                "new_rt": new_rt,
-                "new_at": new_at,
-                "result": "success",
-            })
+            self.call_log.append(
+                {
+                    "thread": threading.current_thread().name,
+                    "incoming_rt": incoming_rt,
+                    "new_rt": new_rt,
+                    "new_at": new_at,
+                    "result": "success",
+                }
+            )
 
             return {
                 "access_token": new_at,
@@ -98,6 +102,7 @@ class TokenRotationSimulator:
 # Test: Concurrent refresh with distributed lock
 # ---------------------------------------------------------------------------
 
+
 def test_concurrent_oauth_refresh_with_lock():
     """Test that distributed lock prevents concurrent token refresh race condition."""
 
@@ -107,7 +112,10 @@ def test_concurrent_oauth_refresh_with_lock():
 
     # Connect to Redis
     redis_client = redis.Redis(
-        host=redis_host, port=redis_port, password=redis_password, db=15,
+        host=redis_host,
+        port=redis_port,
+        password=redis_password,
+        db=15,
     )  # Use DB 15 for testing
     redis_client.ping()
 
@@ -159,9 +167,7 @@ def test_concurrent_oauth_refresh_with_lock():
                         with db_lock:
                             current_creds = dict(db_state)
 
-                        if current_creds["expires_at"] != -1 and (
-                            current_creds["expires_at"] - 60
-                        ) < int(time.time()):
+                        if current_creds["expires_at"] != -1 and (current_creds["expires_at"] - 60) < int(time.time()):
                             # Actually refresh
                             refreshed = simulator.refresh(current_creds)
 
@@ -188,9 +194,7 @@ def test_concurrent_oauth_refresh_with_lock():
                         retries += 1
                         with db_lock:
                             current_creds = dict(db_state)
-                        if current_creds["expires_at"] != -1 and (
-                            current_creds["expires_at"] - 60
-                        ) >= int(time.time()):
+                        if current_creds["expires_at"] != -1 and (current_creds["expires_at"] - 60) >= int(time.time()):
                             break
                         backoff = min(backoff * 2, 1.0)
                     result["action"] = "read_from_db"
@@ -258,9 +262,7 @@ def test_concurrent_oauth_refresh_with_lock():
         f"Expected exactly 1 refresh call, but got {simulator.call_count}. "
         f"The distributed lock failed to prevent concurrent refreshes."
     )
-    assert simulator.success_count == 1, (
-        f"Expected exactly 1 successful refresh, got {simulator.success_count}"
-    )
+    assert simulator.success_count == 1, f"Expected exactly 1 successful refresh, got {simulator.success_count}"
     assert simulator.invalid_grant_count == 0, (
         f"Got {simulator.invalid_grant_count} invalid_grant errors. "
         f"This means multiple threads attempted refresh simultaneously."
@@ -307,6 +309,7 @@ def test_concurrent_oauth_refresh_with_lock():
 # ---------------------------------------------------------------------------
 # Comparison test: WITHOUT lock (demonstrates the race condition)
 # ---------------------------------------------------------------------------
+
 
 def test_concurrent_oauth_refresh_without_lock_shows_race():
     """Demonstrates that WITHOUT the lock, race condition causes invalid_grant.
@@ -389,9 +392,7 @@ def test_concurrent_oauth_refresh_without_lock_shows_race():
         print(f"  {entry}")
 
     # Without lock, we expect MULTIPLE refresh calls
-    assert simulator.call_count > 1, (
-        f"Expected multiple refresh calls without lock, got {simulator.call_count}"
-    )
+    assert simulator.call_count > 1, f"Expected multiple refresh calls without lock, got {simulator.call_count}"
 
     # We expect invalid_grant errors due to token rotation
     assert simulator.invalid_grant_count > 0, (

--- a/api/tests/integration_tests/test_oauth_refresh_lock_concurrency.py
+++ b/api/tests/integration_tests/test_oauth_refresh_lock_concurrency.py
@@ -1,0 +1,411 @@
+"""
+Integration test: OAuth token refresh distributed lock under concurrency.
+
+This test verifies that when multiple threads simultaneously detect an expired
+OAuth access_token, only ONE thread actually refreshes the token, while the
+others safely read the latest credentials from DB. This prevents the race
+condition where refresh token rotation (e.g., QuickBooks) causes invalid_grant.
+
+Requirements:
+    - Redis running at localhost:6379 (or REDIS_HOST env var)
+    - Run with: uv run --project api python -m pytest api/tests/integration_tests/test_oauth_refresh_lock_concurrency.py -v -o "addopts=" -s
+
+Simulated scenario:
+    1. A BuiltinToolProvider row exists with expires_at in the past
+    2. 10 threads concurrently call the refresh logic
+    3. OAuthHandler.refresh_credentials simulates token rotation:
+       - Returns new access_token + new refresh_token each call
+       - If called with an already-consumed refresh_token, raises error (invalid_grant)
+    4. Expected: only 1 thread refreshes; the rest read from DB
+"""
+
+import json
+import os
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import redis
+
+# ---------------------------------------------------------------------------
+# Simulated token rotation state
+# ---------------------------------------------------------------------------
+
+class TokenRotationSimulator:
+    """Simulates an OAuth provider with refresh token rotation (like QuickBooks).
+
+    Each call to refresh() consumes the current refresh_token and issues a new one.
+    If called with an already-consumed token, it raises an error (invalid_grant).
+    """
+
+    def __init__(self, initial_refresh_token: str = "rt_v1"):
+        self._lock = threading.Lock()
+        self._current_valid_refresh_token = initial_refresh_token
+        self._version = 1
+        self.call_count = 0
+        self.success_count = 0
+        self.invalid_grant_count = 0
+        self.call_log: list[dict] = []
+
+    def refresh(self, credentials: dict) -> dict:
+        """Simulate an OAuth token refresh with rotation."""
+        incoming_rt = credentials.get("refresh_token", "")
+
+        # Add artificial delay to simulate network latency
+        time.sleep(0.05)
+
+        with self._lock:
+            self.call_count += 1
+
+            if incoming_rt != self._current_valid_refresh_token:
+                self.invalid_grant_count += 1
+                self.call_log.append({
+                    "thread": threading.current_thread().name,
+                    "incoming_rt": incoming_rt,
+                    "expected_rt": self._current_valid_refresh_token,
+                    "result": "invalid_grant",
+                })
+                raise RuntimeError(
+                    f"invalid_grant: refresh_token '{incoming_rt}' has been revoked. "
+                    f"Current valid token is '{self._current_valid_refresh_token}'"
+                )
+
+            # Token rotation: consume old, issue new
+            self._version += 1
+            new_rt = f"rt_v{self._version}"
+            new_at = f"at_v{self._version}"
+            self._current_valid_refresh_token = new_rt
+            self.success_count += 1
+
+            self.call_log.append({
+                "thread": threading.current_thread().name,
+                "incoming_rt": incoming_rt,
+                "new_rt": new_rt,
+                "new_at": new_at,
+                "result": "success",
+            })
+
+            return {
+                "access_token": new_at,
+                "refresh_token": new_rt,
+                "expires_at": int(time.time()) + 3600,
+            }
+
+
+# ---------------------------------------------------------------------------
+# Test: Concurrent refresh with distributed lock
+# ---------------------------------------------------------------------------
+
+def test_concurrent_oauth_refresh_with_lock():
+    """Test that distributed lock prevents concurrent token refresh race condition."""
+
+    redis_host = os.environ.get("REDIS_HOST", "localhost")
+    redis_port = int(os.environ.get("REDIS_PORT", "6379"))
+    redis_password = os.environ.get("REDIS_PASSWORD", None)
+
+    # Connect to Redis
+    redis_client = redis.Redis(
+        host=redis_host, port=redis_port, password=redis_password, db=15,
+    )  # Use DB 15 for testing
+    redis_client.ping()
+
+    # Clean up any leftover lock keys
+    for key in redis_client.keys("oauth_test_lock:*"):
+        redis_client.delete(key)
+
+    # Set up simulator
+    simulator = TokenRotationSimulator(initial_refresh_token="rt_v1")
+
+    # Shared state (simulates DB)
+    db_state = {
+        "access_token": "at_v1",
+        "refresh_token": "rt_v1",
+        "expires_at": int(time.time()) - 100,  # Expired
+    }
+    db_lock = threading.Lock()
+    db_refresh_count = 0
+
+    # Track per-thread results
+    thread_results: list[dict] = []
+    results_lock = threading.Lock()
+
+    NUM_THREADS = 10
+    LOCK_KEY = "oauth_test_lock:tenant1_provider1"
+    barrier = threading.Barrier(NUM_THREADS)
+
+    def worker(thread_id: int):
+        nonlocal db_refresh_count
+        thread_name = f"thread-{thread_id}"
+        threading.current_thread().name = thread_name
+        result = {"thread": thread_name, "action": None, "error": None}
+
+        try:
+            # Wait for all threads to be ready
+            barrier.wait(timeout=5)
+
+            # Read current credentials (simulates reading from DB)
+            with db_lock:
+                current_creds = dict(db_state)
+
+            # Check if expired
+            if current_creds["expires_at"] != -1 and (current_creds["expires_at"] - 60) < int(time.time()):
+                lock = redis_client.lock(LOCK_KEY, timeout=30)
+
+                if lock.acquire(blocking=False):
+                    try:
+                        # Double-check: re-read from DB
+                        with db_lock:
+                            current_creds = dict(db_state)
+
+                        if current_creds["expires_at"] != -1 and (
+                            current_creds["expires_at"] - 60
+                        ) < int(time.time()):
+                            # Actually refresh
+                            refreshed = simulator.refresh(current_creds)
+
+                            # Update DB
+                            with db_lock:
+                                db_state["access_token"] = refreshed["access_token"]
+                                db_state["refresh_token"] = refreshed["refresh_token"]
+                                db_state["expires_at"] = refreshed["expires_at"]
+                                db_refresh_count += 1
+
+                            result["action"] = "refreshed"
+                            result["new_at"] = refreshed["access_token"]
+                            result["new_rt"] = refreshed["refresh_token"]
+                        else:
+                            result["action"] = "double_check_skipped"
+                    finally:
+                        lock.release()
+                else:
+                    # Another thread is refreshing; poll DB with exponential backoff
+                    backoff = 0.1
+                    retries = 0
+                    for _ in range(5):
+                        time.sleep(backoff)
+                        retries += 1
+                        with db_lock:
+                            current_creds = dict(db_state)
+                        if current_creds["expires_at"] != -1 and (
+                            current_creds["expires_at"] - 60
+                        ) >= int(time.time()):
+                            break
+                        backoff = min(backoff * 2, 1.0)
+                    result["action"] = "read_from_db"
+                    result["retries"] = retries
+                    result["read_at"] = current_creds["access_token"]
+                    result["read_rt"] = current_creds["refresh_token"]
+                    result["got_fresh"] = current_creds["expires_at"] > int(time.time())
+            else:
+                result["action"] = "not_expired"
+
+        except Exception as e:
+            result["error"] = str(e)
+            result["action"] = "error"
+
+        with results_lock:
+            thread_results.append(result)
+
+    # Launch threads
+    threads = []
+    for i in range(NUM_THREADS):
+        t = threading.Thread(target=worker, args=(i,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join(timeout=10)
+
+    # Clean up
+    for key in redis_client.keys("oauth_test_lock:*"):
+        redis_client.delete(key)
+    redis_client.close()
+
+    # ---------------------------------------------------------------------------
+    # Assertions
+    # ---------------------------------------------------------------------------
+
+    print("\n" + "=" * 70)
+    print("TEST RESULTS: Concurrent OAuth Refresh with Distributed Lock")
+    print("=" * 70)
+
+    print(f"\nThreads: {NUM_THREADS}")
+    print(f"Simulator call count: {simulator.call_count}")
+    print(f"Simulator success count: {simulator.success_count}")
+    print(f"Simulator invalid_grant count: {simulator.invalid_grant_count}")
+    print(f"DB refresh count: {db_refresh_count}")
+
+    print(f"\nFinal DB state:")
+    print(f"  access_token: {db_state['access_token']}")
+    print(f"  refresh_token: {db_state['refresh_token']}")
+    print(f"  expires_at: {db_state['expires_at']} (now: {int(time.time())})")
+
+    print(f"\nPer-thread results:")
+    for r in sorted(thread_results, key=lambda x: x["thread"]):
+        extra = ""
+        if r["action"] == "read_from_db":
+            extra = f", retries={r.get('retries')}, got_fresh={r.get('got_fresh')}, read_at={r.get('read_at')}"
+        print(f"  {r['thread']}: action={r['action']}{extra}, error={r.get('error')}")
+
+    print(f"\nSimulator call log:")
+    for entry in simulator.call_log:
+        print(f"  {entry}")
+
+    # Core assertion: only 1 refresh should have happened
+    assert simulator.call_count == 1, (
+        f"Expected exactly 1 refresh call, but got {simulator.call_count}. "
+        f"The distributed lock failed to prevent concurrent refreshes."
+    )
+    assert simulator.success_count == 1, (
+        f"Expected exactly 1 successful refresh, got {simulator.success_count}"
+    )
+    assert simulator.invalid_grant_count == 0, (
+        f"Got {simulator.invalid_grant_count} invalid_grant errors. "
+        f"This means multiple threads attempted refresh simultaneously."
+    )
+
+    # DB should have been updated exactly once
+    assert db_refresh_count == 1, f"DB updated {db_refresh_count} times, expected 1"
+
+    # Final DB state should reflect the refreshed token
+    assert db_state["access_token"] == "at_v2"
+    assert db_state["refresh_token"] == "rt_v2"
+    assert db_state["expires_at"] > int(time.time())
+
+    # Every thread should have succeeded (no errors)
+    errors = [r for r in thread_results if r["action"] == "error"]
+    assert len(errors) == 0, f"Some threads failed: {errors}"
+
+    # Exactly 1 thread should have refreshed
+    refreshed = [r for r in thread_results if r["action"] == "refreshed"]
+    assert len(refreshed) == 1, f"Expected 1 refreshed thread, got {len(refreshed)}"
+
+    # All waiting threads should have eventually got fresh credentials
+    waiters = [r for r in thread_results if r["action"] == "read_from_db"]
+    fresh_waiters = [r for r in waiters if r.get("got_fresh")]
+    stale_waiters = [r for r in waiters if not r.get("got_fresh")]
+
+    print(f"\n✓ ALL ASSERTIONS PASSED")
+    print(f"  - Only 1 refresh call was made (lock prevented race condition)")
+    print(f"  - 0 invalid_grant errors")
+    print(f"  - DB updated exactly once")
+    print(f"  - All threads completed without errors")
+    print(f"  - {len(fresh_waiters)}/{len(waiters)} waiting threads got fresh credentials via retry")
+    if stale_waiters:
+        print(f"  - {len(stale_waiters)} threads timed out (will use stale creds as fallback)")
+    print("=" * 70)
+
+    # All waiting threads should have got fresh credentials
+    assert len(fresh_waiters) == len(waiters), (
+        f"{len(stale_waiters)}/{len(waiters)} waiting threads did NOT get fresh credentials. "
+        f"Retry mechanism may need tuning."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comparison test: WITHOUT lock (demonstrates the race condition)
+# ---------------------------------------------------------------------------
+
+def test_concurrent_oauth_refresh_without_lock_shows_race():
+    """Demonstrates that WITHOUT the lock, race condition causes invalid_grant.
+
+    This test is expected to show multiple refresh calls and potential
+    invalid_grant errors when no distributed lock is used.
+    """
+
+    simulator = TokenRotationSimulator(initial_refresh_token="rt_v1")
+
+    db_state = {
+        "access_token": "at_v1",
+        "refresh_token": "rt_v1",
+        "expires_at": int(time.time()) - 100,
+    }
+    db_lock = threading.Lock()
+
+    thread_results: list[dict] = []
+    results_lock = threading.Lock()
+
+    NUM_THREADS = 10
+    barrier = threading.Barrier(NUM_THREADS)
+
+    def worker_no_lock(thread_id: int):
+        thread_name = f"thread-{thread_id}"
+        threading.current_thread().name = thread_name
+        result = {"thread": thread_name, "action": None, "error": None}
+
+        try:
+            barrier.wait(timeout=5)
+
+            # Read current credentials (all threads read same expired creds)
+            with db_lock:
+                current_creds = dict(db_state)
+
+            if current_creds["expires_at"] != -1 and (current_creds["expires_at"] - 60) < int(time.time()):
+                # NO LOCK - just refresh directly (this is the bug)
+                try:
+                    refreshed = simulator.refresh(current_creds)
+                    with db_lock:
+                        db_state["access_token"] = refreshed["access_token"]
+                        db_state["refresh_token"] = refreshed["refresh_token"]
+                        db_state["expires_at"] = refreshed["expires_at"]
+                    result["action"] = "refreshed"
+                except RuntimeError as e:
+                    result["action"] = "invalid_grant"
+                    result["error"] = str(e)
+
+        except Exception as e:
+            result["error"] = str(e)
+            result["action"] = "error"
+
+        with results_lock:
+            thread_results.append(result)
+
+    threads = []
+    for i in range(NUM_THREADS):
+        t = threading.Thread(target=worker_no_lock, args=(i,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join(timeout=10)
+
+    print("\n" + "=" * 70)
+    print("COMPARISON: Concurrent OAuth Refresh WITHOUT Lock (race condition)")
+    print("=" * 70)
+
+    print(f"\nThreads: {NUM_THREADS}")
+    print(f"Simulator call count: {simulator.call_count}")
+    print(f"Simulator success count: {simulator.success_count}")
+    print(f"Simulator invalid_grant count: {simulator.invalid_grant_count}")
+
+    print(f"\nPer-thread results:")
+    for r in sorted(thread_results, key=lambda x: x["thread"]):
+        print(f"  {r['thread']}: action={r['action']}")
+
+    print(f"\nSimulator call log:")
+    for entry in simulator.call_log:
+        print(f"  {entry}")
+
+    # Without lock, we expect MULTIPLE refresh calls
+    assert simulator.call_count > 1, (
+        f"Expected multiple refresh calls without lock, got {simulator.call_count}"
+    )
+
+    # We expect invalid_grant errors due to token rotation
+    assert simulator.invalid_grant_count > 0, (
+        f"Expected invalid_grant errors without lock, got {simulator.invalid_grant_count}"
+    )
+
+    invalid_grants = [r for r in thread_results if r["action"] == "invalid_grant"]
+    print(f"\n✓ RACE CONDITION DEMONSTRATED")
+    print(f"  - {simulator.call_count} refresh calls (should be 1)")
+    print(f"  - {simulator.invalid_grant_count} invalid_grant errors")
+    print(f"  - {len(invalid_grants)}/{NUM_THREADS} threads hit invalid_grant")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    print("Running test WITH lock...")
+    test_concurrent_oauth_refresh_with_lock()
+    print("\n\nRunning test WITHOUT lock (showing race condition)...")
+    test_concurrent_oauth_refresh_without_lock_shows_race()

--- a/api/tests/unit_tests/core/tools/test_tool_manager_oauth_refresh_lock.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager_oauth_refresh_lock.py
@@ -18,12 +18,7 @@ from core.tools.plugin_tool.provider import PluginToolProviderController
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_builtin_provider(
-    *,
-    expires_at: int = -1,
-    encrypted_credentials: str | None = None,
-):
-    """Create a mock BuiltinToolProvider."""
+def _make_builtin_provider(*, expires_at: int = -1):
     provider = MagicMock()
     provider.id = "bp-001"
     provider.provider = "test-plugin/test-provider"
@@ -31,15 +26,14 @@ def _make_builtin_provider(
     provider.user_id = "user-1"
     provider.credential_type = "oauth2"
     provider.expires_at = expires_at
-    provider.encrypted_credentials = encrypted_credentials or json.dumps(
+    provider.encrypted_credentials = json.dumps(
         {"access_token": "old_at", "refresh_token": "old_rt"}
     )
-    provider.credentials = json.loads(provider.encrypted_credentials)
+    provider.credentials = {"access_token": "old_at", "refresh_token": "old_rt"}
     return provider
 
 
 def _make_encrypter_and_cache(decrypted: dict | None = None):
-    """Create mock encrypter and cache objects."""
     enc = MagicMock()
     enc.decrypt.return_value = decrypted or {"access_token": "old_at", "refresh_token": "old_rt"}
     enc.encrypt.return_value = {"access_token": "enc_new_at", "refresh_token": "enc_new_rt"}
@@ -48,7 +42,6 @@ def _make_encrypter_and_cache(decrypted: dict | None = None):
 
 
 def _make_refreshed_response(expires_at: int | None = None):
-    """Create a mock refreshed credentials response."""
     resp = MagicMock()
     resp.credentials = {"access_token": "new_at", "refresh_token": "new_rt"}
     resp.expires_at = expires_at or int(time.time()) + 3600
@@ -56,7 +49,6 @@ def _make_refreshed_response(expires_at: int | None = None):
 
 
 def _make_provider_controller():
-    """Create a mock PluginToolProviderController that passes isinstance check."""
     ctrl = MagicMock(spec=PluginToolProviderController)
     ctrl.need_credentials = True
     ctrl.get_tool.return_value = MagicMock()
@@ -64,39 +56,20 @@ def _make_provider_controller():
     return ctrl
 
 
-def _setup_common_patches(
-    mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-    builtin_provider, encrypter, cache, lock_acquired=True,
-):
-    """Set up common mock configurations."""
-    mock_db.session.scalar.return_value = builtin_provider
-    mock_create_encrypter.return_value = (encrypter, cache)
-
+def _setup_common(mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+                  bp, enc, cache, lock_acquired=True):
+    mock_db.session.scalar.return_value = bp
+    mock_create_encrypter.return_value = (enc, cache)
     mock_lock = MagicMock()
     mock_lock.acquire.return_value = lock_acquired
     mock_redis.lock.return_value = mock_lock
-
     mock_get_provider.return_value = _make_provider_controller()
-
     return mock_lock
 
 
-# Common decorator stack for all tests
-_COMMON_PATCHES = [
-    patch("core.helper.credential_utils.check_credential_policy_compliance"),
-    patch("core.tools.tool_manager.is_valid_uuid", return_value=True),
-    patch("core.tools.tool_manager.create_provider_encrypter"),
-    patch("core.tools.tool_manager.redis_client"),
-    patch("core.tools.tool_manager.db"),
-    patch("core.tools.tool_manager.ToolManager.get_builtin_provider"),
-]
-
-
 def _call_get_tool_runtime():
-    """Call ToolManager.get_tool_runtime with standard test arguments."""
     from core.tools.entities.tool_entities import ToolProviderType
     from core.tools.tool_manager import ToolManager
-
     return ToolManager.get_tool_runtime(
         provider_type=ToolProviderType.BUILT_IN,
         provider_id="test-plugin/test-provider",
@@ -106,13 +79,18 @@ def _call_get_tool_runtime():
     )
 
 
+def _pid_mock():
+    pid = MagicMock()
+    pid.provider_name = "test-provider"
+    pid.plugin_id = "test-plugin"
+    return pid
+
+
 # ---------------------------------------------------------------------------
-# Test: Lock acquired → credentials refreshed
+# Test: Lock acquired, credentials expired → refresh
 # ---------------------------------------------------------------------------
 
 class TestOAuthRefreshLockAcquired:
-    """When the lock is successfully acquired, credentials should be refreshed."""
-
     @patch("core.helper.credential_utils.check_credential_policy_compliance")
     @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
     @patch("core.tools.tool_manager.create_provider_encrypter")
@@ -121,60 +99,42 @@ class TestOAuthRefreshLockAcquired:
     @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
     def test_lock_acquired_refreshes_credentials(
         self, mock_get_provider, mock_db, mock_redis,
-        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+        mock_create_encrypter, mock_is_uuid, _,
     ):
-        """When lock is acquired and token is expired, credentials should be refreshed."""
         expired_at = int(time.time()) - 100
         new_expires_at = int(time.time()) + 3600
-
         bp = _make_builtin_provider(expires_at=expired_at)
         enc, cache = _make_encrypter_and_cache()
-        mock_db.session.refresh.side_effect = lambda obj: None  # Keep expired
-        mock_lock = _setup_common_patches(
-            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-            bp, enc, cache, lock_acquired=True,
-        )
-
+        mock_db.session.refresh.side_effect = lambda obj: None
+        mock_lock = _setup_common(mock_db, mock_redis, mock_create_encrypter,
+                                  mock_get_provider, bp, enc, cache, lock_acquired=True)
         refreshed = _make_refreshed_response(expires_at=new_expires_at)
 
         with (
             patch("core.plugin.impl.oauth.OAuthHandler") as mock_oauth_cls,
-            patch("services.tools.builtin_tools_manage_service.BuiltinToolManageService") as mock_manage_svc,
-            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
-            patch("core.tools.tool_manager.dify_config") as mock_config,
+            patch("services.tools.builtin_tools_manage_service.BuiltinToolManageService") as mock_svc,
+            patch("core.tools.tool_manager.ToolProviderID", return_value=_pid_mock()),
+            patch("core.tools.tool_manager.dify_config", CONSOLE_API_URL="https://app.dify.ai"),
         ):
-            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
-            mock_pid = MagicMock()
-            mock_pid.provider_name = "test-provider"
-            mock_pid.plugin_id = "test-plugin"
-            mock_pid_cls.return_value = mock_pid
-            mock_manage_svc.get_oauth_client.return_value = {"client_id": "cid"}
+            mock_svc.get_oauth_client.return_value = {"client_id": "cid"}
             mock_oauth = MagicMock()
             mock_oauth.refresh_credentials.return_value = refreshed
             mock_oauth_cls.return_value = mock_oauth
-
             _call_get_tool_runtime()
 
-        # Lock was acquired and released
-        mock_redis.lock.assert_called_once()
         mock_lock.acquire.assert_called_once_with(blocking=False)
         mock_lock.release.assert_called_once()
-        # OAuth refresh was called
         mock_oauth.refresh_credentials.assert_called_once()
-        # DB was committed
         mock_db.session.commit.assert_called_once()
         assert bp.expires_at == new_expires_at
-        # Cache was invalidated
         cache.delete.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# Test: Lock acquired but double-check shows already refreshed
+# Test: Lock acquired, but another thread already refreshed (double-check)
 # ---------------------------------------------------------------------------
 
 class TestOAuthRefreshDoubleCheck:
-    """When lock is acquired but another request already refreshed, skip refresh."""
-
     @patch("core.helper.credential_utils.check_credential_policy_compliance")
     @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
     @patch("core.tools.tool_manager.create_provider_encrypter")
@@ -183,51 +143,32 @@ class TestOAuthRefreshDoubleCheck:
     @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
     def test_double_check_skips_refresh(
         self, mock_get_provider, mock_db, mock_redis,
-        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+        mock_create_encrypter, mock_is_uuid, _,
     ):
-        """Lock acquired, but double-check shows token was already refreshed."""
         expired_at = int(time.time()) - 100
         fresh_at = int(time.time()) + 3600
-
         bp = _make_builtin_provider(expires_at=expired_at)
         enc, cache = _make_encrypter_and_cache()
-
-        # After db.session.refresh(), expires_at becomes fresh
-        def _fake_refresh(obj):
-            obj.expires_at = fresh_at
-
-        mock_db.session.refresh.side_effect = _fake_refresh
-        mock_lock = _setup_common_patches(
-            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-            bp, enc, cache, lock_acquired=True,
-        )
+        mock_db.session.refresh.side_effect = lambda obj: setattr(obj, 'expires_at', fresh_at)
+        mock_lock = _setup_common(mock_db, mock_redis, mock_create_encrypter,
+                                  mock_get_provider, bp, enc, cache, lock_acquired=True)
 
         with (
-            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
-            patch("core.tools.tool_manager.dify_config") as mock_config,
+            patch("core.tools.tool_manager.ToolProviderID", return_value=_pid_mock()),
+            patch("core.tools.tool_manager.dify_config", CONSOLE_API_URL="https://app.dify.ai"),
         ):
-            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
-            mock_pid = MagicMock()
-            mock_pid.provider_name = "test-provider"
-            mock_pid.plugin_id = "test-plugin"
-            mock_pid_cls.return_value = mock_pid
-
             _call_get_tool_runtime()
 
         mock_lock.acquire.assert_called_once_with(blocking=False)
         mock_lock.release.assert_called_once()
-        mock_db.session.refresh.assert_called_with(bp)
-        # No commit since double-check found fresh credentials
         mock_db.session.commit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# Test: Lock NOT acquired → read from DB
+# Test: Lock NOT acquired → poll DB with exponential backoff
 # ---------------------------------------------------------------------------
 
 class TestOAuthRefreshLockNotAcquired:
-    """When the lock is not acquired, retry polling DB until credentials are fresh."""
-
     @patch("core.tools.tool_manager.time")
     @patch("core.helper.credential_utils.check_credential_policy_compliance")
     @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
@@ -235,67 +176,48 @@ class TestOAuthRefreshLockNotAcquired:
     @patch("core.tools.tool_manager.redis_client")
     @patch("core.tools.tool_manager.db")
     @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
-    def test_lock_not_acquired_retries_then_reads_fresh(
+    def test_lock_not_acquired_polls_db_until_fresh(
         self, mock_get_provider, mock_db, mock_redis,
-        mock_create_encrypter, mock_is_uuid, mock_check_policy, mock_time,
+        mock_create_encrypter, mock_is_uuid, _, mock_time,
     ):
-        """When lock not acquired, should retry polling DB until credentials become fresh."""
+        """Poll DB with backoff; break early when credentials become fresh."""
         now = int(time.time())
-        expired_at = now - 100
-        fresh_at = now + 3600
-
-        bp = _make_builtin_provider(expires_at=expired_at)
-        refreshed_creds = {"access_token": "refreshed_by_other", "refresh_token": "refreshed_rt"}
-        enc, cache = _make_encrypter_and_cache(decrypted=refreshed_creds)
-
-        mock_lock = _setup_common_patches(
-            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-            bp, enc, cache, lock_acquired=False,
-        )
-
-        # time.time() returns current time; time.sleep() is a no-op in unit test
+        bp = _make_builtin_provider(expires_at=now - 100)
+        enc, cache = _make_encrypter_and_cache()
         mock_time.time.return_value = now
         mock_time.sleep = MagicMock()
 
-        # Simulate: first db.session.refresh still expired, second one is fresh
-        call_count = 0
+        mock_lock = _setup_common(mock_db, mock_redis, mock_create_encrypter,
+                                  mock_get_provider, bp, enc, cache, lock_acquired=False)
+
+        # Simulate: 2nd db.session.refresh makes credentials fresh
+        refresh_count = 0
         def _fake_refresh(obj):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 2:
-                obj.expires_at = fresh_at
+            nonlocal refresh_count
+            refresh_count += 1
+            if refresh_count >= 2:
+                obj.expires_at = now + 3600
 
         mock_db.session.refresh.side_effect = _fake_refresh
 
         with (
-            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
-            patch("core.tools.tool_manager.dify_config") as mock_config,
+            patch("core.tools.tool_manager.ToolProviderID", return_value=_pid_mock()),
+            patch("core.tools.tool_manager.dify_config", CONSOLE_API_URL="https://app.dify.ai"),
         ):
-            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
-            mock_pid = MagicMock()
-            mock_pid.provider_name = "test-provider"
-            mock_pid.plugin_id = "test-plugin"
-            mock_pid_cls.return_value = mock_pid
-
             _call_get_tool_runtime()
 
         mock_lock.acquire.assert_called_once_with(blocking=False)
         mock_lock.release.assert_not_called()
-        # time.sleep was called for backoff
         assert mock_time.sleep.call_count >= 1
-        # DB was polled multiple times
         assert mock_db.session.refresh.call_count >= 2
-        enc.decrypt.assert_called()
         mock_db.session.commit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# Test: Lock release on exception
+# Test: Lock released even on exception
 # ---------------------------------------------------------------------------
 
 class TestOAuthRefreshLockRelease:
-    """Lock should always be released, even when refresh raises an exception."""
-
     @patch("core.helper.credential_utils.check_credential_policy_compliance")
     @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
     @patch("core.tools.tool_manager.create_provider_encrypter")
@@ -304,35 +226,24 @@ class TestOAuthRefreshLockRelease:
     @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
     def test_lock_released_on_exception(
         self, mock_get_provider, mock_db, mock_redis,
-        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+        mock_create_encrypter, mock_is_uuid, _,
     ):
-        """Lock must be released in finally block even if refresh raises."""
-        expired_at = int(time.time()) - 100
-        bp = _make_builtin_provider(expires_at=expired_at)
+        bp = _make_builtin_provider(expires_at=int(time.time()) - 100)
         enc, cache = _make_encrypter_and_cache()
         mock_db.session.refresh.side_effect = lambda obj: None
-
-        mock_lock = _setup_common_patches(
-            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-            bp, enc, cache, lock_acquired=True,
-        )
+        mock_lock = _setup_common(mock_db, mock_redis, mock_create_encrypter,
+                                  mock_get_provider, bp, enc, cache, lock_acquired=True)
 
         with (
             patch("core.plugin.impl.oauth.OAuthHandler") as mock_oauth_cls,
-            patch("services.tools.builtin_tools_manage_service.BuiltinToolManageService") as mock_manage_svc,
-            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
-            patch("core.tools.tool_manager.dify_config") as mock_config,
+            patch("services.tools.builtin_tools_manage_service.BuiltinToolManageService") as mock_svc,
+            patch("core.tools.tool_manager.ToolProviderID", return_value=_pid_mock()),
+            patch("core.tools.tool_manager.dify_config", CONSOLE_API_URL="https://app.dify.ai"),
         ):
-            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
-            mock_pid = MagicMock()
-            mock_pid.provider_name = "test-provider"
-            mock_pid.plugin_id = "test-plugin"
-            mock_pid_cls.return_value = mock_pid
-            mock_manage_svc.get_oauth_client.return_value = {}
+            mock_svc.get_oauth_client.return_value = {}
             mock_oauth = MagicMock()
             mock_oauth.refresh_credentials.side_effect = RuntimeError("OAuth unreachable")
             mock_oauth_cls.return_value = mock_oauth
-
             with pytest.raises(RuntimeError, match="OAuth unreachable"):
                 _call_get_tool_runtime()
 
@@ -341,12 +252,10 @@ class TestOAuthRefreshLockRelease:
 
 
 # ---------------------------------------------------------------------------
-# Test: Non-expired token → no lock needed
+# Test: Non-expired → no lock at all
 # ---------------------------------------------------------------------------
 
 class TestOAuthRefreshNotExpired:
-    """When credentials are not expired, no lock or refresh should happen."""
-
     @patch("core.helper.credential_utils.check_credential_policy_compliance")
     @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
     @patch("core.tools.tool_manager.create_provider_encrypter")
@@ -355,29 +264,17 @@ class TestOAuthRefreshNotExpired:
     @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
     def test_non_expired_skips_lock(
         self, mock_get_provider, mock_db, mock_redis,
-        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+        mock_create_encrypter, mock_is_uuid, _,
     ):
-        """Non-expired credentials should bypass the lock entirely."""
-        future_at = int(time.time()) + 3600
-        bp = _make_builtin_provider(expires_at=future_at)
+        bp = _make_builtin_provider(expires_at=int(time.time()) + 3600)
         enc, cache = _make_encrypter_and_cache()
-        _setup_common_patches(
-            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-            bp, enc, cache,
-        )
-
+        _setup_common(mock_db, mock_redis, mock_create_encrypter,
+                      mock_get_provider, bp, enc, cache)
         with (
-            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
-            patch("core.tools.tool_manager.dify_config") as mock_config,
+            patch("core.tools.tool_manager.ToolProviderID", return_value=_pid_mock()),
+            patch("core.tools.tool_manager.dify_config", CONSOLE_API_URL="https://app.dify.ai"),
         ):
-            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
-            mock_pid = MagicMock()
-            mock_pid.provider_name = "test-provider"
-            mock_pid.plugin_id = "test-plugin"
-            mock_pid_cls.return_value = mock_pid
-
             _call_get_tool_runtime()
-
         mock_redis.lock.assert_not_called()
 
 
@@ -386,8 +283,6 @@ class TestOAuthRefreshNotExpired:
 # ---------------------------------------------------------------------------
 
 class TestOAuthRefreshNeverExpires:
-    """When expires_at is -1, no lock needed."""
-
     @patch("core.helper.credential_utils.check_credential_policy_compliance")
     @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
     @patch("core.tools.tool_manager.create_provider_encrypter")
@@ -396,26 +291,15 @@ class TestOAuthRefreshNeverExpires:
     @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
     def test_never_expires_skips_lock(
         self, mock_get_provider, mock_db, mock_redis,
-        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+        mock_create_encrypter, mock_is_uuid, _,
     ):
-        """expires_at == -1 means no expiration; should not attempt lock."""
         bp = _make_builtin_provider(expires_at=-1)
         enc, cache = _make_encrypter_and_cache()
-        _setup_common_patches(
-            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
-            bp, enc, cache,
-        )
-
+        _setup_common(mock_db, mock_redis, mock_create_encrypter,
+                      mock_get_provider, bp, enc, cache)
         with (
-            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
-            patch("core.tools.tool_manager.dify_config") as mock_config,
+            patch("core.tools.tool_manager.ToolProviderID", return_value=_pid_mock()),
+            patch("core.tools.tool_manager.dify_config", CONSOLE_API_URL="https://app.dify.ai"),
         ):
-            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
-            mock_pid = MagicMock()
-            mock_pid.provider_name = "test-provider"
-            mock_pid.plugin_id = "test-plugin"
-            mock_pid_cls.return_value = mock_pid
-
             _call_get_tool_runtime()
-
         mock_redis.lock.assert_not_called()

--- a/api/tests/unit_tests/core/tools/test_tool_manager_oauth_refresh_lock.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager_oauth_refresh_lock.py
@@ -1,0 +1,421 @@
+"""Tests for the distributed lock mechanism in ToolManager OAuth token refresh.
+
+These tests verify the non-blocking Redis lock + double-check pattern that
+prevents concurrent OAuth token refresh race conditions (e.g., QuickBooks
+refresh token rotation causing invalid_grant errors).
+"""
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.tools.plugin_tool.provider import PluginToolProviderController
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_builtin_provider(
+    *,
+    expires_at: int = -1,
+    encrypted_credentials: str | None = None,
+):
+    """Create a mock BuiltinToolProvider."""
+    provider = MagicMock()
+    provider.id = "bp-001"
+    provider.provider = "test-plugin/test-provider"
+    provider.tenant_id = "tenant-1"
+    provider.user_id = "user-1"
+    provider.credential_type = "oauth2"
+    provider.expires_at = expires_at
+    provider.encrypted_credentials = encrypted_credentials or json.dumps(
+        {"access_token": "old_at", "refresh_token": "old_rt"}
+    )
+    provider.credentials = json.loads(provider.encrypted_credentials)
+    return provider
+
+
+def _make_encrypter_and_cache(decrypted: dict | None = None):
+    """Create mock encrypter and cache objects."""
+    enc = MagicMock()
+    enc.decrypt.return_value = decrypted or {"access_token": "old_at", "refresh_token": "old_rt"}
+    enc.encrypt.return_value = {"access_token": "enc_new_at", "refresh_token": "enc_new_rt"}
+    cache = MagicMock()
+    return enc, cache
+
+
+def _make_refreshed_response(expires_at: int | None = None):
+    """Create a mock refreshed credentials response."""
+    resp = MagicMock()
+    resp.credentials = {"access_token": "new_at", "refresh_token": "new_rt"}
+    resp.expires_at = expires_at or int(time.time()) + 3600
+    return resp
+
+
+def _make_provider_controller():
+    """Create a mock PluginToolProviderController that passes isinstance check."""
+    ctrl = MagicMock(spec=PluginToolProviderController)
+    ctrl.need_credentials = True
+    ctrl.get_tool.return_value = MagicMock()
+    ctrl.get_credentials_schema_by_type.return_value = []
+    return ctrl
+
+
+def _setup_common_patches(
+    mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+    builtin_provider, encrypter, cache, lock_acquired=True,
+):
+    """Set up common mock configurations."""
+    mock_db.session.scalar.return_value = builtin_provider
+    mock_create_encrypter.return_value = (encrypter, cache)
+
+    mock_lock = MagicMock()
+    mock_lock.acquire.return_value = lock_acquired
+    mock_redis.lock.return_value = mock_lock
+
+    mock_get_provider.return_value = _make_provider_controller()
+
+    return mock_lock
+
+
+# Common decorator stack for all tests
+_COMMON_PATCHES = [
+    patch("core.helper.credential_utils.check_credential_policy_compliance"),
+    patch("core.tools.tool_manager.is_valid_uuid", return_value=True),
+    patch("core.tools.tool_manager.create_provider_encrypter"),
+    patch("core.tools.tool_manager.redis_client"),
+    patch("core.tools.tool_manager.db"),
+    patch("core.tools.tool_manager.ToolManager.get_builtin_provider"),
+]
+
+
+def _call_get_tool_runtime():
+    """Call ToolManager.get_tool_runtime with standard test arguments."""
+    from core.tools.entities.tool_entities import ToolProviderType
+    from core.tools.tool_manager import ToolManager
+
+    return ToolManager.get_tool_runtime(
+        provider_type=ToolProviderType.BUILT_IN,
+        provider_id="test-plugin/test-provider",
+        tool_name="test-tool",
+        tenant_id="tenant-1",
+        credential_id="bp-001",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock acquired → credentials refreshed
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshLockAcquired:
+    """When the lock is successfully acquired, credentials should be refreshed."""
+
+    @patch("core.helper.credential_utils.check_credential_policy_compliance")
+    @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
+    @patch("core.tools.tool_manager.create_provider_encrypter")
+    @patch("core.tools.tool_manager.redis_client")
+    @patch("core.tools.tool_manager.db")
+    @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
+    def test_lock_acquired_refreshes_credentials(
+        self, mock_get_provider, mock_db, mock_redis,
+        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+    ):
+        """When lock is acquired and token is expired, credentials should be refreshed."""
+        expired_at = int(time.time()) - 100
+        new_expires_at = int(time.time()) + 3600
+
+        bp = _make_builtin_provider(expires_at=expired_at)
+        enc, cache = _make_encrypter_and_cache()
+        mock_db.session.refresh.side_effect = lambda obj: None  # Keep expired
+        mock_lock = _setup_common_patches(
+            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+            bp, enc, cache, lock_acquired=True,
+        )
+
+        refreshed = _make_refreshed_response(expires_at=new_expires_at)
+
+        with (
+            patch("core.plugin.impl.oauth.OAuthHandler") as mock_oauth_cls,
+            patch("services.tools.builtin_tools_manage_service.BuiltinToolManageService") as mock_manage_svc,
+            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
+            patch("core.tools.tool_manager.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_pid = MagicMock()
+            mock_pid.provider_name = "test-provider"
+            mock_pid.plugin_id = "test-plugin"
+            mock_pid_cls.return_value = mock_pid
+            mock_manage_svc.get_oauth_client.return_value = {"client_id": "cid"}
+            mock_oauth = MagicMock()
+            mock_oauth.refresh_credentials.return_value = refreshed
+            mock_oauth_cls.return_value = mock_oauth
+
+            _call_get_tool_runtime()
+
+        # Lock was acquired and released
+        mock_redis.lock.assert_called_once()
+        mock_lock.acquire.assert_called_once_with(blocking=False)
+        mock_lock.release.assert_called_once()
+        # OAuth refresh was called
+        mock_oauth.refresh_credentials.assert_called_once()
+        # DB was committed
+        mock_db.session.commit.assert_called_once()
+        assert bp.expires_at == new_expires_at
+        # Cache was invalidated
+        cache.delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock acquired but double-check shows already refreshed
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshDoubleCheck:
+    """When lock is acquired but another request already refreshed, skip refresh."""
+
+    @patch("core.helper.credential_utils.check_credential_policy_compliance")
+    @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
+    @patch("core.tools.tool_manager.create_provider_encrypter")
+    @patch("core.tools.tool_manager.redis_client")
+    @patch("core.tools.tool_manager.db")
+    @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
+    def test_double_check_skips_refresh(
+        self, mock_get_provider, mock_db, mock_redis,
+        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+    ):
+        """Lock acquired, but double-check shows token was already refreshed."""
+        expired_at = int(time.time()) - 100
+        fresh_at = int(time.time()) + 3600
+
+        bp = _make_builtin_provider(expires_at=expired_at)
+        enc, cache = _make_encrypter_and_cache()
+
+        # After db.session.refresh(), expires_at becomes fresh
+        def _fake_refresh(obj):
+            obj.expires_at = fresh_at
+
+        mock_db.session.refresh.side_effect = _fake_refresh
+        mock_lock = _setup_common_patches(
+            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+            bp, enc, cache, lock_acquired=True,
+        )
+
+        with (
+            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
+            patch("core.tools.tool_manager.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_pid = MagicMock()
+            mock_pid.provider_name = "test-provider"
+            mock_pid.plugin_id = "test-plugin"
+            mock_pid_cls.return_value = mock_pid
+
+            _call_get_tool_runtime()
+
+        mock_lock.acquire.assert_called_once_with(blocking=False)
+        mock_lock.release.assert_called_once()
+        mock_db.session.refresh.assert_called_with(bp)
+        # No commit since double-check found fresh credentials
+        mock_db.session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock NOT acquired → read from DB
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshLockNotAcquired:
+    """When the lock is not acquired, retry polling DB until credentials are fresh."""
+
+    @patch("core.tools.tool_manager.time")
+    @patch("core.helper.credential_utils.check_credential_policy_compliance")
+    @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
+    @patch("core.tools.tool_manager.create_provider_encrypter")
+    @patch("core.tools.tool_manager.redis_client")
+    @patch("core.tools.tool_manager.db")
+    @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
+    def test_lock_not_acquired_retries_then_reads_fresh(
+        self, mock_get_provider, mock_db, mock_redis,
+        mock_create_encrypter, mock_is_uuid, mock_check_policy, mock_time,
+    ):
+        """When lock not acquired, should retry polling DB until credentials become fresh."""
+        now = int(time.time())
+        expired_at = now - 100
+        fresh_at = now + 3600
+
+        bp = _make_builtin_provider(expires_at=expired_at)
+        refreshed_creds = {"access_token": "refreshed_by_other", "refresh_token": "refreshed_rt"}
+        enc, cache = _make_encrypter_and_cache(decrypted=refreshed_creds)
+
+        mock_lock = _setup_common_patches(
+            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+            bp, enc, cache, lock_acquired=False,
+        )
+
+        # time.time() returns current time; time.sleep() is a no-op in unit test
+        mock_time.time.return_value = now
+        mock_time.sleep = MagicMock()
+
+        # Simulate: first db.session.refresh still expired, second one is fresh
+        call_count = 0
+        def _fake_refresh(obj):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                obj.expires_at = fresh_at
+
+        mock_db.session.refresh.side_effect = _fake_refresh
+
+        with (
+            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
+            patch("core.tools.tool_manager.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_pid = MagicMock()
+            mock_pid.provider_name = "test-provider"
+            mock_pid.plugin_id = "test-plugin"
+            mock_pid_cls.return_value = mock_pid
+
+            _call_get_tool_runtime()
+
+        mock_lock.acquire.assert_called_once_with(blocking=False)
+        mock_lock.release.assert_not_called()
+        # time.sleep was called for backoff
+        assert mock_time.sleep.call_count >= 1
+        # DB was polled multiple times
+        assert mock_db.session.refresh.call_count >= 2
+        enc.decrypt.assert_called()
+        mock_db.session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock release on exception
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshLockRelease:
+    """Lock should always be released, even when refresh raises an exception."""
+
+    @patch("core.helper.credential_utils.check_credential_policy_compliance")
+    @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
+    @patch("core.tools.tool_manager.create_provider_encrypter")
+    @patch("core.tools.tool_manager.redis_client")
+    @patch("core.tools.tool_manager.db")
+    @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
+    def test_lock_released_on_exception(
+        self, mock_get_provider, mock_db, mock_redis,
+        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+    ):
+        """Lock must be released in finally block even if refresh raises."""
+        expired_at = int(time.time()) - 100
+        bp = _make_builtin_provider(expires_at=expired_at)
+        enc, cache = _make_encrypter_and_cache()
+        mock_db.session.refresh.side_effect = lambda obj: None
+
+        mock_lock = _setup_common_patches(
+            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+            bp, enc, cache, lock_acquired=True,
+        )
+
+        with (
+            patch("core.plugin.impl.oauth.OAuthHandler") as mock_oauth_cls,
+            patch("services.tools.builtin_tools_manage_service.BuiltinToolManageService") as mock_manage_svc,
+            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
+            patch("core.tools.tool_manager.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_pid = MagicMock()
+            mock_pid.provider_name = "test-provider"
+            mock_pid.plugin_id = "test-plugin"
+            mock_pid_cls.return_value = mock_pid
+            mock_manage_svc.get_oauth_client.return_value = {}
+            mock_oauth = MagicMock()
+            mock_oauth.refresh_credentials.side_effect = RuntimeError("OAuth unreachable")
+            mock_oauth_cls.return_value = mock_oauth
+
+            with pytest.raises(RuntimeError, match="OAuth unreachable"):
+                _call_get_tool_runtime()
+
+        mock_lock.release.assert_called_once()
+        mock_db.session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: Non-expired token → no lock needed
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshNotExpired:
+    """When credentials are not expired, no lock or refresh should happen."""
+
+    @patch("core.helper.credential_utils.check_credential_policy_compliance")
+    @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
+    @patch("core.tools.tool_manager.create_provider_encrypter")
+    @patch("core.tools.tool_manager.redis_client")
+    @patch("core.tools.tool_manager.db")
+    @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
+    def test_non_expired_skips_lock(
+        self, mock_get_provider, mock_db, mock_redis,
+        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+    ):
+        """Non-expired credentials should bypass the lock entirely."""
+        future_at = int(time.time()) + 3600
+        bp = _make_builtin_provider(expires_at=future_at)
+        enc, cache = _make_encrypter_and_cache()
+        _setup_common_patches(
+            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+            bp, enc, cache,
+        )
+
+        with (
+            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
+            patch("core.tools.tool_manager.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_pid = MagicMock()
+            mock_pid.provider_name = "test-provider"
+            mock_pid.plugin_id = "test-plugin"
+            mock_pid_cls.return_value = mock_pid
+
+            _call_get_tool_runtime()
+
+        mock_redis.lock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: expires_at == -1 → never expires, no lock
+# ---------------------------------------------------------------------------
+
+class TestOAuthRefreshNeverExpires:
+    """When expires_at is -1, no lock needed."""
+
+    @patch("core.helper.credential_utils.check_credential_policy_compliance")
+    @patch("core.tools.tool_manager.is_valid_uuid", return_value=True)
+    @patch("core.tools.tool_manager.create_provider_encrypter")
+    @patch("core.tools.tool_manager.redis_client")
+    @patch("core.tools.tool_manager.db")
+    @patch("core.tools.tool_manager.ToolManager.get_builtin_provider")
+    def test_never_expires_skips_lock(
+        self, mock_get_provider, mock_db, mock_redis,
+        mock_create_encrypter, mock_is_uuid, mock_check_policy,
+    ):
+        """expires_at == -1 means no expiration; should not attempt lock."""
+        bp = _make_builtin_provider(expires_at=-1)
+        enc, cache = _make_encrypter_and_cache()
+        _setup_common_patches(
+            mock_db, mock_redis, mock_create_encrypter, mock_get_provider,
+            bp, enc, cache,
+        )
+
+        with (
+            patch("core.tools.tool_manager.ToolProviderID") as mock_pid_cls,
+            patch("core.tools.tool_manager.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_pid = MagicMock()
+            mock_pid.provider_name = "test-provider"
+            mock_pid.plugin_id = "test-plugin"
+            mock_pid_cls.return_value = mock_pid
+
+            _call_get_tool_runtime()
+
+        mock_redis.lock.assert_not_called()

--- a/api/tests/unit_tests/services/test_datasource_provider_oauth_refresh_lock.py
+++ b/api/tests/unit_tests/services/test_datasource_provider_oauth_refresh_lock.py
@@ -91,6 +91,7 @@ def _make_redis_lock(*, acquired=True):
 # Test: Lock acquired → credentials refreshed
 # ---------------------------------------------------------------------------
 
+
 class TestDatasourceProviderOAuthRefreshLockAcquired:
     """When the lock is successfully acquired, credentials should be refreshed."""
 
@@ -142,12 +143,16 @@ class TestDatasourceProviderOAuthRefreshLockAcquired:
         svc = DatasourceProviderService()
 
         with (
-            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
-                "access_token": "old_at", "refresh_token": "old_rt"
-            }),
-            patch.object(svc, "encrypt_datasource_provider_credentials", return_value={
-                "access_token": "encrypted_new_at", "refresh_token": "encrypted_new_rt"
-            }),
+            patch.object(
+                svc,
+                "decrypt_datasource_provider_credentials",
+                return_value={"access_token": "old_at", "refresh_token": "old_rt"},
+            ),
+            patch.object(
+                svc,
+                "encrypt_datasource_provider_credentials",
+                return_value={"access_token": "encrypted_new_at", "refresh_token": "encrypted_new_rt"},
+            ),
             patch.object(svc, "get_oauth_client", return_value={"client_id": "cid"}),
             patch.object(svc, "extract_secret_variables", return_value=[]),
             patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
@@ -185,6 +190,7 @@ class TestDatasourceProviderOAuthRefreshLockAcquired:
 # ---------------------------------------------------------------------------
 # Test: Lock acquired but double-check shows already refreshed
 # ---------------------------------------------------------------------------
+
 
 class TestDatasourceProviderOAuthRefreshDoubleCheck:
     """When lock is acquired but double-check shows already refreshed, skip refresh."""
@@ -224,9 +230,11 @@ class TestDatasourceProviderOAuthRefreshDoubleCheck:
         svc = DatasourceProviderService()
 
         with (
-            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
-                "access_token": "refreshed_at", "refresh_token": "refreshed_rt"
-            }),
+            patch.object(
+                svc,
+                "decrypt_datasource_provider_credentials",
+                return_value={"access_token": "refreshed_at", "refresh_token": "refreshed_rt"},
+            ),
             patch.object(svc, "extract_secret_variables", return_value=[]),
             patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
         ):
@@ -249,6 +257,7 @@ class TestDatasourceProviderOAuthRefreshDoubleCheck:
 # ---------------------------------------------------------------------------
 # Test: Lock NOT acquired → poll DB with exponential backoff
 # ---------------------------------------------------------------------------
+
 
 class TestDatasourceProviderOAuthRefreshLockNotAcquired:
     """When the lock is not acquired (LockError), poll Redis signal then read DB once."""
@@ -291,9 +300,11 @@ class TestDatasourceProviderOAuthRefreshLockNotAcquired:
         svc = DatasourceProviderService()
 
         with (
-            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
-                "access_token": "refreshed_by_other", "refresh_token": "refreshed_rt"
-            }),
+            patch.object(
+                svc,
+                "decrypt_datasource_provider_credentials",
+                return_value={"access_token": "refreshed_by_other", "refresh_token": "refreshed_rt"},
+            ),
             patch.object(svc, "extract_secret_variables", return_value=[]),
             patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
         ):
@@ -316,6 +327,7 @@ class TestDatasourceProviderOAuthRefreshLockNotAcquired:
 # ---------------------------------------------------------------------------
 # Test: Lock release on exception
 # ---------------------------------------------------------------------------
+
 
 class TestDatasourceProviderOAuthRefreshLockRelease:
     """Lock should always be released (via context manager __exit__) on exception."""
@@ -360,9 +372,11 @@ class TestDatasourceProviderOAuthRefreshLockRelease:
         svc = DatasourceProviderService()
 
         with (
-            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
-                "access_token": "old_at", "refresh_token": "old_rt"
-            }),
+            patch.object(
+                svc,
+                "decrypt_datasource_provider_credentials",
+                return_value={"access_token": "old_at", "refresh_token": "old_rt"},
+            ),
             patch.object(svc, "get_oauth_client", return_value={"client_id": "cid"}),
             patch.object(svc, "extract_secret_variables", return_value=[]),
             patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
@@ -393,6 +407,7 @@ class TestDatasourceProviderOAuthRefreshLockRelease:
 # Test: Non-expired token → no lock needed
 # ---------------------------------------------------------------------------
 
+
 class TestDatasourceProviderOAuthRefreshNotExpired:
     """When credentials are not expired, no lock or refresh should happen."""
 
@@ -419,9 +434,11 @@ class TestDatasourceProviderOAuthRefreshNotExpired:
         svc = DatasourceProviderService()
 
         with (
-            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
-                "access_token": "valid_at", "refresh_token": "valid_rt"
-            }),
+            patch.object(
+                svc,
+                "decrypt_datasource_provider_credentials",
+                return_value={"access_token": "valid_at", "refresh_token": "valid_rt"},
+            ),
             patch.object(svc, "extract_secret_variables", return_value=[]),
             patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
         ):
@@ -440,6 +457,7 @@ class TestDatasourceProviderOAuthRefreshNotExpired:
 # ---------------------------------------------------------------------------
 # Test: expires_at == -1 → never expires, no lock
 # ---------------------------------------------------------------------------
+
 
 class TestDatasourceProviderOAuthRefreshNeverExpires:
     """When expires_at is -1, credentials never expire; no lock needed."""
@@ -466,9 +484,11 @@ class TestDatasourceProviderOAuthRefreshNeverExpires:
         svc = DatasourceProviderService()
 
         with (
-            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
-                "access_token": "valid_at", "refresh_token": "valid_rt"
-            }),
+            patch.object(
+                svc,
+                "decrypt_datasource_provider_credentials",
+                return_value={"access_token": "valid_at", "refresh_token": "valid_rt"},
+            ),
             patch.object(svc, "extract_secret_variables", return_value=[]),
             patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
         ):

--- a/api/tests/unit_tests/services/test_datasource_provider_oauth_refresh_lock.py
+++ b/api/tests/unit_tests/services/test_datasource_provider_oauth_refresh_lock.py
@@ -1,0 +1,470 @@
+"""Tests for the distributed lock mechanism in DatasourceProviderService OAuth token refresh.
+
+These tests verify the non-blocking Redis lock + double-check pattern that
+prevents concurrent OAuth token refresh race conditions.
+"""
+
+import time
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_datasource_provider(
+    *,
+    provider_id: str = "dp-001",
+    tenant_id: str = "tenant-1",
+    provider: str = "test-provider",
+    plugin_id: str = "test-plugin",
+    auth_type: str = "oauth2",
+    expires_at: int = -1,
+    encrypted_credentials: dict | None = None,
+):
+    """Create a mock DatasourceProvider with the given attributes."""
+    dp = MagicMock()
+    dp.id = provider_id
+    dp.tenant_id = tenant_id
+    dp.provider = provider
+    dp.plugin_id = plugin_id
+    dp.auth_type = auth_type
+    dp.expires_at = expires_at
+    dp.encrypted_credentials = encrypted_credentials or {
+        "access_token": "encrypted_old_at",
+        "refresh_token": "encrypted_old_rt",
+    }
+    return dp
+
+
+def _make_refreshed_credentials(
+    access_token: str = "new_at",
+    refresh_token: str = "new_rt",
+    expires_at: int | None = None,
+):
+    """Create a mock PluginOAuthCredentialsResponse."""
+    resp = MagicMock()
+    resp.credentials = {"access_token": access_token, "refresh_token": refresh_token}
+    resp.expires_at = expires_at or int(time.time()) + 3600
+    return resp
+
+
+def _make_mock_session(datasource_provider):
+    """Create a mock Session that returns the given datasource_provider on query."""
+    mock_session = MagicMock()
+    mock_query = MagicMock()
+    mock_query.filter_by.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.first.return_value = datasource_provider
+    mock_session.query.return_value = mock_query
+    mock_session.refresh = MagicMock()
+    mock_session.commit = MagicMock()
+    return mock_session
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock acquired → credentials refreshed
+# ---------------------------------------------------------------------------
+
+class TestDatasourceProviderOAuthRefreshLockAcquired:
+    """When the lock is successfully acquired, credentials should be refreshed."""
+
+    @patch("services.datasource_provider_service.redis_client")
+    @patch("services.datasource_provider_service.db")
+    @patch("services.datasource_provider_service.OAuthHandler")
+    @patch("services.datasource_provider_service.get_current_user")
+    def test_lock_acquired_refreshes_credentials(
+        self,
+        mock_get_user,
+        mock_oauth_cls,
+        mock_db,
+        mock_redis,
+    ):
+        """When lock is acquired and token is expired, credentials should be refreshed."""
+        from services.datasource_provider_service import DatasourceProviderService
+
+        # Arrange
+        expired_at = int(time.time()) - 100
+        new_expires_at = int(time.time()) + 3600
+
+        dp = _make_datasource_provider(expires_at=expired_at)
+        mock_session = _make_mock_session(dp)
+
+        # Session context manager
+        mock_db.engine = MagicMock()
+        mock_session_cls = MagicMock()
+        mock_session_cls.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.__exit__ = MagicMock(return_value=False)
+
+        # db.session.refresh keeps expired (double-check passes)
+        mock_session.refresh.side_effect = lambda obj: None
+
+        # Lock acquired
+        mock_lock = MagicMock()
+        mock_lock.acquire.return_value = True
+        mock_redis.lock.return_value = mock_lock
+
+        # OAuth refresh
+        refreshed = _make_refreshed_credentials(expires_at=new_expires_at)
+        mock_oauth = MagicMock()
+        mock_oauth.refresh_credentials.return_value = refreshed
+        mock_oauth_cls.return_value = mock_oauth
+
+        # Current user
+        mock_user = MagicMock()
+        mock_user.id = "user-1"
+        mock_get_user.return_value = mock_user
+
+        svc = DatasourceProviderService()
+
+        with (
+            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
+                "access_token": "old_at", "refresh_token": "old_rt"
+            }),
+            patch.object(svc, "encrypt_datasource_provider_credentials", return_value={
+                "access_token": "encrypted_new_at", "refresh_token": "encrypted_new_rt"
+            }),
+            patch.object(svc, "get_oauth_client", return_value={"client_id": "cid"}),
+            patch.object(svc, "extract_secret_variables", return_value=[]),
+            patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
+            patch("services.datasource_provider_service.DatasourceProviderID") as mock_dp_id_cls,
+            patch("services.datasource_provider_service.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_dp_id = MagicMock()
+            mock_dp_id.provider_name = "test-provider"
+            mock_dp_id.plugin_id = "test-plugin"
+            mock_dp_id_cls.return_value = mock_dp_id
+
+            # Act
+            svc.get_datasource_credentials(
+                tenant_id="tenant-1",
+                provider="test-provider",
+                plugin_id="test-plugin",
+                credential_id="dp-001",
+            )
+
+        # Assert
+        mock_redis.lock.assert_called_once()
+        mock_lock.acquire.assert_called_once_with(blocking=False)
+        mock_lock.release.assert_called_once()
+        mock_oauth.refresh_credentials.assert_called_once()
+        mock_session.commit.assert_called_once()
+        assert dp.expires_at == new_expires_at
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock acquired but double-check shows already refreshed
+# ---------------------------------------------------------------------------
+
+class TestDatasourceProviderOAuthRefreshDoubleCheck:
+    """When lock is acquired but double-check shows already refreshed, skip refresh."""
+
+    @patch("services.datasource_provider_service.redis_client")
+    @patch("services.datasource_provider_service.db")
+    def test_lock_acquired_but_already_refreshed(
+        self,
+        mock_db,
+        mock_redis,
+    ):
+        """Lock acquired, but double-check shows token was already refreshed."""
+        from services.datasource_provider_service import DatasourceProviderService
+
+        # Arrange
+        expired_at = int(time.time()) - 100
+        fresh_expires_at = int(time.time()) + 3600
+
+        dp = _make_datasource_provider(expires_at=expired_at)
+        mock_session = _make_mock_session(dp)
+
+        mock_db.engine = MagicMock()
+        mock_session_cls = MagicMock()
+        mock_session_cls.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.__exit__ = MagicMock(return_value=False)
+
+        # After session.refresh(), expires_at becomes fresh
+        def _fake_refresh(obj):
+            obj.expires_at = fresh_expires_at
+
+        mock_session.refresh.side_effect = _fake_refresh
+
+        # Lock acquired
+        mock_lock = MagicMock()
+        mock_lock.acquire.return_value = True
+        mock_redis.lock.return_value = mock_lock
+
+        svc = DatasourceProviderService()
+
+        with (
+            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
+                "access_token": "refreshed_at", "refresh_token": "refreshed_rt"
+            }),
+            patch.object(svc, "extract_secret_variables", return_value=[]),
+            patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
+        ):
+            # Act
+            svc.get_datasource_credentials(
+                tenant_id="tenant-1",
+                provider="test-provider",
+                plugin_id="test-plugin",
+                credential_id="dp-001",
+            )
+
+        # Assert
+        mock_lock.acquire.assert_called_once_with(blocking=False)
+        mock_lock.release.assert_called_once()
+        mock_session.refresh.assert_called_with(dp)
+        # No commit since double-check found fresh credentials
+        mock_session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock NOT acquired → read from DB
+# ---------------------------------------------------------------------------
+
+class TestDatasourceProviderOAuthRefreshLockNotAcquired:
+    """When the lock is not acquired, retry polling DB until credentials are fresh."""
+
+    @patch("services.datasource_provider_service.time")
+    @patch("services.datasource_provider_service.redis_client")
+    @patch("services.datasource_provider_service.db")
+    def test_lock_not_acquired_retries_then_reads_fresh(
+        self,
+        mock_db,
+        mock_redis,
+        mock_time,
+    ):
+        """When lock not acquired, should retry polling DB until credentials become fresh."""
+        from services.datasource_provider_service import DatasourceProviderService
+
+        # Arrange
+        now = int(time.time())
+        expired_at = now - 100
+        fresh_at = now + 3600
+
+        dp = _make_datasource_provider(expires_at=expired_at)
+        mock_session = _make_mock_session(dp)
+
+        mock_db.engine = MagicMock()
+        mock_session_cls = MagicMock()
+        mock_session_cls.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.__exit__ = MagicMock(return_value=False)
+
+        # time.time() returns current time; time.sleep() is a no-op in unit test
+        mock_time.time.return_value = now
+        mock_time.sleep = MagicMock()
+
+        # Lock NOT acquired
+        mock_lock = MagicMock()
+        mock_lock.acquire.return_value = False
+        mock_redis.lock.return_value = mock_lock
+
+        # Simulate: first session.refresh still expired, second one is fresh
+        call_count = 0
+        def _fake_refresh(obj):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                obj.expires_at = fresh_at
+
+        mock_session.refresh.side_effect = _fake_refresh
+
+        svc = DatasourceProviderService()
+
+        with (
+            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
+                "access_token": "refreshed_by_other", "refresh_token": "refreshed_rt"
+            }),
+            patch.object(svc, "extract_secret_variables", return_value=[]),
+            patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
+        ):
+            # Act
+            svc.get_datasource_credentials(
+                tenant_id="tenant-1",
+                provider="test-provider",
+                plugin_id="test-plugin",
+                credential_id="dp-001",
+            )
+
+        # Assert
+        mock_lock.acquire.assert_called_once_with(blocking=False)
+        mock_lock.release.assert_not_called()
+        # time.sleep was called for backoff
+        assert mock_time.sleep.call_count >= 1
+        # DB was polled multiple times
+        assert mock_session.refresh.call_count >= 2
+        mock_session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: Lock release on exception
+# ---------------------------------------------------------------------------
+
+class TestDatasourceProviderOAuthRefreshLockRelease:
+    """Lock should always be released, even when refresh raises an exception."""
+
+    @patch("services.datasource_provider_service.redis_client")
+    @patch("services.datasource_provider_service.db")
+    @patch("services.datasource_provider_service.OAuthHandler")
+    @patch("services.datasource_provider_service.get_current_user")
+    def test_lock_released_on_refresh_exception(
+        self,
+        mock_get_user,
+        mock_oauth_cls,
+        mock_db,
+        mock_redis,
+    ):
+        """Lock must be released in finally block even if refresh raises."""
+        from services.datasource_provider_service import DatasourceProviderService
+
+        # Arrange
+        expired_at = int(time.time()) - 100
+        dp = _make_datasource_provider(expires_at=expired_at)
+        mock_session = _make_mock_session(dp)
+
+        mock_db.engine = MagicMock()
+        mock_session_cls = MagicMock()
+        mock_session_cls.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.__exit__ = MagicMock(return_value=False)
+
+        mock_session.refresh.side_effect = lambda obj: None
+
+        mock_lock = MagicMock()
+        mock_lock.acquire.return_value = True
+        mock_redis.lock.return_value = mock_lock
+
+        mock_user = MagicMock()
+        mock_user.id = "user-1"
+        mock_get_user.return_value = mock_user
+
+        mock_oauth = MagicMock()
+        mock_oauth.refresh_credentials.side_effect = RuntimeError("OAuth unreachable")
+        mock_oauth_cls.return_value = mock_oauth
+
+        svc = DatasourceProviderService()
+
+        with (
+            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
+                "access_token": "old_at", "refresh_token": "old_rt"
+            }),
+            patch.object(svc, "get_oauth_client", return_value={"client_id": "cid"}),
+            patch.object(svc, "extract_secret_variables", return_value=[]),
+            patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
+            patch("services.datasource_provider_service.DatasourceProviderID") as mock_dp_id_cls,
+            patch("services.datasource_provider_service.dify_config") as mock_config,
+        ):
+            mock_config.CONSOLE_API_URL = "https://app.dify.ai"
+            mock_dp_id = MagicMock()
+            mock_dp_id.provider_name = "test-provider"
+            mock_dp_id.plugin_id = "test-plugin"
+            mock_dp_id_cls.return_value = mock_dp_id
+
+            # Act & Assert
+            with pytest.raises(RuntimeError, match="OAuth unreachable"):
+                svc.get_datasource_credentials(
+                    tenant_id="tenant-1",
+                    provider="test-provider",
+                    plugin_id="test-plugin",
+                    credential_id="dp-001",
+                )
+
+        # Lock must still be released
+        mock_lock.release.assert_called_once()
+        mock_session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: Non-expired token → no lock needed
+# ---------------------------------------------------------------------------
+
+class TestDatasourceProviderOAuthRefreshNotExpired:
+    """When credentials are not expired, no lock or refresh should happen."""
+
+    @patch("services.datasource_provider_service.redis_client")
+    @patch("services.datasource_provider_service.db")
+    def test_non_expired_credentials_skip_lock(
+        self,
+        mock_db,
+        mock_redis,
+    ):
+        """Non-expired credentials should bypass the lock entirely."""
+        from services.datasource_provider_service import DatasourceProviderService
+
+        # Arrange
+        future_expires_at = int(time.time()) + 3600
+        dp = _make_datasource_provider(expires_at=future_expires_at)
+        mock_session = _make_mock_session(dp)
+
+        mock_db.engine = MagicMock()
+        mock_session_cls = MagicMock()
+        mock_session_cls.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.__exit__ = MagicMock(return_value=False)
+
+        svc = DatasourceProviderService()
+
+        with (
+            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
+                "access_token": "valid_at", "refresh_token": "valid_rt"
+            }),
+            patch.object(svc, "extract_secret_variables", return_value=[]),
+            patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
+        ):
+            # Act
+            svc.get_datasource_credentials(
+                tenant_id="tenant-1",
+                provider="test-provider",
+                plugin_id="test-plugin",
+                credential_id="dp-001",
+            )
+
+        # Assert: no lock interaction at all
+        mock_redis.lock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: expires_at == -1 → never expires, no lock
+# ---------------------------------------------------------------------------
+
+class TestDatasourceProviderOAuthRefreshNeverExpires:
+    """When expires_at is -1, credentials never expire; no lock needed."""
+
+    @patch("services.datasource_provider_service.redis_client")
+    @patch("services.datasource_provider_service.db")
+    def test_never_expires_skips_lock(
+        self,
+        mock_db,
+        mock_redis,
+    ):
+        """expires_at == -1 means no expiration; should not attempt lock."""
+        from services.datasource_provider_service import DatasourceProviderService
+
+        # Arrange
+        dp = _make_datasource_provider(expires_at=-1)
+        mock_session = _make_mock_session(dp)
+
+        mock_db.engine = MagicMock()
+        mock_session_cls = MagicMock()
+        mock_session_cls.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.__exit__ = MagicMock(return_value=False)
+
+        svc = DatasourceProviderService()
+
+        with (
+            patch.object(svc, "decrypt_datasource_provider_credentials", return_value={
+                "access_token": "valid_at", "refresh_token": "valid_rt"
+            }),
+            patch.object(svc, "extract_secret_variables", return_value=[]),
+            patch("services.datasource_provider_service.Session", return_value=mock_session_cls),
+        ):
+            # Act
+            svc.get_datasource_credentials(
+                tenant_id="tenant-1",
+                provider="test-provider",
+                plugin_id="test-plugin",
+                credential_id="dp-001",
+            )
+
+        # Assert
+        mock_redis.lock.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the OAuth token refresh logic that cause:

1. **Refreshed credentials never persist to the database** — `db.session.commit()` after a successful OAuth refresh does not persist in Celery worker and gevent greenlet contexts because Flask-SQLAlchemy's scoped `db.session` is not reliable in these contexts. Every subsequent request re-reads the stale `expires_at` and re-triggers the refresh, leading to hundreds of unnecessary OAuth calls per day.

2. **No distributed lock on concurrent refresh** — Multiple concurrent workers (e.g., `GraphWorker-0` and `GraphWorker-1` in workflow execution) can simultaneously detect expired credentials and call the OAuth provider to refresh. With providers that use refresh token rotation (e.g., QuickBooks), this leads to `invalid_grant` errors and permanent failure requiring manual re-authorization.

Together, these bugs create a cascading failure: the token is refreshed hundreds of times but never saved, until the original refresh token is eventually invalidated by the OAuth provider.

## Changes

### `api/core/tools/tool_manager.py`
- Add non-blocking Redis distributed lock around the OAuth refresh block
- Replace `db.session.refresh()` / `db.session.commit()` with explicit `Session(db.engine)` and `session.get()` / `session.commit()` to ensure persistence in all execution contexts
- Add double-check after lock acquisition (another request may have already refreshed)
- Add exponential backoff polling for requests that don't acquire the lock

### `api/services/datasource_provider_service.py`
- Add the same non-blocking Redis distributed lock + double-check pattern
- This file already uses explicit `Session(db.engine)`, so only the lock was needed

### New test files
- `api/tests/unit_tests/core/tools/test_tool_manager_oauth_refresh_lock.py` — 6 tests covering lock acquired + refresh, double-check skip, lock not acquired + polling, lock release on exception, non-expired skip, never-expires skip
- `api/tests/unit_tests/services/test_datasource_provider_oauth_refresh_lock.py` — 6 matching tests for datasource provider

## Evidence from production

Before fix (24 hours):
- **693** OAuth refresh HTTP calls (expected: ~24)
- Database `updated_at == created_at` — credentials never persisted
- Concurrent refresh race condition caused permanent `invalid_grant` failure

After fix (5.5 hours):
- **3** OAuth refresh calls (1 manual test + 2 automatic hourly refreshes)
- Database `updated_at` correctly updated on each refresh
- Zero errors, zero concurrent conflicts
- All workflows executing successfully

## Related issue

Closes #32174

## Test plan

- [x] 6 unit tests for `tool_manager.py` OAuth refresh lock — all pass
- [x] 6 unit tests for `datasource_provider_service.py` OAuth refresh lock — all pass
- [x] 78 existing tools tests — zero regressions
- [x] Production deployment verified: token refresh persists, lock prevents concurrent refresh