### PR TITLE
refactor(api): inject code executor from node factory

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -110,7 +110,6 @@ ignore_imports =
     core.workflow.nodes.agent.agent_node -> core.model_manager
     core.workflow.nodes.agent.agent_node -> core.provider_manager
     core.workflow.nodes.agent.agent_node -> core.tools.tool_manager
-    core.workflow.nodes.code.code_node -> core.helper.code_executor.code_executor
     core.workflow.nodes.datasource.datasource_node -> models.model
     core.workflow.nodes.datasource.datasource_node -> models.tools
     core.workflow.nodes.datasource.datasource_node -> services.datasource_provider_service

--- a/api/tests/integration_tests/workflow/nodes/test_code.py
+++ b/api/tests/integration_tests/workflow/nodes/test_code.py
@@ -68,6 +68,7 @@ def init_code_node(code_config: dict):
         config=code_config,
         graph_init_params=init_params,
         graph_runtime_state=graph_runtime_state,
+        code_executor=node_factory._code_executor,
         code_limits=CodeNodeLimits(
             max_string_length=dify_config.CODE_MAX_STRING_LENGTH,
             max_number=dify_config.CODE_MAX_NUMBER,

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_mock_nodes_template_code.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_mock_nodes_template_code.py
@@ -24,6 +24,16 @@ DEFAULT_CODE_LIMITS = CodeNodeLimits(
 )
 
 
+class _NoopCodeExecutor:
+    def execute(self, *, language: object, code: str, inputs: dict[str, object]) -> dict[str, object]:
+        _ = (language, code, inputs)
+        return {}
+
+    def is_execution_error(self, error: Exception) -> bool:
+        _ = error
+        return False
+
+
 class TestMockTemplateTransformNode:
     """Test cases for MockTemplateTransformNode."""
 
@@ -319,6 +329,7 @@ class TestMockCodeNode:
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
             mock_config=mock_config,
+            code_executor=_NoopCodeExecutor(),
             code_limits=DEFAULT_CODE_LIMITS,
         )
 
@@ -384,6 +395,7 @@ class TestMockCodeNode:
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
             mock_config=mock_config,
+            code_executor=_NoopCodeExecutor(),
             code_limits=DEFAULT_CODE_LIMITS,
         )
 
@@ -453,6 +465,7 @@ class TestMockCodeNode:
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
             mock_config=mock_config,
+            code_executor=_NoopCodeExecutor(),
             code_limits=DEFAULT_CODE_LIMITS,
         )
 


### PR DESCRIPTION
## Summary

Part of #30506

This PR removes the import-linter allowlist dependency from `core.workflow.nodes.code.code_node` to `core.helper.code_executor.code_executor` by moving code-executor construction/injection into the workflow node factory.

### Changes

- Introduce `WorkflowCodeExecutor` protocol in `CodeNode` with instance methods:
  - `execute(...)`
  - `is_execution_error(...)`
- Remove direct `CodeExecutor` imports from `CodeNode`; execute through injected dependency.
- Add `DefaultWorkflowCodeExecutor` in `DifyNodeFactory` and inject it into `CodeNode`.
- Remove this import-linter ignore entry:
  - `core.workflow.nodes.code.code_node -> core.helper.code_executor.code_executor`
- Update touched tests to pass an executor instance where `CodeNode` is directly instantiated.


## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
