### PR TITLE
feat(api): add WebSocket endpoints for real-time streaming

### DIFF
--- a/api/controllers/service_api/app/websocket.py
+++ b/api/controllers/service_api/app/websocket.py
@@ -1,0 +1,198 @@
+"""WebSocket endpoints for the Service API.
+
+Provides ``/v1/ws/chat-messages`` and ``/v1/ws/completion-messages`` that
+stream generation events over a persistent WebSocket connection instead of
+SSE, enabling long-lived tunnels for messaging-platform integrations such
+as WhatsApp, Telegram, Feishu and Slack.
+"""
+
+import logging
+from typing import Any
+
+from flask import Blueprint, request
+from flask_sock import Sock
+from pydantic import ValidationError
+from werkzeug.exceptions import Forbidden, NotFound, Unauthorized
+
+from controllers.service_api.app.completion import ChatRequestPayload, CompletionRequestPayload
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.helper.trace_id_helper import get_external_trace_id
+from extensions.ext_database import db
+from libs.websocket import stream_events_to_websocket
+from models.model import App, AppMode
+from services.app_generate_service import AppGenerateService
+from services.end_user_service import EndUserService
+
+logger = logging.getLogger(__name__)
+
+# Dedicated blueprint so that WebSocket routes can be registered with their
+# own URL prefix while reusing the same ``/v1`` namespace.
+ws_bp = Blueprint("service_api_ws", __name__, url_prefix="/v1/ws")
+sock = Sock()
+
+
+def _authenticate_ws() -> tuple[App, Any]:
+    """Validate the API token supplied via the ``Authorization`` query param or header.
+
+    WebSocket clients cannot always set HTTP headers, so the token may be
+    passed as ``?token=<bearer_token>`` query parameter as a fallback.
+
+    Returns the resolved ``(app_model, end_user)`` tuple.
+    """
+    from services.api_token_service import ApiTokenCache, fetch_token_with_single_flight, record_token_usage
+
+    # Try header first, then query param
+    auth_token: str | None = None
+    auth_header = request.headers.get("Authorization")
+    if auth_header and " " in auth_header:
+        scheme, token = auth_header.split(None, 1)
+        if scheme.lower() == "bearer":
+            auth_token = token
+
+    if not auth_token:
+        auth_token = request.args.get("token")
+
+    if not auth_token:
+        raise Unauthorized("Authorization token must be provided via header or 'token' query param.")
+
+    cached_token = ApiTokenCache.get(auth_token, "app")
+    if cached_token is not None:
+        record_token_usage(auth_token, "app")
+        api_token = cached_token
+    else:
+        api_token = fetch_token_with_single_flight(auth_token, "app")
+
+    app_model = db.session.query(App).where(App.id == api_token.app_id).first()
+    if not app_model:
+        raise Forbidden("The app no longer exists.")
+    if app_model.status != "normal":
+        raise Forbidden("The app's status is abnormal.")
+    if not app_model.enable_api:
+        raise Forbidden("The app's API service has been disabled.")
+
+    # Resolve end-user from query param or first WS message
+    user_id = request.args.get("user")
+    if not user_id:
+        raise Forbidden("The 'user' query parameter is required.")
+
+    end_user = EndUserService.get_or_create_end_user(app_model, str(user_id))
+    return app_model, end_user
+
+
+@sock.route("/chat-messages", bp=ws_bp)
+def ws_chat_messages(ws):
+    """WebSocket endpoint for chat message streaming.
+
+    Connect: ``ws://<host>/v1/ws/chat-messages?token=<api_key>&user=<user_id>``
+
+    After the connection is established, send a JSON payload matching the
+    ``ChatRequestPayload`` schema.  The server responds with a stream of JSON
+    frames identical to the SSE ``data:`` payloads.  The connection closes
+    automatically once the terminal event is sent.
+    """
+    try:
+        app_model, end_user = _authenticate_ws()
+    except Exception as exc:
+        ws.send(f'{{"error": "{exc}"}}')
+        ws.close()
+        return
+
+    app_mode = AppMode.value_of(app_model.mode)
+    if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT}:
+        ws.send('{"error": "This app is not a chat application."}')
+        ws.close()
+        return
+
+    # Receive the chat payload from the client
+    raw = ws.receive(timeout=30)
+    if raw is None:
+        ws.close()
+        return
+
+    try:
+        import json
+
+        data = json.loads(raw)
+        payload = ChatRequestPayload.model_validate(data)
+    except (ValidationError, Exception) as exc:
+        ws.send(f'{{"error": "Invalid payload: {exc}"}}')
+        ws.close()
+        return
+
+    external_trace_id = get_external_trace_id(request)
+    args = payload.model_dump(exclude_none=True)
+    if external_trace_id:
+        args["external_trace_id"] = external_trace_id
+
+    try:
+        response = AppGenerateService.generate(
+            app_model=app_model,
+            user=end_user,
+            args=args,
+            invoke_from=InvokeFrom.SERVICE_API,
+            streaming=True,
+        )
+        stream_events_to_websocket(ws, response)
+    except Exception as exc:
+        logger.exception("WebSocket chat-messages error")
+        ws.send(f'{{"error": "{exc}"}}')
+    finally:
+        ws.close()
+
+
+@sock.route("/completion-messages", bp=ws_bp)
+def ws_completion_messages(ws):
+    """WebSocket endpoint for completion message streaming.
+
+    Connect: ``ws://<host>/v1/ws/completion-messages?token=<api_key>&user=<user_id>``
+
+    After the connection is established, send a JSON payload matching the
+    ``CompletionRequestPayload`` schema.
+    """
+    try:
+        app_model, end_user = _authenticate_ws()
+    except Exception as exc:
+        ws.send(f'{{"error": "{exc}"}}')
+        ws.close()
+        return
+
+    if app_model.mode != AppMode.COMPLETION:
+        ws.send('{"error": "This app is not a completion application."}')
+        ws.close()
+        return
+
+    raw = ws.receive(timeout=30)
+    if raw is None:
+        ws.close()
+        return
+
+    try:
+        import json
+
+        data = json.loads(raw)
+        payload = CompletionRequestPayload.model_validate(data)
+    except (ValidationError, Exception) as exc:
+        ws.send(f'{{"error": "Invalid payload: {exc}"}}')
+        ws.close()
+        return
+
+    external_trace_id = get_external_trace_id(request)
+    args = payload.model_dump(exclude_none=True)
+    if external_trace_id:
+        args["external_trace_id"] = external_trace_id
+    args["auto_generate_name"] = False
+
+    try:
+        response = AppGenerateService.generate(
+            app_model=app_model,
+            user=end_user,
+            args=args,
+            invoke_from=InvokeFrom.SERVICE_API,
+            streaming=True,
+        )
+        stream_events_to_websocket(ws, response)
+    except Exception as exc:
+        logger.exception("WebSocket completion-messages error")
+        ws.send(f'{{"error": "{exc}"}}')
+    finally:
+        ws.close()

