### PR TITLE
fix(web): restore folding for LLM think/output separation

### DIFF
--- a/web/app/components/base/markdown-blocks/__tests__/think-block.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/think-block.spec.tsx
@@ -74,6 +74,18 @@ describe('ThinkBlock', () => {
       expect(screen.getByText('Thinking content')).toBeInTheDocument()
     })
 
+    it('should render think block when dataThink is true', () => {
+      renderWithContext(
+        <ThinkBlock dataThink={true}>
+          <p>Thinking content</p>
+        </ThinkBlock>,
+        true,
+      )
+
+      expect(screen.getByText(/Thinking\.\.\./)).toBeInTheDocument()
+      expect(screen.getByText('Thinking content')).toBeInTheDocument()
+    })
+
     it('should render thought state when content has ENDTHINKFLAG', () => {
       renderWithContext(
         <ThinkBlock data-think={true}>

--- a/web/app/components/base/markdown-blocks/think-block.tsx
+++ b/web/app/components/base/markdown-blocks/think-block.tsx
@@ -72,13 +72,15 @@ const useThinkTimer = (children: any) => {
 
 type ThinkBlockProps = React.ComponentProps<'details'> & {
   'data-think'?: boolean
+  'dataThink'?: boolean
 }
 
 const ThinkBlock = ({ children, ...props }: ThinkBlockProps) => {
   const { elapsedTime, isComplete } = useThinkTimer(children)
   const displayContent = removeEndThink(children)
   const { t } = useTranslation()
-  const { 'data-think': isThink = false, className, open, ...rest } = props
+  const { 'data-think': dataThinkAttr, dataThink: dataThinkProp, className, open, ...rest } = props
+  const isThink = Boolean(dataThinkAttr ?? dataThinkProp)
 
   if (!isThink)
     return (<details {...props}>{children}</details>)

--- a/web/app/components/base/markdown/streamdown-wrapper.tsx
+++ b/web/app/components/base/markdown/streamdown-wrapper.tsx
@@ -55,7 +55,7 @@ const ALLOWED_TAGS: Record<string, string[]> = {
   input: ['type', 'name', 'value', 'placeholder', 'checked', 'dataTip', 'dataOptions'],
   textarea: ['name', 'placeholder', 'value'],
   label: ['htmlFor'],
-  details: ['dataThink'],
+  details: ['dataThink', 'data-think'],
   video: ['src'],
   audio: ['src'],
   source: ['src'],

--- a/web/app/components/base/markdown/streamdown-wrapper.tsx
+++ b/web/app/components/base/markdown/streamdown-wrapper.tsx
@@ -43,8 +43,9 @@ const mathPlugin = createMathPlugin({
 
 /**
  * Allowed HTML tags and their permitted data attributes for rehype-sanitize.
- * Keys = tag names to allow; values = attribute names in **hast** property format
- * (camelCase, e.g. `dataThink` for `data-think`).
+ * Keys = tag names to allow; values = attribute names used by the sanitize schema.
+ * Prefer **hast** property format (camelCase, e.g. `dataThink` for `data-think`),
+ * but include kebab-case variants when different parser paths can emit both forms.
  *
  * Prefer explicit attribute lists over wildcards (e.g. `data*`) to
  * minimise the attack surface when LLM-generated content is rendered.


### PR DESCRIPTION
Fixes #33356

## Summary

- restore separation/folding of LLM thinking content by handling both `data-think` and `dataThink` on `details`
- update `ThinkBlock` to treat either attribute form as a thinking block
- update markdown sanitize allow-list for `details` to preserve both attribute forms
- add a regression test covering `dataThink={true}` rendering path

## Root Cause

`preprocessThinkTag` emits `<details data-think=true>`, but in the markdown/render pipeline the attribute can be normalized to camelCase (`dataThink`). `ThinkBlock` previously only read `data-think`, so that path rendered plain `<details>` instead of the foldable think block UI.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
