### PR TITLE
fix: test_get_credentials_and_config_selects_plugin_id_and_key_api_ke…

### DIFF
--- a/api/tests/unit_tests/services/test_website_service.py
+++ b/api/tests/unit_tests/services/test_website_service.py
@@ -125,7 +125,7 @@ def test_get_credentials_and_config_selects_plugin_id_and_key_firecrawl(monkeypa
 @pytest.mark.parametrize(
     ("provider", "plugin_id"),
     [
-        ("watercrawl", "langgenius/watercrawl_datasource"),
+        ("watercrawl", "watercrawl/watercrawl_datasource"),
         ("jinareader", "langgenius/jina_datasource"),
     ],
 )


### PR DESCRIPTION
…y test failed

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #33360

modify code

```
        if provider == "firecrawl":
            plugin_id = "langgenius/firecrawl_datasource"
        elif provider == "watercrawl":
            plugin_id = "watercrawl/watercrawl_datasource"
        elif provider == "jinareader":
            plugin_id = "langgenius/jina_datasource"
```

but not modify test

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
