### PR TITLE
refactor(web): replace resolutions with pnpm.overrides

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -264,7 +264,9 @@
       "array.prototype.flatmap": "npm:@nolyfill/array.prototype.flatmap@^1",
       "array.prototype.tosorted": "npm:@nolyfill/array.prototype.tosorted@^1",
       "assert": "npm:@nolyfill/assert@^1",
+      "brace-expansion": "~2.0",
       "brace-expansion@<2.0.2": "2.0.2",
+      "canvas": "^3.2.0",
       "devalue@<5.3.2": "5.3.2",
       "es-iterator-helpers": "npm:@nolyfill/es-iterator-helpers@^1",
       "esbuild@<0.27.2": "0.27.2",
@@ -280,13 +282,16 @@
       "object.fromentries": "npm:@nolyfill/object.fromentries@^1",
       "object.groupby": "npm:@nolyfill/object.groupby@^1",
       "object.values": "npm:@nolyfill/object.values@^1",
+      "pbkdf2": "~3.1.3",
       "pbkdf2@<3.1.3": "3.1.3",
+      "prismjs": "~1.30",
       "prismjs@<1.30.0": "1.30.0",
       "safe-buffer": "^5.2.1",
       "safe-regex-test": "npm:@nolyfill/safe-regex-test@^1",
       "safer-buffer": "npm:@nolyfill/safer-buffer@^1",
       "side-channel": "npm:@nolyfill/side-channel@^1",
       "solid-js": "1.9.11",
+      "string-width": "~4.2.3",
       "string.prototype.includes": "npm:@nolyfill/string.prototype.includes@^1",
       "string.prototype.matchall": "npm:@nolyfill/string.prototype.matchall@^1",
       "string.prototype.repeat": "npm:@nolyfill/string.prototype.repeat@^1",
@@ -303,13 +308,6 @@
       "esbuild",
       "sharp"
     ]
-  },
-  "resolutions": {
-    "brace-expansion": "~2.0",
-    "canvas": "^3.2.0",
-    "pbkdf2": "~3.1.3",
-    "prismjs": "~1.30",
-    "string-width": "~4.2.3"
   },
   "lint-staged": {
     "*": "eslint --fix"


### PR DESCRIPTION
## Summary
Replaces the yarn-style `resolutions` field in `web/package.json` with `pnpm.overrides`, which is the pnpm-native equivalent.

### Changes
- Moved all 5 entries from `resolutions` (`brace-expansion`, `canvas`, `pbkdf2`, `prismjs`, `string-width`) into `pnpm.overrides`
- Removed the now-empty `resolutions` field
- Sorted `pnpm.overrides` alphabetically for consistency
- Verified `pnpm install` succeeds with no issues

Closes #32764