### PR TITLE
test: header account about, account setting and account dropdown

### DIFF
--- a/web/app/components/header/account-about/index.spec.tsx
+++ b/web/app/components/header/account-about/index.spec.tsx
@@ -91,9 +91,9 @@ describe('AccountAbout', () => {
   })
 
   it('renders branding logo if enabled', () => {
-    vi.mocked(useGlobalPublicStore).mockReturnValue({
-      branding: { enabled: true, workspace_logo: 'custom-logo.png' },
-    } as unknown as SystemFeatures)
+    vi.mocked(useGlobalPublicStore).mockImplementation(selector => selector({
+      systemFeatures: { branding: { enabled: true, workspace_logo: 'custom-logo.png' } },
+    } as unknown as GlobalPublicStore))
     render(<AccountAbout langGeniusVersionInfo={mockVersionInfo} onCancel={mockOnCancel} />)
     const img = screen.getByAltText('logo')
     expect(img).toBeDefined()

--- a/web/app/components/header/account-about/index.spec.tsx
+++ b/web/app/components/header/account-about/index.spec.tsx
@@ -14,8 +14,6 @@ vi.mock('@/config', () => ({
   get IS_CE_EDITION() { return mockIsCEEdition },
 }))
 
-// Redacted for brevity as it's a deletion of lines 16-24
-
 vi.mock('@/app/components/header/plan-badge', () => ({
   default: ({ plan }: { plan: string }) => <div data-testid="plan-badge">{plan}</div>,
 }))

--- a/web/app/components/header/account-about/index.spec.tsx
+++ b/web/app/components/header/account-about/index.spec.tsx
@@ -1,0 +1,104 @@
+import type { LangGeniusVersionResponse } from '@/models/common'
+import type { SystemFeatures } from '@/types/feature'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useGlobalPublicStore } from '@/context/global-public-context'
+import AccountAbout from './index'
+
+vi.mock('@/context/global-public-context', () => ({
+  useGlobalPublicStore: vi.fn(),
+}))
+
+let mockIsCEEdition = false
+vi.mock('@/config', () => ({
+  get IS_CE_EDITION() { return mockIsCEEdition },
+}))
+
+// Redacted for brevity as it's a deletion of lines 16-24
+
+vi.mock('@/app/components/header/plan-badge', () => ({
+  default: ({ plan }: { plan: string }) => <div data-testid="plan-badge">{plan}</div>,
+}))
+
+vi.mock('@/app/components/base/modal', () => ({
+  default: ({ children, onClose }: { children: React.ReactNode, onClose: () => void }) => (
+    <div data-testid="modal">
+      <button onClick={onClose} data-testid="modal-close">Close</button>
+      {children}
+    </div>
+  ),
+}))
+
+type GlobalPublicStore = {
+  systemFeatures: SystemFeatures
+  setSystemFeatures: (systemFeatures: SystemFeatures) => void
+}
+
+describe('AccountAbout', () => {
+  const mockVersionInfo = {
+    current_version: '0.6.0',
+    latest_version: '0.6.0',
+    release_notes: 'https://github.com/langgenius/dify/releases/tag/0.6.0',
+    version: '0.6.0',
+    release_date: '2024-01-01',
+    can_auto_update: false,
+    current_env: 'production',
+  }
+
+  const mockOnCancel = vi.fn()
+
+  beforeEach(() => {
+    vi.mocked(useGlobalPublicStore).mockImplementation(selector => selector({
+      systemFeatures: { branding: { enabled: false } },
+    } as unknown as GlobalPublicStore))
+  })
+
+  it('renders correctly with version information', () => {
+    render(<AccountAbout langGeniusVersionInfo={mockVersionInfo as unknown as LangGeniusVersionResponse} onCancel={mockOnCancel} />)
+    expect(screen.getByText(/^Version/)).toBeDefined()
+    expect(screen.getAllByText(/0.6.0/).length).toBeGreaterThan(0)
+  })
+
+  it('shows "Latest Available" when current version equals latest', () => {
+    render(<AccountAbout langGeniusVersionInfo={mockVersionInfo as unknown as LangGeniusVersionResponse} onCancel={mockOnCancel} />)
+    expect(screen.getByText(/about.latestAvailable/)).toBeDefined()
+  })
+
+  it('shows "Now Available" when current version is behind', () => {
+    const behindVersionInfo = { ...mockVersionInfo, latest_version: '0.7.0' }
+    render(<AccountAbout langGeniusVersionInfo={behindVersionInfo as unknown as LangGeniusVersionResponse} onCancel={mockOnCancel} />)
+    expect(screen.getByText(/about.nowAvailable/)).toBeDefined()
+    expect(screen.getByText(/about.updateNow/)).toBeDefined()
+  })
+
+  it('calls onCancel when close button is clicked', () => {
+    render(<AccountAbout langGeniusVersionInfo={mockVersionInfo} onCancel={mockOnCancel} />)
+    fireEvent.click(screen.getByTestId('modal-close'))
+    expect(mockOnCancel).toHaveBeenCalled()
+  })
+
+  it('renders correctly in Community Edition (IS_CE_EDITION = true)', () => {
+    mockIsCEEdition = true
+    render(<AccountAbout langGeniusVersionInfo={mockVersionInfo as unknown as LangGeniusVersionResponse} onCancel={mockOnCancel} />)
+    expect(screen.getByText(/Open Source License/)).toBeDefined()
+    mockIsCEEdition = false // Reset
+  })
+
+  it('hides update button in Community Edition when behind version', () => {
+    mockIsCEEdition = true
+    const behindVersionInfo = { ...mockVersionInfo, latest_version: '0.7.0' }
+    render(<AccountAbout langGeniusVersionInfo={behindVersionInfo as unknown as LangGeniusVersionResponse} onCancel={mockOnCancel} />)
+    expect(screen.queryByText(/about.updateNow/)).toBeNull()
+    mockIsCEEdition = false // Reset
+  })
+
+  it('renders branding logo if enabled', () => {
+    vi.mocked(useGlobalPublicStore).mockReturnValue({
+      branding: { enabled: true, workspace_logo: 'custom-logo.png' },
+    } as unknown as SystemFeatures)
+    render(<AccountAbout langGeniusVersionInfo={mockVersionInfo} onCancel={mockOnCancel} />)
+    const img = screen.getByAltText('logo')
+    expect(img).toBeDefined()
+    expect(img.getAttribute('src')).toBe('custom-logo.png')
+  })
+})

--- a/web/app/components/header/account-dropdown/compliance.spec.tsx
+++ b/web/app/components/header/account-dropdown/compliance.spec.tsx
@@ -1,0 +1,193 @@
+import type { ModalContextState } from '@/context/modal-context'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Plan } from '@/app/components/billing/type'
+import { ACCOUNT_SETTING_TAB } from '@/app/components/header/account-setting/constants'
+import { useModalContext } from '@/context/modal-context'
+import { baseProviderContextValue, useProviderContext } from '@/context/provider-context'
+import { getDocDownloadUrl } from '@/service/common'
+import { downloadUrl } from '@/utils/download'
+import Toast from '../../base/toast'
+import Compliance from './compliance'
+
+vi.mock('@/context/provider-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/provider-context')>()
+  return {
+    ...actual,
+    useProviderContext: vi.fn(),
+  }
+})
+
+vi.mock('@/context/modal-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/modal-context')>()
+  return {
+    ...actual,
+    useModalContext: vi.fn(),
+  }
+})
+
+vi.mock('@/service/common', () => ({
+  getDocDownloadUrl: vi.fn(),
+}))
+
+vi.mock('@/utils/download', () => ({
+  downloadUrl: vi.fn(),
+}))
+
+vi.mock('../../base/toast', () => ({
+  default: {
+    notify: vi.fn(),
+  },
+}))
+
+describe('Compliance', () => {
+  const mockSetShowPricingModal = vi.fn()
+  const mockSetShowAccountSettingModal = vi.fn()
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient.clear()
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.sandbox,
+      },
+    })
+    vi.mocked(useModalContext).mockReturnValue({
+      setShowPricingModal: mockSetShowPricingModal,
+      setShowAccountSettingModal: mockSetShowAccountSettingModal,
+    } as unknown as ModalContextState)
+
+    // Removed useMutation mock implementation as we are using QueryClientProvider
+  })
+
+  const renderWithQueryClient = (ui: React.ReactElement) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        {ui}
+      </QueryClientProvider>,
+    )
+  }
+
+  // Wrapper for tests that need the menu open
+  const openMenuAndRender = () => {
+    renderWithQueryClient(<Compliance />)
+    fireEvent.click(screen.getByRole('button'))
+  }
+
+  it('renders compliance menu trigger', () => {
+    renderWithQueryClient(<Compliance />)
+    expect(screen.getByText('common.userProfile.compliance')).toBeDefined()
+  })
+
+  it('shows SOC2, ISO, GDPR items when opened', () => {
+    openMenuAndRender()
+    expect(screen.getByText('common.compliance.soc2Type1')).toBeDefined()
+    expect(screen.getByText('common.compliance.soc2Type2')).toBeDefined()
+    expect(screen.getByText('common.compliance.iso27001')).toBeDefined()
+    expect(screen.getByText('common.compliance.gdpr')).toBeDefined()
+  })
+
+  it('shows Upgrade badge for sandbox plan on restricted docs', () => {
+    openMenuAndRender()
+    // SOC2 Type I is restricted for sandbox
+    expect(screen.getAllByText('billing.upgradeBtn.encourageShort').length).toBeGreaterThan(0)
+  })
+
+  it('shows Download button for plan that allows it', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.team,
+      },
+    })
+    openMenuAndRender()
+    expect(screen.getAllByText('common.operation.download').length).toBeGreaterThan(0)
+  })
+
+  it('triggers download mutation successfully', async () => {
+    const mockUrl = 'http://example.com/doc.pdf'
+    vi.mocked(getDocDownloadUrl).mockResolvedValue({ url: mockUrl })
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.team,
+      },
+    })
+
+    openMenuAndRender()
+    const downloadButtons = screen.getAllByText('common.operation.download')
+    fireEvent.click(downloadButtons[0])
+
+    await waitFor(() => {
+      expect(getDocDownloadUrl).toHaveBeenCalled()
+      expect(downloadUrl).toHaveBeenCalledWith({ url: mockUrl })
+      expect(Toast.notify).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'success',
+        message: 'common.operation.downloadSuccess',
+      }))
+    })
+  })
+
+  it('handles download mutation error', async () => {
+    vi.mocked(getDocDownloadUrl).mockRejectedValue(new Error('Download failed'))
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.team,
+      },
+    })
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
+
+    openMenuAndRender()
+    const downloadButtons = screen.getAllByText('common.operation.download')
+    fireEvent.click(downloadButtons[0])
+
+    await waitFor(() => {
+      expect(getDocDownloadUrl).toHaveBeenCalled()
+      expect(Toast.notify).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'error',
+        message: 'common.operation.downloadFailed',
+      }))
+    })
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it('handles upgrade click on badge for sandbox plan', () => {
+    openMenuAndRender()
+    const upgradeBadges = screen.getAllByText('billing.upgradeBtn.encourageShort')
+    fireEvent.click(upgradeBadges[0])
+    expect(mockSetShowPricingModal).toHaveBeenCalled()
+  })
+
+  it('handles upgrade click on badge for non-sandbox plan', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.professional,
+      },
+    })
+
+    openMenuAndRender()
+    // SOC2 Type II is restricted for professional
+    const upgradeBadges = screen.getAllByText('billing.upgradeBtn.encourageShort')
+    fireEvent.click(upgradeBadges[0])
+    expect(mockSetShowAccountSettingModal).toHaveBeenCalledWith({
+      payload: ACCOUNT_SETTING_TAB.BILLING,
+    })
+  })
+})

