### PR TITLE
ci: add anti-slop GitHub Action to detect low-quality AI PRs

### DIFF
--- a/.github/workflows/anti-slop.yml
+++ b/.github/workflows/anti-slop.yml
@@ -1,0 +1,17 @@
+name: Anti-Slop PR Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  anti-slop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peakoss/anti-slop@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #33133 — Adds the [`peakoss/anti-slop`](https://github.com/peakoss/anti-slop) GitHub Action to automatically detect and flag pull requests that contain AI-generated boilerplate or low-quality content.

### What it does

The action runs on `pull_request_target` events (opened, edited, synchronize) and scans PR descriptions and diffs for patterns commonly associated with AI-generated "slop" — generic filler text, templated responses, etc.

### Why

Dify already has PR automation workflows:
- `semantic-pull-request.yml` — enforces conventional commit titles
- `labeler.yml` — auto-labels PRs by file path

Anti-slop is a natural complement, helping maintainers quickly identify PRs that may need extra review for substance.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/anti-slop.yml` | New workflow file (17 lines) |

### Configuration

The action works out of the box with sensible defaults. Maintainers can optionally add configuration if needed (e.g. `exempt-maintainers`, `exempt-bots`) — see [anti-slop docs](https://github.com/peakoss/anti-slop).