### PR TITLE
fix(api): fix the issue that workflow_runs.started_at is overwritten while resuming

### DIFF
--- a/api/core/repositories/sqlalchemy_workflow_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_execution_repository.py
@@ -194,6 +194,13 @@ class SQLAlchemyWorkflowExecutionRepository(WorkflowExecutionRepository):
 
         # Create a new database session
         with self._session_factory() as session:
+            existing_model = session.get(WorkflowRun, db_model.id)
+            if existing_model:
+                if existing_model.tenant_id != self._tenant_id:
+                    raise ValueError("Unauthorized access to workflow run")
+                # Preserve the original start time for pause/resume flows.
+                db_model.created_at = existing_model.created_at
+
             # SQLAlchemy merge intelligently handles both insert and update operations
             # based on the presence of the primary key
             session.merge(db_model)

--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -66,6 +66,7 @@ def run_migrations_offline():
     context.configure(
         url=url, target_metadata=get_metadata(), literal_binds=True
     )
+    logger.info("Generating offline migration SQL with url: %s", url)
 
     with context.begin_transaction():
         context.run_migrations()

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
-addopts = --cov=./api --cov-report=json
+pythonpath = .
+addopts = --cov=./api --cov-report=json --import-mode=importlib
 env =
     ANTHROPIC_API_KEY = sk-ant-api11-IamNotARealKeyJustForMockTestKawaiiiiiiiiii-NotBaka-ASkksz
     AZURE_OPENAI_API_BASE = https://difyai-openai.openai.azure.com
@@ -19,7 +20,7 @@ env =
     GOOGLE_API_KEY = abcdefghijklmnopqrstuvwxyz
     HUGGINGFACE_API_KEY = hf-awuwuwuwuwuwuwuwuwuwuwuwuwuwuwuwuwu
     HUGGINGFACE_EMBEDDINGS_ENDPOINT_URL = c
-    HUGGINGFACE_TEXT2TEXT_GEN_ENDPOINT_URL = b
+    HUGGINGFACE_TEXT2TEXT_GEN_ENDPOINT_URL =    b
     HUGGINGFACE_TEXT_GEN_ENDPOINT_URL = a
     MIXEDBREAD_API_KEY = mk-aaaaaaaaaaaaaaaaaaaa
     MOCK_SWITCH = true

