### PR TITLE
fix: resolve pyright bad-index errors in parser.py

### DIFF
--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -2,7 +2,7 @@ import re
 from json import dumps as json_dumps
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
-from typing import Any
+from typing import Any, TypedDict
 
 import httpx
 from flask import request
@@ -12,6 +12,12 @@ from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiToolBundle
 from core.tools.entities.tool_entities import ApiProviderSchemaType, ToolParameter
 from core.tools.errors import ToolApiSchemaError, ToolNotSupportedError, ToolProviderNotFoundError
+
+
+class _OpenAPIInterface(TypedDict):
+    path: str
+    method: str
+    operation: dict[str, Any]
 
 
 class ApiBasedToolSchemaParser:
@@ -35,17 +41,17 @@ class ApiBasedToolSchemaParser:
             server_url = matched_servers[0] if matched_servers else server_url
 
         # list all interfaces
-        interfaces = []
+        interfaces: list[_OpenAPIInterface] = []
         for path, path_item in openapi["paths"].items():
             methods = ["get", "post", "put", "delete", "patch", "head", "options", "trace"]
             for method in methods:
                 if method in path_item:
                     interfaces.append(
-                        {
-                            "path": path,
-                            "method": method,
-                            "operation": path_item[method],
-                        }
+                        _OpenAPIInterface(
+                            path=path,
+                            method=method,
+                            operation=path_item[method],
+                        )
                     )
 
         # get all parameters


### PR DESCRIPTION
## Summary
Add `_OpenAPIInterface` TypedDict to properly type the `interfaces` list in `parse_openapi_to_tool_bundle`. This resolves pyright `bad-index` errors where `interface["operation"]` was inferred as `str` instead of `dict`.

## Changes
- Added `_OpenAPIInterface` TypedDict with typed fields (`path: str`, `method: str`, `operation: dict[str, Any]`)
- Annotated the `interfaces` list with the TypedDict type
- Used TypedDict constructor for dict creation to maintain type safety

## Related Issue
Fixes #32506