### PR TITLE
fix(web): preserve public workflow SSE reconnect after pause

### DIFF
--- a/web/app/components/share/text-generation/result/__tests__/workflow-stream-handlers.spec.ts
+++ b/web/app/components/share/text-generation/result/__tests__/workflow-stream-handlers.spec.ts
@@ -328,7 +328,7 @@ describe('createWorkflowStreamHandlers', () => {
     vi.clearAllMocks()
   })
 
-  const setupHandlers = (overrides: { isTimedOut?: () => boolean } = {}) => {
+  const setupHandlers = (overrides: { isPublicAPI?: boolean, isTimedOut?: () => boolean } = {}) => {
     let completionRes = ''
     let currentTaskId: string | null = null
     let isStopping = false
@@ -359,6 +359,7 @@ describe('createWorkflowStreamHandlers', () => {
     const handlers = createWorkflowStreamHandlers({
       getCompletionRes: () => completionRes,
       getWorkflowProcessData: () => workflowProcessData,
+      isPublicAPI: overrides.isPublicAPI ?? false,
       isTimedOut: overrides.isTimedOut ?? (() => false),
       markEnded,
       notify,
@@ -391,7 +392,7 @@ describe('createWorkflowStreamHandlers', () => {
   }
 
   it('should process workflow success and paused events', () => {
-    const setup = setupHandlers()
+    const setup = setupHandlers({ isPublicAPI: true })
     const handlers = setup.handlers as Required<Pick<IOtherOptions, 'onWorkflowStarted' | 'onTextChunk' | 'onHumanInputRequired' | 'onHumanInputFormFilled' | 'onHumanInputFormTimeout' | 'onWorkflowPaused' | 'onWorkflowFinished' | 'onNodeStarted' | 'onNodeFinished' | 'onIterationStart' | 'onIterationNext' | 'onIterationFinish' | 'onLoopStart' | 'onLoopNext' | 'onLoopFinish'>>
 
     act(() => {
@@ -546,7 +547,11 @@ describe('createWorkflowStreamHandlers', () => {
       resultText: 'Hello',
       status: WorkflowRunningStatus.Succeeded,
     }))
-    expect(sseGetMock).toHaveBeenCalledWith('/workflow/run-1/events', {}, expect.any(Object))
+    expect(sseGetMock).toHaveBeenCalledWith(
+      '/workflow/run-1/events',
+      {},
+      expect.objectContaining({ isPublicAPI: true }),
+    )
     expect(setup.messageId()).toBe('run-1')
     expect(setup.onCompleted).toHaveBeenCalledWith('{"answer":"Hello"}', 3, true)
     expect(setup.setRespondingFalse).toHaveBeenCalled()
@@ -647,6 +652,7 @@ describe('createWorkflowStreamHandlers', () => {
     const handlers = createWorkflowStreamHandlers({
       getCompletionRes: () => '',
       getWorkflowProcessData: () => existingProcess,
+      isPublicAPI: false,
       isTimedOut: () => false,
       markEnded: vi.fn(),
       notify: setup.notify,

--- a/web/app/components/share/text-generation/result/hooks/__tests__/use-result-sender.spec.ts
+++ b/web/app/components/share/text-generation/result/hooks/__tests__/use-result-sender.spec.ts
@@ -351,6 +351,7 @@ describe('useResultSender', () => {
     await waitFor(() => {
       expect(createWorkflowStreamHandlersMock).toHaveBeenCalledWith(expect.objectContaining({
         getCompletionRes: harness.runState.getCompletionRes,
+        isPublicAPI: true,
         resetRunState: harness.runState.resetRunState,
         setWorkflowProcessData: harness.runState.setWorkflowProcessData,
       }))
@@ -371,6 +372,30 @@ describe('useResultSender', () => {
       })
     })
     expect(harness.runState.clearMoreLikeThis).not.toHaveBeenCalled()
+  })
+
+  it('should configure workflow handlers for installed apps as non-public', async () => {
+    const harness = createRunStateHarness()
+
+    const { result } = renderSender({
+      appSourceType: AppSourceTypeEnum.installedApp,
+      isWorkflow: true,
+      runState: harness.runState,
+    })
+
+    await act(async () => {
+      expect(await result.current.handleSend()).toBe(true)
+    })
+
+    expect(createWorkflowStreamHandlersMock).toHaveBeenCalledWith(expect.objectContaining({
+      isPublicAPI: false,
+    }))
+    expect(sendWorkflowMessageMock).toHaveBeenCalledWith(
+      { inputs: { name: 'Alice' } },
+      expect.any(Object),
+      AppSourceTypeEnum.installedApp,
+      'app-1',
+    )
   })
 
   it('should stringify non-Error workflow failures', async () => {

--- a/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
+++ b/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
@@ -1,11 +1,11 @@
 import type { ResultInputValue } from '../result-request'
 import type { ResultRunStateController } from './use-result-run-state'
 import type { PromptConfig } from '@/models/debug'
-import type { AppSourceType } from '@/service/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { useCallback, useEffect, useRef } from 'react'
 import { TEXT_GENERATION_TIMEOUT_MS } from '@/config'
 import {
+  AppSourceType,
   sendCompletionMessage,
   sendWorkflowMessage,
 } from '@/service/share'
@@ -117,6 +117,7 @@ export const useResultSender = ({
       const otherOptions = createWorkflowStreamHandlers({
         getCompletionRes: runState.getCompletionRes,
         getWorkflowProcessData: runState.getWorkflowProcessData,
+        isPublicAPI: appSourceType === AppSourceType.webApp,
         isTimedOut: () => isTimeout,
         markEnded: () => {
           isEnd = true

--- a/web/app/components/share/text-generation/result/workflow-stream-handlers.ts
+++ b/web/app/components/share/text-generation/result/workflow-stream-handlers.ts
@@ -13,6 +13,7 @@ type Translate = (key: string, options?: Record<string, unknown>) => string
 type CreateWorkflowStreamHandlersParams = {
   getCompletionRes: () => string
   getWorkflowProcessData: () => WorkflowProcess | undefined
+  isPublicAPI: boolean
   isTimedOut: () => boolean
   markEnded: () => void
   notify: Notify
@@ -255,6 +256,7 @@ const serializeWorkflowOutputs = (outputs: WorkflowFinishedResponse['data']['out
 export const createWorkflowStreamHandlers = ({
   getCompletionRes,
   getWorkflowProcessData,
+  isPublicAPI,
   isTimedOut,
   markEnded,
   notify,
@@ -287,6 +289,7 @@ export const createWorkflowStreamHandlers = ({
   }
 
   const otherOptions: IOtherOptions = {
+    isPublicAPI,
     onWorkflowStarted: ({ workflow_run_id, task_id }) => {
       const workflowProcessData = getWorkflowProcessData()
       if (workflowProcessData?.tracing.length) {
@@ -378,6 +381,7 @@ export const createWorkflowStreamHandlers = ({
     },
     onWorkflowPaused: ({ data }) => {
       tempMessageId = data.workflow_run_id
+      // WebApp workflows must keep using the public API namespace after pause/resume.
       void sseGet(`/workflow/${data.workflow_run_id}/events`, {}, otherOptions)
       setWorkflowProcessData(applyWorkflowPaused(getWorkflowProcessData()))
     },


### PR DESCRIPTION
Fixes #33551

## Summary

- keep the WebApp workflow pause/resume SSE reconnect on the public API namespace by carrying `isPublicAPI` in the workflow stream handlers
- derive the workflow handler public/private mode from `AppSourceType` in `use-result-sender`
- add regression coverage for the pause-resume reconnect path and for WebApp vs installed-app handler configuration

## Screenshots

| Before | After |
|--------|-------|
| Paused WebApp workflow runs reconnect to `/console/api/workflow/<run_id>/events` and the stream stops. | Paused WebApp workflow runs reconnect to `/api/workflow/<run_id>/events` and continue streaming. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

## Notes

- Frontend tests and lint were not run in this workspace because `web/node_modules` is absent and `pnpm test ...` fails immediately with `vp: command not found`.
