### PR TITLE
refactor(api): remove dead STT error handlers from TTS endpoints

### DIFF
--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -134,14 +134,6 @@ class ChatMessageTextApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:
@@ -183,14 +175,6 @@ class TextModesApi(Resource):
             return response
         except services.errors.audio.ProviderNotSupportTextToSpeechLanageServiceError:
             raise AppUnavailableError("Text to audio voices language parameter loss.")
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -129,14 +129,6 @@ class TextApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:


### PR DESCRIPTION
## Summary

Remove unreachable exception handlers from text-to-speech endpoints.

## Changes

Removed the following dead exception handlers from TTS endpoints:
- `NoAudioUploadedServiceError`
- `AudioTooLargeServiceError`
- `UnsupportedAudioTypeServiceError`
- `ProviderNotSupportSpeechToTextServiceError`

### Affected endpoints:
- `TextApi.post()` in `service_api/app/audio.py`
- `ChatMessageTextApi.post()` in `console/app/audio.py`
- `TextModesApi.get()` in `console/app/audio.py`

## Why these are dead code

TTS (Text-to-Speech) services:
- Receive **text** input, not audio files
- Perform speech **synthesis**, not recognition

These exceptions can only be raised by STT (Speech-to-Text) operations:
- `NoAudioUploadedServiceError` - TTS doesn't accept audio uploads
- `AudioTooLargeServiceError` - TTS doesn't process audio files
- `UnsupportedAudioTypeServiceError` - TTS doesn't validate audio types
- `ProviderNotSupportSpeechToTextServiceError` - TTS is not STT

The handlers appear to have been copy-pasted from the STT endpoint (`AudioApi`/`ChatMessageAudioApi`) which legitimately needs them.

## Testing

- [x] Code review: verified these exceptions are never raised by `AudioService.transcript_tts()` or `AudioService.transcript_tts_voices()`
- [x] STT endpoints (`AudioApi`, `ChatMessageAudioApi`) still have the necessary exception handlers

Closes #32982