### PR TITLE
feat(enterprise): auto-join newly registered accounts to the default workspace

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -291,9 +291,9 @@ class AccountService:
 
         # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
         if getattr(dify_config, "ENTERPRISE_ENABLED", False):
-            from services.enterprise.enterprise_service import try_join_default_workspace_async
+            from services.enterprise.enterprise_service import try_join_default_workspace
 
-            try_join_default_workspace_async(str(account.id))
+            try_join_default_workspace(str(account.id))
 
         return account
 
@@ -1416,9 +1416,9 @@ class RegisterService:
 
             # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
             if getattr(dify_config, "ENTERPRISE_ENABLED", False):
-                from services.enterprise.enterprise_service import try_join_default_workspace_async
+                from services.enterprise.enterprise_service import try_join_default_workspace
 
-                try_join_default_workspace_async(str(account.id))
+                try_join_default_workspace(str(account.id))
         except WorkSpaceNotAllowedCreateError:
             db.session.rollback()
             logger.exception("Register failed")

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -290,9 +290,10 @@ class AccountService:
         TenantService.create_owner_tenant_if_not_exist(account=account)
 
         # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
-        from services.enterprise.enterprise_service import try_join_default_workspace
+        if getattr(dify_config, "ENTERPRISE_ENABLED", False):
+            from services.enterprise.enterprise_service import try_join_default_workspace
 
-        try_join_default_workspace(str(account.id))
+            try_join_default_workspace(str(account.id))
 
         return account
 
@@ -1414,9 +1415,10 @@ class RegisterService:
             db.session.commit()
 
             # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
-            from services.enterprise.enterprise_service import try_join_default_workspace
+            if getattr(dify_config, "ENTERPRISE_ENABLED", False):
+                from services.enterprise.enterprise_service import try_join_default_workspace
 
-            try_join_default_workspace(str(account.id))
+                try_join_default_workspace(str(account.id))
         except WorkSpaceNotAllowedCreateError:
             db.session.rollback()
             logger.exception("Register failed")

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -289,6 +289,11 @@ class AccountService:
 
         TenantService.create_owner_tenant_if_not_exist(account=account)
 
+        # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
+        from services.enterprise.enterprise_service import try_join_default_workspace
+
+        try_join_default_workspace(str(account.id))
+
         return account
 
     @staticmethod
@@ -1407,6 +1412,11 @@ class RegisterService:
                 tenant_was_created.send(tenant)
 
             db.session.commit()
+
+            # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
+            from services.enterprise.enterprise_service import try_join_default_workspace
+
+            try_join_default_workspace(str(account.id))
         except WorkSpaceNotAllowedCreateError:
             db.session.rollback()
             logger.exception("Register failed")

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -291,9 +291,9 @@ class AccountService:
 
         # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
         if getattr(dify_config, "ENTERPRISE_ENABLED", False):
-            from services.enterprise.enterprise_service import try_join_default_workspace
+            from services.enterprise.enterprise_service import try_join_default_workspace_async
 
-            try_join_default_workspace(str(account.id))
+            try_join_default_workspace_async(str(account.id))
 
         return account
 
@@ -1416,9 +1416,9 @@ class RegisterService:
 
             # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
             if getattr(dify_config, "ENTERPRISE_ENABLED", False):
-                from services.enterprise.enterprise_service import try_join_default_workspace
+                from services.enterprise.enterprise_service import try_join_default_workspace_async
 
-                try_join_default_workspace(str(account.id))
+                try_join_default_workspace_async(str(account.id))
         except WorkSpaceNotAllowedCreateError:
             db.session.rollback()
             logger.exception("Register failed")

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -290,7 +290,7 @@ class AccountService:
         TenantService.create_owner_tenant_if_not_exist(account=account)
 
         # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
