### PR TITLE
fix: set daemon=True on auxiliary threads to allow clean shutdown

### DIFF
--- a/api/core/base/tts/app_generator_tts_publisher.py
+++ b/api/core/base/tts/app_generator_tts_publisher.py
@@ -74,7 +74,7 @@ class AppGeneratorTTSPublisher:
         self.max_sentence = 2
         self._last_audio_event: AudioTrunk | None = None
         # FIXME better way to handle this threading.start
-        threading.Thread(target=self._runtime).start()
+        threading.Thread(target=self._runtime, daemon=True).start()
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
     def publish(self, message: WorkflowQueueMessage | MessageQueueMessage | None, /):
@@ -82,7 +82,7 @@ class AppGeneratorTTSPublisher:
 
     def _runtime(self):
         future_queue: queue.Queue[concurrent.futures.Future[Iterable[bytes] | None] | None] = queue.Queue()
-        threading.Thread(target=_process_future, args=(future_queue, self._audio_queue)).start()
+        threading.Thread(target=_process_future, args=(future_queue, self._audio_queue), daemon=True).start()
         while True:
             try:
                 message = self._msg_queue.get()

--- a/api/core/moderation/output_moderation.py
+++ b/api/core/moderation/output_moderation.py
@@ -78,6 +78,7 @@ class OutputModeration(BaseModel):
                 "flask_app": current_app._get_current_object(),  # type: ignore
                 "buffer_size": buffer_size if buffer_size > 0 else dify_config.MODERATION_BUFFER_SIZE,
             },
+            daemon=True,
         )
 
         thread.start()


### PR DESCRIPTION
## Summary
- Set `daemon=True` on moderation and TTS publisher threads
- Non-daemon threads prevent Python process from exiting when main thread finishes or receives SIGTERM
- These auxiliary threads should not block shutdown

## Test plan
- [x] Moderation and TTS still function correctly
- [x] Process shuts down cleanly on SIGTERM

🤖 Generated with [Claude Code](https://claude.com/claude-code)