### PR TITLE
fix: correct misleading retry count in error message

### DIFF
--- a/api/core/workflow/nodes/http_request/executor.py
+++ b/api/core/workflow/nodes/http_request/executor.py
@@ -366,7 +366,9 @@ class Executor:
                 **request_args,
                 max_retries=self.max_retries,
             )
-        except (self._http_client.max_retries_exceeded_error, self._http_client.request_error) as e:
+        except self._http_client.max_retries_exceeded_error as e:
+            raise HttpRequestNodeError(f"Reached maximum retries for URL {self.url}") from e
+        except self._http_client.request_error as e:
             raise HttpRequestNodeError(str(e)) from e
         return response
 


### PR DESCRIPTION
## Summary

This is an alternative solution to PR #31075 for Issue #31071.
As I mentioned in [my comment](https://github.com/langgenius/dify/pull/31075#issuecomment-3757432118), while #31075 resolves the error message issue, it also has the side effect of excessively increasing the actual number of retries.

Since there has been no response from the author or maintainers on #31075 for a month after my comment, I’m submitting this PR as a follow-up.

In this PR, I’m focusing solely on correcting the error message.
When an error indicating that the retry limit has been exceeded is returned from the SSRF Proxy client, I re-throw a new error message so that the confusing retry count included in the original message is not propagated up the stack.

Closes #31071

## Screenshots

| Before | After |
|--------|-------|
| <img width="847" height="270" alt="image" src="https://github.com/user-attachments/assets/164722a2-3414-4302-b11f-df8fd65487f4" /> | <img width="827" height="298" alt="image" src="https://github.com/user-attachments/assets/3f68b1c5-13f4-44bb-89bb-570e8d328dc9" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
