### PR TITLE
fix: local development fixes for skill-bundler branch

### DIFF
--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -83,7 +83,7 @@ class BasePluginClient:
             request_kwargs["content"] = prepared_data
 
         try:
-            response = httpx.request(**request_kwargs)
+            response = httpx.request(**request_kwargs, trust_env=False)
         except httpx.RequestError:
             logger.exception("Request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
@@ -170,7 +170,7 @@ class BasePluginClient:
             stream_kwargs["content"] = prepared_data
 
         try:
-            with httpx.stream(**stream_kwargs) as response:
+            with httpx.stream(**stream_kwargs, trust_env=False) as response:
                 for raw_line in response.iter_lines():
                     if not raw_line:
                         continue

--- a/api/core/workflow/nodes/llm/node.py
+++ b/api/core/workflow/nodes/llm/node.py
@@ -1511,7 +1511,6 @@ class LLMNode(Node[LLMNodeData]):
                         bundle=bundle,
                         document=SkillDocument(skill_id="anonymous", content=result_text, metadata={}),
                         file_tree=file_tree,
-                        base_path=AppAssets.PATH,
                     )
                     result_text = skill_entry.content
 
@@ -1550,7 +1549,6 @@ class LLMNode(Node[LLMNodeData]):
                         bundle=bundle,
                         document=SkillDocument(skill_id="anonymous", content=plain_text, metadata={}),
                         file_tree=file_tree,
-                        base_path=AppAssets.PATH,
                     )
                     plain_text = skill_entry.content
 
@@ -1823,7 +1821,6 @@ class LLMNode(Node[LLMNodeData]):
                     bundle=bundle,
                     document=SkillDocument(skill_id="anonymous", content=prompt.text, metadata={}),
                     file_tree=file_tree,
-                    base_path=AppAssets.PATH,
                 )
                 tool_deps_list.append(skill_entry.tools)
 


### PR DESCRIPTION
## Changes

This PR fixes two issues found when testing the skill-bundler branch locally:

### 1. trust_env=False for httpx calls
- File: `api/core/plugin/impl/base.py`
- Same fix as #33558, applied to this branch
- Fixes connection issues when running from source on macOS

### 2. Remove invalid base_path parameter
- File: `api/core/workflow/nodes/llm/node.py`
- `compile_one()` method doesn't have `base_path` parameter in its signature
- Removing the invalid parameter allows skill compilation to work

## Testing

Tested locally with:
- Dify API running from source
- Plugin daemon in Docker
- Chatflow with skills working correctly

Related: #33558