### PR TITLE
fix(web): stabilize dayjs timezone tests against DST transitions

### DIFF
--- a/web/app/components/base/date-and-time-picker/time-picker/__tests__/index.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/time-picker/__tests__/index.spec.tsx
@@ -503,7 +503,7 @@ describe('TimePicker', () => {
       const emitted = onChange.mock.calls[0][0]
       expect(isDayjsObject(emitted)).toBe(true)
       // 10:30 UTC converted to America/New_York (UTC-5 in Jan) = 05:30
-      expect(emitted.utcOffset()).toBe(dayjs().tz('America/New_York').utcOffset())
+      expect(emitted.utcOffset()).toBe(dayjs.tz('2024-01-01', 'America/New_York').utcOffset())
       expect(emitted.hour()).toBe(5)
       expect(emitted.minute()).toBe(30)
     })

--- a/web/app/components/base/date-and-time-picker/utils/__tests__/dayjs.spec.ts
+++ b/web/app/components/base/date-and-time-picker/utils/__tests__/dayjs.spec.ts
@@ -20,7 +20,7 @@ describe('dayjs utilities', () => {
     const result = toDayjs('07:15 PM', { timezone: tz })
     expect(result).toBeDefined()
     expect(result?.format('HH:mm')).toBe('19:15')
-    expect(result?.utcOffset()).toBe(getDateWithTimezone({ timezone: tz }).utcOffset())
+    expect(result?.utcOffset()).toBe(getDateWithTimezone({ timezone: tz }).startOf('day').utcOffset())
   })
 
   it('isDayjsObject detects dayjs instances', () => {


### PR DESCRIPTION
## Summary
- Two timezone-related test assertions used `dayjs()` (current moment) to compute expected UTC offsets, while the values under test derived their offsets from specific dates
- On non-DST-transition days the offsets coincidentally matched; on transition days (twice a year) the mismatch caused failures
- Fixed by anchoring expected offsets to the same date the code operates on

## Test plan
- [x] `pnpm vitest run` on both affected test files passes on DST transition day (2026-03-08)