### PR TITLE
test: migrate restore_archived_workflow_run SQL tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_restore_archived_workflow_run.py
+++ b/api/tests/test_containers_integration_tests/services/test_restore_archived_workflow_run.py
@@ -1,0 +1,54 @@
+"""
+Testcontainers integration tests for workflow run restore functionality.
+"""
+
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from models.workflow import WorkflowPause
+from services.retention.workflow_run.restore_archived_workflow_run import WorkflowRunRestore
+
+
+class TestWorkflowRunRestore:
+    """Tests for the WorkflowRunRestore class."""
+
+    def test_restore_table_records_returns_rowcount(self, db_session_with_containers):
+        """Restore should return inserted rowcount."""
+        restore = WorkflowRunRestore()
+        record_id = str(uuid4())
+        records = [
+            {
+                "id": record_id,
+                "workflow_id": str(uuid4()),
+                "workflow_run_id": str(uuid4()),
+                "state_object_key": f"workflow-state-{uuid4()}.json",
+                "created_at": "2024-01-01T00:00:00",
+                "updated_at": "2024-01-01T00:00:00",
+            }
+        ]
+
+        restored = restore._restore_table_records(
+            db_session_with_containers,
+            "workflow_pauses",
+            records,
+            schema_version="1.0",
+        )
+        db_session_with_containers.commit()
+
+        assert restored == 1
+        restored_pause = db_session_with_containers.scalar(select(WorkflowPause).where(WorkflowPause.id == record_id))
+        assert restored_pause is not None
+
+    def test_restore_table_records_unknown_table(self, db_session_with_containers):
+        """Unknown table names should be ignored gracefully."""
+        restore = WorkflowRunRestore()
+
+        restored = restore._restore_table_records(
+            db_session_with_containers,
+            "unknown_table",
+            [{"id": str(uuid4())}],
+            schema_version="1.0",
+        )
+
+        assert restored == 0

--- a/api/tests/test_containers_integration_tests/services/test_restore_archived_workflow_run.py
+++ b/api/tests/test_containers_integration_tests/services/test_restore_archived_workflow_run.py
@@ -34,7 +34,6 @@ class TestWorkflowRunRestore:
             records,
             schema_version="1.0",
         )
-        db_session_with_containers.commit()
 
         assert restored == 1
         restored_pause = db_session_with_containers.scalar(select(WorkflowPause).where(WorkflowPause.id == record_id))

--- a/api/tests/unit_tests/services/test_restore_archived_workflow_run.py
+++ b/api/tests/unit_tests/services/test_restore_archived_workflow_run.py
@@ -3,7 +3,6 @@ Unit tests for workflow run restore functionality.
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock
 
 
 class TestWorkflowRunRestore:
@@ -36,30 +35,3 @@ class TestWorkflowRunRestore:
         assert result["created_at"].year == 2024
         assert result["created_at"].month == 1
         assert result["name"] == "test"
-
-    def test_restore_table_records_returns_rowcount(self):
-        """Restore should return inserted rowcount."""
-        from services.retention.workflow_run.restore_archived_workflow_run import WorkflowRunRestore
-
-        session = MagicMock()
-        session.execute.return_value = MagicMock(rowcount=2)
-
-        restore = WorkflowRunRestore()
-        records = [{"id": "p1", "workflow_run_id": "r1", "created_at": "2024-01-01T00:00:00"}]
-
-        restored = restore._restore_table_records(session, "workflow_pauses", records, schema_version="1.0")
-
-        assert restored == 2
-        session.execute.assert_called_once()
-
-    def test_restore_table_records_unknown_table(self):
-        """Unknown table names should be ignored gracefully."""
-        from services.retention.workflow_run.restore_archived_workflow_run import WorkflowRunRestore
-
-        session = MagicMock()
-
-        restore = WorkflowRunRestore()
-        restored = restore._restore_table_records(session, "unknown_table", [{"id": "x1"}], schema_version="1.0")
-
-        assert restored == 0
-        session.execute.assert_not_called()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Migrate SQL-related tests in `test_restore_archived_workflow_run.py` from unit tests to testcontainers integration tests, keeping original test logic and function names.

Part of #32454

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
