### PR TITLE
fix: avoid invalid DOM nesting when inline image is not first paragraph child

### DIFF
--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -6,13 +6,36 @@
 import * as React from 'react'
 import ImageGallery from '@/app/components/base/image-gallery'
 
-const Paragraph = (paragraph: any) => {
-  const { node }: any = paragraph
+type MdastNode = {
+  tagName?: string
+  children?: MdastNode[]
+  properties?: Record<string, unknown>
+}
+
+type ParagraphProps = {
+  node: MdastNode
+  children: React.ReactNode[]
+}
+
+const hasImageChild = (children?: MdastNode[]): boolean => {
+  if (!children)
+    return false
+  return children.some((child: MdastNode) => {
+    if (child.tagName === 'img')
+      return true
+    if (child.children)
+      return hasImageChild(child.children)
+    return false
+  })
+}
+
+const Paragraph = (paragraph: ParagraphProps) => {
+  const { node } = paragraph
   const children_node = node.children
   if (children_node && children_node[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
     return (
       <div className="markdown-img-wrapper">
-        <ImageGallery srcs={[children_node[0].properties.src]} />
+        <ImageGallery srcs={[(children_node[0].properties as Record<string, string>)?.src]} />
         {
           Array.isArray(paragraph.children) && paragraph.children.length > 1 && (
             <div className="mt-2">{paragraph.children.slice(1)}</div>
@@ -21,6 +44,12 @@ const Paragraph = (paragraph: any) => {
       </div>
     )
   }
+  // When an image appears anywhere in the paragraph (not just as the first child),
+  // render as <div> instead of <p> to avoid invalid DOM nesting.
+  // Block-level elements like <div> (from Img/ImageGallery) cannot be nested inside <p>.
+  if (hasImageChild(children_node))
+    return <div className="markdown-img-wrapper">{paragraph.children}</div>
+
   return <p>{paragraph.children}</p>
 }
 


### PR DESCRIPTION
## Problem

When rendering Markdown where an inline image appears inside a paragraph but is **not** the first child (e.g. `Text before ![img](url) text after`), the `Paragraph` component falls through to rendering `<p>`, while the `Img` renderer wraps the image in a `<div>`. This creates invalid `<p><div>...</div></p>` nesting, which triggers Next.js hydration warnings:

> In HTML, `<div>` cannot be a descendant of `<p>`. This will cause a hydration error.

## Solution

Added a check for image tags among **all** children of the paragraph node, not just the first child. When any child is an image, the component renders a `<div>` wrapper instead of `<p>`, preventing invalid DOM nesting.

The existing first-child optimization (which extracts the image into an `ImageGallery`) is preserved for backwards compatibility.

## Changes

- `web/app/components/base/markdown-blocks/paragraph.tsx`: Added `hasImageChild` helper and fallback `<div>` rendering when images are found in non-first positions.

Fixes #32362