### PR TITLE
fix: include submitted form data in Human Input node tracing inputs (#33578)

### DIFF
--- a/api/dify_graph/nodes/human_input/human_input_node.py
+++ b/api/dify_graph/nodes/human_input/human_input_node.py
@@ -299,9 +299,12 @@ class HumanInputNode(Node[HumanInputNodeData]):
             action_text=action_text,
         )
 
+        # Include submitted form data as inputs for tracing/auditing so execution
+        # details display the user-provided payload in the Tracing UI.
         yield StreamCompletedEvent(
             node_run_result=NodeRunResult(
                 status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                inputs=dict(submitted_data),
                 outputs=outputs,
                 edge_source_handle=selected_action_id,
             )

--- a/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
+++ b/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
@@ -8,6 +8,7 @@ from dify_graph.graph_events import (
     NodeRunHumanInputFormFilledEvent,
     NodeRunHumanInputFormTimeoutEvent,
     NodeRunStartedEvent,
+    NodeRunSucceededEvent,
 )
 from dify_graph.nodes.human_input.enums import HumanInputFormStatus
 from dify_graph.nodes.human_input.human_input_node import HumanInputNode
@@ -165,6 +166,20 @@ def test_human_input_node_emits_form_filled_event_before_succeeded():
     assert filled_event.rendered_content.endswith("Alice")
     assert filled_event.action_id == "Accept"
     assert filled_event.action_text == "Approve"
+
+
+def test_human_input_node_includes_submitted_data_in_tracing_inputs():
+    """Submitted form data must appear in node_run_result.inputs for Tracing UI."""
+    node = _build_node()
+
+    events = list(node.run())
+
+    assert len(events) >= 3
+    succeeded_event = events[2]
+    assert isinstance(succeeded_event, NodeRunSucceededEvent)
+    assert succeeded_event.node_run_result.inputs == {"name": "Alice"}
+    assert succeeded_event.node_run_result.outputs["name"] == "Alice"
+    assert succeeded_event.node_run_result.outputs["__action_id"] == "Accept"
 
 
 def test_human_input_node_emits_timeout_event_before_succeeded():

--- a/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
+++ b/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
@@ -174,7 +174,7 @@ def test_human_input_node_includes_submitted_data_in_tracing_inputs():
 
     events = list(node.run())
 
-    assert len(events) >= 3
+    assert len(events) == 3
     succeeded_event = events[2]
     assert isinstance(succeeded_event, NodeRunSucceededEvent)
     assert succeeded_event.node_run_result.inputs == {"name": "Alice"}


### PR DESCRIPTION
## Summary

Fixes langgenius/graphon#58.

**Root cause:** The Human Input node did not pass `inputs` to `NodeRunResult` when the form was submitted. The persistence layer stores both `inputs` and `outputs` from the node run result for tracing. Without `inputs`, the Tracing UI showed empty execution details for the Human Input node even though the user had submitted form data.

**Fix:** Add `inputs=dict(submitted_data)` to the `NodeRunResult` when yielding `StreamCompletedEvent` after form submission. The submitted form payload is now persisted as inputs so the Tracing UI can display it for debugging and auditing.

## Changes

- `api/dify_graph/nodes/human_input/human_input_node.py`: Pass `inputs=dict(submitted_data)` in `NodeRunResult` when form is filled
- `api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py`: Add `test_human_input_node_includes_submitted_data_in_tracing_inputs` to verify submitted data appears in `node_run_result.inputs`

## Testing

- Added `test_human_input_node_includes_submitted_data_in_tracing_inputs` covering the scenario where form is submitted and the resulting `NodeRunSucceededEvent` has both `inputs` and `outputs` populated with the submitted data
- Minimal change, follows existing patterns (e.g. Start node, LLM node pass inputs for tracing)

## Checklist

- [x] I have read the contribution guidelines
- [x] There is an associated issue
- [x] Fixes langgenius/graphon#58
- [x] I have added a test for the change
- [ ] Documentation update (N/A - bug fix only)
- [ ] Ran make lint and type-check (CI will run)
