### PR TITLE
fix: allow key-value rows to grow for multiline values in HTTP panel

### DIFF
--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
@@ -59,12 +59,12 @@ const InputItem: FC<Props> = ({
   }, [onRemove])
 
   return (
-    <div className={cn(className, 'hover:cursor-text hover:bg-state-base-hover', 'relative flex !h-[30px] items-center')}>
+    <div className={cn(className, 'hover:cursor-text hover:bg-state-base-hover', 'relative flex min-h-[30px] items-stretch')}>
       {(!readOnly)
         ? (
             <Input
               instanceId={instanceId}
-              className={cn(isFocus ? 'bg-components-input-bg-active' : 'bg-width', 'h-full w-0 grow px-3 py-1')}
+              className={cn(isFocus ? 'bg-components-input-bg-active' : 'bg-width', 'min-h-[30px] w-0 grow px-3 py-1')}
               value={value}
               onChange={onChange}
               readOnly={readOnly}
@@ -79,13 +79,13 @@ const InputItem: FC<Props> = ({
           )
         : (
             <div
-              className="h-full w-full pl-0.5 leading-[18px]"
+              className="min-h-[30px] w-full pl-0.5 leading-[18px]"
             >
               {!hasValue && <div className="text-xs font-normal text-text-quaternary">{placeholder}</div>}
               {hasValue && (
                 <Input
                   instanceId={instanceId}
-                  className={cn(isFocus ? 'border-components-input-border-active bg-components-input-bg-active shadow-xs' : 'border-components-input-border-hover bg-components-input-bg-normal', 'h-full w-0 grow rounded-lg border px-3 py-[6px]')}
+                  className={cn(isFocus ? 'border-components-input-border-active bg-components-input-bg-active shadow-xs' : 'border-components-input-border-hover bg-components-input-bg-normal', 'min-h-[30px] w-0 grow rounded-lg border px-3 py-[6px]')}
                   value={value}
                   onChange={onChange}
                   readOnly={readOnly}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/33263

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
