### PR TITLE
fix(agent): accumulate llm usage across agent rounds

### DIFF
--- a/api/dify_graph/nodes/agent/agent_node.py
+++ b/api/dify_graph/nodes/agent/agent_node.py
@@ -583,15 +583,15 @@ class AgentNode(Node[AgentNodeData]):
                 if node_type == NodeType.AGENT:
                     if isinstance(message.message.json_object, dict):
                         msg_metadata: dict[str, Any] = message.message.json_object.pop("execution_metadata", {})
-                        llm_usage = LLMUsage.from_metadata(cast(LLMUsageMetadata, msg_metadata))
+                        new_usage = LLMUsage.from_metadata(cast(LLMUsageMetadata, msg_metadata))
+                        if new_usage.total_tokens > 0:
+                            llm_usage = llm_usage.plus(new_usage)
                         agent_execution_metadata = {
                             WorkflowNodeExecutionMetadataKey(key): value
                             for key, value in msg_metadata.items()
                             if key in WorkflowNodeExecutionMetadataKey.__members__.values()
                         }
                     else:
-                        msg_metadata = {}
-                        llm_usage = LLMUsage.empty_usage()
                         agent_execution_metadata = {}
                 if message.message.json_object:
                     json_list.append(message.message.json_object)

--- a/api/dify_graph/nodes/agent/agent_node.py
+++ b/api/dify_graph/nodes/agent/agent_node.py
@@ -583,8 +583,8 @@ class AgentNode(Node[AgentNodeData]):
                 if node_type == NodeType.AGENT:
                     if isinstance(message.message.json_object, dict):
                         msg_metadata: dict[str, Any] = message.message.json_object.pop("execution_metadata", {})
