### PR TITLE
improve frontend-code-review skill description and review process

### DIFF
--- a/.agents/skills/frontend-code-review/SKILL.md
+++ b/.agents/skills/frontend-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-code-review
-description: "Trigger when the user requests a review of frontend files (e.g., `.tsx`, `.ts`, `.js`). Support both pending-change reviews and focused file reviews while applying the checklist rules."
+description: "Reviews React and TypeScript frontend code for conditional classname handling, Tailwind-first styling, prop memoization, React Flow hook usage, and workflowStore misuse. Trigger when the user asks to review, audit, or check frontend files (`.tsx`, `.ts`, `.js`), requests a code review, PR review, component review, or says 'review this component'. Supports pending-change reviews and focused file reviews."
 ---
 
 # Frontend Code Review
@@ -16,11 +16,16 @@ Stick to the checklist below for every applicable file and mode.
 ## Checklist
 See [references/code-quality.md](references/code-quality.md), [references/performance.md](references/performance.md), [references/business-logic.md](references/business-logic.md) for the living checklist split by category—treat it as the canonical set of rules to follow.
 
-Flag each rule violation with urgency metadata so future reviewers can prioritize fixes.
+Flag each rule violation with urgency metadata so future reviewers can prioritize fixes:
+- **Urgent** — causes runtime errors, blank screens, or silent data loss (e.g., using `workflowStore` inside a node component where no provider exists)
+- **Suggestion** — deviates from project conventions or creates maintainability risk but does not break functionality (e.g., inline ternary for classnames instead of `cn()`)
 
 ## Review Process
-1. Open the relevant component/module. Gather lines that relate to class names, React Flow hooks, prop memoization, and styling.
-2. For each rule in the review point, note where the code deviates and capture a representative snippet.
+1. Open the relevant component/module. Scan for class name construction, React Flow hook usage, prop memoization, and styling approach.
+2. For each checklist rule, check whether the code violates it. Capture a representative snippet for each violation. Example violations:
+   - **Conditional classnames without `cn()`**: `className={isActive ? 'text-primary-600' : 'text-gray-500'}` — should use `cn()` from `@/utils/classnames`
+   - **Inline object prop causing re-renders**: `<HeavyComp config={{ provider, detail }} />` — should wrap in `useMemo`
+   - **workflowStore in node component**: `import useNodes from '@/app/components/workflow/store/workflow/use-nodes'` — should use `import { useNodes } from 'reactflow'`
 3. Compose the review section per the template below. Group violations first by **Urgent** flag, then by category order (Code Quality, Performance, Business Logic).
 
 ## Required output


### PR DESCRIPTION
hey @langgenius, thanks for building dify in the open and making your agent skills available to the community. Kudos on soon hitting 130k stars! I just starred it.

was running your skills through some evals and noticed a few things on frontend-code-review that were pretty quick to improve (moving from `68%` to `100%` agent performance):

- expanded capabilities description + trigger terms like _code review, PR review, component review_ so agents can reliably match user requests to this skill

- added urgency classification criteria with inline examples so agents know when to flag _urgent_ vs _suggestion_

- added `3` concrete violation examples directly in the review process steps (_classnames without cn(), inline object props, workflowStore misuse_)

these were easy changes to bring the skill in line with what performs well against **Anthropic's best practices**. honest disclosure, I work at a company where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `4` skills here, if you want to do it yourself, evals are free and open to run: [link](https://tessl.io/registry/skills/github/langgenius/dify) otherwise happy to make the improvements for you.