### PR TITLE
fix(mcp): propagate workflow description updates to MCP server

### DIFF
--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -104,7 +104,8 @@ class AppMCPServerController(Resource):
 
         description = payload.description
         if description is None:
-            pass
+            # Sync with current app description when user doesn't explicitly provide one
+            server.description = app_model.description or ""
         elif not description:
             server.description = app_model.description or ""
         else:


### PR DESCRIPTION
## Summary

Fixes #33626

When a workflow description was updated and the MCP server was subsequently updated, the new description was not being reflected in the MCP server configuration.

## Root Cause

In the MCP server update endpoint (PUT /apps/{app_id}/server), when payload.description was None (indicating the user did not explicitly provide a description), the code did nothing (pass), leaving the stale description in place instead of syncing with the updated app description.

## Fix

Changed the logic to sync with the current app_model.description when description is None:

```python
if description is None:
    # Sync with current app description when user doesn't explicitly provide one
    server.description = app_model.description or ""
```

This ensures that workflow description updates are automatically propagated to the MCP server when users update their MCP configuration.

## Testing

- Verified syntax with python3 -m py_compile
- Minimal change (2 lines added, 1 line removed)

## Checklist

- [x] I have read the Contributing Guide
- [x] This PR fixes an existing issue
- [x] The change is minimal and focused
