### PR TITLE
refactor: replace remaining sa.String with EnumText 2

### DIFF
--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -1,5 +1,4 @@
 import json
-from enum import StrEnum
 
 from flask_restx import Resource, marshal_with
 from pydantic import BaseModel, Field
@@ -11,17 +10,13 @@ from controllers.console.wraps import account_initialization_required, edit_perm
 from extensions.ext_database import db
 from fields.app_fields import app_server_fields
 from libs.login import current_account_with_tenant, login_required
+from models.enums import AppMCPServerStatus
 from models.model import AppMCPServer
 
 DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
 
 # Register model for flask_restx to avoid dict type issues in Swagger
 app_server_model = console_ns.model("AppServer", app_server_fields)
-
-
-class AppMCPServerStatus(StrEnum):
-    ACTIVE = "active"
-    INACTIVE = "inactive"
 
 
 class MCPServerCreatePayload(BaseModel):
@@ -117,9 +112,10 @@ class AppMCPServerController(Resource):
 
         server.parameters = json.dumps(payload.parameters, ensure_ascii=False)
         if payload.status:
-            if payload.status not in [status.value for status in AppMCPServerStatus]:
+            try:
+                server.status = AppMCPServerStatus(payload.status)
+            except ValueError:
                 raise ValueError("Invalid status")
-            server.status = payload.status
         db.session.commit()
         return server
 

--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -43,7 +43,7 @@ from libs.datetime_utils import naive_utc_now
 from libs.helper import EmailStr, TimestampField, extract_remote_ip, timezone
 from libs.login import current_account_with_tenant, login_required
 from models import AccountIntegrate, InvitationCode
-from models.account import AccountStatus
+from models.account import AccountStatus, InvitationCodeStatus
 from services.account_service import AccountService
 from services.billing_service import BillingService
 from services.errors.account import CurrentPasswordIncorrectError as ServiceCurrentPasswordIncorrectError
@@ -216,7 +216,7 @@ class AccountInitApi(Resource):
                 db.session.query(InvitationCode)
                 .where(
                     InvitationCode.code == args.invitation_code,
-                    InvitationCode.status == "unused",
+                    InvitationCode.status == InvitationCodeStatus.UNUSED,
                 )
                 .first()
             )
@@ -224,7 +224,7 @@ class AccountInitApi(Resource):
             if not invitation_code:
                 raise InvalidInvitationCodeError()
 
-            invitation_code.status = "used"
+            invitation_code.status = InvitationCodeStatus.USED
             invitation_code.used_at = naive_utc_now()
             invitation_code.used_by_tenant_id = account.current_tenant_id
             invitation_code.used_by_account_id = account.id

--- a/api/controllers/mcp/mcp.py
+++ b/api/controllers/mcp/mcp.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.orm import Session
 
 from controllers.common.schema import register_schema_model
-from controllers.console.app.mcp_server import AppMCPServerStatus
 from controllers.mcp import mcp_ns
 from core.mcp import types as mcp_types
 from core.mcp.server.streamable_http import handle_mcp_request
 from dify_graph.variables.input_entities import VariableEntity
 from extensions.ext_database import db
 from libs import helper
+from models.enums import AppMCPServerStatus
 from models.model import App, AppMCPServer, AppMode, EndUser
 
 

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -323,6 +323,11 @@ class AccountIntegrate(TypeBase):
     )
 
 
