### PR TITLE
test: migrate remaining DocumentSegment navigation SQL tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/models/test_dataset_models.py
+++ b/api/tests/test_containers_integration_tests/models/test_dataset_models.py
@@ -373,3 +373,60 @@ class TestDocumentSegmentNavigationProperties:
         # Assert
         assert related_document is not None
         assert related_document.id == document.id
+
+    def test_document_segment_previous_segment(self, db_session_with_containers: Session) -> None:
+        """Test segment can access previous segment."""
+        # Arrange
+        tenant_id = str(uuid4())
+        created_by = str(uuid4())
+        dataset = Dataset(
+            tenant_id=tenant_id,
+            name="Test Dataset",
+            data_source_type="upload_file",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(dataset)
+        db_session_with_containers.flush()
+
+        document = Document(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            position=1,
+            data_source_type="upload_file",
+            batch="batch_001",
+            name="test.pdf",
+            created_from="web",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(document)
+        db_session_with_containers.flush()
+
+        previous_segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=1,
+            content="Previous",
+            word_count=1,
+            tokens=2,
+            created_by=created_by,
+        )
+        segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=2,
+            content="Current",
+            word_count=1,
+            tokens=2,
+            created_by=created_by,
+        )
+        db_session_with_containers.add_all([previous_segment, segment])
+        db_session_with_containers.flush()
+
+        # Act
+        prev_seg = segment.previous_segment
+
+        # Assert
+        assert prev_seg is not None
+        assert prev_seg.position == 1

--- a/api/tests/test_containers_integration_tests/models/test_dataset_models.py
+++ b/api/tests/test_containers_integration_tests/models/test_dataset_models.py
@@ -269,3 +269,60 @@ class TestDatasetDocumentProperties:
         db_session_with_containers.flush()
 
         assert doc.hit_count == 25
