### PR TITLE
refactor: inherit ABC in AppQueueManager for proper abstract method usage

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -2,7 +2,7 @@ import logging
 import queue
 import threading
 import time
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from enum import IntEnum, auto
 from typing import Any
 
@@ -31,7 +31,7 @@ class PublishFrom(IntEnum):
     TASK_PIPELINE = auto()
 
 
-class AppQueueManager:
+class AppQueueManager(ABC):
     def __init__(self, task_id: str, user_id: str, invoke_from: InvokeFrom):
         if not user_id:
             raise ValueError("user is required")


### PR DESCRIPTION
## Summary
This PR fixes `AppQueueManager` in `base_app_queue_manager.py` to properly inherit from `ABC` (Abstract Base Class).

## Problem
`AppQueueManager` uses `@abstractmethod` decorator on its `_publish` method, but the class does not inherit from `ABC`. While the code works at runtime because child classes override `_publish`, using `@abstractmethod` without inheriting `ABC` is not recommended as:
- It does not enforce the abstract contract (you can instantiate the base class directly without implementing abstract methods)
- Static analysis tools and IDEs cannot properly detect missing implementations
- It goes against Python's intended usage of the `abc` module

See: https://stackoverflow.com/questions/49051638/python-abstract-method-in-normal-class

## Changes
- Import `ABC` from the `abc` module (alongside the existing `abstractmethod` import)
- Make `AppQueueManager` inherit from `ABC`

## Impact
Minimal — all existing subclasses (`WorkflowAppQueueManager`, `MessageBasedAppQueueManager`, `PipelineQueueManager`) already properly implement `_publish`, so this change is fully backward compatible.

Closes #32390