### PR TITLE
chore(ci): fold pyrefly diff comments

### DIFF
--- a/.github/workflows/pyrefly-diff-comment.yml
+++ b/.github/workflows/pyrefly-diff-comment.yml
@@ -77,8 +77,15 @@ jobs:
             }
 
             const body = diff.trim()
-              ? `### Pyrefly Diff (base → PR)\\n\\`\\`\\`diff\\n${diff}\\n\\`\\`\\``
-              : '### Pyrefly Diff\\nNo changes detected.';
+              ? `### Pyrefly Diff
+<details>
+<summary>base → PR</summary>
+
+\`\`\`diff
+${diff}
+\`\`\`
+</details>`
+              : '### Pyrefly Diff\nNo changes detected.';
 
             await github.rest.issues.createComment({
               issue_number: prNumber,

--- a/.github/workflows/pyrefly-diff.yml
+++ b/.github/workflows/pyrefly-diff.yml
@@ -74,7 +74,14 @@ jobs:
             }
 
             const body = diff.trim()
-              ? `### Pyrefly Diff (base → PR)\n\`\`\`diff\n${diff}\n\`\`\``
+              ? `### Pyrefly Diff
+<details>
+<summary>base → PR</summary>
+
+\`\`\`diff
+${diff}
+\`\`\`
+</details>`
               : '### Pyrefly Diff\nNo changes detected.';
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary

Fixes #32684

This PR folds long `Pyrefly Diff (base → PR)` outputs in PR comments by wrapping the diff block in a collapsible `<details>` section.

Changes:
- Update `.github/workflows/pyrefly-diff.yml` comment body to render folded diff markdown.
- Update `.github/workflows/pyrefly-diff-comment.yml` comment body to render folded diff markdown.
- Keep existing truncation logic and empty-diff fallback behavior.

## Screenshots

| Before | After |
|--------|-------|
| Expanded full diff shown inline | Diff hidden under a collapsed `<details>` block |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
