### PR TITLE
fix: use parameterized queries to prevent SQL injection in vector stores

### DIFF
--- a/api/core/rag/datasource/vdb/pgvecto_rs/pgvecto_rs.py
+++ b/api/core/rag/datasource/vdb/pgvecto_rs/pgvecto_rs.py
@@ -135,9 +135,7 @@ class PGVectoRS(BaseVector):
     def get_ids_by_metadata_field(self, key: str, value: str):
         result = None
         with Session(self._client) as session:
-            select_statement = sql_text(
-                f"SELECT id FROM {self._collection_name} WHERE meta->>:key = :value"
-            )
+            select_statement = sql_text(f"SELECT id FROM {self._collection_name} WHERE meta->>:key = :value")
             result = session.execute(select_statement, {"key": key, "value": value}).fetchall()
         if result:
             return [item[0] for item in result]

--- a/api/core/rag/datasource/vdb/pgvecto_rs/pgvecto_rs.py
+++ b/api/core/rag/datasource/vdb/pgvecto_rs/pgvecto_rs.py
@@ -135,8 +135,10 @@ class PGVectoRS(BaseVector):
     def get_ids_by_metadata_field(self, key: str, value: str):
         result = None
         with Session(self._client) as session:
-            select_statement = sql_text(f"SELECT id FROM {self._collection_name} WHERE meta->>'{key}' = '{value}'; ")
-            result = session.execute(select_statement).fetchall()
+            select_statement = sql_text(
+                f"SELECT id FROM {self._collection_name} WHERE meta->>:key = :value"
+            )
+            result = session.execute(select_statement, {"key": key, "value": value}).fetchall()
         if result:
             return [item[0] for item in result]
         else:
@@ -172,9 +174,9 @@ class PGVectoRS(BaseVector):
     def text_exists(self, id: str) -> bool:
         with Session(self._client) as session:
             select_statement = sql_text(
-                f"SELECT id FROM {self._collection_name} WHERE meta->>'doc_id' = '{id}' limit 1; "
+                f"SELECT id FROM {self._collection_name} WHERE meta->>'doc_id' = :doc_id limit 1"
             )
-            result = session.execute(select_statement).fetchall()
+            result = session.execute(select_statement, {"doc_id": id}).fetchall()
         return len(result) > 0
 
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/core/rag/datasource/vdb/relyt/relyt_vector.py
+++ b/api/core/rag/datasource/vdb/relyt/relyt_vector.py
@@ -155,9 +155,9 @@ class RelytVector(BaseVector):
         result = None
         with Session(self.client) as session:
             select_statement = sql_text(
-                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>'{key}' = '{value}'; """
+                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>:key = :value"""
             )
-            result = session.execute(select_statement).fetchall()
+            result = session.execute(select_statement, {"key": key, "value": value}).fetchall()
         if result:
             return [item[0] for item in result]
         else:
@@ -201,11 +201,10 @@ class RelytVector(BaseVector):
 
     def delete_by_ids(self, ids: list[str]):
         with Session(self.client) as session:
-            ids_str = ",".join(f"'{doc_id}'" for doc_id in ids)
             select_statement = sql_text(
-                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>'doc_id' in ({ids_str}); """
+                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>'doc_id' = ANY(:doc_ids)"""
             )
-            result = session.execute(select_statement).fetchall()
+            result = session.execute(select_statement, {"doc_ids": ids}).fetchall()
         if result:
             ids = [item[0] for item in result]
             self.delete_by_uuids(ids)
@@ -218,9 +217,9 @@ class RelytVector(BaseVector):
     def text_exists(self, id: str) -> bool:
         with Session(self.client) as session:
             select_statement = sql_text(
-                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>'doc_id' = '{id}' limit 1; """
+                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>'doc_id' = :doc_id limit 1"""
             )
-            result = session.execute(select_statement).fetchall()
+            result = session.execute(select_statement, {"doc_id": id}).fetchall()
         return len(result) > 0
 
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/core/rag/datasource/vdb/relyt/relyt_vector.py
+++ b/api/core/rag/datasource/vdb/relyt/relyt_vector.py
@@ -154,9 +154,7 @@ class RelytVector(BaseVector):
     def get_ids_by_metadata_field(self, key: str, value: str):
         result = None
         with Session(self.client) as session:
-            select_statement = sql_text(
-                f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>:key = :value"""
-            )
+            select_statement = sql_text(f"""SELECT id FROM "{self._collection_name}" WHERE metadata->>:key = :value""")
             result = session.execute(select_statement, {"key": key, "value": value}).fetchall()
         if result:
             return [item[0] for item in result]


### PR DESCRIPTION
## Summary
- Replace f-string SQL interpolation with SQLAlchemy `text()` bind parameters in `pgvecto_rs.py` and `relyt_vector.py` to prevent SQL injection
- Fix `get_ids_by_metadata_field()` and `text_exists()` in both files, plus `delete_by_ids()` in relyt
- User-controlled `key`, `value`, and `id` parameters are now safely parameterized

## Changes
- **`pgvecto_rs.py`**: Parameterized `key` and `value` in `get_ids_by_metadata_field()`; parameterized `id` in `text_exists()`
- **`relyt_vector.py`**: Parameterized `key` and `value` in `get_ids_by_metadata_field()`; replaced manual string-joined `ids_str` with `ANY(:doc_ids)` in `delete_by_ids()`; parameterized `id` in `text_exists()`

Closes #33420