### PR TITLE
chore: use selectinload instead of joinedload in conversation query

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -5,7 +5,7 @@ from flask import abort, request
 from flask_restx import Resource, fields, marshal_with
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, or_
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import selectinload
 from werkzeug.exceptions import NotFound
 
 from controllers.console import console_ns
@@ -376,7 +376,7 @@ class CompletionConversationApi(Resource):
 
         # FIXME, the type ignore in this file
         if args.annotation_status == "annotated":
-            query = query.options(joinedload(Conversation.message_annotations)).join(  # type: ignore
+            query = query.options(selectinload(Conversation.message_annotations)).join(  # type: ignore
                 MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
             )
         elif args.annotation_status == "not_annotated":
@@ -511,7 +511,7 @@ class ChatConversationApi(Resource):
 
         match args.annotation_status:
             case "annotated":
-                query = query.options(joinedload(Conversation.message_annotations)).join(  # type: ignore
+                query = query.options(selectinload(Conversation.message_annotations)).join(  # type: ignore
                     MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
                 )
             case "not_annotated":

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -513,7 +513,7 @@ class ChatConversationApi(Resource):
             case "annotated":
                 query = query.options(selectinload(Conversation.message_annotations)).join(  # type: ignore
                     MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
-                )
+                ).distinct()
             case "not_annotated":
                 query = (
                     query.outerjoin(MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id)

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -377,7 +377,7 @@ class CompletionConversationApi(Resource):
         # FIXME, the type ignore in this file
         if args.annotation_status == "annotated":
             query = (
-                query.options(selectinload(Conversation.message_annotations))
+                query.options(selectinload(Conversation.message_annotations))  # type: ignore[arg-type]
                 .join(  # type: ignore
                     MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
                 )
@@ -516,7 +516,7 @@ class ChatConversationApi(Resource):
         match args.annotation_status:
             case "annotated":
                 query = (
-                    query.options(selectinload(Conversation.message_annotations))
+                    query.options(selectinload(Conversation.message_annotations))  # type: ignore[arg-type]
                     .join(  # type: ignore
                         MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
                     )

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -378,7 +378,7 @@ class CompletionConversationApi(Resource):
         if args.annotation_status == "annotated":
             query = query.options(selectinload(Conversation.message_annotations)).join(  # type: ignore
                 MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
-            )
+            ).distinct()
         elif args.annotation_status == "not_annotated":
             query = (
                 query.outerjoin(MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id)

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -376,9 +376,13 @@ class CompletionConversationApi(Resource):
 
         # FIXME, the type ignore in this file
         if args.annotation_status == "annotated":
-            query = query.options(selectinload(Conversation.message_annotations)).join(  # type: ignore
-                MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
-            ).distinct()
+            query = (
+                query.options(selectinload(Conversation.message_annotations))
+                .join(  # type: ignore
+                    MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
+                )
+                .distinct()
+            )
         elif args.annotation_status == "not_annotated":
             query = (
                 query.outerjoin(MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id)
@@ -511,9 +515,13 @@ class ChatConversationApi(Resource):
 
         match args.annotation_status:
             case "annotated":
-                query = query.options(selectinload(Conversation.message_annotations)).join(  # type: ignore
-                    MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
-                ).distinct()
+                query = (
+                    query.options(selectinload(Conversation.message_annotations))
+                    .join(  # type: ignore
+                        MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id
+                    )
+                    .distinct()
+                )
             case "not_annotated":
                 query = (
                     query.outerjoin(MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: .

## Summary

This PR addresses Issue #32387 by replacing joinedload with selectinload in the conversation query. The change is aimed at improving SQL query performance when loading Conversation and MessageAnnotation relationships.

The use of selectinload instead of joinedload can avoid potential performance issues caused by repeated data and Cartesian products that often occur with join queries on related tables. selectinload loads related data in separate queries but caches the results, which is more efficient for many-to-one or one-to-many relationships.

Changes:
1. Changed import statement from from sqlalchemy.orm import joinedload to from sqlalchemy.orm import selectinload
2. Updated query in CompletionConversationApi.get() method
3. Updated query in ChatConversationApi.get() method

## Fixes #32387

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran 🔧 Running ruff format, check with fixes, import linter, and dotenv-linter... and 📝 Running type checks (basedpyright + mypy)... (backend) and → No staged files found. (frontend) to appease the lint gods