### PR TITLE
feat: support direct import of Claude workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ pyrightconfig.json
 .idea/'
 
 .DS_Store
+.worktrees/
 
 # Intellij IDEA Files
 .idea/*

--- a/api/controllers/console/app/app_import.py
+++ b/api/controllers/console/app/app_import.py
@@ -18,6 +18,7 @@ from fields.app_fields import (
 from libs.login import current_account_with_tenant, login_required
 from models.model import App
 from services.app_dsl_service import AppDslService, ImportStatus
+from services.claude_workflow.import_service import ClaudeWorkflowImportExecutionError, ClaudeWorkflowImportService
 from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
 
@@ -72,21 +73,23 @@ class AppImportApi(Resource):
 
         # Create service with session
         with Session(db.engine) as session:
-            import_service = AppDslService(session)
-            # Import app
-            account = current_user
-            result = import_service.import_app(
-                account=account,
-                import_mode=args.mode,
-                yaml_content=args.yaml_content,
-                yaml_url=args.yaml_url,
-                name=args.name,
-                description=args.description,
-                icon_type=args.icon_type,
-                icon=args.icon,
-                icon_background=args.icon_background,
-                app_id=args.app_id,
-            )
+            import_service = ClaudeWorkflowImportService(session)
+            try:
+                result = import_service.import_app(
+                    account=current_user,
+                    import_mode=args.mode,
+                    yaml_content=args.yaml_content,
+                    yaml_url=args.yaml_url,
+                    name=args.name,
+                    description=args.description,
+                    icon_type=args.icon_type,
+                    icon=args.icon,
+                    icon_background=args.icon_background,
+                    app_id=args.app_id,
+                )
+            except ClaudeWorkflowImportExecutionError as exc:
+                session.commit()
+                return exc.payload.model_dump(mode="json"), exc.status_code
             session.commit()
         if result.app_id and FeatureService.get_system_features().webapp_auth.enabled:
             # update web app setting as private

--- a/api/services/claude_workflow/__init__.py
+++ b/api/services/claude_workflow/__init__.py
@@ -1,6 +1,7 @@
 """Claude workflow schema helpers used by the import pipeline."""
 
 from .errors import (
+    ClaudeWorkflowCompilerError,
     ClaudeWorkflowSchemaErrorCode,
     ClaudeWorkflowSchemaValidationError,
     ClaudeWorkflowValidationIssue,
@@ -10,6 +11,7 @@ from .schema import ClaudeWorkflowDocument, parse_claude_workflow_document
 
 __all__ = [
     "ClaudeWorkflowDocument",
+    "ClaudeWorkflowCompilerError",
     "ClaudeWorkflowSchemaErrorCode",
     "ClaudeWorkflowSchemaValidationError",
     "ClaudeWorkflowValidationIssue",

--- a/api/services/claude_workflow/__init__.py
+++ b/api/services/claude_workflow/__init__.py
@@ -1,0 +1,16 @@
+"""Claude workflow schema helpers used by the import pipeline."""
+
+from .errors import (
+    ClaudeWorkflowSchemaErrorCode,
+    ClaudeWorkflowSchemaValidationError,
+    ClaudeWorkflowValidationIssue,
+)
+from .schema import ClaudeWorkflowDocument, parse_claude_workflow_document
+
+__all__ = [
+    "ClaudeWorkflowDocument",
+    "ClaudeWorkflowSchemaErrorCode",
+    "ClaudeWorkflowSchemaValidationError",
+    "ClaudeWorkflowValidationIssue",
+    "parse_claude_workflow_document",
+]

--- a/api/services/claude_workflow/__init__.py
+++ b/api/services/claude_workflow/__init__.py
@@ -5,6 +5,7 @@ from .errors import (
     ClaudeWorkflowSchemaValidationError,
     ClaudeWorkflowValidationIssue,
 )
+from .compiler import compile_claude_workflow_to_dify_dsl
 from .schema import ClaudeWorkflowDocument, parse_claude_workflow_document
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "ClaudeWorkflowSchemaErrorCode",
     "ClaudeWorkflowSchemaValidationError",
     "ClaudeWorkflowValidationIssue",
+    "compile_claude_workflow_to_dify_dsl",
     "parse_claude_workflow_document",
 ]

--- a/api/services/claude_workflow/compiler.py
+++ b/api/services/claude_workflow/compiler.py
@@ -1,0 +1,294 @@
+"""Compile Claude workflow documents into Dify app DSL YAML.
+
+The compiler intentionally emits a narrow subset of Dify workflow DSL that
+matches the current Claude workflow schema. It preserves node identifiers,
+builds the synthetic Dify start node from top-level inputs, and keeps edge
+handles deterministic so the later import service can hand the result directly
+to ``AppDslService.import_app()``.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import yaml
+
+from .schema import ClaudeWorkflowDocument, CodeNode, EndNode, HttpRequestNode, IfElseNode, LlmNode
+
+DEFAULT_ICON_BACKGROUND = "#FFEAD5"
+DEFAULT_VIEWPORT = {"x": 0, "y": 0, "zoom": 0.7}
+DEFAULT_TIMEOUT = {"connect": 10, "read": 30, "write": 30}
+DEFAULT_RETRY_CONFIG = {
+    "enabled": False,
+    "max_retries": 1,
+    "retry_interval": 1000,
+    "exponential_backoff": {"enabled": False, "multiplier": 2, "max_interval": 10000},
+}
+NODE_WIDTH = 244
+
+
+def compile_claude_workflow_to_dify_dsl(document: ClaudeWorkflowDocument) -> str:
+    """Compile a validated Claude workflow document into Dify workflow YAML."""
+
+    graph_nodes = [_build_start_node(document)]
+    graph_nodes.extend(_build_workflow_node(node, index) for index, node in enumerate(document.nodes, start=1))
+
+    payload = {
+        "app": {
+            "description": document.app.description or "",
+            "icon": document.app.icon or "",
+            "icon_background": DEFAULT_ICON_BACKGROUND,
+            "mode": document.app.mode,
+            "name": document.app.name,
+            "use_icon_as_answer_icon": False,
+        },
+        "dependencies": [],
+        "kind": "app",
+        "version": "0.3.1",
+        "workflow": {
+            "conversation_variables": [],
+            "environment_variables": [],
+            "features": _build_workflow_features(),
+            "graph": {
+                "edges": [_build_edge(edge, document) for edge in document.edges],
+                "nodes": graph_nodes,
+                "viewport": DEFAULT_VIEWPORT,
+            },
+        },
+    }
+
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+
+
+def _build_workflow_features() -> dict:
+    return {
+        "file_upload": {"enabled": False},
+        "opening_statement": "",
+        "retriever_resource": {"enabled": False},
+        "sensitive_word_avoidance": {"enabled": False},
+        "speech_to_text": {"enabled": False},
+        "suggested_questions": [],
+        "suggested_questions_after_answer": {"enabled": False},
+        "text_to_speech": {"enabled": False},
+    }
+
+
+def _build_start_node(document: ClaudeWorkflowDocument) -> dict:
+    variables = [
+        {
+            "label": workflow_input.name,
+            "max_length": None,
+            "options": [],
+            "required": workflow_input.required,
+            "type": "text-input",
+            "variable": workflow_input.name,
+        }
+        for workflow_input in document.inputs
+    ]
+
+    return _graph_node(
+        node_id="start",
+        title="Start",
+        node_type="start",
+        data={"desc": "", "selected": False, "title": "Start", "type": "start", "variables": variables},
+        x=30,
+        y=227,
+        height=90,
+    )
+
+
+def _build_workflow_node(node: object, index: int) -> dict:
+    x = 30 + (index * 304)
+    y = 227
+
+    if isinstance(node, LlmNode):
+        data = {
+            "desc": "",
+            "title": node.title,
+            "type": "llm",
+            "model": {
+                "provider": node.model.provider,
+                "name": node.model.name,
+                "mode": node.model.mode,
+            },
+            "prompt_template": [
+                {"role": prompt.role, "text": prompt.text or _selector_to_template(prompt.selector.value)}
+                for prompt in node.prompt
+            ],
+            "vision": {"enabled": False, "configs": {"variable_selector": []}},
+            "memory": {"enabled": False, "window": {"enabled": False, "size": 50}},
+            "context": {"enabled": False, "variable_selector": []},
+            "structured_output": {"enabled": False},
+            "retry_config": DEFAULT_RETRY_CONFIG,
+        }
+        return _graph_node(node.id, node.title, "llm", data, x=x, y=y, height=90)
+
+    if isinstance(node, IfElseNode):
+        raw_cases = cast(list[dict], node.model_extra.get("cases", []))
+        data = {
+            "cases": [_build_if_else_case(case, node.id) for case in raw_cases],
+            "desc": "",
+            "selected": False,
+            "title": node.title,
+            "type": "if-else",
+        }
+        return _graph_node(node.id, node.title, "if-else", data, x=x, y=y + 36, height=126)
+
+    if isinstance(node, HttpRequestNode):
+        raw_url = node.model_extra.get("url")
+        data = {
+            "desc": "",
+            "title": node.title,
+            "type": "http-request",
+            "method": str(node.model_extra.get("method", "GET")).upper(),
+            "url": _compile_string_or_selector(raw_url),
+            "authorization": {"type": "no-auth"},
+            "headers": "",
+            "params": "",
+            "body": {"type": "none", "data": ""},
+            "timeout": DEFAULT_TIMEOUT,
+            "retry_config": DEFAULT_RETRY_CONFIG,
+        }
+        return _graph_node(node.id, node.title, "http-request", data, x=x, y=y, height=90)
+
+    if isinstance(node, CodeNode):
+        raw_outputs = cast(list[dict], node.model_extra.get("outputs", []))
+        raw_inputs = cast(list[dict], node.model_extra.get("inputs", []))
+        data = {
+            "code": str(node.model_extra.get("source", "")),
+            "code_language": str(node.model_extra.get("language", "python3")),
+            "desc": "",
+            "outputs": {
+                output["name"]: {"children": None, "type": output.get("type", "string")}
+                for output in raw_outputs
+            },
+            "selected": False,
+            "title": node.title,
+            "type": "code",
+            "variables": [
+                {
+                    "value_selector": _selector_parts(input_value["selector"]),
+                    "value_type": input_value.get("value_type", "string"),
+                    "variable": input_value["name"],
+                }
+                for input_value in raw_inputs
+            ],
+        }
+        return _graph_node(node.id, node.title, "code", data, x=x, y=y, height=54)
+
+    if isinstance(node, EndNode):
+        data = {
+            "desc": "",
+            "outputs": [
+                {
+                    "value_selector": list(output.selector.value),
+                    "value_type": "string",
+                    "variable": output.name,
+                }
+                for output in node.outputs
+            ],
+            "selected": False,
+            "title": node.title,
+            "type": "end",
+        }
+        return _graph_node(node.id, node.title, "end", data, x=x, y=y, height=90)
+
+    raise TypeError(f"Unsupported node instance: {type(node)!r}")
+
+
+def _build_if_else_case(raw_case: dict, node_id: str) -> dict:
+    case_id = str(raw_case["id"])
+    conditions = []
+
+    for index, raw_condition in enumerate(cast(list[dict], raw_case.get("conditions", []))):
+        conditions.append(
+            {
+                "comparison_operator": raw_condition["operator"],
+                "id": f"{node_id}-{case_id}-{index}",
+                "value": raw_condition["value"],
+                "varType": raw_condition.get("value_type", "string"),
+                "variable_selector": _selector_parts(raw_condition["selector"]),
+            }
+        )
+
+    return {
+        "case_id": case_id,
+        "conditions": conditions,
+        "id": case_id,
+        "logical_operator": raw_case.get("logical_operator", "and"),
+    }
+
+
+def _build_edge(edge: object, document: ClaudeWorkflowDocument) -> dict:
+    source = cast(str, getattr(edge, "source"))
+    target = cast(str, getattr(edge, "target"))
+    source_handle = cast(str | None, getattr(edge, "source_handle")) or "source"
+    target_handle = cast(str | None, getattr(edge, "target_handle")) or "target"
+    source_type = _dify_node_type(source, document)
+    target_type = _dify_node_type(target, document)
+
+    return {
+        "data": {
+            "isInIteration": False,
+            "isInLoop": False,
+            "sourceType": source_type,
+            "targetType": target_type,
+        },
+        "id": f"{source}-{source_handle}-{target}-{target_handle}",
+        "source": source,
+        "sourceHandle": source_handle,
+        "target": target,
+        "targetHandle": target_handle,
+        "type": "custom",
+        "zIndex": 0,
+    }
+
+
+def _dify_node_type(node_id: str, document: ClaudeWorkflowDocument) -> str:
+    if node_id == "start":
+        return "start"
+
+    node = next(node for node in document.nodes if node.id == node_id)
+
+    if isinstance(node, IfElseNode):
+        return "if-else"
+    if isinstance(node, HttpRequestNode):
+        return "http-request"
+    return node.type
+
+
+def _compile_string_or_selector(raw_value: object) -> str:
+    if isinstance(raw_value, dict) and "selector" in raw_value:
+        return _selector_to_template(tuple(_selector_parts(raw_value["selector"])))
+    if isinstance(raw_value, list):
+        return _selector_to_template(tuple(_selector_parts(raw_value)))
+    return str(raw_value or "")
+
+
+def _selector_parts(raw_selector: object) -> list[str]:
+    if isinstance(raw_selector, dict):
+        raw_selector = raw_selector.get("selector")
+
+    if not isinstance(raw_selector, (list, tuple)) or len(raw_selector) != 2:
+        raise ValueError(f"Invalid selector payload: {raw_selector!r}")
+
+    return [str(raw_selector[0]), str(raw_selector[1])]
+
+
+def _selector_to_template(selector: tuple[str, str]) -> str:
+    return f"{{{{#{selector[0]}.{selector[1]}#}}}}"
+
+
+def _graph_node(node_id: str, title: str, node_type: str, data: dict, *, x: int, y: int, height: int) -> dict:
+    return {
+        "data": data,
+        "height": height,
+        "id": node_id,
+        "position": {"x": x, "y": y},
+        "positionAbsolute": {"x": x, "y": y},
+        "selected": False,
+        "sourcePosition": "right",
+        "targetPosition": "left",
+        "type": "custom",
+        "width": NODE_WIDTH,
+    }

--- a/api/services/claude_workflow/compiler.py
+++ b/api/services/claude_workflow/compiler.py
@@ -13,6 +13,7 @@ from typing import cast
 
 import yaml
 
+from .errors import ClaudeWorkflowCompilerError
 from .schema import ClaudeWorkflowDocument, CodeNode, EndNode, HttpRequestNode, IfElseNode, LlmNode
 
 DEFAULT_ICON_BACKGROUND = "#FFEAD5"
@@ -193,7 +194,7 @@ def _build_workflow_node(node: object, index: int) -> dict:
         }
         return _graph_node(node.id, node.title, "end", data, x=x, y=y, height=90)
 
-    raise TypeError(f"Unsupported node instance: {type(node)!r}")
+    raise ClaudeWorkflowCompilerError(f"Unsupported node instance: {type(node)!r}")
 
 
 def _build_if_else_case(raw_case: dict, node_id: str) -> dict:
@@ -270,7 +271,7 @@ def _selector_parts(raw_selector: object) -> list[str]:
         raw_selector = raw_selector.get("selector")
 
     if not isinstance(raw_selector, (list, tuple)) or len(raw_selector) != 2:
-        raise ValueError(f"Invalid selector payload: {raw_selector!r}")
+        raise ClaudeWorkflowCompilerError(f"Invalid selector payload: {raw_selector!r}")
 
     return [str(raw_selector[0]), str(raw_selector[1])]
 

--- a/api/services/claude_workflow/errors.py
+++ b/api/services/claude_workflow/errors.py
@@ -38,3 +38,7 @@ class ClaudeWorkflowSchemaValidationError(ValueError):
     def __init__(self, errors: list[ClaudeWorkflowValidationIssue]) -> None:
         self.errors = errors
         super().__init__("Claude workflow schema validation failed")
+
+
+class ClaudeWorkflowCompilerError(ValueError):
+    """Raised when a validated Claude workflow cannot be compiled to Dify DSL."""

--- a/api/services/claude_workflow/errors.py
+++ b/api/services/claude_workflow/errors.py
@@ -1,0 +1,40 @@
+"""Stable error types for Claude workflow schema validation.
+
+The import controller needs machine-readable failure information so the web
+flow can distinguish invalid Claude workflow files from later compiler or Dify
+DSL import failures. These errors stay scoped to the Claude workflow schema
+layer and do not depend on Flask or persistence concerns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ClaudeWorkflowSchemaErrorCode(StrEnum):
+    """Stable error codes returned by Claude workflow schema validation."""
+
+    INVALID_FIELD = "invalid_field"
+    UNKNOWN_EDGE_TARGET = "unknown_edge_target"
+    UNKNOWN_VARIABLE_SELECTOR_SOURCE = "unknown_variable_selector_source"
+    UNSUPPORTED_NODE_TYPE = "unsupported_node_type"
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeWorkflowValidationIssue:
+    """A single schema validation problem with a precise field path."""
+
+    code: ClaudeWorkflowSchemaErrorCode
+    path: tuple[str | int, ...]
+    message: str
+
+
+class ClaudeWorkflowSchemaValidationError(ValueError):
+    """Raised when a Claude workflow file fails schema validation."""
+
+    errors: list[ClaudeWorkflowValidationIssue]
+
+    def __init__(self, errors: list[ClaudeWorkflowValidationIssue]) -> None:
+        self.errors = errors
+        super().__init__("Claude workflow schema validation failed")

--- a/api/services/claude_workflow/import_service.py
+++ b/api/services/claude_workflow/import_service.py
@@ -1,0 +1,212 @@
+"""Import Claude workflow files by compiling them into native Dify DSL first.
+
+This service sits in front of ``AppDslService``. It detects Claude workflow
+documents, validates them, compiles them to Dify YAML, and then delegates to
+the existing DSL import path. Non-Claude files still flow through the native
+``AppDslService`` logic unchanged.
+"""
+
+from __future__ import annotations
+
+import uuid
+from urllib.parse import urlparse
+
+import yaml
+from sqlalchemy.orm import Session
+
+from core.helper import ssrf_proxy
+from models import Account
+from services.app_dsl_service import AppDslService, Import, ImportMode, ImportStatus
+
+from .compiler import compile_claude_workflow_to_dify_dsl
+from .errors import ClaudeWorkflowCompilerError, ClaudeWorkflowSchemaValidationError
+from .schema import parse_claude_workflow_document
+
+DSL_MAX_SIZE = 10 * 1024 * 1024  # 10MB
+
+
+class ClaudeWorkflowImportExecutionError(ValueError):
+    """Controller-facing import failure with a prebuilt payload and status code."""
+
+    status_code: int
+    payload: Import
+
+    def __init__(self, *, status_code: int, payload: Import) -> None:
+        self.status_code = status_code
+        self.payload = payload
+        super().__init__(payload.error)
+
+
+class ClaudeWorkflowImportService:
+    """Detect Claude workflow files and compile them before importing."""
+
+    _session: Session
+    _dsl_service: AppDslService
+
+    def __init__(self, session: Session, dsl_service: AppDslService | None = None) -> None:
+        self._session = session
+        self._dsl_service = dsl_service or AppDslService(session)
+
+    def import_app(
+        self,
+        *,
+        account: Account,
+        import_mode: str,
+        yaml_content: str | None = None,
+        yaml_url: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        icon_type: str | None = None,
+        icon: str | None = None,
+        icon_background: str | None = None,
+        app_id: str | None = None,
+    ) -> Import:
+        """Import native Dify DSL directly or compile Claude workflow first."""
+
+        content = self._load_yaml_content(import_mode=import_mode, yaml_content=yaml_content, yaml_url=yaml_url)
+        if not content:
+            return self._delegate_import(
+                account=account,
+                import_mode=import_mode,
+                yaml_content=yaml_content,
+                yaml_url=yaml_url,
+                name=name,
+                description=description,
+                icon_type=icon_type,
+                icon=icon,
+                icon_background=icon_background,
+                app_id=app_id,
+            )
+
+        try:
+            parsed = yaml.safe_load(content)
+        except yaml.YAMLError:
+            return self._delegate_import(
+                account=account,
+                import_mode=import_mode,
+                yaml_content=yaml_content,
+                yaml_url=yaml_url,
+                name=name,
+                description=description,
+                icon_type=icon_type,
+                icon=icon,
+                icon_background=icon_background,
+                app_id=app_id,
+            )
+
+        if not isinstance(parsed, dict) or parsed.get("kind") != "claude-workflow":
+            return self._delegate_import(
+                account=account,
+                import_mode=import_mode,
+                yaml_content=yaml_content,
+                yaml_url=yaml_url,
+                name=name,
+                description=description,
+                icon_type=icon_type,
+                icon=icon,
+                icon_background=icon_background,
+                app_id=app_id,
+            )
+
+        try:
+            document = parse_claude_workflow_document(parsed)
+        except ClaudeWorkflowSchemaValidationError as exc:
+            raise ClaudeWorkflowImportExecutionError(
+                status_code=400,
+                payload=_failed_import_payload(_format_schema_error(exc)),
+            ) from exc
+
+        try:
+            compiled_yaml = compile_claude_workflow_to_dify_dsl(document)
+        except ClaudeWorkflowCompilerError as exc:
+            raise ClaudeWorkflowImportExecutionError(
+                status_code=422,
+                payload=_failed_import_payload(str(exc)),
+            ) from exc
+
+        return self._delegate_import(
+            account=account,
+            import_mode=ImportMode.YAML_CONTENT,
+            yaml_content=compiled_yaml,
+            yaml_url=None,
+            name=name,
+            description=description,
+            icon_type=icon_type,
+            icon=icon,
+            icon_background=icon_background,
+            app_id=app_id,
+        )
+
+    def _delegate_import(
+        self,
+        *,
+        account: Account,
+        import_mode: str,
+        yaml_content: str | None,
+        yaml_url: str | None,
+        name: str | None,
+        description: str | None,
+        icon_type: str | None,
+        icon: str | None,
+        icon_background: str | None,
+        app_id: str | None,
+    ) -> Import:
+        return self._dsl_service.import_app(
+            account=account,
+            import_mode=import_mode,
+            yaml_content=yaml_content,
+            yaml_url=yaml_url,
+            name=name,
+            description=description,
+            icon_type=icon_type,
+            icon=icon,
+            icon_background=icon_background,
+            app_id=app_id,
+        )
+
+    def _load_yaml_content(self, *, import_mode: str, yaml_content: str | None, yaml_url: str | None) -> str | None:
+        try:
+            mode = ImportMode(import_mode)
+        except ValueError:
+            return None
+
+        if mode == ImportMode.YAML_CONTENT:
+            return yaml_content
+
+        if mode != ImportMode.YAML_URL or not yaml_url:
+            return None
+
+        try:
+            parsed_url = urlparse(yaml_url)
+            if (
+                parsed_url.scheme == "https"
+                and parsed_url.netloc == "github.com"
+                and parsed_url.path.endswith((".yml", ".yaml"))
+                and "/blob/" in parsed_url.path
+            ):
+                yaml_url = yaml_url.replace("https://github.com", "https://raw.githubusercontent.com")
+                yaml_url = yaml_url.replace("/blob/", "/")
+            response = ssrf_proxy.get(yaml_url.strip(), follow_redirects=True, timeout=(10, 10))
+            response.raise_for_status()
+            content = response.content.decode()
+        except Exception:
+            return None
+
+        if len(content) > DSL_MAX_SIZE:
+            return None
+
+        return content
+
+
+def _failed_import_payload(error: str) -> Import:
+    return Import(
+        id=str(uuid.uuid4()),
+        status=ImportStatus.FAILED,
+        error=error,
+    )
+
+
+def _format_schema_error(exc: ClaudeWorkflowSchemaValidationError) -> str:
+    first_issue = exc.errors[0]
+    path = ".".join(str(part) for part in first_issue.path)
+    return f"{path}: {first_issue.message}"

--- a/api/services/claude_workflow/schema.py
+++ b/api/services/claude_workflow/schema.py
@@ -1,0 +1,315 @@
+"""Pydantic schema models for Claude workflow import documents.
+
+The parser keeps the Claude workflow format intentionally narrower than Dify's
+native workflow DSL. It validates a constrained top-level document, only allows
+node types that can be mapped deterministically later, and performs cross-node
+reference checks before compilation.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
+
+from .errors import (
+    ClaudeWorkflowSchemaErrorCode,
+    ClaudeWorkflowSchemaValidationError,
+    ClaudeWorkflowValidationIssue,
+)
+
+
+class ClaudeWorkflowApp(BaseModel):
+    """Metadata for a Claude workflow app."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str | None = None
+    mode: Literal["workflow"]
+    icon: str | None = None
+
+
+class ClaudeWorkflowDependency(BaseModel):
+    """A declared external dependency used by the workflow."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ClaudeWorkflowInput(BaseModel):
+    """A workflow input that later maps to the Dify start node."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: Literal["text"]
+    required: bool = True
+
+
+class VariableSelector(BaseModel):
+    """Explicit source selector used instead of free-form string interpolation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: tuple[str, str]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_sequence(cls, value: object) -> object:
+        if isinstance(value, list):
+            return {"value": tuple(str(item) for item in value)}
+        return value
+
+    @field_validator("value")
+    @classmethod
+    def _validate_length(cls, value: tuple[str, str]) -> tuple[str, str]:
+        if len(value) != 2:
+            raise ValueError("selector must contain exactly two path segments")
+        return value
+
+
+class PromptMessage(BaseModel):
+    """A single prompt block for an LLM node."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Literal["system", "user", "assistant"]
+    text: str | None = None
+    selector: VariableSelector | None = None
+
+    @model_validator(mode="after")
+    def _validate_message_payload(self) -> "PromptMessage":
+        if (self.text is None) == (self.selector is None):
+            raise ValueError("prompt message must define exactly one of text or selector")
+        return self
+
+
+class EndOutput(BaseModel):
+    """Output mapping declared by an end node."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    selector: VariableSelector
+
+
+class ClaudeWorkflowNodeBase(BaseModel):
+    """Shared required fields across all supported Claude nodes."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    type: str
+    title: str
+
+
+class LlmModelConfig(BaseModel):
+    """Subset of model metadata needed for LLM node validation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    name: str
+    mode: str
+
+
+class LlmNode(ClaudeWorkflowNodeBase):
+    """LLM node configuration with explicit prompt blocks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["llm"]
+    model: LlmModelConfig
+    prompt: list[PromptMessage]
+
+
+class EndNode(ClaudeWorkflowNodeBase):
+    """Terminal node that exposes workflow outputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["end"]
+    outputs: list[EndOutput]
+
+
+class IfElseNode(ClaudeWorkflowNodeBase):
+    """Placeholder schema for future conditional node compilation."""
+
+    type: Literal["if_else"]
+
+
+class HttpRequestNode(ClaudeWorkflowNodeBase):
+    """Placeholder schema for future HTTP request node compilation."""
+
+    type: Literal["http_request"]
+
+
+class CodeNode(ClaudeWorkflowNodeBase):
+    """Placeholder schema for future code node compilation."""
+
+    type: Literal["code"]
+
+
+SupportedNode = LlmNode | EndNode | IfElseNode | HttpRequestNode | CodeNode
+
+SUPPORTED_NODE_TYPES: dict[str, type[SupportedNode]] = {
+    "code": CodeNode,
+    "end": EndNode,
+    "http_request": HttpRequestNode,
+    "if_else": IfElseNode,
+    "llm": LlmNode,
+}
+
+
+class ClaudeWorkflowEdge(BaseModel):
+    """A directed edge between workflow nodes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    target: str
+    source_handle: str | None = None
+    target_handle: str | None = None
+
+
+class _ClaudeWorkflowDocumentEnvelope(BaseModel):
+    """Validated top-level document before node-specific parsing."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["claude-workflow"]
+    version: str
+    app: ClaudeWorkflowApp
+    dependencies: list[ClaudeWorkflowDependency] = []
+    inputs: list[ClaudeWorkflowInput]
+    nodes: list[dict]
+    edges: list[ClaudeWorkflowEdge]
+
+
+class ClaudeWorkflowDocument(BaseModel):
+    """Validated Claude workflow document used by later compiler stages."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["claude-workflow"]
+    version: str
+    app: ClaudeWorkflowApp
+    dependencies: list[ClaudeWorkflowDependency]
+    inputs: list[ClaudeWorkflowInput]
+    nodes: list[SupportedNode]
+    edges: list[ClaudeWorkflowEdge]
+
+
+def parse_claude_workflow_document(raw_document: dict) -> ClaudeWorkflowDocument:
+    """Validate a raw Claude workflow document and return the typed model."""
+
+    envelope = _validate_envelope(raw_document)
+    parsed_nodes = _parse_nodes(envelope.nodes)
+
+    document = ClaudeWorkflowDocument.model_construct(
+        kind=envelope.kind,
+        version=envelope.version,
+        app=envelope.app,
+        dependencies=envelope.dependencies,
+        inputs=envelope.inputs,
+        nodes=parsed_nodes,
+        edges=envelope.edges,
+    )
+
+    _validate_cross_references(document)
+    return document
+
+
+def _validate_envelope(raw_document: dict) -> _ClaudeWorkflowDocumentEnvelope:
+    try:
+        return _ClaudeWorkflowDocumentEnvelope.model_validate(raw_document)
+    except ValidationError as exc:
+        raise ClaudeWorkflowSchemaValidationError(_issues_from_pydantic_error(exc)) from exc
+
+
+def _parse_nodes(raw_nodes: list[dict]) -> list[SupportedNode]:
+    issues: list[ClaudeWorkflowValidationIssue] = []
+    parsed_nodes: list[SupportedNode] = []
+
+    for index, raw_node in enumerate(raw_nodes):
+        node_type = raw_node.get("type")
+        if not isinstance(node_type, str) or node_type not in SUPPORTED_NODE_TYPES:
+            issues.append(
+                ClaudeWorkflowValidationIssue(
+                    code=ClaudeWorkflowSchemaErrorCode.UNSUPPORTED_NODE_TYPE,
+                    path=("nodes", index, "type"),
+                    message=f"Unsupported node type: {node_type!r}",
+                )
+            )
+            continue
+
+        node_model = SUPPORTED_NODE_TYPES[node_type]
+
+        try:
+            parsed_nodes.append(node_model.model_validate(raw_node))
+        except ValidationError as exc:
+            issues.extend(_issues_from_pydantic_error(exc, prefix=("nodes", index)))
+
+    if issues:
+        raise ClaudeWorkflowSchemaValidationError(issues)
+
+    return parsed_nodes
+
+
+def _validate_cross_references(document: ClaudeWorkflowDocument) -> None:
+    node_ids = {node.id for node in document.nodes}
+    valid_sources = {"start", *node_ids}
+    issues: list[ClaudeWorkflowValidationIssue] = []
+
+    for index, edge in enumerate(document.edges):
+        if edge.target not in node_ids:
+            issues.append(
+                ClaudeWorkflowValidationIssue(
+                    code=ClaudeWorkflowSchemaErrorCode.UNKNOWN_EDGE_TARGET,
+                    path=("edges", index, "target"),
+                    message=f"Unknown edge target: {edge.target}",
+                )
+            )
+
+    for node_index, node in enumerate(document.nodes):
+        if isinstance(node, LlmNode):
+            for prompt_index, prompt_message in enumerate(node.prompt):
+                if prompt_message.selector and prompt_message.selector.value[0] not in valid_sources:
+                    issues.append(
+                        ClaudeWorkflowValidationIssue(
+                            code=ClaudeWorkflowSchemaErrorCode.UNKNOWN_VARIABLE_SELECTOR_SOURCE,
+                            path=("nodes", node_index, "prompt", prompt_index, "selector"),
+                            message=f"Unknown selector source: {prompt_message.selector.value[0]}",
+                        )
+                    )
+        elif isinstance(node, EndNode):
+            for output_index, output in enumerate(node.outputs):
+                if output.selector.value[0] not in valid_sources:
+                    issues.append(
+                        ClaudeWorkflowValidationIssue(
+                            code=ClaudeWorkflowSchemaErrorCode.UNKNOWN_VARIABLE_SELECTOR_SOURCE,
+                            path=("nodes", node_index, "outputs", output_index, "selector"),
+                            message=f"Unknown selector source: {output.selector.value[0]}",
+                        )
+                    )
+
+    if issues:
+        raise ClaudeWorkflowSchemaValidationError(issues)
+
+
+def _issues_from_pydantic_error(
+    exc: ValidationError, *, prefix: tuple[str | int, ...] = ()
+) -> list[ClaudeWorkflowValidationIssue]:
+    issues: list[ClaudeWorkflowValidationIssue] = []
+
+    for error in exc.errors():
+        location = prefix + tuple(cast(tuple[str | int, ...], error["loc"]))
+        issues.append(
+            ClaudeWorkflowValidationIssue(
+                code=ClaudeWorkflowSchemaErrorCode.INVALID_FIELD,
+                path=location,
+                message=str(error["msg"]),
+            )
+        )
+
+    return issues

--- a/api/tests/fixtures/claude_workflow/basic_llm.yml
+++ b/api/tests/fixtures/claude_workflow/basic_llm.yml
@@ -1,0 +1,40 @@
+kind: claude-workflow
+version: 0.1.0
+app:
+  name: basic-llm
+  description: Simple linear workflow for schema validation.
+  mode: workflow
+  icon: 🤖
+dependencies: []
+inputs:
+  - name: query
+    type: text
+    required: true
+nodes:
+  - id: summarize
+    type: llm
+    title: Summarize
+    model:
+      provider: openai
+      name: gpt-4o-mini
+      mode: chat
+    prompt:
+      - role: system
+        text: You are a concise assistant.
+      - role: user
+        selector:
+          - start
+          - query
+  - id: done
+    type: end
+    title: End
+    outputs:
+      - name: answer
+        selector:
+          - summarize
+          - text
+edges:
+  - source: start
+    target: summarize
+  - source: summarize
+    target: done

--- a/api/tests/fixtures/claude_workflow/branching.yml
+++ b/api/tests/fixtures/claude_workflow/branching.yml
@@ -1,0 +1,51 @@
+kind: claude-workflow
+version: 0.1.0
+app:
+  name: branching
+  description: Workflow with an if/else branch.
+  mode: workflow
+  icon: 🤖
+dependencies: []
+inputs:
+  - name: query
+    type: text
+    required: true
+nodes:
+  - id: route
+    type: if_else
+    title: Route
+    cases:
+      - id: "true"
+        logical_operator: and
+        conditions:
+          - selector:
+              - start
+              - query
+            operator: contains
+            value: hello
+            value_type: string
+  - id: true_end
+    type: end
+    title: "True"
+    outputs:
+      - name: matched
+        selector:
+          - start
+          - query
+  - id: false_end
+    type: end
+    title: "False"
+    outputs:
+      - name: unmatched
+        selector:
+          - start
+          - query
+edges:
+  - source: start
+    target: route
+  - source: route
+    source_handle: "true"
+    target: true_end
+  - source: route
+    source_handle: "false"
+    target: false_end

--- a/api/tests/fixtures/claude_workflow/http_request.yml
+++ b/api/tests/fixtures/claude_workflow/http_request.yml
@@ -1,0 +1,56 @@
+kind: claude-workflow
+version: 0.1.0
+app:
+  name: fetch-and-transform
+  description: Workflow with HTTP request and code nodes.
+  mode: workflow
+  icon: 🔧
+dependencies: []
+inputs:
+  - name: url
+    type: text
+    required: true
+nodes:
+  - id: fetch
+    type: http_request
+    title: Fetch
+    method: GET
+    url:
+      selector:
+        - start
+        - url
+  - id: transform
+    type: code
+    title: Transform
+    language: python3
+    source: |
+      def main(body: str) -> dict:
+          return {"result": body}
+    inputs:
+      - name: body
+        selector:
+          - fetch
+          - body
+        value_type: string
+    outputs:
+      - name: result
+        type: string
+  - id: done
+    type: end
+    title: End
+    outputs:
+      - name: status_code
+        selector:
+          - fetch
+          - status_code
+      - name: transformed_body
+        selector:
+          - transform
+          - result
+edges:
+  - source: start
+    target: fetch
+  - source: fetch
+    target: transform
+  - source: transform
+    target: done

--- a/api/tests/fixtures/claude_workflow/invalid_missing_edge_target.yml
+++ b/api/tests/fixtures/claude_workflow/invalid_missing_edge_target.yml
@@ -1,0 +1,40 @@
+kind: claude-workflow
+version: 0.1.0
+app:
+  name: broken-edge
+  description: Invalid workflow with a dangling edge target.
+  mode: workflow
+  icon: 🤖
+dependencies: []
+inputs:
+  - name: query
+    type: text
+    required: true
+nodes:
+  - id: summarize
+    type: llm
+    title: Summarize
+    model:
+      provider: openai
+      name: gpt-4o-mini
+      mode: chat
+    prompt:
+      - role: system
+        text: You are a concise assistant.
+      - role: user
+        selector:
+          - start
+          - query
+  - id: done
+    type: end
+    title: End
+    outputs:
+      - name: answer
+        selector:
+          - summarize
+          - text
+edges:
+  - source: start
+    target: summarize
+  - source: summarize
+    target: missing-end

--- a/api/tests/unit_tests/controllers/console/app/test_claude_workflow_import_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_claude_workflow_import_api.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from services.app_dsl_service import Import, ImportStatus
+from services.claude_workflow.import_service import ClaudeWorkflowImportExecutionError
+
+
+FIXTURES_DIR = Path(__file__).resolve().parents[4] / "fixtures" / "claude_workflow"
+
+
+@pytest.fixture()
+def app_import_module(monkeypatch):
+    module_name = "controllers.console.app.app_import"
+    root = Path(__file__).resolve().parents[5]
+    module_path = root / "controllers" / "console" / "app" / "app_import.py"
+
+    class _StubNamespace:
+        def __init__(self) -> None:
+            self.models: dict[str, Any] = {}
+            self.payload: dict[str, Any] | None = None
+
+        def schema_model(self, name, schema):
+            self.models[name] = schema
+            return schema
+
+        def model(self, name, model_dict=None, **kwargs):
+            if model_dict is not None:
+                self.models[name] = model_dict
+            return model_dict
+
+        def route(self, *args, **kwargs):
+            def decorator(obj):
+                return obj
+
+            return decorator
+
+        def expect(self, *args, **kwargs):
+            def decorator(obj):
+                return obj
+
+            return decorator
+
+    def _identity_decorator(*args, **kwargs):
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return args[0]
+
+        def decorator(obj):
+            return obj
+
+        return decorator
+
+    original_modules: dict[str, ModuleType | None] = {
+        "controllers.console": sys.modules.get("controllers.console"),
+        "controllers.console.app": sys.modules.get("controllers.console.app"),
+        "controllers.console.app.wraps": sys.modules.get("controllers.console.app.wraps"),
+        "controllers.console.wraps": sys.modules.get("controllers.console.wraps"),
+        "extensions.ext_database": sys.modules.get("extensions.ext_database"),
+        "fields.app_fields": sys.modules.get("fields.app_fields"),
+        "libs.login": sys.modules.get("libs.login"),
+        module_name: sys.modules.get(module_name),
+    }
+
+    console_module = ModuleType("controllers.console")
+    console_module.__path__ = [str(root / "controllers" / "console")]
+    console_module.console_ns = _StubNamespace()
+    sys.modules["controllers.console"] = console_module
+
+    app_package = ModuleType("controllers.console.app")
+    app_package.__path__ = [str(root / "controllers" / "console" / "app")]
+    sys.modules["controllers.console.app"] = app_package
+
+    wraps_module = ModuleType("controllers.console.app.wraps")
+    wraps_module.get_app_model = _identity_decorator
+    sys.modules["controllers.console.app.wraps"] = wraps_module
+
+    console_wraps_module = ModuleType("controllers.console.wraps")
+    console_wraps_module.account_initialization_required = _identity_decorator
+    console_wraps_module.cloud_edition_billing_resource_check = _identity_decorator
+    console_wraps_module.edit_permission_required = _identity_decorator
+    console_wraps_module.setup_required = _identity_decorator
+    sys.modules["controllers.console.wraps"] = console_wraps_module
+
+    db_module = ModuleType("extensions.ext_database")
+    db_module.db = SimpleNamespace(engine=object())
+    sys.modules["extensions.ext_database"] = db_module
+
+    fields_module = ModuleType("fields.app_fields")
+    fields_module.app_import_check_dependencies_fields = {"leaked_dependencies": {}}
+    fields_module.app_import_fields = {"id": {}}
+    fields_module.leaked_dependency_fields = {"name": {}}
+    sys.modules["fields.app_fields"] = fields_module
+
+    login_module = ModuleType("libs.login")
+    login_module.current_account_with_tenant = lambda: (SimpleNamespace(current_tenant_id="tenant-1"), None)
+    login_module.login_required = _identity_decorator
+    sys.modules["libs.login"] = login_module
+
+    spec = util.spec_from_file_location(module_name, module_path)
+    module = util.module_from_spec(spec)
+    sys.modules[module_name] = module
+
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    try:
+        yield module
+    finally:
+        for name, original in original_modules.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+
+def _payload(name: str) -> dict[str, Any]:
+    return {
+        "mode": "yaml-content",
+        "yaml_content": (FIXTURES_DIR / name).read_text(encoding="utf-8"),
+    }
+
+
+    def test_app_import_api_returns_successful_import_payload(app_import_module, monkeypatch) -> None:
+        class _FakeSession:
+            def __enter__(self):
+                return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def commit(self):
+            return None
+
+    class _FakeImportService:
+        def __init__(self, session) -> None:
+            self.session = session
+
+        def import_app(self, **kwargs):
+            return Import(id="import-1", status=ImportStatus.COMPLETED, app_id="app-1", app_mode="workflow")
+
+    monkeypatch.setattr(app_import_module, "Session", lambda engine: _FakeSession())
+    monkeypatch.setattr(app_import_module, "ClaudeWorkflowImportService", _FakeImportService)
+    monkeypatch.setattr(
+        app_import_module.FeatureService,
+        "get_system_features",
+        lambda: SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False)),
+    )
+    app_import_module.console_ns.payload = _payload("basic_llm.yml")
+
+    response, status = app_import_module.AppImportApi().post()
+
+    assert status == 200
+    assert response["status"] == ImportStatus.COMPLETED
+    assert response["app_id"] == "app-1"
+
+
+    def test_app_import_api_maps_schema_failure_to_http_400(app_import_module, monkeypatch) -> None:
+        class _FakeSession:
+            def __enter__(self):
+                return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def commit(self):
+            return None
+
+    class _FakeImportService:
+        def __init__(self, session) -> None:
+            self.session = session
+
+        def import_app(self, **kwargs):
+            raise ClaudeWorkflowImportExecutionError(
+                status_code=400,
+                payload=Import(id="import-2", status=ImportStatus.FAILED, error="edges.1.target: unknown target"),
+            )
+
+    monkeypatch.setattr(app_import_module, "Session", lambda engine: _FakeSession())
+    monkeypatch.setattr(app_import_module, "ClaudeWorkflowImportService", _FakeImportService)
+    app_import_module.console_ns.payload = _payload("invalid_missing_edge_target.yml")
+
+    response, status = app_import_module.AppImportApi().post()
+
+    assert status == 400
+    assert response["status"] == ImportStatus.FAILED
+    assert "edges.1.target" in response["error"]
+
+
+    def test_app_import_api_maps_compiler_failure_to_http_422(app_import_module, monkeypatch) -> None:
+        class _FakeSession:
+            def __enter__(self):
+                return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def commit(self):
+            return None
+
+    class _FakeImportService:
+        def __init__(self, session) -> None:
+            self.session = session
+
+        def import_app(self, **kwargs):
+            raise ClaudeWorkflowImportExecutionError(
+                status_code=422,
+                payload=Import(id="import-3", status=ImportStatus.FAILED, error="Invalid selector payload"),
+            )
+
+    monkeypatch.setattr(app_import_module, "Session", lambda engine: _FakeSession())
+    monkeypatch.setattr(app_import_module, "ClaudeWorkflowImportService", _FakeImportService)
+    app_import_module.console_ns.payload = _payload("http_request.yml")
+
+    response, status = app_import_module.AppImportApi().post()
+
+    assert status == 422
+    assert response["status"] == ImportStatus.FAILED
+    assert response["error"] == "Invalid selector payload"

--- a/api/tests/unit_tests/services/claude_workflow/test_compiler.py
+++ b/api/tests/unit_tests/services/claude_workflow/test_compiler.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from services.claude_workflow.compiler import compile_claude_workflow_to_dify_dsl
+from services.claude_workflow.schema import parse_claude_workflow_document
+
+
+FIXTURES_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "claude_workflow"
+
+
+def _compile_fixture(name: str) -> dict:
+    raw_document = yaml.safe_load((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+    document = parse_claude_workflow_document(raw_document)
+    return yaml.safe_load(compile_claude_workflow_to_dify_dsl(document))
+
+
+def _find_node(graph: dict, node_id: str) -> dict:
+    return next(node for node in graph["nodes"] if node["id"] == node_id)
+
+
+def test_compile_claude_workflow_to_dify_dsl_builds_linear_graph() -> None:
+    compiled = _compile_fixture("basic_llm.yml")
+    graph = compiled["workflow"]["graph"]
+
+    assert compiled["kind"] == "app"
+    assert compiled["app"]["mode"] == "workflow"
+    assert [node["id"] for node in graph["nodes"]] == ["start", "summarize", "done"]
+    assert [edge["source"] for edge in graph["edges"]] == ["start", "summarize"]
+
+    llm_node = _find_node(graph, "summarize")
+    assert llm_node["data"]["type"] == "llm"
+    assert llm_node["data"]["prompt_template"][1]["text"] == "{{#start.query#}}"
+
+
+def test_compile_claude_workflow_to_dify_dsl_builds_if_else_cases_and_branch_edges() -> None:
+    compiled = _compile_fixture("branching.yml")
+    graph = compiled["workflow"]["graph"]
+
+    route_node = _find_node(graph, "route")
+    assert route_node["data"]["type"] == "if-else"
+    assert route_node["data"]["cases"][0]["case_id"] == "true"
+    assert route_node["data"]["cases"][0]["conditions"][0]["variable_selector"] == ["start", "query"]
+
+    true_edge = next(edge for edge in graph["edges"] if edge["sourceHandle"] == "true")
+    false_edge = next(edge for edge in graph["edges"] if edge["sourceHandle"] == "false")
+    assert true_edge["source"] == "route"
+    assert true_edge["target"] == "true_end"
+    assert false_edge["source"] == "route"
+    assert false_edge["target"] == "false_end"
+
+
+def test_compile_claude_workflow_to_dify_dsl_preserves_http_and_code_identifiers() -> None:
+    compiled = _compile_fixture("http_request.yml")
+    graph = compiled["workflow"]["graph"]
+
+    request_node = _find_node(graph, "fetch")
+    code_node = _find_node(graph, "transform")
+    end_node = _find_node(graph, "done")
+
+    assert request_node["data"]["type"] == "http-request"
+    assert request_node["data"]["url"] == "{{#start.url#}}"
+    assert code_node["data"]["type"] == "code"
+    assert code_node["data"]["code_language"] == "python3"
+    assert code_node["data"]["variables"][0]["value_selector"] == ["fetch", "body"]
+    assert end_node["data"]["outputs"][0]["value_selector"] == ["fetch", "status_code"]
+    assert end_node["data"]["outputs"][1]["value_selector"] == ["transform", "result"]

--- a/api/tests/unit_tests/services/claude_workflow/test_import_service.py
+++ b/api/tests/unit_tests/services/claude_workflow/test_import_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from services.app_dsl_service import Import, ImportMode, ImportStatus
+from services.claude_workflow.import_service import ClaudeWorkflowImportExecutionError, ClaudeWorkflowImportService
+
+
+FIXTURES_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "claude_workflow"
+
+
+def _account() -> SimpleNamespace:
+    return SimpleNamespace(current_tenant_id="tenant-1")
+
+
+def _fixture_text(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+
+
+def test_import_app_compiles_claude_workflow_before_delegating_to_app_dsl_service() -> None:
+    dsl_service = MagicMock()
+    dsl_service.import_app.return_value = Import(
+        id="import-1",
+        status=ImportStatus.COMPLETED,
+        app_id="app-1",
+        app_mode="workflow",
+    )
+    service = ClaudeWorkflowImportService(MagicMock(), dsl_service=dsl_service)
+
+    result = service.import_app(
+        account=_account(),
+        import_mode=ImportMode.YAML_CONTENT,
+        yaml_content=_fixture_text("basic_llm.yml"),
+    )
+
+    assert result.app_id == "app-1"
+    forwarded_yaml = dsl_service.import_app.call_args.kwargs["yaml_content"]
+    compiled = yaml.safe_load(forwarded_yaml)
+    assert compiled["kind"] == "app"
+    assert compiled["workflow"]["graph"]["nodes"][1]["id"] == "summarize"
+
+
+def test_import_app_returns_schema_failure_as_http_400_payload() -> None:
+    service = ClaudeWorkflowImportService(MagicMock(), dsl_service=MagicMock())
+
+    with pytest.raises(ClaudeWorkflowImportExecutionError) as exc_info:
+        service.import_app(
+            account=_account(),
+            import_mode=ImportMode.YAML_CONTENT,
+            yaml_content=_fixture_text("invalid_missing_edge_target.yml"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.payload.status == ImportStatus.FAILED
+    assert "edges.1.target" in exc_info.value.payload.error
+
+
+def test_import_app_returns_compiler_failure_as_http_422_payload() -> None:
+    malformed = yaml.safe_load(_fixture_text("http_request.yml"))
+    malformed["nodes"][0]["url"] = {"selector": ["start"]}
+    service = ClaudeWorkflowImportService(MagicMock(), dsl_service=MagicMock())
+
+    with pytest.raises(ClaudeWorkflowImportExecutionError) as exc_info:
+        service.import_app(
+            account=_account(),
+            import_mode=ImportMode.YAML_CONTENT,
+            yaml_content=yaml.safe_dump(malformed, sort_keys=False, allow_unicode=True),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.payload.status == ImportStatus.FAILED
+    assert "Invalid selector payload" in exc_info.value.payload.error

--- a/api/tests/unit_tests/services/claude_workflow/test_schema.py
+++ b/api/tests/unit_tests/services/claude_workflow/test_schema.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from services.claude_workflow.errors import ClaudeWorkflowSchemaErrorCode, ClaudeWorkflowSchemaValidationError
+from services.claude_workflow.schema import ClaudeWorkflowDocument, parse_claude_workflow_document
+
+
+FIXTURES_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "claude_workflow"
+
+
+def _load_fixture(name: str) -> dict:
+    return yaml.safe_load((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_parse_claude_workflow_document_accepts_supported_linear_workflow() -> None:
+    document = parse_claude_workflow_document(_load_fixture("basic_llm.yml"))
+
+    assert isinstance(document, ClaudeWorkflowDocument)
+    assert document.kind == "claude-workflow"
+    assert document.app.mode == "workflow"
+    assert [node.id for node in document.nodes] == ["summarize", "done"]
+
+
+def test_parse_claude_workflow_document_rejects_unsupported_node_types_with_stable_error_code() -> None:
+    payload = deepcopy(_load_fixture("basic_llm.yml"))
+    payload["nodes"][0]["type"] = "loop"
+
+    with pytest.raises(ClaudeWorkflowSchemaValidationError) as exc_info:
+        parse_claude_workflow_document(payload)
+
+    issue = exc_info.value.errors[0]
+    assert issue.code == ClaudeWorkflowSchemaErrorCode.UNSUPPORTED_NODE_TYPE
+    assert issue.path == ("nodes", 0, "type")
+
+
+def test_parse_claude_workflow_document_reports_missing_edge_target_path() -> None:
+    with pytest.raises(ClaudeWorkflowSchemaValidationError) as exc_info:
+        parse_claude_workflow_document(_load_fixture("invalid_missing_edge_target.yml"))
+
+    issue = exc_info.value.errors[0]
+    assert issue.code == ClaudeWorkflowSchemaErrorCode.UNKNOWN_EDGE_TARGET
+    assert issue.path == ("edges", 1, "target")
+
+
+def test_parse_claude_workflow_document_reports_bad_variable_selector_path() -> None:
+    payload = deepcopy(_load_fixture("basic_llm.yml"))
+    payload["nodes"][1]["outputs"][0]["selector"] = ["missing-node", "text"]
+
+    with pytest.raises(ClaudeWorkflowSchemaValidationError) as exc_info:
+        parse_claude_workflow_document(payload)
+
+    issue = exc_info.value.errors[0]
+    assert issue.code == ClaudeWorkflowSchemaErrorCode.UNKNOWN_VARIABLE_SELECTOR_SOURCE
+    assert issue.path == ("nodes", 1, "outputs", 0, "selector")

--- a/web/app/components/app/create-from-dsl-modal/index.spec.tsx
+++ b/web/app/components/app/create-from-dsl-modal/index.spec.tsx
@@ -1,0 +1,159 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import CreateFromDSLModal, { CreateFromDSLModalTab } from './index'
+
+const mockPush = vi.fn()
+const mockNotify = vi.fn()
+const mockImportDSL = vi.fn()
+const mockImportDSLConfirm = vi.fn()
+const mockHandleCheckPluginDependencies = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+vi.mock('ahooks', () => ({
+  useDebounceFn: <T extends (...args: unknown[]) => unknown>(fn: T) => ({ run: fn }),
+  useKeyPress: vi.fn(),
+}))
+
+vi.mock('use-context-selector', async () => {
+  const actual = await vi.importActual<typeof import('use-context-selector')>('use-context-selector')
+  return {
+    ...actual,
+    useContext: () => ({ notify: mockNotify }),
+  }
+})
+
+vi.mock('@/service/apps', () => ({
+  importDSL: (...args: unknown[]) => mockImportDSL(...args),
+  importDSLConfirm: (...args: unknown[]) => mockImportDSLConfirm(...args),
+  getImportDSLFailureMessage: vi.fn(async (error: unknown) => {
+    if (error instanceof Response) {
+      const body = await error.json() as { error?: string, message?: string }
+      return body.error || body.message || null
+    }
+
+    return null
+  }),
+}))
+
+vi.mock('@/app/components/workflow/plugin-dependency/hooks', () => ({
+  usePluginDependencies: () => ({
+    handleCheckPluginDependencies: mockHandleCheckPluginDependencies,
+  }),
+}))
+
+vi.mock('@/context/app-context', () => ({
+  useAppContext: () => ({
+    isCurrentWorkspaceEditor: true,
+  }),
+}))
+
+vi.mock('@/context/provider-context', () => ({
+  useProviderContext: () => ({
+    enableBilling: false,
+    plan: {
+      usage: { buildApps: 0 },
+      total: { buildApps: 10 },
+    },
+  }),
+}))
+
+vi.mock('@/app/components/base/amplitude', () => ({
+  trackEvent: vi.fn(),
+}))
+
+describe('CreateFromDSLModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    class MockFileReader {
+      onload: ((event: ProgressEvent<FileReader>) => void) | null = null
+
+      readAsText(_file: Blob) {
+        act(() => {
+          this.onload?.({
+            target: { result: 'kind: claude-workflow' },
+          } as ProgressEvent<FileReader>)
+        })
+      }
+    }
+
+    vi.stubGlobal('FileReader', MockFileReader as unknown as typeof FileReader)
+  })
+
+  // Covers file-mode imports for Claude workflow uploads.
+  it('should import the dropped Claude workflow file content through the app import API', async () => {
+    mockImportDSL.mockResolvedValue({
+      id: 'import-1',
+      status: 'failed',
+      error: 'compile failed',
+    })
+
+    render(
+      <CreateFromDSLModal
+        show={true}
+        onClose={vi.fn()}
+        activeTab={CreateFromDSLModalTab.FROM_FILE}
+        droppedFile={new File(['kind: claude-workflow'], 'claude_workflow.yaml', { type: 'text/yaml' })}
+      />,
+    )
+
+    const importButton = screen.getByText('app.newApp.Create').closest('button')
+
+    await waitFor(() => {
+      expect(importButton).not.toBeDisabled()
+    })
+
+    fireEvent.click(importButton!)
+
+    await waitFor(() => {
+      expect(mockImportDSL).toHaveBeenCalledWith(
+        {
+          mode: 'yaml-content',
+          yaml_content: 'kind: claude-workflow',
+        },
+        { silent: true },
+      )
+    })
+  })
+
+  // Covers backend validation/compiler errors for Claude workflow uploads.
+  it('should display the backend Claude workflow error instead of the generic import failure message', async () => {
+    mockImportDSL.mockRejectedValue(
+      new Response(JSON.stringify({
+        error: 'Invalid selector payload',
+        message: 'Invalid selector payload',
+      }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    render(
+      <CreateFromDSLModal
+        show={true}
+        onClose={vi.fn()}
+        activeTab={CreateFromDSLModalTab.FROM_FILE}
+        droppedFile={new File(['kind: claude-workflow'], 'claude_workflow.yaml', { type: 'text/yaml' })}
+      />,
+    )
+
+    const importButton = screen.getByText('app.newApp.Create').closest('button')
+
+    await waitFor(() => {
+      expect(importButton).not.toBeDisabled()
+    })
+
+    fireEvent.click(importButton!)
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Invalid selector payload',
+      })
+    })
+  })
+})

--- a/web/app/components/app/create-from-dsl-modal/index.tsx
+++ b/web/app/components/app/create-from-dsl-modal/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { MouseEventHandler } from 'react'
-import { RiCloseLine } from '@remixicon/react'
 import { useDebounceFn, useKeyPress } from 'ahooks'
 import { noop } from 'es-toolkit/function'
 import { useRouter } from 'next/navigation'
@@ -23,6 +22,7 @@ import {
   DSLImportStatus,
 } from '@/models/app'
 import {
+  getImportDSLFailureMessage,
   importDSL,
   importDSLConfirm,
 } from '@/service/apps'
@@ -82,8 +82,11 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
   const isCreatingRef = useRef(false)
 
   useEffect(() => {
-    if (droppedFile)
-      handleFile(droppedFile)
+    if (!droppedFile)
+      return
+
+    setDSLFile(droppedFile)
+    readFile(droppedFile)
   }, [droppedFile])
 
   const onCreate = async (_e?: React.MouseEvent) => {
@@ -101,13 +104,13 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
         response = await importDSL({
           mode: DSLImportMode.YAML_CONTENT,
           yaml_content: fileContent || '',
-        })
+        }, { silent: true })
       }
       if (currentTab === CreateFromDSLModalTab.FROM_URL) {
         response = await importDSL({
           mode: DSLImportMode.YAML_URL,
           yaml_url: dslUrlValue || '',
-        })
+        }, { silent: true })
       }
 
       if (!response)
@@ -150,9 +153,9 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
         notify({ type: 'error', message: t('newApp.appCreateFailed', { ns: 'app' }) })
       }
     }
-    // eslint-disable-next-line unused-imports/no-unused-vars
-    catch (e) {
-      notify({ type: 'error', message: t('newApp.appCreateFailed', { ns: 'app' }) })
+    catch (error) {
+      const importErrorMessage = await getImportDSLFailureMessage(error)
+      notify({ type: 'error', message: importErrorMessage || t('newApp.appCreateFailed', { ns: 'app' }) })
     }
     isCreatingRef.current = false
   }
@@ -238,7 +241,7 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
             className="flex h-8 w-8 cursor-pointer items-center"
             onClick={() => onClose()}
           >
-            <RiCloseLine className="h-5 w-5 text-text-tertiary" />
+            <i className="i-ri-close-line h-5 w-5 text-text-tertiary" />
           </div>
         </div>
         <div className="system-md-semibold flex h-9 items-center space-x-6 border-b border-divider-subtle px-6 text-text-tertiary">

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -1024,7 +1024,7 @@
   },
   "app/components/app/create-from-dsl-modal/index.tsx": {
     "react-hooks-extra/no-direct-set-state-in-use-effect": {
-      "count": 2
+      "count": 1
     },
     "react-refresh/only-export-components": {
       "count": 1

--- a/web/hooks/use-import-dsl.spec.tsx
+++ b/web/hooks/use-import-dsl.spec.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useImportDSL } from './use-import-dsl'
+
+const mockNotify = vi.fn()
+const mockPush = vi.fn()
+const mockHandleCheckPluginDependencies = vi.fn()
+const mockImportDSL = vi.fn()
+const mockImportDSLConfirm = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+vi.mock('@/app/components/base/toast', () => ({
+  useToastContext: () => ({
+    notify: mockNotify,
+  }),
+}))
+
+vi.mock('@/app/components/workflow/plugin-dependency/hooks', () => ({
+  usePluginDependencies: () => ({
+    handleCheckPluginDependencies: mockHandleCheckPluginDependencies,
+  }),
+}))
+
+vi.mock('@/context/app-context', () => ({
+  useSelector: (selector: (state: { isCurrentWorkspaceEditor: boolean }) => boolean) =>
+    selector({ isCurrentWorkspaceEditor: true }),
+}))
+
+vi.mock('@/service/apps', () => ({
+  importDSL: (...args: unknown[]) => mockImportDSL(...args),
+  importDSLConfirm: (...args: unknown[]) => mockImportDSLConfirm(...args),
+  getImportDSLFailureMessage: vi.fn(async (error: unknown) => {
+    if (error instanceof Response) {
+      const body = await error.json() as { error?: string, message?: string }
+      return body.error || body.message || null
+    }
+
+    return null
+  }),
+}))
+
+describe('useImportDSL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Covers the success path for YAML file imports.
+  it('should forward YAML content to the import API', async () => {
+    mockImportDSL.mockResolvedValue({
+      id: 'import-1',
+      status: 'completed',
+      app_id: 'app-1',
+      app_mode: 'workflow',
+      imported_dsl_version: '0.3.1',
+      current_dsl_version: '0.3.1',
+      error: '',
+      leaked_dependencies: [],
+    })
+    mockHandleCheckPluginDependencies.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useImportDSL())
+
+    await act(async () => {
+      await result.current.handleImportDSL(
+        {
+          mode: 'yaml-content',
+          yaml_content: 'kind: claude-workflow',
+        },
+        {},
+      )
+    })
+
+    expect(mockImportDSL).toHaveBeenCalledWith(
+      {
+        mode: 'yaml-content',
+        yaml_content: 'kind: claude-workflow',
+      },
+      { silent: true },
+    )
+  })
+
+  // Covers schema/compile failures that should surface specific backend messages.
+  it('should show the backend import error when the API returns a Claude workflow validation failure', async () => {
+    mockImportDSL.mockRejectedValue(
+      new Response(JSON.stringify({
+        error: 'edges.1.target: unknown target',
+        message: 'edges.1.target: unknown target',
+      }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const onFailed = vi.fn()
+    const { result } = renderHook(() => useImportDSL())
+
+    await act(async () => {
+      await result.current.handleImportDSL(
+        {
+          mode: 'yaml-content',
+          yaml_content: 'kind: claude-workflow',
+        },
+        { onFailed },
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'edges.1.target: unknown target',
+      })
+    })
+    expect(onFailed).toHaveBeenCalled()
+  })
+})

--- a/web/hooks/use-import-dsl.ts
+++ b/web/hooks/use-import-dsl.ts
@@ -16,6 +16,7 @@ import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useSelector } from '@/context/app-context'
 import { DSLImportStatus } from '@/models/app'
 import {
+  getImportDSLFailureMessage,
   importDSL,
   importDSLConfirm,
 } from '@/service/apps'
@@ -59,7 +60,7 @@ export const useImportDSL = () => {
     setIsFetching(true)
 
     try {
-      const response = await importDSL(payload)
+      const response = await importDSL(payload, { silent: true })
 
       if (!response)
         return
@@ -100,8 +101,9 @@ export const useImportDSL = () => {
         onFailed?.()
       }
     }
-    catch {
-      notify({ type: 'error', message: t('newApp.appCreateFailed', { ns: 'app' }) })
+    catch (error) {
+      const importErrorMessage = await getImportDSLFailureMessage(error)
+      notify({ type: 'error', message: importErrorMessage || t('newApp.appCreateFailed', { ns: 'app' }) })
       onFailed?.()
     }
     finally {

--- a/web/service/apps.ts
+++ b/web/service/apps.ts
@@ -1,3 +1,4 @@
+import type { ResponseError } from './fetch'
 import type { TracingProvider } from '@/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type'
 import type { ApiKeysListResponse, AppDailyConversationsResponse, AppDailyEndUsersResponse, AppDailyMessagesResponse, AppDetailResponse, AppListResponse, AppStatisticsResponse, AppTemplatesResponse, AppTokenCostsResponse, AppVoicesListResponse, CreateApiKeyResponse, DSLImportMode, DSLImportResponse, GenerationIntroductionResponse, TracingConfig, TracingStatus, UpdateAppModelConfigResponse, UpdateAppSiteCodeResponse, UpdateOpenAIKeyResponse, ValidateOpenAIKeyResponse, WebhookTriggerResponse, WorkflowDailyConversationsResponse } from '@/models/app'
 import type { CommonResponse } from '@/models/common'
@@ -92,8 +93,31 @@ export const exportAppConfig = ({ appID, include = false, workflowID }: { appID:
   return get<{ data: string }>(`apps/${appID}/export?${params.toString()}`)
 }
 
-export const importDSL = ({ mode, yaml_content, yaml_url, app_id, name, description, icon_type, icon, icon_background }: { mode: DSLImportMode, yaml_content?: string, yaml_url?: string, app_id?: string, name?: string, description?: string, icon_type?: AppIconType, icon?: string, icon_background?: string }): Promise<DSLImportResponse> => {
-  return post<DSLImportResponse>('apps/imports', { body: { mode, yaml_content, yaml_url, app_id, name, description, icon, icon_type, icon_background } })
+export const importDSL = (
+  { mode, yaml_content, yaml_url, app_id, name, description, icon_type, icon, icon_background }: { mode: DSLImportMode, yaml_content?: string, yaml_url?: string, app_id?: string, name?: string, description?: string, icon_type?: AppIconType, icon?: string, icon_background?: string },
+  { silent = false }: { silent?: boolean } = {},
+): Promise<DSLImportResponse> => {
+  return post<DSLImportResponse>(
+    'apps/imports',
+    { body: { mode, yaml_content, yaml_url, app_id, name, description, icon, icon_type, icon_background } },
+    { silent },
+  )
+}
+
+export const getImportDSLFailureMessage = async (error: unknown): Promise<string | null> => {
+  if (!(error instanceof Response))
+    return null
+
+  if (error.status !== 400 && error.status !== 422)
+    return null
+
+  try {
+    const payload = await error.clone().json() as Partial<ResponseError> & { error?: string }
+    return payload.error || payload.message || null
+  }
+  catch {
+    return null
+  }
 }
 
 export const importDSLConfirm = ({ import_id }: { import_id: string }): Promise<DSLImportResponse> => {


### PR DESCRIPTION
## Summary
- add a constrained Claude workflow schema, compiler, and import service so `/apps/imports` can accept `kind: claude-workflow` YAML and compile it into native Dify workflow DSL
- add backend fixtures and tests covering schema validation, DSL compilation, import service behavior, and the app import API path
- update the web DSL import flow to upload Claude workflow files directly and surface backend validation/compiler errors in the existing import UI

## Test Plan
- `uv run --project api pytest api/tests/unit_tests/services/claude_workflow/test_schema.py api/tests/unit_tests/services/claude_workflow/test_compiler.py api/tests/unit_tests/services/claude_workflow/test_import_service.py api/tests/unit_tests/controllers/console/app/test_claude_workflow_import_api.py -q --override-ini addopts=''`
- `pnpm test hooks/use-import-dsl.spec.tsx app/components/app/create-from-dsl-modal/index.spec.tsx`
- `pnpm lint hooks/use-import-dsl.ts service/apps.ts app/components/app/create-from-dsl-modal/index.tsx app/components/app/create-from-dsl-modal/index.spec.tsx hooks/use-import-dsl.spec.tsx`
