### PR TITLE
fix(app-copy): inherit web app permission from original app

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -660,6 +660,19 @@ class AppCopyApi(Resource):
             )
             session.commit()
 
+            # Inherit web app permission from original app
+            if result.app_id and FeatureService.get_system_features().webapp_auth.enabled:
+                try:
+                    # Get the original app's access mode
+                    original_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_model.id)
+                    access_mode = original_settings.access_mode
+                except Exception:
+                    # If original app has no settings (old app), default to public to match fallback behavior
+                    access_mode = "public"
+
+                # Apply the same access mode to the copied app
+                EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, access_mode)
+
             stmt = select(App).where(App.id == result.app_id)
             app = session.scalar(stmt)
 


### PR DESCRIPTION
## Summary

When copying an app, the copied app was not getting a `web_app_settings` record created. This caused the enterprise service to query for settings that don't exist, falling back to default behavior which could expose copied apps unintentionally.

## Changes

This fix ensures copied apps inherit the same access mode as the original app:

- **If original has explicit settings** (public/private/private_all/sso_verified) → copy gets the same setting
- **If original has no settings** (old apps) → copy defaults to "public" to match the original's effective permission via fallback

## Implementation

Added permission inheritance logic in `AppCopyApi.post()` (api/controllers/console/app/app.py):

1. After app import completes, check if webapp_auth feature is enabled
2. Try to get the original app's access mode from enterprise service
3. If original has settings, inherit the same access mode
4. If original has no settings (exception), default to "public" to preserve effective behavior
5. Apply the access mode to the copied app via `EnterpriseService.WebAppAuth.update_app_access_mode()`

## Code Changes

```python
# After session.commit() in AppCopyApi.post():

# Inherit web app permission from original app
if result.app_id and FeatureService.get_system_features().webapp_auth.enabled:
    try:
        # Get the original app's access mode
        original_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_model.id)
        access_mode = original_settings.access_mode
    except Exception:
        # If original app has no settings (old app), default to public to match fallback behavior
        access_mode = "public"
    
    # Apply the same access mode to the copied app
    EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, access_mode)
```

## Testing

Manual testing should verify:
- ✅ Copying a public app → copy is public
- ✅ Copying a private app → copy is private
- ✅ Copying a private_all app → copy is private_all
- ✅ Copying a sso_verified app → copy requires SSO
- ✅ Copying an old app (no web_app_settings) → copy gets "public" (matches original effective permission)

## Impact

- **Before:** Copied apps had no permission record → fell back to default behavior (inconsistent with original)
- **After:** Copied apps get explicit permission record matching original app
- **Backward Compatibility:** Old apps without settings get "public" default (preserves current effective behavior)

## Related

- langgenius/dify-enterprise#423 - Enterprise PR that changes fallback default from public to private
- This fix ensures copied apps get explicit permissions, preventing reliance on fallback behavior

## Files Changed

- `api/controllers/console/app/app.py` (+13 lines)