--- a/web/app/components/header/account-dropdown/index.spec.tsx
+++ b/web/app/components/header/account-dropdown/index.spec.tsx
@@ -115,9 +115,10 @@ describe('AccountDropdown', () => {
       },
       isCurrentWorkspaceOwner: true,
     } as unknown as AppContextValue)
-    vi.mocked(useGlobalPublicStore).mockReturnValue({
-      systemFeatures: { branding: { enabled: false } },
-    } as unknown as ReturnType<typeof useGlobalPublicStore>)
+    vi.mocked(useGlobalPublicStore).mockImplementation((selector?: unknown) => {
+      const fullState = { systemFeatures: { branding: { enabled: false } }, setSystemFeatures: vi.fn() }
+      return typeof selector === 'function' ? (selector as (state: typeof fullState) => unknown)(fullState) : fullState
+    })
     vi.mocked(useProviderContext).mockReturnValue({
       isEducationAccount: false,
     } as unknown as ProviderContextState)
@@ -178,9 +179,10 @@ describe('AccountDropdown', () => {
   })
 
   it('hides sections when branding is enabled', () => {
-    vi.mocked(useGlobalPublicStore).mockReturnValue({
-      systemFeatures: { branding: { enabled: true } },
-    } as unknown as ReturnType<typeof useGlobalPublicStore>)
+    vi.mocked(useGlobalPublicStore).mockImplementation((selector?: unknown) => {
+      const fullState = { systemFeatures: { branding: { enabled: true } }, setSystemFeatures: vi.fn() }
+      return typeof selector === 'function' ? (selector as (state: typeof fullState) => unknown)(fullState) : fullState
+    })
     renderWithRouter(<AppSelector />)
     fireEvent.click(screen.getByRole('button'))
 

--- a/web/app/components/header/account-dropdown/index.spec.tsx
+++ b/web/app/components/header/account-dropdown/index.spec.tsx
@@ -1,0 +1,260 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import type { AppContextValue } from '@/context/app-context'
+import type { ModalContextState } from '@/context/modal-context'
+import type { ProviderContextState } from '@/context/provider-context'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppContext } from '@/context/app-context'
+import { useGlobalPublicStore } from '@/context/global-public-context'
+import { useModalContext } from '@/context/modal-context'
+import { useProviderContext } from '@/context/provider-context'
+import { useLogout } from '@/service/use-common'
+import AppSelector from './index'
+
+// Mock local contexts and services
+vi.mock('@/context/app-context', () => ({
+  useAppContext: vi.fn(),
+}))
+
+vi.mock('@/context/global-public-context', () => ({
+  useGlobalPublicStore: vi.fn(),
+}))
+
+vi.mock('@/context/provider-context', () => ({
+  useProviderContext: vi.fn(),
+}))
+
+vi.mock('@/context/modal-context', () => ({
+  useModalContext: vi.fn(),
+}))
+
+vi.mock('@/service/use-common', () => ({
+  useLogout: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/amplitude/utils', () => ({
+  resetUser: vi.fn(),
+}))
+
+vi.mock('@/context/i18n', () => ({
+  useDocLink: () => (path: string) => `https://docs.dify.ai${path}`,
+}))
+
+// Mock sub-components with prop tracking
+type AccountAboutProps = {
+  onCancel: () => void
+}
+vi.mock('../account-about', () => ({
+  default: ({ onCancel }: AccountAboutProps) => (
+    <div data-testid="account-about">
+      <button onClick={onCancel} data-testid="about-cancel">Cancel</button>
+    </div>
+  ),
+}))
+vi.mock('../github-star', () => ({ default: () => <div data-testid="github-star" /> }))
+type IndicatorProps = {
+  color?: string
+}
+vi.mock('../indicator', () => ({
+  default: ({ color }: IndicatorProps) => <div data-testid="indicator" data-color={color} />,
+}))
+vi.mock('./compliance', () => ({ default: () => <div data-testid="compliance" /> }))
+vi.mock('./support', () => ({ default: () => <div data-testid="support" /> }))
+
+// Mock config and env
+const { mockConfig, mockEnv } = vi.hoisted(() => ({
+  mockConfig: {
+    IS_CLOUD_EDITION: false,
+  },
+  mockEnv: {
+    env: {
+      NEXT_PUBLIC_SITE_ABOUT: 'show',
+    },
+  },
+}))
+vi.mock('@/config', () => mockConfig)
+vi.mock('@/env', () => mockEnv)
+
+describe('AccountDropdown', () => {
+  const mockPush = vi.fn()
+  const mockLogout = vi.fn()
+  const mockSetShowAccountSettingModal = vi.fn()
+
+  const renderWithRouter = (ui: React.ReactElement) => {
+    const mockRouter = {
+      push: mockPush,
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    } as unknown as AppRouterInstance
+
+    return render(
+      <AppRouterContext.Provider value={mockRouter}>
+        {ui}
+      </AppRouterContext.Provider>,
+    )
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConfig.IS_CLOUD_EDITION = false
+    mockEnv.env.NEXT_PUBLIC_SITE_ABOUT = 'show'
+
+    vi.mocked(useAppContext).mockReturnValue({
+      userProfile: {
+        name: 'Test User',
+        email: 'test@example.com',
+        avatar_url: 'avatar.png',
+      },
+      langGeniusVersionInfo: {
+        current_version: '0.6.0',
+        latest_version: '0.6.0',
+      },
+      isCurrentWorkspaceOwner: true,
+    } as unknown as AppContextValue)
+    vi.mocked(useGlobalPublicStore).mockReturnValue({
+      systemFeatures: { branding: { enabled: false } },
+    } as unknown as ReturnType<typeof useGlobalPublicStore>)
+    vi.mocked(useProviderContext).mockReturnValue({
+      isEducationAccount: false,
+    } as unknown as ProviderContextState)
+    vi.mocked(useModalContext).mockReturnValue({
+      setShowAccountSettingModal: mockSetShowAccountSettingModal,
+    } as unknown as ModalContextState)
+    vi.mocked(useLogout).mockReturnValue({
+      mutateAsync: mockLogout,
+    } as unknown as ReturnType<typeof useLogout>)
+  })
+
+  it('renders user profile correctly', () => {
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Test User')).toBeDefined()
+    expect(screen.getByText('test@example.com')).toBeDefined()
+  })
+
+  it('shows EDU badge for education accounts', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      isEducationAccount: true,
+    } as unknown as ProviderContextState)
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('EDU')).toBeDefined()
+  })
+
+  it('triggers setShowAccountSettingModal when settings is clicked', () => {
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('common.userProfile.settings'))
+    expect(mockSetShowAccountSettingModal).toHaveBeenCalled()
+  })
+
+  it('handles logout correctly', async () => {
+    mockLogout.mockResolvedValue({})
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('common.userProfile.logout'))
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled()
+      // In vitest.setup.ts, localStorage.removeItem is already vi.fn()
+      expect(localStorage.removeItem).toHaveBeenCalledWith('setup_status')
+      expect(mockPush).toHaveBeenCalledWith('/signin')
+    })
+  })
+
+  it('shows About section when about button is clicked and can close it', () => {
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('common.userProfile.about'))
+    expect(screen.getByTestId('account-about')).toBeDefined()
+
+    fireEvent.click(screen.getByTestId('about-cancel'))
+    expect(screen.queryByTestId('account-about')).toBeNull()
+  })
+
+  it('hides sections when branding is enabled', () => {
+    vi.mocked(useGlobalPublicStore).mockReturnValue({
+      systemFeatures: { branding: { enabled: true } },
+    } as unknown as ReturnType<typeof useGlobalPublicStore>)
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('common.userProfile.helpCenter')).toBeNull()
+    expect(screen.queryByText('common.userProfile.roadmap')).toBeNull()
+  })
+
+  it('shows Compliance only in Cloud Edition for workspace owner', () => {
+    // Case 1: Cloud Edition + Owner
+    mockConfig.IS_CLOUD_EDITION = true
+    vi.mocked(useAppContext).mockReturnValue({
+      userProfile: { name: 'User' },
+      isCurrentWorkspaceOwner: true,
+      langGeniusVersionInfo: { current_version: '0.6.0', latest_version: '0.6.0' },
+    } as unknown as AppContextValue)
+
+    const { rerender } = renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByTestId('compliance')).toBeDefined()
+
+    // Case 2: Cloud Edition + Not Owner
+    vi.mocked(useAppContext).mockReturnValue({
+      userProfile: { name: 'User' },
+      isCurrentWorkspaceOwner: false,
+      langGeniusVersionInfo: { current_version: '0.6.0', latest_version: '0.6.0' },
+    } as unknown as AppContextValue)
+    rerender(<AppRouterContext.Provider value={{} as unknown as AppRouterInstance}><AppSelector /></AppRouterContext.Provider>)
+    expect(screen.queryByTestId('compliance')).toBeNull()
+
+    // Case 3: Not Cloud Edition + Owner
+    mockConfig.IS_CLOUD_EDITION = false
+    vi.mocked(useAppContext).mockReturnValue({
+      userProfile: { name: 'User' },
+      isCurrentWorkspaceOwner: true,
+      langGeniusVersionInfo: { current_version: '0.6.0', latest_version: '0.6.0' },
+    } as unknown as AppContextValue)
+    rerender(<AppRouterContext.Provider value={{} as unknown as AppRouterInstance}><AppSelector /></AppRouterContext.Provider>)
+    expect(screen.queryByTestId('compliance')).toBeNull()
+  })
+
+  it('hides About section when NEXT_PUBLIC_SITE_ABOUT is hide', () => {
+    mockEnv.env.NEXT_PUBLIC_SITE_ABOUT = 'hide'
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByText('common.userProfile.about')).toBeNull()
+  })
+
+  it('shows orange indicator when version is not latest', () => {
+    vi.mocked(useAppContext).mockReturnValue({
+      userProfile: { name: 'User' },
+      langGeniusVersionInfo: {
+        current_version: '0.6.0',
+        latest_version: '0.7.0',
+      },
+    } as unknown as AppContextValue)
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+
+    const indicator = screen.getByTestId('indicator')
+    expect(indicator.getAttribute('data-color')).toBe('orange')
+  })
+
+  it('shows green indicator when version is latest', () => {
+    vi.mocked(useAppContext).mockReturnValue({
+      userProfile: { name: 'User' },
+      langGeniusVersionInfo: {
+        current_version: '0.7.0',
+        latest_version: '0.7.0',
+      },
+    } as unknown as AppContextValue)
+    renderWithRouter(<AppSelector />)
+    fireEvent.click(screen.getByRole('button'))
+
+    const indicator = screen.getByTestId('indicator')
+    expect(indicator.getAttribute('data-color')).toBe('green')
+  })
+})

