### PR TITLE
fix: replace 13 bare except clauses with except Exception

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -81,7 +81,7 @@ def reset_password(email, new_password, password_confirm):
 
         try:
             valid_password(new_password)
-        except:
+        except Exception:
             click.echo(click.style(f"Invalid password. Must match {password_pattern}", fg="red"))
             return
 
@@ -121,7 +121,7 @@ def reset_email(email, new_email, email_confirm):
 
         try:
             email_validate(normalized_new_email)
-        except:
+        except Exception:
             click.echo(click.style(f"Invalid email: {new_email}", fg="red"))
             return
 

--- a/api/core/agent/output_parser/cot_output_parser.py
+++ b/api/core/agent/output_parser/cot_output_parser.py
@@ -49,7 +49,7 @@ class CotAgentOutputParser:
                     json_text = re.sub(r"^[a-zA-Z]+\n", "", block.strip(), flags=re.MULTILINE)
                     json_blocks.append(json.loads(json_text, strict=False))
                 return json_blocks
-            except:
+            except Exception:
                 return []
 
         code_block_cache = ""

--- a/api/core/agent/output_parser/cot_output_parser.py
+++ b/api/core/agent/output_parser/cot_output_parser.py
@@ -49,7 +49,7 @@ class CotAgentOutputParser:
                     json_text = re.sub(r"^[a-zA-Z]+\n", "", block.strip(), flags=re.MULTILINE)
                     json_blocks.append(json.loads(json_text, strict=False))
                 return json_blocks
-            except Exception:
+            except json.JSONDecodeError:
                 return []
 
         code_block_cache = ""

--- a/api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py
+++ b/api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py
@@ -57,7 +57,7 @@ class AnalyticdbVectorOpenAPI:
         try:
             from alibabacloud_gpdb20160503.client import Client  # type: ignore
             from alibabacloud_tea_openapi import models as open_api_models  # type: ignore
-        except Exception:
+        except ImportError:
             raise ImportError(_import_err_msg)
         self._collection_name = collection_name.lower()
         self.config = config

--- a/api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py
+++ b/api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py
@@ -57,7 +57,7 @@ class AnalyticdbVectorOpenAPI:
         try:
             from alibabacloud_gpdb20160503.client import Client  # type: ignore
             from alibabacloud_tea_openapi import models as open_api_models  # type: ignore
-        except:
+        except Exception:
             raise ImportError(_import_err_msg)
         self._collection_name = collection_name.lower()
         self.config = config

--- a/api/core/rag/datasource/vdb/lindorm/lindorm_vector.py
+++ b/api/core/rag/datasource/vdb/lindorm/lindorm_vector.py
@@ -231,7 +231,7 @@ class LindormVectorStore(BaseVector):
                 params["routing"] = self._routing
             self._client.get(index=self._collection_name, id=id, params=params)
             return True
-        except:
+        except Exception:
             return False
 
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
+++ b/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
@@ -167,7 +167,7 @@ class OpenSearchVector(BaseVector):
         try:
             self._client.get(index=self._collection_name.lower(), id=id)
             return True
-        except Exception:
+        except NotFoundError:
             return False
 
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
+++ b/api/core/rag/datasource/vdb/opensearch/opensearch_vector.py
@@ -167,7 +167,7 @@ class OpenSearchVector(BaseVector):
         try:
             self._client.get(index=self._collection_name.lower(), id=id)
             return True
-        except:
+        except Exception:
             return False
 
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/core/variables/segments.py
+++ b/api/core/variables/segments.py
@@ -230,7 +230,7 @@ def get_segment_discriminator(v: Any) -> SegmentType | None:
 #
 # Note:
 # - All variants in `SegmentUnion` must inherit from the `Segment` class.
-# - The union must include all non-abstract subclasses of `Segment`, except:
+# - The union must include all non-abstract subclasses of `Segment`, except Exception:
 #   - `SegmentGroup`, which is not added to the variable pool.
 #   - `VariableBase` and its subclasses, which are handled by `Variable`.
 SegmentUnion: TypeAlias = Annotated[

--- a/api/extensions/storage/aws_s3_storage.py
+++ b/api/extensions/storage/aws_s3_storage.py
@@ -80,7 +80,7 @@ class AwsS3Storage(BaseStorage):
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=filename)
             return True
-        except:
+        except Exception:
             return False
 
     def delete(self, filename):

--- a/api/extensions/storage/oracle_oci_storage.py
+++ b/api/extensions/storage/oracle_oci_storage.py
@@ -52,7 +52,7 @@ class OracleOCIStorage(BaseStorage):
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=filename)
             return True
-        except:
+        except Exception:
             return False
 
     def delete(self, filename):

--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -212,7 +212,7 @@ def check_csrf_token(request: Request, user_id: str):
     verified = {}
     try:
         verified = PassportService().verify(csrf_token)
-    except:
+    except Exception:
         _unauthorized()
 
     if verified.get("sub") != user_id:

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -409,7 +409,7 @@ class AppService:
                         if provider is None:
                             raise ValueError(f"provider not found for tool {tool_name}")
                         meta["tool_icons"][tool_name] = json.loads(provider.icon)
-                    except:
+                    except Exception:
                         meta["tool_icons"][tool_name] = {"background": "#252525", "content": "\ud83d\ude01"}
 
         return meta

--- a/api/services/trigger/webhook_service.py
+++ b/api/services/trigger/webhook_service.py
@@ -816,7 +816,7 @@ class WebhookService:
                     response_data = {"message": response_body}
             else:
                 response_data = {"status": "success", "message": "Webhook processed successfully"}
-        except:
+        except Exception:
             response_data = {"message": response_body or "Webhook processed successfully"}
 
         return response_data, status_code

--- a/api/tests/integration_tests/vdb/clickzetta/test_docker_integration.py
+++ b/api/tests/integration_tests/vdb/clickzetta/test_docker_integration.py
@@ -70,7 +70,7 @@ def test_dify_api():
             if response.status_code == 200:
                 print("✓ Dify API is ready")
                 break
-        except:
+        except Exception:
             if i == max_retries - 1:
                 print("✗ Dify API is not responding")
                 return False


### PR DESCRIPTION
## What
Replace 13 bare `except:` clauses with `except Exception:` across 12 files.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.