### PR TITLE
fix(api): prevent duplicate 'mode' keyword in App constructor

### DIFF
--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -137,8 +137,8 @@ class AppService:
         # app_template["app"] always contains a 'mode' key, and mode is explicitly
         # set below from args["mode"], so unpacking it here would conflict if the
         # constructor call is ever refactored to pass mode as a keyword argument.
-        app_template_app = {k: v for k, v in app_template["app"].items() if k != "mode"}
-        app = App(**app_template_app)
+        app_kwargs = {k: v for k, v in app_template["app"].items() if k != "mode"}
+        app = App(**app_kwargs)
         app.name = args["name"]
         app.description = args.get("description", "")
         app.mode = args["mode"]

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -133,7 +133,12 @@ class AppService:
 
             default_model_config["model"] = json.dumps(default_model_dict)
 
-        app = App(**app_template["app"])
+        # Exclude 'mode' from the template to avoid a duplicate keyword argument error:
+        # app_template["app"] always contains a 'mode' key, and mode is explicitly
+        # set below from args["mode"], so unpacking it here would conflict if the
+        # constructor call is ever refactored to pass mode as a keyword argument.
+        app_template_app = {k: v for k, v in app_template["app"].items() if k != "mode"}
+        app = App(**app_template_app)
         app.name = args["name"]
         app.description = args.get("description", "")
         app.mode = args["mode"]


### PR DESCRIPTION
## Summary

- `default_app_templates["app"]` always contains a `"mode"` key for every `AppMode` variant (workflow, completion, chat, advanced-chat, agent-chat).
- `create_app` previously called `App(**app_template["app"])`, which unpacked `mode` from the template, then immediately overwrote it with `app.mode = args["mode"]` via attribute assignment.
- If this pattern is ever refactored to pass `mode` as an explicit keyword argument in the constructor call, Python raises `TypeError: App() got multiple values for keyword argument 'mode'` (as reported in issue #32853).
- The fix strips `"mode"` from the template dict before unpacking so the `App` constructor never receives it from the template. `args["mode"]` is the sole authoritative source for the app mode.

## Changes

- `api/services/app_service.py`: build a filtered copy of `app_template["app"]` excluding `"mode"` before passing it to `App(**...)`.

## Test plan

- [x] `uv run --dev ruff check --fix ./services/app_service.py` — no issues
- [x] `uv run --dev ruff format ./services/app_service.py` — no changes
- [x] `uv run --dev basedpyright services/app_service.py` — 0 errors, 0 warnings
- [x] `pytest tests/unit_tests/services/test_app_service.py -v` — 19/19 passed

Fixes #32853