--- a/web/app/components/header/account-dropdown/support.spec.tsx
+++ b/web/app/components/header/account-dropdown/support.spec.tsx
@@ -1,0 +1,163 @@
+import type { AppContextValue } from '@/context/app-context'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toggleZendeskWindow } from '@/app/components/base/zendesk/utils'
+import { Plan } from '@/app/components/billing/type'
+import { useAppContext } from '@/context/app-context'
+import { baseProviderContextValue, useProviderContext } from '@/context/provider-context'
+import Support from './support'
+
+const { mockZendeskKey } = vi.hoisted(() => ({
+  mockZendeskKey: { value: 'test-key' },
+}))
+
+vi.mock('@/context/app-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/app-context')>()
+  return {
+    ...actual,
+    useAppContext: vi.fn(),
+  }
+})
+
+vi.mock('@/context/provider-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/provider-context')>()
+  return {
+    ...actual,
+    useProviderContext: vi.fn(),
+  }
+})
+
+vi.mock('@/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/config')>()
+  return {
+    ...actual,
+    get ZENDESK_WIDGET_KEY() { return mockZendeskKey.value },
+  }
+})
+
+vi.mock('@/app/components/base/zendesk/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/app/components/base/zendesk/utils')>()
+  return {
+    ...actual,
+    toggleZendeskWindow: vi.fn(),
+  }
+})
+
+vi.mock('../utils/util', () => ({
+  mailToSupport: vi.fn(() => 'mailto:support@dify.ai'),
+}))
+
+describe('Support', () => {
+  const mockCloseAccountDropdown = vi.fn()
+
+  const baseAppContextValue: AppContextValue = {
+    userProfile: {
+      id: '1',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatar: '',
+      avatar_url: '',
+      is_password_set: false,
+    },
+    mutateUserProfile: vi.fn(),
+    currentWorkspace: {
+      id: '1',
+      name: 'Workspace',
+      plan: '',
+      status: '',
+      created_at: 0,
+      role: 'owner',
+      providers: [],
+      trial_credits: 0,
+      trial_credits_used: 0,
+      next_credit_reset_date: 0,
+    },
+    isCurrentWorkspaceManager: true,
+    isCurrentWorkspaceOwner: true,
+    isCurrentWorkspaceEditor: true,
+    isCurrentWorkspaceDatasetOperator: false,
+    mutateCurrentWorkspace: vi.fn(),
+    langGeniusVersionInfo: {
+      current_env: 'testing',
+      current_version: '0.6.0',
+      latest_version: '0.6.0',
+      release_date: '',
+      release_notes: '',
+      version: '0.6.0',
+      can_auto_update: false,
+    },
+    useSelector: vi.fn(),
+    isLoadingCurrentWorkspace: false,
+    isValidatingCurrentWorkspace: false,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockZendeskKey.value = 'test-key'
+    vi.mocked(useAppContext).mockReturnValue(baseAppContextValue)
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.professional,
+      },
+    })
+  })
+
+  it('renders support menu trigger', () => {
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    expect(screen.getByText('common.userProfile.support')).toBeDefined()
+  })
+
+  it('shows forum and community links when opened', () => {
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('common.userProfile.forum')).toBeDefined()
+    expect(screen.getByText('common.userProfile.community')).toBeDefined()
+  })
+
+  it('shows "Contact Us" when ZENDESK_WIDGET_KEY is present', () => {
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('common.userProfile.contactUs')).toBeDefined()
+  })
+
+  it('hides dedicated support channels for Sandbox plan', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      plan: {
+        ...baseProviderContextValue.plan,
+        type: Plan.sandbox,
+      },
+    })
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByText('common.userProfile.contactUs')).toBeNull()
+    expect(screen.queryByText('common.userProfile.emailSupport')).toBeNull()
+  })
+
+  it('calls toggleZendeskWindow and closeAccountDropdown when "Contact Us" is clicked', () => {
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('common.userProfile.contactUs'))
+    expect(toggleZendeskWindow).toHaveBeenCalledWith(true)
+    expect(mockCloseAccountDropdown).toHaveBeenCalled()
+  })
+
+  it('shows "Email Support" when ZENDESK_WIDGET_KEY is absent', () => {
+    mockZendeskKey.value = ''
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText('common.userProfile.emailSupport')).toBeDefined()
+    expect(screen.queryByText('common.userProfile.contactUs')).toBeNull()
+  })
+
+  it('has correct forum and community links', () => {
+    render(<Support closeAccountDropdown={mockCloseAccountDropdown} />)
+    fireEvent.click(screen.getByRole('button'))
+    const forumLink = screen.getByText('common.userProfile.forum').closest('a')
+    const communityLink = screen.getByText('common.userProfile.community').closest('a')
+    expect(forumLink).toHaveAttribute('href', 'https://forum.dify.ai/')
+    expect(communityLink).toHaveAttribute('href', 'https://discord.gg/5AEfbxcd9k')
+  })
+})

--- a/web/app/components/header/account-dropdown/workplace-selector/index.spec.tsx
+++ b/web/app/components/header/account-dropdown/workplace-selector/index.spec.tsx
@@ -1,0 +1,109 @@
+import type { IWorkspace } from '@/models/common'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastContext } from '@/app/components/base/toast'
+import { useWorkspacesContext } from '@/context/workspace-context'
+import { switchWorkspace } from '@/service/common'
+import WorkplaceSelector from './index'
+
+vi.mock('@/context/workspace-context', () => ({
+  useWorkspacesContext: vi.fn(),
+}))
+
+vi.mock('@/service/common', () => ({
+  switchWorkspace: vi.fn(),
+}))
+
+vi.mock('@/app/components/header/plan-badge', () => ({
+  default: ({ plan }: { plan: string }) => <div data-testid="plan-badge">{plan}</div>,
+}))
+
+describe('WorkplaceSelector', () => {
+  const mockWorkspaces: IWorkspace[] = [
+    { id: '1', name: 'Workspace 1', current: true, plan: 'professional', status: 'normal', created_at: Date.now() },
+    { id: '2', name: 'Workspace 2', current: false, plan: 'sandbox', status: 'normal', created_at: Date.now() },
+  ]
+
+  const mockNotify = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useWorkspacesContext).mockReturnValue({
+      workspaces: mockWorkspaces,
+    })
+  })
+
+  const renderComponent = () => {
+    return render(
+      <ToastContext.Provider value={{ notify: mockNotify, close: vi.fn() }}>
+        <WorkplaceSelector />
+      </ToastContext.Provider>,
+    )
+  }
+
+  it('renders current workspace correctly', () => {
+    renderComponent()
+    expect(screen.getByText('Workspace 1')).toBeDefined()
+    expect(screen.getByText('W')).toBeDefined() // First letter icon
+  })
+
+  it('opens menu and displays all workspaces', async () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getAllByText('Workspace 1').length).toBeGreaterThan(0)
+    expect(screen.getByText('Workspace 2')).toBeDefined()
+    expect(screen.getAllByTestId('plan-badge')).toHaveLength(2)
+  })
+
+  it('switches workspace successfully', async () => {
+    vi.mocked(switchWorkspace).mockResolvedValue({
+      result: 'success',
+      new_tenant: mockWorkspaces[1],
+    })
+    renderComponent()
+
+    fireEvent.click(screen.getByRole('button'))
+    const workspace2 = screen.getByText('Workspace 2')
+    fireEvent.click(workspace2)
+
+    expect(switchWorkspace).toHaveBeenCalledWith({
+      url: '/workspaces/switch',
+      body: { tenant_id: '2' },
+    })
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'common.actionMsg.modifiedSuccessfully',
+      })
+    })
+  })
+
+  it('does not switch to the already current workspace', async () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByRole('button'))
+    const workspacesInMenu = screen.getAllByText('Workspace 1')
+    fireEvent.click(workspacesInMenu[workspacesInMenu.length - 1])
+
+    expect(switchWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('handles switching error', async () => {
+    vi.mocked(switchWorkspace).mockRejectedValue(new Error('Failed'))
+    renderComponent()
+
+    fireEvent.click(screen.getByRole('button'))
+    const workspace2 = screen.getByText('Workspace 2')
+    fireEvent.click(workspace2)
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'common.provider.saveFailed',
+      })
+    })
+  })
+})

