### PR TITLE
fix: clarify webhook debug endpoint behavior

### DIFF
--- a/api/controllers/trigger/webhook.py
+++ b/api/controllers/trigger/webhook.py
@@ -70,7 +70,14 @@ def handle_webhook(webhook_id: str):
 
 @bp.route("/webhook-debug/<string:webhook_id>", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])
 def handle_webhook_debug(webhook_id: str):
-    """Handle webhook debug calls without triggering production workflow execution."""
+    """Handle webhook debug calls without triggering production workflow execution.
+
+    The debug webhook endpoint is only for draft inspection flows. It never enqueues
+    Celery work for the published workflow; instead it dispatches an in-memory debug
+    event to an active Variable Inspector listener. Returning a clear error when no
+    listener is registered prevents a misleading 200 response for requests that are
+    effectively dropped.
+    """
     try:
         webhook_trigger, _, node_config, webhook_data, error = _prepare_webhook_execution(webhook_id, is_debug=True)
         if error:
@@ -94,11 +101,32 @@ def handle_webhook_debug(webhook_id: str):
                 "method": webhook_data.get("method"),
             },
         )
-        TriggerDebugEventBus.dispatch(
+        dispatch_count = TriggerDebugEventBus.dispatch(
             tenant_id=webhook_trigger.tenant_id,
             event=event,
             pool_key=pool_key,
         )
+        if dispatch_count == 0:
+            logger.warning(
+                "Webhook debug request dropped without an active listener for webhook %s (tenant=%s, app=%s, node=%s)",
+                webhook_trigger.webhook_id,
+                webhook_trigger.tenant_id,
+                webhook_trigger.app_id,
+                webhook_trigger.node_id,
+            )
+            return (
+                jsonify(
+                    {
+                        "error": "No active debug listener",
+                        "message": (
+                            "The webhook debug URL only works while the Variable Inspector is listening. "
+                            "Use the published webhook URL to execute the workflow in Celery."
+                        ),
+                        "execution_url": webhook_trigger.webhook_url,
+                    }
+                ),
+                409,
+            )
         response_data, status_code = WebhookService.generate_webhook_response(node_config)
         return jsonify(response_data), status_code
 

--- a/api/tests/unit_tests/controllers/trigger/test_webhook.py
+++ b/api/tests/unit_tests/controllers/trigger/test_webhook.py
@@ -23,6 +23,7 @@ def mock_jsonify():
 
 class DummyWebhookTrigger:
     webhook_id = "wh-1"
+    webhook_url = "http://localhost:5001/triggers/webhook/wh-1"
     tenant_id = "tenant-1"
     app_id = "app-1"
     node_id = "node-1"
@@ -104,7 +105,28 @@ class TestHandleWebhookDebug:
     @patch.object(module.WebhookService, "get_webhook_trigger_and_workflow")
     @patch.object(module.WebhookService, "extract_and_validate_webhook_data")
     @patch.object(module.WebhookService, "build_workflow_inputs", return_value={"x": 1})
-    @patch.object(module.TriggerDebugEventBus, "dispatch")
+    @patch.object(module.TriggerDebugEventBus, "dispatch", return_value=0)
+    def test_debug_requires_active_listener(
+        self,
+        mock_dispatch,
+        mock_build_inputs,
+        mock_extract,
+        mock_get,
+    ):
+        mock_get.return_value = (DummyWebhookTrigger(), None, "node_config")
+        mock_extract.return_value = {"method": "POST"}
+
+        response, status = module.handle_webhook_debug("wh-1")
+
+        assert status == 409
+        assert response["error"] == "No active debug listener"
+        assert response["execution_url"] == DummyWebhookTrigger.webhook_url
+        mock_dispatch.assert_called_once()
+
+    @patch.object(module.WebhookService, "get_webhook_trigger_and_workflow")
+    @patch.object(module.WebhookService, "extract_and_validate_webhook_data")
+    @patch.object(module.WebhookService, "build_workflow_inputs", return_value={"x": 1})
+    @patch.object(module.TriggerDebugEventBus, "dispatch", return_value=1)
     @patch.object(module.WebhookService, "generate_webhook_response")
     def test_debug_success(
         self,

--- a/api/tests/unit_tests/controllers/trigger/test_webhook.py
+++ b/api/tests/unit_tests/controllers/trigger/test_webhook.py
@@ -120,6 +120,10 @@ class TestHandleWebhookDebug:
 
         assert status == 409
         assert response["error"] == "No active debug listener"
+        assert response["message"] == (
+            "The webhook debug URL only works while the Variable Inspector is listening. "
+            "Use the published webhook URL to execute the workflow in Celery."
+        )
         assert response["execution_url"] == DummyWebhookTrigger.webhook_url
         mock_dispatch.assert_called_once()
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #33595

Return an explicit conflict response when the webhook debug URL is called without an active debug listener, and include the published execution URL so callers can use the correct endpoint for workflow execution.

This prevents a misleading success response when the request cannot produce a workflow run.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
