### PR TITLE
fix(workflow): handle unavailable tracing service gracefully

### DIFF
--- a/api/core/ops/mlflow_trace/mlflow_trace.py
+++ b/api/core/ops/mlflow_trace/mlflow_trace.py
@@ -39,8 +39,16 @@ def datetime_to_nanoseconds(dt: datetime | None) -> int | None:
 
 
 class MLflowDataTrace(BaseTraceInstance):
+    # Default timeout for MLflow HTTP requests (in seconds)
+    DEFAULT_TIMEOUT = 30
+
     def __init__(self, config: MLflowConfig | DatabricksConfig):
         super().__init__(config)
+        # Set HTTP request timeout to prevent indefinite hangs when MLflow is unavailable
+        # This must be set before any mlflow operations
+        if "MLFLOW_HTTP_REQUEST_TIMEOUT" not in os.environ:
+            os.environ["MLFLOW_HTTP_REQUEST_TIMEOUT"] = str(self.DEFAULT_TIMEOUT)
+
         if isinstance(config, DatabricksConfig):
             self._setup_databricks(config)
         else:
@@ -86,7 +94,10 @@ class MLflowDataTrace(BaseTraceInstance):
         self._project_url = f"{config.tracking_uri}/#/experiments/{config.experiment_id}/traces"
 
     def trace(self, trace_info: BaseTraceInfo):
-        """Simple dispatch to trace methods"""
+        """Simple dispatch to trace methods with graceful error handling.
+        
+        Connection errors to MLflow should not break workflow execution.
+        """
         try:
             if isinstance(trace_info, WorkflowTraceInfo):
                 self.workflow_trace(trace_info)
@@ -103,8 +114,8 @@ class MLflowDataTrace(BaseTraceInstance):
             elif isinstance(trace_info, GenerateNameTraceInfo):
                 self.generate_name_trace(trace_info)
         except Exception:
-            logger.exception("[MLflow] Trace error")
-            raise
+            # Log the error but don't raise - tracing failures should not break workflow execution
+            logger.exception("[MLflow] Trace failed (service may be unavailable)")
 
     def workflow_trace(self, trace_info: WorkflowTraceInfo):
         """Create workflow span as root, with node spans as children"""

--- a/api/tests/unit_tests/core/ops/mlflow_trace/test_mlflow_trace.py
+++ b/api/tests/unit_tests/core/ops/mlflow_trace/test_mlflow_trace.py
@@ -237,6 +237,8 @@ class TestInit:
         mock_mlflow.set_experiment.assert_called_with(experiment_id="0")
         assert trace.get_project_url() == "http://localhost:5000/#/experiments/0/traces"
         assert os.environ["MLFLOW_ENABLE_ASYNC_TRACE_LOGGING"] == "true"
+        # Verify timeout is set to prevent indefinite hangs
+        assert os.environ["MLFLOW_HTTP_REQUEST_TIMEOUT"] == "30"
 
     def test_mlflow_config_with_auth(self, mock_mlflow):
         config = MLflowConfig(
@@ -319,10 +321,12 @@ class TestTraceDispatcher:
             trace_instance.trace(_make_generate_name_trace_info())
             mock_gn.assert_called_once()
 
-    def test_reraises_exception(self, trace_instance, mock_tracing, mock_db):
+    def test_handles_exception_gracefully(self, trace_instance, mock_tracing, mock_db):
+        """Test that trace failures are handled gracefully and don't break workflow execution."""
         with patch.object(trace_instance, "workflow_trace", side_effect=RuntimeError("boom")):
-            with pytest.raises(RuntimeError, match="boom"):
-                trace_instance.trace(_make_workflow_trace_info())
+            # Should not raise exception - just log and continue
+            trace_instance.trace(_make_workflow_trace_info())
+            # The method should complete without raising
 
 
 # ── workflow_trace ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #33627

When MLflow (or other tracing services) is enabled but unavailable, the Workflow UI keeps spinning indefinitely. This fix ensures that:

1. **HTTP request timeouts are set** - MLflow HTTP requests now have a 30-second timeout to prevent indefinite hangs when the service is unavailable.

2. **Graceful error handling** - Trace failures are logged but no longer raise exceptions that could block workflow execution.

## Changes

- Added `DEFAULT_TIMEOUT = 30` constant to prevent indefinite HTTP hangs
- Set `MLFLOW_HTTP_REQUEST_TIMEOUT` environment variable during initialization
- Changed `trace()` method to log exceptions instead of re-raising them
- Updated tests to verify graceful error handling

## Testing

- Updated unit tests in `test_mlflow_trace.py` to verify timeout configuration and graceful error handling
- Verified that exceptions in trace methods are handled gracefully without breaking workflow execution

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests updated and passing
- [x] Changes are limited to the fix scope