--- a/api/controllers/web/websocket.py
+++ b/api/controllers/web/websocket.py
@@ -1,0 +1,134 @@
+"""WebSocket endpoints for the Web App API.
+
+Provides ``/api/ws/chat-messages`` and ``/api/ws/completion-messages`` that
+stream generation events over a persistent WebSocket connection instead of
+SSE, enabling long-lived tunnels for messaging-platform integrations.
+"""
+
+import logging
+from typing import Any
+
+from flask import Blueprint, request
+from flask_sock import Sock
+from pydantic import ValidationError
+
+from controllers.web.completion import ChatMessagePayload, CompletionMessagePayload
+from controllers.web.wraps import decode_jwt_token
+from core.app.entities.app_invoke_entities import InvokeFrom
+from libs.websocket import stream_events_to_websocket
+from models.model import AppMode
+from services.app_generate_service import AppGenerateService
+
+logger = logging.getLogger(__name__)
+
+ws_web_bp = Blueprint("web_ws", __name__, url_prefix="/api/ws")
+sock = Sock()
+
+
+def _authenticate_web_ws() -> tuple[Any, Any]:
+    """Authenticate a web-app WebSocket connection.
+
+    The passport token can be passed via the ``X-App-Passport`` header or
+    the ``passport`` query parameter.  ``X-App-Code`` can likewise be passed
+    as a query parameter ``app_code``.
+    """
+    return decode_jwt_token()
+
+
+@sock.route("/chat-messages", bp=ws_web_bp)
+def ws_web_chat_messages(ws):
+    """WebSocket chat endpoint for web applications."""
+    try:
+        app_model, end_user = _authenticate_web_ws()
+    except Exception as exc:
+        ws.send(f'{{"error": "{exc}"}}')
+        ws.close()
+        return
+
+    app_mode = AppMode.value_of(app_model.mode)
+    if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT}:
+        ws.send('{"error": "This app is not a chat application."}')
+        ws.close()
+        return
+
+    raw = ws.receive(timeout=30)
+    if raw is None:
+        ws.close()
+        return
+
+    try:
+        import json
+
+        data = json.loads(raw)
+        payload = ChatMessagePayload.model_validate(data)
+    except (ValidationError, Exception) as exc:
+        ws.send(f'{{"error": "Invalid payload: {exc}"}}')
+        ws.close()
+        return
+
+    args = payload.model_dump(exclude_none=True)
+    args["auto_generate_name"] = False
+
+    try:
+        response = AppGenerateService.generate(
+            app_model=app_model,
+            user=end_user,
+            args=args,
+            invoke_from=InvokeFrom.WEB_APP,
+            streaming=True,
+        )
+        stream_events_to_websocket(ws, response)
+    except Exception as exc:
+        logger.exception("WebSocket web chat-messages error")
+        ws.send(f'{{"error": "{exc}"}}')
+    finally:
+        ws.close()
+
+
+@sock.route("/completion-messages", bp=ws_web_bp)
+def ws_web_completion_messages(ws):
+    """WebSocket completion endpoint for web applications."""
+    try:
+        app_model, end_user = _authenticate_web_ws()
+    except Exception as exc:
+        ws.send(f'{{"error": "{exc}"}}')
+        ws.close()
+        return
+
+    if app_model.mode != AppMode.COMPLETION:
+        ws.send('{"error": "This app is not a completion application."}')
+        ws.close()
+        return
+
+    raw = ws.receive(timeout=30)
+    if raw is None:
+        ws.close()
+        return
+
+    try:
+        import json
+
+        data = json.loads(raw)
+        payload = CompletionMessagePayload.model_validate(data)
+    except (ValidationError, Exception) as exc:
+        ws.send(f'{{"error": "Invalid payload: {exc}"}}')
+        ws.close()
+        return
+
+    args = payload.model_dump(exclude_none=True)
+    args["auto_generate_name"] = False
+
+    try:
+        response = AppGenerateService.generate(
+            app_model=app_model,
+            user=end_user,
+            args=args,
+            invoke_from=InvokeFrom.WEB_APP,
+            streaming=True,
+        )
+        stream_events_to_websocket(ws, response)
+    except Exception as exc:
+        logger.exception("WebSocket web completion-messages error")
+        ws.send(f'{{"error": "{exc}"}}')
+    finally:
+        ws.close()

