### PR TITLE
refactor(otel): migrate from deprecated opentelemetry.semconv imports

### DIFF
--- a/api/core/ops/aliyun_trace/data_exporter/traceclient.py
+++ b/api/core/ops/aliyun_trace/data_exporter/traceclient.py
@@ -16,7 +16,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
-from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.semconv import ResourceAttributes
 from opentelemetry.trace import Link, SpanContext, TraceFlags
 
 from configs import dify_config

--- a/api/core/ops/tencent_trace/client.py
+++ b/api/core/ops/tencent_trace/client.py
@@ -26,7 +26,7 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.semconv import ResourceAttributes
 from opentelemetry.trace import SpanKind
 from opentelemetry.util.types import AttributeValue
 

--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -26,7 +26,7 @@ def init_app(app: DifyApp):
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
-    from opentelemetry.semconv.resource import ResourceAttributes
+    from opentelemetry.semconv import ResourceAttributes
     from opentelemetry.trace import set_tracer_provider
 
     from extensions.otel.instrumentation import init_instruments

--- a/api/extensions/otel/instrumentation.py
+++ b/api/extensions/otel/instrumentation.py
@@ -7,7 +7,7 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.metrics import get_meter, get_meter_provider
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv import SpanAttributes
 from opentelemetry.trace import Span, get_tracer_provider
 from opentelemetry.trace.status import StatusCode
 


### PR DESCRIPTION
## Summary

Fixed issue #32600: Migrated from deprecated `opentelemetry.semconv` imports to the new module path.

### Problem

The OpenTelemetry library deprecated importing `SpanAttributes` and `ResourceAttributes` from sub-modules (`opentelemetry.semconv.trace` and `opentelemetry.semconv.resource`). These imports now trigger deprecation warnings:

```
WARN `SpanAttributes` is deprecated [deprecated]
  --> extensions/otel/instrumentation.py:10:41
   |
10 | from opentelemetry.semconv.trace import SpanAttributes
   |                                         --------------

WARN `ResourceAttributes` is deprecated [deprecated]
  --> extensions/ext_otel.py:29:48
   |
29 |     from opentelemetry.semconv.resource import ResourceAttributes
   |                                                ------------------
```

### Solution

Changed all imports to use the new top-level `opentelemetry.semconv` module:

- `from opentelemetry.semconv.trace import SpanAttributes` → `from opentelemetry.semconv import SpanAttributes`
- `from opentelemetry.semconv.resource import ResourceAttributes` → `from opentelemetry.semconv import ResourceAttributes`

### Files Changed

1. `api/extensions/otel/instrumentation.py` - SpanAttributes import
2. `api/extensions/ext_otel.py` - ResourceAttributes import
3. `api/core/ops/tencent_trace/client.py` - ResourceAttributes import
4. `api/core/ops/aliyun_trace/data_exporter/traceclient.py` - ResourceAttributes import

### Test Plan

- [x] Code compiles without import errors
- [x] No deprecation warnings for OpenTelemetry semconv imports

Closes #32600