### PR TITLE
refactor: remove dead STT error handlers from TTS endpoints

### DIFF
--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -134,14 +134,6 @@ class ChatMessageTextApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -129,14 +129,6 @@ class TextApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:


### PR DESCRIPTION
## Summary
Fixes #32982 - Remove dead code from text-to-speech (TTS) endpoints.

## Problem
The text-to-audio (TTS) endpoints in both service API and console API catch STT-specific exceptions that can never be raised:

| Exception | Why Dead |
|-----------|--------|
| `NoAudioUploadedServiceError` | TTS receives text, not audio upload |
| `AudioTooLargeServiceError` | Not applicable to TTS (no audio file) |
| `UnsupportedAudioTypeServiceError` | Not applicable to TTS (no audio file) |
| `ProviderNotSupportSpeechToTextServiceError` | TTS is synthesis, not recognition |

These handlers were likely copy-pasted from the audio-to-text (STT) endpoint.

## Solution
Remove the dead exception handlers from:
- `api/controllers/service_api/app/audio.py` - `TextApi.post()`
- `api/controllers/console/app/audio.py` - `ChatMessageTextApi.post()`

The audio-to-text (STT) endpoints retain these handlers as they are valid there.

## Changes
| File | Change |
|------|--------|
| `api/controllers/service_api/app/audio.py` | Removed 4 dead exception handlers |
| `api/controllers/console/app/audio.py` | Removed 4 dead exception handlers |

## Testing
- No functional change
- Dead code removal only
- CI should pass

Closes #32982