### PR TITLE
chore: expand overlay migration ESLint rules to popover, dropdown, dialog

### DIFF
--- a/web/docs/overlay-migration.md
+++ b/web/docs/overlay-migration.md
@@ -10,6 +10,9 @@ This document tracks the migration away from legacy overlay APIs.
   - `@/app/components/base/modal`
   - `@/app/components/base/confirm`
   - `@/app/components/base/select` (including `custom` / `pure`)
+  - `@/app/components/base/popover`
+  - `@/app/components/base/dropdown`
+  - `@/app/components/base/dialog`
 - Replacement primitives:
   - `@/app/components/base/ui/tooltip`
   - `@/app/components/base/ui/dropdown-menu`

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -275,6 +275,9 @@
     }
   },
   "app/account/(commonLayout)/delete-account/components/feed-back.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 1
     }
@@ -285,6 +288,11 @@
     },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 3
+    }
+  },
+  "app/account/(commonLayout)/delete-account/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "app/account/(commonLayout)/header.tsx": {
@@ -436,6 +444,9 @@
     }
   },
   "app/components/app/annotation/header-opts/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react/no-nested-component-definitions": {
       "count": 1
     },
@@ -965,6 +976,11 @@
       "count": 1
     }
   },
+  "app/components/app/configuration/debug/debug-with-multiple-model/debug-item.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
   "app/components/app/configuration/debug/debug-with-multiple-model/index.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 5
@@ -1375,7 +1391,7 @@
   },
   "app/components/apps/app-card.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 3
     },
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
       "count": 1
@@ -2864,6 +2880,16 @@
       "count": 1
     }
   },
+  "app/components/base/tag-management/panel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "app/components/base/tag-management/selector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "app/components/base/tag-management/tag-item-editor.tsx": {
     "no-restricted-imports": {
       "count": 2
@@ -3182,6 +3208,11 @@
       "count": 1
     }
   },
+  "app/components/datasets/create-from-pipeline/list/template-card/actions.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "app/components/datasets/create-from-pipeline/list/template-card/content.tsx": {
     "tailwindcss/enforce-consistent-class-order": {
       "count": 3
@@ -3271,7 +3302,7 @@
   },
   "app/components/datasets/create/step-two/components/indexing-mode-section.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 8
@@ -3306,6 +3337,9 @@
     }
   },
   "app/components/datasets/create/step-two/language-select/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 2
     }
@@ -3439,7 +3473,7 @@
   },
   "app/components/datasets/documents/components/operations.tsx": {
     "no-restricted-imports": {
-      "count": 2
+      "count": 3
     }
   },
   "app/components/datasets/documents/components/rename-modal.tsx": {
@@ -3859,6 +3893,9 @@
     }
   },
   "app/components/datasets/documents/detail/segment-add/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-refresh/only-export-components": {
       "count": 1
     },
@@ -4070,6 +4107,11 @@
   },
   "app/components/datasets/list/dataset-card/components/description.tsx": {
     "tailwindcss/enforce-consistent-class-order": {
+      "count": 1
+    }
+  },
+  "app/components/datasets/list/dataset-card/components/operations-popover.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -4506,6 +4548,9 @@
     }
   },
   "app/components/header/account-setting/data-source-page-new/operator.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 5
     }
@@ -4810,6 +4855,9 @@
     }
   },
   "app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 1
     }

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -195,6 +195,24 @@ export default antfu(
             '**/base/confirm/index',
           ],
           message: 'Deprecated: use @/app/components/base/ui/alert-dialog instead. See issue #32767.',
+        }, {
+          group: [
+            '**/base/popover',
+            '**/base/popover/index',
+          ],
+          message: 'Deprecated: use @/app/components/base/ui/popover instead. See issue #32767.',
+        }, {
+          group: [
+            '**/base/dropdown',
+            '**/base/dropdown/index',
+          ],
+          message: 'Deprecated: use @/app/components/base/ui/dropdown-menu instead. See issue #32767.',
+        }, {
+          group: [
+            '**/base/dialog',
+            '**/base/dialog/index',
+          ],
+          message: 'Deprecated: use @/app/components/base/ui/dialog instead. See issue #32767.',
         }],
       }],
     },


### PR DESCRIPTION
## Summary
- Add `base/popover`, `base/dropdown`, and `base/dialog` to the `no-restricted-imports` ESLint rule, since they already have `base/ui/` replacements (`ui/popover`, `ui/dropdown-menu`, `ui/dialog`)
- Update `docs/overlay-migration.md` to list the three newly deprecated imports
- Suppress existing violations (~15 files) so the codebase stays green while legacy callers are migrated incrementally

## Test plan
- [x] `pnpm lint` passes with 0 errors (warnings only)
- [x] Pre-commit hooks (lint-staged) pass
- [ ] Verify new files importing `base/popover`, `base/dropdown`, or `base/dialog` trigger an ESLint error