### PR TITLE
fix(web): display file icons in workflow response node output panel

### DIFF
--- a/web/app/components/workflow/panel/workflow-preview.tsx
+++ b/web/app/components/workflow/panel/workflow-preview.tsx
@@ -61,6 +61,8 @@ const WorkflowPreview = () => {
 
     if ((status === WorkflowRunningStatus.Succeeded || status === WorkflowRunningStatus.Failed) && !workflowRunningData.resultText && !workflowRunningData.result.files?.length)
       switchTab('DETAIL')
+    if ((status === WorkflowRunningStatus.Succeeded || status === WorkflowRunningStatus.Failed) && !workflowRunningData.resultText && !!workflowRunningData.result.files?.length)
+      switchTab('RESULT')
     if (status === WorkflowRunningStatus.Paused)
       switchTab('RESULT')
   }, [workflowRunningData])

--- a/web/app/components/workflow/run/output-panel.tsx
+++ b/web/app/components/workflow/run/output-panel.tsx
@@ -9,6 +9,8 @@ import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import StatusContainer from '@/app/components/workflow/run/status-container'
 
+const DIFY_FILE_IDENTITY = '__dify__file__'
+
 type OutputPanelProps = {
   isRunning?: boolean
   outputs?: any
@@ -44,9 +46,9 @@ const OutputPanel: FC<OutputPanelProps> = ({
       return false
     return fileList.length > 0 && Object.keys(outputs).every((key) => {
       const val = outputs[key]
-      if (Array.isArray(val))
-        return val.every((item: any) => item?.dify_model_identity === '__dify__file__')
-      return val?.dify_model_identity === '__dify__file__'
+      return Array.isArray(val)
+        ? val.every((item: any) => item?.dify_model_identity === DIFY_FILE_IDENTITY)
+        : val?.dify_model_identity === DIFY_FILE_IDENTITY
     })
   }, [outputs, fileList])
 

--- a/web/app/components/workflow/run/output-panel.tsx
+++ b/web/app/components/workflow/run/output-panel.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import { useMemo } from 'react'
 import LoadingAnim from '@/app/components/base/chat/chat/loading-anim'
 import { FileList } from '@/app/components/base/file-uploader'
-import { getProcessedFilesFromResponse } from '@/app/components/base/file-uploader/utils'
+import { getFilesInLogs } from '@/app/components/base/file-uploader/utils'
 import { Markdown } from '@/app/components/base/markdown'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
@@ -34,25 +34,22 @@ const OutputPanel: FC<OutputPanelProps> = ({
   }, [outputs])
 
   const fileList = useMemo(() => {
-    const fileList: any[] = []
     if (!outputs)
-      return fileList
-    if (Object.keys(outputs).length > 1)
-      return fileList
-    for (const key in outputs) {
-      if (Array.isArray(outputs[key])) {
-        outputs[key].map((output: any) => {
-          if (output?.dify_model_identity === '__dify__file__')
-            fileList.push(output)
-          return null
-        })
-      }
-      else if (outputs[key]?.dify_model_identity === '__dify__file__') {
-        fileList.push(outputs[key])
-      }
-    }
-    return getProcessedFilesFromResponse(fileList)
+      return []
+    return getFilesInLogs(outputs)
   }, [outputs])
+
+  const isFileOnlyOutput = useMemo(() => {
+    if (!outputs || typeof outputs !== 'object')
+      return false
+    return fileList.length > 0 && Object.keys(outputs).every((key) => {
+      const val = outputs[key]
+      if (Array.isArray(val))
+        return val.every((item: any) => item?.dify_model_identity === '__dify__file__')
+      return val?.dify_model_identity === '__dify__file__'
+    })
+  }, [outputs, fileList])
+
   return (
     <div className="p-2">
       {isRunning && (
@@ -82,16 +79,21 @@ const OutputPanel: FC<OutputPanelProps> = ({
         </div>
       )}
       {fileList.length > 0 && (
-        <div className="px-4 py-2">
-          <FileList
-            files={fileList}
-            showDeleteAction={false}
-            showDownloadAction
-            canPreview
-          />
+        <div className="flex flex-col gap-2 px-4 py-2">
+          {fileList.map((item: any) => (
+            <div key={item.varName} className="flex flex-col gap-1 system-xs-regular">
+              <div className="py-1 text-text-tertiary">{item.varName}</div>
+              <FileList
+                files={item.list}
+                showDeleteAction={false}
+                showDownloadAction
+                canPreview
+              />
+            </div>
+          ))}
         </div>
       )}
-      {!isTextOutput && outputs && Object.keys(outputs).length > 0 && height! > 0 && (
+      {!isTextOutput && !isFileOnlyOutput && outputs && Object.keys(outputs).length > 0 && height! > 0 && (
         <div className="flex flex-col gap-2">
           <CodeEditor
             showFileList


### PR DESCRIPTION
## Summary

Fixes #33419 — files returned by the response/answer/end node in the workflow result panel do not show file icons; only a raw UUID link is displayed.

### Root Cause

`output-panel.tsx` (used in the RESULT tab for historical workflow runs) had two bugs in its `fileList` memo:

1. **Early return on multi-key outputs** — `if (Object.keys(outputs).length > 1) return fileList` caused the file list to always be empty. The Answer/End node always emits at least two output keys (e.g. `"answer"` + `"files"`), so the guard fired unconditionally and no files were ever collected.

2. **Wrong utility + wrong data shape** — files were accumulated manually and passed to `getProcessedFilesFromResponse(FileResponse[])`, which returns a flat `FileEntity[]`. The `FileList` component in the rest of the run panel (e.g. `result-text.tsx`) expects a `{varName: string, list: FileEntity[]}[]` grouped structure from `getFilesInLogs`.

### Changes

**`web/app/components/workflow/run/output-panel.tsx`**
- Replace the manual file-collection loop and `getProcessedFilesFromResponse` with `getFilesInLogs(outputs)`, consistent with `result-text.tsx` and the rest of the run panel.
- Add `isFileOnlyOutput` memo to suppress the raw JSON code editor when every output value is a file object (previously raw JSON with UUIDs was always rendered alongside/instead of file icons).
- Render files as grouped rows with a variable-name label above each `FileList`, matching the established pattern.

**`web/app/components/workflow/panel/workflow-preview.tsx`**
- Add a branch in the `workflowRunningData` effect to auto-switch to the RESULT tab when a run finishes with file outputs but no text result (previously it fell through to DETAIL unconditionally).

## Test plan

- [ ] Run a workflow with an Answer node that returns file outputs; confirm files are shown with proper icons and filenames in the RESULT tab.
- [ ] Run a workflow with an End node that returns only files; confirm `isFileOnlyOutput` suppresses the JSON code editor and only file icons are shown.
- [ ] Run a workflow with a mix of text and file outputs; confirm text renders as Markdown and files render below it.
- [ ] Run a workflow with only text outputs; confirm existing text rendering is unchanged.
- [ ] Verify that after a file-only workflow run completes, the panel auto-switches to the RESULT tab.