### PR TITLE
fix: replace deprecated SpanAttributes and ResourceAttributes with new semconv imports

### DIFF
--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -26,11 +26,11 @@ def init_app(app: DifyApp):
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
-    from opentelemetry.semconv.attributes.service_attributes import SERVICE_NAME, SERVICE_VERSION
     from opentelemetry.semconv._incubating.attributes.deployment_attributes import DEPLOYMENT_ENVIRONMENT_NAME
     from opentelemetry.semconv._incubating.attributes.host_attributes import HOST_ARCH, HOST_ID, HOST_NAME
     from opentelemetry.semconv._incubating.attributes.os_attributes import OS_DESCRIPTION, OS_TYPE, OS_VERSION
     from opentelemetry.semconv._incubating.attributes.process_attributes import PROCESS_PID
+    from opentelemetry.semconv.attributes.service_attributes import SERVICE_NAME, SERVICE_VERSION
     from opentelemetry.trace import set_tracer_provider
 
     from extensions.otel.instrumentation import init_instruments

--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -26,7 +26,11 @@ def init_app(app: DifyApp):
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
-    from opentelemetry.semconv.resource import ResourceAttributes
+    from opentelemetry.semconv.attributes.service_attributes import SERVICE_NAME, SERVICE_VERSION
+    from opentelemetry.semconv._incubating.attributes.deployment_attributes import DEPLOYMENT_ENVIRONMENT_NAME
+    from opentelemetry.semconv._incubating.attributes.host_attributes import HOST_ARCH, HOST_ID, HOST_NAME
+    from opentelemetry.semconv._incubating.attributes.os_attributes import OS_DESCRIPTION, OS_TYPE, OS_VERSION
+    from opentelemetry.semconv._incubating.attributes.process_attributes import PROCESS_PID
     from opentelemetry.trace import set_tracer_provider
 
     from extensions.otel.instrumentation import init_instruments
@@ -37,17 +41,17 @@ def init_app(app: DifyApp):
     # Follow Semantic Convertions 1.32.0 to define resource attributes
     resource = Resource(
         attributes={
-            ResourceAttributes.SERVICE_NAME: dify_config.APPLICATION_NAME,
-            ResourceAttributes.SERVICE_VERSION: f"dify-{dify_config.project.version}-{dify_config.COMMIT_SHA}",
-            ResourceAttributes.PROCESS_PID: os.getpid(),
-            ResourceAttributes.DEPLOYMENT_ENVIRONMENT: f"{dify_config.DEPLOY_ENV}-{dify_config.EDITION}",
-            ResourceAttributes.HOST_NAME: socket.gethostname(),
-            ResourceAttributes.HOST_ARCH: platform.machine(),
+            SERVICE_NAME: dify_config.APPLICATION_NAME,
+            SERVICE_VERSION: f"dify-{dify_config.project.version}-{dify_config.COMMIT_SHA}",
+            PROCESS_PID: os.getpid(),
+            DEPLOYMENT_ENVIRONMENT_NAME: f"{dify_config.DEPLOY_ENV}-{dify_config.EDITION}",
+            HOST_NAME: socket.gethostname(),
+            HOST_ARCH: platform.machine(),
             "custom.deployment.git_commit": dify_config.COMMIT_SHA,
-            ResourceAttributes.HOST_ID: platform.node(),
-            ResourceAttributes.OS_TYPE: platform.system().lower(),
-            ResourceAttributes.OS_DESCRIPTION: platform.platform(),
-            ResourceAttributes.OS_VERSION: platform.version(),
+            HOST_ID: platform.node(),
+            OS_TYPE: platform.system().lower(),
+            OS_DESCRIPTION: platform.platform(),
+            OS_VERSION: platform.version(),
         }
     )
     sampler = ParentBasedTraceIdRatio(dify_config.OTEL_SAMPLING_RATE)