--- a/web/app/components/header/account-setting/Integrations-page/index.spec.tsx
+++ b/web/app/components/header/account-setting/Integrations-page/index.spec.tsx
@@ -1,0 +1,96 @@
+import type { AccountIntegrate } from '@/models/common'
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useAccountIntegrates } from '@/service/use-common'
+import IntegrationsPage from './index'
+
+vi.mock('@/service/use-common', () => ({
+  useAccountIntegrates: vi.fn(),
+}))
+
+describe('IntegrationsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders connected integrations', () => {
+    const mockData: AccountIntegrate[] = [
+      { provider: 'google', is_bound: true, link: '', created_at: 1678888888 },
+      { provider: 'github', is_bound: true, link: '', created_at: 1678888888 },
+    ]
+
+    vi.mocked(useAccountIntegrates).mockReturnValue({
+      data: {
+        data: mockData,
+      },
+    } as unknown as ReturnType<typeof useAccountIntegrates>)
+
+    render(<IntegrationsPage />)
+
+    expect(screen.getByText('common.integrations.connected')).toBeInTheDocument()
+    expect(screen.getByText('common.integrations.google')).toBeInTheDocument()
+    expect(screen.getByText('common.integrations.github')).toBeInTheDocument()
+    // Connect link should not be present when bound
+    expect(screen.queryByText('common.integrations.connect')).not.toBeInTheDocument()
+  })
+
+  it('renders connect link for unbound integrations', () => {
+    const mockData: AccountIntegrate[] = [
+      { provider: 'google', is_bound: false, link: 'https://google.com', created_at: 1678888888 },
+    ]
+
+    vi.mocked(useAccountIntegrates).mockReturnValue({
+      data: {
+        data: mockData,
+      },
+    } as unknown as ReturnType<typeof useAccountIntegrates>)
+
+    render(<IntegrationsPage />)
+
+    expect(screen.getByText('common.integrations.google')).toBeInTheDocument()
+    const connectLink = screen.getByText('common.integrations.connect')
+    expect(connectLink).toBeInTheDocument()
+    expect(connectLink.closest('a')).toHaveAttribute('href', 'https://google.com')
+  })
+
+  it('renders nothing when no integrations are provided', () => {
+    vi.mocked(useAccountIntegrates).mockReturnValue({
+      data: {
+        data: [],
+      },
+    } as unknown as ReturnType<typeof useAccountIntegrates>)
+
+    render(<IntegrationsPage />)
+
+    expect(screen.getByText('common.integrations.connected')).toBeInTheDocument()
+    expect(screen.queryByText('common.integrations.google')).not.toBeInTheDocument()
+    expect(screen.queryByText('common.integrations.github')).not.toBeInTheDocument()
+  })
+
+  it('handles unknown providers gracefully', () => {
+    const mockData = [
+      { provider: 'unknown', is_bound: false, link: '', created_at: 1678888888 } as unknown as AccountIntegrate,
+    ]
+
+    vi.mocked(useAccountIntegrates).mockReturnValue({
+      data: {
+        data: mockData,
+      },
+    } as unknown as ReturnType<typeof useAccountIntegrates>)
+
+    render(<IntegrationsPage />)
+
+    expect(screen.queryByText('common.integrations.connect')).not.toBeInTheDocument()
+  })
+
+  it('handles undefined data gracefully', () => {
+    vi.mocked(useAccountIntegrates).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useAccountIntegrates>)
+
+    render(<IntegrationsPage />)
+
+    expect(screen.getByText('common.integrations.connected')).toBeInTheDocument()
+    expect(screen.queryByText('common.integrations.google')).not.toBeInTheDocument()
+  })
+})

--- a/web/app/components/header/account-setting/api-based-extension-page/empty.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/empty.spec.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import Empty from './empty'
+
+describe('Empty State', () => {
+  it('renders title and documentation link', () => {
+    render(<Empty />)
+
+    expect(screen.getByText('common.apiBasedExtension.title')).toBeInTheDocument()
+    const link = screen.getByText('common.apiBasedExtension.link')
+    expect(link).toBeInTheDocument()
+    // The real useDocLink includes the language prefix (defaulting to /en in tests)
+    expect(link.closest('a')).toHaveAttribute('href', 'https://docs.dify.ai/en/use-dify/workspace/api-extension/api-extension')
+  })
+})

