### PR TITLE
fix(weaviate): add an exception-triggered schema migration

### DIFF
--- a/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
+++ b/api/core/rag/datasource/vdb/weaviate/weaviate_vector.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, model_validator
 from weaviate.classes.data import DataObject
 from weaviate.classes.init import Auth
 from weaviate.classes.query import Filter, MetadataQuery
-from weaviate.exceptions import UnexpectedStatusCodeError
+from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateQueryError
 
 from configs import dify_config
 from core.rag.datasource.vdb.field import Field
@@ -237,10 +237,11 @@ class WeaviateVector(BaseVector):
                 raise
 
     def _ensure_properties(self) -> None:
-        """
-        Ensures all required properties exist in the collection schema.
+        """Ensures all required properties exist in the collection schema.
 
-        Adds missing properties if the collection exists but lacks them.
+        Adds missing properties (document_id, doc_id, doc_type, chunk_index) if the
+        collection exists but lacks them. This handles backward compatibility for
+        collections created before these properties were introduced.
         """
         if not self._client.collections.exists(self._collection_name):
             return
@@ -265,7 +266,7 @@ class WeaviateVector(BaseVector):
             except Exception as e:
                 logger.warning("Could not add property %s: %s", prop.name, e)
 
-    def _get_uuids(self, documents: list[Document]) -> list[str]:
+    def _get_uuids(self, texts: list[Document]) -> list[str]:
         """
         Generates deterministic UUIDs for documents based on their content.
 
@@ -274,7 +275,7 @@ class WeaviateVector(BaseVector):
         URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
 
         uuids = []
-        for doc in documents:
+        for doc in texts:
             uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
             uuids.append(str(uuid_val))
 
@@ -385,6 +386,22 @@ class WeaviateVector(BaseVector):
         if not self._client.collections.exists(self._collection_name):
             return []
 
+        try:
+            return self._do_search_by_vector(query_vector, **kwargs)
+        except WeaviateQueryError as exc:
+            # NOTE: This string match is coupled to the Weaviate error message format.
+            # If the weaviate-python client changes the wording, this check may need updating.
+            if "no such prop" not in str(exc):
+                raise
+            logger.info(
+                "Collection %s is missing a required property, migrating schema and retrying query.",
+                self._collection_name,
+            )
+            self._ensure_properties()
+            return self._do_search_by_vector(query_vector, **kwargs)
+
+    def _do_search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:
+        """Internal helper that executes the actual near-vector query."""
         col = self._client.collections.use(self._collection_name)
         props = list({*self._attributes, self._DOCUMENT_ID_PROPERTY, Field.TEXT_KEY.value})
 
@@ -432,6 +449,22 @@ class WeaviateVector(BaseVector):
         if not self._client.collections.exists(self._collection_name):
             return []
 
+        try:
+            return self._do_search_by_full_text(query, **kwargs)
+        except WeaviateQueryError as exc:
+            # NOTE: This string match is coupled to the Weaviate error message format.
+            # If the weaviate-python client changes the wording, this check may need updating.
+            if "no such prop" not in str(exc):
+                raise
+            logger.info(
+                "Collection %s is missing a required property, migrating schema and retrying query.",
+                self._collection_name,
+            )
+            self._ensure_properties()
+            return self._do_search_by_full_text(query, **kwargs)
+
+    def _do_search_by_full_text(self, query: str, **kwargs: Any) -> list[Document]:
+        """Internal helper that executes the actual BM25 query."""
         col = self._client.collections.use(self._collection_name)
         props = list({*self._attributes, Field.TEXT_KEY.value})
 

--- a/api/tests/unit_tests/core/rag/datasource/vdb/weaviate/test_weaviate_vector.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/weaviate/test_weaviate_vector.py
@@ -316,9 +316,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_col = MagicMock()
         mock_client.collections.use.return_value = mock_col
 
