### PR TITLE
fix(web): resolve hydration warning caused by nesting div inside p in markdown image rendere

### DIFF
--- a/web/app/components/base/image-gallery/index.tsx
+++ b/web/app/components/base/image-gallery/index.tsx
@@ -36,22 +36,22 @@ const ImageGallery: FC<Props> = ({
   const imgNum = srcs.length
   const imgStyle = getWidthStyle(imgNum)
   return (
-    <div className={cn(s[`img-${imgNum}`], 'flex flex-wrap')}>
+    <span className={cn(s[`img-${imgNum}`])} style={{ display: 'flex', flexWrap: 'wrap' }}>
       {srcs.map((src, index) => (
         !src
           ? null
           : (
-              <img
-                key={index}
-                className={s.item}
-                style={imgStyle}
-                src={src}
-                alt=""
-                data-testid="gallery-image" // Added for testing
-                onClick={() => setImagePreviewUrl(src)}
-                onError={e => e.currentTarget.remove()}
-              />
-            )
+            <img
+              key={index}
+              className={s.item}
+              style={imgStyle}
+              src={src}
+              alt=""
+              data-testid="gallery-image" // Added for testing
+              onClick={() => setImagePreviewUrl(src)}
+              onError={e => e.currentTarget.remove()}
+            />
+          )
       ))}
       {
         imagePreviewUrl && (
@@ -62,7 +62,7 @@ const ImageGallery: FC<Props> = ({
           />
         )
       }
-    </div>
+    </span>
   )
 }
 

--- a/web/app/components/base/markdown-blocks/img.tsx
+++ b/web/app/components/base/markdown-blocks/img.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import ImageGallery from '@/app/components/base/image-gallery'
 
 const Img = ({ src }: any) => {
-  return <div className="markdown-img-wrapper"><ImageGallery srcs={[src]} /></div>
+  return <span className="markdown-img-wrapper" style={{ display: 'block' }}><ImageGallery srcs={[src]} /></span>
 }
 
 export default Img

--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -11,14 +11,14 @@ const Paragraph = (paragraph: any) => {
   const children_node = node.children
   if (children_node && children_node[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
     return (
-      <div className="markdown-img-wrapper">
+      <span className="markdown-img-wrapper" style={{ display: 'block' }}>
         <ImageGallery srcs={[children_node[0].properties.src]} />
         {
           Array.isArray(paragraph.children) && paragraph.children.length > 1 && (
-            <div className="mt-2">{paragraph.children.slice(1)}</div>
+            <span className="mt-2" style={{ display: 'block' }}>{paragraph.children.slice(1)}</span>
           )
         }
-      </div>
+      </span>
     )
   }
   return <p>{paragraph.children}</p>

--- a/web/app/components/base/markdown-blocks/plugin-img.tsx
+++ b/web/app/components/base/markdown-blocks/plugin-img.tsx
@@ -42,8 +42,8 @@ export const PluginImg: React.FC<ImgProps> = ({ src, pluginInfo }) => {
   }, [blobUrl, pluginId, src])
 
   return (
-    <div className="markdown-img-wrapper">
+    <span className="markdown-img-wrapper" style={{ display: 'block' }}>
       <ImageGallery srcs={[imageUrl]} />
-    </div>
+    </span>
   )
 }

--- a/web/app/components/base/markdown-blocks/plugin-paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/plugin-paragraph.tsx
@@ -58,12 +58,12 @@ export const PluginParagraph: React.FC<PluginParagraphProps> = ({ pluginInfo, no
     const remainingChildren = Array.isArray(children) && children.length > 1 ? children.slice(1) : undefined
 
     return (
-      <div className="markdown-img-wrapper" data-testid="image-paragraph-wrapper">
+      <span className="markdown-img-wrapper" style={{ display: 'block' }} data-testid="image-paragraph-wrapper">
         <ImageGallery srcs={[imageUrl]} />
         {remainingChildren && (
-          <div className="mt-2" data-testid="remaining-children">{remainingChildren}</div>
+          <span className="mt-2" style={{ display: 'block' }} data-testid="remaining-children">{remainingChildren}</span>
         )}
-      </div>
+      </span>
     )
   }
   return <p data-testid="standard-paragraph">{children}</p>


### PR DESCRIPTION
### Motivation
When rendering Markdown content that includes an inline image inside a paragraph, the web app logs an invalid DOM nesting warning and triggers a hydration mismatch in Next.js SSR:

> In HTML, `<div>` cannot be a descendant of `<p>`. This will cause a hydration error.

Fixes langgenius/dify#32362

### Approach
Replaced all block-level `<div>` wrappers used in the image rendering pipeline with `<span style={{ display: 'block' }}>`. A `<span>` is phrasing content and is valid inside `<p>`, while `display: block` preserves the existing visual layout. This change touches the full affected call chain identified in the issue:

- `img.tsx` — outer `markdown-img-wrapper`
- `plugin-img.tsx` — outer `markdown-img-wrapper`
- `paragraph.tsx` — image-first branch wrapper + remaining-children wrapper
- `plugin-paragraph.tsx` — image-first branch wrapper + remaining-children wrapper
- `image-gallery/index.tsx` — root container element (also replaced Tailwind `flex flex-wrap` utility with equivalent inline styles for consistency)

### Testing
- Verified that the DOM output no longer produces `<p><div>...</div></p>` nesting in any code path.
- Existing test suite (`plugin-img.spec.tsx`) remains green as the change is purely at the HTML element level.
- Checked that `display: block` on `<span>` visually matches the previous `<div>` rendering in all image gallery layouts (single, 2-up, 3-up grids).
