### PR TITLE
refactor(select): align with Base UI data attributes and Figma specs

### DIFF
--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -158,9 +158,9 @@ describe('Select wrappers', () => {
       expect(trigger.className).toContain('data-[disabled]:data-[placeholder]:text-components-input-text-disabled')
     })
 
-    it('should show error icon and apply destructive styling when intent is destructive', () => {
+    it('should show error icon and apply destructive styling when variant is destructive', () => {
       renderOpenSelect({
-        triggerProps: { intent: 'destructive' },
+        triggerProps: { variant: 'destructive' },
       })
 
       const trigger = screen.getByRole('combobox', { name: 'city select' })
@@ -170,9 +170,9 @@ describe('Select wrappers', () => {
       expect(errorIcon).toBeInTheDocument()
     })
 
-    it('should hide clear button when intent is destructive even if clearable', () => {
+    it('should hide clear button when variant is destructive even if clearable', () => {
       renderOpenSelect({
-        triggerProps: { clearable: true, intent: 'destructive' },
+        triggerProps: { clearable: true, variant: 'destructive' },
       })
 
       expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()

--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -109,6 +109,63 @@ describe('Select wrappers', () => {
       const clearButton = screen.getByRole('button', { name: /clear selection/i })
       expect(() => fireEvent.click(clearButton)).not.toThrow()
     })
+
+    it('should apply regular size variant classes by default', () => {
+      renderOpenSelect()
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toMatch(/system-sm-regular/)
+      expect(trigger.className).toMatch(/rounded-lg/)
+    })
+
+    it('should apply small size variant classes when size is small', () => {
+      renderOpenSelect({
+        triggerProps: { size: 'small' },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toMatch(/system-xs-regular/)
+      expect(trigger.className).toMatch(/rounded-md/)
+    })
+
+    it('should apply large size variant classes when size is large', () => {
+      renderOpenSelect({
+        triggerProps: { size: 'large' },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toMatch(/system-md-regular/)
+    })
+
+    it('should apply disabled styling with semantic tokens when disabled', () => {
+      renderOpenSelect({
+        triggerProps: { disabled: true },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toContain('bg-components-input-bg-disabled')
+      expect(trigger.className).toContain('text-components-input-text-filled-disabled')
+    })
+
+    it('should show error icon and apply destructive styling when destructive is true', () => {
+      renderOpenSelect({
+        triggerProps: { destructive: true },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toContain('border-components-input-border-destructive')
+      expect(trigger.className).toContain('bg-components-input-bg-destructive')
+      const errorIcon = trigger.querySelector('.i-ri-error-warning-line')
+      expect(errorIcon).toBeInTheDocument()
+    })
+
+    it('should hide clear button when destructive is true even if clearable', () => {
+      renderOpenSelect({
+        triggerProps: { clearable: true, destructive: true },
+      })
+
+      expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
+    })
   })
 
   describe('SelectContent', () => {

--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -158,9 +158,9 @@ describe('Select wrappers', () => {
       expect(trigger.className).toContain('data-[disabled]:data-[placeholder]:text-components-input-text-disabled')
     })
 
-    it('should show error icon and apply destructive styling when destructive is true', () => {
+    it('should show error icon and apply destructive styling when intent is destructive', () => {
       renderOpenSelect({
-        triggerProps: { destructive: true },
+        triggerProps: { intent: 'destructive' },
       })
 
       const trigger = screen.getByRole('combobox', { name: 'city select' })
@@ -170,9 +170,9 @@ describe('Select wrappers', () => {
       expect(errorIcon).toBeInTheDocument()
     })
 
-    it('should hide clear button when destructive is true even if clearable', () => {
+    it('should hide clear button when intent is destructive even if clearable', () => {
       renderOpenSelect({
-        triggerProps: { clearable: true, destructive: true },
+        triggerProps: { clearable: true, intent: 'destructive' },
       })
 
       expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()

--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -3,16 +3,18 @@ import { describe, expect, it, vi } from 'vitest'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../index'
 
 const renderOpenSelect = ({
+  rootProps = {},
   triggerProps = {},
   contentProps = {},
   onValueChange,
 }: {
+  rootProps?: Record<string, unknown>
   triggerProps?: Record<string, unknown>
   contentProps?: Record<string, unknown>
   onValueChange?: (value: string | null) => void
 } = {}) => {
   return render(
-    <Select open defaultValue="seattle" onValueChange={onValueChange}>
+    <Select open defaultValue="seattle" onValueChange={onValueChange} {...rootProps}>
       <SelectTrigger aria-label="city select" {...triggerProps}>
         <SelectValue />
       </SelectTrigger>
@@ -137,14 +139,23 @@ describe('Select wrappers', () => {
       expect(trigger.className).toMatch(/system-md-regular/)
     })
 
-    it('should apply disabled styling with semantic tokens when disabled', () => {
+    it('should apply disabled styling via data attributes when disabled', () => {
       renderOpenSelect({
         triggerProps: { disabled: true },
       })
 
       const trigger = screen.getByRole('combobox', { name: 'city select' })
-      expect(trigger.className).toContain('bg-components-input-bg-disabled')
-      expect(trigger.className).toContain('text-components-input-text-filled-disabled')
+      expect(trigger).toHaveAttribute('data-disabled')
+      expect(trigger.className).toContain('data-[disabled]:bg-components-input-bg-disabled')
+    })
+
+    it('should apply disabled placeholder color class for compound state', () => {
+      renderOpenSelect({
+        triggerProps: { disabled: true },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toContain('data-[disabled]:data-[placeholder]:text-components-input-text-disabled')
     })
 
     it('should show error icon and apply destructive styling when destructive is true', () => {
@@ -165,6 +176,41 @@ describe('Select wrappers', () => {
       })
 
       expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument()
+    })
+
+    it('should apply readonly styling via data attributes when Root is readOnly', () => {
+      renderOpenSelect({
+        rootProps: { readOnly: true },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger).toHaveAttribute('data-readonly')
+      expect(trigger.className).toContain('data-[readonly]:bg-transparent')
+    })
+
+    it('should hide arrow icon via CSS when Root is readOnly', () => {
+      renderOpenSelect({
+        rootProps: { readOnly: true },
+      })
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      const iconWrapper = trigger.querySelector('[class*="group-data-[readonly]:hidden"]')
+      expect(iconWrapper).toBeInTheDocument()
+    })
+
+    it('should set aria-hidden on decorative icons', () => {
+      renderOpenSelect()
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      const arrowIcon = trigger.querySelector('.i-ri-arrow-down-s-line')
+      expect(arrowIcon).toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('should include placeholder color class via data attribute', () => {
+      renderOpenSelect()
+
+      const trigger = screen.getByRole('combobox', { name: 'city select' })
+      expect(trigger.className).toContain('data-[placeholder]:text-components-input-text-placeholder')
     })
   })
 

--- a/web/app/components/base/ui/select/index.tsx
+++ b/web/app/components/base/ui/select/index.tsx
@@ -23,14 +23,14 @@ export const selectTriggerVariants = cva(
         regular: 'h-8 gap-0.5 rounded-lg px-2 py-1 system-sm-regular',
         large: 'h-9 gap-0.5 rounded-[10px] px-2.5 py-1 system-md-regular',
       },
-      intent: {
+      variant: {
         default: '',
         destructive: 'border border-components-input-border-destructive bg-components-input-bg-destructive shadow-xs hover:border-components-input-border-destructive hover:bg-components-input-bg-destructive',
       },
     },
     defaultVariants: {
       size: 'regular',
-      intent: 'default',
+      variant: 'default',
     },
   },
 )
@@ -51,14 +51,14 @@ export function SelectTrigger({
   className,
   children,
   size = 'regular',
-  intent = 'default',
+  variant = 'default',
   clearable = false,
   onClear,
   loading = false,
   ...props
 }: SelectTriggerProps) {
   const paddingClass = contentPadding[size ?? 'regular']
-  const isDestructive = intent === 'destructive'
+  const isDestructive = variant === 'destructive'
 
   let trailingIcon: React.ReactNode = null
   if (loading) {
@@ -106,7 +106,7 @@ export function SelectTrigger({
         'group relative flex w-full items-center border-0 bg-components-input-bg-normal text-left text-components-input-text-filled outline-none',
         'hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt',
         'data-[placeholder]:text-components-input-text-placeholder',
-        selectTriggerVariants({ size, intent }),
+        selectTriggerVariants({ size, variant }),
         'data-[readonly]:cursor-default data-[readonly]:bg-transparent data-[readonly]:hover:bg-transparent',
         'data-[disabled]:cursor-not-allowed data-[disabled]:bg-components-input-bg-disabled data-[disabled]:text-components-input-text-filled-disabled data-[disabled]:hover:bg-components-input-bg-disabled',
         'data-[disabled]:data-[placeholder]:text-components-input-text-disabled',

--- a/web/app/components/base/ui/select/index.tsx
+++ b/web/app/components/base/ui/select/index.tsx
@@ -23,9 +23,14 @@ export const selectTriggerVariants = cva(
         regular: 'h-8 gap-0.5 rounded-lg px-2 py-1 system-sm-regular',
         large: 'h-9 gap-0.5 rounded-[10px] px-2.5 py-1 system-md-regular',
       },
+      intent: {
+        default: '',
+        destructive: 'border border-components-input-border-destructive bg-components-input-bg-destructive shadow-xs hover:border-components-input-border-destructive hover:bg-components-input-bg-destructive',
+      },
     },
     defaultVariants: {
       size: 'regular',
+      intent: 'default',
     },
   },
 )
@@ -40,20 +45,20 @@ type SelectTriggerProps = React.ComponentPropsWithoutRef<typeof BaseSelect.Trigg
   clearable?: boolean
   onClear?: () => void
   loading?: boolean
-  destructive?: boolean
 } & VariantProps<typeof selectTriggerVariants>
 
 export function SelectTrigger({
   className,
   children,
   size = 'regular',
+  intent = 'default',
   clearable = false,
   onClear,
   loading = false,
-  destructive = false,
   ...props
 }: SelectTriggerProps) {
   const paddingClass = contentPadding[size ?? 'regular']
+  const isDestructive = intent === 'destructive'
 
   let trailingIcon: React.ReactNode = null
   if (loading) {
@@ -63,7 +68,7 @@ export function SelectTrigger({
       </span>
     )
   }
-  else if (destructive) {
+  else if (isDestructive) {
     trailingIcon = (
       <span className="shrink-0 text-text-destructive-secondary" aria-hidden="true">
         <span className="i-ri-error-warning-line h-4 w-4" />
@@ -101,11 +106,10 @@ export function SelectTrigger({
         'group relative flex w-full items-center border-0 bg-components-input-bg-normal text-left text-components-input-text-filled outline-none',
         'hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt',
         'data-[placeholder]:text-components-input-text-placeholder',
-        selectTriggerVariants({ size }),
+        selectTriggerVariants({ size, intent }),
         'data-[readonly]:cursor-default data-[readonly]:bg-transparent data-[readonly]:hover:bg-transparent',
         'data-[disabled]:cursor-not-allowed data-[disabled]:bg-components-input-bg-disabled data-[disabled]:text-components-input-text-filled-disabled data-[disabled]:hover:bg-components-input-bg-disabled',
         'data-[disabled]:data-[placeholder]:text-components-input-text-disabled',
-        destructive && 'border border-components-input-border-destructive bg-components-input-bg-destructive shadow-xs hover:border-components-input-border-destructive hover:bg-components-input-bg-destructive',
         className,
       )}
       {...props}

--- a/web/app/components/base/ui/select/index.tsx
+++ b/web/app/components/base/ui/select/index.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import type { VariantProps } from 'class-variance-authority'
 import type { Placement } from '@/app/components/base/ui/placement'
 import { Select as BaseSelect } from '@base-ui/react/select'
+import { cva } from 'class-variance-authority'
 import * as React from 'react'
 import { parsePlacement } from '@/app/components/base/ui/placement'
 import { cn } from '@/utils/classnames'
@@ -12,61 +14,100 @@ export const SelectGroup = BaseSelect.Group
 export const SelectGroupLabel = BaseSelect.GroupLabel
 export const SelectSeparator = BaseSelect.Separator
 
+export const selectTriggerVariants = cva(
+  '',
+  {
+    variants: {
+      size: {
+        small: 'h-6 gap-px rounded-md px-[5px] py-0 system-xs-regular',
+        regular: 'h-8 gap-0.5 rounded-lg px-2 py-1 system-sm-regular',
+        large: 'h-9 gap-0.5 rounded-[10px] px-2.5 py-1 system-md-regular',
+      },
+    },
+    defaultVariants: {
+      size: 'regular',
+    },
+  },
+)
+
+const contentPadding: Record<string, string> = {
+  small: 'px-[3px] py-1',
+  regular: 'p-1',
+  large: 'px-1.5 py-1',
+}
+
 type SelectTriggerProps = React.ComponentPropsWithoutRef<typeof BaseSelect.Trigger> & {
   clearable?: boolean
   onClear?: () => void
   loading?: boolean
-}
+  destructive?: boolean
+} & VariantProps<typeof selectTriggerVariants>
 
 export function SelectTrigger({
   className,
   children,
+  size = 'regular',
   clearable = false,
   onClear,
   loading = false,
+  destructive = false,
+  disabled,
   ...props
 }: SelectTriggerProps) {
-  const showClear = clearable && !loading
+  const showClear = clearable && !loading && !destructive
+  const paddingClass = contentPadding[size ?? 'regular']
 
   return (
     <BaseSelect.Trigger
       className={cn(
-        'group relative flex h-8 w-full items-center rounded-lg border-0 bg-components-input-bg-normal px-2 text-left text-components-input-text-filled outline-none',
-        'hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt disabled:cursor-not-allowed disabled:opacity-50',
+        'group relative flex w-full items-center border-0 bg-components-input-bg-normal text-left text-components-input-text-filled outline-none',
+        'hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt',
+        selectTriggerVariants({ size }),
+        disabled && 'cursor-not-allowed bg-components-input-bg-disabled text-components-input-text-filled-disabled hover:bg-components-input-bg-disabled',
+        destructive && 'border border-components-input-border-destructive bg-components-input-bg-destructive shadow-xs hover:border-components-input-border-destructive hover:bg-components-input-bg-destructive',
         className,
       )}
+      disabled={disabled}
       {...props}
     >
-      <span className="grow truncate">{children}</span>
+      <span className={cn('grow truncate', paddingClass)}>
+        {children}
+      </span>
       {loading
         ? (
-            <span className="ml-1 shrink-0 text-text-quaternary">
+            <span className="shrink-0 text-text-quaternary">
               <span className="i-ri-loader-4-line h-3.5 w-3.5 animate-spin" />
             </span>
           )
-        : showClear
+        : destructive
           ? (
-              <span
-                role="button"
-                aria-label="Clear selection"
-                tabIndex={-1}
-                className="ml-1 shrink-0 cursor-pointer text-text-quaternary hover:text-text-secondary"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onClear?.()
-                }}
-                onMouseDown={(e) => {
-                  e.stopPropagation()
-                }}
-              >
-                <span className="i-ri-close-circle-fill h-3.5 w-3.5" />
+              <span className="shrink-0 text-text-destructive-secondary">
+                <span className="i-ri-error-warning-line h-4 w-4" />
               </span>
             )
-          : (
-              <BaseSelect.Icon className="ml-1 shrink-0 text-text-quaternary transition-colors group-hover:text-text-secondary data-[open]:text-text-secondary">
-                <span className="i-ri-arrow-down-s-line h-4 w-4" />
-              </BaseSelect.Icon>
-            )}
+          : showClear
+            ? (
+                <span
+                  role="button"
+                  aria-label="Clear selection"
+                  tabIndex={-1}
+                  className="shrink-0 cursor-pointer text-text-quaternary hover:text-text-secondary"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onClear?.()
+                  }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation()
+                  }}
+                >
+                  <span className="i-ri-close-circle-fill h-3.5 w-3.5" />
+                </span>
+              )
+            : (
+                <BaseSelect.Icon className="shrink-0 text-text-quaternary transition-colors group-hover:text-text-secondary data-[open]:text-text-secondary">
+                  <span className="i-ri-arrow-down-s-line h-4 w-4" />
+                </BaseSelect.Icon>
+              )}
     </BaseSelect.Trigger>
   )
 }

--- a/web/app/components/base/ui/select/index.tsx
+++ b/web/app/components/base/ui/select/index.tsx
@@ -51,63 +51,69 @@ export function SelectTrigger({
   onClear,
   loading = false,
   destructive = false,
-  disabled,
   ...props
 }: SelectTriggerProps) {
-  const showClear = clearable && !loading && !destructive
   const paddingClass = contentPadding[size ?? 'regular']
+
+  let trailingIcon: React.ReactNode = null
+  if (loading) {
+    trailingIcon = (
+      <span className="shrink-0 text-text-quaternary" aria-hidden="true">
+        <span className="i-ri-loader-4-line h-3.5 w-3.5 animate-spin" />
+      </span>
+    )
+  }
+  else if (destructive) {
+    trailingIcon = (
+      <span className="shrink-0 text-text-destructive-secondary" aria-hidden="true">
+        <span className="i-ri-error-warning-line h-4 w-4" />
+      </span>
+    )
+  }
+  else if (clearable) {
+    trailingIcon = (
+      <span
+        role="button"
+        aria-label="Clear selection"
+        tabIndex={-1}
+        className="shrink-0 cursor-pointer text-text-quaternary hover:text-text-secondary group-data-[disabled]:hidden group-data-[readonly]:hidden"
+        onClick={(e) => {
+          e.stopPropagation()
+          onClear?.()
+        }}
+        onMouseDown={e => e.stopPropagation()}
+      >
+        <span className="i-ri-close-circle-fill h-3.5 w-3.5" aria-hidden="true" />
+      </span>
+    )
+  }
+  else {
+    trailingIcon = (
+      <BaseSelect.Icon className="shrink-0 text-text-quaternary transition-colors group-hover:text-text-secondary data-[open]:text-text-secondary group-data-[readonly]:hidden">
+        <span className="i-ri-arrow-down-s-line h-4 w-4" aria-hidden="true" />
+      </BaseSelect.Icon>
+    )
+  }
 
   return (
     <BaseSelect.Trigger
       className={cn(
         'group relative flex w-full items-center border-0 bg-components-input-bg-normal text-left text-components-input-text-filled outline-none',
         'hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt',
+        'data-[placeholder]:text-components-input-text-placeholder',
         selectTriggerVariants({ size }),
-        disabled && 'cursor-not-allowed bg-components-input-bg-disabled text-components-input-text-filled-disabled hover:bg-components-input-bg-disabled',
+        'data-[readonly]:cursor-default data-[readonly]:bg-transparent data-[readonly]:hover:bg-transparent',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:bg-components-input-bg-disabled data-[disabled]:text-components-input-text-filled-disabled data-[disabled]:hover:bg-components-input-bg-disabled',
+        'data-[disabled]:data-[placeholder]:text-components-input-text-disabled',
         destructive && 'border border-components-input-border-destructive bg-components-input-bg-destructive shadow-xs hover:border-components-input-border-destructive hover:bg-components-input-bg-destructive',
         className,
       )}
-      disabled={disabled}
       {...props}
     >
-      <span className={cn('grow truncate', paddingClass)}>
+      <span className={cn('min-w-0 grow truncate', paddingClass)}>
         {children}
       </span>
-      {loading
-        ? (
-            <span className="shrink-0 text-text-quaternary">
-              <span className="i-ri-loader-4-line h-3.5 w-3.5 animate-spin" />
-            </span>
-          )
-        : destructive
-          ? (
-              <span className="shrink-0 text-text-destructive-secondary">
-                <span className="i-ri-error-warning-line h-4 w-4" />
-              </span>
-            )
-          : showClear
-            ? (
-                <span
-                  role="button"
-                  aria-label="Clear selection"
-                  tabIndex={-1}
-                  className="shrink-0 cursor-pointer text-text-quaternary hover:text-text-secondary"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onClear?.()
-                  }}
-                  onMouseDown={(e) => {
-                    e.stopPropagation()
-                  }}
-                >
-                  <span className="i-ri-close-circle-fill h-3.5 w-3.5" />
-                </span>
-              )
-            : (
-                <BaseSelect.Icon className="shrink-0 text-text-quaternary transition-colors group-hover:text-text-secondary data-[open]:text-text-secondary">
-                  <span className="i-ri-arrow-down-s-line h-4 w-4" />
-                </BaseSelect.Icon>
-              )}
+      {trailingIcon}
     </BaseSelect.Trigger>
   )
 }
@@ -193,11 +199,11 @@ export function SelectItem({
       )}
       {...props}
     >
-      <BaseSelect.ItemText className="mr-1 grow truncate px-1">
+      <BaseSelect.ItemText className="mr-1 min-w-0 grow truncate px-1">
         {children}
       </BaseSelect.ItemText>
       <BaseSelect.ItemIndicator className="flex shrink-0 items-center text-text-accent">
-        <span className="i-ri-check-line h-4 w-4" />
+        <span className="i-ri-check-line h-4 w-4" aria-hidden="true" />
       </BaseSelect.ItemIndicator>
     </BaseSelect.Item>
   )


### PR DESCRIPTION
## Summary
- Add CVA size variants (small/regular/large) with typography tokens aligned to Figma specs
- Replace JS boolean conditions with CSS data-attribute selectors (`data-[disabled]:`, `data-[readonly]:`, `data-[placeholder]:`) to leverage Base UI's native state management
- Add `destructive`, `loading`, and `clearable` trailing icon states with flat if-else logic
- Add `aria-hidden` on decorative icons and `min-w-0` for proper text truncation
- Add 22 unit tests covering size variants, state styling, accessibility, and interaction behavior

## Test plan
- [x] All 22 Select tests pass (`pnpm test`)
- [x] ESLint passes
- [x] TypeScript type-check passes
- [ ] Visual regression check on Select in Storybook or app