### PR TITLE
fix: clear stale provider credentials during plugin uninstall

### DIFF
--- a/api/services/plugin/plugin_service.py
+++ b/api/services/plugin/plugin_service.py
@@ -519,7 +519,7 @@ class PluginService:
         if not plugin:
             return manager.uninstall(tenant_id, plugin_installation_id)
 
-        with Session(db.engine).begin() as session:
+        with Session(db.engine) as session, session.begin():
             plugin_id = plugin.plugin_id
             logger.info("Deleting credentials for plugin: %s", plugin_id)
 

--- a/api/services/plugin/plugin_service.py
+++ b/api/services/plugin/plugin_service.py
@@ -543,11 +543,7 @@ class PluginService:
                 )
             ).all()
 
-            session.execute(
-                update(Provider)
-                .where(Provider.id.in_(provider_ids))
-                .values(credential_id=None)
-            )
+            session.execute(update(Provider).where(Provider.id.in_(provider_ids)).values(credential_id=None))
 
             for provider_id in provider_ids:
                 ProviderCredentialsCache(

--- a/api/services/plugin/plugin_service.py
+++ b/api/services/plugin/plugin_service.py
@@ -524,7 +524,7 @@ class PluginService:
             logger.info("Deleting credentials for plugin: %s", plugin_id)
 
             # Delete provider credentials that match this plugin
-            credential_ids: list[str] = session.scalars(
+            credential_ids = session.scalars(
                 select(ProviderCredential.id).where(
                     ProviderCredential.tenant_id == tenant_id,
                     ProviderCredential.provider_name.like(f"{plugin_id}/%"),
@@ -535,7 +535,7 @@ class PluginService:
                 logger.info("No credentials found for plugin: %s", plugin_id)
                 return manager.uninstall(tenant_id, plugin_installation_id)
 
-            provider_ids: list[str] = session.scalars(
+            provider_ids = session.scalars(
                 select(Provider.id).where(
                     Provider.tenant_id == tenant_id,
                     Provider.provider_name.like(f"{plugin_id}/%"),


### PR DESCRIPTION
## Summary

This change hardens plugin uninstall credential cleanup to prevent stale provider state after plugin removal.

- Removes the broad exception swallowing around cleanup in `PluginService.uninstall`.
- Switches plugin uninstall cleanup to use an explicit SQLAlchemy `Session` transaction context.
- Collects credentials by plugin-scoped provider namespace and removes all matching rows in bulk iteration.
- Resets affected `provider.credential_id` values and clears the corresponding `ProviderCredentialsCache` entries.
- Returns early to the plugin uninstall flow when target plugin is not found, keeping behavior unchanged.

Fixes #32378

## Screenshots

| Before | After |
|--------|-------|
| Plugin uninstall could leave `provider.credential_id` pointing to non-existing records, causing inconsistent API responses. | Plugin uninstall cleanup removes stale provider credential references and clears provider cache for affected records. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
