### PR TITLE
test: migrate duplicate_document_indexing_task SQL tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from faker import Faker
 
+from core.indexing_runner import DocumentIsPausedError
 from enums.cloud_plan import CloudPlan
 from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
@@ -783,3 +784,75 @@ class TestDuplicateDocumentIndexingTasks:
             document_ids=document_ids,
         )
         mock_queue.delete_task_key.assert_not_called()
+
+    def test_successful_duplicate_document_indexing(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test successful duplicate document indexing flow."""
+        self.test_duplicate_document_indexing_task_success(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+    def test_duplicate_document_indexing_dataset_not_found(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test duplicate document indexing when dataset is not found."""
+        self.test_duplicate_document_indexing_task_dataset_not_found(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+    def test_duplicate_document_indexing_with_billing_enabled_sandbox_plan(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test duplicate document indexing with billing enabled and sandbox plan."""
+        self.test_duplicate_document_indexing_task_billing_sandbox_plan_batch_limit(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+    def test_duplicate_document_indexing_with_billing_limit_exceeded(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test duplicate document indexing when billing limit is exceeded."""
+        self.test_duplicate_document_indexing_task_billing_vector_space_limit_exceeded(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+    def test_duplicate_document_indexing_runner_error(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test duplicate document indexing when IndexingRunner raises an error."""
+        self.test_duplicate_document_indexing_task_indexing_runner_exception(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+    def test_duplicate_document_indexing_document_is_paused(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test duplicate document indexing when document is paused."""
+        # Arrange
+        dataset, documents = self._create_test_dataset_and_documents(
+            db_session_with_containers, mock_external_service_dependencies, document_count=2
+        )
+        document_ids = [doc.id for doc in documents]
+        mock_external_service_dependencies["indexing_runner_instance"].run.side_effect = DocumentIsPausedError(
+            "Document paused"
+        )
+
+        # Act
+        _duplicate_document_indexing_task(dataset.id, document_ids)
+        db_session_with_containers.expire_all()
+
+        # Assert
+        for doc_id in document_ids:
+            updated_document = db_session_with_containers.query(Document).where(Document.id == doc_id).first()
+            assert updated_document.indexing_status == "parsing"
+            assert updated_document.processing_started_at is not None
+        mock_external_service_dependencies["indexing_runner_instance"].run.assert_called_once()
+
+    def test_duplicate_document_indexing_cleans_old_segments(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test that duplicate document indexing cleans old segments."""
+        self.test_duplicate_document_indexing_task_with_segment_cleanup(
+            db_session_with_containers, mock_external_service_dependencies
+        )

--- a/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
@@ -833,6 +833,11 @@ class TestDuplicateDocumentIndexingTasks:
         dataset, documents = self._create_test_dataset_and_documents(
             db_session_with_containers, mock_external_service_dependencies, document_count=2
         )
+        for document in documents:
+            document.is_paused = True
+            db_session_with_containers.add(document)
+        db_session_with_containers.commit()
+
         document_ids = [doc.id for doc in documents]
         mock_external_service_dependencies["indexing_runner_instance"].run.side_effect = DocumentIsPausedError(
             "Document paused"
@@ -845,7 +850,9 @@ class TestDuplicateDocumentIndexingTasks:
         # Assert
         for doc_id in document_ids:
             updated_document = db_session_with_containers.query(Document).where(Document.id == doc_id).first()
+            assert updated_document.is_paused is True
             assert updated_document.indexing_status == "parsing"
+            assert updated_document.display_status == "paused"
             assert updated_document.processing_started_at is not None
         mock_external_service_dependencies["indexing_runner_instance"].run.assert_called_once()
 

--- a/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
@@ -825,7 +825,7 @@ class TestDuplicateDocumentIndexingTasks:
             db_session_with_containers, mock_external_service_dependencies
         )
 
-    def test_duplicate_document_indexing_document_is_paused(
+    def test_duplicate_document_indexing_task_document_is_paused(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing when document is paused."""
@@ -848,6 +848,14 @@ class TestDuplicateDocumentIndexingTasks:
             assert updated_document.indexing_status == "parsing"
             assert updated_document.processing_started_at is not None
         mock_external_service_dependencies["indexing_runner_instance"].run.assert_called_once()
+
+    def test_duplicate_document_indexing_document_is_paused(
+        self, db_session_with_containers, mock_external_service_dependencies
+    ):
+        """Test duplicate document indexing when document is paused."""
+        self.test_duplicate_document_indexing_task_document_is_paused(
+            db_session_with_containers, mock_external_service_dependencies
+        )
 
     def test_duplicate_document_indexing_cleans_old_segments(
         self, db_session_with_containers, mock_external_service_dependencies

--- a/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
@@ -283,7 +283,7 @@ class TestDuplicateDocumentIndexingTasks:
 
         return dataset, documents
 
-    def test_duplicate_document_indexing_task_success(
+    def _test_duplicate_document_indexing_task_success(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """
@@ -325,7 +325,7 @@ class TestDuplicateDocumentIndexingTasks:
         processed_documents = call_args[0][0]  # First argument should be documents list
         assert len(processed_documents) == 3
 
-    def test_duplicate_document_indexing_task_with_segment_cleanup(
+    def _test_duplicate_document_indexing_task_with_segment_cleanup(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """
@@ -375,7 +375,7 @@ class TestDuplicateDocumentIndexingTasks:
         mock_external_service_dependencies["indexing_runner"].assert_called_once()
         mock_external_service_dependencies["indexing_runner_instance"].run.assert_called_once()
 
-    def test_duplicate_document_indexing_task_dataset_not_found(
+    def _test_duplicate_document_indexing_task_dataset_not_found(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """
@@ -446,7 +446,7 @@ class TestDuplicateDocumentIndexingTasks:
         processed_documents = call_args[0][0]  # First argument should be documents list
         assert len(processed_documents) == 2  # Only existing documents
 
-    def test_duplicate_document_indexing_task_indexing_runner_exception(
+    def _test_duplicate_document_indexing_task_indexing_runner_exception(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """
@@ -487,7 +487,7 @@ class TestDuplicateDocumentIndexingTasks:
             assert updated_document.indexing_status == "parsing"
             assert updated_document.processing_started_at is not None
 
-    def test_duplicate_document_indexing_task_billing_sandbox_plan_batch_limit(
+    def _test_duplicate_document_indexing_task_billing_sandbox_plan_batch_limit(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """
@@ -550,7 +550,7 @@ class TestDuplicateDocumentIndexingTasks:
         # Verify indexing runner was not called due to early validation error
         mock_external_service_dependencies["indexing_runner_instance"].run.assert_not_called()
 
-    def test_duplicate_document_indexing_task_billing_vector_space_limit_exceeded(
+    def _test_duplicate_document_indexing_task_billing_vector_space_limit_exceeded(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """
@@ -789,7 +789,7 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test successful duplicate document indexing flow."""
-        self.test_duplicate_document_indexing_task_success(
+        self._test_duplicate_document_indexing_task_success(
             db_session_with_containers, mock_external_service_dependencies
         )
 
@@ -797,7 +797,7 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing when dataset is not found."""
-        self.test_duplicate_document_indexing_task_dataset_not_found(
+        self._test_duplicate_document_indexing_task_dataset_not_found(
             db_session_with_containers, mock_external_service_dependencies
         )
 
@@ -805,7 +805,7 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing with billing enabled and sandbox plan."""
-        self.test_duplicate_document_indexing_task_billing_sandbox_plan_batch_limit(
+        self._test_duplicate_document_indexing_task_billing_sandbox_plan_batch_limit(
             db_session_with_containers, mock_external_service_dependencies
         )
 
@@ -813,7 +813,7 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing when billing limit is exceeded."""
-        self.test_duplicate_document_indexing_task_billing_vector_space_limit_exceeded(
+        self._test_duplicate_document_indexing_task_billing_vector_space_limit_exceeded(
             db_session_with_containers, mock_external_service_dependencies
         )
 
@@ -821,11 +821,11 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing when IndexingRunner raises an error."""
-        self.test_duplicate_document_indexing_task_indexing_runner_exception(
+        self._test_duplicate_document_indexing_task_indexing_runner_exception(
             db_session_with_containers, mock_external_service_dependencies
         )
 
-    def test_duplicate_document_indexing_task_document_is_paused(
+    def _test_duplicate_document_indexing_task_document_is_paused(
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing when document is paused."""
@@ -860,7 +860,7 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test duplicate document indexing when document is paused."""
-        self.test_duplicate_document_indexing_task_document_is_paused(
+        self._test_duplicate_document_indexing_task_document_is_paused(
             db_session_with_containers, mock_external_service_dependencies
         )
 
@@ -868,6 +868,6 @@ class TestDuplicateDocumentIndexingTasks:
         self, db_session_with_containers, mock_external_service_dependencies
     ):
         """Test that duplicate document indexing cleans old segments."""
-        self.test_duplicate_document_indexing_task_with_segment_cleanup(
+        self._test_duplicate_document_indexing_task_with_segment_cleanup(
             db_session_with_containers, mock_external_service_dependencies
         )

--- a/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for non-SQL duplicate document indexing task behaviors.
-"""
+"""Unit tests for queue/wrapper behaviors in duplicate document indexing tasks (non-database logic)."""
 
 import uuid
 from unittest.mock import Mock, patch

--- a/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
@@ -1,158 +1,40 @@
 """
-Unit tests for duplicate document indexing tasks.
-
-This module tests the duplicate document indexing task functionality including:
-- Task enqueuing to different queues (normal, priority, tenant-isolated)
-- Batch processing of multiple duplicate documents
-- Progress tracking through task lifecycle
-- Error handling and retry mechanisms
-- Cleanup of old document data before re-indexing
+Unit tests for non-SQL duplicate document indexing task behaviors.
 """
 
 import uuid
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
-from core.indexing_runner import DocumentIsPausedError, IndexingRunner
 from core.rag.pipeline.queue import TenantIsolatedTaskQueue
-from enums.cloud_plan import CloudPlan
-from models.dataset import Dataset, Document, DocumentSegment
 from tasks.duplicate_document_indexing_task import (
-    _duplicate_document_indexing_task,
     _duplicate_document_indexing_task_with_tenant_queue,
     duplicate_document_indexing_task,
     normal_duplicate_document_indexing_task,
     priority_duplicate_document_indexing_task,
 )
 
-# ============================================================================
-# Fixtures
-# ============================================================================
-
 
 @pytest.fixture
 def tenant_id():
-    """Generate a unique tenant ID for testing."""
     return str(uuid.uuid4())
 
 
 @pytest.fixture
 def dataset_id():
-    """Generate a unique dataset ID for testing."""
     return str(uuid.uuid4())
 
 
 @pytest.fixture
 def document_ids():
-    """Generate a list of document IDs for testing."""
     return [str(uuid.uuid4()) for _ in range(3)]
 
 
 @pytest.fixture
-def mock_dataset(dataset_id, tenant_id):
-    """Create a mock Dataset object."""
-    dataset = Mock(spec=Dataset)
-    dataset.id = dataset_id
-    dataset.tenant_id = tenant_id
-    dataset.indexing_technique = "high_quality"
-    dataset.embedding_model_provider = "openai"
-    dataset.embedding_model = "text-embedding-ada-002"
-    return dataset
-
-
-@pytest.fixture
-def mock_documents(document_ids, dataset_id):
-    """Create mock Document objects."""
-    documents = []
-    for doc_id in document_ids:
-        doc = Mock(spec=Document)
-        doc.id = doc_id
-        doc.dataset_id = dataset_id
-        doc.indexing_status = "waiting"
-        doc.error = None
-        doc.stopped_at = None
-        doc.processing_started_at = None
-        doc.doc_form = "text_model"
-        documents.append(doc)
-    return documents
-
-
-@pytest.fixture
-def mock_document_segments(document_ids):
-    """Create mock DocumentSegment objects."""
-    segments = []
-    for doc_id in document_ids:
-        for i in range(3):
-            segment = Mock(spec=DocumentSegment)
-            segment.id = str(uuid.uuid4())
-            segment.document_id = doc_id
-            segment.index_node_id = f"node-{doc_id}-{i}"
-            segments.append(segment)
-    return segments
-
-
-@pytest.fixture
-def mock_db_session():
-    """Mock database session via session_factory.create_session()."""
-    with patch("tasks.duplicate_document_indexing_task.session_factory", autospec=True) as mock_sf:
-        session = MagicMock()
-        # Allow tests to observe session.close() via context manager teardown
-        session.close = MagicMock()
-        cm = MagicMock()
-        cm.__enter__.return_value = session
-
-        def _exit_side_effect(*args, **kwargs):
-            session.close()
-
-        cm.__exit__.side_effect = _exit_side_effect
-        mock_sf.create_session.return_value = cm
-
-        query = MagicMock()
-        session.query.return_value = query
-        query.where.return_value = query
-        session.scalars.return_value = MagicMock()
-        yield session
-
-
-@pytest.fixture
-def mock_indexing_runner():
-    """Mock IndexingRunner."""
-    with patch("tasks.duplicate_document_indexing_task.IndexingRunner", autospec=True) as mock_runner_class:
-        mock_runner = MagicMock(spec=IndexingRunner)
-        mock_runner_class.return_value = mock_runner
-        yield mock_runner
-
-
-@pytest.fixture
-def mock_feature_service():
-    """Mock FeatureService."""
-    with patch("tasks.duplicate_document_indexing_task.FeatureService", autospec=True) as mock_service:
-        mock_features = Mock()
-        mock_features.billing = Mock()
-        mock_features.billing.enabled = False
-        mock_features.vector_space = Mock()
-        mock_features.vector_space.size = 0
-        mock_features.vector_space.limit = 1000
-        mock_service.get_features.return_value = mock_features
-        yield mock_service
-
-
-@pytest.fixture
-def mock_index_processor_factory():
-    """Mock IndexProcessorFactory."""
-    with patch("tasks.duplicate_document_indexing_task.IndexProcessorFactory", autospec=True) as mock_factory:
-        mock_processor = MagicMock()
-        mock_processor.clean = Mock()
-        mock_factory.return_value.init_index_processor.return_value = mock_processor
-        yield mock_factory
-
-
-@pytest.fixture
 def mock_tenant_isolated_queue():
-    """Mock TenantIsolatedTaskQueue."""
-    with patch("tasks.duplicate_document_indexing_task.TenantIsolatedTaskQueue", autospec=True) as mock_queue_class:
-        mock_queue = MagicMock(spec=TenantIsolatedTaskQueue)
+    with patch("tasks.duplicate_document_indexing_task.TenantIsolatedTaskQueue") as mock_queue_class:
+        mock_queue = Mock(spec=TenantIsolatedTaskQueue)
         mock_queue.pull_tasks.return_value = []
         mock_queue.delete_task_key = Mock()
         mock_queue.set_task_waiting_time = Mock()
@@ -160,15 +42,10 @@ def mock_tenant_isolated_queue():
         yield mock_queue
 
 
-# ============================================================================
-# Tests for deprecated duplicate_document_indexing_task
-# ============================================================================
-
-
 class TestDuplicateDocumentIndexingTask:
     """Tests for the deprecated duplicate_document_indexing_task function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
     def test_duplicate_document_indexing_task_calls_core_function(self, mock_core_func, dataset_id, document_ids):
         """Test that duplicate_document_indexing_task calls the core _duplicate_document_indexing_task function."""
         # Act
@@ -177,7 +54,7 @@ class TestDuplicateDocumentIndexingTask:
         # Assert
         mock_core_func.assert_called_once_with(dataset_id, document_ids)
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
     def test_duplicate_document_indexing_task_with_empty_document_ids(self, mock_core_func, dataset_id):
         """Test duplicate_document_indexing_task with empty document_ids list."""
         # Arrange
@@ -190,262 +67,10 @@ class TestDuplicateDocumentIndexingTask:
         mock_core_func.assert_called_once_with(dataset_id, document_ids)
 
 
-# ============================================================================
-# Tests for _duplicate_document_indexing_task core function
-# ============================================================================
-
-
-class TestDuplicateDocumentIndexingTaskCore:
-    """Tests for the _duplicate_document_indexing_task core function."""
-
-    def test_successful_duplicate_document_indexing(
-        self,
-        mock_db_session,
-        mock_indexing_runner,
-        mock_feature_service,
-        mock_index_processor_factory,
-        mock_dataset,
-        mock_documents,
-        mock_document_segments,
-        dataset_id,
-        document_ids,
-    ):
-        """Test successful duplicate document indexing flow."""
-        # Arrange
-        # Dataset via query.first()
-        mock_db_session.query.return_value.where.return_value.first.return_value = mock_dataset
-        # scalars() call sequence:
-        # 1) documents list
-        # 2..N) segments per document
-
-        def _scalars_side_effect(*args, **kwargs):
-            m = MagicMock()
-            # First call returns documents; subsequent calls return segments
-            if not hasattr(_scalars_side_effect, "_calls"):
-                _scalars_side_effect._calls = 0
-            if _scalars_side_effect._calls == 0:
-                m.all.return_value = mock_documents
-            else:
-                m.all.return_value = mock_document_segments
-            _scalars_side_effect._calls += 1
-            return m
-
-        mock_db_session.scalars.side_effect = _scalars_side_effect
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # Verify IndexingRunner was called
-        mock_indexing_runner.run.assert_called_once()
-
-        # Verify all documents were set to parsing status
-        for doc in mock_documents:
-            assert doc.indexing_status == "parsing"
-            assert doc.processing_started_at is not None
-
-        # Verify session operations
-        assert mock_db_session.commit.called
-        assert mock_db_session.close.called
-
-    def test_duplicate_document_indexing_dataset_not_found(self, mock_db_session, dataset_id, document_ids):
-        """Test duplicate document indexing when dataset is not found."""
-        # Arrange
-        mock_db_session.query.return_value.where.return_value.first.return_value = None
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # Should close the session at least once
-        assert mock_db_session.close.called
-
-    def test_duplicate_document_indexing_with_billing_enabled_sandbox_plan(
-        self,
-        mock_db_session,
-        mock_feature_service,
-        mock_dataset,
-        dataset_id,
-        document_ids,
-    ):
-        """Test duplicate document indexing with billing enabled and sandbox plan."""
-        # Arrange
-        mock_db_session.query.return_value.where.return_value.first.return_value = mock_dataset
-        mock_features = mock_feature_service.get_features.return_value
-        mock_features.billing.enabled = True
-        mock_features.billing.subscription.plan = CloudPlan.SANDBOX
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # For sandbox plan with multiple documents, should fail
-        mock_db_session.commit.assert_called()
-
-    def test_duplicate_document_indexing_with_billing_limit_exceeded(
-        self,
-        mock_db_session,
-        mock_feature_service,
-        mock_dataset,
-        mock_documents,
-        dataset_id,
-        document_ids,
-    ):
-        """Test duplicate document indexing when billing limit is exceeded."""
-        # Arrange
-        mock_db_session.query.return_value.where.return_value.first.return_value = mock_dataset
-        # First scalars() -> documents; subsequent -> empty segments
-
-        def _scalars_side_effect(*args, **kwargs):
-            m = MagicMock()
-            if not hasattr(_scalars_side_effect, "_calls"):
-                _scalars_side_effect._calls = 0
-            if _scalars_side_effect._calls == 0:
-                m.all.return_value = mock_documents
-            else:
-                m.all.return_value = []
-            _scalars_side_effect._calls += 1
-            return m
-
-        mock_db_session.scalars.side_effect = _scalars_side_effect
-        mock_features = mock_feature_service.get_features.return_value
-        mock_features.billing.enabled = True
-        mock_features.billing.subscription.plan = CloudPlan.TEAM
-        mock_features.vector_space.size = 990
-        mock_features.vector_space.limit = 1000
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # Should commit the session
-        assert mock_db_session.commit.called
-        # Should close the session
-        assert mock_db_session.close.called
-
-    def test_duplicate_document_indexing_runner_error(
-        self,
-        mock_db_session,
-        mock_indexing_runner,
-        mock_feature_service,
-        mock_index_processor_factory,
-        mock_dataset,
-        mock_documents,
-        dataset_id,
-        document_ids,
-    ):
-        """Test duplicate document indexing when IndexingRunner raises an error."""
-        # Arrange
-        mock_db_session.query.return_value.where.return_value.first.return_value = mock_dataset
-
-        def _scalars_side_effect(*args, **kwargs):
-            m = MagicMock()
-            if not hasattr(_scalars_side_effect, "_calls"):
-                _scalars_side_effect._calls = 0
-            if _scalars_side_effect._calls == 0:
-                m.all.return_value = mock_documents
-            else:
-                m.all.return_value = []
-            _scalars_side_effect._calls += 1
-            return m
-
-        mock_db_session.scalars.side_effect = _scalars_side_effect
-        mock_indexing_runner.run.side_effect = Exception("Indexing error")
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # Should close the session even after error
-        mock_db_session.close.assert_called_once()
-
-    def test_duplicate_document_indexing_document_is_paused(
-        self,
-        mock_db_session,
-        mock_indexing_runner,
-        mock_feature_service,
-        mock_index_processor_factory,
-        mock_dataset,
-        mock_documents,
-        dataset_id,
-        document_ids,
-    ):
-        """Test duplicate document indexing when document is paused."""
-        # Arrange
-        mock_db_session.query.return_value.where.return_value.first.return_value = mock_dataset
-
-        def _scalars_side_effect(*args, **kwargs):
-            m = MagicMock()
-            if not hasattr(_scalars_side_effect, "_calls"):
-                _scalars_side_effect._calls = 0
-            if _scalars_side_effect._calls == 0:
-                m.all.return_value = mock_documents
-            else:
-                m.all.return_value = []
-            _scalars_side_effect._calls += 1
-            return m
-
-        mock_db_session.scalars.side_effect = _scalars_side_effect
-        mock_indexing_runner.run.side_effect = DocumentIsPausedError("Document paused")
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # Should handle DocumentIsPausedError gracefully
-        mock_db_session.close.assert_called_once()
-
-    def test_duplicate_document_indexing_cleans_old_segments(
-        self,
-        mock_db_session,
-        mock_indexing_runner,
-        mock_feature_service,
-        mock_index_processor_factory,
-        mock_dataset,
-        mock_documents,
-        mock_document_segments,
-        dataset_id,
-        document_ids,
-    ):
-        """Test that duplicate document indexing cleans old segments."""
-        # Arrange
-        mock_db_session.query.return_value.where.return_value.first.return_value = mock_dataset
-
-        def _scalars_side_effect(*args, **kwargs):
-            m = MagicMock()
-            if not hasattr(_scalars_side_effect, "_calls"):
-                _scalars_side_effect._calls = 0
-            if _scalars_side_effect._calls == 0:
-                m.all.return_value = mock_documents
-            else:
-                m.all.return_value = mock_document_segments
-            _scalars_side_effect._calls += 1
-            return m
-
-        mock_db_session.scalars.side_effect = _scalars_side_effect
-        mock_processor = mock_index_processor_factory.return_value.init_index_processor.return_value
-
-        # Act
-        _duplicate_document_indexing_task(dataset_id, document_ids)
-
-        # Assert
-        # Verify clean was called for each document
-        assert mock_processor.clean.call_count == len(mock_documents)
-
-        # Verify segments were deleted in batch (DELETE FROM document_segments)
-        execute_sqls = [" ".join(str(c[0][0]).split()) for c in mock_db_session.execute.call_args_list]
-        assert any("DELETE FROM document_segments" in sql for sql in execute_sqls)
-
-
-# ============================================================================
-# Tests for tenant queue wrapper function
-# ============================================================================
-
-
 class TestDuplicateDocumentIndexingTaskWithTenantQueue:
     """Tests for _duplicate_document_indexing_task_with_tenant_queue function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
     def test_tenant_queue_wrapper_calls_core_function(
         self,
         mock_core_func,
@@ -464,7 +89,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
         # Assert
         mock_core_func.assert_called_once_with(dataset_id, document_ids)
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
     def test_tenant_queue_wrapper_deletes_key_when_no_tasks(
         self,
         mock_core_func,
@@ -484,7 +109,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
         # Assert
         mock_tenant_isolated_queue.delete_task_key.assert_called_once()
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
     def test_tenant_queue_wrapper_processes_next_tasks(
         self,
         mock_core_func,
@@ -514,7 +139,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
             document_ids=document_ids,
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
     def test_tenant_queue_wrapper_handles_core_function_error(
         self,
         mock_core_func,
@@ -536,15 +161,10 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
         mock_tenant_isolated_queue.pull_tasks.assert_called_once()
 
 
-# ============================================================================
-# Tests for normal_duplicate_document_indexing_task
-# ============================================================================
-
-
 class TestNormalDuplicateDocumentIndexingTask:
     """Tests for normal_duplicate_document_indexing_task function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
     def test_normal_task_calls_tenant_queue_wrapper(
         self,
         mock_wrapper_func,
@@ -561,7 +181,7 @@ class TestNormalDuplicateDocumentIndexingTask:
             tenant_id, dataset_id, document_ids, normal_duplicate_document_indexing_task
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
     def test_normal_task_with_empty_document_ids(
         self,
         mock_wrapper_func,
@@ -581,15 +201,10 @@ class TestNormalDuplicateDocumentIndexingTask:
         )
 
 
-# ============================================================================
-# Tests for priority_duplicate_document_indexing_task
-# ============================================================================
-
-
 class TestPriorityDuplicateDocumentIndexingTask:
     """Tests for priority_duplicate_document_indexing_task function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
     def test_priority_task_calls_tenant_queue_wrapper(
         self,
         mock_wrapper_func,
@@ -606,7 +221,7 @@ class TestPriorityDuplicateDocumentIndexingTask:
             tenant_id, dataset_id, document_ids, priority_duplicate_document_indexing_task
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
     def test_priority_task_with_single_document(
         self,
         mock_wrapper_func,
@@ -625,7 +240,7 @@ class TestPriorityDuplicateDocumentIndexingTask:
             tenant_id, dataset_id, document_ids, priority_duplicate_document_indexing_task
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
     def test_priority_task_with_large_batch(
         self,
         mock_wrapper_func,

--- a/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
@@ -31,7 +31,7 @@ def document_ids():
 
 @pytest.fixture
 def mock_tenant_isolated_queue():
-    with patch("tasks.duplicate_document_indexing_task.TenantIsolatedTaskQueue") as mock_queue_class:
+    with patch("tasks.duplicate_document_indexing_task.TenantIsolatedTaskQueue", autospec=True) as mock_queue_class:
         mock_queue = Mock(spec=TenantIsolatedTaskQueue)
         mock_queue.pull_tasks.return_value = []
         mock_queue.delete_task_key = Mock()
@@ -43,7 +43,7 @@ def mock_tenant_isolated_queue():
 class TestDuplicateDocumentIndexingTask:
     """Tests for the deprecated duplicate_document_indexing_task function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_duplicate_document_indexing_task_calls_core_function(self, mock_core_func, dataset_id, document_ids):
         """Test that duplicate_document_indexing_task calls the core _duplicate_document_indexing_task function."""
         # Act
@@ -52,7 +52,7 @@ class TestDuplicateDocumentIndexingTask:
         # Assert
         mock_core_func.assert_called_once_with(dataset_id, document_ids)
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_duplicate_document_indexing_task_with_empty_document_ids(self, mock_core_func, dataset_id):
         """Test duplicate_document_indexing_task with empty document_ids list."""
         # Arrange
@@ -68,7 +68,7 @@ class TestDuplicateDocumentIndexingTask:
 class TestDuplicateDocumentIndexingTaskWithTenantQueue:
     """Tests for _duplicate_document_indexing_task_with_tenant_queue function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_tenant_queue_wrapper_calls_core_function(
         self,
         mock_core_func,
@@ -87,7 +87,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
         # Assert
         mock_core_func.assert_called_once_with(dataset_id, document_ids)
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_tenant_queue_wrapper_deletes_key_when_no_tasks(
         self,
         mock_core_func,
@@ -107,7 +107,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
         # Assert
         mock_tenant_isolated_queue.delete_task_key.assert_called_once()
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_tenant_queue_wrapper_processes_next_tasks(
         self,
         mock_core_func,
@@ -137,7 +137,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
             document_ids=document_ids,
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_tenant_queue_wrapper_handles_core_function_error(
         self,
         mock_core_func,
@@ -162,7 +162,7 @@ class TestDuplicateDocumentIndexingTaskWithTenantQueue:
 class TestNormalDuplicateDocumentIndexingTask:
     """Tests for normal_duplicate_document_indexing_task function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
     def test_normal_task_calls_tenant_queue_wrapper(
         self,
         mock_wrapper_func,
@@ -179,7 +179,7 @@ class TestNormalDuplicateDocumentIndexingTask:
             tenant_id, dataset_id, document_ids, normal_duplicate_document_indexing_task
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
     def test_normal_task_with_empty_document_ids(
         self,
         mock_wrapper_func,
@@ -202,7 +202,7 @@ class TestNormalDuplicateDocumentIndexingTask:
 class TestPriorityDuplicateDocumentIndexingTask:
     """Tests for priority_duplicate_document_indexing_task function."""
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
     def test_priority_task_calls_tenant_queue_wrapper(
         self,
         mock_wrapper_func,
@@ -219,7 +219,7 @@ class TestPriorityDuplicateDocumentIndexingTask:
             tenant_id, dataset_id, document_ids, priority_duplicate_document_indexing_task
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
     def test_priority_task_with_single_document(
         self,
         mock_wrapper_func,
@@ -238,7 +238,7 @@ class TestPriorityDuplicateDocumentIndexingTask:
             tenant_id, dataset_id, document_ids, priority_duplicate_document_indexing_task
         )
 
-    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue")
+    @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task_with_tenant_queue", autospec=True)
     def test_priority_task_with_large_batch(
         self,
         mock_wrapper_func,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Migrated SQL-oriented tests for `duplicate_document_indexing_task` into `api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py`, including parity aliases for original SQL test names.
- Removed migrated SQL tests from `api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py` and kept only non-SQL queue/wrapper tests.
- Verified target integration tests, task unit tests, `make lint`, and `make check` all pass.
- Part of #32454.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
