### PR TITLE
refactor: remove unreachable yield expressions in advanced chat pipeline

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -669,7 +669,6 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
     ) -> Generator[StreamResponse, None, None]:
         """Handle retriever resources events."""
         self._message_cycle_manager.handle_retriever_resources(event)
-        return
         yield  # Make this a generator
 
     def _handle_annotation_reply_event(
@@ -677,7 +676,6 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
     ) -> Generator[StreamResponse, None, None]:
         """Handle annotation reply events."""
         self._message_cycle_manager.handle_annotation_reply(event)
-        return
         yield  # Make this a generator
 
     def _handle_message_replace_event(


### PR DESCRIPTION
## Summary
- remove unreachable `return` statements before `yield` in two generator handlers
- keep the `yield` marker so both handlers remain valid generators

## Details
Updated:
- `api/core/app/apps/advanced_chat/generate_task_pipeline.py`
  - `_handle_retriever_resources_event`
  - `_handle_annotation_reply_event`

Both functions previously had `return` immediately before `yield`, which made the `yield` expression unreachable and triggered static-analysis errors.

Closes #32723
