### PR TITLE
fix: raise block selector overlay z-index

### DIFF
--- a/web/app/components/workflow/block-selector/main.tsx
+++ b/web/app/components/workflow/block-selector/main.tsx
@@ -203,7 +203,7 @@ const NodeSelector: FC<NodeSelectorProps> = ({
               )
         }
       </PortalToFollowElemTrigger>
-      <PortalToFollowElemContent className="z-[1000]">
+      <PortalToFollowElemContent className="z-[1002]">
         <div className={`rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg ${popupClassName}`}>
           <Tabs
             tabs={tabs}

--- a/web/app/components/workflow/block-selector/tool-picker.tsx
+++ b/web/app/components/workflow/block-selector/tool-picker.tsx
@@ -169,7 +169,7 @@ const ToolPicker: FC<Props> = ({
         {trigger}
       </PortalToFollowElemTrigger>
 
-      <PortalToFollowElemContent className="z-[1000]">
+      <PortalToFollowElemContent className="z-[1002]">
         <div className={cn('relative min-h-20 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-sm', panelClassName)}>
           <div className="p-2 pb-1">
             <SearchBox


### PR DESCRIPTION
## Summary
- raise the legacy block selector overlay container from `z-[1000]` to `z-[1002]`
- align `NodeSelector` and `ToolPicker` with the current overlay migration z-index strategy
- avoid extra compatibility logic or interaction changes

## Testing
- pre-commit ESLint hook
- pre-commit `pnpm type-check:tsgo` hook