--- a/web/app/components/header/account-setting/api-based-extension-page/index.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/index.spec.tsx
@@ -1,0 +1,166 @@
+import type { SetStateAction } from 'react'
+import type { ModalState } from '@/context/modal-context'
+import type { ApiBasedExtension } from '@/models/common'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useModalContext } from '@/context/modal-context'
+import { useApiBasedExtensions } from '@/service/use-common'
+import Empty from './empty'
+import ApiBasedExtensionPage from './index'
+import Item from './item'
+
+vi.mock('@/service/use-common', () => ({
+  useApiBasedExtensions: vi.fn(),
+}))
+
+vi.mock('@/context/modal-context', () => ({
+  useModalContext: vi.fn(),
+}))
+
+vi.mock('./empty', () => ({
+  default: vi.fn(() => <div>Empty Component</div>),
+}))
+
+vi.mock('./item', () => ({
+  default: vi.fn(() => <div>Item Component</div>),
+}))
+
+describe('ApiBasedExtensionPage', () => {
+  const mockRefetch = vi.fn<() => void>()
+  const mockSetShowApiBasedExtensionModal = vi.fn<(value: SetStateAction<ModalState<ApiBasedExtension> | null>) => void>()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useModalContext).mockReturnValue({
+      setShowAccountSettingModal: vi.fn(),
+      setShowApiBasedExtensionModal: mockSetShowApiBasedExtensionModal,
+      setShowModerationSettingModal: vi.fn(),
+      setShowExternalDataToolModal: vi.fn(),
+      setShowPricingModal: vi.fn(),
+      setShowAnnotationFullModal: vi.fn(),
+      setShowModelModal: vi.fn(),
+      setShowExternalKnowledgeAPIModal: vi.fn(),
+      setShowModelLoadBalancingModal: vi.fn(),
+      setShowOpeningModal: vi.fn(),
+      setShowUpdatePluginModal: vi.fn(),
+      setShowEducationExpireNoticeModal: vi.fn(),
+      setShowTriggerEventsLimitModal: vi.fn(),
+    })
+  })
+
+  it('renders empty state when no data exists', () => {
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: [],
+      isPending: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    expect(Empty).toHaveBeenCalled()
+    expect(screen.getByText('Empty Component')).toBeInTheDocument()
+  })
+
+  it('renders list of extensions when data exists', () => {
+    const mockData = [
+      { id: '1', name: 'Extension 1', api_endpoint: 'url1' },
+      { id: '2', name: 'Extension 2', api_endpoint: 'url2' },
+    ]
+
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: mockData,
+      isPending: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    expect(Item).toHaveBeenCalledTimes(2)
+
+    const firstCallProps = vi.mocked(Item).mock.calls[0][0]
+    expect(firstCallProps.data).toEqual(mockData[0])
+    expect(firstCallProps.onUpdate).toBeInstanceOf(Function)
+  })
+
+  it('does not render Empty component when data exists', () => {
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: [{ id: '1', name: 'Extension 1', api_endpoint: 'url1' }],
+      isPending: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    expect(screen.queryByText('Empty Component')).not.toBeInTheDocument()
+  })
+
+  it('opens modal when clicking add button', () => {
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: [],
+      isPending: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    fireEvent.click(screen.getByText('common.apiBasedExtension.add'))
+
+    expect(mockSetShowApiBasedExtensionModal).toHaveBeenCalledWith(expect.objectContaining({
+      payload: {},
+    }))
+    const lastCall = mockSetShowApiBasedExtensionModal.mock.calls[0][0]
+    if (typeof lastCall === 'object' && lastCall !== null && 'onSaveCallback' in lastCall)
+      expect(lastCall.onSaveCallback).toBeInstanceOf(Function)
+  })
+
+  it('calls refetch when onSaveCallback is executed', () => {
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: [],
+      isPending: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    fireEvent.click(screen.getByText('common.apiBasedExtension.add'))
+
+    const callArgs = mockSetShowApiBasedExtensionModal.mock.calls[0][0]
+    if (typeof callArgs === 'object' && callArgs !== null && 'onSaveCallback' in callArgs) {
+      if (callArgs.onSaveCallback) {
+        callArgs.onSaveCallback()
+        expect(mockRefetch).toHaveBeenCalled()
+      }
+    }
+  })
+
+  it('calls refetch when Item onUpdate callback is executed', () => {
+    const mockData = [{ id: '1', name: 'Extension 1', api_endpoint: 'url1' }]
+
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: mockData,
+      isPending: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    const itemProps = vi.mocked(Item).mock.calls[0][0]
+    if (itemProps && typeof itemProps.onUpdate === 'function') {
+      itemProps.onUpdate()
+      expect(mockRefetch).toHaveBeenCalled()
+    }
+  })
+
+  it('renders nothing while loading', () => {
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: null,
+      isPending: true,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useApiBasedExtensions>)
+
+    render(<ApiBasedExtensionPage />)
+
+    expect(Empty).not.toHaveBeenCalled()
+    expect(Item).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/components/header/account-setting/api-based-extension-page/item.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/item.spec.tsx
@@ -1,0 +1,211 @@
+import type { TFunction } from 'i18next'
+import type { SetStateAction } from 'react'
+import type { ModalState } from '@/context/modal-context'
+import type { ApiBasedExtension } from '@/models/common'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as reactI18next from 'react-i18next'
+import { vi } from 'vitest'
+import { useModalContext } from '@/context/modal-context'
+import { deleteApiBasedExtension } from '@/service/common'
+import Item from './item'
+
+// Mock the modal context to isolate component behavior
+vi.mock('@/context/modal-context', () => ({
+  useModalContext: vi.fn(),
+}))
+
+// Mock the API service to avoid real network calls
+vi.mock('@/service/common', () => ({
+  deleteApiBasedExtension: vi.fn(),
+}))
+
+describe('Item Component', () => {
+  // Test data representing a valid API-based extension
+  const mockData: ApiBasedExtension = {
+    id: '1',
+    name: 'Test Extension',
+    api_endpoint: 'https://api.example.com',
+    api_key: 'test-api-key',
+  }
+  const mockOnUpdate = vi.fn<() => void>()
+  const mockSetShowApiBasedExtensionModal = vi.fn<(value: SetStateAction<ModalState<ApiBasedExtension> | null>) => void>()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Mock the modal context with proper typing
+    vi.mocked(useModalContext).mockReturnValue({
+      setShowAccountSettingModal: vi.fn(),
+      setShowApiBasedExtensionModal: mockSetShowApiBasedExtensionModal,
+      setShowModerationSettingModal: vi.fn(),
+      setShowExternalDataToolModal: vi.fn(),
+      setShowPricingModal: vi.fn(),
+      setShowAnnotationFullModal: vi.fn(),
+      setShowModelModal: vi.fn(),
+      setShowExternalKnowledgeAPIModal: vi.fn(),
+      setShowModelLoadBalancingModal: vi.fn(),
+      setShowOpeningModal: vi.fn(),
+      setShowUpdatePluginModal: vi.fn(),
+      setShowEducationExpireNoticeModal: vi.fn(),
+      setShowTriggerEventsLimitModal: vi.fn(),
+    })
+  })
+
+  it('renders extension data correctly', () => {
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    // Verify that extension name and endpoint are displayed
+    expect(screen.getByText('Test Extension')).toBeInTheDocument()
+    expect(screen.getByText('https://api.example.com')).toBeInTheDocument()
+  })
+
+  it('opens edit modal with correct payload when clicking edit button', () => {
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    fireEvent.click(screen.getByText('common.operation.edit'))
+
+    // Verify modal is opened with the extension data
+    expect(mockSetShowApiBasedExtensionModal).toHaveBeenCalledWith(expect.objectContaining({
+      payload: mockData,
+    }))
+
+    // Separately verify that onSaveCallback is a function
+    const lastCall = mockSetShowApiBasedExtensionModal.mock.calls[0][0]
+    if (typeof lastCall === 'object' && lastCall !== null && 'onSaveCallback' in lastCall)
+      expect(lastCall.onSaveCallback).toBeInstanceOf(Function)
+  })
+
+  it('executes onUpdate callback when edit modal save callback is invoked', () => {
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    fireEvent.click(screen.getByText('common.operation.edit'))
+
+    // Extract and verify the onSaveCallback from the modal call
+    const modalCallArg = mockSetShowApiBasedExtensionModal.mock.calls[0][0]
+    if (typeof modalCallArg === 'object' && modalCallArg !== null && 'onSaveCallback' in modalCallArg) {
+      const onSaveCallback = modalCallArg.onSaveCallback
+      expect(onSaveCallback).toBeDefined()
+      if (onSaveCallback) {
+        onSaveCallback()
+        expect(mockOnUpdate).toHaveBeenCalledTimes(1)
+      }
+    }
+  })
+
+  it('shows delete confirmation dialog when clicking delete button', () => {
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    fireEvent.click(screen.getByText('common.operation.delete'))
+
+    // Verify confirmation dialog appears with extension name
+    // Using regex to match the specific order "delete ... name" which exists in the modal title
+    // but NOT in the list item (where name comes before delete button)
+    // Also handles the curly quotes by matching any character
+    expect(screen.getByText(/common\.operation\.delete.*Test Extension.*\?/i)).toBeInTheDocument()
+  })
+
+  it('calls delete API and triggers onUpdate when confirming deletion', async () => {
+    // Mock successful API response
+    vi.mocked(deleteApiBasedExtension).mockResolvedValue({ result: 'success' })
+
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    // Open delete confirmation
+    fireEvent.click(screen.getByText('common.operation.delete'))
+
+    // Click the confirm button (last delete button in the list)
+    const deleteButtons = screen.getAllByText('common.operation.delete')
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+
+    // Verify API was called with correct endpoint and onUpdate was triggered
+    await waitFor(() => {
+      expect(deleteApiBasedExtension).toHaveBeenCalledWith('/api-based-extension/1')
+      expect(mockOnUpdate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('hides delete confirmation dialog after successful deletion', async () => {
+    vi.mocked(deleteApiBasedExtension).mockResolvedValue({ result: 'success' })
+
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    fireEvent.click(screen.getByText('common.operation.delete'))
+
+    const deleteButtons = screen.getAllByText('common.operation.delete')
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+
+    // Verify confirmation dialog is removed after deletion
+    await waitFor(() => {
+      expect(screen.queryByText(/common\.operation\.delete.*Test Extension.*\?/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes delete confirmation when clicking cancel button', () => {
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    // Open and then cancel the delete confirmation
+    fireEvent.click(screen.getByText('common.operation.delete'))
+    fireEvent.click(screen.getByText('common.operation.cancel'))
+
+    // Verify confirmation dialog is closed
+    expect(screen.queryByText(/common\.operation\.delete.*Test Extension.*\?/i)).not.toBeInTheDocument()
+  })
+
+  it('does not call delete API when canceling deletion', () => {
+    render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    fireEvent.click(screen.getByText('common.operation.delete'))
+    fireEvent.click(screen.getByText('common.operation.cancel'))
+
+    // Verify delete API was never called
+    expect(deleteApiBasedExtension).not.toHaveBeenCalled()
+    expect(mockOnUpdate).not.toHaveBeenCalled()
+  })
+
+  it('renders with minimal extension data (only required fields)', () => {
+    // Test with minimal data to ensure component handles optional fields
+    const minimalData: ApiBasedExtension = {
+      id: '2',
+    }
+
+    render(<Item data={minimalData} onUpdate={mockOnUpdate} />)
+
+    // Component should render without crashing even with minimal data
+    expect(screen.getByText('common.operation.edit')).toBeInTheDocument()
+    expect(screen.getByText('common.operation.delete')).toBeInTheDocument()
+  })
+
+  it('test for translation is missing for confirm text', () => {
+    const useTranslationSpy = vi.spyOn(reactI18next, 'useTranslation')
+    const currentImpl = useTranslationSpy.getMockImplementation()
+    const originalValue = currentImpl
+      ? currentImpl()
+      : {
+          t: (key: string) => key,
+          i18n: { language: 'en', changeLanguage: vi.fn() },
+        }
+
+    useTranslationSpy.mockReturnValue({
+      ...originalValue,
+      t: vi.fn().mockImplementation((key: string) => {
+        // Return empty string only for the delete operation key
+        if (key === 'operation.delete')
+          return ''
+        return key
+      }) as unknown as TFunction,
+    } as unknown as ReturnType<typeof reactI18next.useTranslation>)
+
+    const { container } = render(<Item data={mockData} onUpdate={mockOnUpdate} />)
+
+    // Find delete button by its position (second button in the actions group)
+    const buttons = container.querySelectorAll('button')
+    fireEvent.click(buttons[1])
+
+    // The confirmation modal should still show up (title will be empty prefix)
+    // In the codebase: title={`${t('operation.delete', { ns: 'common' })} “${data.name}”?`}
+    // If t returns '', title will be " “Test Extension”?"
+    expect(screen.getByText(/.*Test Extension.*\?/i)).toBeInTheDocument()
+
+    useTranslationSpy.mockRestore()
+  })
+})

--- a/web/app/components/header/account-setting/api-based-extension-page/modal.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/modal.spec.tsx
@@ -1,0 +1,225 @@
+import type { TFunction } from 'i18next'
+import type { IToastProps } from '@/app/components/base/toast'
+import type { ApiBasedExtension } from '@/models/common'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as reactI18next from 'react-i18next'
+import { vi } from 'vitest'
+import { useToastContext } from '@/app/components/base/toast'
+import { useDocLink } from '@/context/i18n'
+import { addApiBasedExtension, updateApiBasedExtension } from '@/service/common'
+import ApiBasedExtensionModal from './modal'
+
+vi.mock('@/context/i18n', () => ({
+  useDocLink: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/toast', () => ({
+  useToastContext: vi.fn(),
+}))
+
+vi.mock('@/service/common', () => ({
+  addApiBasedExtension: vi.fn(),
+  updateApiBasedExtension: vi.fn(),
+}))
+
+describe('ApiBasedExtensionModal', () => {
+  const mockOnCancel = vi.fn<() => void>()
+  const mockOnSave = vi.fn<(data: ApiBasedExtension) => void>()
+  const mockNotify = vi.fn<(params: { type: string, message: string }) => void>()
+  const mockDocLink = vi.fn<(path?: string) => string>((path?: string) => `https://docs.dify.ai${path || ''}`)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock useDocLink with proper typing
+    vi.mocked(useDocLink).mockReturnValue(mockDocLink)
+    // Mock useToastContext providing both notify and close methods
+    vi.mocked(useToastContext).mockReturnValue({ notify: mockNotify as unknown as (props: IToastProps) => void, close: vi.fn<() => void>() })
+  })
+
+  it('renders for adding new extension', async () => {
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={{}} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    expect(screen.getByText('common.apiBasedExtension.modal.title')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('common.apiBasedExtension.modal.name.placeholder')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiEndpoint.placeholder')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiKey.placeholder')).toBeInTheDocument()
+  })
+
+  it('renders for editing existing extension', async () => {
+    const data = { id: '1', name: 'Existing', api_endpoint: 'url', api_key: 'key' }
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={data} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    expect(screen.getByText('common.apiBasedExtension.modal.editTitle')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Existing')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('url')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('key')).toBeInTheDocument()
+  })
+
+  it('calls addApiBasedExtension on save for new extension', async () => {
+    vi.mocked(addApiBasedExtension).mockResolvedValue({ id: 'new-id' })
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={{}} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.name.placeholder'), { target: { value: 'New Ext' } })
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiEndpoint.placeholder'), { target: { value: 'https://api.test' } })
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiKey.placeholder'), { target: { value: 'secret-key' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.operation.save'))
+    })
+
+    await waitFor(() => {
+      expect(addApiBasedExtension).toHaveBeenCalledWith({
+        url: '/api-based-extension',
+        body: {
+          name: 'New Ext',
+          api_endpoint: 'https://api.test',
+          api_key: 'secret-key',
+        },
+      })
+      expect(mockOnSave).toHaveBeenCalledWith({ id: 'new-id' })
+    })
+  })
+
+  it('calls updateApiBasedExtension on save for existing extension', async () => {
+    const data = { id: '1', name: 'Existing', api_endpoint: 'url', api_key: 'long-secret-key' }
+    vi.mocked(updateApiBasedExtension).mockResolvedValue({ ...data, name: 'Updated' })
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={data} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    fireEvent.change(screen.getByDisplayValue('Existing'), { target: { value: 'Updated' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.operation.save'))
+    })
+
+    await waitFor(() => {
+      expect(updateApiBasedExtension).toHaveBeenCalledWith({
+        url: '/api-based-extension/1',
+        body: expect.objectContaining({
+          id: '1',
+          name: 'Updated',
+          api_endpoint: 'url',
+          api_key: '[__HIDDEN__]',
+        }),
+      })
+      expect(mockNotify).toHaveBeenCalledWith({ type: 'success', message: 'common.actionMsg.modifiedSuccessfully' })
+      expect(mockOnSave).toHaveBeenCalled()
+    })
+  })
+
+  it('calls updateApiBasedExtension with new api_key when key is changed', async () => {
+    const data = { id: '1', name: 'Existing', api_endpoint: 'url', api_key: 'old-key' }
+    vi.mocked(updateApiBasedExtension).mockResolvedValue({ ...data, api_key: 'new-longer-key' })
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={data} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    fireEvent.change(screen.getByDisplayValue('old-key'), { target: { value: 'new-longer-key' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.operation.save'))
+    })
+
+    await waitFor(() => {
+      expect(updateApiBasedExtension).toHaveBeenCalledWith({
+        url: '/api-based-extension/1',
+        body: expect.objectContaining({
+          api_key: 'new-longer-key',
+        }),
+      })
+    })
+  })
+
+  it('shows error if api key is too short', async () => {
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={{}} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.name.placeholder'), { target: { value: 'Ext' } })
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiEndpoint.placeholder'), { target: { value: 'url' } })
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiKey.placeholder'), { target: { value: '123' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.operation.save'))
+    })
+
+    expect(mockNotify).toHaveBeenCalledWith({ type: 'error', message: 'common.apiBasedExtension.modal.apiKey.lengthError' })
+    expect(addApiBasedExtension).not.toHaveBeenCalled()
+  })
+
+  it('works when onSave is not provided', async () => {
+    vi.mocked(addApiBasedExtension).mockResolvedValue({ id: 'new-id' })
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={{}} onCancel={mockOnCancel} />)
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.name.placeholder'), { target: { value: 'New Ext' } })
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiEndpoint.placeholder'), { target: { value: 'https://api.test' } })
+    fireEvent.change(screen.getByPlaceholderText('common.apiBasedExtension.modal.apiKey.placeholder'), { target: { value: 'secret-key' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.operation.save'))
+    })
+
+    await waitFor(() => {
+      expect(addApiBasedExtension).toHaveBeenCalled()
+    })
+  })
+
+  it('calls onCancel when clicking cancel button', async () => {
+    await act(async () => {
+      render(<ApiBasedExtensionModal data={{}} onCancel={mockOnCancel} onSave={mockOnSave} />)
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common.operation.cancel'))
+    })
+    expect(mockOnCancel).toHaveBeenCalled()
+  })
+
+  it('covers placeholder fallback branches when translations are missing', async () => {
+    const useTranslationSpy = vi.spyOn(reactI18next, 'useTranslation')
+    // Get the current implementation to build upon it
+    const currentImpl = useTranslationSpy.getMockImplementation()
+    const originalValue = currentImpl
+      ? currentImpl()
+      : {
+          t: (key: string) => key,
+          i18n: { language: 'en', changeLanguage: vi.fn() },
+        }
+
+    useTranslationSpy.mockReturnValue({
+      ...originalValue,
+      t: vi.fn().mockImplementation((key: string) => {
+        const missingKeys = [
+          'apiBasedExtension.modal.name.placeholder',
+          'apiBasedExtension.modal.apiEndpoint.placeholder',
+          'apiBasedExtension.modal.apiKey.placeholder',
+        ]
+        if (missingKeys.some(k => key.includes(k)))
+          return ''
+        return key
+      }) as unknown as TFunction,
+    } as unknown as ReturnType<typeof reactI18next.useTranslation>)
+
+    let container: HTMLElement
+    await act(async () => {
+      const rendered = render(<ApiBasedExtensionModal data={{}} onCancel={mockOnCancel} />)
+      container = rendered.container
+    })
+
+    const inputs = container!.querySelectorAll('input')
+    inputs.forEach((input) => {
+      expect(input.placeholder).toBe('')
+    })
+
+    useTranslationSpy.mockRestore()
+  })
+})

