### PR TITLE
fix: normalize knowledge segment image preview URLs

### DIFF
--- a/api/core/rag/extractor/pdf_extractor.py
+++ b/api/core/rag/extractor/pdf_extractor.py
@@ -114,7 +114,6 @@ class PdfExtractor(BaseExtractor):
         """
         image_content = []
         upload_files = []
-        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
 
         try:
             image_objects = page.get_objects(filter=(pdfium_c.FPDF_PAGEOBJ_IMAGE,))
@@ -164,7 +163,7 @@ class PdfExtractor(BaseExtractor):
                         used_at=naive_utc_now(),
                     )
                     upload_files.append(upload_file)
-                    image_content.append(f"![image]({base_url}/files/{upload_file.id}/file-preview)")
+                    image_content.append(f"![image](/files/{upload_file.id}/file-preview)")
                 except Exception as e:
                     logger.warning("Failed to extract image from PDF: %s", e)
                     continue

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -87,7 +87,6 @@ class WordExtractor(BaseExtractor):
     def _extract_images_from_docx(self, doc):
         image_count = 0
         image_map = {}
-        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
 
         for r_id, rel in doc.part.rels.items():
             if "image" in rel.target_ref:
@@ -126,7 +125,7 @@ class WordExtractor(BaseExtractor):
                             used_at=naive_utc_now(),
                         )
                         db.session.add(upload_file)
-                        image_map[r_id] = f"![image]({base_url}/files/{upload_file.id}/file-preview)"
+                        image_map[r_id] = f"![image](/files/{upload_file.id}/file-preview)"
                 else:
                     image_ext = rel.target_ref.split(".")[-1]
                     if image_ext is None:
@@ -154,7 +153,7 @@ class WordExtractor(BaseExtractor):
                         used_at=naive_utc_now(),
                     )
                     db.session.add(upload_file)
-                    image_map[rel.target_part] = f"![image]({base_url}/files/{upload_file.id}/file-preview)"
+                    image_map[rel.target_part] = f"![image](/files/{upload_file.id}/file-preview)"
         db.session.commit()
         return image_map
 

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -809,7 +809,7 @@ class DocumentSegment(Base):
         text = self.content
 
         # For data before v0.10.0
-        pattern = r"/files/([a-f0-9\-]+)/image-preview(?:\?.*?)?"
+        pattern = r"(?:https?://[^\s\)\"\']+)?/files/([a-f0-9\-]+)/image-preview(?:\?[^\s\)\"\']*)?"
         matches = re.finditer(pattern, text)
         for match in matches:
             upload_file_id = match.group(1)
@@ -826,7 +826,7 @@ class DocumentSegment(Base):
             signed_urls.append((match.start(), match.end(), signed_url))
 
         # For data after v0.10.0
-        pattern = r"/files/([a-f0-9\-]+)/file-preview(?:\?.*?)?"
+        pattern = r"(?:https?://[^\s\)\"\']+)?/files/([a-f0-9\-]+)/file-preview(?:\?[^\s\)\"\']*)?"
         matches = re.finditer(pattern, text)
         for match in matches:
             upload_file_id = match.group(1)

--- a/api/tests/unit_tests/core/rag/extractor/test_pdf_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_pdf_extractor.py
@@ -87,7 +87,7 @@ def test_extract_images_formats(mock_dependencies, monkeypatch, image_bytes, exp
         mock_raw.FPDF_PAGEOBJ_IMAGE = 1
         result = extractor._extract_images(mock_page)
 
-    assert f"![image](http://files.local/files/{file_id}/file-preview)" in result
+    assert f"![image](/files/{file_id}/file-preview)" in result
     assert len(saves) == 1
     assert saves[0][1] == image_bytes
     assert len(db_stub.session.added) == 1
@@ -180,7 +180,7 @@ def test_extract_images_failures(mock_dependencies):
         result = extractor._extract_images(mock_page)
 
     # Should have one success
-    assert "![image](http://files.local/files/test_file_id/file-preview)" in result
+    assert "![image](/files/test_file_id/file-preview)" in result
     assert len(saves) == 1
     assert saves[0][1] == jpeg_bytes
     assert db_stub.session.committed is True

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -565,9 +565,11 @@ class TestDocumentSegmentIndexing:
         import models.dataset as dataset_module
 
         # Act
-        with patch.object(dataset_module.dify_config, "SECRET_KEY", "secret", create=True), patch(
-            "models.dataset.time.time", return_value=1700000000
-        ), patch("models.dataset.os.urandom", return_value=b"\x00" * 16):
+        with (
+            patch.object(dataset_module.dify_config, "SECRET_KEY", "secret", create=True),
+            patch("models.dataset.time.time", return_value=1700000000),
+            patch("models.dataset.os.urandom", return_value=b"\x00" * 16),
+        ):
             signed = segment.get_sign_content()
 
         # Assert

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -547,6 +547,35 @@ class TestDocumentSegmentIndexing:
         assert segment.index_node_hash == index_node_hash
         assert segment.keywords == keywords
 
+    def test_document_segment_sign_content_strips_absolute_files_host(self):
+        """Test that sign_content strips scheme/host from absolute /files URLs and returns a signed relative URL."""
+        # Arrange
+        upload_file_id = "1602650a-4fe4-423c-85a2-af76c083e3c4"
+        segment = DocumentSegment(
+            tenant_id=str(uuid4()),
+            dataset_id=str(uuid4()),
+            document_id=str(uuid4()),
+            position=1,
+            content=f"![image](http://internal.docker:5001/files/{upload_file_id}/file-preview)",
+            word_count=1,
+            tokens=1,
+            created_by=str(uuid4()),
+        )
+
+        import models.dataset as dataset_module
+
+        # Act
+        with patch.object(dataset_module.dify_config, "SECRET_KEY", "secret", create=True), patch(
+            "models.dataset.time.time", return_value=1700000000
+        ), patch("models.dataset.os.urandom", return_value=b"\x00" * 16):
+            signed = segment.get_sign_content()
+
+        # Assert
+        assert "internal.docker:5001" not in signed
+        assert f"/files/{upload_file_id}/file-preview?timestamp=" in signed
+        assert "&nonce=" in signed
+        assert "&sign=" in signed
+
     def test_document_segment_with_answer_field(self):
         """Test creating a document segment with answer field for QA model."""
         # Arrange


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #32448.
This PR normalizes extracted DOCX/PDF image markdown links to relative `/files/<id>/file-preview` URLs to avoid environment-specific host coupling.
It also expands segment URL signing rewrite patterns to handle both absolute and relative `file-preview`/`image-preview` links, and updates unit tests accordingly.

**This PR is drafted by `gpt-5` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while minor breaks may still exist. Reach me to fix in this case.**

## Screenshots

| Before | After |
|--------|-------|
| N/A (backend behavior) | N/A (backend behavior) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