+class InvitationCodeStatus(enum.StrEnum):
+    UNUSED = "unused"
+    USED = "used"
+
+
 class InvitationCode(TypeBase):
     __tablename__ = "invitation_codes"
     __table_args__ = (
@@ -334,7 +339,11 @@ class InvitationCode(TypeBase):
     id: Mapped[int] = mapped_column(sa.Integer, init=False)
     batch: Mapped[str] = mapped_column(String(255))
     code: Mapped[str] = mapped_column(String(32))
-    status: Mapped[str] = mapped_column(String(16), server_default=sa.text("'unused'"), default="unused")
+    status: Mapped[InvitationCodeStatus] = mapped_column(
+        EnumText(InvitationCodeStatus, length=16),
+        server_default=sa.text("'unused'"),
+        default=InvitationCodeStatus.UNUSED,
+    )
     used_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
     used_by_tenant_id: Mapped[str | None] = mapped_column(StringUUID, default=None)
     used_by_account_id: Mapped[str | None] = mapped_column(StringUUID, default=None)
@@ -366,10 +375,13 @@ class TenantPluginPermission(TypeBase):
     )
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     install_permission: Mapped[InstallPermission] = mapped_column(
-        String(16), nullable=False, server_default="everyone", default=InstallPermission.EVERYONE
+        EnumText(InstallPermission, length=16),
+        nullable=False,
+        server_default="everyone",
+        default=InstallPermission.EVERYONE,
     )
     debug_permission: Mapped[DebugPermission] = mapped_column(
-        String(16), nullable=False, server_default="noone", default=DebugPermission.NOBODY
+        EnumText(DebugPermission, length=16), nullable=False, server_default="noone", default=DebugPermission.NOBODY
     )
 
 
@@ -395,10 +407,13 @@ class TenantPluginAutoUpgradeStrategy(TypeBase):
     )
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     strategy_setting: Mapped[StrategySetting] = mapped_column(
-        String(16), nullable=False, server_default="fix_only", default=StrategySetting.FIX_ONLY
+        EnumText(StrategySetting, length=16),
+        nullable=False,
+        server_default="fix_only",
+        default=StrategySetting.FIX_ONLY,
     )
     upgrade_mode: Mapped[UpgradeMode] = mapped_column(
-        String(16), nullable=False, server_default="exclude", default=UpgradeMode.EXCLUDE
+        EnumText(UpgradeMode, length=16), nullable=False, server_default="exclude", default=UpgradeMode.EXCLUDE
     )
     exclude_plugins: Mapped[list[str]] = mapped_column(sa.JSON, nullable=False, default_factory=list)
     include_plugins: Mapped[list[str]] = mapped_column(sa.JSON, nullable=False, default_factory=list)

--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -72,3 +72,23 @@ class AppTriggerType(StrEnum):
 
     # for backward compatibility
     UNKNOWN = "unknown"
+
+
+class AppStatus(StrEnum):
+    """App Status Enum"""
+
+    NORMAL = "normal"
+
+
+class AppMCPServerStatus(StrEnum):
+    """AppMCPServer Status Enum"""
+
+    NORMAL = "normal"
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class ConversationStatus(StrEnum):
+    """Conversation Status Enum"""
+
+    NORMAL = "normal"

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -29,7 +29,7 @@ from libs.uuid_utils import uuidv7
 from .account import Account, Tenant
 from .base import Base, TypeBase, gen_uuidv4_string
 from .engine import db
-from .enums import CreatorUserRole, MessageStatus
+from .enums import AppMCPServerStatus, AppStatus, ConversationStatus, CreatorUserRole, MessageStatus
 from .provider_ids import GenericProviderID
 from .types import EnumText, LongText, StringUUID
 
@@ -343,7 +343,9 @@ class App(Base):
     icon_background: Mapped[str | None] = mapped_column(String(255))
     app_model_config_id = mapped_column(StringUUID, nullable=True)
     workflow_id = mapped_column(StringUUID, nullable=True)
-    status: Mapped[str] = mapped_column(String(255), server_default=sa.text("'normal'"))
+    status: Mapped[AppStatus] = mapped_column(
+        EnumText(AppStatus, length=255), server_default=sa.text("'normal'"), default=AppStatus.NORMAL
+    )
     enable_site: Mapped[bool] = mapped_column(sa.Boolean)
     enable_api: Mapped[bool] = mapped_column(sa.Boolean)
     api_rpm: Mapped[int] = mapped_column(sa.Integer, server_default=sa.text("0"))
