### PR TITLE
fix: allow MCP tools to receive empty string parameters

### DIFF
--- a/api/core/tools/mcp_tool/tool.py
+++ b/api/core/tools/mcp_tool/tool.py
@@ -233,14 +233,12 @@ class MCPTool(Tool):
         )
 
     def _handle_none_parameter(self, parameter: dict[str, Any]) -> dict[str, Any]:
+        """Normalize MCP tool parameters by removing only explicit `None` values.
+
+        Empty strings and other falsy values (e.g. 0, False, empty lists) are valid
+        and should be preserved so that MCP tools can receive them as-is.
         """
-        in mcp tool invoke, if the parameter is empty, it will be set to None
-        """
-        return {
-            key: value
-            for key, value in parameter.items()
-            if value is not None and not (isinstance(value, str) and value.strip() == "")
-        }
+        return {key: value for key, value in parameter.items() if value is not None}
 
     def invoke_remote_mcp_tool(self, tool_parameters: dict[str, Any]) -> CallToolResult:
         headers = self.headers.copy() if self.headers else {}

--- a/api/tests/unit_tests/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/tools/test_mcp_tool.py
@@ -351,3 +351,29 @@ class TestMCPToolUsageExtraction:
             )
             if expected_total:
                 assert usage.total_tokens == expected_total
+
+
+class TestMCPToolHandleNoneParameter:
+    def test_handle_none_parameter_preserves_empty_and_falsy_values(self) -> None:
+        tool = _make_mcp_tool()
+        params = {
+            "normal": "value",
+            "empty_str": "",
+            "whitespace_str": "   ",
+            "none_value": None,
+            "zero_int": 0,
+            "zero_float": 0.0,
+            "false_bool": False,
+            "empty_list": [],
+        }
+
+        filtered = tool._handle_none_parameter(params)
+
+        assert "none_value" not in filtered
+        assert filtered["normal"] == "value"
+        assert filtered["empty_str"] == ""
+        assert filtered["whitespace_str"] == "   "
+        assert filtered["zero_int"] == 0
+        assert filtered["zero_float"] == 0.0
+        assert filtered["false_bool"] is False
+        assert filtered["empty_list"] == []


### PR DESCRIPTION
This change updates the MCP tool parameter normalization so that empty string values are preserved and only explicit `None` values are removed.

It also adds unit test coverage to ensure empty strings and other falsy values are passed through correctly.

Closes #33211.