### PR TITLE
refactor: replace string literals with enum values for status fields

### DIFF
--- a/api/core/app/apps/message_based_app_generator.py
+++ b/api/core/app/apps/message_based_app_generator.py
@@ -38,6 +38,7 @@ from models.model import App, AppMode, AppModelConfig, Conversation, EndUser, Me
 from services.errors.app_model_config import AppModelConfigBrokenError
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import MessageNotExistsError
+from models.enums import ConversationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +176,7 @@ class MessageBasedAppGenerator(BaseAppGenerator):
                     introduction=introduction,
                     system_instruction="",
                     system_instruction_tokens=0,
-                    status="normal",
+                    status=ConversationStatus.NORMAL,
                     invoke_from=application_generate_entity.invoke_from.value,
                     from_source=from_source,
                     from_end_user_id=end_user_id,

--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -40,6 +40,7 @@ from models.workflow import Workflow, WorkflowDraftVariable, WorkflowDraftVariab
 from repositories.factory import DifyAPIRepositoryFactory
 from services.file_service import FileService
 from services.variable_truncator import VariableTruncator
+from models.enums import ConversationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -599,7 +600,7 @@ class WorkflowDraftVariableService:
             introduction="",
             system_instruction="",
             system_instruction_tokens=0,
-            status="normal",
+            status=ConversationStatus.NORMAL,
             invoke_from=InvokeFrom.DEBUGGER,
             from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,

--- a/api/tests/integration_tests/controllers/console/app/test_chat_message_permissions.py
+++ b/api/tests/integration_tests/controllers/console/app/test_chat_message_permissions.py
@@ -12,8 +12,8 @@ from controllers.console.app import message as message_api
 from controllers.console.app import wraps
 from libs.datetime_utils import naive_utc_now
 from models import App, Tenant
-from models.account import Account, TenantAccountJoin, TenantAccountRole
-from models.enums import ConversationFromSource
+from models.account import Account, TenantAccountJoin, TenantAccountRole, TenantStatus
+from models.enums import ConversationFromSource, MessageStatus
 from models.model import AppMode
 from services.app_generate_service import AppGenerateService
 
@@ -166,7 +166,7 @@ class TestChatMessageApiPermissions:
             agent_thoughts=[],
             message_files=[],
             message_metadata_dict={},
-            status="normal",
+            status=MessageStatus.NORMAL,
             error="",
             parent_message_id=None,
         )

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
@@ -12,8 +12,8 @@ from dify_graph.enums import WorkflowExecutionStatus
 from libs.datetime_utils import naive_utc_now
 from libs.token import _real_cookie_name, generate_csrf_token
 from models import Account, DifySetup, Tenant, TenantAccountJoin
-from models.account import AccountStatus, TenantAccountRole
-from models.enums import ConversationFromSource, CreatorUserRole
+from models.account import AccountStatus, TenantAccountRole, TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, CreatorUserRole, MessageStatus
 from models.model import App, AppMode, Conversation, Message
 from models.workflow import WorkflowRun
 from services.account_service import AccountService
@@ -30,7 +30,7 @@ def _create_account_and_tenant(db_session: Session) -> tuple[Account, Tenant]:
     db_session.add(account)
     db_session.commit()
 
-    tenant = Tenant(name="Test Tenant", status="normal")
+    tenant = Tenant(name="Test Tenant", status=TenantStatus.NORMAL)
     db_session.add(tenant)
     db_session.commit()
 
@@ -73,7 +73,7 @@ def _create_conversation(db_session: Session, app_id: str, account_id: str) -> C
         app_id=app_id,
         name="Test Conversation",
         inputs={},
-        status="normal",
+        status=ConversationStatus.NORMAL,
         mode=AppMode.CHAT,
         from_source=ConversationFromSource.CONSOLE,
         from_account_id=account_id,
