### PR TITLE
feat: when copy/paste multi nodes not require reconnect them

### DIFF
--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -1606,6 +1606,7 @@ export const useNodesInteractions = () => {
       const offsetX = currentPosition.x - x
       const offsetY = currentPosition.y - y
       let idMapping: Record<string, string> = {}
+      const pastedNodesMap: Record<string, Node> = {}
       const parentChildrenToAppend: { parentId: string, childId: string, childType: BlockEnum }[] = []
       clipboardElements.forEach((nodeToPaste, index) => {
         const nodeType = nodeToPaste.data.type
@@ -1665,7 +1666,21 @@ export const useNodesInteractions = () => {
           newLoopStartNode!.parentId = newNode.id;
           (newNode.data as LoopNodeType).start_node_id = newLoopStartNode!.id
 
+          const oldLoopStartNode = nodes.find(
+            n => n.parentId === nodeToPaste.id && n.type === CUSTOM_LOOP_START_NODE,
+          )
+          if (oldLoopStartNode)
+            idMapping[oldLoopStartNode.id] = newLoopStartNode!.id
+
+          const oldLoopChildren = nodes.filter(
+            n => n.parentId === nodeToPaste.id && n.type !== CUSTOM_LOOP_START_NODE,
+          )
           newChildren = handleNodeLoopChildrenCopy(nodeToPaste.id, newNode.id)
+          oldLoopChildren.forEach((oldChild, childIndex) => {
+            const copiedChild = newChildren[childIndex]
+            if (copiedChild)
+              idMapping[oldChild.id] = copiedChild.id
+          })
           newChildren.forEach((child) => {
             newNode.data._children?.push({
               nodeId: child.id,
@@ -1710,18 +1725,31 @@ export const useNodesInteractions = () => {
           }
         }
 
+        idMapping[nodeToPaste.id] = newNode.id
         nodesToPaste.push(newNode)
+        pastedNodesMap[newNode.id] = newNode
 
-        if (newChildren.length)
+        if (newChildren.length) {
+          newChildren.forEach((child) => {
+            pastedNodesMap[child.id] = child
+          })
           nodesToPaste.push(...newChildren)
+        }
       })
 
-      // only handle edge when paste nested block
+      // Rebuild edges where both endpoints are part of the pasted set.
       edges.forEach((edge) => {
         const sourceId = idMapping[edge.source]
         const targetId = idMapping[edge.target]
 
         if (sourceId && targetId) {
+          const sourceNode = pastedNodesMap[sourceId]
+          const targetNode = pastedNodesMap[targetId]
+          const parentNode = sourceNode?.parentId && sourceNode.parentId === targetNode?.parentId
+            ? pastedNodesMap[sourceNode.parentId] ?? nodes.find(n => n.id === sourceNode.parentId)
+            : null
+          const isInIteration = parentNode?.data.type === BlockEnum.Iteration
+          const isInLoop = parentNode?.data.type === BlockEnum.Loop
           const newEdge: Edge = {
             ...edge,
             id: `${sourceId}-${edge.sourceHandle}-${targetId}-${edge.targetHandle}`,
@@ -1729,8 +1757,19 @@ export const useNodesInteractions = () => {
             target: targetId,
             data: {
               ...edge.data,
+              isInIteration,
+              iteration_id: isInIteration ? parentNode?.id : undefined,
+              isInLoop,
+              loop_id: isInLoop ? parentNode?.id : undefined,
               _connectedNodeIsSelected: false,
             },
+            zIndex: parentNode
+              ? isInIteration
+                ? ITERATION_CHILDREN_Z_INDEX
+                : isInLoop
+                  ? LOOP_CHILDREN_Z_INDEX
+                  : 0
+              : 0,
           }
           edgesToPaste.push(newEdge)
         }

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -1667,20 +1667,21 @@ export const useNodesInteractions = () => {
           (newNode.data as LoopNodeType).start_node_id = newLoopStartNode!.id
 
           const oldLoopStartNode = nodes.find(
-            n => n.parentId === nodeToPaste.id && n.type === CUSTOM_LOOP_START_NODE,
+            n =>
+              n.parentId === nodeToPaste.id
+              && n.type === CUSTOM_LOOP_START_NODE,
           )
           if (oldLoopStartNode)
             idMapping[oldLoopStartNode.id] = newLoopStartNode!.id
 
-          const oldLoopChildren = nodes.filter(
-            n => n.parentId === nodeToPaste.id && n.type !== CUSTOM_LOOP_START_NODE,
-          )
-          newChildren = handleNodeLoopChildrenCopy(nodeToPaste.id, newNode.id)
-          oldLoopChildren.forEach((oldChild, childIndex) => {
-            const copiedChild = newChildren[childIndex]
-            if (copiedChild)
-              idMapping[oldChild.id] = copiedChild.id
-          })
+          const { copyChildren, newIdMapping }
+            = handleNodeLoopChildrenCopy(
+              nodeToPaste.id,
+              newNode.id,
+              idMapping,
+            )
+          newChildren = copyChildren
+          idMapping = newIdMapping
           newChildren.forEach((child) => {
             newNode.data._children?.push({
               nodeId: child.id,

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -1671,8 +1671,7 @@ export const useNodesInteractions = () => {
               n.parentId === nodeToPaste.id
               && n.type === CUSTOM_LOOP_START_NODE,
           )
-          if (oldLoopStartNode)
-            idMapping[oldLoopStartNode.id] = newLoopStartNode!.id
+          idMapping[oldLoopStartNode!.id] = newLoopStartNode!.id
 
           const { copyChildren, newIdMapping }
             = handleNodeLoopChildrenCopy(

--- a/web/app/components/workflow/nodes/loop/use-interactions.ts
+++ b/web/app/components/workflow/nodes/loop/use-interactions.ts
@@ -108,12 +108,13 @@ export const useNodeLoopInteractions = () => {
       handleNodeLoopRerender(parentId)
   }, [store, handleNodeLoopRerender])
 
-  const handleNodeLoopChildrenCopy = useCallback((nodeId: string, newNodeId: string) => {
+  const handleNodeLoopChildrenCopy = useCallback((nodeId: string, newNodeId: string, idMapping: Record<string, string>) => {
     const { getNodes } = store.getState()
     const nodes = getNodes()
     const childrenNodes = nodes.filter(n => n.parentId === nodeId && n.type !== CUSTOM_LOOP_START_NODE)
+    const newIdMapping = { ...idMapping }
 
-    return childrenNodes.map((child, index) => {
+    const copyChildren = childrenNodes.map((child, index) => {
       const childNodeType = child.data.type as BlockEnum
       const { defaultValue } = nodesMetaDataMap![childNodeType]
       const nodesWithSameType = nodes.filter(node => node.data.type === childNodeType)
@@ -139,8 +140,14 @@ export const useNodeLoopInteractions = () => {
         zIndex: LOOP_CHILDREN_Z_INDEX,
       })
       newNode.id = `${newNodeId}${newNode.id + index}`
+      newIdMapping[child.id] = newNode.id
       return newNode
     })
+
+    return {
+      copyChildren,
+      newIdMapping,
+    }
   }, [store, nodesMetaDataMap])
 
   return {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/32629

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots
<img width="1388" height="866" alt="image" src="https://github.com/user-attachments/assets/8c7aade2-0f48-4af4-b5f6-4ebd88e60dfd" />

## Tests
- a node with multi children keep connections when copy
- a node with multi parent keep connections when copy
- the children of loop node keep connections when copy
- the if/else node which has multi branch keep connections when copy

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
