### PR TITLE
fix: include sso_verified in access_mode validation

### DIFF
--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field
 
 from services.enterprise.base import EnterpriseRequest
 
+ALLOWED_ACCESS_MODES = ["public", "private", "private_all", "sso_verified"]
+
 
 class WebAppSettings(BaseModel):
     access_mode: str = Field(
@@ -123,8 +125,8 @@ class EnterpriseService:
         def update_app_access_mode(cls, app_id: str, access_mode: str):
             if not app_id:
                 raise ValueError("app_id must be provided.")
-            if access_mode not in ["public", "private", "private_all", "sso_verified"]:
-                raise ValueError("access_mode must be either 'public', 'private', 'private_all', or 'sso_verified'")
+            if access_mode not in ALLOWED_ACCESS_MODES:
+                raise ValueError(f"access_mode must be one of: {', '.join(ALLOWED_ACCESS_MODES)}")
 
             data = {"appId": app_id, "accessMode": access_mode}
 

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -123,8 +123,8 @@ class EnterpriseService:
         def update_app_access_mode(cls, app_id: str, access_mode: str):
             if not app_id:
                 raise ValueError("app_id must be provided.")
-            if access_mode not in ["public", "private", "private_all"]:
-                raise ValueError("access_mode must be either 'public', 'private', or 'private_all'")
+            if access_mode not in ["public", "private", "private_all", "sso_verified"]:
+                raise ValueError("access_mode must be either 'public', 'private', 'private_all', or 'sso_verified'")
 
             data = {"appId": app_id, "accessMode": access_mode}
 


### PR DESCRIPTION
## Summary

Fixes app duplication error when the original app has `access_mode='sso_verified'`.

## Problem

When duplicating an app, the code inherits the `access_mode` from the original app. However, the validation in `update_app_access_mode()` only allowed `["public", "private", "private_all"]`, missing the `"sso_verified"` value that was documented in the `WebAppSettings` model.

This caused duplication to fail with: `access_mode must be either 'public', 'private', or 'private_all'`

## Changes

- Added `"sso_verified"` to the allowed values in `update_app_access_mode()` validation
- Updated error message to include `"sso_verified"`

## Files Changed

- `api/services/enterprise/enterprise_service.py`

## Testing

- Verified LSP diagnostics are clean
- No new type errors introduced