### PR TITLE
test(web): add high-quality unit tests for Base UI wrapper primitives

### DIFF
--- a/web/app/components/base/ui/dialog/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/dialog/__tests__/index.spec.tsx
@@ -1,7 +1,6 @@
-import type { ComponentPropsWithoutRef } from 'react'
 import { Dialog as BaseDialog } from '@base-ui/react/dialog'
 import { render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   Dialog,
   DialogClose,
@@ -11,133 +10,61 @@ import {
   DialogTrigger,
 } from '../index'
 
-type DivPrimitiveProps = ComponentPropsWithoutRef<'div'>
-type ButtonPrimitiveProps = ComponentPropsWithoutRef<'button'>
-type SectionPrimitiveProps = ComponentPropsWithoutRef<'section'>
-
-vi.mock('@base-ui/react/dialog', () => {
-  const createDivPrimitive = () => {
-    return vi.fn(({ children, ...props }: DivPrimitiveProps) => (
-      <div {...props}>
-        {children}
-      </div>
-    ))
-  }
-
-  const createButtonPrimitive = () => {
-    return vi.fn(({ children, ...props }: ButtonPrimitiveProps) => (
-      <button type="button" {...props}>
-        {children}
-      </button>
-    ))
-  }
-
-  const createPopupPrimitive = () => {
-    return vi.fn(({ children, ...props }: SectionPrimitiveProps) => (
-      <section role="dialog" {...props}>
-        {children}
-      </section>
-    ))
-  }
-
-  return {
-    Dialog: {
-      Root: createDivPrimitive(),
-      Trigger: createDivPrimitive(),
-      Title: createDivPrimitive(),
-      Description: createDivPrimitive(),
-      Close: createButtonPrimitive(),
-      Portal: createDivPrimitive(),
-      Backdrop: createDivPrimitive(),
-      Popup: createPopupPrimitive(),
-    },
-  }
-})
-
 describe('Dialog wrapper', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  // Rendering behavior for wrapper-specific structure and content.
   describe('Rendering', () => {
-    it('should render portal structure and dialog content when DialogContent is rendered', () => {
-      // Arrange
-      const contentText = 'dialog body'
-
-      // Act
+    it('should render dialog content when dialog is open', () => {
       render(
-        <DialogContent>
-          <span>{contentText}</span>
-        </DialogContent>,
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Dialog Title</DialogTitle>
+            <DialogDescription>Dialog Description</DialogDescription>
+          </DialogContent>
+        </Dialog>,
       )
 
-      // Assert
-      expect(vi.mocked(BaseDialog.Portal)).toHaveBeenCalledTimes(1)
-      expect(vi.mocked(BaseDialog.Backdrop)).toHaveBeenCalledTimes(1)
-      expect(vi.mocked(BaseDialog.Popup)).toHaveBeenCalledTimes(1)
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
-      expect(screen.getByText(contentText)).toBeInTheDocument()
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveTextContent('Dialog Title')
+      expect(dialog).toHaveTextContent('Dialog Description')
     })
   })
 
-  // Props behavior for closable semantics and defaults.
   describe('Props', () => {
     it('should not render close button when closable is omitted', () => {
-      // Arrange
       render(
-        <DialogContent>
-          <span>content</span>
-        </DialogContent>,
+        <Dialog open>
+          <DialogContent>
+            <span>Dialog body</span>
+          </DialogContent>
+        </Dialog>,
       )
 
-      // Assert
       expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
     })
 
-    it('should not render close button when closable is false', () => {
-      // Arrange
+    it('should render close button when closable is true', () => {
       render(
-        <DialogContent closable={false}>
-          <span>content</span>
-        </DialogContent>,
+        <Dialog open>
+          <DialogContent closable>
+            <span>Dialog body</span>
+          </DialogContent>
+        </Dialog>,
       )
 
-      // Assert
-      expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
-    })
-
-    it('should render semantic close button when closable is true', () => {
-      // Arrange
-      render(
-        <DialogContent closable>
-          <span>content</span>
-        </DialogContent>,
-      )
-
-      // Assert
+      const dialog = screen.getByRole('dialog')
       const closeButton = screen.getByRole('button', { name: 'Close' })
-      expect(closeButton).toHaveAttribute('aria-label', 'Close')
-      expect(screen.getByRole('dialog')).toContainElement(closeButton)
 
-      const closeIcon = closeButton.querySelector('span')
-      expect(closeIcon).toBeInTheDocument()
-      expect(closeButton).toContainElement(closeIcon)
+      expect(dialog).toContainElement(closeButton)
+      expect(closeButton).toHaveAttribute('aria-label', 'Close')
     })
   })
 
-  // Export mapping ensures wrapper aliases point to base primitives.
   describe('Exports', () => {
     it('should map dialog aliases to the matching base dialog primitives', () => {
-      // Arrange
-      const basePrimitives = BaseDialog
-
-      // Act & Assert
-      expect(Dialog).toBe(basePrimitives.Root)
-      expect(DialogTrigger).toBe(basePrimitives.Trigger)
-      expect(DialogTitle).toBe(basePrimitives.Title)
-      expect(DialogDescription).toBe(basePrimitives.Description)
-      expect(DialogClose).toBe(basePrimitives.Close)
+      expect(Dialog).toBe(BaseDialog.Root)
+      expect(DialogTrigger).toBe(BaseDialog.Trigger)
+      expect(DialogTitle).toBe(BaseDialog.Title)
+      expect(DialogDescription).toBe(BaseDialog.Description)
+      expect(DialogClose).toBe(BaseDialog.Close)
     })
   })
 })

--- a/web/app/components/base/ui/dialog/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/dialog/__tests__/index.spec.tsx
@@ -1,0 +1,143 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import { Dialog as BaseDialog } from '@base-ui/react/dialog'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '../index'
+
+type DivPrimitiveProps = ComponentPropsWithoutRef<'div'>
+type ButtonPrimitiveProps = ComponentPropsWithoutRef<'button'>
+type SectionPrimitiveProps = ComponentPropsWithoutRef<'section'>
+
+vi.mock('@base-ui/react/dialog', () => {
+  const createDivPrimitive = () => {
+    return vi.fn(({ children, ...props }: DivPrimitiveProps) => (
+      <div {...props}>
+        {children}
+      </div>
+    ))
+  }
+
+  const createButtonPrimitive = () => {
+    return vi.fn(({ children, ...props }: ButtonPrimitiveProps) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ))
+  }
+
+  const createPopupPrimitive = () => {
+    return vi.fn(({ children, ...props }: SectionPrimitiveProps) => (
+      <section role="dialog" {...props}>
+        {children}
+      </section>
+    ))
+  }
+
+  return {
+    Dialog: {
+      Root: createDivPrimitive(),
+      Trigger: createDivPrimitive(),
+      Title: createDivPrimitive(),
+      Description: createDivPrimitive(),
+      Close: createButtonPrimitive(),
+      Portal: createDivPrimitive(),
+      Backdrop: createDivPrimitive(),
+      Popup: createPopupPrimitive(),
+    },
+  }
+})
+
+describe('Dialog wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Rendering behavior for wrapper-specific structure and content.
+  describe('Rendering', () => {
+    it('should render portal structure and dialog content when DialogContent is rendered', () => {
+      // Arrange
+      const contentText = 'dialog body'
+
+      // Act
+      render(
+        <DialogContent>
+          <span>{contentText}</span>
+        </DialogContent>,
+      )
+
+      // Assert
+      expect(vi.mocked(BaseDialog.Portal)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(BaseDialog.Backdrop)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(BaseDialog.Popup)).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByText(contentText)).toBeInTheDocument()
+    })
+  })
+
+  // Props behavior for closable semantics and defaults.
+  describe('Props', () => {
+    it('should not render close button when closable is omitted', () => {
+      // Arrange
+      render(
+        <DialogContent>
+          <span>content</span>
+        </DialogContent>,
+      )
+
+      // Assert
+      expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+    })
+
+    it('should not render close button when closable is false', () => {
+      // Arrange
+      render(
+        <DialogContent closable={false}>
+          <span>content</span>
+        </DialogContent>,
+      )
+
+      // Assert
+      expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+    })
+
+    it('should render semantic close button when closable is true', () => {
+      // Arrange
+      render(
+        <DialogContent closable>
+          <span>content</span>
+        </DialogContent>,
+      )
+
+      // Assert
+      const closeButton = screen.getByRole('button', { name: 'Close' })
+      expect(closeButton).toHaveAttribute('aria-label', 'Close')
+      expect(screen.getByRole('dialog')).toContainElement(closeButton)
+
+      const closeIcon = closeButton.querySelector('span')
+      expect(closeIcon).toBeInTheDocument()
+      expect(closeButton).toContainElement(closeIcon)
+    })
+  })
+
+  // Export mapping ensures wrapper aliases point to base primitives.
+  describe('Exports', () => {
+    it('should map dialog aliases to the matching base dialog primitives', () => {
+      // Arrange
+      const basePrimitives = BaseDialog
+
+      // Act & Assert
+      expect(Dialog).toBe(basePrimitives.Root)
+      expect(DialogTrigger).toBe(basePrimitives.Trigger)
+      expect(DialogTitle).toBe(basePrimitives.Title)
+      expect(DialogDescription).toBe(basePrimitives.Description)
+      expect(DialogClose).toBe(basePrimitives.Close)
+    })
+  })
+})

--- a/web/app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx
@@ -1,0 +1,407 @@
+import type { Placement } from '@/app/components/base/ui/placement'
+import { Menu } from '@base-ui/react/menu'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { parsePlacement } from '@/app/components/base/ui/placement'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '../index'
+
+vi.mock('@base-ui/react/menu', async () => {
+  const React = await import('react')
+
+  type PrimitiveProps = React.HTMLAttributes<HTMLDivElement> & {
+    children?: React.ReactNode
+  }
+
+  type PrimitiveOptions = {
+    displayName: string
+    defaultRole?: React.AriaRole
+  }
+
+  type PositionerProps = PrimitiveProps & {
+    side?: string
+    align?: string
+    sideOffset?: number
+    alignOffset?: number
+  }
+
+  const createPrimitive = ({ displayName, defaultRole }: PrimitiveOptions) => {
+    const Primitive = React.forwardRef<HTMLDivElement, PrimitiveProps>(({ children, role, ...props }, ref) => {
+      return React.createElement(
+        'div',
+        {
+          ref,
+          role: role ?? defaultRole,
+          ...props,
+        },
+        children,
+      )
+    })
+    Primitive.displayName = displayName
+    return Primitive
+  }
+
+  const Portal = ({ children }: PrimitiveProps) => {
+    return React.createElement(React.Fragment, null, children)
+  }
+  Portal.displayName = 'menu-portal'
+
+  const Positioner = React.forwardRef<HTMLDivElement, PositionerProps>(({ children, role, side, align, sideOffset, alignOffset, ...props }, ref) => {
+    return React.createElement(
+      'div',
+      {
+        ref,
+        'role': role ?? 'group',
+        'data-side': side,
+        'data-align': align,
+        'data-side-offset': sideOffset,
+        'data-align-offset': alignOffset,
+        ...props,
+      },
+      children,
+    )
+  })
+  Positioner.displayName = 'menu-positioner'
+
+  const Menu = {
+    Root: createPrimitive({ displayName: 'menu-root' }),
+    Portal,
+    Trigger: createPrimitive({ displayName: 'menu-trigger', defaultRole: 'button' }),
+    SubmenuRoot: createPrimitive({ displayName: 'menu-submenu-root' }),
+    Group: createPrimitive({ displayName: 'menu-group', defaultRole: 'group' }),
+    GroupLabel: createPrimitive({ displayName: 'menu-group-label' }),
+    RadioGroup: createPrimitive({ displayName: 'menu-radio-group', defaultRole: 'radiogroup' }),
+    RadioItem: createPrimitive({ displayName: 'menu-radio-item', defaultRole: 'menuitemradio' }),
+    RadioItemIndicator: createPrimitive({ displayName: 'menu-radio-item-indicator' }),
+    CheckboxItem: createPrimitive({ displayName: 'menu-checkbox-item', defaultRole: 'menuitemcheckbox' }),
+    CheckboxItemIndicator: createPrimitive({ displayName: 'menu-checkbox-item-indicator' }),
+    Positioner,
+    Popup: createPrimitive({ displayName: 'menu-popup', defaultRole: 'menu' }),
+    SubmenuTrigger: createPrimitive({ displayName: 'menu-submenu-trigger', defaultRole: 'menuitem' }),
+    Item: createPrimitive({ displayName: 'menu-item', defaultRole: 'menuitem' }),
+    Separator: createPrimitive({ displayName: 'menu-separator', defaultRole: 'separator' }),
+  }
+
+  return { Menu }
+})
+
+vi.mock('@/app/components/base/ui/placement', () => ({
+  parsePlacement: vi.fn((placement: Placement) => {
+    const [side, align] = placement.split('-') as [string, string | undefined]
+    return {
+      side: side as 'top' | 'right' | 'bottom' | 'left',
+      align: (align ?? 'center') as 'start' | 'center' | 'end',
+    }
+  }),
+}))
+
+describe('dropdown-menu wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Ensures exported aliases stay aligned with the wrapped Menu primitives.
+  describe('alias exports', () => {
+    it('should map direct aliases to the corresponding Menu primitive when importing menu roots', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(DropdownMenu).toBe(Menu.Root)
+      expect(DropdownMenuPortal).toBe(Menu.Portal)
+      expect(DropdownMenuTrigger).toBe(Menu.Trigger)
+      expect(DropdownMenuSub).toBe(Menu.SubmenuRoot)
+      expect(DropdownMenuGroup).toBe(Menu.Group)
+      expect(DropdownMenuRadioGroup).toBe(Menu.RadioGroup)
+    })
+  })
+
+  // Verifies content popup placement and passthrough behavior.
+  describe('DropdownMenuContent', () => {
+    it('should position content at bottom-end with default offsets when placement props are omitted', () => {
+      // Arrange
+      const parsePlacementMock = vi.mocked(parsePlacement)
+
+      // Act
+      render(
+        <DropdownMenuContent>
+          <button type="button">content action</button>
+        </DropdownMenuContent>,
+      )
+
+      // Assert
+      const popup = screen.getByRole('menu')
+      const positioner = popup.parentElement
+
+      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
+      expect(parsePlacementMock).toHaveBeenCalledWith('bottom-end')
+      expect(positioner).not.toBeNull()
+      expect(positioner).toHaveAttribute('data-side', 'bottom')
+      expect(positioner).toHaveAttribute('data-align', 'end')
+      expect(positioner).toHaveAttribute('data-side-offset', '4')
+      expect(positioner).toHaveAttribute('data-align-offset', '0')
+      expect(within(popup).getByRole('button', { name: 'content action' })).toBeInTheDocument()
+    })
+
+    it('should apply custom placement offsets when custom positioning props are provided', () => {
+      // Arrange
+      const parsePlacementMock = vi.mocked(parsePlacement)
+
+      // Act
+      render(
+        <DropdownMenuContent
+          placement="top-start"
+          sideOffset={12}
+          alignOffset={-3}
+        >
+          <span>custom content</span>
+        </DropdownMenuContent>,
+      )
+
+      // Assert
+      const popup = screen.getByRole('menu')
+      const positioner = popup.parentElement
+
+      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
+      expect(parsePlacementMock).toHaveBeenCalledWith('top-start')
+      expect(positioner).not.toBeNull()
+      expect(positioner).toHaveAttribute('data-side', 'top')
+      expect(positioner).toHaveAttribute('data-align', 'start')
+      expect(positioner).toHaveAttribute('data-side-offset', '12')
+      expect(positioner).toHaveAttribute('data-align-offset', '-3')
+      expect(within(popup).getByText('custom content')).toBeInTheDocument()
+    })
+
+    it('should forward passthrough attributes and handlers when positionerProps and popupProps are provided', () => {
+      // Arrange
+      const handlePositionerMouseEnter = vi.fn()
+      const handlePopupClick = vi.fn()
+
+      // Act
+      render(
+        <DropdownMenuContent
+          positionerProps={{
+            'aria-label': 'dropdown content positioner',
+            'id': 'dropdown-content-positioner',
+            'onMouseEnter': handlePositionerMouseEnter,
+          }}
+          popupProps={{
+            'aria-label': 'dropdown content popup',
+            'id': 'dropdown-content-popup',
+            'onClick': handlePopupClick,
+          }}
+        >
+          <span>passthrough content</span>
+        </DropdownMenuContent>,
+      )
+
+      // Assert
+      const positioner = screen.getByRole('group', { name: 'dropdown content positioner' })
+      const popup = screen.getByRole('menu', { name: 'dropdown content popup' })
+      fireEvent.mouseEnter(positioner)
+      fireEvent.click(popup)
+
+      expect(positioner).toHaveAttribute('id', 'dropdown-content-positioner')
+      expect(popup).toHaveAttribute('id', 'dropdown-content-popup')
+      expect(handlePositionerMouseEnter).toHaveBeenCalledTimes(1)
+      expect(handlePopupClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Verifies submenu popup placement and passthrough behavior.
+  describe('DropdownMenuSubContent', () => {
+    it('should position sub-content at left-start with default offsets when props are omitted', () => {
+      // Arrange
+      const parsePlacementMock = vi.mocked(parsePlacement)
+
+      // Act
+      render(
+        <DropdownMenuSubContent>
+          <button type="button">sub action</button>
+        </DropdownMenuSubContent>,
+      )
+
+      // Assert
+      const popup = screen.getByRole('menu')
+      const positioner = popup.parentElement
+
+      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
+      expect(parsePlacementMock).toHaveBeenCalledWith('left-start')
+      expect(positioner).not.toBeNull()
+      expect(positioner).toHaveAttribute('data-side', 'left')
+      expect(positioner).toHaveAttribute('data-align', 'start')
+      expect(positioner).toHaveAttribute('data-side-offset', '4')
+      expect(positioner).toHaveAttribute('data-align-offset', '0')
+      expect(within(popup).getByRole('button', { name: 'sub action' })).toBeInTheDocument()
+    })
+
+    it('should apply custom placement offsets and forward passthrough props when custom sub-content props are provided', () => {
+      // Arrange
+      const parsePlacementMock = vi.mocked(parsePlacement)
+      const handlePositionerFocus = vi.fn()
+      const handlePopupClick = vi.fn()
+
+      // Act
+      render(
+        <DropdownMenuSubContent
+          placement="right-end"
+          sideOffset={6}
+          alignOffset={2}
+          positionerProps={{
+            'aria-label': 'dropdown sub positioner',
+            'id': 'dropdown-sub-positioner',
+            'onFocus': handlePositionerFocus,
+          }}
+          popupProps={{
+            'aria-label': 'dropdown sub popup',
+            'id': 'dropdown-sub-popup',
+            'onClick': handlePopupClick,
+          }}
+        >
+          <span>custom sub content</span>
+        </DropdownMenuSubContent>,
+      )
+
+      // Assert
+      const positioner = screen.getByRole('group', { name: 'dropdown sub positioner' })
+      const popup = screen.getByRole('menu', { name: 'dropdown sub popup' })
+      fireEvent.focus(positioner)
+      fireEvent.click(popup)
+
+      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
+      expect(parsePlacementMock).toHaveBeenCalledWith('right-end')
+      expect(positioner).toHaveAttribute('data-side', 'right')
+      expect(positioner).toHaveAttribute('data-align', 'end')
+      expect(positioner).toHaveAttribute('data-side-offset', '6')
+      expect(positioner).toHaveAttribute('data-align-offset', '2')
+      expect(positioner).toHaveAttribute('id', 'dropdown-sub-positioner')
+      expect(popup).toHaveAttribute('id', 'dropdown-sub-popup')
+      expect(handlePositionerFocus).toHaveBeenCalledTimes(1)
+      expect(handlePopupClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Covers submenu trigger behavior with and without destructive flag.
+  describe('DropdownMenuSubTrigger', () => {
+    it('should render label and submenu chevron when trigger children are provided', () => {
+      // Arrange
+
+      // Act
+      render(
+        <DropdownMenuSubTrigger>
+          Trigger item
+        </DropdownMenuSubTrigger>,
+      )
+
+      // Assert
+      const subTrigger = screen.getByRole('menuitem', { name: 'Trigger item' })
+      expect(subTrigger.querySelector('span[aria-hidden="true"]')).not.toBeNull()
+    })
+
+    it.each([true, false])('should remain interactive and not leak destructive prop when destructive is %s', (destructive) => {
+      // Arrange
+      const handleClick = vi.fn()
+
+      // Act
+      render(
+        <DropdownMenuSubTrigger
+          destructive={destructive}
+          aria-label="submenu action"
+          id={`submenu-trigger-${String(destructive)}`}
+          onClick={handleClick}
+        >
+          Trigger item
+        </DropdownMenuSubTrigger>,
+      )
+
+      // Assert
+      const subTrigger = screen.getByRole('menuitem', { name: 'submenu action' })
+      fireEvent.click(subTrigger)
+
+      expect(subTrigger).toHaveAttribute('id', `submenu-trigger-${String(destructive)}`)
+      expect(subTrigger).not.toHaveAttribute('destructive')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Covers menu item behavior with and without destructive flag.
+  describe('DropdownMenuItem', () => {
+    it.each([true, false])('should remain interactive and not leak destructive prop when destructive is %s', (destructive) => {
+      // Arrange
+      const handleClick = vi.fn()
+
+      // Act
+      render(
+        <DropdownMenuItem
+          destructive={destructive}
+          aria-label="menu action"
+          id={`menu-item-${String(destructive)}`}
+          onClick={handleClick}
+        >
+          Item label
+        </DropdownMenuItem>,
+      )
+
+      // Assert
+      const item = screen.getByRole('menuitem', { name: 'menu action' })
+      fireEvent.click(item)
+
+      expect(item).toHaveAttribute('id', `menu-item-${String(destructive)}`)
+      expect(item).not.toHaveAttribute('destructive')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Verifies separator semantics and row separation behavior.
+  describe('DropdownMenuSeparator', () => {
+    it('should forward passthrough props and handlers when separator props are provided', () => {
+      // Arrange
+      const handleMouseEnter = vi.fn()
+
+      // Act
+      render(
+        <DropdownMenuSeparator
+          aria-label="actions divider"
+          id="menu-separator"
+          onMouseEnter={handleMouseEnter}
+        />,
+      )
+
+      // Assert
+      const separator = screen.getByRole('separator', { name: 'actions divider' })
+      fireEvent.mouseEnter(separator)
+
+      expect(separator).toHaveAttribute('id', 'menu-separator')
+      expect(handleMouseEnter).toHaveBeenCalledTimes(1)
+    })
+
+    it('should keep surrounding menu rows rendered when separator is placed between items', () => {
+      // Arrange
+
+      // Act
+      render(
+        <>
+          <DropdownMenuItem>First action</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Second action</DropdownMenuItem>
+        </>,
+      )
+
+      // Assert
+      expect(screen.getByRole('menuitem', { name: 'First action' })).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: 'Second action' })).toBeInTheDocument()
+      expect(screen.getAllByRole('separator')).toHaveLength(1)
+    })
+  })
+})

--- a/web/app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx
@@ -1,7 +1,6 @@
-import type { Placement } from '@/app/components/base/ui/placement'
 import { Menu } from '@base-ui/react/menu'
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { parsePlacement } from '@/app/components/base/ui/placement'
+import { describe, expect, it, vi } from 'vitest'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,108 +15,9 @@ import {
   DropdownMenuTrigger,
 } from '../index'
 
-vi.mock('@base-ui/react/menu', async () => {
-  const React = await import('react')
-
-  type PrimitiveProps = React.HTMLAttributes<HTMLDivElement> & {
-    children?: React.ReactNode
-  }
-
-  type PrimitiveOptions = {
-    displayName: string
-    defaultRole?: React.AriaRole
-  }
-
-  type PositionerProps = PrimitiveProps & {
-    side?: string
-    align?: string
-    sideOffset?: number
-    alignOffset?: number
-  }
-
-  const createPrimitive = ({ displayName, defaultRole }: PrimitiveOptions) => {
-    const Primitive = React.forwardRef<HTMLDivElement, PrimitiveProps>(({ children, role, ...props }, ref) => {
-      return React.createElement(
-        'div',
-        {
-          ref,
-          role: role ?? defaultRole,
-          ...props,
-        },
-        children,
-      )
-    })
-    Primitive.displayName = displayName
-    return Primitive
-  }
-
-  const Portal = ({ children }: PrimitiveProps) => {
-    return React.createElement(React.Fragment, null, children)
-  }
-  Portal.displayName = 'menu-portal'
-
-  const Positioner = React.forwardRef<HTMLDivElement, PositionerProps>(({ children, role, side, align, sideOffset, alignOffset, ...props }, ref) => {
-    return React.createElement(
-      'div',
-      {
-        ref,
-        'role': role ?? 'group',
-        'data-side': side,
-        'data-align': align,
-        'data-side-offset': sideOffset,
-        'data-align-offset': alignOffset,
-        ...props,
-      },
-      children,
-    )
-  })
-  Positioner.displayName = 'menu-positioner'
-
-  const Menu = {
-    Root: createPrimitive({ displayName: 'menu-root' }),
-    Portal,
-    Trigger: createPrimitive({ displayName: 'menu-trigger', defaultRole: 'button' }),
-    SubmenuRoot: createPrimitive({ displayName: 'menu-submenu-root' }),
-    Group: createPrimitive({ displayName: 'menu-group', defaultRole: 'group' }),
-    GroupLabel: createPrimitive({ displayName: 'menu-group-label' }),
-    RadioGroup: createPrimitive({ displayName: 'menu-radio-group', defaultRole: 'radiogroup' }),
-    RadioItem: createPrimitive({ displayName: 'menu-radio-item', defaultRole: 'menuitemradio' }),
-    RadioItemIndicator: createPrimitive({ displayName: 'menu-radio-item-indicator' }),
-    CheckboxItem: createPrimitive({ displayName: 'menu-checkbox-item', defaultRole: 'menuitemcheckbox' }),
-    CheckboxItemIndicator: createPrimitive({ displayName: 'menu-checkbox-item-indicator' }),
-    Positioner,
-    Popup: createPrimitive({ displayName: 'menu-popup', defaultRole: 'menu' }),
-    SubmenuTrigger: createPrimitive({ displayName: 'menu-submenu-trigger', defaultRole: 'menuitem' }),
-    Item: createPrimitive({ displayName: 'menu-item', defaultRole: 'menuitem' }),
-    Separator: createPrimitive({ displayName: 'menu-separator', defaultRole: 'separator' }),
-  }
-
-  return { Menu }
-})
-
-vi.mock('@/app/components/base/ui/placement', () => ({
-  parsePlacement: vi.fn((placement: Placement) => {
-    const [side, align] = placement.split('-') as [string, string | undefined]
-    return {
-      side: side as 'top' | 'right' | 'bottom' | 'left',
-      align: (align ?? 'center') as 'start' | 'center' | 'end',
-    }
-  }),
-}))
-
 describe('dropdown-menu wrapper', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  // Ensures exported aliases stay aligned with the wrapped Menu primitives.
   describe('alias exports', () => {
     it('should map direct aliases to the corresponding Menu primitive when importing menu roots', () => {
-      // Arrange
-
-      // Act
-
-      // Assert
       expect(DropdownMenu).toBe(Menu.Root)
       expect(DropdownMenuPortal).toBe(Menu.Portal)
       expect(DropdownMenuTrigger).toBe(Menu.Trigger)
@@ -127,88 +27,75 @@ describe('dropdown-menu wrapper', () => {
     })
   })
 
-  // Verifies content popup placement and passthrough behavior.
   describe('DropdownMenuContent', () => {
-    it('should position content at bottom-end with default offsets when placement props are omitted', () => {
-      // Arrange
-      const parsePlacementMock = vi.mocked(parsePlacement)
-
-      // Act
+    it('should position content at bottom-end with default placement when props are omitted', () => {
       render(
-        <DropdownMenuContent>
-          <button type="button">content action</button>
-        </DropdownMenuContent>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent positionerProps={{ 'role': 'group', 'aria-label': 'content positioner' }}>
+            <DropdownMenuItem>Content action</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
+      const positioner = screen.getByRole('group', { name: 'content positioner' })
       const popup = screen.getByRole('menu')
-      const positioner = popup.parentElement
 
-      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
-      expect(parsePlacementMock).toHaveBeenCalledWith('bottom-end')
-      expect(positioner).not.toBeNull()
       expect(positioner).toHaveAttribute('data-side', 'bottom')
       expect(positioner).toHaveAttribute('data-align', 'end')
-      expect(positioner).toHaveAttribute('data-side-offset', '4')
-      expect(positioner).toHaveAttribute('data-align-offset', '0')
-      expect(within(popup).getByRole('button', { name: 'content action' })).toBeInTheDocument()
+      expect(within(popup).getByRole('menuitem', { name: 'Content action' })).toBeInTheDocument()
     })
 
-    it('should apply custom placement offsets when custom positioning props are provided', () => {
-      // Arrange
-      const parsePlacementMock = vi.mocked(parsePlacement)
-
-      // Act
+    it('should apply custom placement when custom positioning props are provided', () => {
       render(
-        <DropdownMenuContent
-          placement="top-start"
-          sideOffset={12}
-          alignOffset={-3}
-        >
-          <span>custom content</span>
-        </DropdownMenuContent>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent
+            placement="top-start"
+            sideOffset={12}
+            alignOffset={-3}
+            positionerProps={{ 'role': 'group', 'aria-label': 'custom content positioner' }}
+          >
+            <DropdownMenuItem>Custom content</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
+      const positioner = screen.getByRole('group', { name: 'custom content positioner' })
       const popup = screen.getByRole('menu')
-      const positioner = popup.parentElement
 
-      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
-      expect(parsePlacementMock).toHaveBeenCalledWith('top-start')
-      expect(positioner).not.toBeNull()
       expect(positioner).toHaveAttribute('data-side', 'top')
       expect(positioner).toHaveAttribute('data-align', 'start')
-      expect(positioner).toHaveAttribute('data-side-offset', '12')
-      expect(positioner).toHaveAttribute('data-align-offset', '-3')
-      expect(within(popup).getByText('custom content')).toBeInTheDocument()
+      expect(within(popup).getByRole('menuitem', { name: 'Custom content' })).toBeInTheDocument()
     })
 
     it('should forward passthrough attributes and handlers when positionerProps and popupProps are provided', () => {
-      // Arrange
       const handlePositionerMouseEnter = vi.fn()
       const handlePopupClick = vi.fn()
 
-      // Act
       render(
-        <DropdownMenuContent
-          positionerProps={{
-            'aria-label': 'dropdown content positioner',
-            'id': 'dropdown-content-positioner',
-            'onMouseEnter': handlePositionerMouseEnter,
-          }}
-          popupProps={{
-            'aria-label': 'dropdown content popup',
-            'id': 'dropdown-content-popup',
-            'onClick': handlePopupClick,
-          }}
-        >
-          <span>passthrough content</span>
-        </DropdownMenuContent>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent
+            positionerProps={{
+              'role': 'group',
+              'aria-label': 'dropdown content positioner',
+              'id': 'dropdown-content-positioner',
+              'onMouseEnter': handlePositionerMouseEnter,
+            }}
+            popupProps={{
+              role: 'menu',
+              id: 'dropdown-content-popup',
+              onClick: handlePopupClick,
+            }}
+          >
+            <DropdownMenuItem>Passthrough content</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
       const positioner = screen.getByRole('group', { name: 'dropdown content positioner' })
-      const popup = screen.getByRole('menu', { name: 'dropdown content popup' })
+      const popup = screen.getByRole('menu')
       fireEvent.mouseEnter(positioner)
       fireEvent.click(popup)
 
@@ -219,72 +106,68 @@ describe('dropdown-menu wrapper', () => {
     })
   })
 
-  // Verifies submenu popup placement and passthrough behavior.
   describe('DropdownMenuSubContent', () => {
-    it('should position sub-content at left-start with default offsets when props are omitted', () => {
-      // Arrange
-      const parsePlacementMock = vi.mocked(parsePlacement)
-
-      // Act
+    it('should position sub-content at left-start with default placement when props are omitted', () => {
       render(
-        <DropdownMenuSubContent>
-          <button type="button">sub action</button>
-        </DropdownMenuSubContent>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSub open>
+              <DropdownMenuSubTrigger>More actions</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent positionerProps={{ 'role': 'group', 'aria-label': 'sub positioner' }}>
+                <DropdownMenuItem>Sub action</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
-      const popup = screen.getByRole('menu')
-      const positioner = popup.parentElement
-
-      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
-      expect(parsePlacementMock).toHaveBeenCalledWith('left-start')
-      expect(positioner).not.toBeNull()
+      const positioner = screen.getByRole('group', { name: 'sub positioner' })
       expect(positioner).toHaveAttribute('data-side', 'left')
       expect(positioner).toHaveAttribute('data-align', 'start')
-      expect(positioner).toHaveAttribute('data-side-offset', '4')
-      expect(positioner).toHaveAttribute('data-align-offset', '0')
-      expect(within(popup).getByRole('button', { name: 'sub action' })).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: 'Sub action' })).toBeInTheDocument()
     })
 
-    it('should apply custom placement offsets and forward passthrough props when custom sub-content props are provided', () => {
-      // Arrange
-      const parsePlacementMock = vi.mocked(parsePlacement)
+    it('should apply custom placement and forward passthrough props for sub-content when custom props are provided', () => {
       const handlePositionerFocus = vi.fn()
       const handlePopupClick = vi.fn()
 
-      // Act
       render(
-        <DropdownMenuSubContent
-          placement="right-end"
-          sideOffset={6}
-          alignOffset={2}
-          positionerProps={{
-            'aria-label': 'dropdown sub positioner',
-            'id': 'dropdown-sub-positioner',
-            'onFocus': handlePositionerFocus,
-          }}
-          popupProps={{
-            'aria-label': 'dropdown sub popup',
-            'id': 'dropdown-sub-popup',
-            'onClick': handlePopupClick,
-          }}
-        >
-          <span>custom sub content</span>
-        </DropdownMenuSubContent>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSub open>
+              <DropdownMenuSubTrigger>More actions</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent
+                placement="right-end"
+                sideOffset={6}
+                alignOffset={2}
+                positionerProps={{
+                  'role': 'group',
+                  'aria-label': 'dropdown sub positioner',
+                  'id': 'dropdown-sub-positioner',
+                  'onFocus': handlePositionerFocus,
+                }}
+                popupProps={{
+                  role: 'menu',
+                  id: 'dropdown-sub-popup',
+                  onClick: handlePopupClick,
+                }}
+              >
+                <DropdownMenuItem>Custom sub action</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
       const positioner = screen.getByRole('group', { name: 'dropdown sub positioner' })
-      const popup = screen.getByRole('menu', { name: 'dropdown sub popup' })
+      const popup = screen.getByRole('menu', { name: 'More actions' })
       fireEvent.focus(positioner)
       fireEvent.click(popup)
 
-      expect(parsePlacementMock).toHaveBeenCalledTimes(1)
-      expect(parsePlacementMock).toHaveBeenCalledWith('right-end')
       expect(positioner).toHaveAttribute('data-side', 'right')
       expect(positioner).toHaveAttribute('data-align', 'end')
-      expect(positioner).toHaveAttribute('data-side-offset', '6')
-      expect(positioner).toHaveAttribute('data-align-offset', '2')
       expect(positioner).toHaveAttribute('id', 'dropdown-sub-positioner')
       expect(popup).toHaveAttribute('id', 'dropdown-sub-popup')
       expect(handlePositionerFocus).toHaveBeenCalledTimes(1)
@@ -292,40 +175,43 @@ describe('dropdown-menu wrapper', () => {
     })
   })
 
-  // Covers submenu trigger behavior with and without destructive flag.
   describe('DropdownMenuSubTrigger', () => {
-    it('should render label and submenu chevron when trigger children are provided', () => {
-      // Arrange
-
-      // Act
+    it('should render submenu trigger content when trigger children are provided', () => {
       render(
-        <DropdownMenuSubTrigger>
-          Trigger item
-        </DropdownMenuSubTrigger>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSub open>
+              <DropdownMenuSubTrigger>Trigger item</DropdownMenuSubTrigger>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
-      const subTrigger = screen.getByRole('menuitem', { name: 'Trigger item' })
-      expect(subTrigger.querySelector('span[aria-hidden="true"]')).not.toBeNull()
+      expect(screen.getByRole('menuitem', { name: 'Trigger item' })).toBeInTheDocument()
     })
 
     it.each([true, false])('should remain interactive and not leak destructive prop when destructive is %s', (destructive) => {
-      // Arrange
       const handleClick = vi.fn()
 
-      // Act
       render(
-        <DropdownMenuSubTrigger
-          destructive={destructive}
-          aria-label="submenu action"
-          id={`submenu-trigger-${String(destructive)}`}
-          onClick={handleClick}
-        >
-          Trigger item
-        </DropdownMenuSubTrigger>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSub open>
+              <DropdownMenuSubTrigger
+                destructive={destructive}
+                aria-label="submenu action"
+                id={`submenu-trigger-${String(destructive)}`}
+                onClick={handleClick}
+              >
+                Trigger item
+              </DropdownMenuSubTrigger>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
       const subTrigger = screen.getByRole('menuitem', { name: 'submenu action' })
       fireEvent.click(subTrigger)
 
@@ -335,25 +221,26 @@ describe('dropdown-menu wrapper', () => {
     })
   })
 
-  // Covers menu item behavior with and without destructive flag.
   describe('DropdownMenuItem', () => {
     it.each([true, false])('should remain interactive and not leak destructive prop when destructive is %s', (destructive) => {
-      // Arrange
       const handleClick = vi.fn()
 
-      // Act
       render(
-        <DropdownMenuItem
-          destructive={destructive}
-          aria-label="menu action"
-          id={`menu-item-${String(destructive)}`}
-          onClick={handleClick}
-        >
-          Item label
-        </DropdownMenuItem>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem
+              destructive={destructive}
+              aria-label="menu action"
+              id={`menu-item-${String(destructive)}`}
+              onClick={handleClick}
+            >
+              Item label
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
       const item = screen.getByRole('menuitem', { name: 'menu action' })
       fireEvent.click(item)
 
@@ -363,22 +250,23 @@ describe('dropdown-menu wrapper', () => {
     })
   })
 
-  // Verifies separator semantics and row separation behavior.
   describe('DropdownMenuSeparator', () => {
     it('should forward passthrough props and handlers when separator props are provided', () => {
-      // Arrange
       const handleMouseEnter = vi.fn()
 
-      // Act
       render(
-        <DropdownMenuSeparator
-          aria-label="actions divider"
-          id="menu-separator"
-          onMouseEnter={handleMouseEnter}
-        />,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSeparator
+              aria-label="actions divider"
+              id="menu-separator"
+              onMouseEnter={handleMouseEnter}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
       const separator = screen.getByRole('separator', { name: 'actions divider' })
       fireEvent.mouseEnter(separator)
 
@@ -387,18 +275,17 @@ describe('dropdown-menu wrapper', () => {
     })
 
     it('should keep surrounding menu rows rendered when separator is placed between items', () => {
-      // Arrange
-
-      // Act
       render(
-        <>
-          <DropdownMenuItem>First action</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem>Second action</DropdownMenuItem>
-        </>,
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>First action</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>Second action</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
       )
 
-      // Assert
       expect(screen.getByRole('menuitem', { name: 'First action' })).toBeInTheDocument()
       expect(screen.getByRole('menuitem', { name: 'Second action' })).toBeInTheDocument()
       expect(screen.getAllByRole('separator')).toHaveLength(1)

--- a/web/app/components/base/ui/popover/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/popover/__tests__/index.spec.tsx
@@ -1,0 +1,199 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import { Popover as BasePopover } from '@base-ui/react/popover'
+import { render, screen } from '@testing-library/react'
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverDescription,
+  PopoverTitle,
+  PopoverTrigger,
+} from '..'
+
+type PrimitiveProps = ComponentPropsWithoutRef<'div'> & {
+  children?: ReactNode
+}
+
+type PositionerProps = PrimitiveProps & {
+  side?: 'top' | 'bottom' | 'left' | 'right'
+  align?: 'start' | 'center' | 'end'
+  sideOffset?: number
+  alignOffset?: number
+}
+
+vi.mock('@base-ui/react/popover', () => {
+  const Root = ({ children, ...props }: PrimitiveProps) => (
+    <div {...props}>
+      {children}
+    </div>
+  )
+
+  const Trigger = ({ children, ...props }: ComponentPropsWithoutRef<'button'>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  )
+
+  const Close = ({ children, ...props }: ComponentPropsWithoutRef<'button'>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  )
+
+  const Title = ({ children, ...props }: ComponentPropsWithoutRef<'h2'>) => (
+    <h2 {...props}>
+      {children}
+    </h2>
+  )
+
+  const Description = ({ children, ...props }: ComponentPropsWithoutRef<'p'>) => (
+    <p {...props}>
+      {children}
+    </p>
+  )
+
+  const Portal = ({ children }: PrimitiveProps) => (
+    <div>{children}</div>
+  )
+
+  const Positioner = ({
+    children,
+    side,
+    align,
+    sideOffset,
+    alignOffset,
+    ...props
+  }: PositionerProps) => (
+    <div
+      data-side={side}
+      data-align={align}
+      data-side-offset={String(sideOffset)}
+      data-align-offset={String(alignOffset)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+
+  const Popup = ({ children, ...props }: PrimitiveProps) => (
+    <div {...props}>
+      {children}
+    </div>
+  )
+
+  return {
+    Popover: {
+      Root,
+      Trigger,
+      Close,
+      Title,
+      Description,
+      Portal,
+      Positioner,
+      Popup,
+    },
+  }
+})
+
+describe('PopoverContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Placement and default value behaviors.
+  describe('Placement', () => {
+    it('should use bottom placement and default offsets when placement props are not provided', () => {
+      // Arrange
+      render(
+        <PopoverContent positionerProps={{ 'aria-label': 'default positioner' }}>
+          <span>Default content</span>
+        </PopoverContent>,
+      )
+
+      // Act
+      const positioner = screen.getByLabelText('default positioner')
+
+      // Assert
+      expect(positioner).toHaveAttribute('data-side', 'bottom')
+      expect(positioner).toHaveAttribute('data-align', 'center')
+      expect(positioner).toHaveAttribute('data-side-offset', '8')
+      expect(positioner).toHaveAttribute('data-align-offset', '0')
+      expect(screen.getByText('Default content')).toBeInTheDocument()
+    })
+
+    it('should apply parsed custom placement and custom offsets when placement props are provided', () => {
+      // Arrange
+      render(
+        <PopoverContent
+          placement="top-end"
+          sideOffset={14}
+          alignOffset={6}
+          positionerProps={{ 'aria-label': 'custom positioner' }}
+        >
+          <span>Custom placement content</span>
+        </PopoverContent>,
+      )
+
+      // Act
+      const positioner = screen.getByLabelText('custom positioner')
+
+      // Assert
+      expect(positioner).toHaveAttribute('data-side', 'top')
+      expect(positioner).toHaveAttribute('data-align', 'end')
+      expect(positioner).toHaveAttribute('data-side-offset', '14')
+      expect(positioner).toHaveAttribute('data-align-offset', '6')
+    })
+  })
+
+  // Passthrough behavior for delegated primitives.
+  describe('Passthrough props', () => {
+    it('should forward positionerProps and popupProps when passthrough props are provided', () => {
+      // Arrange
+      render(
+        <PopoverContent
+          positionerProps={{
+            'aria-label': 'popover positioner',
+          }}
+          popupProps={{
+            'id': 'popover-popup-id',
+            'role': 'dialog',
+            'aria-label': 'popover content',
+          }}
+        >
+          <span>Popover body</span>
+        </PopoverContent>,
+      )
+
+      // Act
+      const positioner = screen.getByLabelText('popover positioner')
+      const popup = screen.getByRole('dialog', { name: 'popover content' })
+
+      // Assert
+      expect(positioner).toHaveAttribute('aria-label', 'popover positioner')
+      expect(popup).toHaveAttribute('id', 'popover-popup-id')
+      expect(popup).toHaveAttribute('role', 'dialog')
+      expect(popup).toHaveAttribute('aria-label', 'popover content')
+    })
+  })
+})
+
+describe('Popover aliases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Export mapping behavior to keep wrapper aliases aligned.
+  describe('Export mapping', () => {
+    it('should map aliases to the matching base popover primitives when wrapper exports are imported', () => {
+      // Arrange
+      const basePrimitives = BasePopover
+
+      // Act & Assert
+      expect(Popover).toBe(basePrimitives.Root)
+      expect(PopoverTrigger).toBe(basePrimitives.Trigger)
+      expect(PopoverClose).toBe(basePrimitives.Close)
+      expect(PopoverTitle).toBe(basePrimitives.Title)
+      expect(PopoverDescription).toBe(basePrimitives.Description)
+    })
+  })
+})

--- a/web/app/components/base/ui/popover/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/popover/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
-import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { Popover as BasePopover } from '@base-ui/react/popover'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import {
   Popover,
   PopoverClose,
@@ -10,190 +10,98 @@ import {
   PopoverTrigger,
 } from '..'
 
-type PrimitiveProps = ComponentPropsWithoutRef<'div'> & {
-  children?: ReactNode
-}
-
-type PositionerProps = PrimitiveProps & {
-  side?: 'top' | 'bottom' | 'left' | 'right'
-  align?: 'start' | 'center' | 'end'
-  sideOffset?: number
-  alignOffset?: number
-}
-
-vi.mock('@base-ui/react/popover', () => {
-  const Root = ({ children, ...props }: PrimitiveProps) => (
-    <div {...props}>
-      {children}
-    </div>
-  )
-
-  const Trigger = ({ children, ...props }: ComponentPropsWithoutRef<'button'>) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  )
-
-  const Close = ({ children, ...props }: ComponentPropsWithoutRef<'button'>) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  )
-
-  const Title = ({ children, ...props }: ComponentPropsWithoutRef<'h2'>) => (
-    <h2 {...props}>
-      {children}
-    </h2>
-  )
-
-  const Description = ({ children, ...props }: ComponentPropsWithoutRef<'p'>) => (
-    <p {...props}>
-      {children}
-    </p>
-  )
-
-  const Portal = ({ children }: PrimitiveProps) => (
-    <div>{children}</div>
-  )
-
-  const Positioner = ({
-    children,
-    side,
-    align,
-    sideOffset,
-    alignOffset,
-    ...props
-  }: PositionerProps) => (
-    <div
-      data-side={side}
-      data-align={align}
-      data-side-offset={String(sideOffset)}
-      data-align-offset={String(alignOffset)}
-      {...props}
-    >
-      {children}
-    </div>
-  )
-
-  const Popup = ({ children, ...props }: PrimitiveProps) => (
-    <div {...props}>
-      {children}
-    </div>
-  )
-
-  return {
-    Popover: {
-      Root,
-      Trigger,
-      Close,
-      Title,
-      Description,
-      Portal,
-      Positioner,
-      Popup,
-    },
-  }
-})
-
 describe('PopoverContent', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  // Placement and default value behaviors.
   describe('Placement', () => {
     it('should use bottom placement and default offsets when placement props are not provided', () => {
-      // Arrange
       render(
-        <PopoverContent positionerProps={{ 'aria-label': 'default positioner' }}>
-          <span>Default content</span>
-        </PopoverContent>,
+        <Popover open>
+          <PopoverTrigger aria-label="popover trigger">Open</PopoverTrigger>
+          <PopoverContent
+            positionerProps={{ 'role': 'group', 'aria-label': 'default positioner' }}
+            popupProps={{ 'role': 'dialog', 'aria-label': 'default popover' }}
+          >
+            <span>Default content</span>
+          </PopoverContent>
+        </Popover>,
       )
 
-      // Act
-      const positioner = screen.getByLabelText('default positioner')
+      const positioner = screen.getByRole('group', { name: 'default positioner' })
+      const popup = screen.getByRole('dialog', { name: 'default popover' })
 
-      // Assert
       expect(positioner).toHaveAttribute('data-side', 'bottom')
       expect(positioner).toHaveAttribute('data-align', 'center')
-      expect(positioner).toHaveAttribute('data-side-offset', '8')
-      expect(positioner).toHaveAttribute('data-align-offset', '0')
-      expect(screen.getByText('Default content')).toBeInTheDocument()
+      expect(popup).toHaveTextContent('Default content')
     })
 
     it('should apply parsed custom placement and custom offsets when placement props are provided', () => {
-      // Arrange
       render(
-        <PopoverContent
-          placement="top-end"
-          sideOffset={14}
-          alignOffset={6}
-          positionerProps={{ 'aria-label': 'custom positioner' }}
-        >
-          <span>Custom placement content</span>
-        </PopoverContent>,
+        <Popover open>
+          <PopoverTrigger aria-label="popover trigger">Open</PopoverTrigger>
+          <PopoverContent
+            placement="top-end"
+            sideOffset={14}
+            alignOffset={6}
+            positionerProps={{ 'role': 'group', 'aria-label': 'custom positioner' }}
+            popupProps={{ 'role': 'dialog', 'aria-label': 'custom popover' }}
+          >
+            <span>Custom placement content</span>
+          </PopoverContent>
+        </Popover>,
       )
 
-      // Act
-      const positioner = screen.getByLabelText('custom positioner')
+      const positioner = screen.getByRole('group', { name: 'custom positioner' })
+      const popup = screen.getByRole('dialog', { name: 'custom popover' })
 
-      // Assert
       expect(positioner).toHaveAttribute('data-side', 'top')
       expect(positioner).toHaveAttribute('data-align', 'end')
-      expect(positioner).toHaveAttribute('data-side-offset', '14')
-      expect(positioner).toHaveAttribute('data-align-offset', '6')
+      expect(popup).toHaveTextContent('Custom placement content')
     })
   })
 
-  // Passthrough behavior for delegated primitives.
   describe('Passthrough props', () => {
     it('should forward positionerProps and popupProps when passthrough props are provided', () => {
-      // Arrange
+      const onPopupClick = vi.fn()
+
       render(
-        <PopoverContent
-          positionerProps={{
-            'aria-label': 'popover positioner',
-          }}
-          popupProps={{
-            'id': 'popover-popup-id',
-            'role': 'dialog',
-            'aria-label': 'popover content',
-          }}
-        >
-          <span>Popover body</span>
-        </PopoverContent>,
+        <Popover open>
+          <PopoverTrigger aria-label="popover trigger">Open</PopoverTrigger>
+          <PopoverContent
+            positionerProps={{
+              'role': 'group',
+              'aria-label': 'popover positioner',
+              'id': 'popover-positioner-id',
+            }}
+            popupProps={{
+              'id': 'popover-popup-id',
+              'role': 'dialog',
+              'aria-label': 'popover content',
+              'onClick': onPopupClick,
+            }}
+          >
+            <span>Popover body</span>
+          </PopoverContent>
+        </Popover>,
       )
 
-      // Act
-      const positioner = screen.getByLabelText('popover positioner')
+      const positioner = screen.getByRole('group', { name: 'popover positioner' })
       const popup = screen.getByRole('dialog', { name: 'popover content' })
+      fireEvent.click(popup)
 
-      // Assert
-      expect(positioner).toHaveAttribute('aria-label', 'popover positioner')
+      expect(positioner).toHaveAttribute('id', 'popover-positioner-id')
       expect(popup).toHaveAttribute('id', 'popover-popup-id')
-      expect(popup).toHaveAttribute('role', 'dialog')
-      expect(popup).toHaveAttribute('aria-label', 'popover content')
+      expect(onPopupClick).toHaveBeenCalledTimes(1)
     })
   })
 })
 
 describe('Popover aliases', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  // Export mapping behavior to keep wrapper aliases aligned.
   describe('Export mapping', () => {
     it('should map aliases to the matching base popover primitives when wrapper exports are imported', () => {
-      // Arrange
-      const basePrimitives = BasePopover
-
-      // Act & Assert
-      expect(Popover).toBe(basePrimitives.Root)
-      expect(PopoverTrigger).toBe(basePrimitives.Trigger)
-      expect(PopoverClose).toBe(basePrimitives.Close)
-      expect(PopoverTitle).toBe(basePrimitives.Title)
-      expect(PopoverDescription).toBe(basePrimitives.Description)
+      expect(Popover).toBe(BasePopover.Root)
+      expect(PopoverTrigger).toBe(BasePopover.Trigger)
+      expect(PopoverClose).toBe(BasePopover.Close)
+      expect(PopoverTitle).toBe(BasePopover.Title)
+      expect(PopoverDescription).toBe(BasePopover.Description)
     })
   })
 })

--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -1,0 +1,325 @@
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+} from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '../index'
+
+type ParsedPlacement = {
+  side: 'top' | 'bottom' | 'left' | 'right'
+  align: 'start' | 'center' | 'end'
+}
+
+const { mockParsePlacement } = vi.hoisted(() => ({
+  mockParsePlacement: vi.fn<(placement: string) => ParsedPlacement>(),
+}))
+
+vi.mock('@/app/components/base/ui/placement', () => ({
+  parsePlacement: mockParsePlacement,
+}))
+
+vi.mock('@base-ui/react/select', () => {
+  type WithChildren = { children?: ReactNode }
+  type PositionerProps = HTMLAttributes<HTMLDivElement> & {
+    side?: 'top' | 'bottom' | 'left' | 'right'
+    align?: 'start' | 'center' | 'end'
+    sideOffset?: number
+    alignOffset?: number
+    alignItemWithTrigger?: boolean
+  }
+
+  const Root = ({ children }: WithChildren) => <div>{children}</div>
+  const Value = ({ children }: WithChildren) => <span>{children}</span>
+  const Group = ({ children }: WithChildren) => <div>{children}</div>
+  const GroupLabel = ({ children }: WithChildren) => <div>{children}</div>
+  const Separator = (props: HTMLAttributes<HTMLHRElement>) => <hr {...props} />
+
+  const Trigger = ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  )
+  const Icon = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
+    <span aria-label="Open select menu" role="img" {...props}>
+      {children}
+    </span>
+  )
+
+  const Portal = ({ children }: WithChildren) => <div>{children}</div>
+  const Positioner = ({
+    children,
+    side,
+    align,
+    sideOffset,
+    alignOffset,
+    alignItemWithTrigger,
+    className,
+    ...props
+  }: PositionerProps) => (
+    <div
+      data-align={align}
+      data-align-offset={alignOffset}
+      data-align-item-with-trigger={alignItemWithTrigger === undefined ? undefined : String(alignItemWithTrigger)}
+      data-side={side}
+      data-side-offset={sideOffset}
+      className={className}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+  const Popup = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>
+      {children}
+    </div>
+  )
+  const List = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>
+      {children}
+    </div>
+  )
+
+  const Item = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div role="option" {...props}>
+      {children}
+    </div>
+  )
+  const ItemText = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
+    <span {...props}>
+      {children}
+    </span>
+  )
+  const ItemIndicator = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
+    <span aria-label="Selected item indicator" role="img" {...props}>
+      {children}
+    </span>
+  )
+
+  return {
+    Select: {
+      Root,
+      Value,
+      Group,
+      GroupLabel,
+      Separator,
+      Trigger,
+      Icon,
+      Portal,
+      Positioner,
+      Popup,
+      List,
+      Item,
+      ItemText,
+      ItemIndicator,
+    },
+  }
+})
+
+describe('Select wrappers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockParsePlacement.mockReturnValue({ side: 'bottom', align: 'start' })
+  })
+
+  // Covers default rendering and visual branches for trigger content.
+  describe('SelectTrigger', () => {
+    it('should render the default icon when clearable and loading are not enabled', () => {
+      // Arrange
+      render(<SelectTrigger>Trigger Label</SelectTrigger>)
+
+      // Assert
+      expect(screen.getByText('Trigger Label')).toBeInTheDocument()
+      expect(screen.getByRole('img', { name: /open select menu/i })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
+    })
+
+    it('should render clear button when clearable is true and loading is false', () => {
+      // Arrange
+      render(<SelectTrigger clearable>Trigger Label</SelectTrigger>)
+
+      // Assert
+      expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument()
+      expect(screen.queryByRole('img', { name: /open select menu/i })).not.toBeInTheDocument()
+    })
+
+    it('should render loading indicator and hide clear button when loading is true', () => {
+      // Arrange
+      render(<SelectTrigger clearable loading>Trigger Label</SelectTrigger>)
+
+      // Assert
+      expect(screen.getByRole('button', { name: /trigger label/i })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('img', { name: /open select menu/i })).not.toBeInTheDocument()
+    })
+
+    it('should forward native trigger props when trigger props are provided', () => {
+      // Arrange
+      render(
+        <SelectTrigger
+          aria-label="Choose option"
+          disabled
+        >
+          Trigger Label
+        </SelectTrigger>,
+      )
+
+      // Assert
+      const trigger = screen.getByRole('button', { name: /choose option/i })
+      expect(trigger).toBeDisabled()
+      expect(trigger).toHaveAttribute('aria-label', 'Choose option')
+    })
+
+    it('should call onClear and stop click propagation when clear button is clicked', () => {
+      // Arrange
+      const onClear = vi.fn()
+      const onTriggerClick = vi.fn()
+      render(
+        <SelectTrigger clearable onClear={onClear} onClick={onTriggerClick}>
+          Trigger Label
+        </SelectTrigger>,
+      )
+
+      // Act
+      fireEvent.click(screen.getByRole('button', { name: /clear selection/i }))
+
+      // Assert
+      expect(onClear).toHaveBeenCalledTimes(1)
+      expect(onTriggerClick).not.toHaveBeenCalled()
+    })
+
+    it('should stop mouse down propagation when clear button receives mouse down', () => {
+      // Arrange
+      const onTriggerMouseDown = vi.fn()
+      render(
+        <SelectTrigger clearable onMouseDown={onTriggerMouseDown}>
+          Trigger Label
+        </SelectTrigger>,
+      )
+
+      // Act
+      fireEvent.mouseDown(screen.getByRole('button', { name: /clear selection/i }))
+
+      // Assert
+      expect(onTriggerMouseDown).not.toHaveBeenCalled()
+    })
+
+    it('should not throw when clear button is clicked without onClear handler', () => {
+      // Arrange
+      render(<SelectTrigger clearable>Trigger Label</SelectTrigger>)
+      const clearButton = screen.getByRole('button', { name: /clear selection/i })
+
+      // Act & Assert
+      expect(() => fireEvent.click(clearButton)).not.toThrow()
+    })
+  })
+
+  // Covers content placement parsing, forwarding props, and slot rendering.
+  describe('SelectContent', () => {
+    it('should call parsePlacement with default placement when placement is not provided', () => {
+      // Arrange
+      mockParsePlacement.mockReturnValueOnce({ side: 'bottom', align: 'start' })
+
+      // Act
+      render(
+        <SelectContent>
+          <span>Option A</span>
+        </SelectContent>,
+      )
+
+      // Assert
+      expect(mockParsePlacement).toHaveBeenCalledWith('bottom-start')
+      expect(screen.getByText('Option A')).toBeInTheDocument()
+    })
+
+    it('should pass parsed side align and offsets to Positioner when custom placement and offsets are provided', () => {
+      // Arrange
+      mockParsePlacement.mockReturnValueOnce({ side: 'top', align: 'end' })
+
+      // Act
+      render(
+        <SelectContent
+          alignOffset={6}
+          placement="top-end"
+          sideOffset={12}
+          positionerProps={{ 'role': 'group', 'aria-label': 'Select positioner' }}
+        >
+          <div>Option A</div>
+        </SelectContent>,
+      )
+
+      // Assert
+      const positioner = screen.getByRole('group', { name: /select positioner/i })
+      expect(mockParsePlacement).toHaveBeenCalledWith('top-end')
+      expect(positioner).toHaveAttribute('data-side', 'top')
+      expect(positioner).toHaveAttribute('data-align', 'end')
+      expect(positioner).toHaveAttribute('data-side-offset', '12')
+      expect(positioner).toHaveAttribute('data-align-offset', '6')
+      expect(positioner).toHaveAttribute('data-align-item-with-trigger', 'false')
+    })
+
+    it('should forward passthrough props to positioner popup and list when passthrough props are provided', () => {
+      // Arrange & Act
+      render(
+        <SelectContent
+          positionerProps={{
+            'role': 'group',
+            'aria-label': 'select positioner',
+          }}
+          popupProps={{
+            'role': 'dialog',
+            'aria-label': 'select popup',
+          }}
+          listProps={{
+            'role': 'listbox',
+            'aria-label': 'select list',
+          }}
+        >
+          <div>Option A</div>
+        </SelectContent>,
+      )
+
+      // Assert
+      const positioner = screen.getByRole('group', { name: /select positioner/i })
+      const popup = screen.getByRole('dialog', { name: /select popup/i })
+      const list = screen.getByRole('listbox', { name: /select list/i })
+
+      expect(positioner).toHaveAttribute('aria-label', 'select positioner')
+      expect(popup).toHaveAttribute('role', 'dialog')
+      expect(popup).toHaveAttribute('aria-label', 'select popup')
+      expect(list).toHaveAttribute('role', 'listbox')
+      expect(list).toHaveAttribute('aria-label', 'select list')
+    })
+  })
+
+  // Covers option item rendering and prop forwarding behavior.
+  describe('SelectItem', () => {
+    it('should render item text and indicator when children are provided', () => {
+      // Arrange
+      render(<SelectItem>Seattle</SelectItem>)
+
+      // Assert
+      expect(screen.getByRole('option', { name: /seattle/i })).toBeInTheDocument()
+      expect(screen.getByRole('img', { name: /selected item indicator/i })).toBeInTheDocument()
+    })
+
+    it('should forward item props when item props are provided', () => {
+      // Arrange
+      render(
+        <SelectItem aria-label="City option" disabled>
+          Seattle
+        </SelectItem>,
+      )
+
+      // Assert
+      const item = screen.getByRole('option', { name: /city option/i })
+      expect(item).toHaveAttribute('aria-label', 'City option')
+      expect(item).toHaveAttribute('disabled')
+    })
+  })
+})

--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -1,325 +1,219 @@
-import type {
-  ButtonHTMLAttributes,
-  HTMLAttributes,
-  ReactNode,
-} from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from '../index'
+import { describe, expect, it, vi } from 'vitest'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../index'
 
-type ParsedPlacement = {
-  side: 'top' | 'bottom' | 'left' | 'right'
-  align: 'start' | 'center' | 'end'
+const renderOpenSelect = ({
+  triggerProps = {},
+  contentProps = {},
+  onValueChange,
+}: {
+  triggerProps?: Record<string, unknown>
+  contentProps?: Record<string, unknown>
+  onValueChange?: (value: string | null) => void
+} = {}) => {
+  return render(
+    <Select open defaultValue="seattle" onValueChange={onValueChange}>
+      <SelectTrigger aria-label="city select" {...triggerProps}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent
+        positionerProps={{
+          'role': 'group',
+          'aria-label': 'select positioner',
+        }}
+        popupProps={{
+          'role': 'dialog',
+          'aria-label': 'select popup',
+        }}
+        listProps={{
+          'role': 'listbox',
+          'aria-label': 'select list',
+        }}
+        {...contentProps}
+      >
+        <SelectItem value="seattle">Seattle</SelectItem>
+        <SelectItem value="new-york">New York</SelectItem>
+      </SelectContent>
+    </Select>,
+  )
 }
 
-const { mockParsePlacement } = vi.hoisted(() => ({
-  mockParsePlacement: vi.fn<(placement: string) => ParsedPlacement>(),
-}))
-
-vi.mock('@/app/components/base/ui/placement', () => ({
-  parsePlacement: mockParsePlacement,
-}))
-
-vi.mock('@base-ui/react/select', () => {
-  type WithChildren = { children?: ReactNode }
-  type PositionerProps = HTMLAttributes<HTMLDivElement> & {
-    side?: 'top' | 'bottom' | 'left' | 'right'
-    align?: 'start' | 'center' | 'end'
-    sideOffset?: number
-    alignOffset?: number
-    alignItemWithTrigger?: boolean
-  }
-
-  const Root = ({ children }: WithChildren) => <div>{children}</div>
-  const Value = ({ children }: WithChildren) => <span>{children}</span>
-  const Group = ({ children }: WithChildren) => <div>{children}</div>
-  const GroupLabel = ({ children }: WithChildren) => <div>{children}</div>
-  const Separator = (props: HTMLAttributes<HTMLHRElement>) => <hr {...props} />
-
-  const Trigger = ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  )
-  const Icon = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
-    <span aria-label="Open select menu" role="img" {...props}>
-      {children}
-    </span>
-  )
-
-  const Portal = ({ children }: WithChildren) => <div>{children}</div>
-  const Positioner = ({
-    children,
-    side,
-    align,
-    sideOffset,
-    alignOffset,
-    alignItemWithTrigger,
-    className,
-    ...props
-  }: PositionerProps) => (
-    <div
-      data-align={align}
-      data-align-offset={alignOffset}
-      data-align-item-with-trigger={alignItemWithTrigger === undefined ? undefined : String(alignItemWithTrigger)}
-      data-side={side}
-      data-side-offset={sideOffset}
-      className={className}
-      {...props}
-    >
-      {children}
-    </div>
-  )
-  const Popup = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
-    <div {...props}>
-      {children}
-    </div>
-  )
-  const List = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
-    <div {...props}>
-      {children}
-    </div>
-  )
-
-  const Item = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
-    <div role="option" {...props}>
-      {children}
-    </div>
-  )
-  const ItemText = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
-    <span {...props}>
-      {children}
-    </span>
-  )
-  const ItemIndicator = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
-    <span aria-label="Selected item indicator" role="img" {...props}>
-      {children}
-    </span>
-  )
-
-  return {
-    Select: {
-      Root,
-      Value,
-      Group,
-      GroupLabel,
-      Separator,
-      Trigger,
-      Icon,
-      Portal,
-      Positioner,
-      Popup,
-      List,
-      Item,
-      ItemText,
-      ItemIndicator,
-    },
-  }
-})
-
 describe('Select wrappers', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockParsePlacement.mockReturnValue({ side: 'bottom', align: 'start' })
-  })
-
-  // Covers default rendering and visual branches for trigger content.
   describe('SelectTrigger', () => {
-    it('should render the default icon when clearable and loading are not enabled', () => {
-      // Arrange
-      render(<SelectTrigger>Trigger Label</SelectTrigger>)
-
-      // Assert
-      expect(screen.getByText('Trigger Label')).toBeInTheDocument()
-      expect(screen.getByRole('img', { name: /open select menu/i })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
-    })
-
     it('should render clear button when clearable is true and loading is false', () => {
-      // Arrange
-      render(<SelectTrigger clearable>Trigger Label</SelectTrigger>)
+      renderOpenSelect({
+        triggerProps: { clearable: true },
+      })
 
-      // Assert
       expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument()
-      expect(screen.queryByRole('img', { name: /open select menu/i })).not.toBeInTheDocument()
     })
 
-    it('should render loading indicator and hide clear button when loading is true', () => {
-      // Arrange
-      render(<SelectTrigger clearable loading>Trigger Label</SelectTrigger>)
+    it('should hide clear button when loading is true', () => {
+      renderOpenSelect({
+        triggerProps: { clearable: true, loading: true },
+      })
 
-      // Assert
-      expect(screen.getByRole('button', { name: /trigger label/i })).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
-      expect(screen.queryByRole('img', { name: /open select menu/i })).not.toBeInTheDocument()
     })
 
     it('should forward native trigger props when trigger props are provided', () => {
-      // Arrange
-      render(
-        <SelectTrigger
-          aria-label="Choose option"
-          disabled
-        >
-          Trigger Label
-        </SelectTrigger>,
-      )
+      renderOpenSelect({
+        triggerProps: {
+          'aria-label': 'Choose option',
+          'disabled': true,
+        },
+      })
 
-      // Assert
-      const trigger = screen.getByRole('button', { name: /choose option/i })
+      const trigger = screen.getByRole('combobox', { name: 'Choose option' })
       expect(trigger).toBeDisabled()
-      expect(trigger).toHaveAttribute('aria-label', 'Choose option')
     })
 
     it('should call onClear and stop click propagation when clear button is clicked', () => {
-      // Arrange
       const onClear = vi.fn()
       const onTriggerClick = vi.fn()
-      render(
-        <SelectTrigger clearable onClear={onClear} onClick={onTriggerClick}>
-          Trigger Label
-        </SelectTrigger>,
-      )
 
-      // Act
+      renderOpenSelect({
+        triggerProps: {
+          clearable: true,
+          onClear,
+          onClick: onTriggerClick,
+        },
+      })
+
       fireEvent.click(screen.getByRole('button', { name: /clear selection/i }))
 
-      // Assert
       expect(onClear).toHaveBeenCalledTimes(1)
       expect(onTriggerClick).not.toHaveBeenCalled()
     })
 
     it('should stop mouse down propagation when clear button receives mouse down', () => {
-      // Arrange
       const onTriggerMouseDown = vi.fn()
-      render(
-        <SelectTrigger clearable onMouseDown={onTriggerMouseDown}>
-          Trigger Label
-        </SelectTrigger>,
-      )
 
-      // Act
+      renderOpenSelect({
+        triggerProps: {
+          clearable: true,
+          onMouseDown: onTriggerMouseDown,
+        },
+      })
+
       fireEvent.mouseDown(screen.getByRole('button', { name: /clear selection/i }))
 
-      // Assert
       expect(onTriggerMouseDown).not.toHaveBeenCalled()
     })
 
     it('should not throw when clear button is clicked without onClear handler', () => {
-      // Arrange
-      render(<SelectTrigger clearable>Trigger Label</SelectTrigger>)
-      const clearButton = screen.getByRole('button', { name: /clear selection/i })
+      renderOpenSelect({
+        triggerProps: { clearable: true },
+      })
 
-      // Act & Assert
+      const clearButton = screen.getByRole('button', { name: /clear selection/i })
       expect(() => fireEvent.click(clearButton)).not.toThrow()
     })
   })
 
-  // Covers content placement parsing, forwarding props, and slot rendering.
   describe('SelectContent', () => {
-    it('should call parsePlacement with default placement when placement is not provided', () => {
-      // Arrange
-      mockParsePlacement.mockReturnValueOnce({ side: 'bottom', align: 'start' })
+    it('should use default placement when placement is not provided', () => {
+      renderOpenSelect()
 
-      // Act
-      render(
-        <SelectContent>
-          <span>Option A</span>
-        </SelectContent>,
-      )
-
-      // Assert
-      expect(mockParsePlacement).toHaveBeenCalledWith('bottom-start')
-      expect(screen.getByText('Option A')).toBeInTheDocument()
+      const positioner = screen.getByRole('group', { name: 'select positioner' })
+      expect(positioner).toHaveAttribute('data-side', 'bottom')
+      expect(positioner).toHaveAttribute('data-align', 'start')
     })
 
-    it('should pass parsed side align and offsets to Positioner when custom placement and offsets are provided', () => {
-      // Arrange
-      mockParsePlacement.mockReturnValueOnce({ side: 'top', align: 'end' })
+    it('should apply custom placement when placement props are provided', () => {
+      renderOpenSelect({
+        contentProps: {
+          placement: 'top-end',
+          sideOffset: 12,
+          alignOffset: 6,
+        },
+      })
 
-      // Act
-      render(
-        <SelectContent
-          alignOffset={6}
-          placement="top-end"
-          sideOffset={12}
-          positionerProps={{ 'role': 'group', 'aria-label': 'Select positioner' }}
-        >
-          <div>Option A</div>
-        </SelectContent>,
-      )
-
-      // Assert
-      const positioner = screen.getByRole('group', { name: /select positioner/i })
-      expect(mockParsePlacement).toHaveBeenCalledWith('top-end')
+      const positioner = screen.getByRole('group', { name: 'select positioner' })
       expect(positioner).toHaveAttribute('data-side', 'top')
       expect(positioner).toHaveAttribute('data-align', 'end')
-      expect(positioner).toHaveAttribute('data-side-offset', '12')
-      expect(positioner).toHaveAttribute('data-align-offset', '6')
-      expect(positioner).toHaveAttribute('data-align-item-with-trigger', 'false')
     })
 
     it('should forward passthrough props to positioner popup and list when passthrough props are provided', () => {
-      // Arrange & Act
+      const onPositionerMouseEnter = vi.fn()
+      const onPopupClick = vi.fn()
+      const onListFocus = vi.fn()
+
       render(
-        <SelectContent
-          positionerProps={{
-            'role': 'group',
-            'aria-label': 'select positioner',
-          }}
-          popupProps={{
-            'role': 'dialog',
-            'aria-label': 'select popup',
-          }}
-          listProps={{
-            'role': 'listbox',
-            'aria-label': 'select list',
-          }}
-        >
-          <div>Option A</div>
-        </SelectContent>,
+        <Select open defaultValue="seattle">
+          <SelectTrigger aria-label="city select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent
+            positionerProps={{
+              'role': 'group',
+              'aria-label': 'select positioner',
+              'id': 'select-positioner',
+              'onMouseEnter': onPositionerMouseEnter,
+            }}
+            popupProps={{
+              'role': 'dialog',
+              'aria-label': 'select popup',
+              'id': 'select-popup',
+              'onClick': onPopupClick,
+            }}
+            listProps={{
+              'role': 'listbox',
+              'aria-label': 'select list',
+              'id': 'select-list',
+              'onFocus': onListFocus,
+            }}
+          >
+            <SelectItem value="seattle">Seattle</SelectItem>
+          </SelectContent>
+        </Select>,
       )
 
-      // Assert
-      const positioner = screen.getByRole('group', { name: /select positioner/i })
-      const popup = screen.getByRole('dialog', { name: /select popup/i })
-      const list = screen.getByRole('listbox', { name: /select list/i })
+      const positioner = screen.getByRole('group', { name: 'select positioner' })
+      const popup = screen.getByRole('dialog', { name: 'select popup' })
+      const list = screen.getByRole('listbox', { name: 'select list' })
 
-      expect(positioner).toHaveAttribute('aria-label', 'select positioner')
-      expect(popup).toHaveAttribute('role', 'dialog')
-      expect(popup).toHaveAttribute('aria-label', 'select popup')
-      expect(list).toHaveAttribute('role', 'listbox')
-      expect(list).toHaveAttribute('aria-label', 'select list')
+      fireEvent.mouseEnter(positioner)
+      fireEvent.click(popup)
+      fireEvent.focus(list)
+
+      expect(positioner).toHaveAttribute('id', 'select-positioner')
+      expect(popup).toHaveAttribute('id', 'select-popup')
+      expect(list).toHaveAttribute('id', 'select-list')
+      expect(onPositionerMouseEnter).toHaveBeenCalledTimes(1)
+      expect(onPopupClick).toHaveBeenCalledTimes(1)
+      expect(onListFocus).toHaveBeenCalledTimes(1)
     })
   })
 
-  // Covers option item rendering and prop forwarding behavior.
   describe('SelectItem', () => {
-    it('should render item text and indicator when children are provided', () => {
-      // Arrange
-      render(<SelectItem>Seattle</SelectItem>)
+    it('should render options when children are provided', () => {
+      renderOpenSelect()
 
-      // Assert
-      expect(screen.getByRole('option', { name: /seattle/i })).toBeInTheDocument()
-      expect(screen.getByRole('img', { name: /selected item indicator/i })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Seattle' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'New York' })).toBeInTheDocument()
     })
 
-    it('should forward item props when item props are provided', () => {
-      // Arrange
+    it('should not call onValueChange when disabled item is clicked', () => {
+      const onValueChange = vi.fn()
+
       render(
-        <SelectItem aria-label="City option" disabled>
-          Seattle
-        </SelectItem>,
+        <Select open defaultValue="seattle" onValueChange={onValueChange}>
+          <SelectTrigger aria-label="city select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent listProps={{ 'role': 'listbox', 'aria-label': 'select list' }}>
+            <SelectItem value="seattle">Seattle</SelectItem>
+            <SelectItem value="new-york" disabled aria-label="Disabled New York">
+              New York
+            </SelectItem>
+          </SelectContent>
+        </Select>,
       )
 
-      // Assert
-      const item = screen.getByRole('option', { name: /city option/i })
-      expect(item).toHaveAttribute('aria-label', 'City option')
-      expect(item).toHaveAttribute('disabled')
+      fireEvent.click(screen.getByRole('option', { name: 'Disabled New York' }))
+
+      expect(onValueChange).not.toHaveBeenCalled()
     })
   })
 })

--- a/web/app/components/base/ui/tooltip/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/tooltip/__tests__/index.spec.tsx
@@ -1,207 +1,95 @@
-import type { ComponentPropsWithoutRef, ReactNode } from 'react'
-import type { Placement } from '@/app/components/base/ui/placement'
 import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
-import { render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../index'
 
-type ParsedPlacement = {
-  side: 'top' | 'bottom' | 'left' | 'right'
-  align: 'start' | 'center' | 'end'
-}
-
-type PositionerMockProps = ComponentPropsWithoutRef<'div'> & {
-  side?: ParsedPlacement['side']
-  align?: ParsedPlacement['align']
-  sideOffset?: number
-  alignOffset?: number
-}
-
-const positionerPropsSpy = vi.fn<(props: PositionerMockProps) => void>()
-const popupPropsSpy = vi.fn<(props: ComponentPropsWithoutRef<'div'>) => void>()
-const parsePlacementMock = vi.fn<(placement: Placement) => ParsedPlacement>()
-
-vi.mock('@/app/components/base/ui/placement', () => ({
-  parsePlacement: (placement: Placement) => parsePlacementMock(placement),
-}))
-
-vi.mock('@base-ui/react/tooltip', () => {
-  const Portal = ({ children }: { children?: ReactNode }) => (
-    <div>{children}</div>
-  )
-
-  const Positioner = ({ children, ...props }: PositionerMockProps) => {
-    positionerPropsSpy(props)
-    return <div>{children}</div>
-  }
-
-  const Popup = ({ children, className, ...props }: ComponentPropsWithoutRef<'div'>) => {
-    popupPropsSpy({ className, ...props })
-    return (
-      <div className={className} {...props}>
-        {children}
-      </div>
-    )
-  }
-
-  const Provider = ({ children }: { children?: ReactNode }) => (
-    <div>{children}</div>
-  )
-
-  const Root = ({ children }: { children?: ReactNode }) => (
-    <div>{children}</div>
-  )
-
-  const Trigger = ({ children }: { children?: ReactNode }) => (
-    <button type="button">
-      {children}
-    </button>
-  )
-
-  return {
-    Tooltip: {
-      Portal,
-      Positioner,
-      Popup,
-      Provider,
-      Root,
-      Trigger,
-    },
-  }
-})
-
 describe('TooltipContent', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    parsePlacementMock.mockReturnValue({ side: 'top', align: 'center' })
-  })
-
   describe('Placement and offsets', () => {
-    it('should use default placement and offsets when optional props are not provided', () => {
-      // Arrange
-      render(<TooltipContent>Tooltip body</TooltipContent>)
+    it('should use default top placement when placement is not provided', () => {
+      render(
+        <Tooltip open>
+          <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
+          <TooltipContent role="tooltip" aria-label="default tooltip">
+            Tooltip body
+          </TooltipContent>
+        </Tooltip>,
+      )
 
-      // Act
-      const positionerProps = positionerPropsSpy.mock.calls.at(-1)?.[0]
-
-      // Assert
-      expect(parsePlacementMock).toHaveBeenCalledWith('top')
-      expect(positionerProps).toEqual(expect.objectContaining({
-        side: 'top',
-        align: 'center',
-        sideOffset: 8,
-        alignOffset: 0,
-      }))
-      expect(screen.getByText('Tooltip body')).toBeInTheDocument()
+      const popup = screen.getByRole('tooltip', { name: 'default tooltip' })
+      expect(popup).toHaveAttribute('data-side', 'top')
+      expect(popup).toHaveAttribute('data-align', 'center')
+      expect(popup).toHaveTextContent('Tooltip body')
     })
 
-    it('should use parsed placement and custom offsets when placement props are provided', () => {
-      // Arrange
-      parsePlacementMock.mockReturnValue({ side: 'bottom', align: 'start' })
-      const customPlacement: Placement = 'bottom-start'
-
-      // Act
+    it('should apply custom placement when placement props are provided', () => {
       render(
-        <TooltipContent
-          placement={customPlacement}
-          sideOffset={16}
-          alignOffset={6}
-        >
-          Custom tooltip body
-        </TooltipContent>,
+        <Tooltip open>
+          <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
+          <TooltipContent
+            placement="bottom-start"
+            sideOffset={16}
+            alignOffset={6}
+            role="tooltip"
+            aria-label="custom tooltip"
+          >
+            Custom tooltip body
+          </TooltipContent>
+        </Tooltip>,
       )
-      const positionerProps = positionerPropsSpy.mock.calls.at(-1)?.[0]
 
-      // Assert
-      expect(parsePlacementMock).toHaveBeenCalledWith(customPlacement)
-      expect(positionerProps).toEqual(expect.objectContaining({
-        side: 'bottom',
-        align: 'start',
-        sideOffset: 16,
-        alignOffset: 6,
-      }))
-      expect(screen.getByText('Custom tooltip body')).toBeInTheDocument()
+      const popup = screen.getByRole('tooltip', { name: 'custom tooltip' })
+      expect(popup).toHaveAttribute('data-side', 'bottom')
+      expect(popup).toHaveAttribute('data-align', 'start')
+      expect(popup).toHaveTextContent('Custom tooltip body')
     })
   })
 
-  describe('Variant behavior', () => {
-    it('should compute a different popup presentation contract for plain variant than default', () => {
-      // Arrange
-      const { rerender } = render(
-        <TooltipContent variant="default">
-          Default tooltip body
-        </TooltipContent>,
-      )
-      const defaultPopupProps = popupPropsSpy.mock.calls.at(-1)?.[0]
-
-      // Act
-      rerender(
-        <TooltipContent variant="plain">
-          Plain tooltip body
-        </TooltipContent>,
-      )
-      const plainPopupProps = popupPropsSpy.mock.calls.at(-1)?.[0]
-
-      // Assert
-      expect(screen.getByText('Plain tooltip body')).toBeInTheDocument()
-      expect(defaultPopupProps?.className).toBeTypeOf('string')
-      expect(plainPopupProps?.className).toBeTypeOf('string')
-      expect(plainPopupProps?.className).not.toBe(defaultPopupProps?.className)
-    })
-  })
-
-  describe('Popup prop forwarding', () => {
-    it('should forward popup props to BaseTooltip.Popup when popup props are provided', () => {
-      // Arrange
+  describe('Variant and popup props', () => {
+    it('should render popup content when variant is plain', () => {
       render(
-        <TooltipContent
-          id="popup-id"
-          role="tooltip"
-          aria-label="help text"
-          data-track-id="tooltip-track"
-        >
-          Tooltip body
-        </TooltipContent>,
+        <Tooltip open>
+          <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
+          <TooltipContent variant="plain" role="tooltip" aria-label="plain tooltip">
+            Plain tooltip body
+          </TooltipContent>
+        </Tooltip>,
       )
 
-      // Act
+      expect(screen.getByRole('tooltip', { name: 'plain tooltip' })).toHaveTextContent('Plain tooltip body')
+    })
+
+    it('should forward popup props and handlers when popup props are provided', () => {
+      const onMouseEnter = vi.fn()
+
+      render(
+        <Tooltip open>
+          <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
+          <TooltipContent
+            id="tooltip-popup-id"
+            role="tooltip"
+            aria-label="help text"
+            data-track-id="tooltip-track"
+            onMouseEnter={onMouseEnter}
+          >
+            Tooltip body
+          </TooltipContent>
+        </Tooltip>,
+      )
+
       const popup = screen.getByRole('tooltip', { name: 'help text' })
-      const popupProps = popupPropsSpy.mock.calls.at(-1)?.[0]
+      fireEvent.mouseEnter(popup)
 
-      // Assert
-      expect(popupProps).toEqual(expect.objectContaining({
-        'id': 'popup-id',
-        'role': 'tooltip',
-        'aria-label': 'help text',
-        'data-track-id': 'tooltip-track',
-      }))
-      expect(popup).toHaveAttribute('id', 'popup-id')
-      expect(popup).toHaveAttribute('role', 'tooltip')
-      expect(popup).toHaveAttribute('aria-label', 'help text')
+      expect(popup).toHaveAttribute('id', 'tooltip-popup-id')
       expect(popup).toHaveAttribute('data-track-id', 'tooltip-track')
+      expect(onMouseEnter).toHaveBeenCalledTimes(1)
     })
   })
 })
 
 describe('Tooltip aliases', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('should map alias exports to BaseTooltip components when wrapper exports are imported', () => {
-    // Arrange
-    const provider = BaseTooltip.Provider
-    const root = BaseTooltip.Root
-    const trigger = BaseTooltip.Trigger
-
-    // Act
-    const exportedProvider = TooltipProvider
-    const exportedTooltip = Tooltip
-    const exportedTrigger = TooltipTrigger
-
-    // Assert
-    expect(exportedProvider).toBe(provider)
-    expect(exportedTooltip).toBe(root)
-    expect(exportedTrigger).toBe(trigger)
+    expect(TooltipProvider).toBe(BaseTooltip.Provider)
+    expect(Tooltip).toBe(BaseTooltip.Root)
+    expect(TooltipTrigger).toBe(BaseTooltip.Trigger)
   })
 })

--- a/web/app/components/base/ui/tooltip/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/tooltip/__tests__/index.spec.tsx
@@ -1,0 +1,207 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import type { Placement } from '@/app/components/base/ui/placement'
+import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../index'
+
+type ParsedPlacement = {
+  side: 'top' | 'bottom' | 'left' | 'right'
+  align: 'start' | 'center' | 'end'
+}
+
+type PositionerMockProps = ComponentPropsWithoutRef<'div'> & {
+  side?: ParsedPlacement['side']
+  align?: ParsedPlacement['align']
+  sideOffset?: number
+  alignOffset?: number
+}
+
+const positionerPropsSpy = vi.fn<(props: PositionerMockProps) => void>()
+const popupPropsSpy = vi.fn<(props: ComponentPropsWithoutRef<'div'>) => void>()
+const parsePlacementMock = vi.fn<(placement: Placement) => ParsedPlacement>()
+
+vi.mock('@/app/components/base/ui/placement', () => ({
+  parsePlacement: (placement: Placement) => parsePlacementMock(placement),
+}))
+
+vi.mock('@base-ui/react/tooltip', () => {
+  const Portal = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  )
+
+  const Positioner = ({ children, ...props }: PositionerMockProps) => {
+    positionerPropsSpy(props)
+    return <div>{children}</div>
+  }
+
+  const Popup = ({ children, className, ...props }: ComponentPropsWithoutRef<'div'>) => {
+    popupPropsSpy({ className, ...props })
+    return (
+      <div className={className} {...props}>
+        {children}
+      </div>
+    )
+  }
+
+  const Provider = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  )
+
+  const Root = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  )
+
+  const Trigger = ({ children }: { children?: ReactNode }) => (
+    <button type="button">
+      {children}
+    </button>
+  )
+
+  return {
+    Tooltip: {
+      Portal,
+      Positioner,
+      Popup,
+      Provider,
+      Root,
+      Trigger,
+    },
+  }
+})
+
+describe('TooltipContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    parsePlacementMock.mockReturnValue({ side: 'top', align: 'center' })
+  })
+
+  describe('Placement and offsets', () => {
+    it('should use default placement and offsets when optional props are not provided', () => {
+      // Arrange
+      render(<TooltipContent>Tooltip body</TooltipContent>)
+
+      // Act
+      const positionerProps = positionerPropsSpy.mock.calls.at(-1)?.[0]
+
+      // Assert
+      expect(parsePlacementMock).toHaveBeenCalledWith('top')
+      expect(positionerProps).toEqual(expect.objectContaining({
+        side: 'top',
+        align: 'center',
+        sideOffset: 8,
+        alignOffset: 0,
+      }))
+      expect(screen.getByText('Tooltip body')).toBeInTheDocument()
+    })
+
+    it('should use parsed placement and custom offsets when placement props are provided', () => {
+      // Arrange
+      parsePlacementMock.mockReturnValue({ side: 'bottom', align: 'start' })
+      const customPlacement: Placement = 'bottom-start'
+
+      // Act
+      render(
+        <TooltipContent
+          placement={customPlacement}
+          sideOffset={16}
+          alignOffset={6}
+        >
+          Custom tooltip body
+        </TooltipContent>,
+      )
+      const positionerProps = positionerPropsSpy.mock.calls.at(-1)?.[0]
+
+      // Assert
+      expect(parsePlacementMock).toHaveBeenCalledWith(customPlacement)
+      expect(positionerProps).toEqual(expect.objectContaining({
+        side: 'bottom',
+        align: 'start',
+        sideOffset: 16,
+        alignOffset: 6,
+      }))
+      expect(screen.getByText('Custom tooltip body')).toBeInTheDocument()
+    })
+  })
+
+  describe('Variant behavior', () => {
+    it('should compute a different popup presentation contract for plain variant than default', () => {
+      // Arrange
+      const { rerender } = render(
+        <TooltipContent variant="default">
+          Default tooltip body
+        </TooltipContent>,
+      )
+      const defaultPopupProps = popupPropsSpy.mock.calls.at(-1)?.[0]
+
+      // Act
+      rerender(
+        <TooltipContent variant="plain">
+          Plain tooltip body
+        </TooltipContent>,
+      )
+      const plainPopupProps = popupPropsSpy.mock.calls.at(-1)?.[0]
+
+      // Assert
+      expect(screen.getByText('Plain tooltip body')).toBeInTheDocument()
+      expect(defaultPopupProps?.className).toBeTypeOf('string')
+      expect(plainPopupProps?.className).toBeTypeOf('string')
+      expect(plainPopupProps?.className).not.toBe(defaultPopupProps?.className)
+    })
+  })
+
+  describe('Popup prop forwarding', () => {
+    it('should forward popup props to BaseTooltip.Popup when popup props are provided', () => {
+      // Arrange
+      render(
+        <TooltipContent
+          id="popup-id"
+          role="tooltip"
+          aria-label="help text"
+          data-track-id="tooltip-track"
+        >
+          Tooltip body
+        </TooltipContent>,
+      )
+
+      // Act
+      const popup = screen.getByRole('tooltip', { name: 'help text' })
+      const popupProps = popupPropsSpy.mock.calls.at(-1)?.[0]
+
+      // Assert
+      expect(popupProps).toEqual(expect.objectContaining({
+        'id': 'popup-id',
+        'role': 'tooltip',
+        'aria-label': 'help text',
+        'data-track-id': 'tooltip-track',
+      }))
+      expect(popup).toHaveAttribute('id', 'popup-id')
+      expect(popup).toHaveAttribute('role', 'tooltip')
+      expect(popup).toHaveAttribute('aria-label', 'help text')
+      expect(popup).toHaveAttribute('data-track-id', 'tooltip-track')
+    })
+  })
+})
+
+describe('Tooltip aliases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should map alias exports to BaseTooltip components when wrapper exports are imported', () => {
+    // Arrange
+    const provider = BaseTooltip.Provider
+    const root = BaseTooltip.Root
+    const trigger = BaseTooltip.Trigger
+
+    // Act
+    const exportedProvider = TooltipProvider
+    const exportedTooltip = Tooltip
+    const exportedTrigger = TooltipTrigger
+
+    // Assert
+    expect(exportedProvider).toBe(provider)
+    expect(exportedTooltip).toBe(root)
+    expect(exportedTrigger).toBe(trigger)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for 5 Base UI wrapper primitives under `web/app/components/base/ui/`
- focus on behavior-driven assertions (no CSS/class assertions)
- prefer semantic queries and avoid test-id driven checks
- cover rendering, props forwarding, placement parsing, interaction branches, and export alias mapping

## Files
- `web/app/components/base/ui/select/__tests__/index.spec.tsx`
- `web/app/components/base/ui/tooltip/__tests__/index.spec.tsx`
- `web/app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx`
- `web/app/components/base/ui/popover/__tests__/index.spec.tsx`
- `web/app/components/base/ui/dialog/__tests__/index.spec.tsx`

## Verification
- `pnpm lint app/components/base/ui/select/__tests__/index.spec.tsx app/components/base/ui/tooltip/__tests__/index.spec.tsx app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx app/components/base/ui/popover/__tests__/index.spec.tsx app/components/base/ui/dialog/__tests__/index.spec.tsx`
- `pnpm test app/components/base/ui/select/__tests__/index.spec.tsx app/components/base/ui/tooltip/__tests__/index.spec.tsx app/components/base/ui/dropdown-menu/__tests__/index.spec.tsx app/components/base/ui/popover/__tests__/index.spec.tsx app/components/base/ui/dialog/__tests__/index.spec.tsx`
- `pnpm type-check:tsgo`