--- a/api/tests/integration_tests/controllers/console/app/test_description_validation.py
+++ b/api/tests/integration_tests/controllers/console/app/test_description_validation.py
@@ -5,13 +5,9 @@ This test module validates the 400-character limit enforcement
 for App descriptions across all creation and editing endpoints.
 """
 
-import os
 import sys
 
 import pytest
-
-# Add the API root to Python path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 
 
 class TestAppDescriptionValidationUnit:

--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -10,8 +10,11 @@ more reliable and realistic test scenarios.
 import logging
 import os
 from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Protocol, TypeVar
 
+import psycopg2
 import pytest
 from flask import Flask
 from flask.testing import FlaskClient
@@ -29,6 +32,25 @@ from extensions.ext_database import db
 # Configure logging for test containers
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+
+class _CloserProtocol(Protocol):
+    """_Closer is any type which implement the close() method."""
+
+    def close(self):
+        """close the current object, release any external resouece (file, transaction, connection etc.)
+        associated with it.
+        """
+        pass
+
+
+_Closer = TypeVar("_Closer", bound=_CloserProtocol)
+
+
+@contextmanager
+def _auto_close(closer: _Closer) -> Generator[_Closer, None, None]:
+    yield closer
+    closer.close()
 
 
 class DifyTestContainers:
@@ -97,45 +119,28 @@ class DifyTestContainers:
         wait_for_logs(self.postgres, "is ready to accept connections", timeout=30)
         logger.info("PostgreSQL container is ready and accepting connections")
 
-        # Install uuid-ossp extension for UUID generation
-        logger.info("Installing uuid-ossp extension...")
-        try:
-            import psycopg2
-
-            conn = psycopg2.connect(
-                host=db_host,
-                port=db_port,
-                user=self.postgres.username,
-                password=self.postgres.password,
-                database=self.postgres.dbname,
-            )
-            conn.autocommit = True
-            cursor = conn.cursor()
-            cursor.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
-            cursor.close()
-            conn.close()
+        conn = psycopg2.connect(
+            host=db_host,
+            port=db_port,
+            user=self.postgres.username,
+            password=self.postgres.password,
+            database=self.postgres.dbname,
+        )
+        conn.autocommit = True
+        with _auto_close(conn):
+            with conn.cursor() as cursor:
+                # Install uuid-ossp extension for UUID generation
+                logger.info("Installing uuid-ossp extension...")
+                cursor.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
             logger.info("uuid-ossp extension installed successfully")
-        except Exception as e:
-            logger.warning("Failed to install uuid-ossp extension: %s", e)
 
-        # Create plugin database for dify-plugin-daemon
-        logger.info("Creating plugin database...")
-        try:
-            conn = psycopg2.connect(
-                host=db_host,
-                port=db_port,
-                user=self.postgres.username,
-                password=self.postgres.password,
-                database=self.postgres.dbname,
-            )
-            conn.autocommit = True
-            cursor = conn.cursor()
-            cursor.execute("CREATE DATABASE dify_plugin;")
-            cursor.close()
-            conn.close()
+            # NOTE: We cannot use `with conn.cursor() as cursor:` as it will wrap the statement
+            # inside a transaction. However, the `CREATE DATABASE` statement cannot run inside a transaction block.
+            with _auto_close(conn.cursor()) as cursor:
+                # Create plugin database for dify-plugin-daemon
+                logger.info("Creating plugin database...")
+                cursor.execute("CREATE DATABASE dify_plugin;")
             logger.info("Plugin database created successfully")
-        except Exception as e:
-            logger.warning("Failed to create plugin database: %s", e)
 
         # Set up storage environment variables
         os.environ.setdefault("STORAGE_TYPE", "opendal")
@@ -258,23 +263,16 @@ class DifyTestContainers:
         containers = [self.redis, self.postgres, self.dify_sandbox, self.dify_plugin_daemon]
         for container in containers:
             if container:
-                try:
-                    container_name = container.image
-                    logger.info("Stopping container: %s", container_name)
-                    container.stop()
-                    logger.info("Successfully stopped container: %s", container_name)
-                except Exception as e:
-                    # Log error but don't fail the test cleanup
-                    logger.warning("Failed to stop container %s: %s", container, e)
+                container_name = container.image
+                logger.info("Stopping container: %s", container_name)
+                container.stop()
+                logger.info("Successfully stopped container: %s", container_name)
 
         # Stop and remove the network
         if self.network:
-            try:
-                logger.info("Removing Docker network...")
-                self.network.remove()
-                logger.info("Successfully removed Docker network")
-            except Exception as e:
-                logger.warning("Failed to remove Docker network: %s", e)
+            logger.info("Removing Docker network...")
+            self.network.remove()
+            logger.info("Successfully removed Docker network")
 
         self._containers_started = False
         logger.info("All test containers stopped and cleaned up successfully")

--- a/api/tests/unit_tests/conftest.py
+++ b/api/tests/unit_tests/conftest.py
@@ -32,11 +32,6 @@ os.environ.setdefault("OPENDAL_SCHEME", "fs")
 os.environ.setdefault("OPENDAL_FS_ROOT", "/tmp/dify-storage")
 os.environ.setdefault("STORAGE_TYPE", "opendal")
 
-# Add the API directory to Python path to ensure proper imports
-import sys
-
-sys.path.insert(0, PROJECT_DIR)
-
 from core.db.session_factory import configure_session_factory, session_factory
 from extensions import ext_redis
 

--- a/api/tests/unit_tests/core/app/apps/test_pause_resume.py
+++ b/api/tests/unit_tests/core/app/apps/test_pause_resume.py
@@ -4,10 +4,6 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
-API_DIR = str(Path(__file__).resolve().parents[5])
-if API_DIR not in sys.path:
-    sys.path.insert(0, API_DIR)
-
 import dify_graph.nodes.human_input.entities  # noqa: F401
 from core.app.apps.advanced_chat import app_generator as adv_app_gen_module
 from core.app.apps.workflow import app_generator as wf_app_gen_module

--- a/api/tests/unit_tests/core/app/apps/test_pause_resume.py
+++ b/api/tests/unit_tests/core/app/apps/test_pause_resume.py
@@ -1,6 +1,5 @@
 import sys
 import time
-from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
@@ -2,11 +2,11 @@ from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.repositories.sqlalchemy_workflow_execution_repository import SQLAlchemyWorkflowExecutionRepository
+from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
 from models import Account, WorkflowRun
 from models.enums import WorkflowRunTriggeredFrom
 

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
@@ -2,11 +2,11 @@ from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.repositories.sqlalchemy_workflow_execution_repository import SQLAlchemyWorkflowExecutionRepository
+from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
 from models import Account, WorkflowRun
 from models.enums import WorkflowRunTriggeredFrom
 
@@ -68,6 +68,7 @@ def test_save_preserves_existing_created_at_when_record_already_exists():
     existing_created_at = datetime(2026, 1, 1, 12, 0, 0)
     existing_run = WorkflowRun()
     existing_run.id = execution_id
+    existing_run.tenant_id = repository._tenant_id
     existing_run.created_at = existing_created_at
     session.get.return_value = existing_run
 

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
@@ -2,11 +2,11 @@ from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.repositories.sqlalchemy_workflow_execution_repository import SQLAlchemyWorkflowExecutionRepository
-from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
 from models import Account, WorkflowRun
 from models.enums import WorkflowRunTriggeredFrom
 

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.repositories.sqlalchemy_workflow_execution_repository import SQLAlchemyWorkflowExecutionRepository
+from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
+from models import Account, WorkflowRun
+from models.enums import WorkflowRunTriggeredFrom
+
+
+def _build_repository_with_mocked_session(session: MagicMock) -> SQLAlchemyWorkflowExecutionRepository:
+    engine = create_engine("sqlite:///:memory:")
+    real_session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    user = MagicMock(spec=Account)
+    user.id = str(uuid4())
+    user.current_tenant_id = str(uuid4())
+
+    repository = SQLAlchemyWorkflowExecutionRepository(
+        session_factory=real_session_factory,
+        user=user,
+        app_id="app-id",
+        triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+    )
+
+    session_context = MagicMock()
+    session_context.__enter__.return_value = session
+    session_context.__exit__.return_value = False
+    repository._session_factory = MagicMock(return_value=session_context)
+    return repository
+
+
+def _build_execution(*, execution_id: str, started_at: datetime) -> WorkflowExecution:
+    return WorkflowExecution.new(
+        id_=execution_id,
+        workflow_id="workflow-id",
+        workflow_type=WorkflowType.WORKFLOW,
+        workflow_version="1.0.0",
+        graph={"nodes": [], "edges": []},
+        inputs={"query": "hello"},
+        started_at=started_at,
+    )
+
+
+def test_save_uses_execution_started_at_when_record_does_not_exist():
+    session = MagicMock()
+    session.get.return_value = None
+    repository = _build_repository_with_mocked_session(session)
+
+    started_at = datetime(2026, 1, 1, 12, 0, 0)
+    execution = _build_execution(execution_id=str(uuid4()), started_at=started_at)
+
+    repository.save(execution)
+
+    saved_model = session.merge.call_args.args[0]
+    assert saved_model.created_at == started_at
+    session.commit.assert_called_once()
+
+
+def test_save_preserves_existing_created_at_when_record_already_exists():
+    session = MagicMock()
+    repository = _build_repository_with_mocked_session(session)
+
+    execution_id = str(uuid4())
+    existing_created_at = datetime(2026, 1, 1, 12, 0, 0)
+    existing_run = WorkflowRun()
+    existing_run.id = execution_id
+    existing_run.created_at = existing_created_at
+    session.get.return_value = existing_run
+
+    execution = _build_execution(
+        execution_id=execution_id,
+        started_at=datetime(2026, 1, 1, 12, 30, 0),
+    )
+
+    repository.save(execution)
+
+    saved_model = session.merge.call_args.args[0]
+    assert saved_model.created_at == existing_created_at
+    session.commit.assert_called_once()

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.repositories.sqlalchemy_workflow_execution_repository import SQLAlchemyWorkflowExecutionRepository
-from core.workflow.entities.workflow_execution import WorkflowExecution, WorkflowType
+from dify_graph.entities.workflow_execution import WorkflowExecution, WorkflowType
 from models import Account, WorkflowRun
 from models.enums import WorkflowRunTriggeredFrom
 

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_mock_iteration_simple.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_mock_iteration_simple.py
@@ -2,7 +2,6 @@
 Simple test to verify MockNodeFactory works with iteration nodes.
 """
 
