### PR TITLE
refactor(tests): use enum values instead of string literals for status fields

### DIFF
--- a/api/tests/test_containers_integration_tests/core/rag/pipeline/test_queue_integration.py
+++ b/api/tests/test_containers_integration_tests/core/rag/pipeline/test_queue_integration.py
@@ -18,7 +18,7 @@ from faker import Faker
 
 from core.rag.pipeline.queue import TaskWrapper, TenantIsolatedTaskQueue
 from extensions.ext_redis import redis_client
-from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models import Account, AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 
 
 @dataclass
@@ -47,7 +47,7 @@ class TestTenantIsolatedTaskQueueIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -55,7 +55,7 @@ class TestTenantIsolatedTaskQueueIntegration:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -101,7 +101,7 @@ class TestTenantIsolatedTaskQueueIntegration:
         # Create second tenant
         tenant2 = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant2)
         db_session_with_containers.commit()
@@ -410,7 +410,7 @@ class TestTenantIsolatedTaskQueueCompatibility:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -418,7 +418,7 @@ class TestTenantIsolatedTaskQueueCompatibility:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()


### PR DESCRIPTION
## Summary
Replace string literals (`"active"`, `"normal"`) with proper enum values (`AccountStatus.ACTIVE`, `TenantStatus.NORMAL`) in `test_queue_integration.py` to resolve type checker errors.

## Issue
Fixes part of #33439

## Changes
- Added `AccountStatus` and `TenantStatus` imports from `models`
- Replaced `status="active"` with `status=AccountStatus.ACTIVE` (lines 50, 413)
- Replaced `status="normal"` with `status=TenantStatus.NORMAL` (lines 58, 104, 421)

## Testing
- The enums are `StrEnum` types, so the runtime behavior is identical — the enum values are the same strings
- This only affects type checker satisfaction, no functional change