### PR TITLE
refactor: use `generate_valid_password` helper for creating test account passwords

### DIFF
--- a/api/tests/test_containers_integration_tests/core/rag/retrieval/test_dataset_retrieval_integration.py
+++ b/api/tests/test_containers_integration_tests/core/rag/retrieval/test_dataset_retrieval_integration.py
@@ -8,6 +8,7 @@ from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
 from dify_graph.repositories.rag_retrieval_protocol import KnowledgeRetrievalRequest
 from models.dataset import Dataset, Document
 from services.account_service import AccountService, TenantService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestGetAvailableDatasetsIntegration:
@@ -22,7 +23,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -83,7 +84,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -136,7 +137,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -189,7 +190,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -252,7 +253,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -286,7 +287,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account1, name=fake.company())
         tenant1 = account1.current_tenant
@@ -295,7 +296,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account2, name=fake.company())
         tenant2 = account2.current_tenant
@@ -362,7 +363,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -384,7 +385,7 @@ class TestGetAvailableDatasetsIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -445,7 +446,7 @@ class TestKnowledgeRetrievalIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -513,7 +514,7 @@ class TestKnowledgeRetrievalIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -561,7 +562,7 @@ class TestKnowledgeRetrievalIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/helpers/__init__.py
+++ b/api/tests/test_containers_integration_tests/helpers/__init__.py
@@ -1,1 +1,24 @@
 """Helper utilities for integration tests."""
+
+import re
+
+
+def generate_valid_password(fake, length: int = 12) -> str:
+    """Generate a password that always satisfies the project's password validation rules.
+
+    The password validation rule in ``api/libs/password.py`` requires passwords to
+    contain **both letters and digits** with a minimum length of 8:
+
+        ``^(?=.*[a-zA-Z])(?=.*\\d).{8,}$``
+
+    ``Faker.password()`` does **not** guarantee that the generated password will
+    contain both character types, which can cause intermittent test failures.
+
+    This helper re-generates until the result is valid (typically first attempt).
+    """
+    for _ in range(100):
+        pwd = fake.password(length=length)
+        if re.search(r"[a-zA-Z]", pwd) and re.search(r"\d", pwd):
+            return pwd
+    # Fallback: should never be reached in practice
+    return fake.password(length=max(length - 2, 6)) + "a1"

--- a/api/tests/test_containers_integration_tests/services/test_account_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_account_service.py
@@ -20,6 +20,7 @@ from services.errors.account import (
     TenantNotFoundError,
 )
 from services.errors.workspace import WorkSpaceNotAllowedCreateError, WorkspacesLimitExceededError
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestAccountService:
@@ -53,7 +54,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -133,7 +134,7 @@ class TestAccountService:
                 email=email,
                 name=name,
                 interface_language="en-US",
