### PR TITLE
fix: YAML syntax error in pyrefly-diff-comment workflow

### DIFF
--- a/.github/workflows/pyrefly-diff-comment.yml
+++ b/.github/workflows/pyrefly-diff-comment.yml
@@ -77,14 +77,7 @@ jobs:
             }
 
             const body = diff.trim()
-              ? `### Pyrefly Diff
-<details>
-<summary>base → PR</summary>
-
-\`\`\`diff
-${diff}
-\`\`\`
-</details>`
+              ? '### Pyrefly Diff\n<details>\n<summary>base → PR</summary>\n\n```diff\n' + diff + '\n```\n</details>'
               : '### Pyrefly Diff\nNo changes detected.';
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary

Fixes #32717

The `script: |` block in the "Post comment" step of `.github/workflows/pyrefly-diff-comment.yml` contains a JavaScript template literal whose HTML content lines (`<details>`, `<summary>`, etc.) start at column 0. This violates YAML block scalar indentation rules — all content lines must be indented at least as much as the first content line (12 spaces in this case). YAML parsers reject the file at line 81.

## Fix

Replaced the template literal with string concatenation so all JavaScript stays at the correct YAML indentation level. The generated PR comment body is identical.

**Before** (invalid — HTML lines break out of YAML indentation):
```yaml
            const body = diff.trim()
              ? `### Pyrefly Diff
<details>
<summary>base → PR</summary>
...
</details>`
```

**After** (valid — all content properly indented):
```yaml
            const body = diff.trim()
              ? '### Pyrefly Diff\n<details>\n<summary>base → PR</summary>\n\n```diff\n' + diff + '\n```\n</details>'
```

## Test plan

- [x] YAML validates successfully with `yaml.safe_load()` / `js-yaml`
- [x] Output string produces the same markdown comment body as the original template literal