### PR TITLE
fix: add return type annotation to Moderation.validate_config abstract method

### DIFF
--- a/api/core/moderation/base.py
+++ b/api/core/moderation/base.py
@@ -47,7 +47,7 @@ class Moderation(Extensible, ABC):
         :param config: the form config data
         :return:
         """
-        ...
+        raise NotImplementedError
 
     @abstractmethod
     def moderation_for_inputs(self, inputs: dict, query: str = "") -> ModerationInputsResult:

--- a/api/core/moderation/base.py
+++ b/api/core/moderation/base.py
@@ -39,7 +39,7 @@ class Moderation(Extensible, ABC):
 
     @classmethod
     @abstractmethod
-    def validate_config(cls, tenant_id: str, config: dict):
+    def validate_config(cls, tenant_id: str, config: dict) -> None:
         """
         Validate the incoming form config data.
 
@@ -47,7 +47,7 @@ class Moderation(Extensible, ABC):
         :param config: the form config data
         :return:
         """
-        raise NotImplementedError
+        ...
 
     @abstractmethod
     def moderation_for_inputs(self, inputs: dict, query: str = "") -> ModerationInputsResult:


### PR DESCRIPTION
## Summary
Fixes #32484

The `Moderation.validate_config` abstract method was missing a return type annotation and used `raise NotImplementedError` as its body, causing the inferred return type to be `Never`. This led to a `bad-override` type error in subclasses like `ApiModeration` whose `validate_config` implicitly returns `None`.

## Changes
- Added `-> None` return type annotation to `Moderation.validate_config` in `api/core/moderation/base.py`
- Replaced `raise NotImplementedError` with `...` (ellipsis) which is the idiomatic body for abstract methods