-                        new_usage = LLMUsage.from_metadata(cast(LLMUsageMetadata, msg_metadata))
-                        if new_usage.total_tokens > 0:
+                        if msg_metadata:
+                            new_usage = LLMUsage.from_metadata(cast(LLMUsageMetadata, msg_metadata))
                             llm_usage = llm_usage.plus(new_usage)
                         agent_execution_metadata = {
                             WorkflowNodeExecutionMetadataKey(key): value

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_agent_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_agent_node.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.utils.message_transformer import ToolFileMessageTransformer
+from dify_graph.enums import NodeType
+from dify_graph.model_runtime.entities.llm_entities import LLMUsage, LLMUsageMetadata
+from dify_graph.model_runtime.utils.encoders import jsonable_encoder
+from dify_graph.node_events import NodeRunResult, StreamCompletedEvent
+from dify_graph.nodes.agent.agent_node import AgentNode
+from dify_graph.runtime import GraphRuntimeState, VariablePool
+from dify_graph.system_variable import SystemVariable
+from tests.workflow_test_utils import build_test_graph_init_params
+
+
+@pytest.fixture
+def agent_node() -> AgentNode:
+    graph_config: dict[str, Any] = {
+        "nodes": [
+            {
+                "id": "agent-node",
+                "data": {
+                    "type": "agent",
+                    "title": "Agent",
+                    "desc": "",
+                    "agent_strategy_provider_name": "provider/plugin",
+                    "agent_strategy_name": "test-agent",
+                    "agent_strategy_label": "Test Agent",
+                    "agent_parameters": {},
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+    init_params = build_test_graph_init_params(
+        workflow_id="workflow-id",
+        graph_config=graph_config,
+        tenant_id="tenant-id",
+        app_id="app-id",
+        user_id="user-id",
+        user_from="account",
+        invoke_from="debugger",
+        call_depth=0,
+    )
+
+    graph_runtime_state = GraphRuntimeState(
+        variable_pool=VariablePool(system_variables=SystemVariable(user_id="user-id", files=[]), user_inputs={}),
+        start_at=0.0,
+    )
+
+    return AgentNode(
+        id="node-instance",
+        config=graph_config["nodes"][0],
+        graph_init_params=init_params,
+        graph_runtime_state=graph_runtime_state,
+    )
+
+
+def _build_json_message(payload: dict[str, Any]) -> ToolInvokeMessage:
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.JSON,
+        message=ToolInvokeMessage.JsonMessage(json_object=payload),
+    )
+
+
+def _run_transform(agent_node: AgentNode, messages: list[ToolInvokeMessage]) -> NodeRunResult:
+    def _identity_transform(
+        messages: Generator[ToolInvokeMessage, None, None], *_args: Any, **_kwargs: Any
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        return messages
+
+    with patch.object(
+        ToolFileMessageTransformer, "transform_tool_invoke_messages", side_effect=_identity_transform, autospec=True
+    ):
+        events = list(
+            agent_node._transform_message(
+                messages=iter(messages),
+                tool_info={"agent_strategy": "test-agent"},
+                parameters_for_log={},
+                user_id="user-id",
+                tenant_id="tenant-id",
+                node_type=NodeType.AGENT,
+                node_id=agent_node._node_id,
+                node_execution_id=agent_node.id,
+            )
+        )
+
+    completed_events = [event for event in events if isinstance(event, StreamCompletedEvent)]
+    assert len(completed_events) == 1
+    return completed_events[0].node_run_result
+
+
+def test_transform_message_accumulates_usage_across_json_messages(agent_node: AgentNode) -> None:
+    metadata_one: LLMUsageMetadata = {
+        "prompt_tokens": 12,
+        "completion_tokens": 8,
+        "total_tokens": 20,
+        "total_price": "0.15",
+        "latency": 0.4,
+    }
+    metadata_two: LLMUsageMetadata = {
+        "prompt_tokens": 5,
+        "completion_tokens": 7,
+        "total_tokens": 12,
+        "total_price": "0.25",
+        "latency": 0.6,
+    }
+
+    result = _run_transform(
+        agent_node,
+        [
+            _build_json_message({"execution_metadata": dict(metadata_one), "step": 1}),
+            _build_json_message({"execution_metadata": dict(metadata_two), "step": 2}),
+        ],
+    )
+
+    expected_usage = LLMUsage.from_metadata(metadata_one) + LLMUsage.from_metadata(metadata_two)
+
+    assert result.llm_usage == expected_usage
+    assert result.outputs["usage"] == jsonable_encoder(expected_usage)
+
+
+def test_transform_message_keeps_single_round_usage(agent_node: AgentNode) -> None:
+    metadata: LLMUsageMetadata = {
+        "prompt_tokens": 6,
+        "completion_tokens": 4,
+        "total_tokens": 10,
+        "total_price": "0.08",
+        "latency": 0.3,
+    }
+
+    result = _run_transform(
+        agent_node,
+        [
+            _build_json_message({"execution_metadata": dict(metadata), "step": 1}),
+        ],
+    )
+
+    expected_usage = LLMUsage.from_metadata(metadata)
+
+    assert result.llm_usage == expected_usage
+    assert result.outputs["usage"] == jsonable_encoder(expected_usage)
+
+
+def test_transform_message_keeps_existing_usage_when_later_json_has_no_metadata(agent_node: AgentNode) -> None:
+    metadata: LLMUsageMetadata = {
+        "prompt_tokens": 9,
+        "completion_tokens": 3,
+        "total_tokens": 12,
+        "total_price": "0.11",
+        "latency": 0.2,
+    }
+
+    result = _run_transform(
+        agent_node,
+        [
+            _build_json_message({"execution_metadata": dict(metadata), "step": 1}),
+            _build_json_message({"step": 2}),
+        ],
+    )
+
+    expected_usage = LLMUsage.from_metadata(metadata)
+
+    assert result.llm_usage == expected_usage
+    assert result.outputs["usage"] == jsonable_encoder(expected_usage)

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_agent_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_agent_node.py
@@ -169,3 +169,31 @@ def test_transform_message_keeps_existing_usage_when_later_json_has_no_metadata(
 
     assert result.llm_usage == expected_usage
     assert result.outputs["usage"] == jsonable_encoder(expected_usage)
+
+
+def test_transform_message_accumulates_zero_token_usage_metadata(agent_node: AgentNode) -> None:
+    metadata_with_tokens: LLMUsageMetadata = {
+        "prompt_tokens": 9,
+        "completion_tokens": 3,
+        "total_tokens": 12,
+        "total_price": "0.11",
+        "latency": 0.2,
+    }
+    metadata_without_tokens: LLMUsageMetadata = {
+        "total_tokens": 0,
+        "total_price": "0.04",
+        "latency": 0.5,
+    }
+
+    result = _run_transform(
+        agent_node,
+        [
+            _build_json_message({"execution_metadata": dict(metadata_with_tokens), "step": 1}),
+            _build_json_message({"execution_metadata": dict(metadata_without_tokens), "step": 2}),
+        ],
+    )
+
+    expected_usage = LLMUsage.from_metadata(metadata_with_tokens) + LLMUsage.from_metadata(metadata_without_tokens)
+
+    assert result.llm_usage == expected_usage
+    assert result.outputs["usage"] == jsonable_encoder(expected_usage)


### PR DESCRIPTION
## Summary

This PR fixes an issue in `AgentNode._transform_message()` where `llm_usage` was overwritten by later JSON chunks instead of being accumulated across the full agent execution.

## Problem

During multi-round agent execution, `AgentNode._transform_message()` initializes `llm_usage` with `LLMUsage.empty_usage()`, but each JSON message with `execution_metadata` replaced the current usage with a newly parsed value.

As a result, only the last round's usage was preserved in:

- `NodeRunResult.llm_usage`
- `outputs["usage"]`

This caused underreported token and price statistics for multi-round agent runs.

## Root cause

Other workflow/runtime components already treat usage as an accumulated value, but `AgentNode` used overwrite semantics for JSON chunks.

## Fix

- Parse each JSON chunk's usage into `new_usage`
- Accumulate it with the existing value using the existing `LLMUsage.plus()` behavior
- Avoid clearing previously accumulated usage when a later JSON message does not contain usage metadata

## Tests

Added unit tests covering:

1. usage is accumulated across multiple JSON messages
2. later JSON messages without `execution_metadata` do not clear previously accumulated usage
3. single-round behavior remains compatible

## Scope

This PR intentionally only fixes `llm_usage`.

Although `agent_execution_metadata` also uses overwrite semantics nearby, its merge behavior is less obvious and may require key-specific rules. Keeping this PR focused makes the bugfix smaller and easier to review.