### PR TITLE
fix(web): improve chat edit input behavior and shortcuts

### DIFF
--- a/web/app/components/base/chat/chat/question.spec.tsx
+++ b/web/app/components/base/chat/chat/question.spec.tsx
@@ -245,6 +245,50 @@ describe('Question component', () => {
     expect(onRegenerate).not.toHaveBeenCalled()
   })
 
+  it('should not confirm editing when Enter is pressed during IME composition', () => {
+    const onRegenerate = vi.fn() as unknown as OnRegenerate
+
+    renderWithProvider(makeItem(), onRegenerate)
+
+    fireEvent.click(screen.getByTestId('edit-btn'))
+    const textbox = screen.getByRole('textbox')
+
+    fireEvent.compositionStart(textbox)
+    fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
+
+    expect(onRegenerate).not.toHaveBeenCalled()
+  })
+
+  it('should keep Enter suppressed if a new composition starts before previous composition-end timer finishes', () => {
+    vi.useFakeTimers()
+
+    try {
+      const onRegenerate = vi.fn() as unknown as OnRegenerate
+      renderWithProvider(makeItem(), onRegenerate)
+
+      fireEvent.click(screen.getByTestId('edit-btn'))
+      const textbox = screen.getByRole('textbox')
+
+      fireEvent.compositionStart(textbox)
+      fireEvent.compositionEnd(textbox)
+      fireEvent.compositionStart(textbox)
+
+      vi.advanceTimersByTime(50)
+
+      fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
+      expect(onRegenerate).not.toHaveBeenCalled()
+
+      fireEvent.compositionEnd(textbox)
+      vi.advanceTimersByTime(50)
+
+      fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
+      expect(onRegenerate).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('should switch siblings when prev/next buttons are clicked', async () => {
     const user = userEvent.setup()
     const switchSibling = vi.fn()

--- a/web/app/components/base/chat/chat/question.spec.tsx
+++ b/web/app/components/base/chat/chat/question.spec.tsx
@@ -257,9 +257,10 @@ describe('Question component', () => {
     fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
 
     expect(onRegenerate).not.toHaveBeenCalled()
+    expect(textbox).toHaveValue('This is the question content')
   })
 
-  it('should keep Enter suppressed if a new composition starts before previous composition-end timer finishes', () => {
+  it('should keep text unchanged and suppress Enter if a new composition starts before previous composition-end timer finishes', async () => {
     vi.useFakeTimers()
 
     try {
@@ -268,6 +269,7 @@ describe('Question component', () => {
 
       fireEvent.click(screen.getByTestId('edit-btn'))
       const textbox = screen.getByRole('textbox')
+      fireEvent.change(textbox, { target: { value: 'IME guard text' } })
 
       fireEvent.compositionStart(textbox)
       fireEvent.compositionEnd(textbox)
@@ -275,14 +277,17 @@ describe('Question component', () => {
 
       vi.advanceTimersByTime(50)
 
-      fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
+      const blockedEnterEvent = new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', bubbles: true, cancelable: true })
+      textbox.dispatchEvent(blockedEnterEvent)
       expect(onRegenerate).not.toHaveBeenCalled()
+      expect(blockedEnterEvent.defaultPrevented).toBe(true)
+      expect(textbox).toHaveValue('IME guard text')
 
       fireEvent.compositionEnd(textbox)
       vi.advanceTimersByTime(50)
 
       fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
-      expect(onRegenerate).toHaveBeenCalledTimes(1)
+      expect(onRegenerate).toHaveBeenCalledWith(makeItem(), { message: 'IME guard text', files: [] })
     }
     finally {
       vi.useRealTimers()

--- a/web/app/components/base/chat/chat/question.spec.tsx
+++ b/web/app/components/base/chat/chat/question.spec.tsx
@@ -1,7 +1,7 @@
 import type { Theme } from '../embedded-chatbot/theme/theme-context'
 import type { ChatConfig, ChatItem, OnRegenerate } from '../types'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import copy from 'copy-to-clipboard'
 import * as React from 'react'
@@ -180,7 +180,7 @@ describe('Question component', () => {
     await user.clear(textbox)
     await user.type(textbox, 'Edited question')
 
-    const resendBtn = screen.getByRole('button', { name: /chat.resend/i })
+    const resendBtn = screen.getByRole('button', { name: /operation.save/i })
     await user.click(resendBtn)
 
     await waitFor(() => {
@@ -207,6 +207,42 @@ describe('Question component', () => {
       const md = container.querySelector('.markdown-body')
       expect(md).toBeInTheDocument()
     })
+  })
+
+  it('should confirm editing when Enter is pressed', async () => {
+    const user = userEvent.setup()
+    const onRegenerate = vi.fn() as unknown as OnRegenerate
+
+    renderWithProvider(makeItem(), onRegenerate)
+
+    await user.click(screen.getByTestId('edit-btn'))
+    const textbox = await screen.findByRole('textbox')
+
+    await user.clear(textbox)
+    await user.type(textbox, 'Edited with Enter')
+
+    fireEvent.keyDown(textbox, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => {
+      expect(onRegenerate).toHaveBeenCalledWith(makeItem(), { message: 'Edited with Enter', files: [] })
+    })
+  })
+
+  it('should insert a new line when Shift+Enter is pressed', async () => {
+    const user = userEvent.setup()
+    const onRegenerate = vi.fn() as unknown as OnRegenerate
+
+    renderWithProvider(makeItem(), onRegenerate)
+
+    await user.click(screen.getByTestId('edit-btn'))
+    const textbox = await screen.findByRole('textbox')
+
+    await user.clear(textbox)
+    await user.type(textbox, 'Line 1')
+    await user.type(textbox, '{Shift>}{Enter}{/Shift}')
+
+    expect(textbox).toHaveValue('Line 1\n')
+    expect(onRegenerate).not.toHaveBeenCalled()
   })
 
   it('should switch siblings when prev/next buttons are clicked', async () => {

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -151,9 +151,9 @@ const Question: FC<QuestionProps> = ({
           ref={contentRef}
           data-testid="question-content"
           className={cn(
-            'w-full text-sm',
-            !isEditing && 'rounded-2xl bg-background-gradient-bg-fill-chat-bubble-bg-3 px-4 py-3 text-text-primary',
-            isEditing && 'rounded-[24px] border-[3px] border-components-option-card-option-selected-border bg-components-panel-bg-blur px-4 py-3 shadow-lg',
+            'w-full text-sm px-4 py-3',
+            !isEditing && 'rounded-2xl bg-background-gradient-bg-fill-chat-bubble-bg-3 text-text-primary',
+            isEditing && 'rounded-[24px] border-[3px] border-components-option-card-option-selected-border bg-components-panel-bg-blur shadow-lg',
           )}
           style={(!isEditing && theme?.chatBubbleColorStyle) ? CssTransform(theme.chatBubbleColorStyle) : {}}
         >

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -151,7 +151,7 @@ const Question: FC<QuestionProps> = ({
           ref={contentRef}
           data-testid="question-content"
           className={cn(
-            'w-full text-sm px-4 py-3',
+            'w-full px-4 py-3 text-sm',
             !isEditing && 'rounded-2xl bg-background-gradient-bg-fill-chat-bubble-bg-3 text-text-primary',
             isEditing && 'rounded-[24px] border-[3px] border-components-option-card-option-selected-border bg-components-panel-bg-blur shadow-lg',
           )}

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -186,8 +186,8 @@ const Question: FC<QuestionProps> = ({
                     />
                   </div>
                   <div className="flex items-center justify-end gap-2">
-                    <Button className="min-w-[96px]" onClick={handleCancelEditing}>{t('operation.cancel', { ns: 'common' })}</Button>
-                    <Button className="min-w-[96px]" variant="primary" onClick={handleResend}>{t('operation.save', { ns: 'common' })}</Button>
+                    <Button className="min-w-24" onClick={handleCancelEditing}>{t('operation.cancel', { ns: 'common' })}</Button>
+                    <Button className="min-w-24" variant="primary" onClick={handleResend}>{t('operation.save', { ns: 'common' })}</Button>
                   </div>
                 </div>
               )}

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -57,6 +57,7 @@ const Question: FC<QuestionProps> = ({
   const [contentWidth, setContentWidth] = useState(0)
   const contentRef = useRef<HTMLDivElement>(null)
   const isComposingRef = useRef(false)
+  const compositionEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleEdit = useCallback(() => {
     setIsEditing(true)
@@ -84,15 +85,26 @@ const Question: FC<QuestionProps> = ({
     handleResend()
   }, [handleResend])
 
-  const handleCompositionStart = useCallback(() => {
-    isComposingRef.current = true
+  const clearCompositionEndTimer = useCallback(() => {
+    if (!compositionEndTimerRef.current)
+      return
+
+    clearTimeout(compositionEndTimerRef.current)
+    compositionEndTimerRef.current = null
   }, [])
 
+  const handleCompositionStart = useCallback(() => {
+    clearCompositionEndTimer()
+    isComposingRef.current = true
+  }, [clearCompositionEndTimer])
+
   const handleCompositionEnd = useCallback(() => {
-    setTimeout(() => {
+    clearCompositionEndTimer()
+    compositionEndTimerRef.current = setTimeout(() => {
       isComposingRef.current = false
+      compositionEndTimerRef.current = null
     }, 50)
-  }, [])
+  }, [clearCompositionEndTimer])
 
   const handleSwitchSibling = useCallback((direction: 'prev' | 'next') => {
     if (direction === 'prev') {
@@ -121,6 +133,12 @@ const Question: FC<QuestionProps> = ({
       resizeObserver.disconnect()
     }
   }, [])
+
+  useEffect(() => {
+    return () => {
+      clearCompositionEndTimer()
+    }
+  }, [clearCompositionEndTimer])
 
   return (
     <div className="mb-2 flex justify-end last:mb-0">

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -56,6 +56,7 @@ const Question: FC<QuestionProps> = ({
   const [editedContent, setEditedContent] = useState(content)
   const [contentWidth, setContentWidth] = useState(0)
   const contentRef = useRef<HTMLDivElement>(null)
+  const isComposingRef = useRef(false)
 
   const handleEdit = useCallback(() => {
     setIsEditing(true)
@@ -71,6 +72,27 @@ const Question: FC<QuestionProps> = ({
     setIsEditing(false)
     setEditedContent(content)
   }, [content])
+
+  const handleEditInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== 'Enter' || e.shiftKey)
+      return
+
+    if (e.nativeEvent.isComposing || isComposingRef.current)
+      return
+
+    e.preventDefault()
+    handleResend()
+  }, [handleResend])
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true
+  }, [])
+
+  const handleCompositionEnd = useCallback(() => {
+    setTimeout(() => {
+      isComposingRef.current = false
+    }, 50)
+  }, [])
 
   const handleSwitchSibling = useCallback((direction: 'prev' | 'next') => {
     if (direction === 'prev') {
@@ -128,13 +150,17 @@ const Question: FC<QuestionProps> = ({
         <div
           ref={contentRef}
           data-testid="question-content"
-          className="w-full rounded-2xl bg-background-gradient-bg-fill-chat-bubble-bg-3 px-4 py-3 text-sm text-text-primary"
-          style={theme?.chatBubbleColorStyle ? CssTransform(theme.chatBubbleColorStyle) : {}}
+          className={cn(
+            'w-full text-sm',
+            !isEditing && 'rounded-2xl bg-background-gradient-bg-fill-chat-bubble-bg-3 px-4 py-3 text-text-primary',
+            isEditing && 'rounded-[24px] border-[3px] border-components-option-card-option-selected-border bg-components-panel-bg-blur px-4 py-3 shadow-lg',
+          )}
+          style={(!isEditing && theme?.chatBubbleColorStyle) ? CssTransform(theme.chatBubbleColorStyle) : {}}
         >
           {
             !!message_files?.length && (
               <FileList
-                className="mb-2"
+                className={cn(isEditing ? 'mb-3' : 'mb-2')}
                 files={message_files}
                 showDeleteAction={false}
                 showDownloadAction={true}
@@ -144,25 +170,24 @@ const Question: FC<QuestionProps> = ({
           {!isEditing
             ? <Markdown content={content} />
             : (
-                <div className="
-                flex flex-col gap-2 rounded-xl
-                border border-components-chat-input-border bg-components-panel-bg-blur p-[9px] shadow-md
-              "
-                >
-                  <div className="max-h-[158px] overflow-y-auto overflow-x-hidden">
+                <div className="flex flex-col gap-4">
+                  <div className="max-h-[158px] overflow-y-auto overflow-x-hidden pr-1">
                     <Textarea
                       className={cn(
-                        'w-full p-1 leading-6 text-text-tertiary outline-none body-lg-regular',
+                        'w-full resize-none bg-transparent p-0 leading-7 text-text-primary outline-none body-lg-regular',
                       )}
                       autoFocus
                       minRows={1}
                       value={editedContent}
                       onChange={e => setEditedContent(e.target.value)}
+                      onKeyDown={handleEditInputKeyDown}
+                      onCompositionStart={handleCompositionStart}
+                      onCompositionEnd={handleCompositionEnd}
                     />
                   </div>
-                  <div className="flex justify-end gap-2">
-                    <Button variant="ghost" onClick={handleCancelEditing}>{t('operation.cancel', { ns: 'common' })}</Button>
-                    <Button variant="primary" onClick={handleResend}>{t('chat.resend', { ns: 'common' })}</Button>
+                  <div className="flex items-center justify-end gap-2">
+                    <Button className="min-w-[96px]" onClick={handleCancelEditing}>{t('operation.cancel', { ns: 'common' })}</Button>
+                    <Button className="min-w-[96px]" variant="primary" onClick={handleResend}>{t('operation.save', { ns: 'common' })}</Button>
                   </div>
                 </div>
               )}

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -65,11 +65,21 @@ const Question: FC<QuestionProps> = ({
   }, [content])
 
   const handleResend = useCallback(() => {
+    if (compositionEndTimerRef.current) {
+      clearTimeout(compositionEndTimerRef.current)
+      compositionEndTimerRef.current = null
+    }
+    isComposingRef.current = false
     setIsEditing(false)
     onRegenerate?.(item, { message: editedContent, files: message_files })
   }, [editedContent, message_files, item, onRegenerate])
 
   const handleCancelEditing = useCallback(() => {
+    if (compositionEndTimerRef.current) {
+      clearTimeout(compositionEndTimerRef.current)
+      compositionEndTimerRef.current = null
+    }
+    isComposingRef.current = false
     setIsEditing(false)
     setEditedContent(content)
   }, [content])
@@ -78,8 +88,13 @@ const Question: FC<QuestionProps> = ({
     if (e.key !== 'Enter' || e.shiftKey)
       return
 
-    if (e.nativeEvent.isComposing || isComposingRef.current)
+    if (e.nativeEvent.isComposing)
       return
+
+    if (isComposingRef.current) {
+      e.preventDefault()
+      return
+    }
 
     e.preventDefault()
     handleResend()


### PR DESCRIPTION
## Summary

Fixes #32756

This PR improves the chat message edit input behavior to align with currently supported capabilities and expected keyboard interactions.

- Disabled manual resize in the edit textarea and kept autosize behavior via `react-textarea-autosize`.
- Added edit-mode keyboard shortcuts:
  - `Enter` confirms/saves.
  - `Shift + Enter` inserts a newline.
- Added/updated tests for Enter-confirm and Shift+Enter newline behavior.

## Screenshots

| Before | After |
|--------|-------|
| <img width="733" height="144" alt="Screenshot 2026-03-01 at 5 48 31 AM" src="https://github.com/user-attachments/assets/2d49dfce-914c-4748-b356-91a60c55ccef" /> | <img width="734" height="257" alt="Screenshot 2026-03-01 at 5 42 48 AM" src="https://github.com/user-attachments/assets/94ef3068-05f0-4289-8346-8fb8855dc2c1" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
