### PR TITLE
fix: copy button stays disabled after Human Input node pause/resume

### DIFF
--- a/web/app/components/share/text-generation/result/index.tsx
+++ b/web/app/components/share/text-generation/result/index.tsx
@@ -551,6 +551,7 @@ const Result: FC<IResultProps> = ({
           }))
         },
         onWorkflowPaused: ({ data: workflowPausedData }) => {
+          tempMessageId = workflowPausedData.workflow_run_id
           const url = `/workflow/${workflowPausedData.workflow_run_id}/events`
           sseGet(
             url,


### PR DESCRIPTION
## Summary

Fixes the copy button remaining disabled after a workflow completes following a Human Input node pause/resume cycle.

Closes #32649

## Root Cause

In `web/app/components/share/text-generation/result/index.tsx`, `tempMessageId` is a local variable set in `onWorkflowStarted`. When the workflow pauses at a Human Input node, `onWorkflowPaused` reconnects SSE via `sseGet`. The resumed SSE fires `onWorkflowStarted` again, but since `workflowProcessData.tracing` already has entries, it takes the `if` branch which does NOT re-assign `tempMessageId`. If `tempMessageId` was lost or not properly captured in the new closure, `onWorkflowFinished` sets `messageId` to an empty/undefined value, keeping the copy button disabled (`disabled={isError || !messageId}`).

## Fix

Re-assign `tempMessageId` from `workflowPausedData.workflow_run_id` in `onWorkflowPaused` before reconnecting SSE. This ensures the value is always available when `onWorkflowFinished` fires after resume.

```diff
 onWorkflowPaused: ({ data: workflowPausedData }) => {
+  tempMessageId = workflowPausedData.workflow_run_id
   const url = \`/workflow/\${workflowPausedData.workflow_run_id}/events\`
   sseGet(url, {}, otherOptions)
```

## Notes

- The chat hooks version (`web/app/components/base/chat/chat/hooks.ts`) is not affected because `messageId` is a function parameter there, not a closure variable.
- This is a one-line defensive fix with no behavioral change for the non-paused workflow path.