### PR TITLE
fix: use functional state update in handleConversationIdInfoChange to fix reset conversation

### DIFF
--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -149,7 +149,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     if (appId) {
       setConversationIdInfo((prev) => {
         const prevAppConversations = prev?.[appId || '']
-        const base = typeof prevAppConversations === 'object' && prevAppConversations
+        const base = (typeof prevAppConversations === 'object' && prevAppConversations)
           ? prevAppConversations
           : {}
         return {

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -148,13 +148,14 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
     if (appId) {
       setConversationIdInfo((prev) => {
-        let prevValue = prev?.[appId || '']
-        if (typeof prevValue === 'string')
-          prevValue = {}
+        const prevAppConversations = prev?.[appId || '']
+        const base = typeof prevAppConversations === 'object' && prevAppConversations
+          ? prevAppConversations
+          : {}
         return {
           ...prev,
           [appId || '']: {
-            ...prevValue,
+            ...base,
             [userId || 'DEFAULT']: changeConversationId,
           },
         }

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -147,18 +147,20 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   const currentConversationId = useMemo(() => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '', [appId, conversationIdInfo, userId])
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
     if (appId) {
-      let prevValue = conversationIdInfo?.[appId || '']
-      if (typeof prevValue === 'string')
-        prevValue = {}
-      setConversationIdInfo({
-        ...conversationIdInfo,
-        [appId || '']: {
-          ...prevValue,
-          [userId || 'DEFAULT']: changeConversationId,
-        },
+      setConversationIdInfo((prev) => {
+        let prevValue = prev?.[appId || '']
+        if (typeof prevValue === 'string')
+          prevValue = {}
+        return {
+          ...prev,
+          [appId || '']: {
+            ...prevValue,
+            [userId || 'DEFAULT']: changeConversationId,
+          },
+        }
       })
     }
-  }, [appId, conversationIdInfo, setConversationIdInfo, userId])
+  }, [appId, setConversationIdInfo, userId])
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {
     if (currentConversationId === newConversationId)

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -116,18 +116,20 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const currentConversationId = useMemo(() => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || conversationId || '', [appId, conversationIdInfo, userId, conversationId])
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
     if (appId) {
-      let prevValue = conversationIdInfo?.[appId || '']
-      if (typeof prevValue === 'string')
-        prevValue = {}
-      setConversationIdInfo({
-        ...conversationIdInfo,
-        [appId || '']: {
-          ...prevValue,
-          [userId || 'DEFAULT']: changeConversationId,
-        },
+      setConversationIdInfo((prev) => {
+        let prevValue = prev?.[appId || '']
+        if (typeof prevValue === 'string')
+          prevValue = {}
+        return {
+          ...prev,
+          [appId || '']: {
+            ...prevValue,
+            [userId || 'DEFAULT']: changeConversationId,
+          },
+        }
       })
     }
-  }, [appId, conversationIdInfo, setConversationIdInfo, userId])
+  }, [appId, setConversationIdInfo, userId])
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {
     if (currentConversationId === newConversationId)
@@ -369,7 +371,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     handleChangeConversation('')
     handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())
     setClearChatList(true)
-  }, [isTryApp, setShowNewConversationItemInList, handleNewConversationInputsChange, setClearChatList])
+  }, [isTryApp, setShowNewConversationItemInList, handleChangeConversation, handleNewConversationInputsChange, setClearChatList])
   const handleNewConversationCompleted = useCallback((newConversationId: string) => {
     setNewConversationId(newConversationId)
     handleConversationIdInfoChange(newConversationId)

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -118,7 +118,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     if (appId) {
       setConversationIdInfo((prev) => {
         const prevAppConversations = prev?.[appId || '']
-        const base = typeof prevAppConversations === 'object' && prevAppConversations
+        const base = (typeof prevAppConversations === 'object' && prevAppConversations)
           ? prevAppConversations
           : {}
         return {

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -117,13 +117,14 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
     if (appId) {
       setConversationIdInfo((prev) => {
-        let prevValue = prev?.[appId || '']
-        if (typeof prevValue === 'string')
-          prevValue = {}
+        const prevAppConversations = prev?.[appId || '']
+        const base = typeof prevAppConversations === 'object' && prevAppConversations
+          ? prevAppConversations
+          : {}
         return {
           ...prev,
           [appId || '']: {
-            ...prevValue,
+            ...base,
             [userId || 'DEFAULT']: changeConversationId,
           },
         }


### PR DESCRIPTION
## Summary

Fix the chatflow conversation reset button not properly clearing `conversationIdInfo`, causing new messages to be sent within the old conversation session.

Fixes #33362

## Root Cause

`handleConversationIdInfoChange` in both `chat-with-history/hooks.tsx` and `embedded-chatbot/hooks.tsx` captured `conversationIdInfo` from its closure and spread it when calling `setConversationIdInfo`. This caused stale state when the callback was invoked after `conversationIdInfo` had changed but before the callback was re-created by React.

Additionally, `handleChangeConversation` was missing from the dependency array of `handleNewConversation` in `embedded-chatbot/hooks.tsx`, creating another stale closure path.

## Changes

- Use functional update form `(prev) => ...` in `setConversationIdInfo` to always read the latest state (matching the pattern already used by `removeConversationIdInfo`)
- Remove `conversationIdInfo` from the dependency array since it's no longer captured in the closure
- Add missing `handleChangeConversation` to `handleNewConversation` deps in `embedded-chatbot/hooks.tsx`

## Test plan

- All 232 existing tests pass (64 chat-with-history + 168 embedded-chatbot)
- ESLint and TypeScript type-check pass
- The fix follows the same functional update pattern already used by `removeConversationIdInfo` in the same file