### PR TITLE
fix: add return type annotation to abstract _publish method

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -133,7 +133,7 @@ class AppQueueManager(ABC):
         self._publish(event, pub_from)
 
     @abstractmethod
-    def _publish(self, event: AppQueueEvent, pub_from: PublishFrom):
+    def _publish(self, event: AppQueueEvent, pub_from: PublishFrom) -> None:
         """
         Publish event to queue
         :param event:


### PR DESCRIPTION
## Summary

This PR fixes a type checking error (`bad-override`) by adding the missing `-> None` return type annotation to the abstract `_publish` method in `AppQueueManager`.

## Problem

The type checker was reporting: ERROR Class member PipelineQueueManager._publish overrides parent class AppQueueManager in an inconsistent manner [bad-override]


This occurred because the base class method had no return type annotation (inferred as `Never` due to `raise NotImplementedError`), while subclasses used `-> None`.

## Solution

Added explicit `-> None` return type annotation to the abstract method:

```python
@abstractmethod
def _publish(self, event: AppQueueEvent, pub_from: PublishFrom) -> None:
    raise NotImplementedError

Related Issue
Closes #32492

Checklist
 Code follows the project's style guidelines
 Changes are minimal and focused
 No breaking changes introduced