### PR TITLE
fix: compatible with emoji/object icons in plugin card icon resolver

### DIFF
--- a/web/app/components/plugins/utils.ts
+++ b/web/app/components/plugins/utils.ts
@@ -21,11 +21,14 @@ const hasUrlProtocol = (value: string) => /^[a-z][a-z\d+.-]*:/i.test(value)
 
 export const getPluginCardIconUrl = (
   plugin: Pick<Plugin, 'from' | 'name' | 'org' | 'type'>,
-  icon: string | undefined,
+  icon: string | { content: string, background: string } | undefined,
   tenantId: string,
 ) => {
   if (!icon)
     return ''
+
+  if (typeof icon === 'object')
+    return icon
 
   if (hasUrlProtocol(icon) || icon.startsWith('/'))
     return icon


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #33731

This PR updates the plugin card icon resolver to handle non-string (emoji/object) icons in addition to URL strings, enabling plugin cards to render AppIcon-style icons consistently.

### Changes:
- Expanded `getPluginCardIconUrl` parameter type to accept `{ content: string; background: string }`.
- Added an early return to pass object icons through without URL transformation.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