-        if getattr(dify_config, "ENTERPRISE_ENABLED", False):
+        if dify_config.ENTERPRISE_ENABLED:
             from services.enterprise.enterprise_service import try_join_default_workspace
 
             try_join_default_workspace(str(account.id))

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -1415,7 +1415,7 @@ class RegisterService:
             db.session.commit()
 
             # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
-            if getattr(dify_config, "ENTERPRISE_ENABLED", False):
+            if dify_config.ENTERPRISE_ENABLED:
                 from services.enterprise.enterprise_service import try_join_default_workspace
 
                 try_join_default_workspace(str(account.id))

--- a/api/services/enterprise/base.py
+++ b/api/services/enterprise/base.py
@@ -39,6 +39,9 @@ class BaseRequest:
         endpoint: str,
         json: Any | None = None,
         params: Mapping[str, Any] | None = None,
+        *,
+        timeout: float | httpx.Timeout | None = None,
+        raise_for_status: bool = False,
     ) -> Any:
         headers = {"Content-Type": "application/json", cls.secret_key_header: cls.secret_key}
         url = f"{cls.base_url}{endpoint}"
@@ -53,7 +56,9 @@ class BaseRequest:
             logger.debug("Failed to generate traceparent header", exc_info=True)
 
         with httpx.Client(mounts=mounts) as client:
-            response = client.request(method, url, json=json, params=params, headers=headers)
+            response = client.request(method, url, json=json, params=params, headers=headers, timeout=timeout)
+            if raise_for_status:
+                response.raise_for_status()
         return response.json()
 
 

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -10,6 +11,14 @@ from services.enterprise.base import EnterpriseRequest
 logger = logging.getLogger(__name__)
 
 DEFAULT_WORKSPACE_JOIN_TIMEOUT_SECONDS = 1.0
+DEFAULT_WORKSPACE_JOIN_ASYNC_MAX_WORKERS = 1
+
+# Fire-and-forget executor for signup-time enterprise side effects.
+# Best-effort means we accept that tasks may be dropped on process restart.
+_default_workspace_join_executor = ThreadPoolExecutor(
+    max_workers=DEFAULT_WORKSPACE_JOIN_ASYNC_MAX_WORKERS,
+    thread_name_prefix="enterprise-default-workspace-join",
+)
 
 
 class WebAppSettings(BaseModel):
@@ -81,6 +90,32 @@ def try_join_default_workspace(account_id: str) -> None:
             )
     except Exception:
         logger.warning("Failed to join enterprise default workspace for account %s", account_id, exc_info=True)
+
+
+def try_join_default_workspace_async(account_id: str) -> None:
+    """
+    Async best-effort wrapper for try_join_default_workspace().
+
+    This is intended for request paths (signup/registration) where we do not want to
+    add latency or tie up web workers waiting on the enterprise service.
+    """
+
+    if not dify_config.ENTERPRISE_ENABLED:
+        return
+
+    future: Future[None] = _default_workspace_join_executor.submit(try_join_default_workspace, account_id)
+
+    def _on_done(f: Future[None], *, _account_id: str = account_id) -> None:
+        try:
+            f.result()
+        except Exception:
+            logger.warning(
+                "Async join enterprise default workspace failed for account %s",
+                _account_id,
+                exc_info=True,
+            )
+
+    future.add_done_callback(_on_done)
 
 
 class EnterpriseService:

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -9,6 +9,8 @@ from services.enterprise.base import EnterpriseRequest
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_WORKSPACE_JOIN_TIMEOUT_SECONDS = 1.0
+
 
 class WebAppSettings(BaseModel):
     access_mode: str = Field(
@@ -97,7 +99,13 @@ class EnterpriseService:
         # Ensure we are sending a UUID-shaped string (enterprise side validates too).
         uuid.UUID(account_id)
 
-        data = EnterpriseRequest.send_request("POST", "/default-workspace/members", json={"account_id": account_id})
+        data = EnterpriseRequest.send_request(
+            "POST",
+            "/default-workspace/members",
+            json={"account_id": account_id},
+            timeout=DEFAULT_WORKSPACE_JOIN_TIMEOUT_SECONDS,
+            raise_for_status=True,
+        )
         if not isinstance(data, dict):
             raise ValueError("Invalid response format from enterprise default workspace API")
         return DefaultWorkspaceJoinResult.model_validate(data)

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -1,8 +1,13 @@
+import logging
+import uuid
 from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from configs import dify_config
 from services.enterprise.base import EnterpriseRequest
+
+logger = logging.getLogger(__name__)
 
 
 class WebAppSettings(BaseModel):
@@ -30,6 +35,47 @@ class WorkspacePermission(BaseModel):
     )
 
 
