### PR TITLE
fix(api): resolve type errors in service API wraps tests

### DIFF
--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Callable
 from enum import StrEnum, auto
 from functools import wraps
-from typing import Concatenate, ParamSpec, TypeVar, cast
+from typing import Concatenate, ParamSpec, TypeVar, cast, overload
 
 from flask import current_app, request
 from flask_login import user_logged_in
@@ -44,10 +44,22 @@ class FetchUserArg(BaseModel):
     required: bool = False
 
 
-def validate_app_token(view: Callable[P, R] | None = None, *, fetch_user_arg: FetchUserArg | None = None):
-    def decorator(view_func: Callable[P, R]):
+@overload
+def validate_app_token(view: Callable[P, R]) -> Callable[P, R]: ...
+
+
+@overload
+def validate_app_token(
+    view: None = None, *, fetch_user_arg: FetchUserArg | None = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+
+
+def validate_app_token(
+    view: Callable[P, R] | None = None, *, fetch_user_arg: FetchUserArg | None = None
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(view_func: Callable[P, R]) -> Callable[P, R]:
         @wraps(view_func)
-        def decorated_view(*args: P.args, **kwargs: P.kwargs):
+        def decorated_view(*args: P.args, **kwargs: P.kwargs) -> R:
             api_token = validate_and_get_api_token("app")
 
             app_model = db.session.query(App).where(App.id == api_token.app_id).first()
@@ -213,10 +225,20 @@ def cloud_edition_billing_rate_limit_check(resource: str, api_token_type: str):
     return interceptor
 
 
-def validate_dataset_token(view: Callable[Concatenate[T, P], R] | None = None):
-    def decorator(view: Callable[Concatenate[T, P], R]):
-        @wraps(view)
-        def decorated(*args: P.args, **kwargs: P.kwargs):
+@overload
+def validate_dataset_token(view: Callable[Concatenate[T, P], R]) -> Callable[P, R]: ...
+
+
+@overload
+def validate_dataset_token(view: None = None) -> Callable[[Callable[Concatenate[T, P], R]], Callable[P, R]]: ...
+
+
+def validate_dataset_token(
+    view: Callable[Concatenate[T, P], R] | None = None,
+) -> Callable[P, R] | Callable[[Callable[Concatenate[T, P], R]], Callable[P, R]]:
+    def decorator(view_func: Callable[Concatenate[T, P], R]) -> Callable[P, R]:
+        @wraps(view_func)
+        def decorated(*args: P.args, **kwargs: P.kwargs) -> R:
             api_token = validate_and_get_api_token("dataset")
 
             # get url path dataset_id from positional args or kwargs
@@ -287,7 +309,7 @@ def validate_dataset_token(view: Callable[Concatenate[T, P], R] | None = None):
                     raise Unauthorized("Tenant owner account does not exist.")
             else:
                 raise Unauthorized("Tenant does not exist.")
-            return view(api_token.tenant_id, *args, **kwargs)
+            return view_func(api_token.tenant_id, *args, **kwargs)  # type: ignore[arg-type]
 
         return decorated
 


### PR DESCRIPTION
## Summary

- Add `@overload` type signatures to `validate_app_token` and `validate_dataset_token` in `api/controllers/service_api/wraps.py`
- Without overloads, type checkers inferred an ambiguous return type (`decorator | decorated_view`), causing `[missing-argument]` errors at lines 187, 210, 234, and 489 of `test_wraps.py`
- Add explicit return-type annotations to inner `decorator` and `decorated_view`/`decorated` functions for completeness

## Root Cause

Both `validate_app_token` and `validate_dataset_token` support two calling conventions:

1. **No-parens** (`@validate_app_token`): called with the view function directly — returns the wrapped callable
2. **With-parens** (`@validate_app_token(fetch_user_arg=...)` / `@validate_dataset_token()`): returns a decorator

Without `@overload` stubs, the type checker sees the return type as `Callable | Callable[[Callable], Callable]`, and cannot statically determine which branch applies. When the no-parens form is used in tests, the result type was inferred as the inner `decorator` function (which expects a `view_func` argument), causing the four `[missing-argument]` errors.

## Fix

```python
@overload
def validate_app_token(view: Callable[P, R]) -> Callable[P, R]: ...

@overload
def validate_app_token(
    view: None = None, *, fetch_user_arg: FetchUserArg | None = None
) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
```

Same pattern applied to `validate_dataset_token`.

## Test plan

- [x] `uv run --dev basedpyright controllers/service_api/wraps.py tests/unit_tests/controllers/service_api/test_wraps.py` — 0 errors
- [x] `uv run --dev ruff check controllers/service_api/wraps.py` — all checks passed
- [x] `uv run --dev pytest tests/unit_tests/controllers/service_api/test_wraps.py -v` — 21 passed, 0 failed

Closes #32835