+
+
+class TestDocumentSegmentNavigationProperties:
+    """Integration tests for DocumentSegment navigation properties."""
+
+    @pytest.fixture(autouse=True)
+    def _auto_rollback(self, db_session_with_containers: Session) -> Generator[None, None, None]:
+        """Automatically rollback session changes after each test."""
+        yield
+        db_session_with_containers.rollback()
+
+    def test_document_segment_dataset_property(self, db_session_with_containers: Session) -> None:
+        """Test segment can access its parent dataset."""
+        # Arrange
+        tenant_id = str(uuid4())
+        created_by = str(uuid4())
+        dataset = Dataset(
+            tenant_id=tenant_id,
+            name="Test Dataset",
+            data_source_type="upload_file",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(dataset)
+        db_session_with_containers.flush()
+
+        document = Document(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            position=1,
+            data_source_type="upload_file",
+            batch="batch_001",
+            name="test.pdf",
+            created_from="web",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(document)
+        db_session_with_containers.flush()
+
+        segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=1,
+            content="Test",
+            word_count=1,
+            tokens=2,
+            created_by=created_by,
+        )
+        db_session_with_containers.add(segment)
+        db_session_with_containers.flush()
+
+        # Act
+        related_dataset = segment.dataset
+
+        # Assert
+        assert related_dataset is not None
+        assert related_dataset.id == dataset.id

--- a/api/tests/test_containers_integration_tests/models/test_dataset_models.py
+++ b/api/tests/test_containers_integration_tests/models/test_dataset_models.py
@@ -430,3 +430,60 @@ class TestDocumentSegmentNavigationProperties:
         # Assert
         assert prev_seg is not None
         assert prev_seg.position == 1
+
+    def test_document_segment_next_segment(self, db_session_with_containers: Session) -> None:
+        """Test segment can access next segment."""
+        # Arrange
+        tenant_id = str(uuid4())
+        created_by = str(uuid4())
+        dataset = Dataset(
+            tenant_id=tenant_id,
+            name="Test Dataset",
+            data_source_type="upload_file",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(dataset)
+        db_session_with_containers.flush()
+
+        document = Document(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            position=1,
+            data_source_type="upload_file",
+            batch="batch_001",
+            name="test.pdf",
+            created_from="web",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(document)
+        db_session_with_containers.flush()
+
+        segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=1,
+            content="Current",
+            word_count=1,
+            tokens=2,
+            created_by=created_by,
+        )
+        next_segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=2,
+            content="Next",
+            word_count=1,
+            tokens=2,
+            created_by=created_by,
+        )
+        db_session_with_containers.add_all([segment, next_segment])
+        db_session_with_containers.flush()
+
+        # Act
+        next_seg = segment.next_segment
+
+        # Assert
+        assert next_seg is not None
+        assert next_seg.position == 2

--- a/api/tests/test_containers_integration_tests/models/test_dataset_models.py
+++ b/api/tests/test_containers_integration_tests/models/test_dataset_models.py
@@ -326,3 +326,50 @@ class TestDocumentSegmentNavigationProperties:
         # Assert
         assert related_dataset is not None
         assert related_dataset.id == dataset.id
+
+    def test_document_segment_document_property(self, db_session_with_containers: Session) -> None:
+        """Test segment can access its parent document."""
+        # Arrange
+        tenant_id = str(uuid4())
+        created_by = str(uuid4())
+        dataset = Dataset(
+            tenant_id=tenant_id,
+            name="Test Dataset",
+            data_source_type="upload_file",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(dataset)
+        db_session_with_containers.flush()
+
+        document = Document(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            position=1,
+            data_source_type="upload_file",
+            batch="batch_001",
+            name="test.pdf",
+            created_from="web",
+            created_by=created_by,
+        )
+        db_session_with_containers.add(document)
+        db_session_with_containers.flush()
+
+        segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=1,
+            content="Test",
+            word_count=1,
+            tokens=2,
+            created_by=created_by,
+        )
+        db_session_with_containers.add(segment)
+        db_session_with_containers.flush()
+
+        # Act
+        related_document = segment.document
+
+        # Assert
+        assert related_document is not None
+        assert related_document.id == document.id

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -957,41 +957,6 @@ class TestChildChunk:
 class TestDocumentSegmentNavigation:
     """Test suite for DocumentSegment navigation properties."""
 
-    def test_document_segment_previous_segment(self):
-        """Test segment can access previous segment."""
-        # Arrange
-        document_id = str(uuid4())
-        segment = DocumentSegment(
-            tenant_id=str(uuid4()),
-            dataset_id=str(uuid4()),
-            document_id=document_id,
-            position=2,
-            content="Test",
-            word_count=1,
-            tokens=2,
-            created_by=str(uuid4()),
-        )
-
-        previous_segment = DocumentSegment(
-            tenant_id=str(uuid4()),
-            dataset_id=str(uuid4()),
-            document_id=document_id,
-            position=1,
-            content="Previous",
-            word_count=1,
-            tokens=2,
-            created_by=str(uuid4()),
-        )
-
-        # Mock the database session scalar
-        with patch("models.dataset.db.session.scalar", return_value=previous_segment):
-            # Act
-            prev_seg = segment.previous_segment
-
-            # Assert
-            assert prev_seg is not None
-            assert prev_seg.position == 1
-
     def test_document_segment_next_segment(self):
         """Test segment can access next segment."""
         # Arrange

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -954,45 +954,6 @@ class TestChildChunk:
         assert child_chunk.index_node_hash == index_node_hash
 
 
-class TestDocumentSegmentNavigation:
-    """Test suite for DocumentSegment navigation properties."""
-
-    def test_document_segment_next_segment(self):
-        """Test segment can access next segment."""
-        # Arrange
-        document_id = str(uuid4())
-        segment = DocumentSegment(
-            tenant_id=str(uuid4()),
-            dataset_id=str(uuid4()),
-            document_id=document_id,
-            position=1,
-            content="Test",
-            word_count=1,
-            tokens=2,
-            created_by=str(uuid4()),
-        )
-
-        next_segment = DocumentSegment(
-            tenant_id=str(uuid4()),
-            dataset_id=str(uuid4()),
-            document_id=document_id,
-            position=2,
-            content="Next",
-            word_count=1,
-            tokens=2,
-            created_by=str(uuid4()),
-        )
-
-        # Mock the database session scalar
-        with patch("models.dataset.db.session.scalar", return_value=next_segment):
-            # Act
-            next_seg = segment.next_segment
-
-            # Assert
-            assert next_seg is not None
-            assert next_seg.position == 2
-
-
 class TestModelIntegration:
     """Test suite for model integration scenarios."""
 

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -957,42 +957,6 @@ class TestChildChunk:
 class TestDocumentSegmentNavigation:
     """Test suite for DocumentSegment navigation properties."""
 
-    def test_document_segment_document_property(self):
-        """Test segment can access its parent document."""
-        # Arrange
-        document_id = str(uuid4())
-        segment = DocumentSegment(
-            tenant_id=str(uuid4()),
-            dataset_id=str(uuid4()),
-            document_id=document_id,
-            position=1,
-            content="Test",
-            word_count=1,
-            tokens=2,
-            created_by=str(uuid4()),
-        )
-
-        mock_document = Document(
-            tenant_id=str(uuid4()),
-            dataset_id=str(uuid4()),
-            position=1,
-            data_source_type="upload_file",
-            batch="batch_001",
-            name="test.pdf",
-            created_from="web",
-            created_by=str(uuid4()),
-        )
-        mock_document.id = document_id
-
-        # Mock the database session scalar
-        with patch("models.dataset.db.session.scalar", return_value=mock_document):
-            # Act
-            document = segment.document
-
-            # Assert
-            assert document is not None
-            assert document.id == document_id
-
     def test_document_segment_previous_segment(self):
         """Test segment can access previous segment."""
         # Arrange

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -957,38 +957,6 @@ class TestChildChunk:
 class TestDocumentSegmentNavigation:
     """Test suite for DocumentSegment navigation properties."""
 
-    def test_document_segment_dataset_property(self):
-        """Test segment can access its parent dataset."""
-        # Arrange
-        dataset_id = str(uuid4())
-        segment = DocumentSegment(
-            tenant_id=str(uuid4()),
-            dataset_id=dataset_id,
-            document_id=str(uuid4()),
-            position=1,
-            content="Test",
-            word_count=1,
-            tokens=2,
-            created_by=str(uuid4()),
-        )
-
-        mock_dataset = Dataset(
-            tenant_id=str(uuid4()),
-            name="Test Dataset",
-            data_source_type="upload_file",
-            created_by=str(uuid4()),
-        )
-        mock_dataset.id = dataset_id
-
-        # Mock the database session scalar
-        with patch("models.dataset.db.session.scalar", return_value=mock_dataset):
-            # Act
-            dataset = segment.dataset
-
-            # Assert
-            assert dataset is not None
-            assert dataset.id == dataset_id
-
     def test_document_segment_document_property(self):
         """Test segment can access its parent document."""
         # Arrange


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR migrates the remaining SQL-mock tests in
`api/tests/unit_tests/models/test_dataset_models.py`
to testcontainers integration tests in
`api/tests/test_containers_integration_tests/models/test_dataset_models.py`.

Migrated navigation properties:
- `segment.dataset`
- `segment.document`
- `segment.previous_segment`
- `segment.next_segment`

Also removed corresponding unit tests (SQL-mock based), and removed the empty `TestDocumentSegmentNavigation` class.

Part of #32454

Follow-up to #32487

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