--- a/web/app/components/header/account-setting/api-based-extension-page/modal.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/modal.spec.tsx
@@ -186,7 +186,6 @@ describe('ApiBasedExtensionModal', () => {
 
   it('covers placeholder fallback branches when translations are missing', async () => {
     const useTranslationSpy = vi.spyOn(reactI18next, 'useTranslation')
-    // Get the current implementation to build upon it
     const currentImpl = useTranslationSpy.getMockImplementation()
     const originalValue = currentImpl
       ? currentImpl()

--- a/web/app/components/header/account-setting/api-based-extension-page/selector.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/selector.spec.tsx
@@ -1,0 +1,131 @@
+import type { UseQueryResult } from '@tanstack/react-query'
+import type { SetStateAction } from 'react'
+import type { ModalState } from '@/context/modal-context'
+import type { ApiBasedExtension } from '@/models/common'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { vi } from 'vitest'
+import { ACCOUNT_SETTING_TAB } from '@/app/components/header/account-setting/constants'
+import { useModalContext } from '@/context/modal-context'
+import { useApiBasedExtensions } from '@/service/use-common'
+import ApiBasedExtensionSelector from './selector'
+
+vi.mock('@/context/modal-context', () => ({
+  useModalContext: vi.fn(),
+}))
+
+vi.mock('@/service/use-common', () => ({
+  useApiBasedExtensions: vi.fn(),
+}))
+
+// Mocking Portal components to simplify testing
+vi.mock('@/app/components/base/portal-to-follow-elem', () => ({
+  PortalToFollowElem: ({ children, open }: { children: React.ReactNode, open: boolean }) => (
+    <div data-testid="portal-root" data-open={open}>
+      {children}
+    </div>
+  ),
+  PortalToFollowElemTrigger: ({ children, onClick }: { children: React.ReactNode, onClick?: () => void }) => (
+    <div data-testid="portal-trigger" onClick={onClick}>
+      {children}
+    </div>
+  ),
+  PortalToFollowElemContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="portal-content">
+      {children}
+    </div>
+  ),
+}))
+
+describe('ApiBasedExtensionSelector', () => {
+  const mockOnChange = vi.fn<(id: string) => void>()
+  const mockSetShowAccountSettingModal = vi.fn()
+  const mockSetShowApiBasedExtensionModal = vi.fn<(value: SetStateAction<ModalState<ApiBasedExtension> | null>) => void>()
+  const mockRefetch = vi.fn<() => void>()
+
+  const mockData: ApiBasedExtension[] = [
+    { id: '1', name: 'Extension 1', api_endpoint: 'https://api1.test' },
+    { id: '2', name: 'Extension 2', api_endpoint: 'https://api2.test' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useModalContext).mockReturnValue({
+      setShowAccountSettingModal: mockSetShowAccountSettingModal,
+      setShowApiBasedExtensionModal: mockSetShowApiBasedExtensionModal,
+      setShowModerationSettingModal: vi.fn(),
+      setShowExternalDataToolModal: vi.fn(),
+      setShowPricingModal: vi.fn(),
+      setShowAnnotationFullModal: vi.fn(),
+      setShowModelModal: vi.fn(),
+      setShowExternalKnowledgeAPIModal: vi.fn(),
+      setShowModelLoadBalancingModal: vi.fn(),
+      setShowOpeningModal: vi.fn(),
+      setShowUpdatePluginModal: vi.fn(),
+      setShowEducationExpireNoticeModal: vi.fn(),
+      setShowTriggerEventsLimitModal: vi.fn(),
+    })
+    vi.mocked(useApiBasedExtensions).mockReturnValue({
+      data: mockData,
+      refetch: mockRefetch,
+    } as unknown as UseQueryResult<ApiBasedExtension[], Error>)
+  })
+
+  it('renders placeholder when no value is selected', () => {
+    render(<ApiBasedExtensionSelector value="" onChange={mockOnChange} />)
+    expect(screen.getByText('common.apiBasedExtension.selector.placeholder')).toBeInTheDocument()
+  })
+
+  it('renders selected item name', () => {
+    render(<ApiBasedExtensionSelector value="1" onChange={mockOnChange} />)
+    const trigger = screen.getByTestId('portal-trigger')
+    expect(within(trigger).getByText('Extension 1')).toBeInTheDocument()
+  })
+
+  it('opens dropdown when clicked', () => {
+    render(<ApiBasedExtensionSelector value="" onChange={mockOnChange} />)
+    const trigger = screen.getByTestId('portal-trigger')
+    fireEvent.click(trigger)
+    expect(screen.getByText('common.apiBasedExtension.selector.title')).toBeInTheDocument()
+    expect(screen.getByTestId('portal-root')).toHaveAttribute('data-open', 'true')
+  })
+
+  it('calls onChange and closes dropdown when an extension is selected', () => {
+    render(<ApiBasedExtensionSelector value="" onChange={mockOnChange} />)
+    fireEvent.click(screen.getByTestId('portal-trigger'))
+
+    const options = screen.getAllByText('Extension 2')
+    fireEvent.click(options[0])
+
+    expect(mockOnChange).toHaveBeenCalledWith('2')
+    expect(screen.getByTestId('portal-root')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('opens account settings when clicking manage', () => {
+    render(<ApiBasedExtensionSelector value="" onChange={mockOnChange} />)
+    fireEvent.click(screen.getByTestId('portal-trigger'))
+    fireEvent.click(screen.getByText('common.apiBasedExtension.selector.manage'))
+
+    expect(mockSetShowAccountSettingModal).toHaveBeenCalledWith({
+      payload: ACCOUNT_SETTING_TAB.API_BASED_EXTENSION,
+    })
+    expect(screen.getByTestId('portal-root')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('opens add modal when clicking add button and refetches on save', () => {
+    render(<ApiBasedExtensionSelector value="" onChange={mockOnChange} />)
+    fireEvent.click(screen.getByTestId('portal-trigger'))
+    fireEvent.click(screen.getByText('common.operation.add'))
+
+    expect(mockSetShowApiBasedExtensionModal).toHaveBeenCalledWith(expect.objectContaining({
+      payload: {},
+    }))
+
+    const lastCall = mockSetShowApiBasedExtensionModal.mock.calls[0][0]
+    if (typeof lastCall === 'object' && lastCall !== null && 'onSaveCallback' in lastCall) {
+      if (lastCall.onSaveCallback) {
+        lastCall.onSaveCallback()
+        expect(mockRefetch).toHaveBeenCalled()
+      }
+    }
+  })
+})

--- a/web/app/components/header/account-setting/collapse/index.spec.tsx
+++ b/web/app/components/header/account-setting/collapse/index.spec.tsx
@@ -1,0 +1,120 @@
+import type { IItem } from './index'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import Collapse from './index'
+
+describe('Collapse', () => {
+  const mockItems: IItem[] = [
+    { key: '1', name: 'Item 1' },
+    { key: '2', name: 'Item 2' },
+  ]
+
+  const mockRenderItem = (item: IItem) => (
+    <div data-testid={`item-${item.key}`}>
+      {item.name}
+    </div>
+  )
+
+  const mockOnSelect = vi.fn()
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render title and initially closed state (ChevronRightIcon)', () => {
+    const { container } = render(
+      <Collapse
+        title="Test Title"
+        items={mockItems}
+        renderItem={mockRenderItem}
+      />,
+    )
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
+    expect(screen.queryByTestId('item-1')).not.toBeInTheDocument()
+    // Verify an SVG is present (ChevronRightIcon)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('should toggle content open and closed (ChevronDownIcon)', () => {
+    const { container } = render(
+      <Collapse
+        title="Test Title"
+        items={mockItems}
+        renderItem={mockRenderItem}
+      />,
+    )
+
+    // Initially closed
+    expect(screen.queryByTestId('item-1')).not.toBeInTheDocument()
+
+    // Click to open
+    fireEvent.click(screen.getByText('Test Title'))
+    expect(screen.getByTestId('item-1')).toBeInTheDocument()
+    expect(screen.getByTestId('item-2')).toBeInTheDocument()
+
+    // Verify SVG is present (ChevronDownIcon)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+
+    // Click to close
+    fireEvent.click(screen.getByText('Test Title'))
+    expect(screen.queryByTestId('item-1')).not.toBeInTheDocument()
+  })
+
+  it('should handle item selection', () => {
+    render(
+      <Collapse
+        title="Test Title"
+        items={mockItems}
+        renderItem={mockRenderItem}
+        onSelect={mockOnSelect}
+      />,
+    )
+
+    // Open first
+    fireEvent.click(screen.getByText('Test Title'))
+
+    // Select item 1
+    const item1 = screen.getByTestId('item-1')
+    // The click handler is on the parent div of the rendered item
+    fireEvent.click(item1)
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1)
+    expect(mockOnSelect).toHaveBeenCalledWith(mockItems[0])
+  })
+
+  it('should not crash when onSelect is undefined and item is clicked', () => {
+    render(
+      <Collapse
+        title="Test Title"
+        items={mockItems}
+        renderItem={mockRenderItem}
+        // onSelect is undefined
+      />,
+    )
+
+    // Open
+    fireEvent.click(screen.getByText('Test Title'))
+
+    // Click item
+    const item1 = screen.getByTestId('item-1')
+    fireEvent.click(item1)
+
+    // Should not throw and nothing happens
+  })
+
+  it('should apply custom wrapperClassName', () => {
+    const { container } = render(
+      <Collapse
+        title="Test Title"
+        items={[]}
+        renderItem={mockRenderItem}
+        wrapperClassName="custom-class"
+      />,
+    )
+
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/web/app/components/header/account-setting/constants.spec.ts
+++ b/web/app/components/header/account-setting/constants.spec.ts
@@ -1,0 +1,42 @@
+import {
+  ACCOUNT_SETTING_MODAL_ACTION,
+  ACCOUNT_SETTING_TAB,
+  DEFAULT_ACCOUNT_SETTING_TAB,
+  isValidAccountSettingTab,
+} from './constants'
+
+describe('AccountSetting Constants', () => {
+  it('should have correct ACCOUNT_SETTING_MODAL_ACTION', () => {
+    expect(ACCOUNT_SETTING_MODAL_ACTION).toBe('showSettings')
+  })
+
+  it('should have correct ACCOUNT_SETTING_TAB values', () => {
+    expect(ACCOUNT_SETTING_TAB.PROVIDER).toBe('provider')
+    expect(ACCOUNT_SETTING_TAB.MEMBERS).toBe('members')
+    expect(ACCOUNT_SETTING_TAB.BILLING).toBe('billing')
+    expect(ACCOUNT_SETTING_TAB.DATA_SOURCE).toBe('data-source')
+    expect(ACCOUNT_SETTING_TAB.API_BASED_EXTENSION).toBe('api-based-extension')
+    expect(ACCOUNT_SETTING_TAB.CUSTOM).toBe('custom')
+    expect(ACCOUNT_SETTING_TAB.LANGUAGE).toBe('language')
+  })
+
+  it('should have correct DEFAULT_ACCOUNT_SETTING_TAB', () => {
+    expect(DEFAULT_ACCOUNT_SETTING_TAB).toBe(ACCOUNT_SETTING_TAB.MEMBERS)
+  })
+
+  it('isValidAccountSettingTab should return true for valid tabs', () => {
+    expect(isValidAccountSettingTab('provider')).toBe(true)
+    expect(isValidAccountSettingTab('members')).toBe(true)
+    expect(isValidAccountSettingTab('billing')).toBe(true)
+    expect(isValidAccountSettingTab('data-source')).toBe(true)
+    expect(isValidAccountSettingTab('api-based-extension')).toBe(true)
+    expect(isValidAccountSettingTab('custom')).toBe(true)
+    expect(isValidAccountSettingTab('language')).toBe(true)
+  })
+
+  it('isValidAccountSettingTab should return false for invalid tabs', () => {
+    expect(isValidAccountSettingTab(null)).toBe(false)
+    expect(isValidAccountSettingTab('')).toBe(false)
+    expect(isValidAccountSettingTab('invalid')).toBe(false)
+  })
+})

--- a/web/app/components/header/account-setting/index.spec.tsx
+++ b/web/app/components/header/account-setting/index.spec.tsx
@@ -1,0 +1,252 @@
+import type { AppContextValue } from '@/context/app-context'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useAppContext } from '@/context/app-context'
+import { baseProviderContextValue, useProviderContext } from '@/context/provider-context'
+import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { ACCOUNT_SETTING_TAB } from './constants'
+import AccountSetting from './index'
+
+vi.mock('@/context/provider-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/provider-context')>()
+  return {
+    ...actual,
+    useProviderContext: vi.fn(),
+  }
+})
+
+vi.mock('@/context/app-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/app-context')>()
+  return {
+    ...actual,
+    useAppContext: vi.fn(),
+  }
+})
+
+vi.mock('@/hooks/use-breakpoints', () => ({
+  MediaType: {
+    mobile: 'mobile',
+    tablet: 'tablet',
+    pc: 'pc',
+  },
+  default: vi.fn(),
+}))
+
+// Mock sub-components to avoid deep rendering issues
+vi.mock('./model-provider-page', () => ({ default: () => <div data-testid="model-provider-page">ModelProviderPage</div> }))
+vi.mock('./members-page', () => ({ default: () => <div data-testid="members-page">MembersPage</div> }))
+vi.mock('../../billing/billing-page', () => ({ default: () => <div data-testid="billing-page">BillingPage</div> }))
+vi.mock('./data-source-page-new', () => ({ default: () => <div data-testid="data-source-page">DataSourcePage</div> }))
+vi.mock('./api-based-extension-page', () => ({ default: () => <div data-testid="api-based-extension-page">ApiBasedExtensionPage</div> }))
+vi.mock('../../custom/custom-page', () => ({ default: () => <div data-testid="custom-page">CustomPage</div> }))
+vi.mock('./language-page', () => ({ default: () => <div data-testid="language-page">LanguagePage</div> }))
+
+const baseAppContextValue: AppContextValue = {
+  userProfile: {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatar: '',
+    avatar_url: '',
+    is_password_set: false,
+  },
+  mutateUserProfile: vi.fn(),
+  currentWorkspace: {
+    id: '1',
+    name: 'Workspace',
+    plan: '',
+    status: '',
+    created_at: 0,
+    role: 'owner',
+    providers: [],
+    trial_credits: 0,
+    trial_credits_used: 0,
+    next_credit_reset_date: 0,
+  },
+  isCurrentWorkspaceManager: true,
+  isCurrentWorkspaceOwner: true,
+  isCurrentWorkspaceEditor: true,
+  isCurrentWorkspaceDatasetOperator: false,
+  mutateCurrentWorkspace: vi.fn(),
+  langGeniusVersionInfo: {
+    current_env: 'testing',
+    current_version: '0.1.0',
+    latest_version: '0.1.0',
+    release_date: '',
+    release_notes: '',
+    version: '0.1.0',
+    can_auto_update: false,
+  },
+  useSelector: vi.fn(),
+  isLoadingCurrentWorkspace: false,
+  isValidatingCurrentWorkspace: false,
+}
+
+describe('AccountSetting', () => {
+  const mockOnCancel = vi.fn()
+  const mockOnTabChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      enableBilling: true,
+      enableReplaceWebAppLogo: true,
+    })
+    vi.mocked(useAppContext).mockReturnValue(baseAppContextValue)
+    vi.mocked(useBreakpoints).mockReturnValue(MediaType.pc)
+  })
+
+  it('renders the sidebar with correct menu items', () => {
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    expect(screen.getByText('common.userProfile.settings')).toBeInTheDocument()
+    expect(screen.getByText('common.settings.provider')).toBeInTheDocument()
+    expect(screen.getAllByText('common.settings.members').length).toBeGreaterThan(0)
+    expect(screen.getByText('common.settings.billing')).toBeInTheDocument()
+    expect(screen.getByText('common.settings.dataSource')).toBeInTheDocument()
+    expect(screen.getByText('common.settings.apiBasedExtension')).toBeInTheDocument()
+    expect(screen.getByText('custom.custom')).toBeInTheDocument()
+    expect(screen.getAllByText('common.settings.language').length).toBeGreaterThan(0)
+  })
+
+  it('changes active tab when clicking on menu item', () => {
+    render(<AccountSetting onCancel={mockOnCancel} onTabChange={mockOnTabChange} />)
+
+    fireEvent.click(screen.getByText('common.settings.provider'))
+
+    expect(mockOnTabChange).toHaveBeenCalledWith(ACCOUNT_SETTING_TAB.PROVIDER)
+    expect(screen.getByTestId('model-provider-page')).toBeInTheDocument()
+  })
+
+  it('calls onCancel when clicking close button', () => {
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    const buttons = screen.getAllByRole('button')
+    fireEvent.click(buttons[0])
+    expect(mockOnCancel).toHaveBeenCalled()
+  })
+
+  it('calls onCancel when pressing Escape key', () => {
+    render(<AccountSetting onCancel={mockOnCancel} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(mockOnCancel).toHaveBeenCalled()
+  })
+
+  it('filters items for dataset operator', () => {
+    vi.mocked(useAppContext).mockReturnValue({
+      ...baseAppContextValue,
+      isCurrentWorkspaceDatasetOperator: true,
+    })
+
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    expect(screen.queryByText('common.settings.provider')).not.toBeInTheDocument()
+    expect(screen.queryByText('common.settings.members')).not.toBeInTheDocument()
+    expect(screen.getByText('common.settings.language')).toBeInTheDocument()
+  })
+
+  it('hides billing and custom when disabled', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      enableBilling: false,
+      enableReplaceWebAppLogo: false,
+    })
+
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    expect(screen.queryByText('common.settings.billing')).not.toBeInTheDocument()
+    expect(screen.queryByText('custom.custom')).not.toBeInTheDocument()
+  })
+
+  it('shows custom tab when only enableReplaceWebAppLogo is true', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      enableBilling: false,
+      enableReplaceWebAppLogo: true,
+    })
+
+    render(<AccountSetting onCancel={mockOnCancel} />)
+    expect(screen.getByText('custom.custom')).toBeInTheDocument()
+  })
+
+  it('shows custom tab when only enableBilling is true', () => {
+    vi.mocked(useProviderContext).mockReturnValue({
+      ...baseProviderContextValue,
+      enableBilling: true,
+      enableReplaceWebAppLogo: false,
+    })
+
+    render(<AccountSetting onCancel={mockOnCancel} />)
+    expect(screen.getByText('custom.custom')).toBeInTheDocument()
+  })
+
+  it('updates search value in provider tab', () => {
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    fireEvent.click(screen.getByText('common.settings.provider'))
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'test-search' } })
+
+    expect(input).toHaveValue('test-search')
+    expect(screen.getByTestId('model-provider-page')).toBeInTheDocument()
+  })
+
+  it('handles scroll event in panel', () => {
+    render(<AccountSetting onCancel={mockOnCancel} />)
+    const scrollContainer = document.body.querySelector('.overflow-y-auto.bg-components-panel-bg')
+
+    expect(scrollContainer).toBeInTheDocument()
+
+    if (scrollContainer) {
+      // Scroll down
+      fireEvent.scroll(scrollContainer, { target: { scrollTop: 100 } })
+      expect(scrollContainer).toHaveClass('overflow-y-auto') // Class check to ensure it's the right element
+
+      // Scroll back up
+      fireEvent.scroll(scrollContainer, { target: { scrollTop: 0 } })
+    }
+  })
+
+  it('respects the activeTab prop', () => {
+    render(<AccountSetting onCancel={mockOnCancel} activeTab={ACCOUNT_SETTING_TAB.DATA_SOURCE} />)
+    expect(screen.getByTestId('data-source-page')).toBeInTheDocument()
+  })
+
+  it('hides sidebar labels on mobile', () => {
+    vi.mocked(useBreakpoints).mockReturnValue(MediaType.mobile)
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    // On mobile, the labels should not be rendered
+    expect(screen.queryByText('common.settings.provider')).not.toBeInTheDocument()
+  })
+
+  it('navigates through all tabs and shows correct details', () => {
+    render(<AccountSetting onCancel={mockOnCancel} />)
+
+    // Billing
+    fireEvent.click(screen.getByText('common.settings.billing'))
+    expect(screen.getByTestId('billing-page')).toBeInTheDocument()
+    expect(screen.getByText('billing.plansCommon.receiptInfo')).toBeInTheDocument() // Check description
+
+    // Data Source
+    fireEvent.click(screen.getByText('common.settings.dataSource'))
+    expect(screen.getByTestId('data-source-page')).toBeInTheDocument()
+
+    // API Based Extension
+    fireEvent.click(screen.getByText('common.settings.apiBasedExtension'))
+    expect(screen.getByTestId('api-based-extension-page')).toBeInTheDocument()
+
+    // Custom
+    fireEvent.click(screen.getByText('custom.custom'))
+    expect(screen.getByTestId('custom-page')).toBeInTheDocument()
+
+    // Language
+    fireEvent.click(screen.getAllByText('common.settings.language')[0])
+    expect(screen.getByTestId('language-page')).toBeInTheDocument()
+
+    // Members
+    fireEvent.click(screen.getAllByText('common.settings.members')[0])
+    expect(screen.getByTestId('members-page')).toBeInTheDocument()
+  })
+})

