### PR TITLE
refactor(web): harden constrained nuqs parsers and infer query-state types

### DIFF
--- a/web/__tests__/datasets/document-management.test.tsx
+++ b/web/__tests__/datasets/document-management.test.tsx
@@ -101,7 +101,7 @@ describe('Document Management Flow', () => {
       })
     })
 
-    it('should update query and push to router', async () => {
+    it('should update keyword query with replace history', async () => {
       const { result, onUrlUpdate } = renderQueryStateHook()
 
       act(() => {
@@ -110,7 +110,7 @@ describe('Document Management Flow', () => {
 
       await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
       const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1][0]
-      expect(update.options.history).toBe('push')
+      expect(update.options.history).toBe('replace')
       expect(update.searchParams.get('keyword')).toBe('test')
       expect(update.searchParams.get('page')).toBe('2')
     })
@@ -124,7 +124,7 @@ describe('Document Management Flow', () => {
 
       await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
       const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1][0]
-      expect(update.options.history).toBe('push')
+      expect(update.options.history).toBe('replace')
       expect(update.searchParams.toString()).toBe('')
     })
   })

--- a/web/__tests__/datasets/document-management.test.tsx
+++ b/web/__tests__/datasets/document-management.test.tsx
@@ -29,7 +29,7 @@ const { useDocumentSort } = await import(
 const { useDocumentSelection } = await import(
   '@/app/components/datasets/documents/components/document-list/hooks/use-document-selection',
 )
-const { default: useDocumentListQueryState } = await import(
+const { useDocumentListQueryState } = await import(
   '@/app/components/datasets/documents/hooks/use-document-list-query-state',
 )
 

--- a/web/app/components/datasets/documents/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/__tests__/index.spec.tsx
@@ -4,7 +4,7 @@ import { useDatasetDetailContextWithSelector } from '@/context/dataset-detail'
 import { useProviderContext } from '@/context/provider-context'
 import { DataSourceType } from '@/models/datasets'
 import { useDocumentList } from '@/service/knowledge/use-document'
-import useDocumentsPageState from '../hooks/use-documents-page-state'
+import { useDocumentsPageState } from '../hooks/use-documents-page-state'
 import Documents from '../index'
 
 // Type for mock selector function - use `as MockState` to bypass strict type checking in tests
@@ -121,9 +121,8 @@ const mockUpdatePollingState = vi.fn()
 const mockAdjustPageForTotal = vi.fn()
 
 vi.mock('../hooks/use-documents-page-state', () => ({
-  default: vi.fn(() => ({
+  useDocumentsPageState: vi.fn(() => ({
     inputValue: '',
-    searchValue: '',
     debouncedSearchValue: '',
     handleInputChange: mockHandleInputChange,
     statusFilterValue: 'all',
@@ -595,7 +594,6 @@ describe('Documents', () => {
     it('should enable polling when documents are indexing', () => {
       vi.mocked(useDocumentsPageState).mockReturnValueOnce({
         inputValue: '',
-        searchValue: '',
         debouncedSearchValue: '',
         handleInputChange: mockHandleInputChange,
         statusFilterValue: 'all',
@@ -635,7 +633,6 @@ describe('Documents', () => {
     it('should handle page changes', () => {
       vi.mocked(useDocumentsPageState).mockReturnValueOnce({
         inputValue: '',
-        searchValue: '',
         debouncedSearchValue: '',
         handleInputChange: mockHandleInputChange,
         statusFilterValue: 'all',
@@ -664,7 +661,6 @@ describe('Documents', () => {
     it('should display selected count', () => {
       vi.mocked(useDocumentsPageState).mockReturnValueOnce({
         inputValue: '',
-        searchValue: '',
         debouncedSearchValue: '',
         handleInputChange: mockHandleInputChange,
         statusFilterValue: 'all',
@@ -693,7 +689,6 @@ describe('Documents', () => {
     it('should pass filter value to list', () => {
       vi.mocked(useDocumentsPageState).mockReturnValueOnce({
         inputValue: 'test search',
-        searchValue: 'test search',
         debouncedSearchValue: 'test search',
         handleInputChange: mockHandleInputChange,
         statusFilterValue: 'completed',

--- a/web/app/components/datasets/documents/hooks/__tests__/use-document-list-query-state.spec.tsx
+++ b/web/app/components/datasets/documents/hooks/__tests__/use-document-list-query-state.spec.tsx
@@ -2,7 +2,7 @@ import type { DocumentListQuery } from '../use-document-list-query-state'
 import { act, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHookWithNuqs } from '@/test/nuqs-testing'
-import useDocumentListQueryState from '../use-document-list-query-state'
+import { useDocumentListQueryState } from '../use-document-list-query-state'
 
 vi.mock('@/models/datasets', () => ({
   DisplayStatusList: [

--- a/web/app/components/datasets/documents/hooks/__tests__/use-document-list-query-state.spec.tsx
+++ b/web/app/components/datasets/documents/hooks/__tests__/use-document-list-query-state.spec.tsx
@@ -227,6 +227,21 @@ describe('useDocumentListQueryState', () => {
       await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
       const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1][0]
       expect(update.searchParams.get('keyword')).toBe('test query')
+      expect(update.options.history).toBe('replace')
+    })
+
+    it('should use replace history when keyword update also resets page', async () => {
+      const { result, onUrlUpdate } = renderWithAdapter('?page=3')
+
+      act(() => {
+        result.current.updateQuery({ keyword: 'hello', page: 1 })
+      })
+
+      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1][0]
+      expect(update.searchParams.get('keyword')).toBe('hello')
+      expect(update.searchParams.has('page')).toBe(false)
+      expect(update.options.history).toBe('replace')
     })
 
     it('should remove keyword from URL when keyword is empty', async () => {
@@ -239,6 +254,7 @@ describe('useDocumentListQueryState', () => {
       await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
       const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1][0]
       expect(update.searchParams.has('keyword')).toBe(false)
+      expect(update.options.history).toBe('replace')
     })
 
     it('should remove keyword from URL when keyword contains only whitespace', async () => {

--- a/web/app/components/datasets/documents/hooks/__tests__/use-documents-page-state.spec.ts
+++ b/web/app/components/datasets/documents/hooks/__tests__/use-documents-page-state.spec.ts
@@ -1,12 +1,10 @@
 import type { DocumentListQuery } from '../use-document-list-query-state'
-import type { DocumentListResponse } from '@/models/datasets'
 
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useDocumentsPageState } from '../use-documents-page-state'
 
 const mockUpdateQuery = vi.fn()
-const mockResetQuery = vi.fn()
 let mockQuery: DocumentListQuery = { page: 1, limit: 10, keyword: '', status: 'all', sort: '-created_at' }
 
 vi.mock('@/models/datasets', () => ({
@@ -22,17 +20,10 @@ vi.mock('@/models/datasets', () => ({
   ],
 }))
 
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
-  usePathname: () => '/datasets/test-id/documents',
-  useSearchParams: () => new URLSearchParams(),
-}))
-
 vi.mock('ahooks', () => ({
   useDebounce: (value: unknown, _options?: { wait?: number }) => value,
 }))
 
-// Mock the dependent hook
 vi.mock('../use-document-list-query-state', async () => {
   const React = await import('react')
   return {
@@ -44,49 +35,10 @@ vi.mock('../use-document-list-query-state', async () => {
           mockUpdateQuery(updates)
           setQuery(prev => ({ ...prev, ...updates }))
         },
-        resetQuery: () => {
-          mockResetQuery()
-          setQuery({ page: 1, limit: 10, keyword: '', status: 'all', sort: '-created_at' })
-        },
       }
     },
   }
 })
-
-// Factory for creating DocumentListResponse test data
-function createDocumentListResponse(overrides: Partial<DocumentListResponse> = {}): DocumentListResponse {
-  return {
-    data: [],
-    has_more: false,
-    total: 0,
-    page: 1,
-    limit: 10,
-    ...overrides,
-  }
-}
-
-// Factory for creating a minimal document item
-function createDocumentItem(overrides: Record<string, unknown> = {}) {
-  return {
-    id: `doc-${Math.random().toString(36).slice(2, 8)}`,
-    name: 'test-doc.txt',
-    indexing_status: 'completed' as string,
-    display_status: 'available' as string,
-    enabled: true,
-    archived: false,
-    word_count: 100,
-    created_at: Date.now(),
-    updated_at: Date.now(),
-    created_from: 'web' as const,
-    created_by: 'user-1',
-    dataset_process_rule_id: 'rule-1',
-    doc_form: 'text_model' as const,
-    doc_language: 'en',
-    position: 1,
-    data_source_type: 'upload_file',
-    ...overrides,
-  }
-}
 
 describe('useDocumentsPageState', () => {
   beforeEach(() => {
@@ -96,78 +48,42 @@ describe('useDocumentsPageState', () => {
 
   // Initial state verification
   describe('initial state', () => {
-    it('should return correct initial search state', () => {
+    it('should return correct initial query-derived state', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       expect(result.current.inputValue).toBe('')
       expect(result.current.debouncedSearchValue).toBe('')
-    })
-
-    it('should return correct initial filter and sort state', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
       expect(result.current.statusFilterValue).toBe('all')
       expect(result.current.sortValue).toBe('-created_at')
       expect(result.current.normalizedStatusFilterValue).toBe('all')
-    })
-
-    it('should return correct initial pagination state', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      // page is query.page - 1 = 0
       expect(result.current.currPage).toBe(0)
       expect(result.current.limit).toBe(10)
-    })
-
-    it('should return correct initial selection state', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
       expect(result.current.selectedIds).toEqual([])
     })
 
-    it('should return correct initial polling state', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should initialize from query when query has keyword', () => {
-      mockQuery = { ...mockQuery, keyword: 'initial search' }
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      expect(result.current.inputValue).toBe('initial search')
-    })
-
-    it('should initialize pagination from query with non-default page', () => {
-      mockQuery = { ...mockQuery, page: 3, limit: 25 }
+    it('should initialize from non-default query values', () => {
+      mockQuery = {
+        page: 3,
+        limit: 25,
+        keyword: 'initial',
+        status: 'enabled',
+        sort: 'hit_count',
+      }
 
       const { result } = renderHook(() => useDocumentsPageState())
 
-      expect(result.current.currPage).toBe(2) // page - 1
+      expect(result.current.inputValue).toBe('initial')
+      expect(result.current.currPage).toBe(2)
       expect(result.current.limit).toBe(25)
-    })
-
-    it('should initialize status filter from query', () => {
-      mockQuery = { ...mockQuery, status: 'error' }
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      expect(result.current.statusFilterValue).toBe('error')
-    })
-
-    it('should initialize sort from query', () => {
-      mockQuery = { ...mockQuery, sort: 'hit_count' }
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
+      expect(result.current.statusFilterValue).toBe('enabled')
+      expect(result.current.normalizedStatusFilterValue).toBe('available')
       expect(result.current.sortValue).toBe('hit_count')
     })
   })
 
   // Handler behaviors
   describe('handleInputChange', () => {
-    it('should update input value when called', () => {
+    it('should update keyword and reset page', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -178,20 +94,56 @@ describe('useDocumentsPageState', () => {
       expect(mockUpdateQuery).toHaveBeenCalledWith({ keyword: 'new value', page: 1 })
     })
 
-    it('should update search value when called', () => {
+    it('should clear selected ids when keyword changes', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
-        result.current.handleInputChange('search term')
+        result.current.setSelectedIds(['doc-1'])
+      })
+      expect(result.current.selectedIds).toEqual(['doc-1'])
+
+      act(() => {
+        result.current.handleInputChange('keyword')
       })
 
-      expect(result.current.inputValue).toBe('search term')
-      expect(result.current.debouncedSearchValue).toBe('search term')
+      expect(result.current.selectedIds).toEqual([])
+    })
+
+    it('should keep selected ids when keyword is unchanged', () => {
+      mockQuery = { ...mockQuery, keyword: 'same' }
+      const { result } = renderHook(() => useDocumentsPageState())
+
+      act(() => {
+        result.current.setSelectedIds(['doc-1'])
+      })
+
+      act(() => {
+        result.current.handleInputChange('same')
+      })
+
+      expect(result.current.selectedIds).toEqual(['doc-1'])
+      expect(mockUpdateQuery).toHaveBeenCalledWith({ keyword: 'same', page: 1 })
     })
   })
 
   describe('handleStatusFilterChange', () => {
-    it('should update status filter value when called with valid status', () => {
+    it('should sanitize status, reset page, and clear selection', () => {
+      const { result } = renderHook(() => useDocumentsPageState())
+
+      act(() => {
+        result.current.setSelectedIds(['doc-1'])
+      })
+
+      act(() => {
+        result.current.handleStatusFilterChange('invalid')
+      })
+
+      expect(result.current.statusFilterValue).toBe('all')
+      expect(result.current.selectedIds).toEqual([])
+      expect(mockUpdateQuery).toHaveBeenCalledWith({ status: 'all', page: 1 })
+    })
+
+    it('should update to valid status value', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -199,61 +151,23 @@ describe('useDocumentsPageState', () => {
       })
 
       expect(result.current.statusFilterValue).toBe('error')
-    })
-
-    it('should reset page to 0 when status filter changes', () => {
-      mockQuery = { ...mockQuery, page: 3 }
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('error')
-      })
-
-      expect(result.current.currPage).toBe(0)
-    })
-
-    it('should call updateQuery with sanitized status and page 1', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('error')
-      })
-
       expect(mockUpdateQuery).toHaveBeenCalledWith({ status: 'error', page: 1 })
-    })
-
-    it('should sanitize invalid status to all', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('invalid')
-      })
-
-      expect(result.current.statusFilterValue).toBe('all')
-      expect(mockUpdateQuery).toHaveBeenCalledWith({ status: 'all', page: 1 })
     })
   })
 
   describe('handleStatusFilterClear', () => {
-    it('should set status to all and reset page when status is not all', () => {
+    it('should reset status to all when status is not all', () => {
+      mockQuery = { ...mockQuery, status: 'error' }
       const { result } = renderHook(() => useDocumentsPageState())
 
-      // First set a non-all status
-      act(() => {
-        result.current.handleStatusFilterChange('error')
-      })
-      vi.clearAllMocks()
-
-      // Then clear
       act(() => {
         result.current.handleStatusFilterClear()
       })
 
-      expect(result.current.statusFilterValue).toBe('all')
       expect(mockUpdateQuery).toHaveBeenCalledWith({ status: 'all', page: 1 })
     })
 
-    it('should not call updateQuery when status is already all', () => {
+    it('should do nothing when status is already all', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -265,7 +179,7 @@ describe('useDocumentsPageState', () => {
   })
 
   describe('handleSortChange', () => {
-    it('should update sort value and call updateQuery when value changes', () => {
+    it('should update sort and reset page when sort changes', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -276,18 +190,7 @@ describe('useDocumentsPageState', () => {
       expect(mockUpdateQuery).toHaveBeenCalledWith({ sort: 'hit_count', page: 1 })
     })
 
-    it('should reset page to 0 when sort changes', () => {
-      mockQuery = { ...mockQuery, page: 5 }
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleSortChange('hit_count')
-      })
-
-      expect(result.current.currPage).toBe(0)
-    })
-
-    it('should not call updateQuery when sort value is same as current', () => {
+    it('should ignore sort update when value is unchanged', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -298,8 +201,8 @@ describe('useDocumentsPageState', () => {
     })
   })
 
-  describe('handlePageChange', () => {
-    it('should update current page and call updateQuery', () => {
+  describe('pagination handlers', () => {
+    it('should update page with one-based value', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -307,23 +210,10 @@ describe('useDocumentsPageState', () => {
       })
 
       expect(result.current.currPage).toBe(2)
-      expect(mockUpdateQuery).toHaveBeenCalledWith({ page: 3 }) // newPage + 1
+      expect(mockUpdateQuery).toHaveBeenCalledWith({ page: 3 })
     })
 
-    it('should handle page 0 (first page)', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handlePageChange(0)
-      })
-
-      expect(result.current.currPage).toBe(0)
-      expect(mockUpdateQuery).toHaveBeenCalledWith({ page: 1 })
-    })
-  })
-
-  describe('handleLimitChange', () => {
-    it('should update limit, reset page to 0, and call updateQuery', () => {
+    it('should update limit and reset page', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       act(() => {
@@ -336,358 +226,29 @@ describe('useDocumentsPageState', () => {
     })
   })
 
-  // Selection state
-  describe('selection state', () => {
-    it('should update selectedIds via setSelectedIds', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.setSelectedIds(['doc-1', 'doc-2'])
-      })
-
-      expect(result.current.selectedIds).toEqual(['doc-1', 'doc-2'])
-    })
-  })
-
-  // Polling state management
-  describe('updatePollingState', () => {
-    it('should not update timer when documentsRes is undefined', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.updatePollingState(undefined)
-      })
-
-      // timerCanRun remains true (initial value)
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should not update timer when documentsRes.data is undefined', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.updatePollingState({ data: undefined } as unknown as DocumentListResponse)
-      })
-
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should set timerCanRun to false when all documents are completed and status filter is all', () => {
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'completed' }),
-          createDocumentItem({ indexing_status: 'completed' }),
-        ] as DocumentListResponse['data'],
-        total: 2,
-      })
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      expect(result.current.timerCanRun).toBe(false)
-    })
-
-    it('should set timerCanRun to true when some documents are not completed', () => {
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'completed' }),
-          createDocumentItem({ indexing_status: 'indexing' }),
-        ] as DocumentListResponse['data'],
-        total: 2,
-      })
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should count paused documents as completed for polling purposes', () => {
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'paused' }),
-          createDocumentItem({ indexing_status: 'completed' }),
-        ] as DocumentListResponse['data'],
-        total: 2,
-      })
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      // All docs are "embedded" (completed, paused, error), so hasIncomplete = false
-      // statusFilter is 'all', so shouldForcePolling = false
-      expect(result.current.timerCanRun).toBe(false)
-    })
-
-    it('should count error documents as completed for polling purposes', () => {
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'error' }),
-          createDocumentItem({ indexing_status: 'completed' }),
-        ] as DocumentListResponse['data'],
-        total: 2,
-      })
-
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      expect(result.current.timerCanRun).toBe(false)
-    })
-
-    it('should force polling when status filter is a transient status (queuing)', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      // Set status filter to queuing
-      act(() => {
-        result.current.handleStatusFilterChange('queuing')
-      })
-
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'completed' }),
-        ] as DocumentListResponse['data'],
-        total: 1,
-      })
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      // shouldForcePolling = true (queuing is transient), hasIncomplete = false
-      // timerCanRun = true || false = true
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should force polling when status filter is indexing', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('indexing')
-      })
-
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'completed' }),
-        ] as DocumentListResponse['data'],
-        total: 1,
-      })
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should force polling when status filter is paused', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('paused')
-      })
-
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'paused' }),
-        ] as DocumentListResponse['data'],
-        total: 1,
-      })
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      expect(result.current.timerCanRun).toBe(true)
-    })
-
-    it('should not force polling when status filter is a non-transient status (error)', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('error')
-      })
-
-      const response = createDocumentListResponse({
-        data: [
-          createDocumentItem({ indexing_status: 'error' }),
-        ] as DocumentListResponse['data'],
-        total: 1,
-      })
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      // shouldForcePolling = false (error is not transient), hasIncomplete = false (error is embedded)
-      expect(result.current.timerCanRun).toBe(false)
-    })
-
-    it('should set timerCanRun to true when data is empty and filter is transient', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('indexing')
-      })
-
-      const response = createDocumentListResponse({ data: [] as DocumentListResponse['data'], total: 0 })
-
-      act(() => {
-        result.current.updatePollingState(response)
-      })
-
-      // shouldForcePolling = true (indexing is transient), hasIncomplete = false (0 !== 0 is false)
-      expect(result.current.timerCanRun).toBe(true)
-    })
-  })
-
-  // Page adjustment
-  describe('adjustPageForTotal', () => {
-    it('should not adjust page when documentsRes is undefined', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.adjustPageForTotal(undefined)
-      })
-
-      expect(result.current.currPage).toBe(0)
-    })
-
-    it('should not adjust page when currPage is within total pages', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      const response = createDocumentListResponse({ total: 20 })
-
-      act(() => {
-        result.current.adjustPageForTotal(response)
-      })
-
-      // currPage is 0, totalPages is 2, so no adjustment needed
-      expect(result.current.currPage).toBe(0)
-    })
-
-    it('should adjust page to last page when currPage exceeds total pages', () => {
-      mockQuery = { ...mockQuery, page: 6 }
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      // currPage should be 5 (page - 1)
-      expect(result.current.currPage).toBe(5)
-
-      const response = createDocumentListResponse({ total: 30 }) // 30/10 = 3 pages
-
-      act(() => {
-        result.current.adjustPageForTotal(response)
-      })
-
-      // currPage (5) + 1 > totalPages (3), so adjust to totalPages - 1 = 2
-      expect(result.current.currPage).toBe(2)
-      expect(mockUpdateQuery).toHaveBeenCalledWith({ page: 3 }) // handlePageChange passes newPage + 1
-    })
-
-    it('should adjust page to 0 when total is 0 and currPage > 0', () => {
-      mockQuery = { ...mockQuery, page: 3 }
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      const response = createDocumentListResponse({ total: 0 })
-
-      act(() => {
-        result.current.adjustPageForTotal(response)
-      })
-
-      // totalPages = 0, so adjust to max(0 - 1, 0) = 0
-      expect(result.current.currPage).toBe(0)
-      expect(mockUpdateQuery).toHaveBeenCalledWith({ page: 1 })
-    })
-
-    it('should not adjust page when currPage is 0 even if total is 0', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      const response = createDocumentListResponse({ total: 0 })
-
-      act(() => {
-        result.current.adjustPageForTotal(response)
-      })
-
-      // currPage is 0, condition is currPage > 0 so no adjustment
-      expect(mockUpdateQuery).not.toHaveBeenCalled()
-    })
-  })
-
-  // Normalized status filter value
-  describe('normalizedStatusFilterValue', () => {
-    it('should return all for default status', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      expect(result.current.normalizedStatusFilterValue).toBe('all')
-    })
-
-    it('should normalize enabled to available', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('enabled')
-      })
-
-      expect(result.current.normalizedStatusFilterValue).toBe('available')
-    })
-
-    it('should return non-aliased status as-is', () => {
-      const { result } = renderHook(() => useDocumentsPageState())
-
-      act(() => {
-        result.current.handleStatusFilterChange('error')
-      })
-
-      expect(result.current.normalizedStatusFilterValue).toBe('error')
-    })
-  })
-
   // Return value shape
   describe('return value', () => {
     it('should return all expected properties', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
-      // Search state
       expect(result.current).toHaveProperty('inputValue')
       expect(result.current).toHaveProperty('debouncedSearchValue')
       expect(result.current).toHaveProperty('handleInputChange')
-
-      // Filter & sort state
       expect(result.current).toHaveProperty('statusFilterValue')
       expect(result.current).toHaveProperty('sortValue')
       expect(result.current).toHaveProperty('normalizedStatusFilterValue')
       expect(result.current).toHaveProperty('handleStatusFilterChange')
       expect(result.current).toHaveProperty('handleStatusFilterClear')
       expect(result.current).toHaveProperty('handleSortChange')
-
-      // Pagination state
       expect(result.current).toHaveProperty('currPage')
       expect(result.current).toHaveProperty('limit')
       expect(result.current).toHaveProperty('handlePageChange')
       expect(result.current).toHaveProperty('handleLimitChange')
-
-      // Selection state
       expect(result.current).toHaveProperty('selectedIds')
       expect(result.current).toHaveProperty('setSelectedIds')
-
-      // Polling state
-      expect(result.current).toHaveProperty('timerCanRun')
-      expect(result.current).toHaveProperty('updatePollingState')
-      expect(result.current).toHaveProperty('adjustPageForTotal')
     })
 
-    it('should have function types for all handlers', () => {
+    it('should expose function handlers', () => {
       const { result } = renderHook(() => useDocumentsPageState())
 
       expect(typeof result.current.handleInputChange).toBe('function')
@@ -697,8 +258,6 @@ describe('useDocumentsPageState', () => {
       expect(typeof result.current.handlePageChange).toBe('function')
       expect(typeof result.current.handleLimitChange).toBe('function')
       expect(typeof result.current.setSelectedIds).toBe('function')
-      expect(typeof result.current.updatePollingState).toBe('function')
-      expect(typeof result.current.adjustPageForTotal).toBe('function')
     })
   })
 })

--- a/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
@@ -59,6 +59,7 @@ export const documentListParsers = {
 
 export type DocumentListQuery = inferParserType<typeof documentListParsers>
 
+// Search input updates can be frequent; throttle URL writes to reduce history/api churn.
 const KEYWORD_URL_UPDATE_THROTTLE = throttle(300)
 
 export function useDocumentListQueryState() {
@@ -77,6 +78,8 @@ export function useDocumentListQueryState() {
     if ('keyword' in patch && typeof patch.keyword === 'string' && patch.keyword.trim() === '')
       patch.keyword = ''
 
+    // If keyword is part of this patch (even with page reset), treat it as a search update:
+    // use replace to avoid creating a history entry per input-driven change.
     if ('keyword' in patch) {
       setQuery(patch, {
         history: 'replace',

--- a/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
@@ -89,7 +89,7 @@ export function useDocumentListQueryState() {
   }, [setQuery])
 
   const resetQuery = useCallback(() => {
-    setQuery(null)
+    setQuery(null, { history: 'replace' })
   }, [setQuery])
 
   return useMemo(() => ({

--- a/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
@@ -1,3 +1,4 @@
+import type { inferParserType } from 'nuqs'
 import type { SortType } from '@/service/datasets'
 import { createParser, parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useMemo } from 'react'
@@ -18,14 +19,6 @@ const sanitizePageValue = (value: number): number => {
 
 const sanitizeLimitValue = (value: number): number => {
   return Number.isInteger(value) && value > 0 && value <= 100 ? value : 10
-}
-
-export type DocumentListQuery = {
-  page: number
-  limit: number
-  keyword: string
-  status: string
-  sort: SortType
 }
 
 const parseAsPage = createParser<number>({
@@ -63,6 +56,8 @@ export const documentListParsers = {
   status: parseAsDocStatus,
   sort: parseAsDocSort,
 }
+
+export type DocumentListQuery = inferParserType<typeof documentListParsers>
 
 function useDocumentListQueryState() {
   const [query, setQuery] = useQueryStates(documentListParsers, {

--- a/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
@@ -89,7 +89,7 @@ export function useDocumentListQueryState() {
   }, [setQuery])
 
   const resetQuery = useCallback(() => {
-    setQuery(null, { history: 'replace' })
+    setQuery(null)
   }, [setQuery])
 
   return useMemo(() => ({

--- a/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-document-list-query-state.ts
@@ -61,7 +61,7 @@ export type DocumentListQuery = inferParserType<typeof documentListParsers>
 
 const KEYWORD_URL_UPDATE_THROTTLE = throttle(300)
 
-function useDocumentListQueryState() {
+export function useDocumentListQueryState() {
   const [query, setQuery] = useQueryStates(documentListParsers)
 
   const updateQuery = useCallback((updates: Partial<DocumentListQuery>) => {
@@ -98,5 +98,3 @@ function useDocumentListQueryState() {
     resetQuery,
   }), [query, updateQuery, resetQuery])
 }
-
-export default useDocumentListQueryState

--- a/web/app/components/datasets/documents/hooks/use-documents-page-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-documents-page-state.ts
@@ -1,4 +1,3 @@
-import type { DocumentListResponse } from '@/models/datasets'
 import type { SortType } from '@/service/datasets'
 import { useDebounce } from 'ahooks'
 import { useCallback, useState } from 'react'
@@ -19,7 +18,6 @@ export function useDocumentsPageState() {
   const limit = query.limit
 
   const [selectedIds, setSelectedIds] = useState<string[]>([])
-  const [timerCanRun, setTimerCanRun] = useState(true)
 
   const handlePageChange = useCallback((newPage: number) => {
     updateQuery({ page: newPage + 1 })
@@ -55,34 +53,6 @@ export function useDocumentsPageState() {
     updateQuery({ sort: next, page: 1 })
   }, [sortValue, updateQuery])
 
-  const updatePollingState = useCallback((documentsRes: DocumentListResponse | undefined) => {
-    if (!documentsRes?.data)
-      return
-
-    let completedNum = 0
-    documentsRes.data.forEach((documentItem) => {
-      const { indexing_status } = documentItem
-      const isEmbedded = indexing_status === 'completed' || indexing_status === 'paused' || indexing_status === 'error'
-      if (isEmbedded)
-        completedNum++
-    })
-
-    const hasIncompleteDocuments = completedNum !== documentsRes.data.length
-    const transientStatuses = ['queuing', 'indexing', 'paused']
-    const shouldForcePolling = normalizedStatusFilterValue === 'all'
-      ? false
-      : transientStatuses.includes(normalizedStatusFilterValue)
-    setTimerCanRun(shouldForcePolling || hasIncompleteDocuments)
-  }, [normalizedStatusFilterValue])
-
-  const adjustPageForTotal = useCallback((documentsRes: DocumentListResponse | undefined) => {
-    if (!documentsRes)
-      return
-    const totalPages = Math.ceil(documentsRes.total / limit)
-    if (currPage > 0 && currPage + 1 > totalPages)
-      handlePageChange(totalPages > 0 ? totalPages - 1 : 0)
-  }, [limit, currPage, handlePageChange])
-
   return {
     inputValue,
     debouncedSearchValue,
@@ -102,9 +72,5 @@ export function useDocumentsPageState() {
 
     selectedIds,
     setSelectedIds,
-
-    timerCanRun,
-    updatePollingState,
-    adjustPageForTotal,
   }
 }

--- a/web/app/components/datasets/documents/hooks/use-documents-page-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-documents-page-state.ts
@@ -3,7 +3,7 @@ import type { SortType } from '@/service/datasets'
 import { useDebounce, useDebounceFn } from 'ahooks'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { normalizeStatusForQuery, sanitizeStatusValue } from '../status-filter'
-import useDocumentListQueryState from './use-document-list-query-state'
+import { useDocumentListQueryState } from './use-document-list-query-state'
 
 /**
  * Custom hook to manage documents page state including:

--- a/web/app/components/datasets/documents/hooks/use-documents-page-state.ts
+++ b/web/app/components/datasets/documents/hooks/use-documents-page-state.ts
@@ -1,138 +1,60 @@
 import type { DocumentListResponse } from '@/models/datasets'
 import type { SortType } from '@/service/datasets'
-import { useDebounce, useDebounceFn } from 'ahooks'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useDebounce } from 'ahooks'
+import { useCallback, useState } from 'react'
 import { normalizeStatusForQuery, sanitizeStatusValue } from '../status-filter'
 import { useDocumentListQueryState } from './use-document-list-query-state'
 
-/**
- * Custom hook to manage documents page state including:
- * - Search state (input value, debounced search value)
- * - Filter state (status filter, sort value)
- * - Pagination state (current page, limit)
- * - Selection state (selected document ids)
- * - Polling state (timer control for auto-refresh)
- */
 export function useDocumentsPageState() {
   const { query, updateQuery } = useDocumentListQueryState()
 
-  // Search state
-  const [inputValue, setInputValue] = useState<string>('')
-  const [searchValue, setSearchValue] = useState<string>('')
-  const debouncedSearchValue = useDebounce(searchValue, { wait: 500 })
+  const inputValue = query.keyword
+  const debouncedSearchValue = useDebounce(query.keyword, { wait: 500 })
 
-  // Filter & sort state
-  const [statusFilterValue, setStatusFilterValue] = useState<string>(() => sanitizeStatusValue(query.status))
-  const [sortValue, setSortValue] = useState<SortType>(query.sort)
-  const normalizedStatusFilterValue = useMemo(
-    () => normalizeStatusForQuery(statusFilterValue),
-    [statusFilterValue],
-  )
+  const statusFilterValue = sanitizeStatusValue(query.status)
+  const sortValue = query.sort
+  const normalizedStatusFilterValue = normalizeStatusForQuery(statusFilterValue)
 
-  // Pagination state
-  const [currPage, setCurrPage] = useState<number>(query.page - 1)
-  const [limit, setLimit] = useState<number>(query.limit)
+  const currPage = query.page - 1
+  const limit = query.limit
 
-  // Selection state
   const [selectedIds, setSelectedIds] = useState<string[]>([])
-
-  // Polling state
   const [timerCanRun, setTimerCanRun] = useState(true)
 
-  // Initialize search value from URL on mount
-  useEffect(() => {
-    if (query.keyword) {
-      setInputValue(query.keyword)
-      setSearchValue(query.keyword)
-    }
-  }, []) // Only run on mount
-
-  // Sync local state with URL query changes
-  useEffect(() => {
-    setCurrPage(query.page - 1)
-    setLimit(query.limit)
-    if (query.keyword !== searchValue) {
-      setInputValue(query.keyword)
-      setSearchValue(query.keyword)
-    }
-    setStatusFilterValue((prev) => {
-      const nextValue = sanitizeStatusValue(query.status)
-      return prev === nextValue ? prev : nextValue
-    })
-    setSortValue(query.sort)
-  }, [query])
-
-  // Update URL when search changes
-  useEffect(() => {
-    if (debouncedSearchValue !== query.keyword) {
-      setCurrPage(0)
-      updateQuery({ keyword: debouncedSearchValue, page: 1 })
-    }
-  }, [debouncedSearchValue, query.keyword, updateQuery])
-
-  // Clear selection when search changes
-  useEffect(() => {
-    if (searchValue !== query.keyword)
-      setSelectedIds([])
-  }, [searchValue, query.keyword])
-
-  // Clear selection when status filter changes
-  useEffect(() => {
-    setSelectedIds([])
-  }, [normalizedStatusFilterValue])
-
-  // Page change handler
   const handlePageChange = useCallback((newPage: number) => {
-    setCurrPage(newPage)
     updateQuery({ page: newPage + 1 })
   }, [updateQuery])
 
-  // Limit change handler
   const handleLimitChange = useCallback((newLimit: number) => {
-    setLimit(newLimit)
-    setCurrPage(0)
     updateQuery({ limit: newLimit, page: 1 })
   }, [updateQuery])
 
-  // Debounced search handler
-  const { run: handleSearch } = useDebounceFn(() => {
-    setSearchValue(inputValue)
-  }, { wait: 500 })
-
-  // Input change handler
   const handleInputChange = useCallback((value: string) => {
-    setInputValue(value)
-    handleSearch()
-  }, [handleSearch])
+    if (value !== query.keyword)
+      setSelectedIds([])
+    updateQuery({ keyword: value, page: 1 })
+  }, [query.keyword, updateQuery])
 
-  // Status filter change handler
   const handleStatusFilterChange = useCallback((value: string) => {
     const selectedValue = sanitizeStatusValue(value)
-    setStatusFilterValue(selectedValue)
-    setCurrPage(0)
+    setSelectedIds([])
     updateQuery({ status: selectedValue, page: 1 })
   }, [updateQuery])
 
-  // Status filter clear handler
   const handleStatusFilterClear = useCallback(() => {
     if (statusFilterValue === 'all')
       return
-    setStatusFilterValue('all')
-    setCurrPage(0)
+    setSelectedIds([])
     updateQuery({ status: 'all', page: 1 })
   }, [statusFilterValue, updateQuery])
 
-  // Sort change handler
   const handleSortChange = useCallback((value: string) => {
     const next = value as SortType
     if (next === sortValue)
       return
-    setSortValue(next)
-    setCurrPage(0)
     updateQuery({ sort: next, page: 1 })
   }, [sortValue, updateQuery])
 
-  // Update polling state based on documents response
   const updatePollingState = useCallback((documentsRes: DocumentListResponse | undefined) => {
     if (!documentsRes?.data)
       return
@@ -153,7 +75,6 @@ export function useDocumentsPageState() {
     setTimerCanRun(shouldForcePolling || hasIncompleteDocuments)
   }, [normalizedStatusFilterValue])
 
-  // Adjust page when total pages change
   const adjustPageForTotal = useCallback((documentsRes: DocumentListResponse | undefined) => {
     if (!documentsRes)
       return
@@ -163,13 +84,10 @@ export function useDocumentsPageState() {
   }, [limit, currPage, handlePageChange])
 
   return {
-    // Search state
     inputValue,
-    searchValue,
     debouncedSearchValue,
     handleInputChange,
 
-    // Filter & sort state
     statusFilterValue,
     sortValue,
     normalizedStatusFilterValue,
@@ -177,21 +95,16 @@ export function useDocumentsPageState() {
     handleStatusFilterClear,
     handleSortChange,
 
-    // Pagination state
     currPage,
     limit,
     handlePageChange,
     handleLimitChange,
 
-    // Selection state
     selectedIds,
     setSelectedIds,
 
-    // Polling state
     timerCanRun,
     updatePollingState,
     adjustPageForTotal,
   }
 }
-
-export default useDocumentsPageState

--- a/web/app/components/datasets/documents/index.tsx
+++ b/web/app/components/datasets/documents/index.tsx
@@ -13,7 +13,7 @@ import useEditDocumentMetadata from '../metadata/hooks/use-edit-dataset-metadata
 import DocumentsHeader from './components/documents-header'
 import EmptyElement from './components/empty-element'
 import List from './components/list'
-import useDocumentsPageState from './hooks/use-documents-page-state'
+import { useDocumentsPageState } from './hooks/use-documents-page-state'
 
 type IDocumentsProps = {
   datasetId: string

--- a/web/app/components/plugins/marketplace/hydration-server.tsx
+++ b/web/app/components/plugins/marketplace/hydration-server.tsx
@@ -1,4 +1,5 @@
-import type { SearchParams } from 'nuqs'
+import type { SearchParams } from 'nuqs/server'
+import type { MarketplaceSearchParams } from './search-params'
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { createLoader } from 'nuqs/server'
 import { getQueryClientServer } from '@/context/query-client-server'
@@ -14,7 +15,7 @@ async function getDehydratedState(searchParams?: Promise<SearchParams>) {
     return
   }
   const loadSearchParams = createLoader(marketplaceSearchParamsParsers)
-  const params = await loadSearchParams(searchParams)
+  const params: MarketplaceSearchParams = await loadSearchParams(searchParams)
 
   if (!PLUGIN_CATEGORY_WITH_COLLECTIONS.has(params.category)) {
     return

--- a/web/app/components/plugins/marketplace/search-params.ts
+++ b/web/app/components/plugins/marketplace/search-params.ts
@@ -1,3 +1,4 @@
+import type { inferParserType } from 'nuqs/server'
 import type { ActivePluginType } from './constants'
 import { parseAsArrayOf, parseAsString, parseAsStringEnum } from 'nuqs/server'
 import { PLUGIN_TYPE_SEARCH_MAP } from './constants'
@@ -7,3 +8,5 @@ export const marketplaceSearchParamsParsers = {
   q: parseAsString.withDefault('').withOptions({ history: 'replace' }),
   tags: parseAsArrayOf(parseAsString).withDefault([]).withOptions({ history: 'replace' }),
 }
+
+export type MarketplaceSearchParams = inferParserType<typeof marketplaceSearchParamsParsers>

--- a/web/app/components/plugins/plugin-page/__tests__/context.spec.tsx
+++ b/web/app/components/plugins/plugin-page/__tests__/context.spec.tsx
@@ -7,6 +7,9 @@ import { PluginPageContext, PluginPageContextProvider, usePluginPageContext } fr
 
 // Mock dependencies
 vi.mock('nuqs', () => ({
+  parseAsStringEnum: vi.fn(() => ({
+    withDefault: vi.fn(() => ({})),
+  })),
   useQueryState: vi.fn(() => ['plugins', vi.fn()]),
 }))
 

--- a/web/app/components/plugins/plugin-page/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/__tests__/index.spec.tsx
@@ -80,6 +80,9 @@ vi.mock('@/service/use-plugins', () => ({
 }))
 
 vi.mock('nuqs', () => ({
+  parseAsStringEnum: vi.fn(() => ({
+    withDefault: vi.fn(() => ({})),
+  })),
   useQueryState: vi.fn(() => ['plugins', vi.fn()]),
 }))
 

--- a/web/app/components/plugins/plugin-page/index.tsx
+++ b/web/app/components/plugins/plugin-page/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { Dependency, PluginDeclaration, PluginManifestInMarket } from '../types'
+import type { PluginPageTab } from './context'
 import {
   RiBookOpenLine,
   RiDragDropLine,
@@ -36,6 +37,16 @@ import InstallPluginDropdown from './install-plugin-dropdown'
 import PluginTasks from './plugin-tasks'
 import useReferenceSetting from './use-reference-setting'
 import { useUploader } from './use-uploader'
+
+const pluginPageTabSet = new Set<string>([
+  PLUGIN_PAGE_TABS_MAP.plugins,
+  PLUGIN_PAGE_TABS_MAP.marketplace,
+  ...Object.values(PLUGIN_TYPE_SEARCH_MAP),
+])
+
+const isPluginPageTab = (value: string): value is PluginPageTab => {
+  return pluginPageTabSet.has(value)
+}
 
 export type PluginPageProps = {
   plugins: React.ReactNode
@@ -154,7 +165,10 @@ const PluginPage = ({
           <div className="flex-1">
             <TabSlider
               value={isPluginsTab ? PLUGIN_PAGE_TABS_MAP.plugins : PLUGIN_PAGE_TABS_MAP.marketplace}
-              onChange={setActiveTab}
+              onChange={(nextTab) => {
+                if (isPluginPageTab(nextTab))
+                  setActiveTab(nextTab)
+              }}
               options={options}
             />
           </div>

--- a/web/app/components/tools/provider-list.tsx
+++ b/web/app/components/tools/provider-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { Collection } from './types'
-import { useQueryState } from 'nuqs'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
@@ -23,6 +23,17 @@ import { useMarketplace } from './marketplace/hooks'
 import MCPList from './mcp'
 import { getToolType } from './utils'
 
+const TOOL_PROVIDER_CATEGORY_VALUES = ['builtin', 'api', 'workflow', 'mcp'] as const
+type ToolProviderCategory = typeof TOOL_PROVIDER_CATEGORY_VALUES[number]
+const toolProviderCategorySet = new Set<string>(TOOL_PROVIDER_CATEGORY_VALUES)
+
+const isToolProviderCategory = (value: string): value is ToolProviderCategory => {
+  return toolProviderCategorySet.has(value)
+}
+
+const parseAsToolProviderCategory = parseAsStringLiteral(TOOL_PROVIDER_CATEGORY_VALUES)
+  .withDefault('builtin')
+
 const ProviderList = () => {
   // const searchParams = useSearchParams()
   // searchParams.get('category') === 'workflow'
@@ -31,9 +42,7 @@ const ProviderList = () => {
   const { enable_marketplace } = useGlobalPublicStore(s => s.systemFeatures)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const [activeTab, setActiveTab] = useQueryState('category', {
-    defaultValue: 'builtin',
-  })
+  const [activeTab, setActiveTab] = useQueryState('category', parseAsToolProviderCategory)
   const options = [
     { value: 'builtin', text: t('type.builtIn', { ns: 'tools' }) },
     { value: 'api', text: t('type.custom', { ns: 'tools' }) },
@@ -124,6 +133,8 @@ const ProviderList = () => {
             <TabSliderNew
               value={activeTab}
               onChange={(state) => {
+                if (!isToolProviderCategory(state))
+                  return
                 setActiveTab(state)
                 if (state !== activeTab)
                   setCurrentProviderId(undefined)

--- a/web/context/modal-context.tsx
+++ b/web/context/modal-context.tsx
@@ -158,7 +158,7 @@ export const ModalContextProvider = ({
 }: ModalContextProviderProps) => {
   // Use nuqs hooks for URL-based modal state management
   const [showPricingModal, setPricingModalOpen] = usePricingModal()
-  const [urlAccountModalState, setUrlAccountModalState] = useAccountSettingModal<AccountSettingTab>()
+  const [urlAccountModalState, setUrlAccountModalState] = useAccountSettingModal()
 
   const accountSettingCallbacksRef = useRef<Omit<ModalState<AccountSettingTab>, 'payload'> | null>(null)
   const accountSettingTab = urlAccountModalState.isOpen

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -3696,11 +3696,6 @@
       "count": 3
     }
   },
-  "app/components/datasets/documents/hooks/use-documents-page-state.ts": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 12
-    }
-  },
   "app/components/datasets/documents/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 2

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -3696,11 +3696,6 @@
       "count": 3
     }
   },
-  "app/components/datasets/documents/index.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
-    }
-  },
   "app/components/datasets/external-api/external-api-modal/Form.tsx": {
     "tailwindcss/enforce-consistent-class-order": {
       "count": 2

--- a/web/hooks/use-query-params.ts
+++ b/web/hooks/use-query-params.ts
@@ -13,14 +13,19 @@
  * - Use shallow routing to avoid unnecessary re-renders
  */
 
+import type { AccountSettingTab } from '@/app/components/header/account-setting/constants'
 import {
   createParser,
-  parseAsString,
+  parseAsStringEnum,
+  parseAsStringLiteral,
   useQueryState,
   useQueryStates,
 } from 'nuqs'
 import { useCallback } from 'react'
-import { ACCOUNT_SETTING_MODAL_ACTION } from '@/app/components/header/account-setting/constants'
+import {
+  ACCOUNT_SETTING_MODAL_ACTION,
+  ACCOUNT_SETTING_TAB,
+} from '@/app/components/header/account-setting/constants'
 import { isServer } from '@/utils/client'
 
 /**
@@ -52,6 +57,10 @@ export function usePricingModal() {
   )
 }
 
+const accountSettingTabValues = Object.values(ACCOUNT_SETTING_TAB) as AccountSettingTab[]
+const parseAsAccountSettingAction = parseAsStringLiteral([ACCOUNT_SETTING_MODAL_ACTION] as const)
+const parseAsAccountSettingTab = parseAsStringEnum<AccountSettingTab>(accountSettingTabValues)
+
 /**
  * Hook to manage account setting modal state via URL
  * @returns [state, setState] - Object with isOpen + payload (tab) and setter
@@ -61,11 +70,11 @@ export function usePricingModal() {
  * setAccountModalState({ payload: 'billing' }) // Sets ?action=showSettings&tab=billing
  * setAccountModalState(null) // Removes both params
  */
-export function useAccountSettingModal<T extends string = string>() {
+export function useAccountSettingModal() {
   const [accountState, setAccountState] = useQueryStates(
     {
-      action: parseAsString,
-      tab: parseAsString,
+      action: parseAsAccountSettingAction,
+      tab: parseAsAccountSettingTab,
     },
     {
       history: 'replace',
@@ -73,7 +82,7 @@ export function useAccountSettingModal<T extends string = string>() {
   )
 
   const setState = useCallback(
-    (state: { payload: T } | null) => {
+    (state: { payload: AccountSettingTab } | null) => {
       if (!state) {
         setAccountState({ action: null, tab: null }, { history: 'replace' })
         return
@@ -88,7 +97,7 @@ export function useAccountSettingModal<T extends string = string>() {
   )
 
   const isOpen = accountState.action === ACCOUNT_SETTING_MODAL_ACTION
-  const currentTab = (isOpen ? accountState.tab : null) as T | null
+  const currentTab = isOpen ? accountState.tab : null
 
   return [{ isOpen, payload: currentTab }, setState] as const
 }

--- a/web/service/knowledge/use-document.ts
+++ b/web/service/knowledge/use-document.ts
@@ -1,3 +1,4 @@
+import type { UseQueryOptions } from '@tanstack/react-query'
 import type { DocumentDownloadResponse, DocumentDownloadZipRequest, MetadataType, SortType } from '../datasets'
 import type { CommonResponse } from '@/models/common'
 import type { DocumentDetailResponse, DocumentListResponse, UpdateDocumentBatchParams } from '@/models/datasets'
@@ -14,6 +15,8 @@ import { useInvalid } from '../use-base'
 const NAME_SPACE = 'knowledge/document'
 
 export const useDocumentListKey = [NAME_SPACE, 'documentList']
+type DocumentListRefetchInterval = UseQueryOptions<DocumentListResponse>['refetchInterval']
+
 export const useDocumentList = (payload: {
   datasetId: string
   query: {
@@ -23,7 +26,7 @@ export const useDocumentList = (payload: {
     sort?: SortType
     status?: string
   }
-  refetchInterval?: number | false
+  refetchInterval?: DocumentListRefetchInterval
 }) => {
   const { query, datasetId, refetchInterval } = payload
   const { keyword, page, limit, sort, status } = query


### PR DESCRIPTION
## Stacked PR Context
- **Base branch**: `refactor/datasets-document-list-nuqs-migration` (PR #32339, base `main`)
- **What the base branch already changed**:
  - migrated dataset document-list URL state to `nuqs`
  - switched document detail back-navigation to `useSearchParams`
  - introduced shared `NuqsTestingAdapter` test helpers and updated related tests/docs

This PR only contains incremental hardening on top of the base branch.

## Summary
- replace loosely typed string parsers with constrained `nuqs` parsers for URL-state fields with finite domains:
  - apps list category
  - tools provider category
  - plugin page tab
  - account setting modal action/tab
- keep runtime callbacks safe where UI components emit raw strings (`TabSlider`, `TabSliderNew`) by adding explicit guards
- infer document list query type from parser map instead of manually maintaining `DocumentListQuery`
- infer marketplace search params type from parser map and use it in server hydration loader path

## Why
- reduce type drift between parser behavior and TypeScript declarations
- make constrained query params self-documenting and compile-time enforceable
- keep stacked changes easy to review by separating base migration from incremental parser/type tightening

## Validation
- pre-commit checks passed (`eslint --fix`, `type-check:tsgo`, unit-test check)
- `pnpm --dir web test hooks/use-query-params.spec.tsx app/components/tools/__tests__/provider-list.spec.tsx app/components/apps/__tests__/list.spec.tsx app/components/plugins/plugin-page/__tests__/context.spec.tsx app/components/plugins/plugin-page/__tests__/index.spec.tsx`
- `pnpm --dir web test app/components/datasets/documents/hooks/__tests__/use-document-list-query-state.spec.tsx app/components/datasets/documents/detail/__tests__/index.spec.tsx __tests__/datasets/document-management.test.tsx`
- `pnpm --dir web test app/components/plugins/marketplace/__tests__/atoms.spec.tsx app/components/plugins/marketplace/__tests__/state.spec.tsx app/components/plugins/marketplace/__tests__/plugin-type-switch.spec.tsx app/components/plugins/marketplace/__tests__/sticky-search-and-switch-wrapper.spec.tsx`
- `pnpm --dir web type-check:tsgo`
