### PR TITLE
refactor(api): replace dict/Mapping with TypedDict in core/app

### DIFF
--- a/api/core/app/app_config/common/parameters_mapping/__init__.py
+++ b/api/core/app/app_config/common/parameters_mapping/__init__.py
@@ -14,17 +14,17 @@ class SystemParametersDict(TypedDict):
 
 
 class AppParametersDict(TypedDict):
-    opening_statement: Any
-    suggested_questions: Any
-    suggested_questions_after_answer: Any
-    speech_to_text: Any
-    text_to_speech: Any
-    retriever_resource: Any
-    annotation_reply: Any
-    more_like_this: Any
+    opening_statement: str | None
+    suggested_questions: list[str]
+    suggested_questions_after_answer: dict[str, Any]
+    speech_to_text: dict[str, Any]
+    text_to_speech: dict[str, Any]
+    retriever_resource: dict[str, Any]
+    annotation_reply: dict[str, Any]
+    more_like_this: dict[str, Any]
     user_input_form: list[dict[str, Any]]
-    sensitive_word_avoidance: Any
-    file_upload: Any
+    sensitive_word_avoidance: dict[str, Any]
+    file_upload: dict[str, Any]
     system_parameters: SystemParametersDict
 
 

--- a/api/core/app/app_config/common/parameters_mapping/__init__.py
+++ b/api/core/app/app_config/common/parameters_mapping/__init__.py
@@ -1,13 +1,36 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypedDict
 
 from configs import dify_config
 from constants import DEFAULT_FILE_NUMBER_LIMITS
 
 
+class SystemParametersDict(TypedDict):
+    image_file_size_limit: int
+    video_file_size_limit: int
+    audio_file_size_limit: int
+    file_size_limit: int
+    workflow_file_upload_limit: int
+
+
+class AppParametersDict(TypedDict):
+    opening_statement: Any
+    suggested_questions: Any
+    suggested_questions_after_answer: Any
+    speech_to_text: Any
+    text_to_speech: Any
+    retriever_resource: Any
+    annotation_reply: Any
+    more_like_this: Any
+    user_input_form: list[dict[str, Any]]
+    sensitive_word_avoidance: Any
+    file_upload: Any
+    system_parameters: SystemParametersDict
+
+
 def get_parameters_from_feature_dict(
     *, features_dict: Mapping[str, Any], user_input_form: list[dict[str, Any]]
-) -> Mapping[str, Any]:
+) -> AppParametersDict:
     """
     Mapping from feature dict to webapp parameters
     """

--- a/api/core/app/apps/common/workflow_response_converter.py
+++ b/api/core/app/apps/common/workflow_response_converter.py
@@ -263,7 +263,7 @@ class WorkflowResponseConverter:
         outputs_mapping = graph_runtime_state.outputs or {}
         encoded_outputs = WorkflowRuntimeTypeConverter().to_json_encodable(outputs_mapping)
 
-        created_by: CreatedByDict
+        created_by: CreatedByDict | dict[str, object] = {}
         user = self._user
         if isinstance(user, Account):
             created_by = AccountCreatedByDict(
@@ -271,7 +271,7 @@ class WorkflowResponseConverter:
                 name=user.name,
                 email=user.email,
             )
-        else:
+        elif isinstance(user, EndUser):
             created_by = EndUserCreatedByDict(
                 id=user.id,
                 user=user.session_id,

--- a/api/core/app/apps/common/workflow_response_converter.py
+++ b/api/core/app/apps/common/workflow_response_converter.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, NewType, Union
+from typing import Any, NewType, TypedDict, Union
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -74,6 +74,20 @@ from services.variable_truncator import BaseTruncator, DummyVariableTruncator, V
 
 NodeExecutionId = NewType("NodeExecutionId", str)
 logger = logging.getLogger(__name__)
+
+
+class AccountCreatedByDict(TypedDict):
+    id: str
+    name: str
+    email: str
+
+
+class EndUserCreatedByDict(TypedDict):
+    id: str
+    user: str
+
+
+CreatedByDict = AccountCreatedByDict | EndUserCreatedByDict
 
 
 @dataclass(slots=True)
@@ -249,19 +263,19 @@ class WorkflowResponseConverter:
         outputs_mapping = graph_runtime_state.outputs or {}
         encoded_outputs = WorkflowRuntimeTypeConverter().to_json_encodable(outputs_mapping)
 
-        created_by: Mapping[str, object] | None
+        created_by: CreatedByDict
         user = self._user
         if isinstance(user, Account):
-            created_by = {
-                "id": user.id,
-                "name": user.name,
-                "email": user.email,
-            }
+            created_by = AccountCreatedByDict(
+                id=user.id,
+                name=user.name,
+                email=user.email,
+            )
         else:
-            created_by = {
-                "id": user.id,
-                "user": user.session_id,
-            }
+            created_by = EndUserCreatedByDict(
+                id=user.id,
+                user=user.session_id,
+            )
 
         return WorkflowFinishStreamResponse(
             task_id=task_id,

--- a/api/core/app/task_pipeline/message_file_utils.py
+++ b/api/core/app/task_pipeline/message_file_utils.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from core.tools.signature import sign_tool_file
 from dify_graph.file import helpers as file_helpers
 from dify_graph.file.enums import FileTransferMethod
@@ -6,7 +8,20 @@ from models.model import MessageFile, UploadFile
 MAX_TOOL_FILE_EXTENSION_LENGTH = 10
 
 
-def prepare_file_dict(message_file: MessageFile, upload_files_map: dict[str, UploadFile]) -> dict:
+class MessageFileInfoDict(TypedDict):
+    related_id: str
+    extension: str
+    filename: str
+    size: int
+    mime_type: str
+    transfer_method: str
+    type: str
+    url: str
+    upload_file_id: str
+    remote_url: str | None
+
+
+def prepare_file_dict(message_file: MessageFile, upload_files_map: dict[str, UploadFile]) -> MessageFileInfoDict:
     """
     Prepare file dictionary for message end stream response.
 


### PR DESCRIPTION
## Summary
- **`task_pipeline/message_file_utils.py`**: Add `MessageFileInfoDict` (10 fields), replace bare `-> dict` return type on `prepare_file_dict`
- **`app_config/common/parameters_mapping/__init__.py`**: Add `SystemParametersDict` and `AppParametersDict`, replace `-> Mapping[str, Any]` on `get_parameters_from_feature_dict`
- **`apps/common/workflow_response_converter.py`**: Add `AccountCreatedByDict`, `EndUserCreatedByDict`, and `CreatedByDict` union; replace `Mapping[str, object]` on `created_by` local variable with discriminated union constructors

## Why only 3 files changed
Most `Mapping[str, Any]` annotations in `core/app/` are Pydantic BaseModel fields on queue/task event classes (`queue_entities.py`, `task_entities.py`) carrying dynamic per-node runtime data (inputs, outputs, process_data, metadata) where keys vary by node type — not convertible. The blocking response converters (`chat/`, `agent_chat/`, `completion/`) have fixed-key dicts but changing return types causes cascading type errors from strict override checking and TypedDict-to-dict incompatibility in basedpyright/pyrefly.

## Test plan
- [x] `ruff check` passes on all changed files
- [x] `make type-check` passes (basedpyright + pyrefly + mypy)
- [x] Existing unit/integration tests pass with no regressions

Part of #32863 (`api/core/app/`)