### PR TITLE
fix: convert UUID to str in deleted_tools API provider check

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -227,7 +227,7 @@ class App(Base):
         with Session(db.engine) as session:
             if api_provider_ids:
                 existing_api_providers = [
-                    api_provider.id
+                    str(api_provider.id)
                     for api_provider in session.execute(
                         text("SELECT id FROM tool_api_providers WHERE id IN :provider_ids"),
                         {"provider_ids": tuple(api_provider_ids)},


### PR DESCRIPTION
## Summary
Fix a type mismatch bug where all API tool providers are incorrectly marked as deleted in the `deleted_tools` property.

## Problem
`api_provider.id` returns a `uuid.UUID` object from SQLAlchemy, but `provider_id` from the app JSON config is a `str`. Since `"abc" != UUID("abc")` in Python, the `in` check always fails, causing every API tool to appear as "removed" in the UI.

## Fix
Cast `api_provider.id` to `str()` so the type comparison works correctly.

```diff
existing_api_providers = [
-    api_provider.id
+    str(api_provider.id)
    for api_provider in session.execute(...)
]
```

## Verification
As reported in the issue: before fix 44 tools marked deleted, after fix 0.

Closes #32205

**Disclosure**: AI-assisted identification of the fix pattern.