### PR TITLE
fix: add null check for weights before accessing keyword_weight

### DIFF
--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -115,6 +115,8 @@ const ConfigContent: FC<Props> = ({
   }
 
   const handleWeightedScoreChange = (value: { value: number[] }) => {
+    if (!datasetConfigs.weights)
+      return;
     const configs = {
       ...datasetConfigs,
       weights: {
@@ -304,13 +306,13 @@ const ConfigContent: FC<Props> = ({
           }
           {
             showWeightedScorePanel
-            && (
+            && datasetConfigs.weights && (
               <div className="mt-2 space-y-4">
                 <WeightedScore
                   value={{
                     value: [
-                      datasetConfigs.weights!.vector_setting.vector_weight,
-                      datasetConfigs.weights!.keyword_setting.keyword_weight,
+                      datasetConfigs.weights.vector_setting.vector_weight,
+                      datasetConfigs.weights.keyword_setting.keyword_weight,
                     ],
                   }}
                   onChange={handleWeightedScoreChange}


### PR DESCRIPTION
## Summary

Fixes #33405 - TypeError when weight config is incomplete (null weights).

### Changes
- Adds null check for `weights` before accessing `keyword_weight` in `config-content.tsx`
- Adds null check for `weights` in `retrieval-param-config/index.tsx`
- Removes unnecessary non-null assertion operators (`!`) that could cause runtime errors

### Root Cause
When the weight configuration is incomplete, `weights` can be null. The code was using non-null assertion operators (`!`) assuming weights would always be present, causing a TypeError when accessing nested properties.

### Testing
- Code compiles without errors
- Logic change maintains existing behavior when weights is present