### PR TITLE
feat(tasks): isolate summary generation to dedicated dataset_summary queue

### DIFF
--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -7,7 +7,7 @@ cd web && pnpm install
 pipx install uv
 
 echo "alias start-api=\"cd $WORKSPACE_ROOT/api && uv run python -m flask run --host 0.0.0.0 --port=5001 --debug\"" >> ~/.bashrc
-echo "alias start-worker=\"cd $WORKSPACE_ROOT/api && uv run python -m celery -A app.celery worker -P threads -c 1 --loglevel INFO -Q dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention\"" >> ~/.bashrc
+echo "alias start-worker=\"cd $WORKSPACE_ROOT/api && uv run python -m celery -A app.celery worker -P threads -c 1 --loglevel INFO -Q dataset,dataset_summary,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention\"" >> ~/.bashrc
 echo "alias start-web=\"cd $WORKSPACE_ROOT/web && pnpm dev:inspect\"" >> ~/.bashrc
 echo "alias start-web-prod=\"cd $WORKSPACE_ROOT/web && pnpm build && pnpm start\"" >> ~/.bashrc
 echo "alias start-containers=\"cd $WORKSPACE_ROOT/docker && docker-compose -f docker-compose.middleware.yaml -p dify --env-file middleware.env up -d\"" >> ~/.bashrc

--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -37,7 +37,7 @@
                 "-c",
                 "1",
                 "-Q",
-                "dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution",
+                "dataset,dataset_summary,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution",
                 "--loglevel",
                 "INFO"
             ],

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -35,10 +35,10 @@ if [[ "${MODE}" == "worker" ]]; then
   if [[ -z "${CELERY_QUEUES}" ]]; then
     if [[ "${EDITION}" == "CLOUD" ]]; then
       # Cloud edition: separate queues for dataset and trigger tasks
-      DEFAULT_QUEUES="api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+      DEFAULT_QUEUES="api_token,dataset,dataset_summary,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
     else
       # Community edition (SELF_HOSTED): dataset, pipeline and workflow have separate queues
-      DEFAULT_QUEUES="api_token,dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+      DEFAULT_QUEUES="api_token,dataset,dataset_summary,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
     fi
   else
     DEFAULT_QUEUES="${CELERY_QUEUES}"

--- a/api/tasks/generate_summary_index_task.py
+++ b/api/tasks/generate_summary_index_task.py
@@ -14,7 +14,7 @@ from services.summary_index_service import SummaryIndexService
 logger = logging.getLogger(__name__)
 
 
-@shared_task(queue="dataset")
+@shared_task(queue="dataset_summary")
 def generate_summary_index_task(dataset_id: str, document_id: str, segment_ids: list[str] | None = None):
     """
     Async generate summary index for document segments.

--- a/api/tasks/regenerate_summary_index_task.py
+++ b/api/tasks/regenerate_summary_index_task.py
@@ -16,7 +16,7 @@ from services.summary_index_service import SummaryIndexService
 logger = logging.getLogger(__name__)
 
 
-@shared_task(queue="dataset")
+@shared_task(queue="dataset_summary")
 def regenerate_summary_index_task(
     dataset_id: str,
     regenerate_reason: str = "summary_model_changed",

--- a/api/tests/unit_tests/tasks/test_summary_queue_isolation.py
+++ b/api/tests/unit_tests/tasks/test_summary_queue_isolation.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for summary index task queue isolation.
+
+These tasks must NOT run on the shared 'dataset' queue because they invoke LLMs
+for each document segment and can occupy all worker slots for hours, blocking
+document indexing tasks.
+"""
+
+from tasks.generate_summary_index_task import generate_summary_index_task
+from tasks.regenerate_summary_index_task import regenerate_summary_index_task
+
+SUMMARY_QUEUE = "dataset_summary"
+INDEXING_QUEUE = "dataset"
+
+
+def test_generate_summary_task_uses_dedicated_queue():
+    """generate_summary_index_task must use the dataset_summary queue, not dataset."""
+    assert generate_summary_index_task.queue == SUMMARY_QUEUE, (
+        f"generate_summary_index_task must run on '{SUMMARY_QUEUE}' queue (not '{INDEXING_QUEUE}'). "
+        "Summary generation is LLM-heavy and will block document indexing if placed on the shared queue."
+    )
+
+
+def test_regenerate_summary_task_uses_dedicated_queue():
+    """regenerate_summary_index_task must use the dataset_summary queue, not dataset."""
+    assert regenerate_summary_index_task.queue == SUMMARY_QUEUE, (
+        f"regenerate_summary_index_task must run on '{SUMMARY_QUEUE}' queue (not '{INDEXING_QUEUE}'). "
+        "Summary regeneration is LLM-heavy and will block document indexing if placed on the shared queue."
+    )
+
+
+def test_summary_tasks_not_on_dataset_queue():
+    """Regression guard: summary tasks must never be placed on the shared dataset queue."""
+    assert generate_summary_index_task.queue != INDEXING_QUEUE
+    assert regenerate_summary_index_task.queue != INDEXING_QUEUE