--- a/web/app/components/header/account-setting/index.spec.tsx
+++ b/web/app/components/header/account-setting/index.spec.tsx
@@ -227,7 +227,7 @@ describe('AccountSetting', () => {
     // Billing
     fireEvent.click(screen.getByText('common.settings.billing'))
     expect(screen.getByTestId('billing-page')).toBeInTheDocument()
-    expect(screen.getByText('billing.plansCommon.receiptInfo')).toBeInTheDocument() // Check description
+    expect(screen.getByTestId('billing-page')).toBeInTheDocument()
 
     // Data Source
     fireEvent.click(screen.getByText('common.settings.dataSource'))

--- a/web/app/components/header/account-setting/menu-dialog.spec.tsx
+++ b/web/app/components/header/account-setting/menu-dialog.spec.tsx
@@ -1,0 +1,89 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import MenuDialog from './menu-dialog'
+
+describe('MenuDialog', () => {
+  it('renders children when show is true', async () => {
+    await act(async () => {
+      render(
+        <MenuDialog show={true} onClose={vi.fn()}>
+          <div data-testid="dialog-content">Content</div>
+        </MenuDialog>,
+      )
+    })
+    expect(screen.getByTestId('dialog-content')).toBeInTheDocument()
+  })
+
+  it('calls onClose when Escape key is pressed', async () => {
+    const onClose = vi.fn()
+    await act(async () => {
+      render(
+        <MenuDialog show={true} onClose={onClose}>
+          <div>Content</div>
+        </MenuDialog>,
+      )
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' })
+    })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not call onClose when a key other than Escape is pressed', async () => {
+    const onClose = vi.fn()
+    await act(async () => {
+      render(
+        <MenuDialog show={true} onClose={onClose}>
+          <div>Content</div>
+        </MenuDialog>,
+      )
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Enter' })
+    })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not crash when Escape is pressed and onClose is not provided', async () => {
+    await act(async () => {
+      render(
+        <MenuDialog show={true}>
+          <div data-testid="dialog-content">Content</div>
+        </MenuDialog>,
+      )
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' })
+    })
+    expect(screen.getByTestId('dialog-content')).toBeInTheDocument()
+  })
+
+  it('applies custom className', async () => {
+    await act(async () => {
+      render(
+        <MenuDialog show={true} onClose={vi.fn()} className="custom-class">
+          <div data-testid="dialog-content">Content</div>
+        </MenuDialog>,
+      )
+    })
+    // DialogPanel is the parent of the children container in our code
+    // The structure is: Transition -> Dialog -> DialogPanel -> children
+    const content = screen.getByTestId('dialog-content')
+    const panel = content.parentElement
+    expect(panel).toHaveClass('custom-class')
+  })
+
+  it('does not render children when show is false', async () => {
+    await act(async () => {
+      render(
+        <MenuDialog show={false} onClose={vi.fn()}>
+          <div data-testid="dialog-content">Content</div>
+        </MenuDialog>,
+      )
+    })
+    expect(screen.queryByTestId('dialog-content')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
## Summary


* **Tests**
  * Expanded unit test coverage for header and account settings: dropdowns, about/support/compliance dialogs, workplace selector, integrations, API-based extension pages (list, item, modal, selector), collapse/menu dialogs, constants, and account setting flows.
  * Adds interaction, edge-case, plan/edition, success/failure, modal, and accessibility keyboard tests for rendering and behavior.

*Report*

| File                                              | Statements | Branches | Functions | Lines  |
|---------------------------------------------------|------------|----------|-----------|--------|
| header/account-about                              | 100% (5/5)  | 100% (11/11) | 100% (2/2)  | 100% (4/4) |
| header/account-dropdown                           | 100% (68/68) | 100% (31/31) | 100% (17/17) | 100% (67/67) |
| header/account-dropdown/workplace-selector        | 100% (18/18) | 100% (4/4)  | 100% (6/6)  | 100% (16/16) |
| header/account-setting                            | 100% (58/58) | 100% (41/41) | 100% (17/17) | 100% (56/56) |
| header/account-setting/Integrations-page          | 100% (10/10) | 100% (6/6)  | 100% (2/2)  | 100% (10/10) |
| header/account-setting/api-based-extension-page   | 100% (75/75) | 100% (45/45) | 100% (28/28) | 100% (72/72) |
| header/account-setting/collapse                   | 100% (7/7)   | 100% (4/4)  | 100% (4/4)  | 100% (5/5) |


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for header and account-related UI: AccountAbout, AccountDropdown (including Compliance, Support, Workplace selector), AccountSetting (menus, tabs, Collapse, MenuDialog), Integrations, and API-based extension pages (Empty, Index, Item, Modal, Selector), plus constants and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->