### PR TITLE
fix: auto-complete missing items in array tool parameter schemas

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -2,7 +2,7 @@ import json
 import logging
 import uuid
 from decimal import Decimal
-from typing import Union, cast
+from typing import Any, Union, cast
 
 from sqlalchemy import select
 
@@ -130,6 +130,55 @@ class BaseAgentRunner(AppRunner):
 
         return app_generate_entity
 
+    @staticmethod
+    def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
+        """
+        Recursively ensure every ``"type": "array"`` node in a JSON-Schema
+        dict carries an ``"items"`` field.  OpenAI's function-calling API
+        rejects array schemas that lack ``items``; this adds a safe default
+        (``{"type": "string"}``) where it is missing.
+
+        The input dict is never mutated – a shallow copy is returned when
+        changes are needed.
+        """
+        if not isinstance(schema, dict):
+            return schema
+
+        changed = False
+        result = schema
+
+        # If this node is an array without items, add a default.
+        if schema.get("type") == "array" and "items" not in schema:
+            result = {**schema, "items": {"type": "string"}}
+            changed = True
+
+        # Recurse into "items" (could itself be an array).
+        if "items" in result and isinstance(result["items"], dict):
+            fixed_items = BaseAgentRunner._ensure_array_items(result["items"])
+            if fixed_items is not result["items"]:
+                if not changed:
+                    result = {**result}
+                result["items"] = fixed_items
+
+        # Recurse into "properties" (object schemas may contain arrays).
+        if "properties" in result and isinstance(result["properties"], dict):
+            new_props: dict[str, Any] = {}
+            props_changed = False
+            for key, value in result["properties"].items():
+                if isinstance(value, dict):
+                    fixed = BaseAgentRunner._ensure_array_items(value)
+                    new_props[key] = fixed
+                    if fixed is not value:
+                        props_changed = True
+                else:
+                    new_props[key] = value
+            if props_changed:
+                if result is schema:
+                    result = {**result}
+                result["properties"] = new_props
+
+        return result
+
     def _convert_tool_to_prompt_message_tool(self, tool: AgentToolEntity) -> tuple[PromptMessageTool, Tool]:
         """
         convert tool to prompt message tool
@@ -167,14 +216,15 @@ class BaseAgentRunner(AppRunner):
             if parameter.type == ToolParameter.ToolParameterType.SELECT:
                 enum = [option.value for option in parameter.options] if parameter.options else []
 
-            message_tool.parameters["properties"][parameter.name] = (
-                {
+            if parameter.input_schema is None:
+                message_tool.parameters["properties"][parameter.name] = {
                     "type": parameter_type,
                     "description": parameter.llm_description or "",
                 }
-                if parameter.input_schema is None
-                else parameter.input_schema
-            )
+            else:
+                message_tool.parameters["properties"][parameter.name] = self._ensure_array_items(
+                    parameter.input_schema
+                )
 
             if len(enum) > 0:
                 message_tool.parameters["properties"][parameter.name]["enum"] = enum
@@ -264,14 +314,15 @@ class BaseAgentRunner(AppRunner):
             if parameter.type == ToolParameter.ToolParameterType.SELECT:
                 enum = [option.value for option in parameter.options] if parameter.options else []
 
-            prompt_tool.parameters["properties"][parameter.name] = (
-                {
+            if parameter.input_schema is None:
+                prompt_tool.parameters["properties"][parameter.name] = {
                     "type": parameter_type,
                     "description": parameter.llm_description or "",
                 }
-                if parameter.input_schema is None
-                else parameter.input_schema
-            )
+            else:
+                prompt_tool.parameters["properties"][parameter.name] = self._ensure_array_items(
+                    parameter.input_schema
+                )
 
             if len(enum) > 0:
                 prompt_tool.parameters["properties"][parameter.name]["enum"] = enum

--- a/api/tests/unit_tests/core/agent/test_ensure_array_items.py
+++ b/api/tests/unit_tests/core/agent/test_ensure_array_items.py
@@ -1,0 +1,110 @@
+"""Tests for BaseAgentRunner._ensure_array_items.
+
+OpenAI's function-calling API requires every ``"type": "array"`` node
+in a JSON Schema to carry an ``"items"`` field.  These tests verify
+that the helper method adds a safe default where it is missing and
+leaves well-formed schemas untouched.
+"""
+
+import pytest
+
+from core.agent.base_agent_runner import BaseAgentRunner
+
+
+class TestEnsureArrayItems:
+    """Unit tests for _ensure_array_items."""
+
+    # ------------------------------------------------------------------
+    # Schemas that should be returned unchanged
+    # ------------------------------------------------------------------
+
+    def test_string_property_unchanged(self):
+        schema = {"type": "string", "description": "a name"}
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result == schema
+
+    def test_object_with_no_arrays_unchanged(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "number"},
+            },
+        }
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result == schema
+
+    def test_array_with_items_unchanged(self):
+        schema = {"type": "array", "items": {"type": "integer"}}
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result == schema
+
+    def test_non_dict_input_returned_as_is(self):
+        assert BaseAgentRunner._ensure_array_items("not a dict") == "not a dict"  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    # Schemas that need "items" added
+    # ------------------------------------------------------------------
+
+    def test_array_without_items_gets_default(self):
+        schema = {"type": "array", "description": "list of URLs"}
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result["items"] == {"type": "string"}
+        assert result["description"] == "list of URLs"
+
+    def test_original_dict_is_not_mutated(self):
+        schema = {"type": "array", "description": "tags"}
+        BaseAgentRunner._ensure_array_items(schema)
+        assert "items" not in schema, "original dict must not be mutated"
+
+    # ------------------------------------------------------------------
+    # Nested schemas
+    # ------------------------------------------------------------------
+
+    def test_nested_array_in_object_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "ids": {"type": "array"},  # missing items
+                "name": {"type": "string"},
+            },
+        }
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result["properties"]["ids"]["items"] == {"type": "string"}
+        assert result["properties"]["name"] == {"type": "string"}
+
+    def test_nested_array_inside_array_items(self):
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "array",  # nested array missing items
+            },
+        }
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result["items"]["items"] == {"type": "string"}
+
+    def test_deeply_nested_array_in_object_in_array(self):
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "tags": {"type": "array"},  # missing items
+                },
+            },
+        }
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result["items"]["properties"]["tags"]["items"] == {"type": "string"}
+
+    def test_already_correct_nested_schema_unchanged(self):
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "values": {"type": "array", "items": {"type": "number"}},
+                },
+            },
+        }
+        result = BaseAgentRunner._ensure_array_items(schema)
+        assert result == schema


### PR DESCRIPTION
## Summary
Fixes #32894

OpenAI's function-calling API **requires** every `"type": "array"` node in a tool's JSON Schema to carry an `"items"` field. When a custom tool or OpenAPI-imported tool defines an array parameter without `"items"`, Dify passes the schema through unchanged and OpenAI rejects it:

```
array schema missing items., 'type': 'invalid_request_error',
'param': 'tools[3].function.parameters',
'code': 'invalid_function_parameters'
```

The same tool works fine with Gemini and Anthropic (which are more lenient), but fails on OpenAI.

### Changes

- Add `BaseAgentRunner._ensure_array_items()` — a static method that recursively walks a JSON Schema dict and inserts `{"type": "string"}` as a safe default wherever `"type": "array"` appears without `"items"`.
- Apply it in both `_convert_tool_to_prompt_message_tool()` and `update_prompt_message_tool()` when `parameter.input_schema` is used.
- The helper never mutates the input dict (returns a shallow copy when changes are needed).
- Add 10 unit tests covering: no-op cases, flat arrays, nested arrays, arrays inside object properties, deep nesting, and mutation safety.

### Why this approach

Rather than requiring users to fix their OpenAPI schemas, Dify should normalize tool parameter schemas before passing them to LLM providers. The `{"type": "string"}` default is the safest choice — it matches the most common use case (string arrays) and still allows the LLM to populate the array correctly.

## Disclosure
This PR was authored by an AI (Claude Opus 4.6). I am applying for a role at Dify and contributing to demonstrate my capabilities. All work is my own analysis and implementation. More context: https://github.com/langgenius/dify/issues/32894