@@ -123,7 +123,7 @@ def _create_message(
         message_price_unit=0.001,
         answer_price_unit=0.001,
         currency="USD",
-        status="normal",
+        status=MessageStatus.NORMAL,
         from_source=ConversationFromSource.CONSOLE,
         from_account_id=account_id,
         workflow_run_id=workflow_run_id,

--- a/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
+++ b/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
@@ -90,11 +90,11 @@ class TestPauseStatePersistenceLayerTestContainers:
     def setup_test_data(self, db_session_with_containers, file_service, workflow_run_service):
         """Set up test data for each test method using TestContainers."""
         # Create test tenant and account
-        from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+        from models.account import Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 
         tenant = Tenant(
             name="Test Tenant",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -103,7 +103,7 @@ class TestPauseStatePersistenceLayerTestContainers:
             email="test@example.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/core/repositories/test_human_input_form_repository_impl.py
+++ b/api/tests/test_containers_integration_tests/core/repositories/test_human_input_form_repository_impl.py
@@ -21,7 +21,7 @@ from dify_graph.nodes.human_input.entities import (
     WebAppDeliveryMethod,
 )
 from dify_graph.repositories.human_input_form_repository import FormCreateParams
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.human_input import (
     EmailExternalRecipientPayload,
     EmailMemberRecipientPayload,
@@ -32,7 +32,7 @@ from models.human_input import (
 
 
 def _create_tenant_with_members(session: Session, member_emails: list[str]) -> tuple[Tenant, list[Account]]:
-    tenant = Tenant(name="Test Tenant", status="normal")
+    tenant = Tenant(name="Test Tenant", status=TenantStatus.NORMAL)
     session.add(tenant)
     session.flush()
 
@@ -42,7 +42,7 @@ def _create_tenant_with_members(session: Session, member_emails: list[str]) -> t
             email=email,
             name=f"Member {index}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         session.add(account)
         session.flush()

--- a/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
+++ b/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
@@ -28,7 +28,7 @@ from dify_graph.runtime import GraphRuntimeState, VariablePool
 from dify_graph.system_variable import SystemVariable
 from libs.datetime_utils import naive_utc_now
 from models import Account
-from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.model import App, AppMode, IconType
 from models.workflow import Workflow, WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom, WorkflowRun
@@ -173,7 +173,7 @@ class TestHumanInputResumeNodeExecutionIntegration:
     def setup_test_data(self, db_session_with_containers: Session):
         tenant = Tenant(
             name="Test Tenant",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -182,7 +182,7 @@ class TestHumanInputResumeNodeExecutionIntegration:
             email="test@example.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
+++ b/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
@@ -6,8 +6,8 @@ from decimal import Decimal
 from uuid import uuid4
 
 from dify_graph.nodes.human_input.entities import FormDefinition, UserAction
-from models.account import Account, Tenant, TenantAccountJoin
-from models.enums import ConversationFromSource, InvokeFrom
+from models.account import Account, Tenant, TenantAccountJoin, TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, InvokeFrom
 from models.execution_extra_content import HumanInputContent
 from models.human_input import HumanInputForm, HumanInputFormStatus
 from models.model import App, Conversation, Message
@@ -78,7 +78,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         summary="",
         introduction="",
         system_instruction="",
-        status="normal",
+        status=ConversationStatus.NORMAL,
         invoke_from=InvokeFrom.EXPLORE,
         from_source=ConversationFromSource.CONSOLE,
         from_account_id=account.id,

--- a/api/tests/test_containers_integration_tests/services/dataset_service_update_delete.py
+++ b/api/tests/test_containers_integration_tests/services/dataset_service_update_delete.py
@@ -19,6 +19,7 @@ from models.enums import DataSourceType
 from models.model import App
 from services.dataset_service import DatasetService
 from services.errors.account import NoPermissionError
+from models.account import AccountStatus, TenantStatus
 
 
 class DatasetUpdateDeleteTestDataFactory:
@@ -37,13 +38,13 @@ class DatasetUpdateDeleteTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         if tenant is None:
-            tenant = Tenant(name=f"tenant-{uuid4()}", status="normal")
+            tenant = Tenant(name=f"tenant-{uuid4()}", status=TenantStatus.NORMAL)
             db_session_with_containers.add(tenant)
             db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/services/test_agent_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_agent_service.py
@@ -13,6 +13,7 @@ from services.account_service import AccountService, TenantService
 from services.agent_service import AgentService
 from services.app_service import AppService
 from tests.test_containers_integration_tests.helpers import generate_valid_password
+from models.account import TenantStatus
 
 
 class TestAgentService:
@@ -163,7 +164,7 @@ class TestAgentService:
             from_end_user_id=None,
             name=fake.sentence(),
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             mode="chat",
             from_source=ConversationFromSource.API,
         )
@@ -404,7 +405,7 @@ class TestAgentService:
             from_end_user_id=end_user.id,
             name=fake.sentence(),
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             mode="chat",
             from_source=ConversationFromSource.API,
         )
@@ -476,7 +477,7 @@ class TestAgentService:
             from_end_user_id=None,
             name=fake.sentence(),
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             mode="chat",
             from_source=ConversationFromSource.API,
         )
@@ -622,7 +623,7 @@ class TestAgentService:
             from_end_user_id=None,
             name=fake.sentence(),
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             mode="chat",
             from_source=ConversationFromSource.API,
             app_model_config_id=None,  # Explicitly set to None

--- a/api/tests/test_containers_integration_tests/services/test_annotation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_annotation_service.py
@@ -6,7 +6,8 @@ from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from models import Account
-from models.enums import ConversationFromSource, InvokeFrom
+from models.account import TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, InvokeFrom
 from models.model import MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.app_service import AppService
@@ -136,7 +137,7 @@ class TestAnnotationService:
             introduction="",
             system_instruction="",
             system_instruction_tokens=0,
-            status="normal",
+            status=ConversationStatus.NORMAL,
             invoke_from=InvokeFrom.EXPLORE,
             from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,

--- a/api/tests/test_containers_integration_tests/services/test_conversation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_conversation_service.py
@@ -9,8 +9,8 @@ import pytest
 from sqlalchemy import select
 
 from core.app.entities.app_invoke_entities import InvokeFrom
-from models.account import Account, Tenant, TenantAccountJoin
-from models.enums import ConversationFromSource
+from models.account import Account, Tenant, TenantAccountJoin, TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, MessageStatus
 from models.model import App, Conversation, EndUser, Message, MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.conversation_service import ConversationService
@@ -106,7 +106,7 @@ class ConversationServiceIntegrationTestDataFactory:
             introduction="",
             system_instruction="",
             system_instruction_tokens=0,
-            status="normal",
+            status=ConversationStatus.NORMAL,
             invoke_from=invoke_from.value,
             from_source=ConversationFromSource.API if isinstance(user, EndUser) else ConversationFromSource.CONSOLE,
             from_end_user_id=user.id if isinstance(user, EndUser) else None,
@@ -153,7 +153,7 @@ class ConversationServiceIntegrationTestDataFactory:
             provider_response_latency=0,
             total_price=Decimal(0),
             currency="USD",
-            status="normal",
+            status=MessageStatus.NORMAL,
             invoke_from=InvokeFrom.WEB_APP.value,
             from_source=ConversationFromSource.API if isinstance(user, EndUser) else ConversationFromSource.CONSOLE,
             from_end_user_id=user.id if isinstance(user, EndUser) else None,

--- a/api/tests/test_containers_integration_tests/services/test_dataset_permission_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_permission_service.py
@@ -19,6 +19,7 @@ from models.dataset import (
 from models.enums import DataSourceType
 from services.dataset_service import DatasetPermissionService, DatasetService
 from services.errors.account import NoPermissionError
+from models.account import AccountStatus, TenantStatus
 
 
 class DatasetPermissionTestDataFactory:
@@ -34,10 +35,10 @@ class DatasetPermissionTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         if tenant is None:
-            tenant = Tenant(name=f"tenant-{uuid4()}", status="normal")
+            tenant = Tenant(name=f"tenant-{uuid4()}", status=TenantStatus.NORMAL)
             db.session.add_all([account, tenant])
         else:
             db.session.add(account)

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from dify_graph.model_runtime.entities.model_entities import ModelType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.dataset import Dataset, DatasetPermissionEnum, Document, ExternalKnowledgeBindings, Pipeline
 from models.enums import DatasetRuntimeMode, DataSourceType, DocumentCreatedFrom, IndexingStatus
 from services.dataset_service import DatasetService
@@ -35,9 +35,9 @@ class DatasetServiceIntegrationDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
-        tenant = Tenant(name=f"tenant-{uuid4()}", status="normal")
+        tenant = Tenant(name=f"tenant-{uuid4()}", status=TenantStatus.NORMAL)
         db_session_with_containers.add_all([account, tenant])
         db_session_with_containers.flush()
 

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 from models.dataset import Dataset, Document
 from models.enums import DataSourceType, DocumentCreatedFrom
 from services.dataset_service import DatasetService
@@ -20,14 +20,14 @@ class DatasetDeleteIntegrationDataFactory:
             email=f"owner-{uuid4()}@example.com",
             name="Owner",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=f"tenant-{uuid4()}",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_get_segments.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_get_segments.py
@@ -16,6 +16,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, DatasetPermissionEnum, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom
 from services.dataset_service import SegmentService
+from models.account import AccountStatus, TenantStatus
 
 
 class SegmentServiceTestDataFactory:
@@ -34,13 +35,13 @@ class SegmentServiceTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         if tenant is None:
-            tenant = Tenant(name=f"tenant-{uuid4()}", status="normal")
+            tenant = Tenant(name=f"tenant-{uuid4()}", status=TenantStatus.NORMAL)
             db_session_with_containers.add(tenant)
             db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_retrieval.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_retrieval.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.dataset import (
     AppDatasetJoin,
     Dataset,
@@ -41,11 +41,11 @@ class DatasetRetrievalTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         tenant = Tenant(
             name=f"tenant-{uuid4()}",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add_all([account, tenant])
         db_session_with_containers.flush()
@@ -71,7 +71,7 @@ class DatasetRetrievalTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.flush()

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from dify_graph.model_runtime.entities.model_entities import ModelType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.dataset import Dataset, ExternalKnowledgeBindings
 from models.enums import DataSourceType
 from services.dataset_service import DatasetService
@@ -24,12 +24,12 @@ class DatasetUpdateTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
-        tenant = Tenant(name=f"tenant-{account.id}", status="normal")
+        tenant = Tenant(name=f"tenant-{account.id}", status=TenantStatus.NORMAL)
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/services/test_file_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_file_service.py
@@ -66,7 +66,7 @@ class TestFileService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -75,13 +75,13 @@ class TestFileService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 
         # Create tenant-account join
-        from models.account import TenantAccountJoin, TenantAccountRole
+        from models.account import TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 
         join = TenantAccountJoin(
             tenant_id=tenant.id,

--- a/api/tests/test_containers_integration_tests/services/test_message_export_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_export_service.py
@@ -6,8 +6,8 @@ from decimal import Decimal
 import pytest
 from sqlalchemy.orm import Session
 
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
-from models.enums import ConversationFromSource, FeedbackFromSource, FeedbackRating
+from models.account import Account, AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, FeedbackFromSource, FeedbackRating
 from models.model import (
     App,
     AppAnnotationHitHistory,
@@ -50,12 +50,12 @@ class TestAppMessageExportServiceIntegration:
             email=f"test-{uuid.uuid4()}@example.com",
             name="tester",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         session.add(account)
         session.flush()
 
-        tenant = Tenant(name=f"tenant-{uuid.uuid4()}", status="normal")
+        tenant = Tenant(name=f"tenant-{uuid.uuid4()}", status=TenantStatus.NORMAL)
         session.add(tenant)
         session.flush()
 
@@ -93,7 +93,7 @@ class TestAppMessageExportServiceIntegration:
             mode="chat",
             name="conv",
             inputs={"seed": 1},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid.uuid4()),
         )

--- a/api/tests/test_containers_integration_tests/services/test_message_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_service.py
@@ -4,7 +4,8 @@ import pytest
 from faker import Faker
 from sqlalchemy.orm import Session
 
-from models.enums import ConversationFromSource, FeedbackRating, InvokeFrom
+from models.account import TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, FeedbackRating, InvokeFrom
 from models.model import MessageFeedback
 from services.app_service import AppService
 from services.errors.message import (
@@ -148,7 +149,7 @@ class TestMessageService:
             introduction="",
             system_instruction="",
             system_instruction_tokens=0,
-            status="normal",
+            status=ConversationStatus.NORMAL,
             invoke_from=InvokeFrom.EXPLORE,
             from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,

--- a/api/tests/test_containers_integration_tests/services/test_message_service_extra_contents.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_service_extra_contents.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 import pytest
 
-from models.enums import ConversationFromSource
+from models.enums import ConversationFromSource, MessageStatus
 from models.model import Message
 from services import message_service
 from tests.test_containers_integration_tests.helpers.execution_extra_content import (
@@ -36,7 +36,7 @@ def test_attach_message_extra_contents_assigns_serialized_payload(db_session_wit
         provider_response_latency=0,
         total_price=Decimal(0),
         currency="USD",
-        status="normal",
+        status=MessageStatus.NORMAL,
         from_source=ConversationFromSource.CONSOLE,
         from_account_id=fixture.account.id,
     )

--- a/api/tests/test_containers_integration_tests/services/test_messages_clean_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_messages_clean_service.py
@@ -11,9 +11,10 @@ from sqlalchemy.orm import Session
 from dify_graph.file.enums import FileType
 from enums.cloud_plan import CloudPlan
 from extensions.ext_redis import redis_client
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 from models.enums import (
     ConversationFromSource,
+    ConversationStatus,
     DataSourceType,
     FeedbackFromSource,
     FeedbackRating,
@@ -117,7 +118,7 @@ class TestMessagesCleanServiceIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.flush()
@@ -125,7 +126,7 @@ class TestMessagesCleanServiceIntegration:
         tenant = Tenant(
             name=fake.company(),
             plan=str(plan),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.flush()
@@ -173,7 +174,7 @@ class TestMessagesCleanServiceIntegration:
             mode="chat",
             name="Test conversation",
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid.uuid4()),
         )

--- a/api/tests/test_containers_integration_tests/services/test_metadata_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_metadata_service.py
@@ -11,6 +11,7 @@ from models.dataset import Dataset, DatasetMetadata, DatasetMetadataBinding, Doc
 from models.enums import DatasetMetadataType, DataSourceType, DocumentCreatedFrom
 from services.entities.knowledge_entities.knowledge_entities import MetadataArgs
 from services.metadata_service import MetadataService
+from models.account import AccountStatus, TenantStatus
 
 
 class TestMetadataService:
@@ -53,7 +54,7 @@ class TestMetadataService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -62,7 +63,7 @@ class TestMetadataService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/test_model_load_balancing_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_model_load_balancing_service.py
@@ -5,7 +5,7 @@ from faker import Faker
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from models.account import TenantAccountJoin, TenantAccountRole
+from models.account import TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.model import Account, Tenant
 from models.provider import LoadBalancingModelConfig, Provider, ProviderModelSetting
 from services.model_load_balancing_service import ModelLoadBalancingService
@@ -86,7 +86,7 @@ class TestModelLoadBalancingService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -95,7 +95,7 @@ class TestModelLoadBalancingService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/test_model_provider_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_model_provider_service.py
@@ -9,6 +9,7 @@ from dify_graph.model_runtime.entities.model_entities import FetchFrom, ModelTyp
 from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.provider import Provider, ProviderModel, ProviderModelSetting, ProviderType
 from services.model_provider_service import ModelProviderService
+from models.account import AccountStatus, TenantStatus
 
 
 class TestModelProviderService:
@@ -48,7 +49,7 @@ class TestModelProviderService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -57,7 +58,7 @@ class TestModelProviderService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -437,7 +438,7 @@ class TestModelProviderService:
             model_properties={},
             deprecated=False,
             provider=provider_entity_1,
-            status="active",
+            status=AccountStatus.ACTIVE,
             load_balancing_enabled=False,
         )
 
@@ -450,7 +451,7 @@ class TestModelProviderService:
             model_properties={},
             deprecated=False,
             provider=provider_entity_2,
-            status="active",
+            status=AccountStatus.ACTIVE,
             load_balancing_enabled=False,
         )
 

--- a/api/tests/test_containers_integration_tests/services/test_saved_message_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_saved_message_service.py
@@ -4,7 +4,8 @@ import pytest
 from faker import Faker
 from sqlalchemy.orm import Session
 
-from models.enums import ConversationFromSource
+from models.account import TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, MessageStatus
 from models.model import EndUser, Message
 from models.web import SavedMessage
 from services.app_service import AppService
@@ -143,7 +144,7 @@ class TestSavedMessageService:
             from_account_id=user.id if is_account else None,
             name=fake.sentence(nb_words=3),
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             mode="chat",
         )
 
@@ -167,7 +168,7 @@ class TestSavedMessageService:
             answer_unit_price=0.002,
             total_price=0.003,
             currency="USD",
-            status="normal",
+            status=MessageStatus.NORMAL,
         )
 
         db_session_with_containers.add(message)

--- a/api/tests/test_containers_integration_tests/services/test_tag_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_tag_service.py
@@ -12,6 +12,7 @@ from models.dataset import Dataset
 from models.enums import DataSourceType, TagType
 from models.model import App, Tag, TagBinding
 from services.tag_service import TagService
+from models.account import AccountStatus, TenantStatus
 
 
 class TestTagService:
@@ -49,7 +50,7 @@ class TestTagService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -58,7 +59,7 @@ class TestTagService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/test_web_conversation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_web_conversation_service.py
@@ -14,6 +14,8 @@ from services.account_service import AccountService, TenantService
 from services.app_service import AppService
 from services.web_conversation_service import WebConversationService
 from tests.test_containers_integration_tests.helpers import generate_valid_password
+from models.account import TenantStatus
+from models.enums import ConversationStatus
 
 
 class TestWebConversationService:
@@ -144,7 +146,7 @@ class TestWebConversationService:
             introduction=fake.text(max_nb_chars=200),
             system_instruction=fake.text(max_nb_chars=300),
             system_instruction_tokens=50,
-            status="normal",
+            status=ConversationStatus.NORMAL,
             invoke_from=InvokeFrom.WEB_APP,
             from_source=ConversationFromSource.CONSOLE if isinstance(user, Account) else ConversationFromSource.API,
             from_end_user_id=user.id if isinstance(user, EndUser) else None,

--- a/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webapp_auth_service.py
@@ -13,6 +13,7 @@ from models.model import App, Site
 from services.errors.account import AccountLoginError, AccountNotFoundError, AccountPasswordError
 from services.webapp_auth_service import WebAppAuthService, WebAppAuthType
 from tests.test_containers_integration_tests.helpers import generate_valid_password
+from models.account import TenantStatus
 
 
 class TestWebAppAuthService:
@@ -67,7 +68,7 @@ class TestWebAppAuthService:
             email=unique_email,
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -76,7 +77,7 @@ class TestWebAppAuthService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -120,7 +121,7 @@ class TestWebAppAuthService:
             email=unique_email,
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         # Hash password
@@ -139,7 +140,7 @@ class TestWebAppAuthService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -200,7 +201,7 @@ class TestWebAppAuthService:
             code=fake.unique.lexify(text="??????"),
             description=fake.text(max_nb_chars=100),
             default_language="en-US",
-            status="normal",
+            status=TenantStatus.NORMAL,
             customize_token_strategy="not_allow",
         )
         db_session_with_containers.add(site)
@@ -343,7 +344,7 @@ class TestWebAppAuthService:
             email=unique_email,
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -714,7 +715,7 @@ class TestWebAppAuthService:
         fake = Faker()
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
 
         db_session_with_containers.add(tenant)
@@ -726,7 +727,7 @@ class TestWebAppAuthService:
             code=fake.unique.lexify(text="??????"),
             description=fake.text(max_nb_chars=100),
             default_language="en-US",
-            status="normal",
+            status=TenantStatus.NORMAL,
             customize_token_strategy="not_allow",
         )
         db_session_with_containers.add(site)

--- a/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
@@ -16,6 +16,7 @@ from services.account_service import AccountService, TenantService
 from services.app_service import AppService
 from services.workflow_run_service import WorkflowRunService
 from tests.test_containers_integration_tests.helpers import generate_valid_password
+from models.account import TenantStatus
 
 
 class TestWorkflowRunService:
@@ -163,7 +164,7 @@ class TestWorkflowRunService:
             app_id=app.id,
             name=fake.sentence(),
             inputs={},
-            status="normal",
+            status=ConversationStatus.NORMAL,
             mode="chat",
             from_source=ConversationFromSource.CONSOLE,
             from_account_id=account.id,

--- a/api/tests/test_containers_integration_tests/services/test_workflow_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_service.py
@@ -49,7 +49,7 @@ class TestWorkflowService:
             email=fake.email(),
             name=fake.name(),
             avatar=fake.url(),
-            status="active",
+            status=AccountStatus.ACTIVE,
             interface_language="en-US",  # Set interface language for Site creation
         )
         account.created_at = fake.date_time_this_year()