+class DefaultWorkspaceJoinResult(BaseModel):
+    """
+    Result of ensuring an account is a member of the enterprise default workspace.
+
+    - joined=True is idempotent (already a member also returns True)
+    - joined=False means enterprise default workspace is not configured or invalid/archived
+    """
+
+    workspace_id: str = ""
+    joined: bool = False
+    message: str = ""
+
+
+def try_join_default_workspace(account_id: str) -> None:
+    """
+    Enterprise-only side-effect: ensure account is a member of the default workspace.
+
+    This is a best-effort integration. Failures must not block user registration.
+    """
+
+    if not dify_config.ENTERPRISE_ENABLED:
+        return
+
+    try:
+        result = EnterpriseService.join_default_workspace(account_id=account_id)
+        if result.joined:
+            logger.info(
+                "Joined enterprise default workspace for account %s (workspace_id=%s)",
+                account_id,
+                result.workspace_id,
+            )
+        else:
+            logger.info(
+                "Skipped joining enterprise default workspace for account %s (message=%s)",
+                account_id,
+                result.message,
+            )
+    except Exception:
+        logger.warning("Failed to join enterprise default workspace for account %s", account_id, exc_info=True)
+
+
 class EnterpriseService:
     @classmethod
     def get_info(cls):
@@ -38,6 +84,23 @@ class EnterpriseService:
     @classmethod
     def get_workspace_info(cls, tenant_id: str):
         return EnterpriseRequest.send_request("GET", f"/workspace/{tenant_id}/info")
+
+    @classmethod
+    def join_default_workspace(cls, *, account_id: str) -> DefaultWorkspaceJoinResult:
+        """
+        Call enterprise inner API to add an account to the default workspace.
+
+        NOTE: EnterpriseRequest.base_url is expected to already include the `/inner/api` prefix,
+        so the endpoint here is `/default-workspace/members`.
+        """
+
+        # Ensure we are sending a UUID-shaped string (enterprise side validates too).
+        uuid.UUID(account_id)
+
+        data = EnterpriseRequest.send_request("POST", "/default-workspace/members", json={"account_id": account_id})
+        if not isinstance(data, dict):
+            raise ValueError("Invalid response format from enterprise default workspace API")
+        return DefaultWorkspaceJoinResult.model_validate(data)
 
     @classmethod
     def get_app_sso_settings_last_update_time(cls) -> datetime:

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from configs import dify_config
 from services.enterprise.base import EnterpriseRequest
@@ -45,14 +45,17 @@ class DefaultWorkspaceJoinResult(BaseModel):
     - joined=False means enterprise default workspace is not configured or invalid/archived
     """
 
-    # Only workspace_id can be empty when "no default workspace configured".
     workspace_id: str = Field(default="", alias="workspaceId")
-
-    # These fields are required to avoid silently treating error payloads as "skipped".
     joined: bool
     message: str
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @model_validator(mode="after")
+    def _check_workspace_id_when_joined(self) -> "DefaultWorkspaceJoinResult":
+        if self.joined and not self.workspace_id:
+            raise ValueError("workspace_id must be non-empty when joined is True")
+        return self
 
 
 def try_join_default_workspace(account_id: str) -> None:

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -46,13 +46,13 @@ class DefaultWorkspaceJoinResult(BaseModel):
     """
 
     # Only workspace_id can be empty when "no default workspace configured".
