### PR TITLE
chore: enable turbopack fs cache for development

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -35,7 +35,6 @@ const nextConfig: NextConfig = {
     removeConsole: isDev ? false : { exclude: ['warn', 'error'] },
   },
   experimental: {
-    turbopackFileSystemCacheForDev: false,
   },
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- to close #33713
- NextJS  has enabled filesystem cache by default for development at
 https://github.com/vercel/next.js/pull/85975 since v16.1.0 in Nov 2025
- remove explicit turbopackFileSystemCacheForDev setting in nextjs experimental configs, with `true` as default value

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
