### PR TITLE
feat(web): add root isolation layer for portal stacking context

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -57,38 +57,40 @@ const LocaleLayout = async ({
         <meta name="msapplication-config" content="/browserconfig.xml" />
       </head>
       <body
-        className="color-scheme h-full select-auto"
+        className="h-full select-auto"
         {...datasetMap}
       >
-        <PWAProvider>
-          <ReactScanLoader />
-          <JotaiProvider>
-            <ThemeProvider
-              attribute="data-theme"
-              defaultTheme="system"
-              enableSystem
-              disableTransitionOnChange
-              enableColorScheme={false}
-            >
-              <NuqsAdapter>
-                <BrowserInitializer>
-                  <SentryInitializer>
-                    <TanstackQueryInitializer>
-                      <I18nServerProvider>
-                        <ToastProvider>
-                          <GlobalPublicStoreProvider>
-                            {children}
-                          </GlobalPublicStoreProvider>
-                        </ToastProvider>
-                      </I18nServerProvider>
-                    </TanstackQueryInitializer>
-                  </SentryInitializer>
-                </BrowserInitializer>
-              </NuqsAdapter>
-            </ThemeProvider>
-          </JotaiProvider>
-          <RoutePrefixHandle />
-        </PWAProvider>
+        <div className="isolate h-full">
+          <PWAProvider>
+            <ReactScanLoader />
+            <JotaiProvider>
+              <ThemeProvider
+                attribute="data-theme"
+                defaultTheme="system"
+                enableSystem
+                disableTransitionOnChange
+                enableColorScheme={false}
+              >
+                <NuqsAdapter>
+                  <BrowserInitializer>
+                    <SentryInitializer>
+                      <TanstackQueryInitializer>
+                        <I18nServerProvider>
+                          <ToastProvider>
+                            <GlobalPublicStoreProvider>
+                              {children}
+                            </GlobalPublicStoreProvider>
+                          </ToastProvider>
+                        </I18nServerProvider>
+                      </TanstackQueryInitializer>
+                    </SentryInitializer>
+                  </BrowserInitializer>
+                </NuqsAdapter>
+              </ThemeProvider>
+            </JotaiProvider>
+            <RoutePrefixHandle />
+          </PWAProvider>
+        </div>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- Wrap all app content inside `<body>` with `<div class="isolate h-full">` to create a separate stacking context
- Portal-based overlays (FloatingPortal, createPortal, etc.) now always render above page content without manual z-index management

Part of #32767