### PR TITLE
fix(ci): fix invalid workflow file pyrefly-diff.yml

### DIFF
--- a/.github/workflows/pyrefly-diff.yml
+++ b/.github/workflows/pyrefly-diff.yml
@@ -74,14 +74,16 @@ jobs:
             }
 
             const body = diff.trim()
-              ? `### Pyrefly Diff
-<details>
-<summary>base → PR</summary>
-
-\`\`\`diff
-${diff}
-\`\`\`
-</details>`
+              ? [
+                  '### Pyrefly Diff',
+                  '<details>',
+                  '<summary>base → PR</summary>',
+                  '',
+                  '```diff',
+                  diff,
+                  '```',
+                  '</details>',
+                ].join('\n')
               : '### Pyrefly Diff\nNo changes detected.';
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary
Fix invalid YAML syntax in `.github/workflows/pyrefly-diff.yml` at line 78.

## Problem
The template literal in the `github-script` step contained lines (e.g. `<details>`, `<summary>`) with zero indentation, which broke the YAML block scalar (`|`). The block scalar's indentation level is determined by its first content line (12 spaces), so any line with less indentation terminates the block and causes a YAML parse error.

## Solution
Replace the template literal with an array `.join('\n')` approach, keeping all JavaScript content properly indented within the YAML block scalar.

Validated with `yaml-lint` — the file now parses correctly.

Closes #32720