### PR TITLE
fix: prevent silent debug email loss when user_id is None or empty

### DIFF
--- a/api/dify_graph/nodes/human_input/entities.py
+++ b/api/dify_graph/nodes/human_input/entities.py
@@ -2,6 +2,7 @@
 Human Input node entities.
 """
 
+import logging
 import re
 import uuid
 from collections.abc import Mapping, Sequence
@@ -17,6 +18,8 @@ from dify_graph.runtime import VariablePool
 from dify_graph.variables.consts import SELECTORS_LENGTH
 
 from .enums import ButtonStyle, DeliveryMethodType, EmailRecipientType, FormInputType, PlaceholderType, TimeoutUnit
+
+logger = logging.getLogger(__name__)
 
 _OUTPUT_VARIABLE_PATTERN = re.compile(r"\{\{#\$output\.(?P<field_name>[a-zA-Z_][a-zA-Z0-9_]{0,29})#\}\}")
 
@@ -74,7 +77,7 @@ class EmailDeliveryConfig(BaseModel):
 
     def with_debug_recipient(self, user_id: str) -> "EmailDeliveryConfig":
         if not user_id:
-            raise ValueError("user_id must not be empty for debug email recipient")
+            raise AssertionError("user_id must not be empty for debug email recipient")
         debug_recipients = EmailRecipients(whole_workspace=False, items=[MemberRecipient(user_id=user_id)])
         return self.model_copy(update={"recipients": debug_recipients})
 
@@ -149,6 +152,7 @@ def apply_debug_email_recipient(
     if not method.config.debug_mode:
         return method
     if not user_id:
+        logger.warning("Debug email recipient skipped: user_id is None or empty")
         return method
     debug_config = method.config.with_debug_recipient(user_id)
     return method.model_copy(update={"config": debug_config})

--- a/api/dify_graph/nodes/human_input/entities.py
+++ b/api/dify_graph/nodes/human_input/entities.py
@@ -74,8 +74,10 @@ class EmailDeliveryConfig(BaseModel):
 
     def with_debug_recipient(self, user_id: str) -> "EmailDeliveryConfig":
         if not user_id:
-            debug_recipients = EmailRecipients(whole_workspace=False, items=[])
-            return self.model_copy(update={"recipients": debug_recipients})
+            raise ValueError(
+                "Cannot create debug email recipient: user_id is empty. "
+                "Ensure the user is authenticated before sending debug emails."
+            )
         debug_recipients = EmailRecipients(whole_workspace=False, items=[MemberRecipient(user_id=user_id)])
         return self.model_copy(update={"recipients": debug_recipients})
 
@@ -149,7 +151,9 @@ def apply_debug_email_recipient(
         return method
     if not method.config.debug_mode:
         return method
-    debug_config = method.config.with_debug_recipient(user_id or "")
+    if not user_id:
+        return method
+    debug_config = method.config.with_debug_recipient(user_id)
     return method.model_copy(update={"config": debug_config})
 
 

--- a/api/dify_graph/nodes/human_input/entities.py
+++ b/api/dify_graph/nodes/human_input/entities.py
@@ -74,10 +74,7 @@ class EmailDeliveryConfig(BaseModel):
 
     def with_debug_recipient(self, user_id: str) -> "EmailDeliveryConfig":
         if not user_id:
-            raise ValueError(
-                "Cannot create debug email recipient: user_id is empty. "
-                "Ensure the user is authenticated before sending debug emails."
-            )
+            raise ValueError("user_id must not be empty for debug email recipient")
         debug_recipients = EmailRecipients(whole_workspace=False, items=[MemberRecipient(user_id=user_id)])
         return self.model_copy(update={"recipients": debug_recipients})
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -952,7 +952,7 @@ class WorkflowService:
         delivery_method = apply_debug_email_recipient(
             delivery_method,
             enabled=True,
-            user_id=account.id or "",
+            user_id=account.id,
         )
 
         variable_pool = self._build_human_input_variable_pool(


### PR DESCRIPTION
## Summary

Fixes #33329

When `user_id` is `None`, the `or ""` pattern at call sites converts it to an empty string. `with_debug_recipient()` then treats `""` as falsy via `if not user_id:` and sets recipients to an empty list, **silently dropping all debug emails** with no error or warning.

### Changes

- **`with_debug_recipient()`**: Raise `ValueError` on empty `user_id` instead of silently creating empty recipients. This makes the contract explicit — callers must provide a valid user_id.
- **`apply_debug_email_recipient()`**: Guard against empty `user_id` before calling `with_debug_recipient()`. When `user_id` is empty, skip the debug transformation and return the original delivery method unchanged. Removed the `or ""` conversion.
- **`workflow_service.py`**: Remove unnecessary `account.id or ""` fallback that masked the empty value.

### Root cause

The `or ""` pattern at call sites and the `if not user_id:` check in `with_debug_recipient()` interact to create a silent failure:

```
user_id=None → or "" → "" → not "" is True → recipients=[] → email silently lost
```

### Affected call sites

| File | Line | Before | After |
|------|------|--------|-------|
| `entities.py` | 154 | `with_debug_recipient(user_id or "")` | `with_debug_recipient(user_id)` |
| `workflow_service.py` | 955 | `user_id=account.id or ""` | `user_id=account.id` |
| `human_input_node.py` | 183 | `user_id=dify_ctx.user_id` | (unchanged, already correct) |