### PR TITLE
fix: add type annotations to BaseStorage.exists and BaseStorage.download

### DIFF
--- a/api/extensions/storage/base_storage.py
+++ b/api/extensions/storage/base_storage.py
@@ -20,7 +20,7 @@ class BaseStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def download(self, filename: str, target_filepath: str):
+    def download(self, filename: str, target_filepath: str) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/api/extensions/storage/base_storage.py
+++ b/api/extensions/storage/base_storage.py
@@ -20,11 +20,11 @@ class BaseStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def download(self, filename, target_filepath):
+    def download(self, filename: str, target_filepath: str):
         raise NotImplementedError
 
     @abstractmethod
-    def exists(self, filename):
+    def exists(self, filename: str) -> bool:
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
## Summary

Add missing type annotations to the abstract methods `exists` and `download` in `BaseStorage` to resolve the type inconsistency where subclasses like `AliyunOssStorage` have typed signatures that don't match the untyped base class methods.

## Changes

- Added `filename: str` and `target_filepath: str` type annotations to `BaseStorage.download`
- Added `filename: str` parameter type and `-> bool` return type to `BaseStorage.exists`

Closes #32598