### PR TITLE
refactor: remove tests and core/rag from pyrefly excludes

### DIFF
--- a/api/pyrefly.toml
+++ b/api/pyrefly.toml
@@ -1,9 +1,7 @@
 project-includes = ["."]
 project-excludes = [
-    "tests/",
     ".venv",
     "migrations/",
-    "core/rag",
 ]
 python-platform = "linux"
 python-version = "3.11.0"


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #32779

Removed `tests/` and `core/rag` from `api/pyrefly.toml` `project-excludes`, while keeping `.venv` and `migrations/` excluded as requested in the issue.

## Screenshots

| Before | After |
|--------|-------|
| N/A (config-only change) | N/A (config-only change) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (N/A: config-only change)
- [ ] I've updated the documentation accordingly. (N/A: no user-facing behavior change)
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
