### PR TITLE
fix(web): avoid invalid DOM nesting when inline images appear in paragraphs

### DIFF
--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -1,15 +1,31 @@
 /**
  * @fileoverview Paragraph component for rendering <p> tags in Markdown.
  * Extracted from the main markdown renderer for modularity.
- * Handles special rendering for paragraphs that directly contain an image.
+ * Handles special rendering for paragraphs that contain images.
+ *
+ * When a paragraph's first child is an image, it renders as a dedicated
+ * image block with ImageGallery. When images appear elsewhere among the
+ * children, it renders as a <div> to avoid invalid HTML nesting
+ * (<div> inside <p>), which causes React hydration warnings.
  */
 import * as React from 'react'
 import ImageGallery from '@/app/components/base/image-gallery'
 
+/**
+ * Check whether any AST child node is an img element.
+ */
+function hasImageChild(children: any[]): boolean {
+  return children.some(
+    child => child && 'tagName' in child && child.tagName === 'img',
+  )
+}
+
 const Paragraph = (paragraph: any) => {
   const { node }: any = paragraph
   const children_node = node.children
-  if (children_node && children_node[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
+
+  // First child is an image → render as dedicated image block
+  if (children_node?.[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
     return (
       <div className="markdown-img-wrapper">
         <ImageGallery srcs={[children_node[0].properties.src]} />
@@ -21,6 +37,12 @@ const Paragraph = (paragraph: any) => {
       </div>
     )
   }
+
+  // If any child is an image, use <div> instead of <p> to avoid
+  // invalid DOM nesting (block-level <div> inside <p>).
+  if (children_node && hasImageChild(children_node))
+    return <div className="markdown-paragraph">{paragraph.children}</div>
+
   return <p>{paragraph.children}</p>
 }
 

--- a/web/app/components/base/markdown-blocks/plugin-paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/plugin-paragraph.tsx
@@ -4,7 +4,12 @@ import { useEffect, useMemo, useState } from 'react'
 /**
  * @fileoverview Paragraph component for rendering <p> tags in Markdown.
  * Extracted from the main markdown renderer for modularity.
- * Handles special rendering for paragraphs that directly contain an image.
+ * Handles special rendering for paragraphs that contain images.
+ *
+ * When a paragraph's first child is an image, it renders as a dedicated
+ * image block with ImageGallery. When images appear elsewhere among the
+ * children, it renders as a <div> to avoid invalid HTML nesting
+ * (<div> inside <p>), which causes React hydration warnings.
  */
 import ImageGallery from '@/app/components/base/image-gallery'
 import { usePluginReadmeAsset } from '@/service/use-plugins'
@@ -54,6 +59,11 @@ export const PluginParagraph: React.FC<PluginParagraphProps> = ({ pluginInfo, no
     return ''
   }, [blobUrl, imageSrc, isImageParagraph, pluginId])
 
+  // Check if any child (not just the first) is an image
+  const hasNonFirstImage = !isImageParagraph && childrenNode?.some(
+    (child: any) => child && 'tagName' in child && child.tagName === 'img',
+  )
+
   if (isImageParagraph) {
     const remainingChildren = Array.isArray(children) && children.length > 1 ? children.slice(1) : undefined
 
@@ -66,5 +76,10 @@ export const PluginParagraph: React.FC<PluginParagraphProps> = ({ pluginInfo, no
       </div>
     )
   }
+  // If any child is an image, use <div> instead of <p> to avoid
+  // invalid DOM nesting (block-level <div> inside <p>).
+  if (hasNonFirstImage)
+    return <div className="markdown-paragraph">{children}</div>
+
   return <p data-testid="standard-paragraph">{children}</p>
 }


### PR DESCRIPTION
## Summary
When a Markdown paragraph contains an inline image that is **not** the first child (e.g. `Text before ![img](url) text after`), the `Img` component renders a block-level `<div>` wrapper. This was placed inside a `<p>` tag, producing invalid HTML and triggering React/Next.js hydration warnings:

> `In HTML, <div> cannot be a descendant of <p>. This will cause a hydration error.`

## Changes
- Updated `Paragraph` component (`web/app/components/base/markdown-blocks/paragraph.tsx`) to detect when **any** child node (not just the first) is an image element.
- When a non-leading image is found, renders as `<div class="markdown-paragraph">` instead of `<p>`, keeping the DOM valid.
- The existing first-child-is-image logic (dedicated `ImageGallery` block) is unchanged.

## Testing
- Rendered Markdown with inline images in various positions within paragraphs
- Confirmed no hydration warning in browser console
- Confirmed existing image-as-first-child rendering is unaffected

Closes #32362