### PR TITLE
fix: add max_retries=0 for executor

### DIFF
--- a/api/dify_graph/nodes/http_request/node.py
+++ b/api/dify_graph/nodes/http_request/node.py
@@ -101,6 +101,9 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
                 timeout=self._get_request_timeout(self.node_data),
                 variable_pool=self.graph_runtime_state.variable_pool,
                 http_request_config=self._http_request_config,
+                # Must be 0: retries are handled at the node level by the graph engine,
+                # so the executor must not retry on its own.
+                max_retries=0,
                 ssl_verify=self.node_data.ssl_verify,
                 http_client=self._http_client,
                 file_manager=self._file_manager,

--- a/api/dify_graph/nodes/http_request/node.py
+++ b/api/dify_graph/nodes/http_request/node.py
@@ -101,8 +101,8 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
                 timeout=self._get_request_timeout(self.node_data),
                 variable_pool=self.graph_runtime_state.variable_pool,
                 http_request_config=self._http_request_config,
-                # Must be 0: retries are handled at the node level by the graph engine,
-                # so the executor must not retry on its own.
+                # Must be 0 to disable executor-level retries, as the graph engine handles them.
+                # This is critical to prevent nested retries.
                 max_retries=0,
                 ssl_verify=self.node_data.ssl_verify,
                 http_client=self._http_client,


### PR DESCRIPTION
## Summary

This PR reintroduces max_retries=0, which was removed by PR #33619.

In PR #33619, the hardcoded `max_retries=0` line was deleted, but this line was actually necessary.
That's because, in the current graph engine, retries are handled at the node level, so the Executor inside the node shouldn't perform retries on its own.

In other words, `max_retries=0` was probably originally set with the following intention:

```text
1st node execution
　- HTTP request from Executor (max_retries=0): 💥 fails  
2nd node execution (retry 1/5)  
　- HTTP request from Executor (max_retries=0): 💥 fails  
3rd node execution (retry 2/5)  
　- HTTP request from Executor (max_retries=0): 💥 fails  
4th node execution (retry 3/5)  
　- HTTP request from Executor (max_retries=0): 💥 fails  
5th node execution (retry 4/5)  
　- HTTP request from Executor (max_retries=0): 💥 fails  
6th node execution (retry 5/5)  
　- HTTP request from Executor (max_retries=0): 💥 fails  
```

But with PR #33619, version 1.13.1 works as follows because the hardcoded `max_retries=0` line was removed and now `max_retries` defaults to 3:

```text
1st node execution 
　- HTTP reques from Executor (max_retries=3): 💥 fails  
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 1/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 2/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 3/3)
2nd node execution (retry 1/5)  
　- HTTP reques from Executor (max_retries=3): 💥 fails  
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 1/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 2/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 3/3)
3rd node execution (retry 2/5)  
　- HTTP reques from Executor (max_retries=3): 💥 fails  
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 1/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 2/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 3/3)
4th node execution (retry 3/5)  
　- HTTP reques from Executor (max_retries=3): 💥 fails  
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 1/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 2/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 3/3)
5th node execution (retry 4/5)  
　- HTTP reques from Executor (max_retries=3): 💥 fails  
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 1/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 2/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 3/3)
6th node execution (retry 5/5)  
　- HTTP reques from Executor (max_retries=3): 💥 fails  
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 1/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 2/3)
　- HTTP reques from Executor (max_retries=3): 💥 fails (retry 3/3)
```

The Issue #33571 mentioned in PR #33619 is actually a duplicate of the #31071 I originally opened.
It's just that the number in the error message was incorrect—the retries were being performed the correct number of times.
So, in PR #32406, I updated the error message so it no longer includes the number of attempts.

Closes #33686

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