-    workspace_id: str = ""
+    workspace_id: str = Field(default="", alias="workspaceId")
 
     # These fields are required to avoid silently treating error payloads as "skipped".
     joined: bool
     message: str
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
 def try_join_default_workspace(account_id: str) -> None:

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -53,6 +53,16 @@ class TestJoinDefaultWorkspace:
         with pytest.raises(ValueError):
             EnterpriseService.join_default_workspace(account_id="not-a-uuid")
 
+    def test_join_default_workspace_missing_required_fields_raises(self):
+        account_id = "11111111-1111-1111-1111-111111111111"
+        response = {"workspace_id": "", "message": "ok"}  # missing "joined"
+
+        with patch("services.enterprise.enterprise_service.EnterpriseRequest.send_request") as mock_send_request:
+            mock_send_request.return_value = response
+
+            with pytest.raises(ValueError, match="Invalid response payload"):
+                EnterpriseService.join_default_workspace(account_id=account_id)
+
 
 class TestTryJoinDefaultWorkspace:
     def test_try_join_default_workspace_enterprise_disabled_noop(self):

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -36,6 +36,8 @@ class TestJoinDefaultWorkspace:
                 "POST",
                 "/default-workspace/members",
                 json={"account_id": account_id},
+                timeout=1.0,
+                raise_for_status=True,
             )
 
     def test_join_default_workspace_invalid_response_format_raises(self):

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -6,6 +6,7 @@ This module covers the enterprise-only default workspace auto-join behavior:
 - Failures (network/invalid response/invalid UUID): soft-fail wrapper must not raise
 """
 
+from concurrent.futures import Future
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,7 @@ from services.enterprise.enterprise_service import (
     DefaultWorkspaceJoinResult,
     EnterpriseService,
     try_join_default_workspace,
+    try_join_default_workspace_async,
 )
 
 
@@ -135,3 +137,46 @@ class TestTryJoinDefaultWorkspace:
 
             # Should not raise even though UUID parsing fails inside join_default_workspace
             try_join_default_workspace("not-a-uuid")
+
+
+class TestTryJoinDefaultWorkspaceAsync:
+    def test_try_join_default_workspace_async_enterprise_disabled_noop(self):
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service._default_workspace_join_executor") as mock_executor,
+        ):
+            mock_config.ENTERPRISE_ENABLED = False
+
+            try_join_default_workspace_async("11111111-1111-1111-1111-111111111111")
+
+            mock_executor.submit.assert_not_called()
+
+    def test_try_join_default_workspace_async_submits_task(self):
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service._default_workspace_join_executor") as mock_executor,
+        ):
+            mock_config.ENTERPRISE_ENABLED = True
+
+            future: Future[None] = Future()
+            future.set_result(None)
+            mock_executor.submit.return_value = future
+
+            try_join_default_workspace_async("11111111-1111-1111-1111-111111111111")
+
+            assert mock_executor.submit.call_count == 1
+
+    def test_try_join_default_workspace_async_logs_warning_on_future_exception(self, caplog):
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service._default_workspace_join_executor") as mock_executor,
+        ):
+            mock_config.ENTERPRISE_ENABLED = True
+
+            future: Future[None] = Future()
+            future.set_exception(Exception("boom"))
+            mock_executor.submit.return_value = future
+
+            try_join_default_workspace_async("11111111-1111-1111-1111-111111111111")
+
+            assert "Async join enterprise default workspace failed" in caplog.text

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -1,0 +1,125 @@
+"""Unit tests for enterprise service integrations.
+
+This module covers the enterprise-only default workspace auto-join behavior:
+- Enterprise mode disabled: no external calls
+- Successful join / skipped join: no errors
+- Failures (network/invalid response/invalid UUID): soft-fail wrapper must not raise
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from services.enterprise.enterprise_service import (
+    DefaultWorkspaceJoinResult,
+    EnterpriseService,
+    try_join_default_workspace,
+)
+
+
+class TestJoinDefaultWorkspace:
+    def test_join_default_workspace_success(self):
+        account_id = "11111111-1111-1111-1111-111111111111"
+        response = {"workspace_id": "22222222-2222-2222-2222-222222222222", "joined": True, "message": "ok"}
+
+        with patch("services.enterprise.enterprise_service.EnterpriseRequest.send_request") as mock_send_request:
+            mock_send_request.return_value = response
+
+            result = EnterpriseService.join_default_workspace(account_id=account_id)
+
+            assert isinstance(result, DefaultWorkspaceJoinResult)
+            assert result.workspace_id == response["workspace_id"]
+            assert result.joined is True
+            assert result.message == "ok"
+
+            mock_send_request.assert_called_once_with(
+                "POST",
+                "/default-workspace/members",
+                json={"account_id": account_id},
+            )
+
+    def test_join_default_workspace_invalid_response_format_raises(self):
+        account_id = "11111111-1111-1111-1111-111111111111"
+
+        with patch("services.enterprise.enterprise_service.EnterpriseRequest.send_request") as mock_send_request:
+            mock_send_request.return_value = "not-a-dict"
+
+            with pytest.raises(ValueError, match="Invalid response format"):
+                EnterpriseService.join_default_workspace(account_id=account_id)
+
+    def test_join_default_workspace_invalid_account_id_raises(self):
+        with pytest.raises(ValueError):
+            EnterpriseService.join_default_workspace(account_id="not-a-uuid")
+
+
+class TestTryJoinDefaultWorkspace:
+    def test_try_join_default_workspace_enterprise_disabled_noop(self):
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
+        ):
+            mock_config.ENTERPRISE_ENABLED = False
+
+            try_join_default_workspace("11111111-1111-1111-1111-111111111111")
+
+            mock_join.assert_not_called()
+
+    def test_try_join_default_workspace_successful_join_does_not_raise(self):
+        account_id = "11111111-1111-1111-1111-111111111111"
+
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
+        ):
+            mock_config.ENTERPRISE_ENABLED = True
+            mock_join.return_value = DefaultWorkspaceJoinResult(
+                workspace_id="22222222-2222-2222-2222-222222222222",
+                joined=True,
+                message="ok",
+            )
+
+            # Should not raise
+            try_join_default_workspace(account_id)
+
+            mock_join.assert_called_once_with(account_id=account_id)
+
+    def test_try_join_default_workspace_skipped_join_does_not_raise(self):
+        account_id = "11111111-1111-1111-1111-111111111111"
+
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
+        ):
+            mock_config.ENTERPRISE_ENABLED = True
+            mock_join.return_value = DefaultWorkspaceJoinResult(
+                workspace_id="",
+                joined=False,
+                message="no default workspace configured",
+            )
+
+            # Should not raise
+            try_join_default_workspace(account_id)
+
+            mock_join.assert_called_once_with(account_id=account_id)
+
+    def test_try_join_default_workspace_api_failure_soft_fails(self):
+        account_id = "11111111-1111-1111-1111-111111111111"
+
+        with (
+            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
+            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
+        ):
+            mock_config.ENTERPRISE_ENABLED = True
+            mock_join.side_effect = Exception("network failure")
+
+            # Should not raise
+            try_join_default_workspace(account_id)
+
+            mock_join.assert_called_once_with(account_id=account_id)
+
+    def test_try_join_default_workspace_invalid_account_id_soft_fails(self):
+        with patch("services.enterprise.enterprise_service.dify_config") as mock_config:
+            mock_config.ENTERPRISE_ENABLED = True
+
+            # Should not raise even though UUID parsing fails inside join_default_workspace
+            try_join_default_workspace("not-a-uuid")

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -63,6 +63,10 @@ class TestJoinDefaultWorkspace:
             with pytest.raises(ValueError, match="Invalid response payload"):
                 EnterpriseService.join_default_workspace(account_id=account_id)
 