--- a/api/extensions/ext_otel.py
+++ b/api/extensions/ext_otel.py
@@ -26,11 +26,26 @@ def init_app(app: DifyApp):
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
-    from opentelemetry.semconv._incubating.attributes.deployment_attributes import DEPLOYMENT_ENVIRONMENT_NAME
-    from opentelemetry.semconv._incubating.attributes.host_attributes import HOST_ARCH, HOST_ID, HOST_NAME
-    from opentelemetry.semconv._incubating.attributes.os_attributes import OS_DESCRIPTION, OS_TYPE, OS_VERSION
-    from opentelemetry.semconv._incubating.attributes.process_attributes import PROCESS_PID
-    from opentelemetry.semconv.attributes.service_attributes import SERVICE_NAME, SERVICE_VERSION
+    from opentelemetry.semconv._incubating.attributes.deployment_attributes import (  # type: ignore[import-untyped]
+        DEPLOYMENT_ENVIRONMENT_NAME,
+    )
+    from opentelemetry.semconv._incubating.attributes.host_attributes import (  # type: ignore[import-untyped]
+        HOST_ARCH,
+        HOST_ID,
+        HOST_NAME,
+    )
+    from opentelemetry.semconv._incubating.attributes.os_attributes import (  # type: ignore[import-untyped]
+        OS_DESCRIPTION,
+        OS_TYPE,
+        OS_VERSION,
+    )
+    from opentelemetry.semconv._incubating.attributes.process_attributes import (  # type: ignore[import-untyped]
+        PROCESS_PID,
+    )
+    from opentelemetry.semconv.attributes.service_attributes import (  # type: ignore[import-untyped]
+        SERVICE_NAME,
+        SERVICE_VERSION,
+    )
     from opentelemetry.trace import set_tracer_provider
 
     from extensions.otel.instrumentation import init_instruments

--- a/api/extensions/otel/instrumentation.py
+++ b/api/extensions/otel/instrumentation.py
@@ -7,7 +7,7 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.metrics import get_meter, get_meter_provider
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv.attributes.http_attributes import HTTP_REQUEST_METHOD, HTTP_ROUTE
 from opentelemetry.trace import Span, get_tracer_provider
 from opentelemetry.trace.status import StatusCode
 
@@ -85,9 +85,9 @@ def init_flask_instrumentor(app: DifyApp) -> None:
                 attributes: dict[str, str | int] = {"status_code": status_code, "status_class": status_class}
                 request = flask.request
                 if request and request.url_rule:
-                    attributes[SpanAttributes.HTTP_TARGET] = str(request.url_rule.rule)
+                    attributes[HTTP_ROUTE] = str(request.url_rule.rule)
                 if request and request.method:
-                    attributes[SpanAttributes.HTTP_METHOD] = str(request.method)
+                    attributes[HTTP_REQUEST_METHOD] = str(request.method)
                 _http_response_counter.add(1, attributes)
             except Exception:
                 logger.exception("Error setting status and attributes")

--- a/api/extensions/otel/instrumentation.py
+++ b/api/extensions/otel/instrumentation.py
@@ -7,7 +7,10 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.metrics import get_meter, get_meter_provider
-from opentelemetry.semconv.attributes.http_attributes import HTTP_REQUEST_METHOD, HTTP_ROUTE
+from opentelemetry.semconv.attributes.http_attributes import (  # type: ignore[import-untyped]
+    HTTP_REQUEST_METHOD,
+    HTTP_ROUTE,
+)
 from opentelemetry.trace import Span, get_tracer_provider
 from opentelemetry.trace.status import StatusCode
 


### PR DESCRIPTION
## Summary

Replace deprecated `opentelemetry-semantic-conventions` imports with the new versioned attribute modules, resolving the deprecation warnings reported in #32600.

## Changes

### `api/extensions/otel/instrumentation.py`
- `SpanAttributes.HTTP_TARGET` → `HTTP_ROUTE` (from `opentelemetry.semconv.attributes.http_attributes`)
- `SpanAttributes.HTTP_METHOD` → `HTTP_REQUEST_METHOD` (from `opentelemetry.semconv.attributes.http_attributes`)

### `api/extensions/ext_otel.py`
- `ResourceAttributes.SERVICE_NAME` → `SERVICE_NAME` (from `opentelemetry.semconv.attributes.service_attributes`)
- `ResourceAttributes.SERVICE_VERSION` → `SERVICE_VERSION`
- `ResourceAttributes.PROCESS_PID` → `PROCESS_PID` (from `opentelemetry.semconv._incubating.attributes.process_attributes`)
- `ResourceAttributes.DEPLOYMENT_ENVIRONMENT` → `DEPLOYMENT_ENVIRONMENT_NAME` (from `opentelemetry.semconv._incubating.attributes.deployment_attributes`)
- `ResourceAttributes.HOST_*` → individual imports from `host_attributes`
- `ResourceAttributes.OS_*` → individual imports from `os_attributes`

### Note on DEPLOYMENT_ENVIRONMENT
`ResourceAttributes.DEPLOYMENT_ENVIRONMENT` (`deployment.environment`) is replaced by `DEPLOYMENT_ENVIRONMENT_NAME` (`deployment.environment.name`) per the [updated semantic conventions spec](https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/). The attribute key changes accordingly.

All new imports are verified to work with the pinned `opentelemetry-semantic-conventions==0.48b0`.

Fixes #32600