### PR TITLE
fix: prevent hydration error from div nested inside p in markdown renderer

### DIFF
--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -21,6 +21,11 @@ const Paragraph = (paragraph: any) => {
       </div>
     )
   }
+  const hasImgChild = children_node?.some(
+    (child: any) => 'tagName' in child && child.tagName === 'img',
+  )
+  if (hasImgChild)
+    return <div>{paragraph.children}</div>
   return <p>{paragraph.children}</p>
 }
 


### PR DESCRIPTION
## Summary

Fixes a Next.js hydration warning caused by invalid DOM nesting when markdown paragraphs contain inline images that aren't the first child.

**Before:** `Text ![img](url) text` renders as `<p>Text <div class="markdown-img-wrapper">...</div> text</p>` — invalid HTML (`<div>` inside `<p>`).

**After:** Detects `img` children at any position and renders `<div>` instead of `<p>` when images are present.

## Changes

- **`web/app/components/base/markdown-blocks/paragraph.tsx`**: Added fallback check for `img` children at non-first positions. When found, renders `<div>` instead of `<p>` to prevent invalid nesting.

The existing first-child image handling (which extracts the image into an `ImageGallery`) is preserved unchanged.

Closes #32362

🤖 Generated with [Claude Code](https://claude.ai/claude-code)