### PR TITLE
fix: downgrade image download failure log from ERROR to WARNING

### DIFF
--- a/api/core/rag/index_processor/index_processor_base.py
+++ b/api/core/rag/index_processor/index_processor_base.py
@@ -294,7 +294,7 @@ class BaseIndexProcessor(ABC):
             logging.warning("Error downloading image from %s: %s", image_url, str(e))
             return None
         except Exception:
-            logging.exception("Unexpected error downloading image from %s", image_url)
+            logging.warning("Unexpected error downloading image from %s", image_url, exc_info=True)
             return None
 
     def _download_tool_file(self, tool_file_id: str, current_user: Account) -> str | None:


### PR DESCRIPTION
## Summary

During website crawl document indexing, external image download failures are logged with `logging.exception()`, which logs at **ERROR** level with a full traceback. Since these failures are non-critical (the main crawl/index flow continues normally), this creates unnecessary noise in production monitoring and can trigger false alerts.

## Changes

Replace `logging.exception()` with `logging.warning(exc_info=True)` in the catch-all exception handler of `_download_image()`. This:

- Downgrades the log level from ERROR to WARNING
- Retains the full traceback via `exc_info=True` for debugging
- Aligns with the existing pattern in the same method (other exception handlers already use `logging.warning()`)

## Related Issue

Fixes #33412