### PR TITLE
fix: graceful degradation when workflow run is missing in conversation history

### DIFF
--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -1,7 +1,10 @@
+import logging
 from collections.abc import Sequence
 
 from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
+
+logger = logging.getLogger(__name__)
 
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
 from core.model_manager import ModelInstance
@@ -65,18 +68,27 @@ class TokenBufferMemory:
             if not app:
                 raise ValueError("App not found for conversation")
 
-            if not message.workflow_run_id:
-                raise ValueError("Workflow run ID not found")
-
-            workflow_run = self.workflow_run_repo.get_workflow_run_by_id(
-                tenant_id=app.tenant_id, app_id=app.id, run_id=message.workflow_run_id
-            )
-            if not workflow_run:
-                raise ValueError(f"Workflow run not found: {message.workflow_run_id}")
-            workflow = db.session.scalar(select(Workflow).where(Workflow.id == workflow_run.workflow_id))
-            if not workflow:
-                raise ValueError(f"Workflow not found: {workflow_run.workflow_id}")
-            file_extra_config = FileUploadConfigManager.convert(workflow.features_dict, is_vision=False)
+            file_extra_config = None
+            if message.workflow_run_id:
+                workflow_run = self.workflow_run_repo.get_workflow_run_by_id(
+                    tenant_id=app.tenant_id, app_id=app.id, run_id=message.workflow_run_id
+                )
+                if workflow_run:
+                    workflow = db.session.scalar(select(Workflow).where(Workflow.id == workflow_run.workflow_id))
+                    if workflow:
+                        file_extra_config = FileUploadConfigManager.convert(workflow.features_dict, is_vision=False)
+                    else:
+                        logger.warning(
+                            "Workflow %s not found for message %s, skipping file processing",
+                            workflow_run.workflow_id,
+                            message.id,
+                        )
+                else:
+                    logger.warning(
+                        "Workflow run %s not found for message %s, skipping file processing",
+                        message.workflow_run_id,
+                        message.id,
+                    )
         else:
             raise AssertionError(f"Invalid app mode: {self.conversation.mode}")
 

--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -73,22 +73,22 @@ class TokenBufferMemory:
                 workflow_run = self.workflow_run_repo.get_workflow_run_by_id(
                     tenant_id=app.tenant_id, app_id=app.id, run_id=message.workflow_run_id
                 )
-                if workflow_run:
-                    workflow = db.session.scalar(select(Workflow).where(Workflow.id == workflow_run.workflow_id))
-                    if workflow:
-                        file_extra_config = FileUploadConfigManager.convert(workflow.features_dict, is_vision=False)
-                    else:
-                        logger.warning(
-                            "Workflow %s not found for message %s, skipping file processing",
-                            workflow_run.workflow_id,
-                            message.id,
-                        )
-                else:
+                if not workflow_run:
                     logger.warning(
                         "Workflow run %s not found for message %s, skipping file processing",
                         message.workflow_run_id,
                         message.id,
                     )
+                elif not (
+                    workflow := db.session.scalar(select(Workflow).where(Workflow.id == workflow_run.workflow_id))
+                ):
+                    logger.warning(
+                        "Workflow %s not found for message %s, skipping file processing",
+                        workflow_run.workflow_id,
+                        message.id,
+                    )
+                else:
+                    file_extra_config = FileUploadConfigManager.convert(workflow.features_dict, is_vision=False)
         else:
             raise AssertionError(f"Invalid app mode: {self.conversation.mode}")
 

