### PR TITLE
chore: refine oRPC contract-first skill guidance

### DIFF
--- a/.agents/skills/orpc-contract-first/SKILL.md
+++ b/.agents/skills/orpc-contract-first/SKILL.md
@@ -29,7 +29,7 @@ web/service/client.ts
 1. Define contract in `web/contract/console/{domain}.ts` or `web/contract/marketplace.ts`
    - Use `base.route({...}).output(type<...>())` as baseline.
    - Add `.input(type<...>())` only when request has `params/query/body`.
-   - For `GET` without input, omit `.input(...)` (do not use `type<unknown>()`).
+   - For `GET` without input, omit `.input(...)` (do not use `.input(type<unknown>())`).
 2. Register contract in `web/contract/router.ts`
    - Import directly from domain files and nest by API prefix.
 3. Consume from UI call sites via oRPC query utils.
@@ -65,7 +65,7 @@ const invoiceQuery = useQuery({
 
 ## Mutation Usage Decision Rule
 
-1. Default: use `useMutation(consoleQuery|marketplaceQuery.xxx.mutationOptions(...))`.
+1. Default: call mutation helpers from `consoleQuery` / `marketplaceQuery`, for example `useMutation(consoleQuery.billing.bindPartnerStack.mutationOptions(...))`.
 2. If mutation flow is heavily custom, use oRPC clients as `mutationFn` (for example `consoleClient.xxx` / `marketplaceClient.xxx`), instead of generic handwritten non-oRPC mutation logic.
 
 ## Key API Guide (`.key` vs `.queryKey` vs `.mutationKey`)
@@ -89,9 +89,9 @@ const invoiceQuery = useQuery({
 ## Contract Rules
 
 - **Input structure**: Always use `{ params, query?, body? }` format
-- **No-input GET**: Omit `.input(...)`; do not write `.input(type<unknown>())`
+- **No-input GET**: Omit `.input(...)`; do not use `.input(type<unknown>())`
 - **Path params**: Use `{paramName}` in path, match in `params` object
-- **Router nesting**: Group by API prefix (e.g., `/billing/*` → `billing: {}`)
+- **Router nesting**: Group by API prefix (e.g., `/billing/*` -> `billing: {}`)
 - **No barrel files**: Import directly from specific files
 - **Types**: Import from `@/types/`, use `type<T>()` helper
 - **Mutations**: Prefer `mutationOptions`; use explicit `mutationKey` mainly for defaults/filtering/devtools

--- a/.agents/skills/orpc-contract-first/SKILL.md
+++ b/.agents/skills/orpc-contract-first/SKILL.md
@@ -8,7 +8,7 @@ description: Guide for implementing oRPC contract-first API patterns in Dify fro
 ## Intent
 
 - Keep contract as single source of truth in `web/contract/*`.
-- Default query usage: call-site `useQuery(consoleQuery|marketplaceQuery.xxx.queryOptions(...))`.
+- Default query usage: call-site `useQuery(consoleQuery|marketplaceQuery.xxx.queryOptions(...))` when endpoint behavior maps 1:1 to the contract.
 - Keep abstractions minimal and preserve TypeScript inference.
 
 ## Minimal Structure
@@ -17,6 +17,7 @@ description: Guide for implementing oRPC contract-first API patterns in Dify fro
 web/contract/
 ├── base.ts
 ├── router.ts
+├── marketplace.ts
 └── console/
     ├── billing.ts
     └── ...other domains
@@ -25,7 +26,7 @@ web/service/client.ts
 
 ## Core Workflow
 
-1. Define contract in `web/contract/console/{domain}.ts`
+1. Define contract in `web/contract/console/{domain}.ts` or `web/contract/marketplace.ts`
    - Use `base.route({...}).output(type<...>())` as baseline.
    - Add `.input(type<...>())` only when request has `params/query/body`.
    - For `GET` without input, omit `.input(...)` (do not use `type<unknown>()`).
@@ -64,8 +65,8 @@ const invoiceQuery = useQuery({
 
 ## Mutation Usage Decision Rule
 
-1. Default: use `useMutation(orpc.xxx.mutationOptions(...))`.
-2. If mutation flow is heavily custom, use oRPC procedure call as `mutationFn` (for example `orpc.xxx.call` / `consoleClient.xxx`), instead of generic handwritten non-oRPC mutation logic.
+1. Default: use `useMutation(consoleQuery|marketplaceQuery.xxx.mutationOptions(...))`.
+2. If mutation flow is heavily custom, use oRPC clients as `mutationFn` (for example `consoleClient.xxx` / `marketplaceClient.xxx`), instead of generic handwritten non-oRPC mutation logic.
 
 ## Key API Guide (`.key` vs `.queryKey` vs `.mutationKey`)
 
@@ -81,7 +82,7 @@ const invoiceQuery = useQuery({
 ## Anti-Patterns
 
 - Do not wrap `useQuery` with `options?: Partial<UseQueryOptions>`.
-- Do not split local `queryKey/queryFn` when oRPC `queryOptions` already exists.
+- Do not split local `queryKey/queryFn` when oRPC `queryOptions` already exists and fits the use case.
 - Do not create thin `use-*` passthrough hooks for a single endpoint.
 - Reason: these patterns can degrade inference (`data` may become `unknown`, especially around `throwOnError`/`select`) and add unnecessary indirection.
 

--- a/.agents/skills/orpc-contract-first/SKILL.md
+++ b/.agents/skills/orpc-contract-first/SKILL.md
@@ -91,7 +91,7 @@ const invoiceQuery = useQuery({
 - **Input structure**: Always use `{ params, query?, body? }` format
 - **No-input GET**: Omit `.input(...)`; do not write `.input(type<unknown>())`
 - **Path params**: Use `{paramName}` in path, match in `params` object
-- **Router nesting**: Group by API prefix (e.g., `/billing/*` -> `billing: {}`)
+- **Router nesting**: Group by API prefix (e.g., `/billing/*` → `billing: {}`)
 - **No barrel files**: Import directly from specific files
 - **Types**: Import from `@/types/`, use `type<T>()` helper
 - **Mutations**: Prefer `mutationOptions`; use explicit `mutationKey` mainly for defaults/filtering/devtools

--- a/.agents/skills/orpc-contract-first/SKILL.md
+++ b/.agents/skills/orpc-contract-first/SKILL.md
@@ -1,43 +1,99 @@
 ---
 name: orpc-contract-first
-description: Guide for implementing oRPC contract-first API patterns in Dify frontend. Triggers when creating new API contracts, adding service endpoints, integrating TanStack Query with typed contracts, or migrating legacy service calls to oRPC. Use for all API layer work in web/contract and web/service directories.
+description: Guide for implementing oRPC contract-first API patterns in Dify frontend. Trigger when creating or updating contracts in web/contract, wiring router composition, integrating TanStack Query with typed contracts, migrating legacy service calls to oRPC, or deciding whether to call queryOptions directly vs extracting a helper or use-* hook in web/service.
 ---
 
 # oRPC Contract-First Development
 
-## Project Structure
+## Intent
 
-```
+- Keep contract as single source of truth in `web/contract/*`.
+- Default query usage: call-site `useQuery(consoleQuery|marketplaceQuery.xxx.queryOptions(...))`.
+- Keep abstractions minimal and preserve TypeScript inference.
+
+## Minimal Structure
+
+```text
 web/contract/
-├── base.ts           # Base contract (inputStructure: 'detailed')
-├── router.ts         # Router composition & type exports
-├── marketplace.ts    # Marketplace contracts
-└── console/          # Console contracts by domain
-    ├── system.ts
-    └── billing.ts
+├── base.ts
+├── router.ts
+└── console/
+    ├── billing.ts
+    └── ...other domains
+web/service/client.ts
 ```
 
-## Workflow
+## Core Workflow
 
-1. **Create contract** in `web/contract/console/{domain}.ts`
-   - Import `base` from `../base` and `type` from `@orpc/contract`
-   - Define route with `path`, `method`, `input`, `output`
+1. Define contract in `web/contract/console/{domain}.ts`
+   - Use `base.route({...}).output(type<...>())` as baseline.
+   - Add `.input(type<...>())` only when request has `params/query/body`.
+   - For `GET` without input, omit `.input(...)` (do not use `type<unknown>()`).
+2. Register contract in `web/contract/router.ts`
+   - Import directly from domain files and nest by API prefix.
+3. Consume from UI call sites via oRPC query utils.
 
-2. **Register in router** at `web/contract/router.ts`
-   - Import directly from domain file (no barrel files)
-   - Nest by API prefix: `billing: { invoices, bindPartnerStack }`
+```typescript
+import { useQuery } from '@tanstack/react-query'
+import { consoleQuery } from '@/service/client'
 
-3. **Create hooks** in `web/service/use-{domain}.ts`
-   - Use `consoleQuery.{group}.{contract}.queryKey()` for query keys
-   - Use `consoleClient.{group}.{contract}()` for API calls
+const invoiceQuery = useQuery(consoleQuery.billing.invoices.queryOptions({
+  staleTime: 5 * 60 * 1000,
+  throwOnError: true,
+  select: invoice => invoice.url,
+}))
+```
 
-## Key Rules
+## Query Usage Decision Rule
+
+1. Default: call site directly uses `*.queryOptions(...)`.
+2. If 3+ call sites share the same extra options (for example `retry: false`), extract a small queryOptions helper, not a `use-*` passthrough hook.
+3. Create `web/service/use-{domain}.ts` only for orchestration:
+   - Combine multiple queries/mutations.
+   - Share domain-level derived state or invalidation helpers.
+
+```typescript
+const invoicesBaseQueryOptions = () =>
+  consoleQuery.billing.invoices.queryOptions({ retry: false })
+
+const invoiceQuery = useQuery({
+  ...invoicesBaseQueryOptions(),
+  throwOnError: true,
+})
+```
+
+## Mutation Usage Decision Rule
+
+1. Default: use `useMutation(orpc.xxx.mutationOptions(...))`.
+2. If mutation flow is heavily custom, use oRPC procedure call as `mutationFn` (for example `orpc.xxx.call` / `consoleClient.xxx`), instead of generic handwritten non-oRPC mutation logic.
+
+## Key API Guide (`.key` vs `.queryKey` vs `.mutationKey`)
+
+- `.key(...)`:
+  - Use for partial matching operations (recommended for invalidation/refetch/cancel patterns).
+  - Example: `queryClient.invalidateQueries({ queryKey: consoleQuery.billing.key() })`
+- `.queryKey(...)`:
+  - Use for a specific query's full key (exact query identity / direct cache addressing).
+- `.mutationKey(...)`:
+  - Use for a specific mutation's full key.
+  - Typical use cases: mutation defaults registration, mutation-status filtering (`useIsMutating`, `queryClient.isMutating`), or explicit devtools grouping.
+
+## Anti-Patterns
+
+- Do not wrap `useQuery` with `options?: Partial<UseQueryOptions>`.
+- Do not split local `queryKey/queryFn` when oRPC `queryOptions` already exists.
+- Do not create thin `use-*` passthrough hooks for a single endpoint.
+- Reason: these patterns can degrade inference (`data` may become `unknown`, especially around `throwOnError`/`select`) and add unnecessary indirection.
+
+## Contract Rules
 
 - **Input structure**: Always use `{ params, query?, body? }` format
+- **No-input GET**: Omit `.input(...)`; do not write `.input(type<unknown>())`
 - **Path params**: Use `{paramName}` in path, match in `params` object
-- **Router nesting**: Group by API prefix (e.g., `/billing/*` → `billing: {}`)
+- **Router nesting**: Group by API prefix (e.g., `/billing/*` -> `billing: {}`)
 - **No barrel files**: Import directly from specific files
 - **Types**: Import from `@/types/`, use `type<T>()` helper
+- **Mutations**: Prefer `mutationOptions`; use explicit `mutationKey` mainly for defaults/filtering/devtools
 
 ## Type Export
 


### PR DESCRIPTION
## Summary
- streamline the `orpc-contract-first` skill to emphasize a single default path: call-site usage of `useQuery(consoleQuery|marketplaceQuery.xxx.queryOptions(...))`
- clarify decision rules for abstraction levels:
  - use call-site `queryOptions` by default
  - extract a small queryOptions helper only when multiple call sites share the same extra options
  - create `use-{domain}.ts` hooks only for orchestration (not thin passthrough wrappers)
- improve mutation guidance:
  - prefer `useMutation(orpc.xxx.mutationOptions(...))`
  - clarify when to use oRPC procedure calls as `mutationFn` for custom flows
- add a concise key usage guide for `.key`, `.queryKey`, and `.mutationKey`
- update contract authoring guidance:
  - omit `.input(...)` for GET endpoints without input
  - avoid `.input(type<unknown>())`

## Why
The previous guidance left room for over-abstraction and inconsistent patterns. This update makes the intended oRPC contract-first usage explicit, keeps type inference stable, and reduces unnecessary wrapper hooks.

## Scope
- docs/skill update only
- no runtime code changes

