### PR TITLE
fix(web): resolve hydration warning for inline images in markdown paragraphs

### DIFF
--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -5,37 +5,42 @@
  * nesting <div> inside <p> which causes hydration warnings in Next.js.
  */
 import * as React from 'react'
+import type { Element } from 'hast'
 import ImageGallery from '@/app/components/base/image-gallery'
 
-const Paragraph = (paragraph: any) => {
-  const { node }: any = paragraph
-  const children_node = node.children
+interface ParagraphProps {
+  node: Element
+  children: React.ReactNode
+}
 
-  // Check if any child is an image (not just the first one)
-  const hasImage = children_node?.some(
-    (child: any) => 'tagName' in child && child.tagName === 'img',
-  )
+const Paragraph = ({ node, children }: ParagraphProps) => {
+  const childrenNodes = node.children
 
-  // If paragraph contains any image, render as div to avoid <div> inside <p> hydration error
-  if (hasImage) {
-    // If the first child is an image, use the special ImageGallery rendering
-    if (children_node[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
-      return (
-        <div className="markdown-img-wrapper">
-          <ImageGallery srcs={[children_node[0].properties.src]} />
-          {
-            Array.isArray(paragraph.children) && paragraph.children.length > 1 && (
-              <div className="mt-2">{paragraph.children.slice(1)}</div>
-            )
-          }
-        </div>
-      )
-    }
-    // For images in the middle/end of paragraph, wrap in div instead of p
-    return <div className="markdown-paragraph">{paragraph.children}</div>
+  // Find the first image index in one pass
+  const firstImageIndex = childrenNodes?.findIndex(
+    (child): child is Element =>
+      child.type === 'element' && child.tagName === 'img',
+  ) ?? -1
+
+  // No image in paragraph, render a normal <p>
+  if (firstImageIndex === -1)
+    return <p>{children}</p>
+
+  // Image is the first element, use special gallery layout
+  if (firstImageIndex === 0) {
+    const firstChild = childrenNodes[0] as Element
+    return (
+      <div className="markdown-img-wrapper">
+        <ImageGallery srcs={[(firstChild.properties?.src as string) || '']} />
+        {Array.isArray(children) && children.length > 1 && (
+          <div className="mt-2">{children.slice(1)}</div>
+        )}
+      </div>
+    )
   }
 
-  return <p>{paragraph.children}</p>
+  // Image is present but not first, render as div to avoid invalid nesting
+  return <div className="markdown-paragraph">{children}</div>
 }
 
 export default Paragraph

--- a/web/app/components/base/markdown-blocks/paragraph.tsx
+++ b/web/app/components/base/markdown-blocks/paragraph.tsx
@@ -1,7 +1,8 @@
 /**
  * @fileoverview Paragraph component for rendering <p> tags in Markdown.
  * Extracted from the main markdown renderer for modularity.
- * Handles special rendering for paragraphs that directly contain an image.
+ * Handles special rendering for paragraphs that contain images to avoid
+ * nesting <div> inside <p> which causes hydration warnings in Next.js.
  */
 import * as React from 'react'
 import ImageGallery from '@/app/components/base/image-gallery'
@@ -9,18 +10,31 @@ import ImageGallery from '@/app/components/base/image-gallery'
 const Paragraph = (paragraph: any) => {
   const { node }: any = paragraph
   const children_node = node.children
-  if (children_node && children_node[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
-    return (
-      <div className="markdown-img-wrapper">
-        <ImageGallery srcs={[children_node[0].properties.src]} />
-        {
-          Array.isArray(paragraph.children) && paragraph.children.length > 1 && (
-            <div className="mt-2">{paragraph.children.slice(1)}</div>
-          )
-        }
-      </div>
-    )
+
+  // Check if any child is an image (not just the first one)
+  const hasImage = children_node?.some(
+    (child: any) => 'tagName' in child && child.tagName === 'img',
+  )
+
+  // If paragraph contains any image, render as div to avoid <div> inside <p> hydration error
+  if (hasImage) {
+    // If the first child is an image, use the special ImageGallery rendering
+    if (children_node[0] && 'tagName' in children_node[0] && children_node[0].tagName === 'img') {
+      return (
+        <div className="markdown-img-wrapper">
+          <ImageGallery srcs={[children_node[0].properties.src]} />
+          {
+            Array.isArray(paragraph.children) && paragraph.children.length > 1 && (
+              <div className="mt-2">{paragraph.children.slice(1)}</div>
+            )
+          }
+        </div>
+      )
+    }
+    // For images in the middle/end of paragraph, wrap in div instead of p
+    return <div className="markdown-paragraph">{paragraph.children}</div>
   }
+
   return <p>{paragraph.children}</p>
 }
 


### PR DESCRIPTION
## Summary
When a paragraph contains an inline image (not as the first child), the Img component renders a `<div>` wrapper which becomes nested inside the `<p>` tag. This is invalid HTML and causes Next.js hydration warnings:

```
In HTML, <div> cannot be a descendant of <p>. This will cause a hydration error.
```

## Changes
- Detect if ANY child (not just the first) is an image using `.some()`
- When images are present but not first, render paragraph as `<div className="markdown-paragraph">` instead of `<p>` to avoid invalid nesting
- Preserve existing behavior for image-first paragraphs

## Test
1. Render markdown with inline image: `Text before ![image](url) text after`
2. Console should no longer show hydration warning

Fixes #32362