### PR TITLE
fix(service): check trial app feature flag before fetching info

### DIFF
--- a/web/service/use-try-app.ts
+++ b/web/service/use-try-app.ts
@@ -1,15 +1,17 @@
 import type { DataSetListResponse } from '@/models/datasets'
 import { useQuery } from '@tanstack/react-query'
+import { useGlobalPublicStore } from '@/context/global-public-context'
 import { consoleQuery } from '@/service/client'
 import { fetchTryAppDatasets, fetchTryAppFlowPreview, fetchTryAppInfo, fetchTryAppParams } from './try-app'
 
 export const useGetTryAppInfo = (appId: string) => {
+  const { systemFeatures } = useGlobalPublicStore()
   return useQuery({
     queryKey: consoleQuery.trialApps.info.queryKey({ input: { params: { appId } } }),
     queryFn: () => {
       return fetchTryAppInfo(appId)
     },
-    enabled: !!appId,
+    enabled: !!appId && systemFeatures.enable_trial_app,
   })
 }
 


### PR DESCRIPTION
Fixes #33549

The Explore Detail modal was returning 403 when trial apps are disabled because `useGetTryAppInfo` unconditionally called the trial app endpoint whenever `appId` was truthy.

When `ENABLE_TRIAL_APP=false`, the backend `trial_feature_enable` decorator returns 403 "Trial app feature is not enabled." This caused the Explore Detail modal to fail loading in self-hosted environments.

Add `systemFeatures.enable_trial_app` check to the `enabled` option so the query only runs when the feature is enabled. This follows the same pattern used elsewhere in the codebase for conditional trial app features.

## Changes
- Modified `web/service/use-try-app.ts` to check `systemFeatures.enable_trial_app` before enabling the query

## Verification
- Type-check passes
- All related tests pass (17 tests in try-app, 33 tests in embedded-chatbot)