--- a/api/tests/unit_tests/tasks/test_summary_queue_isolation.py
+++ b/api/tests/unit_tests/tasks/test_summary_queue_isolation.py
@@ -6,6 +6,8 @@ for each document segment and can occupy all worker slots for hours, blocking
 document indexing tasks.
 """
 
+import pytest
+
 from tasks.generate_summary_index_task import generate_summary_index_task
 from tasks.regenerate_summary_index_task import regenerate_summary_index_task
 
@@ -13,23 +15,26 @@ SUMMARY_QUEUE = "dataset_summary"
 INDEXING_QUEUE = "dataset"
 
 
-def test_generate_summary_task_uses_dedicated_queue():
-    """generate_summary_index_task must use the dataset_summary queue, not dataset."""
-    assert generate_summary_index_task.queue == SUMMARY_QUEUE, (
-        f"generate_summary_index_task must run on '{SUMMARY_QUEUE}' queue (not '{INDEXING_QUEUE}'). "
+def _task_queue(task) -> str | None:
+    # Celery's @shared_task(queue=...) stores the routing key on the task instance
+    # at runtime, but type stubs don't declare it; use getattr to stay type-clean.
+    return getattr(task, "queue", None)
+
+
+@pytest.mark.parametrize(
+    ("task", "task_name"),
+    [
+        (generate_summary_index_task, "generate_summary_index_task"),
+        (regenerate_summary_index_task, "regenerate_summary_index_task"),
+    ],
+)
+def test_summary_task_uses_dedicated_queue(task, task_name):
+    """Summary tasks must use the dataset_summary queue, not the shared dataset queue.
+
+    Summary generation is LLM-heavy and will block document indexing if placed
+    on the shared queue.
+    """
+    assert _task_queue(task) == SUMMARY_QUEUE, (
+        f"{task_name} must run on '{SUMMARY_QUEUE}' queue (not '{INDEXING_QUEUE}'). "
         "Summary generation is LLM-heavy and will block document indexing if placed on the shared queue."
     )
-
-
-def test_regenerate_summary_task_uses_dedicated_queue():
-    """regenerate_summary_index_task must use the dataset_summary queue, not dataset."""
-    assert regenerate_summary_index_task.queue == SUMMARY_QUEUE, (
-        f"regenerate_summary_index_task must run on '{SUMMARY_QUEUE}' queue (not '{INDEXING_QUEUE}'). "
-        "Summary regeneration is LLM-heavy and will block document indexing if placed on the shared queue."
-    )
-
-
-def test_summary_tasks_not_on_dataset_queue():
-    """Regression guard: summary tasks must never be placed on the shared dataset queue."""
-    assert generate_summary_index_task.queue != INDEXING_QUEUE
-    assert regenerate_summary_index_task.queue != INDEXING_QUEUE

--- a/dev/start-worker
+++ b/dev/start-worker
@@ -21,6 +21,7 @@ show_help() {
   echo ""
   echo "Available queues:"
   echo "  dataset                - RAG indexing and document processing"
+  echo "  dataset_summary        - LLM-heavy summary index generation (isolated from indexing)"
   echo "  workflow               - Workflow triggers (community edition)"
   echo "  workflow_professional  - Professional tier workflows (cloud edition)"
   echo "  workflow_team         - Team tier workflows (cloud edition)"
@@ -106,10 +107,10 @@ if [[ -z "${QUEUES}" ]]; then
   # Configure queues based on edition
   if [[ "${EDITION}" == "CLOUD" ]]; then
     # Cloud edition: separate queues for dataset and trigger tasks
-    QUEUES="dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+    QUEUES="dataset,dataset_summary,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow_professional,workflow_team,workflow_sandbox,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
   else
     # Community edition (SELF_HOSTED): dataset and workflow have separate queues
-    QUEUES="dataset,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
+    QUEUES="dataset,dataset_summary,priority_dataset,priority_pipeline,pipeline,mail,ops_trace,app_deletion,plugin,workflow_storage,conversation,workflow,schedule_poller,schedule_executor,triggered_workflow_dispatcher,trigger_refresh_executor,retention,workflow_based_app_execution"
   fi
 
   echo "No queues specified, using edition-based defaults: ${QUEUES}"


### PR DESCRIPTION
## Summary

Move `generate_summary_index_task` and `regenerate_summary_index_task` from the shared `dataset` queue to a dedicated `dataset_summary` queue.

**Problem:** Summary generation tasks are LLM-heavy and can occupy all Celery worker slots for hours, blocking document indexing progress. Both task types compete on the same `dataset` queue, causing starvation when large documents are being indexed.

**Solution:** Route summary tasks to a dedicated `dataset_summary` queue. `dataset_summary` is included in `DEFAULT_QUEUES`, so single-worker deployments retain the same behavior as before (no breaking change). Operators who want true isolation can deploy a dedicated summary worker and exclude `dataset_summary` from their indexing workers:

```sh
# Indexing worker (no summary tasks)
CELERY_WORKER_QUEUES=dataset,priority_dataset,pipeline,... celery worker ...

# Dedicated summary worker
CELERY_WORKER_QUEUES=dataset_summary celery worker ...
```

This is backward-compatible: single-worker deployments continue to process all tasks as before; multi-worker deployments gain the ability to isolate LLM-heavy summary work from document indexing.

## Screenshots

N/A — no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
