### PR TITLE
fix: replace deprecated OpenTelemetry SpanAttributes/ResourceAttributes imports

### DIFF
--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -26,7 +26,13 @@ def init_app(app: DifyApp):
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
-    from opentelemetry.semconv.resource import ResourceAttributes
+    from opentelemetry.semconv._incubating.attributes.deployment_attributes import (
+        DEPLOYMENT_ENVIRONMENT_NAME,
+    )
+    from opentelemetry.semconv._incubating.attributes.host_attributes import HOST_ARCH, HOST_ID, HOST_NAME
+    from opentelemetry.semconv._incubating.attributes.os_attributes import OS_DESCRIPTION, OS_TYPE, OS_VERSION
+    from opentelemetry.semconv._incubating.attributes.process_attributes import PROCESS_PID
+    from opentelemetry.semconv.attributes.service_attributes import SERVICE_NAME, SERVICE_VERSION
     from opentelemetry.trace import set_tracer_provider
 
     from extensions.otel.instrumentation import init_instruments
@@ -37,17 +43,17 @@ def init_app(app: DifyApp):
     # Follow Semantic Convertions 1.32.0 to define resource attributes
     resource = Resource(
         attributes={
-            ResourceAttributes.SERVICE_NAME: dify_config.APPLICATION_NAME,
-            ResourceAttributes.SERVICE_VERSION: f"dify-{dify_config.project.version}-{dify_config.COMMIT_SHA}",
-            ResourceAttributes.PROCESS_PID: os.getpid(),
-            ResourceAttributes.DEPLOYMENT_ENVIRONMENT: f"{dify_config.DEPLOY_ENV}-{dify_config.EDITION}",
-            ResourceAttributes.HOST_NAME: socket.gethostname(),
-            ResourceAttributes.HOST_ARCH: platform.machine(),
+            SERVICE_NAME: dify_config.APPLICATION_NAME,
+            SERVICE_VERSION: f"dify-{dify_config.project.version}-{dify_config.COMMIT_SHA}",
+            PROCESS_PID: os.getpid(),
+            DEPLOYMENT_ENVIRONMENT_NAME: f"{dify_config.DEPLOY_ENV}-{dify_config.EDITION}",
+            HOST_NAME: socket.gethostname(),
+            HOST_ARCH: platform.machine(),
             "custom.deployment.git_commit": dify_config.COMMIT_SHA,
-            ResourceAttributes.HOST_ID: platform.node(),
-            ResourceAttributes.OS_TYPE: platform.system().lower(),
-            ResourceAttributes.OS_DESCRIPTION: platform.platform(),
-            ResourceAttributes.OS_VERSION: platform.version(),
+            HOST_ID: platform.node(),
+            OS_TYPE: platform.system().lower(),
+            OS_DESCRIPTION: platform.platform(),
+            OS_VERSION: platform.version(),
         }
     )
     sampler = ParentBasedTraceIdRatio(dify_config.OTEL_SAMPLING_RATE)

--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -26,9 +26,7 @@ def init_app(app: DifyApp):
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
-    from opentelemetry.semconv._incubating.attributes.deployment_attributes import (
-        DEPLOYMENT_ENVIRONMENT_NAME,
-    )
+    from opentelemetry.semconv._incubating.attributes.deployment_attributes import DEPLOYMENT_ENVIRONMENT_NAME
     from opentelemetry.semconv._incubating.attributes.host_attributes import HOST_ARCH, HOST_ID, HOST_NAME
     from opentelemetry.semconv._incubating.attributes.os_attributes import OS_DESCRIPTION, OS_TYPE, OS_VERSION
     from opentelemetry.semconv._incubating.attributes.process_attributes import PROCESS_PID

--- a/api/extensions/otel/instrumentation.py
+++ b/api/extensions/otel/instrumentation.py
@@ -7,7 +7,8 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.metrics import get_meter, get_meter_provider
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv.attributes.http_attributes import HTTP_REQUEST_METHOD
+from opentelemetry.semconv.attributes.url_attributes import URL_PATH
 from opentelemetry.trace import Span, get_tracer_provider
 from opentelemetry.trace.status import StatusCode
 
@@ -85,9 +86,9 @@ def init_flask_instrumentor(app: DifyApp) -> None:
                 attributes: dict[str, str | int] = {"status_code": status_code, "status_class": status_class}
                 request = flask.request
                 if request and request.url_rule:
-                    attributes[SpanAttributes.HTTP_TARGET] = str(request.url_rule.rule)
+                    attributes[URL_PATH] = str(request.url_rule.rule)
                 if request and request.method:
-                    attributes[SpanAttributes.HTTP_METHOD] = str(request.method)
+                    attributes[HTTP_REQUEST_METHOD] = str(request.method)
                 _http_response_counter.add(1, attributes)
             except Exception:
                 logger.exception("Error setting status and attributes")

--- a/api/pyrightconfig.json
+++ b/api/pyrightconfig.json
@@ -17,6 +17,7 @@
     "opentelemetry.instrumentation.requests",
     "opentelemetry.instrumentation.sqlalchemy",
     "opentelemetry.instrumentation.redis",
+    "opentelemetry.semconv",
     "langfuse",
     "cloudscraper",
     "readabilipy",


### PR DESCRIPTION
## Summary

Replace deprecated `ResourceAttributes` and `SpanAttributes` class-based imports with the new individual attribute constants from the OpenTelemetry semantic conventions library.

### Changes

**`api/extensions/ext_otel.py`**
- `ResourceAttributes.SERVICE_NAME` → `SERVICE_NAME` from `semconv.attributes.service_attributes`
- `ResourceAttributes.DEPLOYMENT_ENVIRONMENT` → `DEPLOYMENT_ENVIRONMENT_NAME` from `semconv._incubating.attributes.deployment_attributes`
- `ResourceAttributes.HOST_*` → individual imports from `semconv._incubating.attributes.host_attributes`
- `ResourceAttributes.OS_*` → individual imports from `semconv._incubating.attributes.os_attributes`
- `ResourceAttributes.PROCESS_PID` → `PROCESS_PID` from `semconv._incubating.attributes.process_attributes`

**`api/extensions/otel/instrumentation.py`**
- `SpanAttributes.HTTP_TARGET` → `URL_PATH` (stable)
- `SpanAttributes.HTTP_METHOD` → `HTTP_REQUEST_METHOD` (stable)

Stable attributes use `opentelemetry.semconv.attributes.*`, incubating ones use `opentelemetry.semconv._incubating.attributes.*`.

Closes #32600