--- a/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
+++ b/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for TokenBufferMemory._build_prompt_message_with_files.
+
+Regression tests for https://github.com/langgenius/dify/issues/32674:
+After workflow runs cleanup, messages with workflow_run_id still exist but the
+referenced WorkflowRun/Workflow rows are gone.  The old code raised ValueError,
+crashing get_history_prompt_messages.  The fix degrades gracefully to text-only
+prompt messages.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from core.memory.token_buffer_memory import TokenBufferMemory
+from core.model_runtime.entities import AssistantPromptMessage, UserPromptMessage
+from models.model import AppMode
+
+
+@pytest.fixture
+def mock_conversation():
+    """Create a mock conversation in ADVANCED_CHAT mode."""
+    conversation = Mock()
+    conversation.mode = AppMode.ADVANCED_CHAT
+    conversation.app = Mock()
+    conversation.app.tenant_id = "tenant-1"
+    conversation.app.id = "app-1"
+    return conversation
+
+
+@pytest.fixture
+def mock_model_instance():
+    return Mock()
+
+
+@pytest.fixture
+def memory(mock_conversation, mock_model_instance):
+    return TokenBufferMemory(conversation=mock_conversation, model_instance=mock_model_instance)
+
+
+@pytest.fixture
+def mock_message_with_workflow_run():
+    """Message whose workflow run still exists."""
+    msg = Mock()
+    msg.id = "msg-1"
+    msg.workflow_run_id = "wr-1"
+    return msg
+
+
+@pytest.fixture
+def mock_message_without_workflow_run():
+    """Message whose workflow_run_id is None."""
+    msg = Mock()
+    msg.id = "msg-2"
+    msg.workflow_run_id = None
+    return msg
+
+
+class TestBuildPromptMessageWithDeletedWorkflowRun:
+    """Verify graceful degradation when workflow run or workflow is missing."""
+
+    def test_missing_workflow_run_returns_text_only_user_message(
+        self,
+        memory,
+        mock_message_with_workflow_run,
+    ):
+        """When workflow run is deleted, return plain text UserPromptMessage."""
+        mock_repo = MagicMock()
+        mock_repo.get_workflow_run_by_id.return_value = None
+        memory._workflow_run_repo = mock_repo
+
+        result = memory._build_prompt_message_with_files(
+            message_files=[Mock()],
+            text_content="hello",
+            message=mock_message_with_workflow_run,
+            app_record=Mock(),
+            is_user_message=True,
+        )
+
+        assert isinstance(result, UserPromptMessage)
+        assert result.content == "hello"
+
+    def test_missing_workflow_run_returns_text_only_assistant_message(
+        self,
+        memory,
+        mock_message_with_workflow_run,
+    ):
+        """When workflow run is deleted, return plain text AssistantPromptMessage."""
+        mock_repo = MagicMock()
+        mock_repo.get_workflow_run_by_id.return_value = None
+        memory._workflow_run_repo = mock_repo
+
+        result = memory._build_prompt_message_with_files(
+            message_files=[Mock()],
+            text_content="answer",
+            message=mock_message_with_workflow_run,
+            app_record=Mock(),
+            is_user_message=False,
+        )
+
+        assert isinstance(result, AssistantPromptMessage)
+        assert result.content == "answer"
+
+    @patch("core.memory.token_buffer_memory.db")
+    def test_missing_workflow_returns_text_only(
+        self,
+        mock_db,
+        memory,
+        mock_message_with_workflow_run,
+    ):
+        """When workflow is deleted but workflow run exists, return plain text."""
+        mock_workflow_run = Mock()
+        mock_workflow_run.workflow_id = "wf-1"
+
+        mock_repo = MagicMock()
+        mock_repo.get_workflow_run_by_id.return_value = mock_workflow_run
+        memory._workflow_run_repo = mock_repo
+
+        # Workflow lookup returns None
+        mock_db.session.scalar.return_value = None
+
+        result = memory._build_prompt_message_with_files(
+            message_files=[Mock()],
+            text_content="hello",
+            message=mock_message_with_workflow_run,
+            app_record=Mock(),
+            is_user_message=True,
+        )
+
+        assert isinstance(result, UserPromptMessage)
+        assert result.content == "hello"
+
+    def test_no_workflow_run_id_returns_text_only(
+        self,
+        memory,
+        mock_message_without_workflow_run,
+    ):
+        """When message.workflow_run_id is None, return plain text."""
+        result = memory._build_prompt_message_with_files(
+            message_files=[Mock()],
+            text_content="hello",
+            message=mock_message_without_workflow_run,
+            app_record=Mock(),
+            is_user_message=True,
+        )
+
+        assert isinstance(result, UserPromptMessage)
+        assert result.content == "hello"
+
+    @patch("core.memory.token_buffer_memory.db")
+    @patch("core.memory.token_buffer_memory.FileUploadConfigManager")
+    @patch("core.memory.token_buffer_memory.file_factory")
+    def test_valid_workflow_run_processes_files(
+        self,
+        mock_file_factory,
+        mock_config_manager,
+        mock_db,
+        memory,
+        mock_message_with_workflow_run,
+    ):
+        """When workflow run and workflow exist, file processing proceeds normally."""
+        mock_workflow_run = Mock()
+        mock_workflow_run.workflow_id = "wf-1"
+
+        mock_repo = MagicMock()
+        mock_repo.get_workflow_run_by_id.return_value = mock_workflow_run
+        memory._workflow_run_repo = mock_repo
+
+        mock_workflow = Mock()
+        mock_workflow.features_dict = {}
+        mock_db.session.scalar.return_value = mock_workflow
+
+        mock_file_config = Mock()
+        mock_file_config.image_config = None
+        mock_config_manager.convert.return_value = mock_file_config
+
+        # file_factory returns empty file objects (no actual images)
+        mock_file_factory.build_from_message_file.return_value = Mock()
+
+        result = memory._build_prompt_message_with_files(
+            message_files=[Mock()],
+            text_content="hello",
+            message=mock_message_with_workflow_run,
+            app_record=Mock(),
+            is_user_message=True,
+        )
+
+        # Should process files and call FileUploadConfigManager
+        mock_config_manager.convert.assert_called_once()
+        # Result should be a UserPromptMessage (with file content list)
+        assert isinstance(result, UserPromptMessage)


### PR DESCRIPTION
## Summary

Fixes #32674 — `get_history_prompt_messages` crashes after workflow runs cleanup when messages with file attachments remain in ADVANCED_CHAT/WORKFLOW modes.

### Root cause

`TokenBufferMemory._build_prompt_message_with_files` raises `ValueError` when:
1. `message.workflow_run_id` is set but the `WorkflowRun` row was deleted by cleanup tasks
2. The `WorkflowRun` exists but its associated `Workflow` row was deleted

Since `Message.workflow_run_id` is nullable with no foreign key constraint, orphaned references are expected after cleanup.

### Fix

Replace hard `ValueError` raises with defensive checks:
- If `workflow_run_id` is `None`, or the `WorkflowRun`/`Workflow` lookup returns `None`, set `file_extra_config = None` and let the existing code path return a text-only prompt message.
- Log a warning so the degradation is observable.

The conversation history loads normally — users just see text content without file attachments for messages whose workflow runs were cleaned up.

### Changes

- `api/core/memory/token_buffer_memory.py` — replaced 3 `ValueError` raises with defensive `None` checks + warning logs
- `api/tests/unit_tests/core/memory/test_token_buffer_memory.py` — 5 unit tests covering all degradation paths plus the happy path

### Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Unit tests pass: `pytest api/tests/unit_tests/core/memory/test_token_buffer_memory.py -v` (5/5 passed)

> AI-assisted testing, AI-assisted review