### PR TITLE
refactor(workflow): move PromptMessageMemory to model_runtime.memory

### DIFF
--- a/api/core/app/workflow/node_factory.py
+++ b/api/core/app/workflow/node_factory.py
@@ -13,6 +13,7 @@ from core.helper.code_executor.code_executor import (
 from core.helper.ssrf_proxy import ssrf_proxy
 from core.model_manager import ModelInstance
 from core.model_runtime.entities.model_entities import ModelType
+from core.model_runtime.memory import PromptMessageMemory
 from core.model_runtime.model_providers.__base.large_language_model import LargeLanguageModel
 from core.prompt.entities.advanced_prompt_entities import MemoryConfig
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
@@ -33,7 +34,6 @@ from core.workflow.nodes.llm import llm_utils
 from core.workflow.nodes.llm.entities import ModelConfig
 from core.workflow.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from core.workflow.nodes.llm.node import LLMNode
-from core.workflow.nodes.llm.protocols import PromptMessageMemory
 from core.workflow.nodes.node_mapping import LATEST_VERSION, NODE_TYPE_CLASSES_MAPPING
 from core.workflow.nodes.parameter_extractor.parameter_extractor_node import ParameterExtractorNode
 from core.workflow.nodes.question_classifier.question_classifier_node import QuestionClassifierNode

--- a/api/core/model_runtime/memory/__init__.py
+++ b/api/core/model_runtime/memory/__init__.py
@@ -1,3 +1,3 @@
-from .prompt_message_memory import PromptMessageMemory
+from .prompt_message_memory import DEFAULT_MEMORY_MAX_TOKEN_LIMIT, PromptMessageMemory
 
-__all__ = ["PromptMessageMemory"]
+__all__ = ["DEFAULT_MEMORY_MAX_TOKEN_LIMIT", "PromptMessageMemory"]

--- a/api/core/model_runtime/memory/__init__.py
+++ b/api/core/model_runtime/memory/__init__.py
@@ -1,0 +1,3 @@
+from .prompt_message_memory import PromptMessageMemory
+
+__all__ = ["PromptMessageMemory"]

--- a/api/core/model_runtime/memory/prompt_message_memory.py
+++ b/api/core/model_runtime/memory/prompt_message_memory.py
@@ -6,11 +6,14 @@ from typing import Protocol
 from core.model_runtime.entities import PromptMessage
 
 
+DEFAULT_MEMORY_MAX_TOKEN_LIMIT = 2000
+
+
 class PromptMessageMemory(Protocol):
     """Port for loading memory as prompt messages."""
 
     def get_history_prompt_messages(
-        self, max_token_limit: int = 2000, message_limit: int | None = None
+        self, max_token_limit: int = DEFAULT_MEMORY_MAX_TOKEN_LIMIT, message_limit: int | None = None
     ) -> Sequence[PromptMessage]:
         """Return historical prompt messages constrained by token/message limits."""
         ...

--- a/api/core/model_runtime/memory/prompt_message_memory.py
+++ b/api/core/model_runtime/memory/prompt_message_memory.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from core.model_runtime.entities import PromptMessage
+
+
+class PromptMessageMemory(Protocol):
+    """Port for loading memory as prompt messages."""
+
+    def get_history_prompt_messages(
+        self, max_token_limit: int = 2000, message_limit: int | None = None
+    ) -> Sequence[PromptMessage]:
+        """Return historical prompt messages constrained by token/message limits."""
+        ...

--- a/api/core/model_runtime/memory/prompt_message_memory.py
+++ b/api/core/model_runtime/memory/prompt_message_memory.py
@@ -5,7 +5,6 @@ from typing import Protocol
 
 from core.model_runtime.entities import PromptMessage
 
-
 DEFAULT_MEMORY_MAX_TOKEN_LIMIT = 2000
 
 

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -37,6 +37,7 @@ from core.model_runtime.entities.message_entities import (
     UserPromptMessage,
 )
 from core.model_runtime.entities.model_entities import ModelFeature, ModelPropertyKey
+from core.model_runtime.memory import PromptMessageMemory
 from core.model_runtime.utils.encoders import jsonable_encoder
 from core.prompt.entities.advanced_prompt_entities import CompletionModelPromptTemplate, MemoryConfig
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
@@ -62,7 +63,7 @@ from core.workflow.node_events import (
 from core.workflow.nodes.base.entities import VariableSelector
 from core.workflow.nodes.base.node import Node
 from core.workflow.nodes.base.variable_template_parser import VariableTemplateParser
-from core.workflow.nodes.llm.protocols import CredentialsProvider, ModelFactory, PromptMessageMemory
+from core.workflow.nodes.llm.protocols import CredentialsProvider, ModelFactory
 from core.workflow.runtime import VariablePool
 from core.workflow.variables import (
     ArrayFileSegment,

--- a/api/core/workflow/nodes/llm/protocols.py
+++ b/api/core/workflow/nodes/llm/protocols.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any, Protocol
 
 from core.model_manager import ModelInstance
-from core.model_runtime.entities import PromptMessage
 
 
 class CredentialsProvider(Protocol):
@@ -20,14 +18,4 @@ class ModelFactory(Protocol):
 
     def init_model_instance(self, provider_name: str, model_name: str) -> ModelInstance:
         """Create a model instance that is ready for schema lookup and invocation."""
-        ...
-
-
-class PromptMessageMemory(Protocol):
-    """Port for loading memory as prompt messages for LLM nodes."""
-
-    def get_history_prompt_messages(
-        self, max_token_limit: int = 2000, message_limit: int | None = None
-    ) -> Sequence[PromptMessage]:
-        """Return historical prompt messages constrained by token/message limits."""
         ...


### PR DESCRIPTION
Fixes #32795

## Summary

This PR moves the `PromptMessageMemory` protocol from the LLM workflow node package to `core.model_runtime.memory` to better align abstraction ownership with runtime model boundaries.

Changes included:
- Added `api/core/model_runtime/memory/prompt_message_memory.py`
- Added `api/core/model_runtime/memory/__init__.py` export
- Removed `PromptMessageMemory` from `api/core/workflow/nodes/llm/protocols.py`
- Updated imports/usages in:
  - `api/core/workflow/nodes/llm/node.py`
  - `api/core/app/workflow/node_factory.py`

This is a behavior-preserving refactor; runtime logic is unchanged.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