+    def test_join_default_workspace_joined_without_workspace_id_raises(self):
+        with pytest.raises(ValueError, match="workspace_id must be non-empty when joined is True"):
+            DefaultWorkspaceJoinResult(workspace_id="", joined=True, message="ok")
+
 
 class TestTryJoinDefaultWorkspace:
     def test_try_join_default_workspace_enterprise_disabled_noop(self):

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1080,7 +1080,9 @@ class TestRegisterService:
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
             patch("services.account_service.TenantService.create_owner_tenant_if_not_exist") as mock_create_workspace,
-            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+            patch(
+                "services.enterprise.enterprise_service.try_join_default_workspace_async"
+            ) as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 
@@ -1111,7 +1113,9 @@ class TestRegisterService:
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
             patch("services.account_service.TenantService.create_owner_tenant_if_not_exist") as mock_create_workspace,
-            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+            patch(
+                "services.enterprise.enterprise_service.try_join_default_workspace_async"
+            ) as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 
@@ -1191,7 +1195,9 @@ class TestRegisterService:
 
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
-            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+            patch(
+                "services.enterprise.enterprise_service.try_join_default_workspace_async"
+            ) as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 
@@ -1221,7 +1227,9 @@ class TestRegisterService:
 
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
-            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+            patch(
+                "services.enterprise.enterprise_service.try_join_default_workspace_async"
+            ) as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1080,9 +1080,7 @@ class TestRegisterService:
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
             patch("services.account_service.TenantService.create_owner_tenant_if_not_exist") as mock_create_workspace,
