### PR TITLE
Fix hydration warning for inline markdown images

### DIFF
--- a/web/app/components/base/markdown-blocks/img.tsx
+++ b/web/app/components/base/markdown-blocks/img.tsx
@@ -4,10 +4,8 @@
  * Uses the ImageGallery component to display images.
  */
 import * as React from 'react'
-import ImageGallery from '@/app/components/base/image-gallery'
 
-const Img = ({ src }: any) => {
-  return <div className="markdown-img-wrapper"><ImageGallery srcs={[src]} /></div>
+export default function Img(props: any) {
+  const { src, alt, ...rest } = props
+  return <img src={src} alt={alt ?? ''} {...rest} />
 }
-
-export default Img

--- a/web/app/dev/markdown-test/page.tsx
+++ b/web/app/dev/markdown-test/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { ReactMarkdownWrapper } from '@/app/components/base/markdown/react-markdown-wrapper'
+
+export default function Page() {
+  const md = 'Text before ![image](https://example.com/a.png) text after'
+  return <ReactMarkdownWrapper latexContent={md} />
+}


### PR DESCRIPTION
**What**
Render inline markdown images as <img> to avoid invalid HTML nesting (<div> inside <p>), preventing hydration warnings.

**Why**
Inline image renderer previously returned a wrapper <div> which can be placed inside <p> nodes by the markdown parser, producing invalid HTML and hydration errors.

**How to test**
Render markdown like: Text before ![image](https://example.com/a.png) text after

Confirm no console warning: “In HTML, <div> cannot be a descendant of <p>”.

Fixes #32362 