### PR TITLE
fix: VTT extractor loses speakerless caption text

### DIFF
--- a/api/dify_graph/nodes/document_extractor/node.py
+++ b/api/dify_graph/nodes/document_extractor/node.py
@@ -730,36 +730,32 @@ def _extract_text_from_vtt(vtt_bytes: bytes) -> str:
 
     # Merge consecutive utterances by the same speaker
     merged_results = []
-    if raw_results:
-        current_speaker, current_text = raw_results[0]
+    current_speaker = None
+    current_text = ""
 
-        for i in range(1, len(raw_results)):
-            spk, txt = raw_results[i]
-            if spk is None:
-                # Flush the current speaker's accumulated text before the speakerless caption
+    for spk, txt in raw_results:
+        if spk is None:
+            # Flush the current speaker's accumulated text before the speakerless caption
+            if current_speaker is not None or current_text:
                 merged_results.append((current_speaker, current_text))
-                merged_results.append((None, txt))
-                # Reset: next caption with a speaker starts fresh
-                current_speaker = None
-                current_text = ""
-                continue
-
-            if current_speaker is None:
-                # Previous caption was speakerless; start a new speaker run
-                current_speaker, current_text = spk, txt
-            elif spk == current_speaker:
-                # If it is the same speaker, merge the utterances (joined by space)
-                current_text += " " + txt
-            else:
-                # If the speaker changes, register the utterance so far and move on
-                merged_results.append((current_speaker, current_text))
-                current_speaker, current_text = spk, txt
-
-        # Add the last element (skip if already flushed by a trailing speakerless caption)
-        if current_speaker is not None or current_text:
+            merged_results.append((None, txt))
+            # Reset: next caption with a speaker starts fresh
+            current_speaker = None
+            current_text = ""
+        elif current_speaker is None:
+            # Previous caption was speakerless (or start of stream); begin a new speaker run
+            current_speaker, current_text = spk, txt
+        elif spk == current_speaker:
+            # If it is the same speaker, merge the utterances (joined by space)
+            current_text += " " + txt
+        else:
+            # If the speaker changes, register the utterance so far and move on
             merged_results.append((current_speaker, current_text))
-    else:
-        merged_results = raw_results
+            current_speaker, current_text = spk, txt
+
+    # Add the last element (skip if already flushed by a trailing speakerless caption)
+    if current_speaker is not None or current_text:
+        merged_results.append((current_speaker, current_text))
 
     # Return the result in the specified format: Speaker "text" style
     formatted = [f'{spk or ""} "{txt}"' for spk, txt in merged_results]

--- a/api/dify_graph/nodes/document_extractor/node.py
+++ b/api/dify_graph/nodes/document_extractor/node.py
@@ -736,10 +736,18 @@ def _extract_text_from_vtt(vtt_bytes: bytes) -> str:
         for i in range(1, len(raw_results)):
             spk, txt = raw_results[i]
             if spk is None:
-                merged_results.append((None, current_text))
+                # Flush the current speaker's accumulated text before the speakerless caption
+                merged_results.append((current_speaker, current_text))
+                merged_results.append((None, txt))
+                # Reset: next caption with a speaker starts fresh
+                current_speaker = None
+                current_text = ""
                 continue
 
-            if spk == current_speaker:
+            if current_speaker is None:
+                # Previous caption was speakerless; start a new speaker run
+                current_speaker, current_text = spk, txt
+            elif spk == current_speaker:
                 # If it is the same speaker, merge the utterances (joined by space)
                 current_text += " " + txt
             else:
@@ -747,8 +755,9 @@ def _extract_text_from_vtt(vtt_bytes: bytes) -> str:
                 merged_results.append((current_speaker, current_text))
                 current_speaker, current_text = spk, txt
 
-        # Add the last element
-        merged_results.append((current_speaker, current_text))
+        # Add the last element (skip if already flushed by a trailing speakerless caption)
+        if current_speaker is not None or current_text:
+            merged_results.append((current_speaker, current_text))
     else:
         merged_results = raw_results
 


### PR DESCRIPTION
## Summary
- Fix data loss in WebVTT text extraction where captions without a speaker voice tag output the wrong text
- The speakerless caption's own text is dropped and replaced with the previous speaker's accumulated text

## Root Cause

In `_extract_text_from_vtt()` in `api/dify_graph/nodes/document_extractor/node.py`, when merging consecutive utterances by speaker, the handling of speakerless captions (`spk is None`) has two bugs:

1. **Wrong text output**: `merged_results.append((None, current_text))` appends `current_text` (the previous speaker's accumulated buffer) instead of `txt` (the current speakerless caption's actual text). This means the speakerless caption's content is completely lost.

2. **No state reset**: After the `continue`, `current_text` still holds the previous speaker's text, so if the next caption has the same speaker, the old text gets merged again, producing duplicates.

### Example

Given this VTT input:
```
WEBVTT

00:00:00.000 --> 00:00:01.000
<v Alice>Hello there</v>

00:00:01.000 --> 00:00:02.000
Background music plays

00:00:02.000 --> 00:00:03.000
<v Bob>Goodbye</v>
```

**Before (buggy):**
```
Alice "Hello there"
 "Hello there"
Bob "Goodbye"
```
The speakerless caption outputs Alice's text instead of "Background music plays".

**After (fixed):**
```
Alice "Hello there"
 "Background music plays"
Bob "Goodbye"
```

## Fix

- When encountering a speakerless caption, flush the current speaker's accumulated text first, then append the speakerless caption with its own text (`txt`)
- Reset `current_speaker` and `current_text` so subsequent captions start fresh
- Handle the transition from speakerless back to a named speaker correctly

## Test plan
- [ ] Extract text from VTT files with mixed speaker/speakerless captions
- [ ] Verify speakerless caption text is preserved correctly
- [ ] Verify consecutive same-speaker captions still merge properly
- [ ] Verify speaker transitions around speakerless captions work correctly
- [ ] Verify VTT files with only speakerless captions work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)