--- a/api/extensions/ext_blueprints.py
+++ b/api/extensions/ext_blueprints.py
@@ -90,6 +90,17 @@ def init_app(app: DifyApp):
     app.register_blueprint(inner_api_bp)
     app.register_blueprint(mcp_bp)
 
+    # Register WebSocket blueprints for persistent streaming connections
+    from controllers.service_api.app.websocket import sock as service_ws_sock
+    from controllers.service_api.app.websocket import ws_bp as service_ws_bp
+    from controllers.web.websocket import sock as web_ws_sock
+    from controllers.web.websocket import ws_web_bp
+
+    service_ws_sock.init_app(app)
+    app.register_blueprint(service_ws_bp)
+    web_ws_sock.init_app(app)
+    app.register_blueprint(ws_web_bp)
+
     # Register trigger blueprint with CORS for webhook calls
     _apply_cors_once(
         trigger_bp,

--- a/api/libs/websocket.py
+++ b/api/libs/websocket.py
@@ -1,0 +1,48 @@
+"""WebSocket utilities for streaming app generation responses.
+
+Bridges the existing Redis pub/sub event streaming infrastructure to WebSocket
+connections, enabling persistent bidirectional communication for messaging
+platform integrations (Slack, Telegram, WhatsApp, Feishu/Lark, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Generator, Mapping
+from typing import Any
+
+from libs.orjson import orjson_dumps
+
+logger = logging.getLogger(__name__)
+
+
+def stream_events_to_websocket(
+    ws: Any,
+    generator: Mapping | Generator[Mapping | str, None, None],
+) -> None:
+    """Stream SSE events over a WebSocket connection.
+
+    Consumes the same generator that ``compact_generate_response`` uses for
+    SSE and forwards each event as a JSON text frame over *ws*.
+
+    For blocking (dict) responses the payload is sent as a single frame and
+    the connection is closed.
+
+    :param ws: A ``flask_sock`` / ``simple_websocket.Server`` object.
+    :param generator: Either a blocking dict response or a streaming generator
+        yielding ``Mapping`` (JSON event) or ``str`` (event-name-only) items.
+    """
+    if isinstance(generator, dict):
+        ws.send(json.dumps(generator))
+        return
+
+    try:
+        for message in generator:
+            if isinstance(message, Mapping | dict):
+                ws.send(orjson_dumps(message))
+            else:
+                # Event-name-only messages (e.g. "ping")
+                ws.send(json.dumps({"event": message}))
+    except Exception:
+        logger.debug("WebSocket connection closed by client")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "flask-compress>=1.17,<1.24",
     "flask-cors~=6.0.0",
     "flask-login~=0.6.3",
+    "flask-sock~=0.7.0",
     "flask-migrate~=4.1.0",
     "flask-orjson~=2.0.0",
     "flask-sqlalchemy~=3.1.1",

--- a/api/tests/unit_tests/libs/test_websocket.py
+++ b/api/tests/unit_tests/libs/test_websocket.py
@@ -1,0 +1,79 @@
+"""Tests for libs.websocket utilities."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+from libs.websocket import stream_events_to_websocket
+
+
+class TestStreamEventsToWebsocket:
+    def test_blocking_dict_response(self):
+        """Blocking (dict) responses are sent as a single JSON frame."""
+        ws = MagicMock()
+        response = {"event": "message", "answer": "hello"}
+
+        stream_events_to_websocket(ws, response)
+
+        ws.send.assert_called_once()
+        import json
+
+        sent = json.loads(ws.send.call_args[0][0])
+        assert sent == response
+
+    def test_streaming_dict_events(self):
+        """Streaming dict events are forwarded as JSON text frames."""
+
+        def gen() -> Generator:
+            yield {"event": "message", "answer": "hi"}
+            yield {"event": "message_end"}
+
+        ws = MagicMock()
+        stream_events_to_websocket(ws, gen())
+
+        assert ws.send.call_count == 2
+        import json
+
+        first = json.loads(ws.send.call_args_list[0][0][0])
+        assert first["event"] == "message"
+        second = json.loads(ws.send.call_args_list[1][0][0])
+        assert second["event"] == "message_end"
+
+    def test_streaming_string_events(self):
+        """String-only events (e.g. 'ping') are wrapped in a JSON envelope."""
+
+        def gen() -> Generator:
+            yield "ping"
+
+        ws = MagicMock()
+        stream_events_to_websocket(ws, gen())
+
+        import json
+
+        sent = json.loads(ws.send.call_args[0][0])
+        assert sent == {"event": "ping"}
+
+    def test_mixed_events(self):
+        """Generator can yield both dict and string events."""
+
+        def gen() -> Generator:
+            yield "ping"
+            yield {"event": "message", "answer": "world"}
+            yield "ping"
+
+        ws = MagicMock()
+        stream_events_to_websocket(ws, gen())
+
+        assert ws.send.call_count == 3
+
+    def test_client_disconnect_handled_gracefully(self):
+        """If the WebSocket client disconnects, the exception is caught."""
+
+        def gen() -> Generator:
+            yield {"event": "message", "answer": "hi"}
+            yield {"event": "message_end"}
+
+        ws = MagicMock()
+        ws.send.side_effect = ConnectionError("client gone")
+
+        # Should not raise
+        stream_events_to_websocket(ws, gen())


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #33542

Add WebSocket support alongside existing SSE (Server-Sent Events) for chat and completion message streaming. This enables persistent bidirectional connections for messaging platform integrations such as WhatsApp, Telegram, Feishu/Lark, and Slack, which require long-lived tunnels rather than traditional webhook-based request/response cycles.

### Changes

- **New dependency**: `flask-sock~=0.7.0` for lightweight WebSocket support on Flask
- **`api/libs/websocket.py`**: Utility that bridges the existing Redis pub/sub event streaming generator to WebSocket frames
- **`api/controllers/service_api/app/websocket.py`**: Service API WebSocket endpoints at `/v1/ws/chat-messages` and `/v1/ws/completion-messages`
- **`api/controllers/web/websocket.py`**: Web App WebSocket endpoints at `/api/ws/chat-messages` and `/api/ws/completion-messages`
- **`api/extensions/ext_blueprints.py`**: Register new WebSocket blueprints
- **`api/tests/unit_tests/libs/test_websocket.py`**: Unit tests for the WebSocket streaming utility

### How it works

1. Client opens a WebSocket connection with auth token (via `Authorization` header or `?token=` query param)
2. Client sends a JSON payload matching the existing `ChatRequestPayload` / `CompletionRequestPayload` schema
3. Server streams the same events as SSE but as individual JSON text frames over the WebSocket
4. Connection closes automatically after the terminal event

### Usage

**Service API:**
```
ws://<host>/v1/ws/chat-messages?token=<api_key>&user=<user_id>
ws://<host>/v1/ws/completion-messages?token=<api_key>&user=<user_id>
```

**Web App:**
```
ws://<host>/api/ws/chat-messages
ws://<host>/api/ws/completion-messages
```

## Screenshots

| Before | After |
|--------|-------|
| SSE-only streaming | SSE + WebSocket streaming available |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods