### PR TITLE
fix: stop think block timer in historical conversations

### DIFF
--- a/web/app/components/base/markdown-blocks/__tests__/think-block.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/think-block.spec.tsx
@@ -171,12 +171,7 @@ describe('ThinkBlock', () => {
         </ThinkBlock>,
       )
 
-      // Advance timer
-      act(() => {
-        vi.advanceTimersByTime(2000)
-      })
-
-      // Timer should be stopped — isResponding undefined means not in active response
+      // Timer should be stopped immediately — isResponding undefined means not in active response
       expect(screen.getByText(/Thought/)).toBeInTheDocument()
     })
   })

--- a/web/app/components/base/markdown-blocks/__tests__/think-block.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/think-block.spec.tsx
@@ -163,25 +163,21 @@ describe('ThinkBlock', () => {
       expect(screen.getByText(/Thought/)).toBeInTheDocument()
     })
 
-    it('should NOT stop timer when isResponding is undefined (outside ChatContextProvider)', () => {
-      // Render without ChatContextProvider
+    it('should stop timer when isResponding is undefined (historical conversation outside active response)', () => {
+      // Render without ChatContextProvider — simulates historical conversation
       render(
         <ThinkBlock data-think={true}>
           <p>Content without ENDTHINKFLAG</p>
         </ThinkBlock>,
       )
 
-      // Initial state should show "Thinking..."
-      expect(screen.getByText(/Thinking\.\.\./)).toBeInTheDocument()
-
       // Advance timer
       act(() => {
         vi.advanceTimersByTime(2000)
       })
 
-      // Timer should still be running (showing "Thinking..." not "Thought")
-      expect(screen.getByText(/Thinking\.\.\./)).toBeInTheDocument()
-      expect(screen.getByText(/\(2\.0s\)/)).toBeInTheDocument()
+      // Timer should be stopped — isResponding undefined means not in active response
+      expect(screen.getByText(/Thought/)).toBeInTheDocument()
     })
   })
 

--- a/web/app/components/base/markdown-blocks/think-block.tsx
+++ b/web/app/components/base/markdown-blocks/think-block.tsx
@@ -62,10 +62,8 @@ const useThinkTimer = (children: any) => {
   useEffect(() => {
     // Stop timer when:
     // 1. Content has [ENDTHINKFLAG] marker (normal completion)
-    // 2. isResponding is explicitly false (user clicked stop button)
-    // 3. isResponding is undefined AND no ENDTHINKFLAG (historical conversation
-    //    rendered outside an active response — timer should not start)
-    if (endThinkDetected || isResponding === false || isResponding === undefined)
+    // 2. isResponding is not true (false = user clicked stop, undefined = historical conversation)
+    if (endThinkDetected || !isResponding)
       setIsComplete(true)
   }, [endThinkDetected, isResponding])
 

--- a/web/app/components/base/markdown-blocks/think-block.tsx
+++ b/web/app/components/base/markdown-blocks/think-block.tsx
@@ -39,9 +39,10 @@ const removeEndThink = (children: any): any => {
 
 const useThinkTimer = (children: any) => {
   const { isResponding } = useChatContext()
+  const endThinkDetected = hasEndThink(children)
   const [startTime] = useState(() => Date.now())
   const [elapsedTime, setElapsedTime] = useState(0)
-  const [isComplete, setIsComplete] = useState(false)
+  const [isComplete, setIsComplete] = useState(() => endThinkDetected)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
@@ -62,10 +63,11 @@ const useThinkTimer = (children: any) => {
     // Stop timer when:
     // 1. Content has [ENDTHINKFLAG] marker (normal completion)
     // 2. isResponding is explicitly false (user clicked stop button)
-    // Note: Don't stop when isResponding is undefined (component used outside ChatContextProvider)
-    if (hasEndThink(children) || isResponding === false)
+    // 3. isResponding is undefined AND no ENDTHINKFLAG (historical conversation
+    //    rendered outside an active response — timer should not start)
+    if (endThinkDetected || isResponding === false || isResponding === undefined)
       setIsComplete(true)
-  }, [children, isResponding])
+  }, [endThinkDetected, isResponding])
 
   return { elapsedTime, isComplete }
 }


### PR DESCRIPTION
## Summary

Fixes #33005 (also related: #32954, #24869, #19125)

The `ThinkBlock` deep thinking timer runs indefinitely when expanding historical conversation records.

**Root cause:** The `useThinkTimer` hook treats `isResponding === undefined` as "keep running". But in historical conversations rendered outside an active streaming response, `isResponding` is always `undefined` from `useChatContext()`, so the timer never stops.

**Fix:**
- Treat `isResponding === undefined` the same as `false` — mark the timer as complete immediately
- Initialize `isComplete` from `hasEndThink(children)` so already-finished think blocks never start a timer
- Update the test case to verify the correct behavior

## Test plan

- [x] Existing ThinkBlock tests pass (11/11)
- [x] ESLint + TypeScript type-check pass
- [ ] Manual: open a conversation with deep thinking history, expand a completed think block — timer should show static elapsed time, not keep counting

🤖 Generated with [Claude Code](https://claude.com/claude-code)