### PR TITLE
chore(api): split resumption queue and execution queue

### DIFF
--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -35,9 +35,9 @@
                 "-P",
                 "solo",
                 "-c",
-                "1",
+                "20",
                 "-Q",
-                "dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution",
+                "workflow_based_app_resumption,workflow_based_app_execution,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention",
                 "--loglevel",
                 "INFO"
             ],

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -35,10 +35,10 @@ if [[ "${MODE}" == "worker" ]]; then
   if [[ -z "${CELERY_QUEUES}" ]]; then
     if [[ "${EDITION}" == "CLOUD" ]]; then
       # Cloud edition: separate queues for dataset and trigger tasks
-      DEFAULT_QUEUES="api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+      DEFAULT_QUEUES="workflow_based_app_resumption,workflow_based_app_execution,api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention"
     else
       # Community edition (SELF_HOSTED): dataset, pipeline and workflow have separate queues
-      DEFAULT_QUEUES="api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+      DEFAULT_QUEUES="workflow_based_app_resumption,workflow_based_app_execution,api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,,"
     fi
   else
     DEFAULT_QUEUES="${CELERY_QUEUES}"

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "${MODE}" == "worker" ]]; then
       DEFAULT_QUEUES="workflow_based_app_resumption,workflow_based_app_execution,api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention"
     else
       # Community edition (SELF_HOSTED): dataset, pipeline and workflow have separate queues
-      DEFAULT_QUEUES="workflow_based_app_resumption,workflow_based_app_execution,api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,,"
+       DEFAULT_QUEUES="workflow_based_app_resumption,workflow_based_app_execution,api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention"
     fi
   else
     DEFAULT_QUEUES="${CELERY_QUEUES}"

--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -33,6 +33,7 @@ from repositories.factory import DifyAPIRepositoryFactory
 logger = logging.getLogger(__name__)
 
 WORKFLOW_BASED_APP_EXECUTION_QUEUE = "workflow_based_app_execution"
+WORKFLOW_BASED_APP_RESUMPTION_QUEUE = "workflow_based_app_resumption"
 
 
 class _UserType(StrEnum):
@@ -267,6 +268,8 @@ def workflow_based_app_execution_task(
 def _resume_app_execution(payload: dict[str, Any]) -> None:
     workflow_run_id = payload["workflow_run_id"]
 
+    logger.info("resume workflow based app execution, workflow_run_id=%s", workflow_run_id)
+
     session_factory = sessionmaker(bind=db.engine, expire_on_commit=False)
     workflow_run_repo = DifyAPIRepositoryFactory.create_api_workflow_run_repository(session_maker=session_factory)
 
@@ -409,6 +412,7 @@ def _resume_advanced_chat(
     generator = AdvancedChatAppGenerator()
 
     try:
+        logger.info("resume chatflow, workflow_run_id=%s", workflow_run_id)
         response = generator.resume(
             app_model=app_model,
             workflow=workflow,
@@ -465,6 +469,7 @@ def _resume_workflow(
     generator = WorkflowAppGenerator()
 
     try:
+        logger.info("resume workflow, workflow_run_id=%s", workflow_run_id)
         response = generator.resume(
             app_model=app_model,
             workflow=workflow,
@@ -486,6 +491,6 @@ def _resume_workflow(
     workflow_run_repo.delete_workflow_pause(pause_entity)
 
 
-@shared_task(queue=WORKFLOW_BASED_APP_EXECUTION_QUEUE, name="resume_app_execution")
+@shared_task(queue=WORKFLOW_BASED_APP_RESUMPTION_QUEUE, name="resume_app_execution")
 def resume_app_execution(payload: dict[str, Any]) -> None:
     _resume_app_execution(payload)

--- a/dev/start-worker
+++ b/dev/start-worker
@@ -106,10 +106,10 @@ if [[ -z "${QUEUES}" ]]; then
   # Configure queues based on edition
   if [[ "${EDITION}" == "CLOUD" ]]; then
     # Cloud edition: separate queues for dataset and trigger tasks
-    QUEUES="dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+    QUEUES="workflow_based_app_resumption,workflow_based_app_execution,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention"
   else
     # Community edition (SELF_HOSTED): dataset and workflow have separate queues
-    QUEUES="dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+    QUEUES="workflow_based_app_resumption,workflow_based_app_execution,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention"
   fi
 
   echo "No queues specified, using edition-based defaults: ${QUEUES}"


### PR DESCRIPTION
## Summary

This PR separates the queues for workflow execution and workflow resumption.

Because resumption tasks are far fewer than execution tasks, sharing a single queue can delay resumptions behind a large execution backlog. Splitting the queues reduces this contention and helps keep resumption latency within a reasonable range.

This is a mitigation, not a root-cause fix. It addresses an operational symptom we observed in Dify, but the underlying reason resumptions can be delayed even when workers appear to have spare capacity still requires further investigation.

Closes #32911
Fix #32912

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
