### PR TITLE
fix(api): decouple enterprise default-workspace join from personal workspace creation

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -74,6 +74,16 @@ from tasks.mail_reset_password_task import (
 logger = logging.getLogger(__name__)
 
 
+def _try_join_enterprise_default_workspace(account_id: str) -> None:
+    """Best-effort join to enterprise default workspace."""
+    if not dify_config.ENTERPRISE_ENABLED:
+        return
+
+    from services.enterprise.enterprise_service import try_join_default_workspace
+
+    try_join_default_workspace(account_id)
+
+
 class TokenPair(BaseModel):
     access_token: str
     refresh_token: str
@@ -287,13 +297,17 @@ class AccountService:
             email=email, name=name, interface_language=interface_language, password=password
         )
 
-        TenantService.create_owner_tenant_if_not_exist(account=account)
+        workspace_creation_error: Exception | None = None
+        try:
+            TenantService.create_owner_tenant_if_not_exist(account=account)
+        except Exception as e:  # noqa: BLE001
+            workspace_creation_error = e
 
-        # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
-        if dify_config.ENTERPRISE_ENABLED:
-            from services.enterprise.enterprise_service import try_join_default_workspace
+        # Enterprise-only side-effect should run independently from personal workspace creation.
+        _try_join_enterprise_default_workspace(str(account.id))
 
-            try_join_default_workspace(str(account.id))
+        if workspace_creation_error is not None:
+            raise workspace_creation_error
 
         return account
 
@@ -1389,6 +1403,7 @@ class RegisterService:
         db.session.begin_nested()
         """Register account"""
         try:
+            workspace_creation_error: Exception | None = None
             account = AccountService.create_account(
                 email=email,
                 name=name,
@@ -1407,18 +1422,20 @@ class RegisterService:
                 and create_workspace_required
                 and FeatureService.get_system_features().license.workspaces.is_available()
             ):
-                tenant = TenantService.create_tenant(f"{account.name}'s Workspace")
-                TenantService.create_tenant_member(tenant, account, role="owner")
-                account.current_tenant = tenant
-                tenant_was_created.send(tenant)
+                try:
+                    tenant = TenantService.create_tenant(f"{account.name}'s Workspace")
+                    TenantService.create_tenant_member(tenant, account, role="owner")
+                    account.current_tenant = tenant
+                    tenant_was_created.send(tenant)
+                except Exception as e:  # noqa: BLE001
+                    workspace_creation_error = e
 
             db.session.commit()
 
-            # Enterprise-only: best-effort add the account to the default workspace (does not switch current workspace).
-            if dify_config.ENTERPRISE_ENABLED:
-                from services.enterprise.enterprise_service import try_join_default_workspace
+            _try_join_enterprise_default_workspace(str(account.id))
 
-                try_join_default_workspace(str(account.id))
+            if workspace_creation_error is not None:
+                raise workspace_creation_error
         except WorkSpaceNotAllowedCreateError:
             db.session.rollback()
             logger.exception("Register failed")

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -297,17 +297,14 @@ class AccountService:
             email=email, name=name, interface_language=interface_language, password=password
         )
 
-        workspace_creation_error: Exception | None = None
         try:
             TenantService.create_owner_tenant_if_not_exist(account=account)
-        except Exception as e:  # noqa: BLE001
-            workspace_creation_error = e
+        except Exception:
+            # Enterprise-only side-effect should run independently from personal workspace creation.
+            _try_join_enterprise_default_workspace(str(account.id))
+            raise
 
-        # Enterprise-only side-effect should run independently from personal workspace creation.
         _try_join_enterprise_default_workspace(str(account.id))
-
-        if workspace_creation_error is not None:
-            raise workspace_creation_error
 
         return account
 
@@ -1403,7 +1400,6 @@ class RegisterService:
         db.session.begin_nested()
         """Register account"""
         try:
-            workspace_creation_error: Exception | None = None
             account = AccountService.create_account(
                 email=email,
                 name=name,
@@ -1427,15 +1423,13 @@ class RegisterService:
                     TenantService.create_tenant_member(tenant, account, role="owner")
                     account.current_tenant = tenant
                     tenant_was_created.send(tenant)
-                except Exception as e:  # noqa: BLE001
-                    workspace_creation_error = e
+                except Exception:
+                    _try_join_enterprise_default_workspace(str(account.id))
+                    raise
 
             db.session.commit()
 
             _try_join_enterprise_default_workspace(str(account.id))
-
-            if workspace_creation_error is not None:
-                raise workspace_creation_error
         except WorkSpaceNotAllowedCreateError:
             db.session.rollback()
             logger.exception("Register failed")

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1304,6 +1304,7 @@ class TestRegisterService:
                 )
 
             mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
+            mock_db_dependencies["db"].session.commit.assert_not_called()
 
     def test_register_still_calls_default_workspace_join_when_workspace_limit_exceeded(
         self, mock_db_dependencies, mock_external_service_dependencies, monkeypatch
@@ -1342,6 +1343,7 @@ class TestRegisterService:
                 )
 
             mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
+            mock_db_dependencies["db"].session.commit.assert_not_called()
 
     def test_register_with_oauth(self, mock_db_dependencies, mock_external_service_dependencies):
         """Test account registration with OAuth integration."""

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1125,6 +1125,38 @@ class TestRegisterService:
             mock_create_workspace.assert_called_once_with(account=mock_account)
             mock_join_default_workspace.assert_not_called()
 
+    def test_create_account_and_tenant_still_calls_default_workspace_join_when_workspace_creation_fails(
+        self, mock_db_dependencies, mock_external_service_dependencies, monkeypatch
+    ):
+        """Default workspace join should still be attempted when personal workspace creation fails."""
+        from services.errors.workspace import WorkSpaceNotAllowedCreateError
+
+        monkeypatch.setattr(dify_config, "ENTERPRISE_ENABLED", True, raising=False)
+        mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
+        mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
+
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock(
+            account_id="11111111-1111-1111-1111-111111111111"
+        )
+
+        with (
+            patch("services.account_service.AccountService.create_account") as mock_create_account,
+            patch("services.account_service.TenantService.create_owner_tenant_if_not_exist") as mock_create_workspace,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+        ):
+            mock_create_account.return_value = mock_account
+            mock_create_workspace.side_effect = WorkSpaceNotAllowedCreateError()
+
+            with pytest.raises(WorkSpaceNotAllowedCreateError):
+                AccountService.create_account_and_tenant(
+                    email="test@example.com",
+                    name="Test User",
+                    interface_language="en-US",
+                    password=None,
+                )
+
+            mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
+
     def test_register_success(self, mock_db_dependencies, mock_external_service_dependencies):
         """Test successful account registration."""
         # Setup mocks
@@ -1234,6 +1266,82 @@ class TestRegisterService:
             )
 
             mock_join_default_workspace.assert_not_called()
+
+    def test_register_still_calls_default_workspace_join_when_personal_workspace_creation_fails(
+        self, mock_db_dependencies, mock_external_service_dependencies, monkeypatch
+    ):
+        """Default workspace join should run even when personal workspace creation raises."""
+        from services.errors.workspace import WorkSpaceNotAllowedCreateError
+
+        monkeypatch.setattr(dify_config, "ENTERPRISE_ENABLED", True, raising=False)
+        mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
+        mock_external_service_dependencies[
+            "feature_service"
+        ].get_system_features.return_value.is_allow_create_workspace = True
+        mock_external_service_dependencies[
+            "feature_service"
+        ].get_system_features.return_value.license.workspaces.is_available.return_value = True
+        mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
+
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock(
+            account_id="11111111-1111-1111-1111-111111111111"
+        )
+
+        with (
+            patch("services.account_service.AccountService.create_account") as mock_create_account,
+            patch("services.account_service.TenantService.create_tenant") as mock_create_tenant,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+        ):
+            mock_create_account.return_value = mock_account
+            mock_create_tenant.side_effect = WorkSpaceNotAllowedCreateError()
+
+            with pytest.raises(AccountRegisterError, match="Workspace is not allowed to create."):
+                RegisterService.register(
+                    email="test@example.com",
+                    name="Test User",
+                    password="password123",
+                    language="en-US",
+                )
+
+            mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
+
+    def test_register_still_calls_default_workspace_join_when_workspace_limit_exceeded(
+        self, mock_db_dependencies, mock_external_service_dependencies, monkeypatch
+    ):
+        """Default workspace join should run before propagating workspace-limit registration failure."""
+        from services.errors.workspace import WorkspacesLimitExceededError
+
+        monkeypatch.setattr(dify_config, "ENTERPRISE_ENABLED", True, raising=False)
+        mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
+        mock_external_service_dependencies[
+            "feature_service"
+        ].get_system_features.return_value.is_allow_create_workspace = True
+        mock_external_service_dependencies[
+            "feature_service"
+        ].get_system_features.return_value.license.workspaces.is_available.return_value = True
+        mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
+
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock(
+            account_id="11111111-1111-1111-1111-111111111111"
+        )
+
+        with (
+            patch("services.account_service.AccountService.create_account") as mock_create_account,
+            patch("services.account_service.TenantService.create_tenant") as mock_create_tenant,
+            patch("services.enterprise.enterprise_service.try_join_default_workspace") as mock_join_default_workspace,
+        ):
+            mock_create_account.return_value = mock_account
+            mock_create_tenant.side_effect = WorkspacesLimitExceededError()
+
+            with pytest.raises(AccountRegisterError, match="Registration failed:"):
+                RegisterService.register(
+                    email="test@example.com",
+                    name="Test User",
+                    password="password123",
+                    language="en-US",
+                )
+
+            mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
 
     def test_register_with_oauth(self, mock_db_dependencies, mock_external_service_dependencies):
         """Test account registration with OAuth integration."""


### PR DESCRIPTION
Fixes #32937

## Summary

This PR fixes an enterprise registration flow bug where failure to create a personal workspace could prevent attempting to join the enterprise default workspace.

### What changed
- Refactored the registration-related service flows in `api/services/account_service.py`:
  - `AccountService.create_account_and_tenant`
  - `RegisterService.register`
- Introduced a shared helper to run enterprise default workspace join side-effect:
  - `_try_join_enterprise_default_workspace(account_id)`
- Ensured default workspace join attempt is executed independently after account creation, regardless of personal workspace creation success/failure.
- Preserved existing exception contracts for controllers (no behavior change in HTTP error mapping).

### Why
Enterprise default workspace join should be an independent side-effect and must not be blocked by personal workspace creation failures.

### Tests
Added/updated unit tests in:
- `api/tests/unit_tests/services/test_account_service.py`

New regression coverage includes:
- `create_account_and_tenant` still attempts default workspace join when personal workspace creation fails.
- `register` still attempts default workspace join when personal workspace creation fails.
- `register` still attempts default workspace join when workspace limit errors occur.

Validation:
- `uv run --project api pytest api/tests/unit_tests/services/test_account_service.py -q`
- Result: `62 passed`

## Screenshots

| Before | After |
|--------|-------|
| N/A (backend service logic) | N/A (backend service logic) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods