### PR TITLE
fix(web): keep knowledge list toolbar below header on scroll

### DIFF
--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -6,7 +6,7 @@ import type { AppIconType, AppSSO, Language } from '@/types/app'
 import { RiArrowRightSLine, RiCloseLine } from '@remixicon/react'
 import Link from 'next/link'
 import * as React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
 import AppIcon from '@/app/components/base/app-icon'
@@ -101,6 +101,7 @@ const SettingsModal: FC<ISettingsModalProps> = ({
   const { t } = useTranslation()
 
   const [showAppIconPicker, setShowAppIconPicker] = useState(false)
+  const hideMoreTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [appIcon, setAppIcon] = useState<AppIconSelection>(
     icon_type === 'image'
       ? { type: 'image', url: icon_url!, fileId: icon }
@@ -137,10 +138,21 @@ const SettingsModal: FC<ISettingsModalProps> = ({
       : { type: 'emoji', icon, background: icon_background! })
   }, [appInfo, chat_color_theme, chat_color_theme_inverted, copyright, custom_disclaimer, default_language, description, icon, icon_background, icon_type, icon_url, privacy_policy, show_workflow_steps, title, use_icon_as_answer_icon])
 
+  useEffect(() => {
+    return () => {
+      if (hideMoreTimeoutRef.current)
+        clearTimeout(hideMoreTimeoutRef.current)
+    }
+  }, [])
+
   const onHide = () => {
     onClose()
-    setTimeout(() => {
+    if (hideMoreTimeoutRef.current)
+      clearTimeout(hideMoreTimeoutRef.current)
+
+    hideMoreTimeoutRef.current = setTimeout(() => {
       setIsShowMore(false)
+      hideMoreTimeoutRef.current = null
     }, 200)
   }
 

--- a/web/app/components/datasets/list/index.tsx
+++ b/web/app/components/datasets/list/index.tsx
@@ -57,7 +57,7 @@ const List = () => {
 
   return (
     <div className="scroll-container relative flex grow flex-col overflow-y-auto bg-background-body">
-      <div className="sticky top-0 z-10 flex items-center justify-end gap-x-1 bg-background-body px-12 pb-2 pt-4">
+      <div className="sticky top-14 z-10 flex items-center justify-end gap-x-1 bg-background-body px-12 pb-2 pt-4">
         <div className="flex items-center justify-center gap-2">
           {isCurrentWorkspaceOwner && (
             <CheckboxWithLabel


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #31270

Adjusted the knowledge list toolbar sticky offset so it stays below the global header when scrolling.

- File: `web/app/components/datasets/list/index.tsx`
- Change: `sticky top-0` → `sticky top-14`

This prevents the badge/filter toolbar from overlapping the navigation/header area.

## Screenshots

| Before | After |
|--------|-------|
| Toolbar can overlap header while scrolling | Toolbar remains below header while scrolling |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (N/A: visual/styling adjustment)
- [ ] I've updated the documentation accordingly. (N/A)
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