-        mock_col.query.near_vector.side_effect = WeaviateQueryError(
-            "some other gRPC error", "GRPC"
-        )
+        mock_col.query.near_vector.side_effect = WeaviateQueryError("some other gRPC error", "GRPC")
 
         wv = WeaviateVector(
             collection_name=self.collection_name,
@@ -458,9 +456,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_col = MagicMock()
         mock_client.collections.use.return_value = mock_col
 
-        mock_col.query.bm25.side_effect = WeaviateQueryError(
-            "some other gRPC error", "GRPC"
-        )
+        mock_col.query.bm25.side_effect = WeaviateQueryError("some other gRPC error", "GRPC")
 
         wv = WeaviateVector(
             collection_name=self.collection_name,

--- a/api/tests/unit_tests/core/rag/datasource/vdb/weaviate/test_weaviate_vector.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/weaviate/test_weaviate_vector.py
@@ -11,6 +11,9 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+from weaviate.exceptions import WeaviateQueryError
+
 from core.rag.datasource.vdb.weaviate import weaviate_vector as weaviate_vector_module
 from core.rag.datasource.vdb.weaviate.weaviate_vector import WeaviateConfig, WeaviateVector
 from core.rag.models.document import Document
@@ -227,6 +230,106 @@ class TestWeaviateVector(unittest.TestCase):
         assert docs[0].metadata.get("doc_type") == "image"
 
     @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
+    def test_search_by_vector_does_not_call_ensure_properties_on_success(self, mock_weaviate_module):
+        """Verify that a successful query does NOT trigger schema migration."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "hello", "doc_id": "id_1"}
+        mock_obj.metadata.distance = 0.2
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_col.query.near_vector.return_value = mock_result
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        wv._ensure_properties = MagicMock()
+        wv.search_by_vector(query_vector=[0.1] * 128, top_k=1)
+
+        wv._ensure_properties.assert_not_called()
+
+    @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
+    def test_search_by_vector_migrates_schema_on_missing_prop_error(self, mock_weaviate_module):
+        """search_by_vector on a pre-upgrade collection should catch, migrate, and retry."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "hello world", "doc_id": "id_1"}
+        mock_obj.metadata.distance = 0.2
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+
+        mock_col.query.near_vector.side_effect = [
+            WeaviateQueryError(
+                "no such prop with name 'doc_type' found in class 'Test_Collection_Node' in the schema",
+                "GRPC",
+            ),
+            mock_result,
+        ]
+
+        existing_props = [
+            SimpleNamespace(name="text"),
+            SimpleNamespace(name="document_id"),
+            SimpleNamespace(name="doc_id"),
+            SimpleNamespace(name="chunk_index"),
+        ]
+        mock_cfg = MagicMock()
+        mock_cfg.properties = existing_props
+        mock_col.config.get.return_value = mock_cfg
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_vector(query_vector=[0.1] * 128, top_k=1)
+
+        add_calls = mock_col.config.add_property.call_args_list
+        added_names = [call.args[0].name for call in add_calls]
+        assert "doc_type" in added_names
+        assert len(docs) == 1
+        assert mock_col.query.near_vector.call_count == 2
+
+    @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
+    def test_search_by_vector_reraises_unrelated_query_error(self, mock_weaviate_module):
+        """Verify that WeaviateQueryError not related to missing props is re-raised."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_col.query.near_vector.side_effect = WeaviateQueryError(
+            "some other gRPC error", "GRPC"
+        )
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+
+        with pytest.raises(WeaviateQueryError):
+            wv.search_by_vector(query_vector=[0.1] * 128, top_k=1)
+
+    @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_returns_doc_type_in_metadata(self, mock_weaviate_module):
         """Test that search_by_full_text also returns doc_type in document metadata."""
         mock_client = MagicMock()
@@ -267,6 +370,106 @@ class TestWeaviateVector(unittest.TestCase):
         # Verify doc_type is in result metadata
         assert len(docs) == 1
         assert docs[0].metadata.get("doc_type") == "image"
+
+    @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_does_not_call_ensure_properties_on_success(self, mock_weaviate_module):
+        """Verify that a successful BM25 query does NOT trigger schema migration."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "hello", "doc_id": "id_1"}
+        mock_obj.vector = {"default": [0.1] * 128}
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_col.query.bm25.return_value = mock_result
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        wv._ensure_properties = MagicMock()
+        wv.search_by_full_text(query="hello", top_k=1)
+
+        wv._ensure_properties.assert_not_called()
+
+    @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_migrates_schema_on_missing_prop_error(self, mock_weaviate_module):
+        """search_by_full_text on a pre-upgrade collection should catch, migrate, and retry."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "hello world", "doc_id": "id_1"}
+        mock_obj.vector = {"default": [0.1] * 128}
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+
+        mock_col.query.bm25.side_effect = [
+            WeaviateQueryError(
+                "no such prop with name 'doc_type' found in class 'Test_Collection_Node' in the schema",
+                "GRPC",
+            ),
+            mock_result,
+        ]
+
+        existing_props = [
+            SimpleNamespace(name="text"),
+            SimpleNamespace(name="document_id"),
+            SimpleNamespace(name="doc_id"),
+            SimpleNamespace(name="chunk_index"),
+        ]
+        mock_cfg = MagicMock()
+        mock_cfg.properties = existing_props
+        mock_col.config.get.return_value = mock_cfg
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_full_text(query="hello", top_k=1)
+
+        add_calls = mock_col.config.add_property.call_args_list
+        added_names = [call.args[0].name for call in add_calls]
+        assert "doc_type" in added_names
+        assert len(docs) == 1
+        assert mock_col.query.bm25.call_count == 2
+
+    @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_reraises_unrelated_query_error(self, mock_weaviate_module):
+        """Verify that WeaviateQueryError not related to missing props is re-raised."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_col.query.bm25.side_effect = WeaviateQueryError(
+            "some other gRPC error", "GRPC"
+        )
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+
+        with pytest.raises(WeaviateQueryError):
+            wv.search_by_full_text(query="hello", top_k=1)
 
     @patch("core.rag.datasource.vdb.weaviate.weaviate_vector.weaviate")
     def test_add_texts_stores_doc_type_in_properties(self, mock_weaviate_module):


### PR DESCRIPTION
## Summary

Weaviate collections created before the `doc_type` / `chunk_index` properties were introduced will fail at query time with:

> `no such prop with name 'doc_type' found in class '..._Node' in the schema`

This is a schema evolution issue I think.

So this PR adds backward-compatible handling: `search_by_vector` and `search_by_full_text` now catch `WeaviateQueryError` containing `"no such prop"`, call `_ensure_properties()` to add the missing properties, and retry the query exactly once. The normal query path remains unaffected. This is a comfortable way to fix IMO.

### Changes

- `search_by_vector` / `search_by_full_text`: catch `WeaviateQueryError` with `"no such prop"`, migrate schema via `_ensure_properties()`, then retry once.
- Extracted `_do_search_by_vector` / `_do_search_by_full_text` as internal query helpers.
- Added unit tests for the exception-triggered migration and re-raise behavior.

## Screenshots

N/A (backend-only change)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods