### PR TITLE
fix: tighten simple prompt template typing

### DIFF
--- a/api/core/prompt/simple_prompt_transform.py
+++ b/api/core/prompt/simple_prompt_transform.py
@@ -2,7 +2,7 @@ import json
 import os
 from collections.abc import Mapping, Sequence
 from enum import StrEnum, auto
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
 from core.app.app_config.entities import PromptTemplateEntity
 from core.app.entities.app_invoke_entities import ModelConfigWithCredentialsEntity
@@ -30,7 +30,31 @@ class ModelMode(StrEnum):
     CHAT = auto()
 
 
-prompt_file_contents: dict[str, Any] = {}
+PromptRuleOrder = Literal["context_prompt", "pre_prompt", "histories_prompt"]
+
+
+class SimplePromptRules(TypedDict):
+    """Typed view of the simple prompt template JSON files."""
+
+    context_prompt: str
+    system_prompt_orders: list[PromptRuleOrder]
+    query_prompt: str
+    stops: list[str] | None
+    human_prefix: str
+    assistant_prefix: str
+    histories_prompt: str
+
+
+class SimplePromptTemplateConfig(TypedDict):
+    """Structured result returned by get_prompt_template()."""
+
+    prompt_template: PromptTemplateParser
+    custom_variable_keys: list[str]
+    special_variable_keys: list[str]
+    prompt_rules: SimplePromptRules
+
+
+prompt_file_contents: dict[str, SimplePromptRules] = {}
 
 
 class SimplePromptTransform(PromptTransform):
@@ -92,7 +116,7 @@ class SimplePromptTransform(PromptTransform):
         query: str | None = None,
         context: str | None = None,
         histories: str | None = None,
-    ) -> tuple[str, dict]:
+    ) -> tuple[str, SimplePromptRules]:
         # get prompt template
         prompt_template_config = self.get_prompt_template(
             app_mode=app_mode,
@@ -104,18 +128,8 @@ class SimplePromptTransform(PromptTransform):
             with_memory_prompt=histories is not None,
         )
 
-        custom_variable_keys_obj = prompt_template_config["custom_variable_keys"]
-        special_variable_keys_obj = prompt_template_config["special_variable_keys"]
-
-        # Type check for custom_variable_keys
-        if not isinstance(custom_variable_keys_obj, list):
-            raise TypeError(f"Expected list for custom_variable_keys, got {type(custom_variable_keys_obj)}")
-        custom_variable_keys = cast(list[str], custom_variable_keys_obj)
-
-        # Type check for special_variable_keys
-        if not isinstance(special_variable_keys_obj, list):
-            raise TypeError(f"Expected list for special_variable_keys, got {type(special_variable_keys_obj)}")
-        special_variable_keys = cast(list[str], special_variable_keys_obj)
+        custom_variable_keys = prompt_template_config["custom_variable_keys"]
+        special_variable_keys = prompt_template_config["special_variable_keys"]
 
         variables = {k: inputs[k] for k in custom_variable_keys if k in inputs}
 
@@ -128,17 +142,9 @@ class SimplePromptTransform(PromptTransform):
             elif v == "#histories#":
                 variables["#histories#"] = histories or ""
 
-        prompt_template = prompt_template_config["prompt_template"]
-        if not isinstance(prompt_template, PromptTemplateParser):
-            raise TypeError(f"Expected PromptTemplateParser, got {type(prompt_template)}")
+        prompt = prompt_template_config["prompt_template"].format(variables)
 
-        prompt = prompt_template.format(variables)
-
-        prompt_rules = prompt_template_config["prompt_rules"]
-        if not isinstance(prompt_rules, dict):
-            raise TypeError(f"Expected dict for prompt_rules, got {type(prompt_rules)}")
-
-        return prompt, prompt_rules
+        return prompt, prompt_template_config["prompt_rules"]
 
     def get_prompt_template(
         self,
@@ -149,7 +155,7 @@ class SimplePromptTransform(PromptTransform):
         has_context: bool,
         query_in_prompt: bool,
         with_memory_prompt: bool = False,
-    ) -> dict[str, object]:
+    ) -> SimplePromptTemplateConfig:
         prompt_rules = self._get_prompt_rule(app_mode=app_mode, provider=provider, model=model)
 
         custom_variable_keys: list[str] = []
@@ -309,7 +315,7 @@ class SimplePromptTransform(PromptTransform):
 
         return prompt_message
 
-    def _get_prompt_rule(self, app_mode: AppMode, provider: str, model: str):
+    def _get_prompt_rule(self, app_mode: AppMode, provider: str, model: str) -> SimplePromptRules:
         """
         Get simple prompt rule.
         :param app_mode: app mode
@@ -321,7 +327,7 @@ class SimplePromptTransform(PromptTransform):
 
         # Check if the prompt file is already loaded
         if prompt_file_name in prompt_file_contents:
-            return cast(dict, prompt_file_contents[prompt_file_name])
+            return prompt_file_contents[prompt_file_name]
 
         # Get the absolute path of the subdirectory
         prompt_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "prompt_templates")
@@ -329,12 +335,21 @@ class SimplePromptTransform(PromptTransform):
 
         # Open the JSON file and read its content
         with open(json_file_path, encoding="utf-8") as json_file:
-            content = json.load(json_file)
+            raw_content = cast(dict[str, object], json.load(json_file))
+            content: SimplePromptRules = {
+                "context_prompt": cast(str, raw_content["context_prompt"]),
+                "system_prompt_orders": cast(list[PromptRuleOrder], raw_content["system_prompt_orders"]),
+                "query_prompt": cast(str, raw_content["query_prompt"]),
+                "stops": cast(list[str] | None, raw_content.get("stops")),
+                "human_prefix": cast(str, raw_content.get("human_prefix", "Human")),
+                "assistant_prefix": cast(str, raw_content.get("assistant_prefix", "Assistant")),
+                "histories_prompt": cast(str, raw_content.get("histories_prompt", "")),
+            }
 
             # Store the content of the prompt file
             prompt_file_contents[prompt_file_name] = content
 
-            return cast(dict, content)
+            return content
 
     def _prompt_file_name(self, app_mode: AppMode, provider: str, model: str) -> str:
         # baichuan


### PR DESCRIPTION
Fixes #32842

## Summary

This change tightens the type contract returned by `SimplePromptTransform.get_prompt_template()`.

`get_prompt_template()` previously returned `dict[str, object]`, which forced downstream consumers and tests to recover concrete types from `object`. That shape is now replaced with typed prompt structures in `api/core/prompt/simple_prompt_transform.py`.

The prompt template JSON is also normalized when it is loaded so the module exposes a stable internal shape for prompt rules, including the existing fallback values for missing prompt prefixes. This keeps the fix in the producer, removes the pyrefly failures in `tests/unit_tests/core/prompt/test_simple_prompt_transform.py`, and does not change prompt construction behavior.

## Testing

- `uv run --directory api pytest tests/unit_tests/core/prompt/test_simple_prompt_transform.py -q`
- `uv run --directory api --dev pyrefly check core/prompt/simple_prompt_transform.py services/workflow/workflow_converter.py tests/unit_tests/core/prompt/test_simple_prompt_transform.py`
- `uv run --directory api basedpyright core/prompt/simple_prompt_transform.py services/workflow/workflow_converter.py`
- `uv run --directory api ruff check core/prompt/simple_prompt_transform.py`

## Screenshots

Not applicable.
