### PR TITLE
refactor(web): migrate auth toast calls to ui toast

### DIFF
--- a/web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 
@@ -24,16 +24,16 @@ export default function CheckCode() {
   const verify = async () => {
     try {
       if (!code.trim()) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.emptyCode', { ns: 'login' }),
+          title: t('checkCode.emptyCode', { ns: 'login' }),
         })
         return
       }
       if (!/\d{6}/.test(code)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.invalidCode', { ns: 'login' }),
+          title: t('checkCode.invalidCode', { ns: 'login' }),
         })
         return
       }

--- a/web/app/(shareLayout)/webapp-reset-password/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/page.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { COUNT_DOWN_KEY, COUNT_DOWN_TIME_MS } from '@/app/components/signin/countdown'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -27,14 +27,14 @@ export default function CheckCode() {
   const handleGetEMailVerificationCode = async () => {
     try {
       if (!email) {
-        Toast.notify({ type: 'error', message: t('error.emailEmpty', { ns: 'login' }) })
+        toast.add({ type: 'error', title: t('error.emailEmpty', { ns: 'login' }) })
         return
       }
 
       if (!emailRegex.test(email)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('error.emailInValid', { ns: 'login' }),
+          title: t('error.emailInValid', { ns: 'login' }),
         })
         return
       }
@@ -48,15 +48,15 @@ export default function CheckCode() {
         router.push(`/webapp-reset-password/check-code?${params.toString()}`)
       }
       else if (res.code === 'account_not_found') {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('error.registrationNotAllowed', { ns: 'login' }),
+          title: t('error.registrationNotAllowed', { ns: 'login' }),
         })
       }
       else {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: res.data,
+          title: res.data,
         })
       }
     }

--- a/web/app/(shareLayout)/webapp-reset-password/set-password/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/set-password/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { validPassword } from '@/config'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { changeWebAppPasswordWithToken } from '@/service/common'
@@ -24,9 +24,9 @@ const ChangePasswordForm = () => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
   const showErrorMessage = useCallback((message: string) => {
-    Toast.notify({
+    toast.add({
       type: 'error',
-      message,
+      title: message,
     })
   }, [])
 

--- a/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 import { useWebAppStore } from '@/context/web-app-context'
@@ -43,23 +43,23 @@ export default function CheckCode() {
     try {
       const appCode = getAppCodeFromRedirectUrl()
       if (!code.trim()) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.emptyCode', { ns: 'login' }),
+          title: t('checkCode.emptyCode', { ns: 'login' }),
         })
         return
       }
       if (!/\d{6}/.test(code)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.invalidCode', { ns: 'login' }),
+          title: t('checkCode.invalidCode', { ns: 'login' }),
         })
         return
       }
       if (!redirectUrl || !appCode) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('error.redirectUrlMissing', { ns: 'login' }),
+          title: t('error.redirectUrlMissing', { ns: 'login' }),
         })
         return
       }

--- a/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useCallback, useEffect } from 'react'
 import AppUnavailable from '@/app/components/base/app-unavailable'
 import Loading from '@/app/components/base/loading'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { useGlobalPublicStore } from '@/context/global-public-context'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { fetchWebOAuth2SSOUrl, fetchWebOIDCSSOUrl, fetchWebSAMLSSOUrl } from '@/service/share'
