### PR TITLE
fix: disable httpx proxy for plugin daemon requests

### DIFF
--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -83,7 +83,7 @@ class BasePluginClient:
             request_kwargs["content"] = prepared_data
 
         try:
-            response = httpx.request(**request_kwargs)
+            response = httpx.request(**request_kwargs, trust_env=False)
         except httpx.RequestError:
             logger.exception("Request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
@@ -170,7 +170,7 @@ class BasePluginClient:
             stream_kwargs["content"] = prepared_data
 
         try:
-            with httpx.stream(**stream_kwargs) as response:
+            with httpx.stream(**stream_kwargs, trust_env=False) as response:
                 for raw_line in response.iter_lines():
                     if not raw_line:
                         continue


### PR DESCRIPTION
## Problem

When running Dify from source on macOS (or other systems with proxy configurations), httpx may attempt to use system proxy settings for localhost requests to the plugin daemon. This causes connection failures with errors like:

```
httpx.RemoteProtocolError: Server disconnected without sending a response
```

or

```
{"code":-401,"message":"unauthorized"}
```

## Root Cause

The `httpx.request()` and `httpx.stream()` functions default to `trust_env=True`, which reads proxy settings from environment variables. Even when system proxy is shown as "disabled" in macOS settings, httpx may still attempt to route localhost traffic through a proxy.

## Solution

Add `trust_env=False` parameter to httpx calls for plugin daemon API requests. Since these are internal network calls to localhost, they should never go through a proxy.

## Testing

Tested locally with:
- Dify API running from source (`flask run`)
- Plugin daemon running in Docker
- Chatflow API calls working correctly after the fix

## Changes

- `api/core/plugin/impl/base.py`: Added `trust_env=False` to `httpx.request()` and `httpx.stream()` calls