### PR TITLE
fix(web): prevent page navigation when closing workflow detail panel

### DIFF
--- a/web/app/components/app/overview/app-card.tsx
+++ b/web/app/components/app/overview/app-card.tsx
@@ -143,6 +143,16 @@ function AppCard({
           setShowEmbedded(true)
         }
       default:
+        // When rendered inside a panel (e.g. the workflow detail panel), navigate to
+        // the develop page in a new tab to avoid triggering a same-page navigation that
+        // would clear the app detail and make the current page disappear.
+        if (isInPanel) {
+          return () => {
+            const pathSegments = pathname.split('/')
+            pathSegments.pop()
+            window.open(`${pathSegments.join('/')}/develop`, '_blank')
+          }
+        }
         // jump to page develop
         return () => {
           const pathSegments = pathname.split('/')


### PR DESCRIPTION
## Summary

- When `AppCard` is rendered inside the `AppInfoDetailPanel` (i.e. `isInPanel=true`), clicking the **API Reference** button on the API card called `router.push()` to navigate to the `/develop` route
- This same-tab navigation changed `pathname`, which triggered the `useEffect([appId, pathname])` in `layout-main.tsx` to re-run, clearing `appDetail` and showing a loading screen — making the workflow canvas appear to "disappear"
- Fixed by checking `isInPanel` in the `default` branch of `genClickFuncByName`: when inside a panel, `window.open(..., '_blank')` is used instead of `router.push()`, so the develop page opens in a new tab without affecting the current page's pathname or state

## Test plan

- [ ] Open a chatflow app and navigate to the workflow canvas (`/app/[id]/workflow`)
- [ ] Click the app icon in the top-left to open the dropdown, then click the app detail icon to open the `AppInfoDetailPanel`
- [ ] In the panel, click the **Settings** button on the Web App card — the Settings modal should open
- [ ] Close the Settings modal (click X or press Escape)
- [ ] Click the **API Reference** button on the Backend Service API card — it should open the develop page in a **new tab**, and the workflow canvas should remain visible and unchanged
- [ ] Click the backdrop/overlay of the `AppInfoDetailPanel` — it should close the panel without any page navigation
- [ ] Verify the same behaviour on the regular app sidebar (non-maximized canvas)

Closes #33278