### PR TITLE
fix: prevent hydration warning when images are nested inside paragraphs

### DIFF
--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -7,9 +7,7 @@ import * as React from 'react'
 import ImageGallery from '@/app/components/base/image-gallery'
 
 const hasImageChild = (children: any[]): boolean => {
-  return children.some(
-    (child: any) => child && 'tagName' in child && child.tagName === 'img',
-  )
+  return children.some((child: any) => child?.tagName === 'img')
 }
 
 const Paragraph = (paragraph: any) => {

--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -6,6 +6,12 @@
 import * as React from 'react'
 import ImageGallery from '@/app/components/base/image-gallery'
 
+const hasImageChild = (children: any[]): boolean => {
+  return children.some(
+    (child: any) => child && 'tagName' in child && child.tagName === 'img',
+  )
+}
+
 const Paragraph = (paragraph: any) => {
   const { node }: any = paragraph
   const children_node = node.children
@@ -21,6 +27,11 @@ const Paragraph = (paragraph: any) => {
       </div>
     )
   }
+  // Use <div> instead of <p> when any child is an image to avoid invalid
+  // <p><div>...</div></p> nesting that triggers React hydration warnings.
+  if (children_node && hasImageChild(children_node))
+    return <div className="markdown-paragraph">{paragraph.children}</div>
+
   return <p>{paragraph.children}</p>
 }
 

--- a/web/app/styles/markdown.scss
+++ b/web/app/styles/markdown.scss
@@ -408,6 +408,7 @@
 }
 
 .markdown-body p,
+.markdown-body .markdown-paragraph,
 .markdown-body blockquote,
 .markdown-body ul,
 .markdown-body ol,


### PR DESCRIPTION
## Summary

Fix React hydration warning caused by invalid `<p><div>...</div></p>` nesting when images appear inside markdown paragraphs.

## Problem

When a markdown paragraph contains an inline image that is **not** the first child (e.g., `some text ![alt](url)`), the `Paragraph` component renders a `<p>` tag. Inside it, the `Img` component renders a `<div>` wrapping `ImageGallery` (which also renders a `<div>`). This creates:

```html
<p>
  some text
  <div class="markdown-img-wrapper">  <!-- ❌ invalid: div inside p -->
    <div class="flex flex-wrap">...</div>
  </div>
</p>
```

This violates the HTML spec (`<p>` cannot contain block-level elements) and triggers Next.js hydration warnings.

The existing check in `Paragraph` only handles the case where the **first** child is an `img` tag.

## Fix

Added a `hasImageChild` helper that checks if **any** child node is an `img` tag. When detected, the paragraph renders as `<div className="markdown-paragraph">` instead of `<p>`, avoiding the invalid nesting.

The existing first-child-is-img optimization (which renders `ImageGallery` directly) is preserved.

Fixes #32362
