### PR TITLE
Remove dead STT error handlers from TTS endpoints

### DIFF
--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -134,14 +134,10 @@ class ChatMessageTextApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
         except AudioTooLargeServiceError as e:
             raise AudioTooLargeError(str(e))
         except UnsupportedAudioTypeServiceError:
             raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:
@@ -183,14 +179,10 @@ class TextModesApi(Resource):
             return response
         except services.errors.audio.ProviderNotSupportTextToSpeechLanageServiceError:
             raise AppUnavailableError("Text to audio voices language parameter loss.")
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
         except AudioTooLargeServiceError as e:
             raise AudioTooLargeError(str(e))
         except UnsupportedAudioTypeServiceError:
             raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -103,14 +103,10 @@ class ChatTextApi(InstalledAppResource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
         except AudioTooLargeServiceError as e:
             raise AudioTooLargeError(str(e))
         except UnsupportedAudioTypeServiceError:
             raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -129,14 +129,10 @@ class TextApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
         except AudioTooLargeServiceError as e:
             raise AudioTooLargeError(str(e))
         except UnsupportedAudioTypeServiceError:
             raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -137,14 +137,10 @@ class TextApi(WebApiResource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
         except AudioTooLargeServiceError as e:
             raise AudioTooLargeError(str(e))
         except UnsupportedAudioTypeServiceError:
             raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:


### PR DESCRIPTION
Fixes #32982. The text-to-audio handlers were catching STT-specific exceptions (NoAudioUploadedServiceError, ProviderNotSupportSpeechToTextServiceError) that can never be raised by the TTS service layer. These errors are only raised by the ASR/speech-to-text service. Removing these dead except clauses improves code clarity with zero runtime impact.