### PR TITLE
fix: avoid hydration error from nesting div inside p in markdown

### DIFF
--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -21,6 +21,11 @@ const Paragraph = (paragraph: any) => {
       </div>
     )
   }
+  const hasBlockChild = children_node?.some(
+    (child: any) => 'tagName' in child && child.tagName === 'img',
+  )
+  if (hasBlockChild)
+    return <div className="markdown-paragraph">{paragraph.children}</div>
   return <p>{paragraph.children}</p>
 }
 


### PR DESCRIPTION
## Summary
Fixes #32362

When a Markdown paragraph contains an inline image in a non-first position (e.g., `Text before ![image](url) text after`), the `Paragraph` component fell through to `<p>{children}</p>`. Since the `Img` component renders a block-level `<div>`, this produced invalid HTML: `<div>` nested inside `<p>`, causing a Next.js hydration warning.

## Changes
- **`paragraph.tsx`**: Added a secondary check that scans all child nodes for `img` tags. When any image is found (not just at position 0), the paragraph renders as `<div className="markdown-paragraph">` instead of `<p>`, preventing the invalid DOM nesting.

## How it works
The existing code already handled images as the first child (lines 12-22) by rendering a `<div>` wrapper. The fix adds a fallback check for images at other positions:

```tsx
const hasBlockChild = children_node?.some(
  (child: any) => 'tagName' in child && child.tagName === 'img',
)
if (hasBlockChild)
  return <div className="markdown-paragraph">{paragraph.children}</div>
```

## Test plan
- [x] Render markdown with `Text ![image](url) more text` — no hydration warning
- [x] Render markdown with `![image](url)` as first child — existing behavior preserved
- [x] Render markdown with no images — renders as `<p>` as before