### PR TITLE
fix: replace unreachable yield expression with yield from ()

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -669,16 +669,14 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
     ) -> Generator[StreamResponse, None, None]:
         """Handle retriever resources events."""
         self._message_cycle_manager.handle_retriever_resources(event)
-        return
-        yield  # Make this a generator
+        yield from ()
 
     def _handle_annotation_reply_event(
         self, event: QueueAnnotationReplyEvent, **kwargs
     ) -> Generator[StreamResponse, None, None]:
         """Handle annotation reply events."""
         self._message_cycle_manager.handle_annotation_reply(event)
-        return
-        yield  # Make this a generator
+        yield from ()
 
     def _handle_message_replace_event(
         self, event: QueueMessageReplaceEvent, **kwargs


### PR DESCRIPTION
## Summary
Replace unreachable `yield` expressions with `yield from ()` in `generate_task_pipeline.py`.

## Problem
`_handle_retriever_resources_event` and `_handle_annotation_reply_event` used the pattern `return; yield` to make them generator functions (required since callers use `yield from handler(...)`). However, the `yield` after `return` is unreachable code.

## Solution
Replace `return; yield` with `yield from ()` which:
- Is reachable (no linter warning)
- Makes the function a generator
- Yields nothing (same behavior as before)

Closes #32723