### PR TITLE
fix: incorrect form field height of input modal

### DIFF
--- a/web/app/components/app/configuration/config-var/config-modal/field.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/field.tsx
@@ -20,10 +20,10 @@ const Field: FC<Props> = ({
   const { t } = useTranslation()
   return (
     <div className={cn(className)}>
-      <div className="system-sm-semibold leading-8 text-text-secondary">
+      <div className="!leading-8 text-text-secondary system-sm-semibold">
         {title}
         {isOptional && (
-          <span className="system-xs-regular ml-1 text-text-tertiary">
+          <span className="ml-1 text-text-tertiary system-xs-regular">
             (
             {t('variableConfig.optional', { ns: 'appDebug' })}
             )

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -560,11 +560,6 @@
       "count": 3
     }
   },
-  "app/components/app/configuration/config-var/config-modal/field.tsx": {
-    "tailwindcss/enforce-consistent-class-order": {
-      "count": 2
-    }
-  },
   "app/components/app/configuration/config-var/config-modal/index.tsx": {
     "tailwindcss/enforce-consistent-class-order": {
       "count": 2


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/32556

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