@@ -57,12 +57,12 @@ class TestWorkflowService:
         account.updated_at = account.created_at
 
         # Create a tenant for the account
-        from models.account import Tenant
+        from models.account import Tenant, AccountStatus, TenantStatus
 
         tenant = Tenant(
             name=f"Test Tenant {fake.company()}",
             plan="basic",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         tenant.id = account.current_tenant_id
         tenant.created_at = fake.date_time_this_year()

--- a/api/tests/test_containers_integration_tests/services/test_workspace_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workspace_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from services.workspace_service import WorkspaceService
+from models.account import AccountStatus, TenantStatus
 
 
 class TestWorkspaceService:
@@ -48,7 +49,7 @@ class TestWorkspaceService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -57,7 +58,7 @@ class TestWorkspaceService:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
             plan="basic",
             custom_config='{"replace_webapp_logo": true, "remove_webapp_brand": false}',
         )

--- a/api/tests/test_containers_integration_tests/services/tools/test_api_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_api_tools_manage_service.py
@@ -53,7 +53,7 @@ class TestApiToolManageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -62,13 +62,13 @@ class TestApiToolManageService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 
         # Create tenant-account join
-        from models.account import TenantAccountJoin, TenantAccountRole
+        from models.account import TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 
         join = TenantAccountJoin(
             tenant_id=tenant.id,

--- a/api/tests/test_containers_integration_tests/services/tools/test_mcp_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_mcp_tools_manage_service.py
@@ -60,7 +60,7 @@ class TestMCPToolManageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -69,13 +69,13 @@ class TestMCPToolManageService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 
         # Create tenant-account join
-        from models.account import TenantAccountJoin, TenantAccountRole
+        from models.account import TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 
         join = TenantAccountJoin(
             tenant_id=tenant.id,

--- a/api/tests/test_containers_integration_tests/services/workflow/test_workflow_converter.py
+++ b/api/tests/test_containers_integration_tests/services/workflow/test_workflow_converter.py
@@ -98,7 +98,7 @@ class TestWorkflowConverter:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -107,13 +107,13 @@ class TestWorkflowConverter:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 
         # Create tenant-account join
-        from models.account import TenantAccountJoin, TenantAccountRole
+        from models.account import TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 
         join = TenantAccountJoin(
             tenant_id=tenant.id,

--- a/api/tests/test_containers_integration_tests/tasks/test_add_document_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_add_document_to_index_task.py
@@ -10,6 +10,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, DatasetAutoDisableLog, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.add_document_to_index_task import add_document_to_index_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestAddDocumentToIndexTask:
@@ -52,14 +53,14 @@ class TestAddDocumentToIndexTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_batch_clean_document_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_batch_clean_document_task.py
@@ -21,6 +21,7 @@ from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from models.model import UploadFile
 from tasks.batch_clean_document_task import batch_clean_document_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestBatchCleanDocumentTask:
@@ -69,7 +70,7 @@ class TestBatchCleanDocumentTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -78,7 +79,7 @@ class TestBatchCleanDocumentTask:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_batch_create_segment_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_batch_create_segment_to_index_task.py
@@ -26,6 +26,7 @@ from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from models.model import UploadFile
 from tasks.batch_create_segment_to_index_task import batch_create_segment_to_index_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestBatchCreateSegmentToIndexTask:
@@ -94,7 +95,7 @@ class TestBatchCreateSegmentToIndexTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -103,7 +104,7 @@ class TestBatchCreateSegmentToIndexTask:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
@@ -41,6 +41,7 @@ from models.enums import (
 )
 from models.model import UploadFile
 from tasks.clean_dataset_task import clean_dataset_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestCleanDatasetTask:
@@ -109,7 +110,7 @@ class TestCleanDatasetTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -119,7 +120,7 @@ class TestCleanDatasetTask:
         tenant = Tenant(
             name=fake.company(),
             plan="basic",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
 
         db_session_with_containers.add(tenant)

--- a/api/tests/test_containers_integration_tests/tasks/test_create_segment_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_create_segment_to_index_task.py
@@ -18,6 +18,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.create_segment_to_index_task import create_segment_to_index_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestCreateSegmentToIndexTask:
@@ -71,7 +72,7 @@ class TestCreateSegmentToIndexTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -80,7 +81,7 @@ class TestCreateSegmentToIndexTask:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
             plan="basic",
         )
         db_session_with_containers.add(tenant)

--- a/api/tests/test_containers_integration_tests/tasks/test_dataset_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_dataset_indexing_task.py
@@ -11,9 +11,9 @@ from core.indexing_runner import DocumentIsPausedError
 from enums.cloud_plan import CloudPlan
 from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document
+from models.account import AccountStatus, TenantStatus
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
 from tasks.document_indexing_task import (
-from models.account import AccountStatus, TenantStatus
     _document_indexing,
     _document_indexing_with_tenant_queue,
     document_indexing_task,

--- a/api/tests/test_containers_integration_tests/tasks/test_dataset_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_dataset_indexing_task.py
@@ -13,6 +13,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
 from tasks.document_indexing_task import (
+from models.account import AccountStatus, TenantStatus
     _document_indexing,
     _document_indexing_with_tenant_queue,
     document_indexing_task,
@@ -118,12 +119,12 @@ class TestDatasetIndexingTaskIntegration:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.flush()
 
-        tenant = Tenant(name=fake.company(), status="normal")
+        tenant = Tenant(name=fake.company(), status=TenantStatus.NORMAL)
         db_session_with_containers.add(tenant)
         db_session_with_containers.flush()
 

--- a/api/tests/test_containers_integration_tests/tasks/test_delete_segment_from_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_delete_segment_from_index_task.py
@@ -16,6 +16,7 @@ from core.rag.index_processor.constant.index_type import IndexStructureType
 from models import Account, Dataset, Document, DocumentSegment, Tenant
 from models.enums import DataSourceType, DocumentCreatedFrom, DocumentDocType, IndexingStatus, SegmentStatus
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task
+from models.account import AccountStatus, TenantStatus
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class TestDeleteSegmentFromIndexTask:
             Tenant: Created test tenant instance
         """
         fake = fake or Faker()
-        tenant = Tenant(name=f"Test Tenant {fake.company()}", plan="basic", status="normal")
+        tenant = Tenant(name=f"Test Tenant {fake.company()}", plan="basic", status=TenantStatus.NORMAL)
         tenant.id = fake.uuid4()
         tenant.created_at = fake.date_time_this_year()
         tenant.updated_at = tenant.created_at
@@ -75,7 +76,7 @@ class TestDeleteSegmentFromIndexTask:
             name=fake.name(),
             email=fake.email(),
             avatar=fake.url(),
-            status="active",
+            status=AccountStatus.ACTIVE,
             interface_language="en-US",
         )
         account.id = fake.uuid4()

--- a/api/tests/test_containers_integration_tests/tasks/test_disable_segment_from_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_disable_segment_from_index_task.py
@@ -21,6 +21,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
+from models.account import AccountStatus, TenantStatus
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ class TestDisableSegmentFromIndexTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -61,7 +62,7 @@ class TestDisableSegmentFromIndexTask:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
             plan="basic",
         )
         db_session_with_containers.add(tenant)

--- a/api/tests/test_containers_integration_tests/tasks/test_disable_segments_from_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_disable_segments_from_index_task.py
@@ -50,7 +50,7 @@ class TestDisableSegmentsFromIndexTask:
             email=fake.email(),
             name=fake.name(),
             avatar=fake.url(),
-            status="active",
+            status=AccountStatus.ACTIVE,
             interface_language="en-US",
         )
         account.id = fake.uuid4()
@@ -62,12 +62,12 @@ class TestDisableSegmentsFromIndexTask:
         account.updated_at = account.created_at
 
         # Create a tenant for the account
-        from models.account import Tenant
+        from models.account import Tenant, AccountStatus, TenantStatus
 
         tenant = Tenant(
             name=f"Test Tenant {fake.company()}",
             plan="basic",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         tenant.id = account.tenant_id
         tenant.created_at = fake.date_time_this_year()

--- a/api/tests/test_containers_integration_tests/tasks/test_document_indexing_sync_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_document_indexing_sync_task.py
@@ -19,6 +19,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.document_indexing_sync_task import document_indexing_sync_task
+from models.account import AccountStatus, TenantStatus
 
 
 class DocumentIndexingSyncTaskTestDataFactory:
@@ -30,12 +31,12 @@ class DocumentIndexingSyncTaskTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.flush()
 
-        tenant = Tenant(name=f"tenant-{account.id}", status="normal")
+        tenant = Tenant(name=f"tenant-{account.id}", status=TenantStatus.NORMAL)
         db_session_with_containers.add(tenant)
         db_session_with_containers.flush()
 

--- a/api/tests/test_containers_integration_tests/tasks/test_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_document_indexing_task.py
@@ -10,6 +10,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
 from tasks.document_indexing_task import (
+from models.account import AccountStatus, TenantStatus
     _document_indexing,  # Core function
     _document_indexing_with_tenant_queue,  # Tenant queue wrapper function
     document_indexing_task,  # Deprecated old interface
@@ -70,14 +71,14 @@ class TestDocumentIndexingTasks:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -152,14 +153,14 @@ class TestDocumentIndexingTasks:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_document_indexing_update_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_document_indexing_update_task.py
@@ -8,6 +8,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.document_indexing_update_task import document_indexing_update_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestDocumentIndexingUpdateTask:
@@ -40,12 +41,12 @@ class TestDocumentIndexingUpdateTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
-        tenant = Tenant(name=fake.company(), status="normal")
+        tenant = Tenant(name=fake.company(), status=TenantStatus.NORMAL)
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
@@ -8,9 +8,9 @@ from core.rag.index_processor.constant.index_type import IndexStructureType
 from enums.cloud_plan import CloudPlan
 from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
+from models.account import AccountStatus, TenantStatus
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.duplicate_document_indexing_task import (
-from models.account import AccountStatus, TenantStatus
     _duplicate_document_indexing_task,  # Core function
     _duplicate_document_indexing_task_with_tenant_queue,  # Tenant queue wrapper function
     duplicate_document_indexing_task,  # Deprecated old interface

--- a/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_duplicate_document_indexing_task.py
@@ -10,6 +10,7 @@ from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.duplicate_document_indexing_task import (
+from models.account import AccountStatus, TenantStatus
     _duplicate_document_indexing_task,  # Core function
     _duplicate_document_indexing_task_with_tenant_queue,  # Tenant queue wrapper function
     duplicate_document_indexing_task,  # Deprecated old interface
@@ -81,14 +82,14 @@ class TestDuplicateDocumentIndexingTasks:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -216,14 +217,14 @@ class TestDuplicateDocumentIndexingTasks:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_enable_segments_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_enable_segments_to_index_task.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from extensions.ext_redis import redis_client
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.enable_segments_to_index_task import enable_segments_to_index_task
@@ -52,14 +52,14 @@ class TestEnableSegmentsToIndexTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_account_deletion_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_account_deletion_task.py
@@ -5,7 +5,7 @@ from faker import Faker
 from sqlalchemy.orm import Session
 
 from libs.email_i18n import EmailType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from tasks.mail_account_deletion_task import send_account_deletion_verification_code, send_deletion_success_task
 
 
@@ -47,7 +47,7 @@ class TestMailAccountDeletionTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -55,7 +55,7 @@ class TestMailAccountDeletionTask:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_change_mail_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_change_mail_task.py
@@ -4,7 +4,7 @@ import pytest
 from faker import Faker
 
 from libs.email_i18n import EmailType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from tasks.mail_change_mail_task import send_change_mail_completed_notification_task, send_change_mail_task
 
 
@@ -46,7 +46,7 @@ class TestMailChangeMailTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -54,7 +54,7 @@ class TestMailChangeMailTask:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_email_code_login_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_email_code_login_task.py
@@ -16,7 +16,7 @@ import pytest
 from faker import Faker
 
 from libs.email_i18n import EmailType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from tasks.mail_email_code_login import send_email_code_login_mail_task
 
 
@@ -89,7 +89,7 @@ class TestSendEmailCodeLoginMailTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -118,7 +118,7 @@ class TestSendEmailCodeLoginMailTask:
         tenant = Tenant(
             name=fake.company(),
             plan="basic",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
 
         db_session_with_containers.add(tenant)

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_owner_transfer_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_owner_transfer_task.py
@@ -13,7 +13,7 @@ import pytest
 from faker import Faker
 
 from libs.email_i18n import EmailType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from tasks.mail_owner_transfer_task import (
     send_new_owner_transfer_notify_email_task,
     send_old_owner_transfer_notify_email_task,
@@ -61,7 +61,7 @@ class TestMailOwnerTransferTask:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -69,7 +69,7 @@ class TestMailOwnerTransferTask:
         # Create tenant
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_rag_pipeline_run_tasks.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_rag_pipeline_run_tasks.py
@@ -17,6 +17,7 @@ from tasks.rag_pipeline.priority_rag_pipeline_run_task import (
     run_single_rag_pipeline_task,
 )
 from tasks.rag_pipeline.rag_pipeline_run_task import rag_pipeline_run_task
+from models.account import AccountStatus, TenantStatus
 
 
 class TestRagPipelineRunTasks:
@@ -69,14 +70,14 @@ class TestRagPipelineRunTasks:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
+++ b/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
@@ -33,7 +33,7 @@ from extensions.ext_storage import storage
 from libs.datetime_utils import naive_utc_now
 from models import Account
 from models import WorkflowPause as WorkflowPauseModel
-from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Tenant, TenantAccountJoin, TenantAccountRole, AccountStatus, TenantStatus
 from models.model import UploadFile
 from models.workflow import Workflow, WorkflowRun
 from repositories.sqlalchemy_api_workflow_run_repository import (
@@ -181,7 +181,7 @@ class TestWorkflowPauseIntegration:
 
         tenant = Tenant(
             name="Test Tenant",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -190,7 +190,7 @@ class TestWorkflowPauseIntegration:
             email="test@example.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -693,7 +693,7 @@ class TestWorkflowPauseIntegration:
 
         tenant2 = Tenant(
             name="Test Tenant 2",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         self.session.add(tenant2)
         self.session.commit()
@@ -702,7 +702,7 @@ class TestWorkflowPauseIntegration:
             email="test2@example.com",
             name="Test User 2",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         self.session.add(account2)
         self.session.commit()

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -59,6 +59,7 @@ from controllers.console.app.workflow_app_log import WorkflowAppLogQuery
 from controllers.console.app.workflow_draft_variable import WorkflowDraftVariableUpdatePayload
 from controllers.console.app.workflow_statistic import WorkflowStatisticQuery
 from controllers.console.app.workflow_trigger import Parser, ParserEnable
+from models.account import AccountStatus
 
 
 def _unwrap(func):
@@ -598,7 +599,7 @@ class TestMCPServerEndpoints:
         assert payload.parameters["url"] == "http://localhost:3000"
 
     def test_mcp_server_update_payload(self):
-        payload = MCPServerUpdatePayload(id="server-1", parameters={"timeout": 30}, status="active")
+        payload = MCPServerUpdatePayload(id="server-1", parameters={"timeout": 30}, status=AccountStatus.ACTIVE)
         assert payload.status == "active"
 
 

--- a/api/tests/unit_tests/controllers/console/test_workspace_members.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_members.py
@@ -5,7 +5,7 @@ import pytest
 from flask import Flask, g
 
 from controllers.console.workspace.members import MemberInviteEmailApi
-from models.account import Account, TenantAccountRole
+from models.account import Account, TenantAccountRole, AccountStatus
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ class TestMemberInviteEmailApi:
         mock_invite_member.return_value = "token-abc"
 
         tenant = SimpleNamespace(id="tenant-1", name="Test Tenant")
-        inviter = SimpleNamespace(email="Owner@Example.com", current_tenant=tenant, status="active")
+        inviter = SimpleNamespace(email="Owner@Example.com", current_tenant=tenant, status=AccountStatus.ACTIVE)
         mock_current_account.return_value = (inviter, tenant.id)
 
         with patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "https://console.example.com"):

--- a/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
@@ -13,6 +13,8 @@ from core.app.task_pipeline import message_cycle_manager
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
 from models.enums import ConversationFromSource
 from models.model import AppMode, Conversation, Message
+from models.account import TenantStatus
+from models.enums import ConversationStatus
 
 
 def _make_app_config() -> WorkflowUIBasedAppConfig:
@@ -91,7 +93,7 @@ def test_init_generate_records_marks_existing_conversation():
         introduction="",
         system_instruction="",
         system_instruction_tokens=0,
-        status="normal",
+        status=ConversationStatus.NORMAL,
         invoke_from=InvokeFrom.WEB_APP.value,
         from_source=ConversationFromSource.API,
         from_end_user_id="user-id",

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -16,7 +16,8 @@ from uuid import uuid4
 
 import pytest
 
-from models.enums import ConversationFromSource
+from models.account import TenantStatus
+from models.enums import ConversationFromSource, ConversationStatus, MessageStatus
 from models.model import (
     App,
     AppAnnotationHitHistory,
@@ -324,7 +325,7 @@ class TestConversationModel:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=from_end_user_id,
         )
@@ -345,7 +346,7 @@ class TestConversationModel:
             app_id=str(uuid4()),
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
         )
@@ -364,7 +365,7 @@ class TestConversationModel:
             app_id=str(uuid4()),
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
         )
@@ -383,7 +384,7 @@ class TestConversationModel:
             app_id=str(uuid4()),
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
             summary="Test summary",
@@ -402,7 +403,7 @@ class TestConversationModel:
             app_id=str(uuid4()),
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
             summary=None,
@@ -425,7 +426,7 @@ class TestConversationModel:
             app_id=str(uuid4()),
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
             override_model_configs='{"model": "gpt-4"}',
@@ -446,7 +447,7 @@ class TestConversationModel:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=from_end_user_id,
             dialogue_count=5,
@@ -629,7 +630,7 @@ class TestMessageModel:
             total_price=Decimal("0.0003"),
             currency="USD",
             from_source=ConversationFromSource.API,
-            status="normal",
+            status=MessageStatus.NORMAL,
         )
         message.id = str(uuid4())
         message._inputs = {"query": "test"}
@@ -988,7 +989,7 @@ class TestModelIntegration:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
         )
@@ -1158,7 +1159,7 @@ class TestConversationStatusCount:
             app_id=str(uuid4()),
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
         )
         conversation.id = str(uuid4())
@@ -1183,7 +1184,7 @@ class TestConversationStatusCount:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
@@ -1215,7 +1216,7 @@ class TestConversationStatusCount:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
@@ -1307,7 +1308,7 @@ class TestConversationStatusCount:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
@@ -1361,7 +1362,7 @@ class TestConversationStatusCount:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
@@ -1418,7 +1419,7 @@ class TestConversationStatusCount:
             app_id=app_id,
             mode=AppMode.CHAT,
             name="Test Conversation",
-            status="normal",
+            status=ConversationStatus.NORMAL,
             from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id


### PR DESCRIPTION
## Summary

Fixes #33439

Replaces raw string literals (`status="active"`, `status="normal"`) with their proper enum counterparts across 60 files:

- `AccountStatus.ACTIVE` for `Account` model constructors
- `TenantStatus.NORMAL` for `Tenant` model constructors
- `ConversationStatus.NORMAL` for `Conversation` model constructors
- `MessageStatus.NORMAL` for `Message` model constructors

This resolves type checker errors like:
```
ERROR Argument `Literal['active']` is not assignable to parameter `status` with type `AccountStatus | SQLCoreOperations[AccountStatus]`
```

### Changes
- **60 files changed** across tests (integration + unit) and 2 production files (`message_based_app_generator.py`, `workflow_draft_variable_service.py`)
- Added missing enum imports where needed
- No behavioral changes - all enums are `StrEnum` with identical string values