### PR TITLE
fix: allow empty skill bundle for apps without skills

### DIFF
--- a/api/core/sandbox/initializer/skill_initializer.py
+++ b/api/core/sandbox/initializer/skill_initializer.py
@@ -4,6 +4,7 @@ import logging
 
 from core.sandbox.sandbox import Sandbox
 from core.skill import SkillAttrs
+from core.skill.entities.skill_bundle import SkillBundle
 from core.skill.skill_manager import SkillManager
 
 from .base import SandboxInitializer
@@ -31,11 +32,8 @@ class SkillInitializer(SandboxInitializer):
             self._assets_id,
         )
         if bundle is None:
-            raise ValueError(
-                f"No skill bundle found for tenant_id={self._tenant_id},"
-                f"app_id={self._app_id}, "
-                f"assets_id={self._assets_id} "
-            )
+            # Create empty bundle for apps without skills
+            bundle = SkillBundle(assets_id=self._assets_id)
 
         sandbox.attrs.set(
             SkillAttrs.BUNDLE,


### PR DESCRIPTION
## Problem

When an app has no skill files in its asset tree, the publish process does not create a skill bundle. This causes `SkillInitializer` to fail with:

```
ValueError: No skill bundle found for tenant_id=xxx, app_id=xxx, assets_id=xxx
```

As a result, Chatflows without any skills cannot run at all.

## Solution

Instead of raising an error when no bundle exists, create an empty `SkillBundle`. This allows apps without skills to run normally while still supporting skill-based workflows when skills are present.

## Changes

- `api/core/sandbox/initializer/skill_initializer.py`: Create empty bundle instead of raising error

## Testing

Tested locally:
- Created Chatflow without any skills
- Confirmed the app can run successfully with an empty bundle