### PR TITLE
fix: re-query Dataset in thread-pool workers to prevent session detach

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -681,6 +681,16 @@ class IndexingRunner:
         embedding_model_instance: ModelInstance | None,
     ):
         with flask_app.app_context():
+            # Re-query dataset and document in the current thread's session to avoid
+            # "Instance is not bound to a Session" errors when the parent thread's
+            # session expires or closes these objects.
+            dataset = db.session.query(Dataset).filter_by(id=dataset.id).first()
+            if not dataset:
+                raise ValueError("no dataset found")
+            dataset_document = db.session.get(DatasetDocument, dataset_document.id)
+            if not dataset_document:
+                raise ValueError("no dataset document found")
+
             # check document is paused
             self._check_document_paused_status(dataset_document.id)
 

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -684,12 +684,14 @@ class IndexingRunner:
             # Re-query dataset and document in the current thread's session to avoid
             # "Instance is not bound to a Session" errors when the parent thread's
             # session expires or closes these objects.
-            dataset = db.session.query(Dataset).filter_by(id=dataset.id).first()
-            if not dataset:
+            current_dataset = db.session.query(Dataset).filter_by(id=dataset.id).first()
+            if not current_dataset:
                 raise ValueError("no dataset found")
-            dataset_document = db.session.get(DatasetDocument, dataset_document.id)
-            if not dataset_document:
+            dataset = current_dataset
+            current_document = db.session.get(DatasetDocument, dataset_document.id)
+            if not current_document:
                 raise ValueError("no dataset document found")
+            dataset_document = current_document
 
             # check document is paused
             self._check_document_paused_status(dataset_document.id)


### PR DESCRIPTION
## Summary

Fixes #33684

When importing documents into a knowledge base, `_process_chunk()` runs inside a `ThreadPoolExecutor` with a new Flask app context (and therefore a new `db.session`). However, the `Dataset` and `DatasetDocument` ORM instances passed into the worker were loaded in the **parent thread's** session. When the parent session expires objects after a commit, or when the worker tries to lazy-load an attribute (e.g. `dataset.is_multimodal`), SQLAlchemy raises:

```
Instance<Dataset at 0x...> is not bound to a Session;
attribute refresh operation cannot proceed
```

### Fix

Re-query both `Dataset` and `DatasetDocument` from the local thread's `db.session` at the start of `_process_chunk()`, exactly matching the pattern already used in `_process_keyword_index()` (which correctly re-queries `Dataset` in its worker thread).

### Why this is intermittent

The error only surfaces when:
1. The parent thread's session expires its identity map (e.g. after another worker's `db.session.commit()`), **and**
2. A worker then accesses a lazy-loaded attribute on the stale `Dataset`/`DatasetDocument` instance

This depends on thread scheduling and which attributes were already loaded, explaining why the issue is reported as "sometimes".

## Test plan

- [ ] Import multiple documents into a knowledge base concurrently — verify no session detach errors
- [ ] Verify document indexing completes successfully with `high_quality` indexing technique (exercises `_process_chunk` thread pool)
- [ ] Verify keyword-only (`economy`) indexing still works (exercises `_process_keyword_index`)