### PR TITLE
fix: serialize data_source_info with json.dumps in Notion sync task

### DIFF
--- a/api/tasks/document_indexing_sync_task.py
+++ b/api/tasks/document_indexing_sync_task.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -125,7 +126,7 @@ def document_indexing_sync_task(dataset_id: str, document_id: str):
 
         data_source_info = document.data_source_info_dict
         data_source_info["last_edited_time"] = last_edited_time
-        document.data_source_info = data_source_info
+        document.data_source_info = json.dumps(data_source_info)
 
         document.indexing_status = "parsing"
         document.processing_started_at = naive_utc_now()

--- a/api/tests/test_containers_integration_tests/tasks/test_document_indexing_sync_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_document_indexing_sync_task.py
@@ -12,19 +12,11 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
-from psycopg2.extensions import register_adapter
-from psycopg2.extras import Json
 
 from core.indexing_runner import DocumentIsPausedError, IndexingRunner
 from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
 from tasks.document_indexing_sync_task import document_indexing_sync_task
-
-
-@pytest.fixture(autouse=True)
-def _register_dict_adapter_for_psycopg2():
-    """Align test DB adapter behavior with dict payloads used in task update flow."""
-    register_adapter(dict, Json)
 
 
 class DocumentIndexingSyncTaskTestDataFactory:


### PR DESCRIPTION
## Summary

Fixes #32705 — Notion sync fails with `psycopg2.ProgrammingError: can't adapt type 'dict'` in v1.13.0.

### Root cause

In `document_indexing_sync_task`, after detecting content changes, the task reads `data_source_info_dict` (which returns a Python `dict`), updates `last_edited_time`, and writes it back:

```python
data_source_info = document.data_source_info_dict   # dict
data_source_info["last_edited_time"] = last_edited_time
document.data_source_info = data_source_info         # ← raw dict to LongText column
```

psycopg2 can't adapt a Python `dict` to a text column, so this raises `ProgrammingError` and the sync silently fails.

This regression was likely introduced in #32129 when the task was refactored to use split DB sessions — the `json.dumps()` call was lost.

### Fix

```python
document.data_source_info = json.dumps(data_source_info)
```

One-line fix, consistent with every other `data_source_info` write in the codebase.

### Test changes

- **Unit test added**: `TestDataSourceInfoSerialization.test_data_source_info_serialized_as_json_string` — exercises the full sync flow and asserts `data_source_info` is a JSON string (not dict) after the update.
- **Integration test cleanup**: Removed the `_register_dict_adapter_for_psycopg2` autouse fixture that was masking this bug by globally registering a `dict → Json` psycopg2 adapter.

### Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Unit tests pass: `pytest api/tests/unit_tests/tasks/test_document_indexing_sync_task.py -v` (4/4 passed)
- [ ] CI: integration tests with testcontainers

> AI-assisted testing, AI-assisted review