### PR TITLE
fix(api): Preserving the content transform logic in fetch_prompt_messages

### DIFF
--- a/api/dify_graph/nodes/llm/llm_utils.py
+++ b/api/dify_graph/nodes/llm/llm_utils.py
@@ -256,9 +256,13 @@ def fetch_prompt_messages(
                 ):
                     continue
                 prompt_message_content.append(content_item)
-            if prompt_message_content:
+            if not prompt_message_content:
+                continue
+            if len(prompt_message_content) == 1 and prompt_message_content[0].type == PromptMessageContentType.TEXT:
+                prompt_message.content = prompt_message_content[0].data
+            else:
                 prompt_message.content = prompt_message_content
-                filtered_prompt_messages.append(prompt_message)
+            filtered_prompt_messages.append(prompt_message)
         elif not prompt_message.is_empty():
             filtered_prompt_messages.append(prompt_message)
 

--- a/api/dify_graph/nodes/llm/llm_utils.py
+++ b/api/dify_graph/nodes/llm/llm_utils.py
@@ -258,10 +258,10 @@ def fetch_prompt_messages(
                 prompt_message_content.append(content_item)
             if not prompt_message_content:
                 continue
-            content = prompt_message_content
-            if len(content) == 1 and isinstance(content[0], TextPromptMessageContent):
-                content = content[0].data
-            prompt_message.content = content
+            if len(prompt_message_content) == 1 and prompt_message_content[0].type == PromptMessageContentType.TEXT:
+                prompt_message.content = prompt_message_content[0].data
+            else:
+                prompt_message.content = prompt_message_content
             filtered_prompt_messages.append(prompt_message)
         elif not prompt_message.is_empty():
             filtered_prompt_messages.append(prompt_message)

--- a/api/dify_graph/nodes/llm/llm_utils.py
+++ b/api/dify_graph/nodes/llm/llm_utils.py
@@ -258,10 +258,10 @@ def fetch_prompt_messages(
                 prompt_message_content.append(content_item)
             if not prompt_message_content:
                 continue
-            if len(prompt_message_content) == 1 and prompt_message_content[0].type == PromptMessageContentType.TEXT:
-                prompt_message.content = prompt_message_content[0].data
-            else:
-                prompt_message.content = prompt_message_content
+            content = prompt_message_content
+            if len(content) == 1 and isinstance(content[0], TextPromptMessageContent):
+                content = content[0].data
+            prompt_message.content = content
             filtered_prompt_messages.append(prompt_message)
         elif not prompt_message.is_empty():
             filtered_prompt_messages.append(prompt_message)

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_llm_utils.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_llm_utils.py
@@ -29,11 +29,7 @@ def _fetch_prompt_messages_with_mocked_content(content):
         ),
         mock.patch(
             "dify_graph.nodes.llm.llm_utils.handle_list_messages",
-            return_value=[
-                SystemPromptMessage(
-                    content=content
-                )
-            ],
+            return_value=[SystemPromptMessage(content=content)],
         ),
         mock.patch(
             "dify_graph.nodes.llm.llm_utils.handle_memory_chat_mode",

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_llm_utils.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_llm_utils.py
@@ -1,0 +1,110 @@
+from unittest import mock
+
+import pytest
+
+from core.model_manager import ModelInstance
+from dify_graph.model_runtime.entities import ImagePromptMessageContent, PromptMessageRole, TextPromptMessageContent
+from dify_graph.model_runtime.entities.message_entities import SystemPromptMessage
+from dify_graph.nodes.llm import llm_utils
+from dify_graph.nodes.llm.entities import LLMNodeChatModelMessage
+from dify_graph.nodes.llm.exc import NoPromptFoundError
+from dify_graph.runtime import VariablePool
+
+
+def _fetch_prompt_messages_with_mocked_content(content):
+    variable_pool = VariablePool.empty()
+    model_instance = mock.MagicMock(spec=ModelInstance)
+    prompt_template = [
+        LLMNodeChatModelMessage(
+            text="You are a classifier.",
+            role=PromptMessageRole.SYSTEM,
+            edition_type="basic",
+        )
+    ]
+
+    with (
+        mock.patch(
+            "dify_graph.nodes.llm.llm_utils.fetch_model_schema",
+            return_value=mock.MagicMock(features=[]),
+        ),
+        mock.patch(
+            "dify_graph.nodes.llm.llm_utils.handle_list_messages",
+            return_value=[
+                SystemPromptMessage(
+                    content=content
+                )
+            ],
+        ),
+        mock.patch(
+            "dify_graph.nodes.llm.llm_utils.handle_memory_chat_mode",
+            return_value=[],
+        ),
+    ):
+        return llm_utils.fetch_prompt_messages(
+            sys_query=None,
+            sys_files=[],
+            context=None,
+            memory=None,
+            model_instance=model_instance,
+            prompt_template=prompt_template,
+            stop=["END"],
+            memory_config=None,
+            vision_enabled=False,
+            vision_detail=ImagePromptMessageContent.DETAIL.HIGH,
+            variable_pool=variable_pool,
+            jinja2_variables=[],
+            template_renderer=None,
+        )
+
+
+def test_fetch_prompt_messages_skips_messages_when_all_contents_are_filtered_out():
+    with pytest.raises(NoPromptFoundError):
+        _fetch_prompt_messages_with_mocked_content(
+            [
+                ImagePromptMessageContent(
+                    format="url",
+                    url="https://example.com/image.png",
+                    mime_type="image/png",
+                ),
+            ]
+        )
+
+
+def test_fetch_prompt_messages_flattens_single_text_content_after_filtering_unsupported_multimodal_items():
+    prompt_messages, stop = _fetch_prompt_messages_with_mocked_content(
+        [
+            TextPromptMessageContent(data="You are a classifier."),
+            ImagePromptMessageContent(
+                format="url",
+                url="https://example.com/image.png",
+                mime_type="image/png",
+            ),
+        ]
+    )
+
+    assert stop == ["END"]
+    assert prompt_messages == [SystemPromptMessage(content="You are a classifier.")]
+
+
+def test_fetch_prompt_messages_keeps_list_content_when_multiple_supported_items_remain():
+    prompt_messages, stop = _fetch_prompt_messages_with_mocked_content(
+        [
+            TextPromptMessageContent(data="You are"),
+            TextPromptMessageContent(data=" a classifier."),
+            ImagePromptMessageContent(
+                format="url",
+                url="https://example.com/image.png",
+                mime_type="image/png",
+            ),
+        ]
+    )
+
+    assert stop == ["END"]
+    assert prompt_messages == [
+        SystemPromptMessage(
+            content=[
+                TextPromptMessageContent(data="You are"),
+                TextPromptMessageContent(data=" a classifier."),
+            ]
+        )
+    ]


### PR DESCRIPTION
## Summary

PR #33400 extracted some static methods used by LLM node into module-level functions. One such function is fetch_prompt_messages.

However, the extraction process not only moved the function, it also adjusted some logic inside that function.

The original logic for prompt_message handling would convert `TextPromptMessageContent` to `str` if there is only one prompt content and its type is `TEXT` ([src](https://github.com/langgenius/dify/pull/33400/changes/e0fe061d0bc64d0f531ba374a3ad82afcea91827#diff-0203c2638ce459b496f9f12f66e1378f2716a454aa3ffee682ecb70fd9fb17e0L937-L940)). The extracted function does not preserve this logic ([src](https://github.com/langgenius/dify/pull/33400/changes/e0fe061d0bc64d0f531ba374a3ad82afcea91827#diff-b23cd5bc2cfd7e8ad090b747bc4d100bab4a6dfbf78f10d00a484331df54a517R179-R182)) and send `TextPromptMessageContent` without transformation, causing plugins not upgraded failed to process those contents.

Fix #33598 
Fix #33640

## Screenshots

| Before | After |
|--------|-------|
| <img width="1303" height="549" alt="image" src="https://github.com/user-attachments/assets/665e1c0e-6074-46fb-b89d-6a362c27f391" /> | <img width="794" height="515" alt="image" src="https://github.com/user-attachments/assets/74ca4755-89d7-43a4-911d-1ab3e27be6f7" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
