### PR TITLE
fix(api): allow punctuation in uploaded filenames

### DIFF
--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -58,8 +58,9 @@ class FileService:
         # get file extension
         extension = os.path.splitext(filename)[1].lstrip(".").lower()
 
-        # check if filename contains invalid characters
-        if any(c in filename for c in ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]):
+        # Only reject path separators here. The original filename is stored as metadata,
+        # while the storage key is UUID-based.
+        if any(c in filename for c in ["/", "\\"]):
             raise ValueError("Filename contains invalid characters")
 
         if len(filename) > 200:

--- a/api/tests/test_containers_integration_tests/services/test_file_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_file_service.py
@@ -263,6 +263,27 @@ class TestFileService:
                 user=account,
             )
 
+    def test_upload_file_allows_regular_punctuation_in_filename(
+        self, db_session_with_containers: Session, engine, mock_external_service_dependencies
+    ):
+        """
+        Test file upload allows punctuation that is safe when stored as metadata.
+        """
+        account = self._create_test_account(db_session_with_containers, mock_external_service_dependencies)
+
+        filename = 'candidate?resume for "dify"<final>|v2:.txt'
+        content = b"test content"
+        mimetype = "text/plain"
+
+        upload_file = FileService(engine).upload_file(
+            filename=filename,
+            content=content,
+            mimetype=mimetype,
+            user=account,
+        )
+
+        assert upload_file.name == filename
+
     def test_upload_file_filename_too_long(
         self, db_session_with_containers: Session, engine, mock_external_service_dependencies
     ):

--- a/api/tests/unit_tests/core/datasource/test_file_upload.py
+++ b/api/tests/unit_tests/core/datasource/test_file_upload.py
@@ -35,7 +35,7 @@ TEST COVERAGE OVERVIEW:
    - Tests hash consistency and determinism
 
 6. Invalid Filename Handling (TestInvalidFilenameHandling)
-   - Validates rejection of filenames with invalid characters (/, \\, :, *, ?, ", <, >, |)
+   - Validates rejection of filenames with path separators (/, \\)
    - Tests filename length truncation (max 200 characters)
    - Prevents path traversal attacks
    - Handles edge cases like empty filenames
@@ -535,30 +535,23 @@ class TestInvalidFilenameHandling:
 
     @pytest.mark.parametrize(
         "invalid_char",
-        ["/", "\\", ":", "*", "?", '"', "<", ">", "|"],
+        ["/", "\\"],
     )
     def test_filename_contains_invalid_characters(self, invalid_char):
         """Test detection of invalid characters in filename.
 
-        Security-critical test that validates rejection of dangerous filename characters.
+        Security-critical test that validates rejection of path separators.
         These characters are blocked because they:
         - / and \\ : Directory separators, could enable path traversal
-        - : : Drive letter separator on Windows, reserved character
-        - * and ? : Wildcards, could cause issues in file operations
-        - " : Quote character, could break command-line operations
-        - < and > : Redirection operators, command injection risk
-        - | : Pipe operator, command injection risk
 
         Blocking these characters prevents:
         - Path traversal attacks (../../etc/passwd)
-        - Command injection
-        - File system corruption
-        - Cross-platform compatibility issues
+        - ZIP entry traversal issues
+        - Ambiguous path handling
         """
         # Arrange - Create filename with invalid character
         filename = f"test{invalid_char}file.txt"
-        # Define complete list of invalid characters
-        invalid_chars = ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]
+        invalid_chars = ["/", "\\"]
 
         # Act - Check if filename contains any invalid character
         has_invalid_char = any(c in filename for c in invalid_chars)
@@ -570,12 +563,22 @@ class TestInvalidFilenameHandling:
         """Test that valid filenames pass validation."""
         # Arrange
         filename = "valid_file-name_123.txt"
-        invalid_chars = ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]
+        invalid_chars = ["/", "\\"]
 
         # Act
         has_invalid_char = any(c in filename for c in invalid_chars)
 
         # Assert
+        assert has_invalid_char is False
+
+    @pytest.mark.parametrize("safe_char", [":", "*", "?", '"', "<", ">", "|"])
+    def test_filename_allows_safe_metadata_characters(self, safe_char):
+        """Test that non-separator punctuation remains allowed in filenames."""
+        filename = f"candidate{safe_char}resume.txt"
+        invalid_chars = ["/", "\\"]
+
+        has_invalid_char = any(c in filename for c in invalid_chars)
+
         assert has_invalid_char is False
 
     def test_extremely_long_filename_truncation(self):
@@ -904,7 +907,7 @@ class TestFilenameValidation:
         """Test that filenames with spaces are handled correctly."""
         # Arrange
         filename = "my document with spaces.pdf"
-        invalid_chars = ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]
+        invalid_chars = ["/", "\\"]
 
         # Act - Check for invalid characters
         has_invalid = any(c in filename for c in invalid_chars)
@@ -921,7 +924,7 @@ class TestFilenameValidation:
             "مستند.txt",  # Arabic
             "ファイル.jpg",  # Japanese
         ]
-        invalid_chars = ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]
+        invalid_chars = ["/", "\\"]
 
         # Act & Assert - Unicode should be allowed
         for filename in unicode_filenames:


### PR DESCRIPTION
## Summary

- narrow upload filename validation to reject only path separators (`/` and `\`)
- keep UUID-based storage keys unchanged so punctuation-only filenames remain metadata-only
- add regression coverage for punctuation-heavy filenames and keep path traversal cases rejected

No linked issue. This PR is opened from a reproduced workflow/chatflow upload bug report.

## Screenshots

| Before | After |
|--------|-------|
| `POST /console/api/files/upload` could return `400 invalid_param` with `Filename contains invalid characters` for punctuation-heavy filenames such as `candidate?resume...pdf`. | The same filenames now pass upload validation; only path-like names containing `/` or `\` remain rejected. |

## Validation

- `uv run --directory api pytest -o addopts='' tests/unit_tests/core/datasource/test_file_upload.py -q`
  - Passed (`123 passed`)
- `uv run --directory api --group dev pytest -o addopts='' tests/test_containers_integration_tests/services/test_file_service.py -q -k "invalid_filename_characters or regular_punctuation"`
  - Blocked by environment: local Docker daemon unavailable (`docker.errors.DockerException: Error while fetching server API version: FileNotFoundError(2, "No such file or directory")`)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
