### PR TITLE
refactor: migrate systemFeatures query to oRPC contract-first pattern

### DIFF
--- a/web/context/global-public-context.tsx
+++ b/web/context/global-public-context.tsx
@@ -4,7 +4,7 @@ import type { SystemFeatures } from '@/types/feature'
 import { useQuery } from '@tanstack/react-query'
 import { create } from 'zustand'
 import Loading from '@/app/components/base/loading'
-import { consoleClient } from '@/service/client'
+import { consoleClient, consoleQuery } from '@/service/client'
 import { defaultSystemFeatures } from '@/types/feature'
 import { fetchSetupStatusWithCache } from '@/utils/setup-status'
 
@@ -18,10 +18,9 @@ export const useGlobalPublicStore = create<GlobalPublicStore>(set => ({
   setSystemFeatures: (systemFeatures: SystemFeatures) => set(() => ({ systemFeatures })),
 }))
 
-const systemFeaturesQueryKey = ['systemFeatures'] as const
 const setupStatusQueryKey = ['setupStatus'] as const
 
-async function fetchSystemFeatures() {
+async function fetchAndSyncSystemFeatures() {
   const data = await consoleClient.systemFeatures()
   const { setSystemFeatures } = useGlobalPublicStore.getState()
   setSystemFeatures({ ...defaultSystemFeatures, ...data })
@@ -30,8 +29,8 @@ async function fetchSystemFeatures() {
 
 export function useSystemFeaturesQuery() {
   return useQuery({
-    queryKey: systemFeaturesQueryKey,
-    queryFn: fetchSystemFeatures,
+    ...consoleQuery.systemFeatures.queryOptions(),
+    queryFn: fetchAndSyncSystemFeatures,
   })
 }
 

--- a/web/contract/console/system.ts
+++ b/web/contract/console/system.ts
@@ -7,5 +7,4 @@ export const systemFeaturesContract = base
     path: '/system-features',
     method: 'GET',
   })
-  .input(type<unknown>())
   .output(type<SystemFeatures>())


### PR DESCRIPTION
## Summary
- Migrate `useSystemFeaturesQuery` in `global-public-context.tsx` to use oRPC `consoleQuery.systemFeatures.queryOptions()` for type-safe query key generation, replacing the manual `['systemFeatures']` constant
- Remove unnecessary `.input(type<unknown>())` from the `systemFeaturesContract` GET endpoint (no-input GET should omit `.input()` per oRPC conventions)
- Preserve zustand store sync directly in `queryFn` to avoid an extra useEffect render cycle

## Test plan
- [ ] Verify system features load correctly on app startup (loading spinner → content)
- [ ] Confirm zustand store is populated with system features data
- [ ] Check that consuming components (`useGlobalPublicStore`) still receive correct feature flags
- [ ] Run existing test suite for `global-public-context` consumers