### PR TITLE
refactor: remove derived state from useEffect in verify-email and app-card

### DIFF
--- a/web/app/account/(commonLayout)/delete-account/components/verify-email.tsx
+++ b/web/app/account/(commonLayout)/delete-account/components/verify-email.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
@@ -18,13 +18,10 @@ export default function VerifyEmail(props: DeleteAccountProps) {
   const { t } = useTranslation()
   const emailToken = useAccountDeleteStore(state => state.sendEmailToken)
   const [verificationCode, setVerificationCode] = useState<string>()
-  const [shouldButtonDisabled, setShouldButtonDisabled] = useState(true)
   const { mutate: sendEmail } = useSendDeleteAccountEmail()
   const { isPending: isDeleting, mutateAsync: confirmDeleteAccount } = useConfirmDeleteAccount()
 
-  useEffect(() => {
-    setShouldButtonDisabled(!(verificationCode && CODE_EXP.test(verificationCode)) || isDeleting)
-  }, [verificationCode, isDeleting])
+  const shouldButtonDisabled = !(verificationCode && CODE_EXP.test(verificationCode)) || isDeleting
 
   const handleConfirm = useCallback(async () => {
     try {

--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -16,7 +16,7 @@ import {
 } from '@remixicon/react'
 import { usePathname, useRouter } from 'next/navigation'
 import * as React from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AppBasic from '@/app/components/app-sidebar/basic'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -160,18 +160,12 @@ function AppCard({
     }
   }
 
-  const [isAppAccessSet, setIsAppAccessSet] = useState(true)
-  useEffect(() => {
-    if (appDetail && appAccessSubjects) {
-      if (appDetail.access_mode === AccessMode.SPECIFIC_GROUPS_MEMBERS && appAccessSubjects.groups?.length === 0 && appAccessSubjects.members?.length === 0)
-        setIsAppAccessSet(false)
-      else
-        setIsAppAccessSet(true)
-    }
-    else {
-      setIsAppAccessSet(true)
-    }
-  }, [appAccessSubjects, appDetail])
+  const isAppAccessSet = !(
+    appDetail && appAccessSubjects
+    && appDetail.access_mode === AccessMode.SPECIFIC_GROUPS_MEMBERS
+    && appAccessSubjects.groups?.length === 0
+    && appAccessSubjects.members?.length === 0
+  )
 
   const handleClickAccessControl = useCallback(() => {
     if (!appDetail)

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -283,9 +283,6 @@
     }
   },
   "app/account/(commonLayout)/delete-account/components/verify-email.tsx": {
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 3
     }
@@ -1225,9 +1222,6 @@
   "app/components/app/overview/app-card.tsx": {
     "no-restricted-imports": {
       "count": 2
-    },
-    "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 3
     },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 8


### PR DESCRIPTION
## Summary

Replace `useState` + `useEffect` patterns with direct computation for values that are purely derived from other state/props, following [React's recommendation](https://react.dev/learn/you-might-not-need-an-effect).

Fixes #25194

## Changes

- **verify-email.tsx**: `shouldButtonDisabled` was computed inside `useEffect` from `verificationCode` and `isDeleting`. Replaced with a direct `const` computation since it's purely derived state.
- **overview/app-card.tsx**: `isAppAccessSet` was computed inside `useEffect` from `appDetail` and `appAccessSubjects`. Replaced with a direct `const` computation. Also removed the unused `useEffect` import.

## Rationale

Per the [eslint-react rule](https://eslint-react.xyz/docs/rules/hooks-extra-no-direct-set-state-in-use-effect) and [React docs](https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state), calling `useState` setters directly inside `useEffect` for derived values causes unnecessary re-renders and adds complexity. Direct computation is simpler and more efficient.

This is an incremental PR targeting the clearest derived-state cases. More cases can be addressed in follow-up PRs.

## Test plan

- All pre-commit checks pass (ESLint, TypeScript type-check, unit tests)
- The logic is equivalent: both values are computed from the same inputs with identical expressions