### PR TITLE
REDIS_MAX_CONNECTIONS is not configured with a default value

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -351,7 +351,7 @@ REDIS_SSL_KEYFILE=
 REDIS_DB=0
 # Optional: limit total Redis connections used by API/Worker (unset for default)
 # Align with API's REDIS_MAX_CONNECTIONS in configs
-REDIS_MAX_CONNECTIONS=
+REDIS_MAX_CONNECTIONS=100
 
 # Whether to use Redis Sentinel mode.
 # If set to true, the application will automatically discover and connect to the master node through Sentinel.


### PR DESCRIPTION
## Summary

The `REDIS_MAX_CONNECTIONS` variable in `.env.example` was previously set to an empty value without a default, which caused Docker Compose to fail starting services correctly when the variable was not explicitly configured.
This PR sets a reasonable default value `100` for `REDIS_MAX_CONNECTIONS` in `.env.example`, ensuring the project can be deployed and run out-of-the-box without manual configuration of this variable.

Fixes #33667 

## Screenshots

| Before | After |
|--------|-------|
| `REDIS_MAX_CONNECTIONS=` | `REDIS_MAX_CONNECTIONS=100` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods.