### PR TITLE
fix: sync workflow description and name to MCP server on update

### DIFF
--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -108,12 +108,12 @@ class AppMCPServerController(Resource):
             raise NotFound()
 
         description = payload.description
-        if description is None:
-            pass
-        elif not description:
+        if description is None or not description:
             server.description = app_model.description or ""
         else:
             server.description = description
+
+        server.name = app_model.name
 
         server.parameters = json.dumps(payload.parameters, ensure_ascii=False)
         if payload.status:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #33626

When a workflow's description is updated and the MCP server is subsequently updated via Tool → MCP → Update, the MCP server description remained stale. This happened because `AppMCPServer.description` was only set at creation time and the update endpoint skipped syncing when no explicit description was provided in the payload (`description=None`).

This PR changes the update logic so that when no explicit description is provided, the MCP server description (and name) are refreshed from the current app/workflow model.
## Screenshots

