### PR TITLE
fix: add raise_for_status() to GitHub OAuth email API response

### DIFF
--- a/api/libs/oauth.py
+++ b/api/libs/oauth.py
@@ -75,8 +75,9 @@ class GitHubOAuth(OAuth):
         user_info = response.json()
 
         email_response = httpx.get(self._EMAIL_INFO_URL, headers=headers)
+        email_response.raise_for_status()
         email_info = email_response.json()
-        primary_email: dict = next((email for email in email_info if email["primary"] == True), {})
+        primary_email: dict = next((email for email in email_info if email["primary"] is True), {})
 
         return {**user_info, "email": primary_email.get("email", "")}
 


### PR DESCRIPTION
## Summary
- Add missing `raise_for_status()` to GitHub email API response in OAuth flow
- Without this check, non-200 responses (rate limits, auth failures) silently produce empty email
- Also fix `== True` to `is True` for Pythonic comparison

## Test plan
- [x] OAuth flow handles email API errors properly
- [x] Successful flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)