### PR TITLE
fix: prevent temp file leak in document extractor on API failure

### DIFF
--- a/api/dify_graph/nodes/document_extractor/node.py
+++ b/api/dify_graph/nodes/document_extractor/node.py
@@ -377,6 +377,7 @@ def _extract_text_from_doc(file_content: bytes, *, unstructured_api_config: Unst
         with tempfile.NamedTemporaryFile(suffix=".doc", delete=False) as temp_file:
             temp_file.write(file_content)
             temp_file.flush()
+        try:
             with open(temp_file.name, "rb") as file:
                 elements = partition_via_api(
                     file=file,
@@ -384,6 +385,7 @@ def _extract_text_from_doc(file_content: bytes, *, unstructured_api_config: Unst
                     api_url=unstructured_api_config.api_url,
                     api_key=api_key,
                 )
+        finally:
             os.unlink(temp_file.name)
         return "\n".join([getattr(element, "text", "") for element in elements])
     except Exception as e:
@@ -624,6 +626,7 @@ def _extract_text_from_ppt(file_content: bytes, *, unstructured_api_config: Unst
             with tempfile.NamedTemporaryFile(suffix=".ppt", delete=False) as temp_file:
                 temp_file.write(file_content)
                 temp_file.flush()
+            try:
                 with open(temp_file.name, "rb") as file:
                     elements = partition_via_api(
                         file=file,
@@ -631,6 +634,7 @@ def _extract_text_from_ppt(file_content: bytes, *, unstructured_api_config: Unst
                         api_url=unstructured_api_config.api_url,
                         api_key=api_key,
                     )
+            finally:
                 os.unlink(temp_file.name)
         else:
             with io.BytesIO(file_content) as file:
@@ -652,6 +656,7 @@ def _extract_text_from_pptx(file_content: bytes, *, unstructured_api_config: Uns
             with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as temp_file:
                 temp_file.write(file_content)
                 temp_file.flush()
+            try:
                 with open(temp_file.name, "rb") as file:
                     elements = partition_via_api(
                         file=file,
@@ -659,6 +664,7 @@ def _extract_text_from_pptx(file_content: bytes, *, unstructured_api_config: Uns
                         api_url=unstructured_api_config.api_url,
                         api_key=api_key,
                     )
+            finally:
                 os.unlink(temp_file.name)
         else:
             with io.BytesIO(file_content) as file:
@@ -679,6 +685,7 @@ def _extract_text_from_epub(file_content: bytes, *, unstructured_api_config: Uns
             with tempfile.NamedTemporaryFile(suffix=".epub", delete=False) as temp_file:
                 temp_file.write(file_content)
                 temp_file.flush()
+            try:
                 with open(temp_file.name, "rb") as file:
                     elements = partition_via_api(
                         file=file,
@@ -686,6 +693,7 @@ def _extract_text_from_epub(file_content: bytes, *, unstructured_api_config: Uns
                         api_url=unstructured_api_config.api_url,
                         api_key=api_key,
                     )
+            finally:
                 os.unlink(temp_file.name)
         else:
             pypandoc.download_pandoc()


### PR DESCRIPTION
## Summary
- Fix temporary file leak in document extractor node when `partition_via_api()` raises an exception
- Affects DOC, PPT, PPTX, and EPUB extraction via Unstructured API

## Root Cause

The `_extract_text_from_doc`, `_extract_text_from_ppt`, `_extract_text_from_pptx`, and `_extract_text_from_epub` functions in `api/dify_graph/nodes/document_extractor/node.py` create temporary files with `delete=False` but only call `os.unlink()` on the success path.

If `partition_via_api()` raises an exception (e.g., network timeout, API error, malformed response), execution jumps to the outer `except` block and the `os.unlink()` call is skipped. The temporary file is never cleaned up, leaking disk space.

In long-running Dify deployments that process many documents, this can accumulate significant orphaned temp files in the system's temp directory.

## Fix

Move `os.unlink()` into a `finally` block so the temporary file is always removed regardless of whether the API call succeeds or fails.

**Before:**
```python
with tempfile.NamedTemporaryFile(suffix=".doc", delete=False) as temp_file:
    temp_file.write(file_content)
    temp_file.flush()
    with open(temp_file.name, "rb") as file:
        elements = partition_via_api(...)
    os.unlink(temp_file.name)  # skipped if partition_via_api raises
```

**After:**
```python
with tempfile.NamedTemporaryFile(suffix=".doc", delete=False) as temp_file:
    temp_file.write(file_content)
    temp_file.flush()
try:
    with open(temp_file.name, "rb") as file:
        elements = partition_via_api(...)
finally:
    os.unlink(temp_file.name)  # always runs
```

## Test plan
- [ ] Verify DOC/PPT/PPTX/EPUB extraction still works normally when Unstructured API succeeds
- [ ] Verify temp files are cleaned up when Unstructured API returns an error
- [ ] Check no temp file accumulation in `/tmp` after processing documents with API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)