### PR TITLE
fix: resolve bad-override in PipelineQueueManager._publish

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -140,7 +140,7 @@ class AppQueueManager(ABC):
         :param pub_from:
         :return:
         """
-        raise NotImplementedError
+        ...
 
     @classmethod
     def set_stop_flag(cls, task_id: str, invoke_from: InvokeFrom, user_id: str):

--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -2,7 +2,7 @@ import re
 from json import dumps as json_dumps
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
-from typing import Any
+from typing import Any, TypedDict
 
 import httpx
 from flask import request
@@ -12,6 +12,12 @@ from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiToolBundle
 from core.tools.entities.tool_entities import ApiProviderSchemaType, ToolParameter
 from core.tools.errors import ToolApiSchemaError, ToolNotSupportedError, ToolProviderNotFoundError
+
+
+class _OpenAPIInterface(TypedDict):
+    path: str
+    method: str
+    operation: dict[str, Any]
 
 
 class ApiBasedToolSchemaParser:
@@ -35,17 +41,17 @@ class ApiBasedToolSchemaParser:
             server_url = matched_servers[0] if matched_servers else server_url
 
         # list all interfaces
-        interfaces = []
+        interfaces: list[_OpenAPIInterface] = []
         for path, path_item in openapi["paths"].items():
             methods = ["get", "post", "put", "delete", "patch", "head", "options", "trace"]
             for method in methods:
                 if method in path_item:
                     interfaces.append(
-                        {
-                            "path": path,
-                            "method": method,
-                            "operation": path_item[method],
-                        }
+                        _OpenAPIInterface(
+                            path=path,
+                            method=method,
+                            operation=path_item[method],
+                        )
                     )
 
         # get all parameters


### PR DESCRIPTION
## Summary
Replace `raise NotImplementedError` with `...` in abstract method `AppQueueManager._publish`. The `raise` statement causes pyright to infer a `Never` return type, which conflicts with the `-> None` annotation and creates a `bad-override` error in subclasses.

## Changes
- Changed abstract method body from `raise NotImplementedError` to `...` (idiomatic Python pattern for abstract methods)

## Related Issue
Fixes #32492