### PR TITLE
chore: tighten log model typings for agent thoughts/tools

### DIFF
--- a/web/models/log.ts
+++ b/web/models/log.ts
@@ -1,9 +1,11 @@
 import type { Viewport } from 'reactflow'
-import type { Metadata } from '@/app/components/base/chat/chat/type'
+import type { Metadata, ThoughtItem } from '@/app/components/base/chat/chat/type'
 import type {
   Edge,
   Node,
 } from '@/app/components/workflow/types'
+import type { Emoji } from '@/app/components/tools/types'
+import type { TypeWithI18N } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import type { VisionFile } from '@/types/app'
 
 export const CompletionParams = ['temperature', 'top_p', 'presence_penalty', 'max_token', 'stop', 'frequency_penalty'] as const
@@ -86,7 +88,7 @@ export type MessageContent = {
   }>
   message_files: VisionFile[]
   metadata: Metadata
-  agent_thoughts: any[] // TODO
+  agent_thoughts: ThoughtItem[]
   workflow_run_id: string
   parent_message_id: string | null
 }
@@ -329,12 +331,12 @@ export type ToolCall = {
   status: string
   error?: string | null
   time_cost?: number
-  tool_icon: any
-  tool_input?: any
-  tool_output?: any
+  tool_icon: string | Emoji
+  tool_input?: string | Record<string, unknown>
+  tool_output?: string | Record<string, unknown>
   tool_name?: string
-  tool_label?: any
-  tool_parameters?: any
+  tool_label?: TypeWithI18N<string>
+  tool_parameters?: Record<string, unknown>
 }
 
 export type AgentIteration = {


### PR DESCRIPTION
- import chat ThoughtItem, tool Emoji, and TypeWithI18N types for reuse
- replace loose any usage with typed structures for agent thoughts and tool data to improve type safety

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