@@ -17,9 +17,9 @@ const ExternalMemberSSOAuth = () => {
   const redirectUrl = searchParams.get('redirect_url')
 
   const showErrorToast = (message: string) => {
-    Toast.notify({
+    toast.add({
       type: 'error',
-      message,
+      title: message,
     })
   }
 

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { COUNT_DOWN_KEY, COUNT_DOWN_TIME_MS } from '@/app/components/signin/countdown'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -22,14 +22,14 @@ export default function MailAndCodeAuth() {
   const handleGetEMailVerificationCode = async () => {
     try {
       if (!email) {
-        Toast.notify({ type: 'error', message: t('error.emailEmpty', { ns: 'login' }) })
+        toast.add({ type: 'error', title: t('error.emailEmpty', { ns: 'login' }) })
         return
       }
 
       if (!emailRegex.test(email)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('error.emailInValid', { ns: 'login' }),
+          title: t('error.emailInValid', { ns: 'login' }),
         })
         return
       }

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
 import { useWebAppStore } from '@/context/web-app-context'
@@ -46,25 +46,25 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
   const appCode = getAppCodeFromRedirectUrl()
   const handleEmailPasswordLogin = async () => {
     if (!email) {
-      Toast.notify({ type: 'error', message: t('error.emailEmpty', { ns: 'login' }) })
+      toast.add({ type: 'error', title: t('error.emailEmpty', { ns: 'login' }) })
       return
     }
     if (!emailRegex.test(email)) {
-      Toast.notify({
+      toast.add({
         type: 'error',
-        message: t('error.emailInValid', { ns: 'login' }),
+        title: t('error.emailInValid', { ns: 'login' }),
       })
       return
     }
     if (!password?.trim()) {
-      Toast.notify({ type: 'error', message: t('error.passwordEmpty', { ns: 'login' }) })
+      toast.add({ type: 'error', title: t('error.passwordEmpty', { ns: 'login' }) })
       return
     }
 
     if (!redirectUrl || !appCode) {
-      Toast.notify({
+      toast.add({
         type: 'error',
-        message: t('error.redirectUrlMissing', { ns: 'login' }),
+        title: t('error.redirectUrlMissing', { ns: 'login' }),
       })
       return
     }
@@ -94,15 +94,15 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
         router.replace(decodeURIComponent(redirectUrl))
       }
       else {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: res.data,
+          title: res.data,
         })
       }
     }
     catch (e: any) {
       if (e.code === 'authentication_failed')
-        Toast.notify({ type: 'error', message: e.message })
+        toast.add({ type: 'error', title: e.message })
     }
     finally {
       setIsLoading(false)

--- a/web/app/(shareLayout)/webapp-signin/components/sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/sso-auth.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import { Lock01 } from '@/app/components/base/icons/src/vender/solid/security'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { fetchMembersOAuth2SSOUrl, fetchMembersOIDCSSOUrl, fetchMembersSAMLSSOUrl } from '@/service/share'
 import { SSOProtocol } from '@/types/feature'
@@ -37,9 +37,9 @@ const SSOAuth: FC<SSOAuthProps> = ({
   const handleSSOLogin = () => {
     const appCode = getAppCodeFromRedirectUrl()
     if (!redirectUrl || !appCode) {
-      Toast.notify({
+      toast.add({
         type: 'error',
-        message: 'invalid redirect URL or app code',
+        title: 'invalid redirect URL or app code',
       })
       return
     }
@@ -66,9 +66,9 @@ const SSOAuth: FC<SSOAuthProps> = ({
       })
     }
     else {
-      Toast.notify({
+      toast.add({
         type: 'error',
-        message: 'invalid SSO protocol',
+        title: 'invalid SSO protocol',
       })
       setIsLoading(false)
     }

--- a/web/app/(shareLayout)/webapp-signin/components/sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/sso-auth.tsx
@@ -39,7 +39,7 @@ const SSOAuth: FC<SSOAuthProps> = ({
     if (!redirectUrl || !appCode) {
       toast.add({
         type: 'error',
-        title: 'invalid redirect URL or app code',
+        title: t('error.invalidRedirectUrlOrAppCode', { ns: 'login' }),
       })
       return
     }
@@ -68,7 +68,7 @@ const SSOAuth: FC<SSOAuthProps> = ({
     else {
       toast.add({
         type: 'error',
-        title: 'invalid SSO protocol',
+        title: t('error.invalidSSOProtocol', { ns: 'login' }),
       })
       setIsLoading(false)
     }

--- a/web/app/forgot-password/ChangePasswordForm.tsx
+++ b/web/app/forgot-password/ChangePasswordForm.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Loading from '@/app/components/base/loading'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { validPassword } from '@/config'
 import { useSearchParams } from '@/next/navigation'
 import { changePasswordWithToken } from '@/service/common'
@@ -29,9 +29,9 @@ const ChangePasswordForm = () => {
   const [showSuccess, setShowSuccess] = useState(false)
 
   const showErrorMessage = useCallback((message: string) => {
-    Toast.notify({
+    toast.add({
       type: 'error',
-      message,
+      title: message,
     })
   }, [])
 

--- a/web/app/reset-password/check-code/page.tsx
+++ b/web/app/reset-password/check-code/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 import { useRouter, useSearchParams } from '@/next/navigation'
@@ -23,16 +23,16 @@ export default function CheckCode() {
   const verify = async () => {
     try {
       if (!code.trim()) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.emptyCode', { ns: 'login' }),
+          title: t('checkCode.emptyCode', { ns: 'login' }),
         })
         return
       }
       if (!/\d{6}/.test(code)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.invalidCode', { ns: 'login' }),
+          title: t('checkCode.invalidCode', { ns: 'login' }),
         })
         return
       }

--- a/web/app/reset-password/page.tsx
+++ b/web/app/reset-password/page.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
 import useDocumentTitle from '@/hooks/use-document-title'
@@ -26,14 +26,14 @@ export default function CheckCode() {
   const handleGetEMailVerificationCode = async () => {
     try {
       if (!email) {
-        Toast.notify({ type: 'error', message: t('error.emailEmpty', { ns: 'login' }) })
+        toast.add({ type: 'error', title: t('error.emailEmpty', { ns: 'login' }) })
         return
       }
 
       if (!emailRegex.test(email)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('error.emailInValid', { ns: 'login' }),
+          title: t('error.emailInValid', { ns: 'login' }),
         })
         return
       }
@@ -47,9 +47,9 @@ export default function CheckCode() {
         router.push(`/reset-password/check-code?${params.toString()}`)
       }
       else {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: res.data,
+          title: res.data,
         })
       }
     }

--- a/web/app/reset-password/set-password/page.tsx
+++ b/web/app/reset-password/set-password/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { validPassword } from '@/config'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { changePasswordWithToken } from '@/service/common'
@@ -24,9 +24,9 @@ const ChangePasswordForm = () => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
   const showErrorMessage = useCallback((message: string) => {
-    Toast.notify({
+    toast.add({
       type: 'error',
-      message,
+      title: message,
     })
   }, [])
 

--- a/web/app/signin/check-code/page.tsx
+++ b/web/app/signin/check-code/page.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { trackEvent } from '@/app/components/base/amplitude'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 
@@ -31,16 +31,16 @@ export default function CheckCode() {
   const verify = async () => {
     try {
       if (!code.trim()) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.emptyCode', { ns: 'login' }),
+          title: t('checkCode.emptyCode', { ns: 'login' }),
         })
         return
       }
       if (!/\d{6}/.test(code)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.invalidCode', { ns: 'login' }),
+          title: t('checkCode.invalidCode', { ns: 'login' }),
         })
         return
       }

--- a/web/app/signin/components/mail-and-code-auth.tsx
+++ b/web/app/signin/components/mail-and-code-auth.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { COUNT_DOWN_KEY, COUNT_DOWN_TIME_MS } from '@/app/components/signin/countdown'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -26,14 +26,14 @@ export default function MailAndCodeAuth({ isInvite }: MailAndCodeAuthProps) {
   const handleGetEMailVerificationCode = async () => {
     try {
       if (!email) {
-        Toast.notify({ type: 'error', message: t('error.emailEmpty', { ns: 'login' }) })
+        toast.add({ type: 'error', title: t('error.emailEmpty', { ns: 'login' }) })
         return
       }
 
       if (!emailRegex.test(email)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('error.emailInValid', { ns: 'login' }),
+          title: t('error.emailInValid', { ns: 'login' }),
         })
         return
       }

--- a/web/app/signin/components/sso-auth.tsx
+++ b/web/app/signin/components/sso-auth.tsx
@@ -51,7 +51,7 @@ const SSOAuth: FC<SSOAuthProps> = ({
     else {
       toast.add({
         type: 'error',
-        title: 'invalid SSO protocol',
+        title: t('error.invalidSSOProtocol', { ns: 'login' }),
       })
       setIsLoading(false)
     }

--- a/web/app/signin/components/sso-auth.tsx
+++ b/web/app/signin/components/sso-auth.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import { Lock01 } from '@/app/components/base/icons/src/vender/solid/security'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { getUserOAuth2SSOUrl, getUserOIDCSSOUrl, getUserSAMLSSOUrl } from '@/service/sso'
 import { SSOProtocol } from '@/types/feature'
@@ -49,9 +49,9 @@ const SSOAuth: FC<SSOAuthProps> = ({
       })
     }
     else {
-      Toast.notify({
+      toast.add({
         type: 'error',
-        message: 'invalid SSO protocol',
+        title: 'invalid SSO protocol',
       })
       setIsLoading(false)
     }

--- a/web/app/signin/normal-form.tsx
+++ b/web/app/signin/normal-form.tsx
@@ -2,7 +2,7 @@ import { RiContractLine, RiDoorLockLine, RiErrorWarningFill } from '@remixicon/r
 import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { IS_CE_EDITION } from '@/config'
 import { useGlobalPublicStore } from '@/context/global-public-context'
 import Link from '@/next/link'
@@ -48,9 +48,9 @@ const NormalForm = () => {
       }
 
       if (message) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message,
+          title: message,
         })
       }
       setAllMethodsAreDisabled(!systemFeatures.enable_social_oauth_login && !systemFeatures.enable_email_code_login && !systemFeatures.enable_email_password_login && !systemFeatures.sso_enforced_for_signin)

--- a/web/app/signup/check-code/page.tsx
+++ b/web/app/signup/check-code/page.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 import { useRouter, useSearchParams } from '@/next/navigation'
@@ -26,16 +26,16 @@ export default function CheckCode() {
   const verify = async () => {
     try {
       if (!code.trim()) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.emptyCode', { ns: 'login' }),
+          title: t('checkCode.emptyCode', { ns: 'login' }),
         })
         return
       }
       if (!/\d{6}/.test(code)) {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.invalidCode', { ns: 'login' }),
+          title: t('checkCode.invalidCode', { ns: 'login' }),
         })
         return
       }
@@ -47,9 +47,9 @@ export default function CheckCode() {
         router.push(`/signup/set-password?${params.toString()}`)
       }
       else {
-        Toast.notify({
+        toast.add({
           type: 'error',
-          message: t('checkCode.invalidCode', { ns: 'login' }),
+          title: t('checkCode.invalidCode', { ns: 'login' }),
         })
       }
     }

--- a/web/app/signup/components/input-mail.tsx
+++ b/web/app/signup/components/input-mail.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import Split from '@/app/signin/split'
 import { emailRegex } from '@/config'
 import { useGlobalPublicStore } from '@/context/global-public-context'
@@ -30,13 +30,13 @@ export default function Form({
       return
 
     if (!email) {
-      Toast.notify({ type: 'error', message: t('error.emailEmpty', { ns: 'login' }) })
+      toast.add({ type: 'error', title: t('error.emailEmpty', { ns: 'login' }) })
       return
     }
     if (!emailRegex.test(email)) {
-      Toast.notify({
+      toast.add({
         type: 'error',
-        message: t('error.emailInValid', { ns: 'login' }),
+        title: t('error.emailInValid', { ns: 'login' }),
       })
       return
     }

--- a/web/app/signup/set-password/page.tsx
+++ b/web/app/signup/set-password/page.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { trackEvent } from '@/app/components/base/amplitude'
 import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
-import Toast from '@/app/components/base/toast'
+import { toast } from '@/app/components/base/ui/toast'
 import { validPassword } from '@/config'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { useMailRegister } from '@/service/use-common'
@@ -37,9 +37,9 @@ const ChangePasswordForm = () => {
   const { mutateAsync: register, isPending } = useMailRegister()
 
   const showErrorMessage = useCallback((message: string) => {
-    Toast.notify({
+    toast.add({
       type: 'error',
-      message,
+      title: message,
     })
   }, [])
 
@@ -82,9 +82,9 @@ const ChangePasswordForm = () => {
         })
         Cookies.remove('utm_info') // Clean up: remove utm_info cookie
 
-        Toast.notify({
+        toast.add({
           type: 'success',
-          message: t('api.actionSuccess', { ns: 'common' }),
+          title: t('api.actionSuccess', { ns: 'common' }),
         })
         router.replace('/apps')
       }

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -189,9 +189,6 @@
     }
   },
   "app/(shareLayout)/webapp-reset-password/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
@@ -205,56 +202,31 @@
     }
   },
   "app/(shareLayout)/webapp-reset-password/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
   },
   "app/(shareLayout)/webapp-reset-password/set-password/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 6
     }
   },
   "app/(shareLayout)/webapp-signin/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
   },
-  "app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 1
     }
   },
   "app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 2
     },
     "ts/no-explicit-any": {
       "count": 2
-    }
-  },
-  "app/(shareLayout)/webapp-signin/components/sso-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "app/(shareLayout)/webapp-signin/layout.tsx": {
@@ -9277,11 +9249,6 @@
       "count": 5
     }
   },
-  "app/forgot-password/ChangePasswordForm.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "app/forgot-password/ForgotPasswordForm.spec.tsx": {
     "ts/no-explicit-any": {
       "count": 5
@@ -9306,9 +9273,6 @@
     }
   },
   "app/reset-password/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
@@ -9322,17 +9286,11 @@
     }
   },
   "app/reset-password/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
   },
   "app/reset-password/set-password/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 6
     }
@@ -9342,26 +9300,13 @@
       "count": 1
     }
   },
-  "app/signin/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "app/signin/components/mail-and-code-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 1
     }
   },
   "app/signin/components/mail-and-password-auth.tsx": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "app/signin/components/sso-auth.tsx": {
-    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -9378,11 +9323,6 @@
       "count": 1
     }
   },