-
 from dify_graph.entities.graph_init_params import DIFY_RUN_CONTEXT_KEY
 from dify_graph.enums import NodeType
 from tests.unit_tests.core.workflow.graph_engine.test_mock_config import MockConfigBuilder

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_mock_iteration_simple.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_mock_iteration_simple.py
@@ -2,8 +2,6 @@
 Simple test to verify MockNodeFactory works with iteration nodes.
 """
 
-import sys
-from pathlib import Path
 
 from dify_graph.entities.graph_init_params import DIFY_RUN_CONTEXT_KEY
 from dify_graph.enums import NodeType

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_mock_iteration_simple.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_mock_iteration_simple.py
@@ -6,11 +6,6 @@ import sys
 from pathlib import Path
 
 from dify_graph.entities.graph_init_params import DIFY_RUN_CONTEXT_KEY
-
-# Add api directory to path
-api_dir = Path(__file__).parent.parent.parent.parent.parent.parent
-sys.path.insert(0, str(api_dir))
-
 from dify_graph.enums import NodeType
 from tests.unit_tests.core.workflow.graph_engine.test_mock_config import MockConfigBuilder
 from tests.unit_tests.core.workflow.graph_engine.test_mock_factory import MockNodeFactory

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_mock_simple.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_mock_simple.py
@@ -6,11 +6,6 @@ import sys
 from pathlib import Path
 
 from dify_graph.entities.graph_init_params import DIFY_RUN_CONTEXT_KEY
-
-# Add api directory to path
-api_dir = Path(__file__).parent.parent.parent.parent.parent.parent
-sys.path.insert(0, str(api_dir))
-
 from dify_graph.enums import NodeType
 from tests.unit_tests.core.workflow.graph_engine.test_mock_config import MockConfig, MockConfigBuilder, NodeMockConfig
 from tests.unit_tests.core.workflow.graph_engine.test_mock_factory import MockNodeFactory

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_mock_simple.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_mock_simple.py
@@ -3,7 +3,6 @@ Simple test to validate the auto-mock system without external dependencies.
 """
 
 import sys
-from pathlib import Path
 
 from dify_graph.entities.graph_init_params import DIFY_RUN_CONTEXT_KEY
 from dify_graph.enums import NodeType


### PR DESCRIPTION
## Summary

Closes #32850.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
