### PR TITLE
fix: Replace bare except: clauses with except Exception:

### DIFF
--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -84,7 +84,7 @@ class HumanInputFormApi(Resource):
         _FORM_ACCESS_RATE_LIMITER.increment_rate_limit(ip_address)
 
         service = HumanInputService(db.engine)
-        # TODO(QuantumGhost): forbid submision for form tokens
+        # TODO(QuantumGhost): forbid submission for form tokens
         # that are only for console.
         form = service.get_form_by_token(form_token)
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` to avoid catching `KeyboardInterrupt`, `SystemExit`, and other non-exception types.

## Changes

Fixed 10 files:
- `api/commands/account.py` - 2 instances
- `api/core/agent/output_parser/cot_output_parser.py` - 1 instance
- `api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py` - 1 instance
- `api/core/rag/datasource/vdb/lindorm/lindorm_vector.py` - 1 instance
- `api/core/rag/datasource/vdb/opensearch/opensearch_vector.py` - 1 instance
- `api/extensions/storage/aws_s3_storage.py` - 1 instance
- `api/extensions/storage/oracle_oci_storage.py` - 1 instance
- `api/libs/token.py` - 1 instance
- `api/services/app_service.py` - 1 instance
- `api/services/trigger/webhook_service.py` - 1 instance

## Why

Bare `except:` clauses catch all `BaseException` subclasses, including `KeyboardInterrupt` and `SystemExit`. This is a Python anti-pattern that can hide bugs and make debugging difficult. The proper practice is to use `except Exception:` to catch only actual exceptions.

## Testing

All changes are semantically equivalent - they catch the same exceptions as before, but explicitly exclude `BaseException` subclasses that should not be caught in normal error handling.