### PR TITLE
fix: set default empty string for OnlineDriveBrowseFilesRequest.prefix field

### DIFF
--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -358,7 +358,7 @@ class OnlineDriveBrowseFilesRequest(BaseModel):
     """
 
     bucket: str | None = Field(None, description="The file bucket")
-    prefix: str = Field(..., description="The parent folder ID")
+    prefix: str = Field(default="", description="The parent folder ID")
     max_keys: int = Field(20, description="Page size for pagination")
     next_page_parameters: dict | None = Field(None, description="Parameters for fetching the next page")
 


### PR DESCRIPTION
## Summary

Fix `OnlineDriveBrowseFilesRequest.prefix` field causing `ValidationError` when no prefix is provided.

## Problem

The `prefix` field was declared as required (`Field(...)`), but multiple callers already treat it as optional:
- `rag_pipeline.py`: `user_inputs.get('prefix', '')`
- `data_source.py`: `query.datasource_parameters or {}` → passes empty dict

When `datasource_parameters` is empty or doesn't include `prefix`, Pydantic raises a `ValidationError` because the required field is missing.

## Fix

Change `prefix` from required to optional with a default of `''` (empty string), consistent with how callers already handle it.

```python
# Before
prefix: str = Field(..., description="The parent folder ID")

# After
prefix: str = Field(default="", description="The parent folder ID")
```

## Related

- Related PR: #31756
- Closes #31761