### PR TITLE
fix: preserve custom icons in exported DSL

### DIFF
--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -556,8 +556,11 @@ class AppDslService:
             "app": {
                 "name": app_model.name,
                 "mode": app_model.mode.value if isinstance(app_model.mode, AppMode) else app_model.mode,
-                "icon": app_model.icon if app_model.icon_type == "image" else "🤖",
-                "icon_background": "#FFEAD5" if app_model.icon_type == "image" else app_model.icon_background,
+                "icon": app_model.icon,
+                "icon_type": (
+                    app_model.icon_type.value if isinstance(app_model.icon_type, IconType) else app_model.icon_type
+                ),
+                "icon_background": app_model.icon_background,
                 "description": app_model.description,
                 "use_icon_as_answer_icon": app_model.use_icon_as_answer_icon,
             },

--- a/api/tests/unit_tests/services/test_app_dsl_service.py
+++ b/api/tests/unit_tests/services/test_app_dsl_service.py
@@ -672,6 +672,44 @@ def test_export_dsl_delegates_by_mode(monkeypatch):
     assert model_calls == [True]
 
 
+def test_export_dsl_preserves_icon_and_icon_type(monkeypatch):
+    monkeypatch.setattr(AppDslService, "_append_workflow_export_data", lambda **_kwargs: None)
+
+    emoji_app = SimpleNamespace(
+        mode=AppMode.WORKFLOW.value,
+        tenant_id="tenant-1",
+        name="Emoji App",
+        icon="🎨",
+        icon_type=IconType.EMOJI,
+        icon_background="#FF5733",
+        description="App with emoji icon",
+        use_icon_as_answer_icon=True,
+        app_model_config=None,
+    )
+    yaml_output = AppDslService.export_dsl(emoji_app)
+    data = yaml.safe_load(yaml_output)
+    assert data["app"]["icon"] == "🎨"
+    assert data["app"]["icon_type"] == "emoji"
+    assert data["app"]["icon_background"] == "#FF5733"
+
+    image_app = SimpleNamespace(
+        mode=AppMode.WORKFLOW.value,
+        tenant_id="tenant-1",
+        name="Image App",
+        icon="https://example.com/icon.png",
+        icon_type=IconType.IMAGE,
+        icon_background="#FFEAD5",
+        description="App with image icon",
+        use_icon_as_answer_icon=False,
+        app_model_config=None,
+    )
+    yaml_output = AppDslService.export_dsl(image_app)
+    data = yaml.safe_load(yaml_output)
+    assert data["app"]["icon"] == "https://example.com/icon.png"
+    assert data["app"]["icon_type"] == "image"
+    assert data["app"]["icon_background"] == "#FFEAD5"
+
+
 def test_append_workflow_export_data_filters_and_overrides(monkeypatch):
     workflow_dict = {
         "graph": {


### PR DESCRIPTION
## Summary
Fixes #33409

This PR fixes a bug where custom emoji icons were being replaced with the default robot emoji (🤖) when exporting workflow DSL, and the `icon_type` field was not being included in the export.

## Root Cause
The `export_dsl` method in `api/services/app_dsl_service.py` had inverted conditional logic:
```python
"icon": app_model.icon if app_model.icon_type == "image" else "🤖",
```
This meant that only image icons were preserved, while emoji and link icons were replaced with 🤖.

## Changes
- Remove conditional logic that replaced non-image icons with 🤖
- Export actual icon value for all icon types (emoji, image, link)
- Add `icon_type` field to exported DSL for proper import
- Convert `icon_type` enum to string value for YAML serialization
- Add comprehensive test to verify icon and icon_type preservation

## Test Plan
- Added `test_export_dsl_preserves_icon_and_icon_type` to verify both emoji and image icons are preserved
- All existing 53 tests in `test_app_dsl_service.py` pass
- Tested export → import cycle to ensure icons are correctly restored

## Related Issues
- #27976 - Non-Image Type Icons Incorrectly Replaced with Default Emoji
- #26301 - Custom icons lost after upgrade to 1.9.0
- #12732 - Custom image icons not working in copied apps