### PR TITLE
fix: add return type annotation to auth decorators

### DIFF
--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -38,7 +38,7 @@ ERROR_MSG_INVALID_ENCRYPTED_CODE = "Invalid encrypted code"
 
 def account_initialization_required(view: Callable[P, R]):
     @wraps(view)
-    def decorated(*args: P.args, **kwargs: P.kwargs):
+    def decorated(*args: P.args, **kwargs: P.kwargs) -> R:
         # check account initialization
         current_user, _ = current_account_with_tenant()
         if current_user.status == AccountStatus.UNINITIALIZED:
@@ -216,7 +216,7 @@ def cloud_utm_record(view: Callable[P, R]):
 
 def setup_required(view: Callable[P, R]):
     @wraps(view)
-    def decorated(*args: P.args, **kwargs: P.kwargs):
+    def decorated(*args: P.args, **kwargs: P.kwargs) -> R:
         # check setup
         if (
             dify_config.EDITION == "SELF_HOSTED"

--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -36,7 +36,7 @@ ERROR_MSG_INVALID_ENCRYPTED_DATA = "Invalid encrypted data"
 ERROR_MSG_INVALID_ENCRYPTED_CODE = "Invalid encrypted code"
 
 
-def account_initialization_required(view: Callable[P, R]):
+def account_initialization_required(view: Callable[P, R]) -> Callable[P, R]:
     @wraps(view)
     def decorated(*args: P.args, **kwargs: P.kwargs) -> R:
         # check account initialization
@@ -214,7 +214,7 @@ def cloud_utm_record(view: Callable[P, R]):
     return decorated
 
 
-def setup_required(view: Callable[P, R]):
+def setup_required(view: Callable[P, R]) -> Callable[P, R]:
     @wraps(view)
     def decorated(*args: P.args, **kwargs: P.kwargs) -> R:
         # check setup

--- a/api/libs/login.py
+++ b/api/libs/login.py
@@ -73,7 +73,7 @@ def login_required(func: Callable[P, R]):
     """
 
     @wraps(func)
-    def decorated_view(*args: P.args, **kwargs: P.kwargs):
+    def decorated_view(*args: P.args, **kwargs: P.kwargs) -> R:
         if request.method in EXEMPT_METHODS or dify_config.LOGIN_DISABLED:
             pass
         elif current_user is not None and not current_user.is_authenticated:

--- a/api/libs/login.py
+++ b/api/libs/login.py
@@ -13,6 +13,8 @@ from libs.token import check_csrf_token
 from models import Account
 
 if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
+
     from models.model import EndUser
 
 
@@ -38,7 +40,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def login_required(func: Callable[P, R]):
+def login_required(func: Callable[P, R]) -> Callable[P, R | ResponseReturnValue]:
     """
     If you decorate a view with this, it will ensure that the current user is
     logged in and authenticated before calling the actual view. (If they are
@@ -73,7 +75,7 @@ def login_required(func: Callable[P, R]):
     """
 
     @wraps(func)
-    def decorated_view(*args: P.args, **kwargs: P.kwargs) -> R:
+    def decorated_view(*args: P.args, **kwargs: P.kwargs) -> R | ResponseReturnValue:
         if request.method in EXEMPT_METHODS or dify_config.LOGIN_DISABLED:
             pass
         elif current_user is not None and not current_user.is_authenticated:


### PR DESCRIPTION
## Summary
- add `-> R` return type annotations to the wrapper functions in `login_required`, `account_initialization_required`, and `setup_required`
- keep behavior unchanged by limiting the change to typing annotations only

## Testing
- `python -m pytest tests/ -x --timeout=300` *(fails: `python: command not found` in this environment)*
- `pyrefly check api/libs/login.py api/controllers/console/wraps.py` *(fails: `pyrefly: command not found` in this environment)*

Fixes #32593