-  "app/signin/normal-form.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "app/signin/one-more-step.tsx": {
     "no-restricted-imports": {
       "count": 3
@@ -9395,17 +9335,11 @@
     }
   },
   "app/signup/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
   },
   "app/signup/components/input-mail.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 4
     }
@@ -9424,9 +9358,6 @@
     }
   },
   "app/signup/set-password/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "tailwindcss/enforce-consistent-class-order": {
       "count": 5
     }

--- a/web/i18n/en-US/login.json
+++ b/web/i18n/en-US/login.json
@@ -35,6 +35,8 @@
   "error.emailEmpty": "Email address is required",
   "error.emailInValid": "Please enter a valid email address",
   "error.invalidEmailOrPassword": "Invalid email or password.",
+  "error.invalidRedirectUrlOrAppCode": "Invalid redirect URL or app code",
+  "error.invalidSSOProtocol": "Invalid SSO protocol",
   "error.nameEmpty": "Name is required",
   "error.passwordEmpty": "Password is required",
   "error.passwordInvalid": "Password must contain letters and numbers, and the length must be greater than 8",


### PR DESCRIPTION
### Motivation

- Migrate legacy direct `Toast.notify(...)` usages to the new overlay primitive API so auth flows use `@/app/components/base/ui/toast` per the overlay migration guide.

### Description

- Replaced imports of the deprecated `@/app/components/base/toast` with `import { toast } from '@/app/components/base/ui/toast'` in multiple signin/signup/reset-password/forgot-password and webapp auth pages.
- Replaced `Toast.notify({...})` call sites with `toast.add({...})` and mapped legacy `message` payloads to the new API `title` field where required.
- Updated call shapes to the new `ToastAddOptions` (e.g. `type` + `title`) and adjusted small helper wrappers that surfaced `message` to pass `title` instead.
- Pruned obsolete `no-restricted-imports` suppressions from `web/eslint-suppressions.json` for the migrated files to reflect removal of legacy imports.

### Testing

- Ran lint and auto-fixes with `pnpm -C web lint:fix --prune-suppressions <changed-files>` and verified ESLint ran (warnings only) and fixes applied successfully.
- Performed type checking with `pnpm -C web type-check:tsgo` and resolved shape mismatches so the type-check completed without errors.
- Pre-commit hooks (ESLint + type-check) and the repo checks executed as part of the local change flow and passed on the final patch.
