### PR TITLE
fix(retrieval): don't require metadata_model_config for manual metadata filtering

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -1290,7 +1290,7 @@ class DatasetRetrieval:
         tenant_id: str,
         user_id: str,
         metadata_filtering_mode: str,
-        metadata_model_config: ModelConfig,
+        metadata_model_config: ModelConfig | None,
         metadata_filtering_conditions: MetadataFilteringCondition | None,
         inputs: dict,
     ) -> tuple[dict[str, list[str]] | None, MetadataCondition | None]:
@@ -1305,6 +1305,9 @@ class DatasetRetrieval:
         if metadata_filtering_mode == "disabled":
             return None, None
         elif metadata_filtering_mode == "automatic":
+            if metadata_model_config is None:
+                raise ValueError("metadata_model_config is required for automatic mode")
+
             automatic_metadata_filters = self._automatic_metadata_filter_func(
                 dataset_ids, query, tenant_id, user_id, metadata_model_config
             )

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -131,9 +131,11 @@ class DatasetRetrieval:
             if request.metadata_filtering_mode == "automatic" and not request.metadata_model_config:
                 raise ValueError("metadata_model_config is required for this method")
 
-            app_metadata_model_config = None
-            if request.metadata_model_config is not None:
-                app_metadata_model_config = ModelConfig.model_validate(request.metadata_model_config.model_dump())
+            app_metadata_model_config = (
+                ModelConfig.model_validate(request.metadata_model_config.model_dump())
+                if request.metadata_model_config is not None
+                else None
+            )
 
             app_metadata_filtering_conditions = None
             if request.metadata_filtering_conditions is not None:

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -128,10 +128,12 @@ class DatasetRetrieval:
 
         if request.metadata_filtering_mode != "disabled":
             # Convert workflow layer types to app_config layer types
-            if not request.metadata_model_config:
+            if request.metadata_filtering_mode == "automatic" and not request.metadata_model_config:
                 raise ValueError("metadata_model_config is required for this method")
 
-            app_metadata_model_config = ModelConfig.model_validate(request.metadata_model_config.model_dump())
+            app_metadata_model_config = None
+            if request.metadata_model_config is not None:
+                app_metadata_model_config = ModelConfig.model_validate(request.metadata_model_config.model_dump())
 
             app_metadata_filtering_conditions = None
             if request.metadata_filtering_conditions is not None:


### PR DESCRIPTION
## Summary
Fix knowledge retrieval with `metadata_filtering_mode="manual"` by requiring `metadata_model_config` only for `automatic` mode.

## Problem
After the retrieval refactor, `knowledge_retrieval` raises:

`metadata_model_config is required for this method`

for all non-disabled metadata modes, including `manual`.

In manual mode this config is not used to build filter conditions, and existing workflows can have it unset.

## Root cause
`DatasetRetrieval.knowledge_retrieval` currently checks:

- `if request.metadata_filtering_mode != "disabled"` then
- always require `request.metadata_model_config`

This is stricter than needed and breaks manual filtering flows.

## Fix
- Gate the requirement to `automatic` mode only.
- Keep converting `metadata_model_config` when present.
- Leave `manual` mode functional without forcing model config.

## Tests
Added unit coverage in:
- `api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval_methods.py`

New test:
- `test_knowledge_retrieval_metadata_filtering_manual_does_not_require_model_config`

Targeted test run:
```bash
uv run --project api --dev pytest api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval_methods.py -k "metadata_filtering_manual_does_not_require_model_config or metadata_filtering_disabled"
```
(2 passed)

Fixes #32372
