### PR TITLE
fix: conversation var unexpected reset after HITL node

### DIFF
--- a/api/dify_graph/runtime/variable_pool.py
+++ b/api/dify_graph/runtime/variable_pool.py
@@ -62,16 +62,13 @@ class VariablePool(BaseModel):
     def model_post_init(self, context: Any, /):
         # Create a mapping from field names to SystemVariableKey enum values
         self._add_system_variables(self.system_variables)
-        # Add environment variables to the variable pool. When restoring from a serialized
+        # Add environment variables to the variable pool
+        for var in self.environment_variables:
+            self.add((ENVIRONMENT_VARIABLE_NODE_ID, var.name), var)
+        # Add conversation variables to the variable pool. When restoring from a serialized
         # snapshot, `variable_dictionary` already carries the latest runtime values.
         # In that case, keep existing entries instead of overwriting them with the
-        # bootstrap lists.
-        for var in self.environment_variables:
-            selector = (ENVIRONMENT_VARIABLE_NODE_ID, var.name)
-            if self._has(selector):
-                continue
-            self.add(selector, var)
-        # Add conversation variables to the variable pool
+        # bootstrap list.
         for var in self.conversation_variables:
             selector = (CONVERSATION_VARIABLE_NODE_ID, var.name)
             if self._has(selector):
@@ -86,10 +83,7 @@ class VariablePool(BaseModel):
                 value = rag_var.value
                 rag_pipeline_variables_map[node_id][key] = value
             for key, value in rag_pipeline_variables_map.items():
-                selector = (RAG_PIPELINE_VARIABLE_NODE_ID, key)
-                if self._has(selector):
-                    continue
-                self.add(selector, value)
+                self.add((RAG_PIPELINE_VARIABLE_NODE_ID, key), value)
 
     def add(self, selector: Sequence[str], value: Any, /):
         """

--- a/api/dify_graph/runtime/variable_pool.py
+++ b/api/dify_graph/runtime/variable_pool.py
@@ -62,12 +62,21 @@ class VariablePool(BaseModel):
     def model_post_init(self, context: Any, /):
         # Create a mapping from field names to SystemVariableKey enum values
         self._add_system_variables(self.system_variables)
-        # Add environment variables to the variable pool
+        # Add environment variables to the variable pool. When restoring from a serialized
+        # snapshot, `variable_dictionary` already carries the latest runtime values.
+        # In that case, keep existing entries instead of overwriting them with the
+        # bootstrap lists.
         for var in self.environment_variables:
-            self.add((ENVIRONMENT_VARIABLE_NODE_ID, var.name), var)
+            selector = (ENVIRONMENT_VARIABLE_NODE_ID, var.name)
+            if self._has(selector):
+                continue
+            self.add(selector, var)
         # Add conversation variables to the variable pool
         for var in self.conversation_variables:
-            self.add((CONVERSATION_VARIABLE_NODE_ID, var.name), var)
+            selector = (CONVERSATION_VARIABLE_NODE_ID, var.name)
+            if self._has(selector):
+                continue
+            self.add(selector, var)
         # Add rag pipeline variables to the variable pool
         if self.rag_pipeline_variables:
             rag_pipeline_variables_map: defaultdict[Any, dict[Any, Any]] = defaultdict(dict)
@@ -77,7 +86,10 @@ class VariablePool(BaseModel):
                 value = rag_var.value
                 rag_pipeline_variables_map[node_id][key] = value
             for key, value in rag_pipeline_variables_map.items():
-                self.add((RAG_PIPELINE_VARIABLE_NODE_ID, key), value)
+                selector = (RAG_PIPELINE_VARIABLE_NODE_ID, key)
+                if self._has(selector):
+                    continue
+                self.add(selector, value)
 
     def add(self, selector: Sequence[str], value: Any, /):
         """

--- a/api/tests/unit_tests/core/workflow/entities/test_graph_runtime_state.py
+++ b/api/tests/unit_tests/core/workflow/entities/test_graph_runtime_state.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dify_graph.constants import CONVERSATION_VARIABLE_NODE_ID
 from dify_graph.model_runtime.entities.llm_entities import LLMUsage
 from dify_graph.runtime import GraphRuntimeState, ReadOnlyGraphRuntimeStateWrapper, VariablePool
+from dify_graph.variables.variables import StringVariable
 
 
 class StubCoordinator:
@@ -278,3 +280,17 @@ class TestGraphRuntimeState:
         assert restored_execution.started is True
 
         assert new_stub.state == "configured"
+
+    def test_snapshot_restore_preserves_updated_conversation_variable(self):
+        variable_pool = VariablePool(
+            conversation_variables=[StringVariable(name="session_name", value="before")],
+        )
+        variable_pool.add((CONVERSATION_VARIABLE_NODE_ID, "session_name"), "after")
+
+        state = GraphRuntimeState(variable_pool=variable_pool, start_at=time())
+        snapshot = state.dumps()
+        restored = GraphRuntimeState.from_snapshot(snapshot)
+
+        restored_value = restored.variable_pool.get((CONVERSATION_VARIABLE_NODE_ID, "session_name"))
+        assert restored_value is not None
+        assert restored_value.value == "after"


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/32934
fix https://github.com/langgenius/dify/issues/32617

When GraphRuntimeState.from_snapshot() restores VariablePool, variable_dictionary already contains the latest runtime values.
But VariablePool.model_post_init() re-initializes conversation_variables and calls add() unconditionally, which overwrites those restored values with stale initial defaults.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
