### PR TITLE
fix(api): re-raise exceptions in MetadataService to prevent silent failures

### DIFF
--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -228,7 +228,6 @@ class MetadataService:
                     doc_metadata[BuiltInField.source] = MetadataDataSource[document.data_source_type]
                 document.doc_metadata = doc_metadata
                 db.session.add(document)
-                db.session.commit()
                 # deal metadata binding
                 if not operation.partial_update:
                     db.session.query(DatasetMetadataBinding).filter_by(document_id=operation.document_id).delete()

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -92,6 +92,8 @@ class MetadataService:
             return metadata
         except Exception:
             logger.exception("Update metadata name failed")
+            db.session.rollback()
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -124,6 +126,8 @@ class MetadataService:
             return metadata
         except Exception:
             logger.exception("Delete metadata failed")
+            db.session.rollback()
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -163,6 +167,8 @@ class MetadataService:
             db.session.commit()
         except Exception:
             logger.exception("Enable built-in field failed")
+            db.session.rollback()
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -194,6 +200,8 @@ class MetadataService:
             db.session.commit()
         except Exception:
             logger.exception("Disable built-in field failed")
+            db.session.rollback()
+            raise
         finally:
             redis_client.delete(lock_key)
 
@@ -248,6 +256,8 @@ class MetadataService:
                 db.session.commit()
             except Exception:
                 logger.exception("Update documents metadata failed")
+                db.session.rollback()
+                raise
             finally:
                 redis_client.delete(lock_key)
 


### PR DESCRIPTION
Fixes #31964

## Summary
- Five `except Exception` blocks in `MetadataService` were catching and logging errors without re-raising, so the API always returned HTTP 200 even when updates failed
- Added `db.session.rollback()` and `raise` to all five blocks: `update_documents_metadata`, `update_metadata_name`, `delete_metadata`, `enable_built_in_field`, `disable_built_in_field`
- Consolidated two separate `db.session.commit()` calls in `update_documents_metadata` into one for atomicity

## Test plan
- [x] All 16 existing metadata unit tests pass
- [ ] Verify batch metadata edit now returns error response on failure instead of false success