-                password=fake.password(length=12),
+                password=generate_valid_password(fake),
             )
 
     def test_create_account_email_in_freeze(
@@ -145,7 +146,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = True
@@ -169,7 +170,7 @@ class TestAccountService:
         """
         fake = Faker()
         email = fake.email()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         with pytest.raises(AccountPasswordError):
             AccountService.authenticate(email, password)
 
@@ -180,7 +181,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -208,8 +209,8 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        correct_password = fake.password(length=12)
-        wrong_password = fake.password(length=12)
+        correct_password = generate_valid_password(fake)
+        wrong_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -234,7 +235,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        new_password = fake.password(length=12)
+        new_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -267,7 +268,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -297,8 +298,8 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        old_password = fake.password(length=12)
-        new_password = fake.password(length=12)
+        old_password = generate_valid_password(fake)
+        new_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -327,9 +328,9 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        old_password = fake.password(length=12)
-        wrong_password = fake.password(length=12)
-        new_password = fake.password(length=12)
+        old_password = generate_valid_password(fake)
+        wrong_password = generate_valid_password(fake)
+        new_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -354,7 +355,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        old_password = fake.password(length=12)
+        old_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -378,7 +379,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies[
@@ -412,7 +413,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies[
@@ -437,7 +438,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies[
@@ -535,7 +536,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -563,7 +564,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         updated_name = fake.name()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -592,7 +593,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -615,7 +616,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         ip_address = fake.ipv4()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -645,7 +646,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         ip_address = fake.ipv4()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -684,7 +685,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -714,7 +715,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -747,7 +748,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant_name = fake.company()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -792,7 +793,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -825,7 +826,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant_name = fake.company()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -864,7 +865,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -892,7 +893,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -926,7 +927,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant_name = fake.company()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -957,7 +958,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -997,7 +998,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1043,7 +1044,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1080,7 +1081,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1110,7 +1111,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1139,7 +1140,7 @@ class TestAccountService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         wrong_code = fake.numerify(text="######")
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -1259,7 +1260,7 @@ class TestTenantService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1291,10 +1292,10 @@ class TestTenantService:
         tenant_name = fake.company()
         email1 = fake.email()
         name1 = fake.name()
-        password1 = fake.password(length=12)
+        password1 = generate_valid_password(fake)
         email2 = fake.email()
         name2 = fake.name()
-        password2 = fake.password(length=12)
+        password2 = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1332,7 +1333,7 @@ class TestTenantService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1364,7 +1365,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant1_name = fake.company()
         tenant2_name = fake.company()
         # Setup mocks
@@ -1403,7 +1404,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant_name = fake.company()
         # Setup mocks
         mock_external_service_dependencies[
@@ -1441,7 +1442,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1466,7 +1467,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant1_name = fake.company()
         tenant2_name = fake.company()
         # Setup mocks
@@ -1507,7 +1508,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1534,7 +1535,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         tenant_name = fake.company()
         # Setup mocks
         mock_external_service_dependencies[
@@ -1562,10 +1563,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         admin_email = fake.email()
         admin_name = fake.name()
-        admin_password = fake.password(length=12)
+        admin_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1631,7 +1632,7 @@ class TestTenantService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1664,10 +1665,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         member_email = fake.email()
         member_name = fake.name()
-        member_password = fake.password(length=12)
+        member_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1705,7 +1706,7 @@ class TestTenantService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         invalid_action = "invalid_action_that_doesnt_exist"
         # Setup mocks
         mock_external_service_dependencies[
@@ -1738,7 +1739,7 @@ class TestTenantService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1770,10 +1771,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         member_email = fake.email()
         member_name = fake.name()
-        member_password = fake.password(length=12)
+        member_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1829,7 +1830,7 @@ class TestTenantService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1861,10 +1862,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         non_member_email = fake.email()
         non_member_name = fake.name()
-        non_member_password = fake.password(length=12)
+        non_member_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1900,10 +1901,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         member_email = fake.email()
         member_name = fake.name()
-        member_password = fake.password(length=12)
+        member_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -1949,10 +1950,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         member_email = fake.email()
         member_name = fake.name()
-        member_password = fake.password(length=12)
+        member_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -2006,10 +2007,10 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         member_email = fake.email()
         member_name = fake.name()
-        member_password = fake.password(length=12)
+        member_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -2071,7 +2072,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         workspace_name = fake.company()
         # Setup mocks
         mock_external_service_dependencies[
@@ -2110,7 +2111,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         existing_tenant_name = fake.company()
         new_workspace_name = fake.company()
         # Setup mocks
@@ -2151,7 +2152,7 @@ class TestTenantService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         workspace_name = fake.company()
         # Setup mocks to disable workspace creation
         mock_external_service_dependencies[
@@ -2178,13 +2179,13 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         admin_email = fake.email()
         admin_name = fake.name()
-        admin_password = fake.password(length=12)
+        admin_password = generate_valid_password(fake)
         normal_email = fake.email()
         normal_name = fake.name()
-        normal_password = fake.password(length=12)
+        normal_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -2244,13 +2245,13 @@ class TestTenantService:
         tenant_name = fake.company()
         owner_email = fake.email()
         owner_name = fake.name()
-        owner_password = fake.password(length=12)
+        owner_password = generate_valid_password(fake)
         operator_email = fake.email()
         operator_name = fake.name()
-        operator_password = fake.password(length=12)
+        operator_password = generate_valid_password(fake)
         normal_email = fake.email()
         normal_name = fake.name()
-        normal_password = fake.password(length=12)
+        normal_password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies[
             "feature_service"
@@ -2351,7 +2352,7 @@ class TestRegisterService:
         fake = Faker()
         admin_email = fake.email()
         admin_name = fake.name()
-        admin_password = fake.password(length=12)
+        admin_password = generate_valid_password(fake)
         ip_address = fake.ipv4()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2399,7 +2400,7 @@ class TestRegisterService:
         fake = Faker()
         admin_email = fake.email()
         admin_name = fake.name()
-        admin_password = fake.password(length=12)
+        admin_password = generate_valid_password(fake)
         ip_address = fake.ipv4()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2440,7 +2441,7 @@ class TestRegisterService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2531,7 +2532,7 @@ class TestRegisterService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2576,7 +2577,7 @@ class TestRegisterService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2614,7 +2615,7 @@ class TestRegisterService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2653,7 +2654,7 @@ class TestRegisterService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2690,7 +2691,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         inviter_email = fake.email()
         inviter_name = fake.name()
-        inviter_password = fake.password(length=12)
+        inviter_password = generate_valid_password(fake)
         new_member_email = fake.email()
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
@@ -2760,10 +2761,10 @@ class TestRegisterService:
         tenant_name = fake.company()
         inviter_email = fake.email()
         inviter_name = fake.name()
-        inviter_password = fake.password(length=12)
+        inviter_password = generate_valid_password(fake)
         existing_member_email = fake.email()
         existing_member_name = fake.name()
-        existing_member_password = fake.password(length=12)
+        existing_member_password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2824,10 +2825,10 @@ class TestRegisterService:
         tenant_name = fake.company()
         inviter_email = fake.email()
         inviter_name = fake.name()
-        inviter_password = fake.password(length=12)
+        inviter_password = generate_valid_password(fake)
         existing_pending_member_email = fake.email()
         existing_pending_member_name = fake.name()
-        existing_pending_member_password = fake.password(length=12)
+        existing_pending_member_password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2914,10 +2915,10 @@ class TestRegisterService:
         tenant_name = fake.company()
         inviter_email = fake.email()
         inviter_name = fake.name()
-        inviter_password = fake.password(length=12)
+        inviter_password = generate_valid_password(fake)
         already_in_tenant_email = fake.email()
         already_in_tenant_name = fake.name()
-        already_in_tenant_password = fake.password(length=12)
+        already_in_tenant_password = generate_valid_password(fake)
         language = fake.random_element(elements=("en-US", "zh-CN"))
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -2967,7 +2968,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -3011,7 +3012,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -3058,7 +3059,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -3101,7 +3102,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -3144,7 +3145,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -3212,7 +3213,7 @@ class TestRegisterService:
         fake = Faker()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         invalid_tenant_id = fake.uuid4()
         token = fake.uuid4()
         # Setup mocks
@@ -3263,7 +3264,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         token = fake.uuid4()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
@@ -3313,7 +3314,7 @@ class TestRegisterService:
         tenant_name = fake.company()
         email = fake.email()
         name = fake.name()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         token = fake.uuid4()
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True

--- a/api/tests/test_containers_integration_tests/services/test_agent_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_agent_service.py
@@ -11,6 +11,7 @@ from models.model import AppModelConfig, Conversation, EndUser, Message, Message
 from services.account_service import AccountService, TenantService
 from services.agent_service import AgentService
 from services.app_service import AppService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestAgentService:
@@ -111,7 +112,7 @@ class TestAgentService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_annotation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_annotation_service.py
@@ -9,6 +9,7 @@ from models import Account
 from models.model import MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.app_service import AppService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestAnnotationService:
@@ -78,7 +79,7 @@ class TestAnnotationService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_api_based_extension_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_api_based_extension_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from models.api_based_extension import APIBasedExtension
 from services.account_service import AccountService, TenantService
 from services.api_based_extension_service import APIBasedExtensionService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestAPIBasedExtensionService:
@@ -55,7 +56,7 @@ class TestAPIBasedExtensionService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
@@ -9,6 +9,7 @@ from models.model import App, AppModelConfig
 from services.account_service import AccountService, TenantService
 from services.app_dsl_service import AppDslService, ImportMode, ImportStatus
 from services.app_service import AppService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestAppDslService:
@@ -89,7 +90,7 @@ class TestAppDslService:
                 email=fake.email(),
                 name=fake.name(),
                 interface_language="en-US",
-                password=fake.password(length=12),
+                password=generate_valid_password(fake),
             )
             TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
             tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_app_generate_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_generate_service.py
@@ -10,6 +10,7 @@ from models.model import EndUser
 from models.workflow import Workflow
 from services.app_generate_service import AppGenerateService
 from services.errors.app import WorkflowIdFormatError, WorkflowNotFoundError
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestAppGenerateService:
@@ -147,7 +148,7 @@ class TestAppGenerateService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_service.py
@@ -8,6 +8,7 @@ from constants.model_template import default_app_templates
 from models import Account
 from models.model import App, Site
 from services.account_service import AccountService, TenantService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 # Delay import of AppService to avoid circular dependency
 # from services.app_service import AppService
@@ -56,7 +57,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -112,7 +113,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -155,7 +156,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -203,7 +204,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -259,7 +260,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -334,7 +335,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -404,7 +405,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -473,7 +474,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -526,7 +527,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -585,7 +586,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -645,7 +646,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -705,7 +706,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -756,7 +757,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -808,7 +809,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -868,7 +869,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -907,7 +908,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -947,7 +948,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -997,7 +998,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -1039,7 +1040,7 @@ class TestAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_message_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_service.py
@@ -13,6 +13,7 @@ from services.errors.message import (
     SuggestedQuestionsAfterAnswerDisabledError,
 )
 from services.message_service import MessageService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestMessageService:
@@ -95,7 +96,7 @@ class TestMessageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -633,7 +634,7 @@ class TestMessageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(other_account, name=fake.company())
 

--- a/api/tests/test_containers_integration_tests/services/test_saved_message_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_saved_message_service.py
@@ -8,6 +8,7 @@ from models.model import EndUser, Message
 from models.web import SavedMessage
 from services.app_service import AppService
 from services.saved_message_service import SavedMessageService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestSavedMessageService:
@@ -64,7 +65,7 @@ class TestSavedMessageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_trigger_provider_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_trigger_provider_service.py
@@ -10,6 +10,7 @@ from core.trigger.entities.entities import Subscription as TriggerSubscriptionEn
 from models.provider_ids import TriggerProviderID
 from models.trigger import TriggerSubscription
 from services.trigger.trigger_provider_service import TriggerProviderService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestTriggerProviderService:
@@ -75,7 +76,7 @@ class TestTriggerProviderService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_web_conversation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_web_conversation_service.py
@@ -12,6 +12,7 @@ from models.web import PinnedConversation
 from services.account_service import AccountService, TenantService
 from services.app_service import AppService
 from services.web_conversation_service import WebConversationService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestWebConversationService:
@@ -69,7 +70,7 @@ class TestWebConversationService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -12,6 +12,7 @@ from models import Account, AccountStatus, Tenant, TenantAccountJoin, TenantAcco
 from models.model import App, Site
 from services.errors.account import AccountLoginError, AccountNotFoundError, AccountPasswordError
 from services.webapp_auth_service import WebAppAuthService, WebAppAuthType
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestWebAppAuthService:
@@ -109,7 +110,7 @@ class TestWebAppAuthService:
             tuple: (account, tenant, password) - Created account, tenant and password
         """
         fake = Faker()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
 
         # Create account with password
         import uuid
@@ -272,7 +273,7 @@ class TestWebAppAuthService:
         """
         # Arrange: Create banned account
         fake = Faker()
-        password = fake.password(length=12)
+        password = generate_valid_password(fake)
         unique_email = f"test_{uuid.uuid4().hex[:8]}@example.com"
 
         account = Account(

--- a/api/tests/test_containers_integration_tests/services/test_webhook_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webhook_service.py
@@ -13,6 +13,7 @@ from models.trigger import AppTrigger, WorkflowWebhookTrigger
 from models.workflow import Workflow
 from services.account_service import AccountService, TenantService
 from services.trigger.webhook_service import WebhookService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestWebhookService:
@@ -60,7 +61,7 @@ class TestWebhookService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_workflow_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_app_service.py
@@ -15,6 +15,7 @@ from services.account_service import AccountService, TenantService
 # Delay import of AppService to avoid circular dependency
 # from services.app_service import AppService
 from services.workflow_app_service import WorkflowAppService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestWorkflowAppService:
@@ -72,7 +73,7 @@ class TestWorkflowAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -120,7 +121,7 @@ class TestWorkflowAppService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
@@ -15,6 +15,7 @@ from models.workflow import WorkflowRun
 from services.account_service import AccountService, TenantService
 from services.app_service import AppService
 from services.workflow_run_service import WorkflowRunService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestWorkflowRunService:
@@ -72,7 +73,7 @@ class TestWorkflowRunService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py
@@ -13,6 +13,7 @@ from models.workflow import Workflow as WorkflowModel
 from services.account_service import AccountService, TenantService
 from services.app_service import AppService
 from services.tools.workflow_tools_manage_service import WorkflowToolManageService
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestWorkflowToolManageService:
@@ -87,7 +88,7 @@ class TestWorkflowToolManageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/tasks/test_clean_notion_document_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_clean_notion_document_task.py
@@ -15,6 +15,7 @@ from faker import Faker
 from models.dataset import Dataset, Document, DocumentSegment
 from services.account_service import AccountService, TenantService
 from tasks.clean_notion_document_task import clean_notion_document_task
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestCleanNotionDocumentTask:
@@ -76,7 +77,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -208,7 +209,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -252,7 +253,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -345,7 +346,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -431,7 +432,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -546,7 +547,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -642,7 +643,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -724,7 +725,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -834,7 +835,7 @@ class TestCleanNotionDocumentTask:
                 email=fake.email(),
                 name=fake.name(),
                 interface_language="en-US",
-                password=fake.password(length=12),
+                password=generate_valid_password(fake),
             )
             TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
             tenant = account.current_tenant
@@ -951,7 +952,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant
@@ -1054,7 +1055,7 @@ class TestCleanNotionDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant

--- a/api/tests/test_containers_integration_tests/tasks/test_deal_dataset_vector_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_deal_dataset_vector_index_task.py
@@ -15,6 +15,7 @@ from faker import Faker
 from models.dataset import Dataset, Document, DocumentSegment
 from services.account_service import AccountService, TenantService
 from tasks.deal_dataset_vector_index_task import deal_dataset_vector_index_task
+from tests.test_containers_integration_tests.helpers import generate_valid_password
 
 
 class TestDealDatasetVectorIndexTask:
@@ -61,7 +62,7 @@ class TestDealDatasetVectorIndexTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            password=fake.password(length=12),
+            password=generate_valid_password(fake),
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
         tenant = account.current_tenant


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #33191

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