@@ -1007,7 +1009,9 @@ class Conversation(Base):
     introduction = mapped_column(LongText)
     system_instruction = mapped_column(LongText)
     system_instruction_tokens: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("0"))
-    status: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[ConversationStatus] = mapped_column(
+        EnumText(ConversationStatus, length=255), nullable=False, default=ConversationStatus.NORMAL
+    )
 
     # The `invoke_from` records how the conversation is created.
     #
@@ -1771,7 +1775,9 @@ class MessageFile(TypeBase):
     )
     message_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     type: Mapped[str] = mapped_column(String(255), nullable=False)
-    transfer_method: Mapped[FileTransferMethod] = mapped_column(String(255), nullable=False)
+    transfer_method: Mapped[FileTransferMethod] = mapped_column(
+        EnumText(FileTransferMethod, length=255), nullable=False
+    )
     created_by_role: Mapped[CreatorUserRole] = mapped_column(EnumText(CreatorUserRole, length=255), nullable=False)
     created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
     belongs_to: Mapped[Literal["user", "assistant"] | None] = mapped_column(String(255), nullable=True, default=None)
@@ -1981,7 +1987,9 @@ class AppMCPServer(TypeBase):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(String(255), nullable=False)
     server_code: Mapped[str] = mapped_column(String(255), nullable=False)
-    status: Mapped[str] = mapped_column(String(255), nullable=False, server_default=sa.text("'normal'"))
+    status: Mapped[AppMCPServerStatus] = mapped_column(
+        EnumText(AppMCPServerStatus, length=255), nullable=False, server_default=sa.text("'normal'")
+    )
     parameters: Mapped[str] = mapped_column(LongText, nullable=False)
 
     created_at: Mapped[datetime] = mapped_column(
@@ -2035,7 +2043,9 @@ class Site(Base):
     customize_domain = mapped_column(String(255))
     customize_token_strategy: Mapped[str] = mapped_column(String(255), nullable=False)
     prompt_public: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    status = mapped_column(String(255), nullable=False, server_default=sa.text("'normal'"))
+    status: Mapped[AppStatus] = mapped_column(
+        EnumText(AppStatus, length=255), nullable=False, server_default=sa.text("'normal'"), default=AppStatus.NORMAL
+    )
     created_by = mapped_column(StringUUID, nullable=True)
     created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
     updated_by = mapped_column(StringUUID, nullable=True)


### PR DESCRIPTION
Summary
- Replace `String(...)` with `EnumText(...)` in `mapped_column()` for all remaining columns that hold enum values, completing the work from #33332
- Create new `StrEnum` classes for columns that lacked them: `AppStatus`, `ConversationStatus`, `AppMCPServerStatus`, `InvitationCodeStatus`
- Move `AppMCPServerStatus` from controller to `models/enums.py` for proper layering
- Update controllers to use enum values instead of string literals

## Changes

**New enums** (`models/enums.py`, `models/account.py`):
- `AppStatus` — `App.status`, `Site.status`
- `ConversationStatus` — `Conversation.status`
- `AppMCPServerStatus` — `AppMCPServer.status` (moved from `controllers/console/app/mcp_server.py`)
- `InvitationCodeStatus` — `InvitationCode.status`

**Columns fixed** (10 total):
- `account.py`: `InvitationCode.status`, `TenantPluginPermission.install_permission`, `.debug_permission`, `TenantPluginAutoUpgradeStrategy.strategy_setting`, `.upgrade_mode`
- `model.py`: `App.status`, `Conversation.status`, `AppMCPServer.status`, `Site.status`, `MessageFile.transfer_method`

**Controller updates**:
- `controllers/console/app/mcp_server.py` — import `AppMCPServerStatus` from `models.enums`, use type-safe assignment
- `controllers/mcp/mcp.py` — update import path
- `controllers/console/workspace/account.py` — use `InvitationCodeStatus` enum values

No database migrations needed — `EnumText` stores values as VARCHAR internally.

Closes #33294