### PR TITLE
test: align file preview mimetype expectation

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -273,9 +273,10 @@ class TestWebAppAuthService:
         # Arrange: Create banned account
         fake = Faker()
         password = fake.password(length=12)
+        unique_email = f"test_{uuid.uuid4().hex[:8]}@example.com"
 
         account = Account(
-            email=fake.email(),
+            email=unique_email,
             name=fake.name(),
             interface_language="en-US",
             status=AccountStatus.BANNED,
@@ -426,8 +427,7 @@ class TestWebAppAuthService:
         - Correct return value (None)
         """
         # Arrange: Use non-existent email
-        fake = Faker()
-        non_existent_email = fake.email()
+        non_existent_email = f"nonexistent_{uuid.uuid4().hex}@example.com"
 
         # Act: Execute user retrieval
         result = WebAppAuthService.get_user_through_email(non_existent_email)

--- a/api/tests/unit_tests/controllers/files/test_image_preview.py
+++ b/api/tests/unit_tests/controllers/files/test_image_preview.py
@@ -107,7 +107,7 @@ class TestFilePreviewApi:
 
         response = get_fn("file-id")
 
-        assert response.mimetype == "text/plain"
+        assert response.mimetype == "application/octet-stream"
         assert response.headers["Content-Length"] == "100"
         assert "Accept-Ranges" not in response.headers
         mock_enforce.assert_called_once()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Follow-up for #32683.

This updates the unit test expectation in `TestFilePreviewApi.test_basic_stream` to match the current `FilePreviewApi` behavior that sets `Content-Type` to `application/octet-stream` for file preview responses.

- Updated assertion from `text/plain` to `application/octet-stream`
- Keeps the rest of the test contract intact (`Content-Length`, no `Accept-Ranges`, `enforce_download_for_html` call)

## Screenshots

| Before | After |
|--------|-------|
| `AssertionError: 'application/octet-stream' != 'text/plain'` | test assertion matches `application/octet-stream` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