-            patch(
-                "services.enterprise.enterprise_service.try_join_default_workspace_async"
-            ) as mock_join_default_workspace,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 
@@ -1113,9 +1111,7 @@ class TestRegisterService:
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
             patch("services.account_service.TenantService.create_owner_tenant_if_not_exist") as mock_create_workspace,
-            patch(
-                "services.enterprise.enterprise_service.try_join_default_workspace_async"
-            ) as mock_join_default_workspace,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 
@@ -1195,9 +1191,7 @@ class TestRegisterService:
 
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
-            patch(
-                "services.enterprise.enterprise_service.try_join_default_workspace_async"
-            ) as mock_join_default_workspace,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 
@@ -1227,9 +1221,7 @@ class TestRegisterService:
 
         with (
             patch("services.account_service.AccountService.create_account") as mock_create_account,
-            patch(
-                "services.enterprise.enterprise_service.try_join_default_workspace_async"
-            ) as mock_join_default_workspace,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
         ):
             mock_create_account.return_value = mock_account
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

Fixes #32307

## Summary

This PR adds an enterprise-only, best-effort integration to ensure newly created accounts are members of the enterprise configured default workspace.

- Calls Enterprise Inner API `POST /default-workspace/members` with body `{ "account_id": "<uuid>" }`
- Executes only when `ENTERPRISE_ENABLED=true`
- Runs synchronously in the registration/account-creation path, but remains best-effort (errors are swallowed and logged as warnings; signup/login continues)
- Uses a small request timeout (`1s`) and treats non-2xx responses as failures
- Validates `account_id` as UUID before sending the request
- Does not change the user’s current workspace (no workspace switch side effects)
- Integrated into new-account creation paths:
  - OAuth/SSO new user (`RegisterService.register`)
  - Email-code new user (`AccountService.create_account_and_tenant`)
- Adds unit tests covering:
  - Enterprise service request/response handling (including invalid payloads / failures)
  - Registration call sites invoking the integration when enterprise is enabled

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods