### PR TITLE
chore: prevent Storybook crash caused by vite-plugin-inspect

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -160,6 +160,8 @@ if (import.meta.hot) {
 
 export default defineConfig(({ mode }) => {
   const isTest = mode === 'test'
+  const isStorybook = process.env.STORYBOOK === 'true'
+    || process.argv.some(arg => arg.toLowerCase().includes('storybook'))
 
   return {
     plugins: isTest
@@ -176,14 +178,19 @@ export default defineConfig(({ mode }) => {
             },
           } as Plugin,
         ]
-      : [
-          Inspect(),
-          createCodeInspectorPlugin(),
-          createForceInspectorClientInjectionPlugin(),
-          react(),
-          vinext(),
-          customI18nHmrPlugin(),
-        ],
+      : isStorybook
+        ? [
+            tsconfigPaths(),
+            react(),
+          ]
+        : [
+            Inspect(),
+            createCodeInspectorPlugin(),
+            createForceInspectorClientInjectionPlugin(),
+            react(),
+            vinext(),
+            customI18nHmrPlugin(),
+          ],
     resolve: {
       alias: {
         '~@': __dirname,
@@ -191,7 +198,7 @@ export default defineConfig(({ mode }) => {
     },
 
     // vinext related config
-    ...(!isTest
+    ...(!isTest && !isStorybook
       ? {
           optimizeDeps: {
             exclude: ['nuqs'],


### PR DESCRIPTION
## Summary
- detect when Vite is loaded by Storybook
- use a minimal plugin set (`tsconfigPaths` + `react`) in Storybook mode
- skip `vite-plugin-inspect`, code inspector injection, `vinext`, and custom i18n HMR plugins in Storybook mode
- skip vinext-specific optimize/build/server settings in Storybook mode

## Problem
Storybook failed during preview build with:
`Error: Can not found environment context for client`
from `vite-plugin-inspect`.

## Verification
- `pnpm storybook`
- `pnpm storybook:build`
