### PR TITLE
fix: handle agent_message event in MCP server streaming response

### DIFF
--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -221,7 +221,6 @@ def process_streaming_response(response: RateLimitGenerator) -> str:
     return answer or last_thought
 
 
-
 def process_mapping_response(app: App, response: Mapping) -> str:
     """Process mapping response based on app mode"""
     if app.mode in {

--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -203,16 +203,23 @@ def extract_answer_from_response(app: App, response: Any) -> str:
 def process_streaming_response(response: RateLimitGenerator) -> str:
     """Process streaming response for agent chat mode"""
     answer = ""
+    last_thought = ""
     for item in response.generator:
         if isinstance(item, str) and item.startswith("data: "):
             try:
                 json_str = item[6:].strip()
                 parsed_data = json.loads(json_str)
-                if parsed_data.get("event") == "agent_thought":
-                    answer += parsed_data.get("thought", "")
+                event = parsed_data.get("event")
+                if event in ("message", "agent_message"):
+                    answer += parsed_data.get("answer", "")
+                elif event == "agent_thought":
+                    thought = parsed_data.get("thought", "")
+                    if thought:
+                        last_thought = thought
             except json.JSONDecodeError:
                 continue
-    return answer
+    return answer or last_thought
+
 
 
 def process_mapping_response(app: App, response: Mapping) -> str:

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -401,7 +401,6 @@ class TestUtilityFunctions:
 
         assert result == "more thinking"
 
-
     def test_process_mapping_response_invalid_mode(self):
         """Test processing mapping response with invalid app mode"""
         app = Mock(spec=App)

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -357,21 +357,50 @@ class TestUtilityFunctions:
         assert result == expected
 
     def test_extract_answer_from_streaming_response(self):
-        """Test extracting answer from streaming response"""
+        """Test extracting answer from streaming response with agent_message events"""
         app = Mock(spec=App)
 
-        # Mock RateLimitGenerator
         mock_generator = Mock(spec=RateLimitGenerator)
         mock_generator.generator = [
             'data: {"event": "agent_thought", "thought": "thinking..."}',
-            'data: {"event": "agent_thought", "thought": "more thinking"}',
-            'data: {"event": "other", "content": "ignore this"}',
+            'data: {"event": "agent_message", "answer": "Hello "}',
+            'data: {"event": "agent_message", "answer": "World"}',
+            'data: {"event": "message_end", "metadata": {}}',
             "not data format",
         ]
 
         result = extract_answer_from_response(app, mock_generator)
 
-        assert result == "thinking...more thinking"
+        assert result == "Hello World"
+
+    def test_extract_answer_from_streaming_response_message_event(self):
+        """Test extracting answer from streaming response with message event"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "message", "answer": "Hello from chat"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "Hello from chat"
+
+    def test_extract_answer_from_streaming_response_fallback_to_thought(self):
+        """Test extracting answer falls back to thought when no message events"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "agent_thought", "thought": "thinking..."}',
+            'data: {"event": "agent_thought", "thought": "more thinking"}',
+            'data: {"event": "other", "content": "ignore this"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "more thinking"
+
 
     def test_process_mapping_response_invalid_mode(self):
         """Test processing mapping response with invalid app mode"""


### PR DESCRIPTION
## Summary
Fix MCP server returning empty text for agent-chat mode apps.

## Problem
`process_streaming_response()` in `api/core/mcp/server/streamable_http.py` only captured `agent_thought` events, but agent-chat mode apps emit `agent_message` events containing the actual LLM answer chunks. This caused MCP clients to receive empty text or only the agent's internal reasoning instead of the real answer.

### Steps to reproduce
1. Create an agent-chat mode app in Dify
2. Enable MCP server for the app
3. Send a `tools/call` JSON-RPC request to the MCP endpoint
4. The agent executes successfully (visible in Dify UI) but the MCP response returns `{"content": [{"type": "text", "text": ""}]}`

## Fix
Updated `process_streaming_response()` to:
- Capture `message` and `agent_message` events as the primary answer source
- Keep `agent_thought` as a fallback when no message events are present
- Return the actual answer text, falling back to the last thought

## Testing
- Updated existing unit test to cover `agent_message` events
- Added test for `message` event (regular chat mode compatibility)
- Added test for fallback to `agent_thought` when no message events present

fixes #32526
