### PR TITLE
fix(api): add `trigger_info` to WorkflowNodeExecutionMetadataKey

### DIFF
--- a/api/core/trigger/constants.py
+++ b/api/core/trigger/constants.py
@@ -3,7 +3,6 @@ from typing import Final
 TRIGGER_WEBHOOK_NODE_TYPE: Final[str] = "trigger-webhook"
 TRIGGER_SCHEDULE_NODE_TYPE: Final[str] = "trigger-schedule"
 TRIGGER_PLUGIN_NODE_TYPE: Final[str] = "trigger-plugin"
-TRIGGER_INFO_METADATA_KEY: Final[str] = "trigger_info"
 
 TRIGGER_NODE_TYPES: Final[frozenset[str]] = frozenset(
     {

--- a/api/core/workflow/nodes/trigger_plugin/trigger_event_node.py
+++ b/api/core/workflow/nodes/trigger_plugin/trigger_event_node.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
-from core.trigger.constants import TRIGGER_INFO_METADATA_KEY, TRIGGER_PLUGIN_NODE_TYPE
+from core.trigger.constants import TRIGGER_PLUGIN_NODE_TYPE
 from dify_graph.constants import SYSTEM_VARIABLE_NODE_ID
 from dify_graph.entities.workflow_node_execution import WorkflowNodeExecutionStatus
 from dify_graph.enums import NodeExecutionType, WorkflowNodeExecutionMetadataKey

--- a/api/core/workflow/nodes/trigger_plugin/trigger_event_node.py
+++ b/api/core/workflow/nodes/trigger_plugin/trigger_event_node.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 
 from core.trigger.constants import TRIGGER_INFO_METADATA_KEY, TRIGGER_PLUGIN_NODE_TYPE
 from dify_graph.constants import SYSTEM_VARIABLE_NODE_ID
@@ -47,7 +47,7 @@ class TriggerEventNode(Node[TriggerEventNodeData]):
 
         # Get trigger data passed when workflow was triggered
         metadata: dict[WorkflowNodeExecutionMetadataKey, Any] = {
-            cast(WorkflowNodeExecutionMetadataKey, TRIGGER_INFO_METADATA_KEY): {
+            WorkflowNodeExecutionMetadataKey.TRIGGER_INFO: {
                 "provider_id": self.node_data.provider_id,
                 "event_name": self.node_data.event_name,
                 "plugin_unique_identifier": self.node_data.plugin_unique_identifier,

--- a/api/dify_graph/enums.py
+++ b/api/dify_graph/enums.py
@@ -245,6 +245,9 @@ _END_STATE = frozenset(
 class WorkflowNodeExecutionMetadataKey(StrEnum):
     """
     Node Run Metadata Key.
+
+    Values in this enum are persisted as execution metadata and must stay in sync
+    with every node that writes `NodeRunResult.metadata`.
     """
 
     TOTAL_TOKENS = "total_tokens"
@@ -266,6 +269,7 @@ class WorkflowNodeExecutionMetadataKey(StrEnum):
     ERROR_STRATEGY = "error_strategy"  # node in continue on error mode return the field
     LOOP_VARIABLE_MAP = "loop_variable_map"  # single loop variable output
     DATASOURCE_INFO = "datasource_info"
+    TRIGGER_INFO = "trigger_info"
     COMPLETED_REASON = "completed_reason"  # completed reason for loop node
 
 

--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -22,14 +22,14 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column
 from typing_extensions import deprecated
 
-from core.trigger.constants import TRIGGER_INFO_METADATA_KEY, TRIGGER_PLUGIN_NODE_TYPE
+from core.trigger.constants import TRIGGER_PLUGIN_NODE_TYPE
 from dify_graph.constants import (
     CONVERSATION_VARIABLE_NODE_ID,
     SYSTEM_VARIABLE_NODE_ID,
 )
 from dify_graph.entities.graph_config import NodeConfigDict, NodeConfigDictAdapter
 from dify_graph.entities.pause_reason import HumanInputRequired, PauseReason, PauseReasonType, SchedulingPause
-from dify_graph.enums import BuiltinNodeTypes, NodeType, WorkflowExecutionStatus
+from dify_graph.enums import BuiltinNodeTypes, NodeType, WorkflowExecutionStatus, WorkflowNodeExecutionMetadataKey
 from dify_graph.file.constants import maybe_file_object
 from dify_graph.file.models import File
 from dify_graph.variables import utils as variable_utils
@@ -936,8 +936,11 @@ class WorkflowNodeExecutionModel(Base):  # This model is expected to have `offlo
             elif self.node_type == BuiltinNodeTypes.DATASOURCE and "datasource_info" in execution_metadata:
                 datasource_info = execution_metadata["datasource_info"]
                 extras["icon"] = datasource_info.get("icon")
-            elif self.node_type == TRIGGER_PLUGIN_NODE_TYPE and TRIGGER_INFO_METADATA_KEY in execution_metadata:
-                trigger_info = execution_metadata[TRIGGER_INFO_METADATA_KEY] or {}
+            elif (
+                self.node_type == TRIGGER_PLUGIN_NODE_TYPE
+                and WorkflowNodeExecutionMetadataKey.TRIGGER_INFO in execution_metadata
+            ):
+                trigger_info = execution_metadata[WorkflowNodeExecutionMetadataKey.TRIGGER_INFO] or {}
                 provider_id = trigger_info.get("provider_id")
                 if provider_id:
                     extras["icon"] = TriggerManager.get_trigger_plugin_icon(

--- a/api/tests/unit_tests/core/workflow/nodes/trigger_plugin/test_trigger_event_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/trigger_plugin/test_trigger_event_node.py
@@ -1,0 +1,68 @@
+from collections.abc import Mapping
+
+from core.trigger.constants import TRIGGER_INFO_METADATA_KEY, TRIGGER_PLUGIN_NODE_TYPE
+from core.workflow.nodes.trigger_plugin.trigger_event_node import TriggerEventNode
+from dify_graph.entities import GraphInitParams
+from dify_graph.entities.graph_config import NodeConfigDict, NodeConfigDictAdapter
+from dify_graph.enums import WorkflowNodeExecutionMetadataKey, WorkflowNodeExecutionStatus
+from dify_graph.runtime import GraphRuntimeState, VariablePool
+from dify_graph.system_variable import SystemVariable
+from tests.workflow_test_utils import build_test_graph_init_params
+
+
+def _build_context(graph_config: Mapping[str, object]) -> tuple[GraphInitParams, GraphRuntimeState]:
+    init_params = build_test_graph_init_params(
+        graph_config=graph_config,
+        user_from="account",
+        invoke_from="debugger",
+    )
+    runtime_state = GraphRuntimeState(
+        variable_pool=VariablePool(
+            system_variables=SystemVariable(user_id="user", files=[]),
+            user_inputs={"payload": "value"},
+        ),
+        start_at=0.0,
+    )
+    return init_params, runtime_state
+
+
+def _build_node_config() -> NodeConfigDict:
+    return NodeConfigDictAdapter.validate_python(
+        {
+            "id": "node-1",
+            "data": {
+                "type": TRIGGER_PLUGIN_NODE_TYPE,
+                "title": "Trigger Event",
+                "plugin_id": "plugin-id",
+                "provider_id": "provider-id",
+                "event_name": "event-name",
+                "subscription_id": "subscription-id",
+                "plugin_unique_identifier": "plugin-unique-identifier",
+                "event_parameters": {},
+            },
+        }
+    )
+
+
+def test_trigger_info_metadata_key_is_supported_by_node_execution_metadata_enum() -> None:
+    assert TRIGGER_INFO_METADATA_KEY in {item.value for item in WorkflowNodeExecutionMetadataKey}
+
+
+def test_trigger_event_node_run_populates_trigger_info_metadata() -> None:
+    init_params, runtime_state = _build_context(graph_config={})
+    node = TriggerEventNode(
+        id="node-1",
+        config=_build_node_config(),
+        graph_init_params=init_params,
+        graph_runtime_state=runtime_state,
+    )
+
+    result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.metadata[TRIGGER_INFO_METADATA_KEY] == {
+        "provider_id": "provider-id",
+        "event_name": "event-name",
+        "plugin_unique_identifier": "plugin-unique-identifier",
+    }
+

--- a/api/tests/unit_tests/core/workflow/nodes/trigger_plugin/test_trigger_event_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/trigger_plugin/test_trigger_event_node.py
@@ -4,7 +4,7 @@ from core.trigger.constants import TRIGGER_INFO_METADATA_KEY, TRIGGER_PLUGIN_NOD
 from core.workflow.nodes.trigger_plugin.trigger_event_node import TriggerEventNode
 from dify_graph.entities import GraphInitParams
 from dify_graph.entities.graph_config import NodeConfigDict, NodeConfigDictAdapter
-from dify_graph.enums import WorkflowNodeExecutionMetadataKey, WorkflowNodeExecutionStatus
+from dify_graph.enums import WorkflowNodeExecutionStatus
 from dify_graph.runtime import GraphRuntimeState, VariablePool
 from dify_graph.system_variable import SystemVariable
 from tests.workflow_test_utils import build_test_graph_init_params
@@ -44,10 +44,6 @@ def _build_node_config() -> NodeConfigDict:
     )
 
 
-def test_trigger_info_metadata_key_is_supported_by_node_execution_metadata_enum() -> None:
-    assert TRIGGER_INFO_METADATA_KEY in {item.value for item in WorkflowNodeExecutionMetadataKey}
-
-
 def test_trigger_event_node_run_populates_trigger_info_metadata() -> None:
     init_params, runtime_state = _build_context(graph_config={})
     node = TriggerEventNode(
@@ -65,4 +61,3 @@ def test_trigger_event_node_run_populates_trigger_info_metadata() -> None:
         "event_name": "event-name",
         "plugin_unique_identifier": "plugin-unique-identifier",
     }
-

--- a/api/tests/unit_tests/core/workflow/nodes/trigger_plugin/test_trigger_event_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/trigger_plugin/test_trigger_event_node.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
 
-from core.trigger.constants import TRIGGER_INFO_METADATA_KEY, TRIGGER_PLUGIN_NODE_TYPE
+from core.trigger.constants import TRIGGER_PLUGIN_NODE_TYPE
 from core.workflow.nodes.trigger_plugin.trigger_event_node import TriggerEventNode
 from dify_graph.entities import GraphInitParams
 from dify_graph.entities.graph_config import NodeConfigDict, NodeConfigDictAdapter
-from dify_graph.enums import WorkflowNodeExecutionStatus
+from dify_graph.enums import WorkflowNodeExecutionMetadataKey, WorkflowNodeExecutionStatus
 from dify_graph.runtime import GraphRuntimeState, VariablePool
 from dify_graph.system_variable import SystemVariable
 from tests.workflow_test_utils import build_test_graph_init_params
@@ -56,7 +56,7 @@ def test_trigger_event_node_run_populates_trigger_info_metadata() -> None:
     result = node._run()
 
     assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
-    assert result.metadata[TRIGGER_INFO_METADATA_KEY] == {
+    assert result.metadata[WorkflowNodeExecutionMetadataKey.TRIGGER_INFO] == {
         "provider_id": "provider-id",
         "event_name": "event-name",
         "plugin_unique_identifier": "plugin-unique-identifier",

--- a/api/tests/unit_tests/dify_graph/node_events/test_base.py
+++ b/api/tests/unit_tests/dify_graph/node_events/test_base.py
@@ -1,5 +1,4 @@
-from core.trigger.constants import TRIGGER_INFO_METADATA_KEY
-from dify_graph.enums import WorkflowNodeExecutionStatus
+from dify_graph.enums import WorkflowNodeExecutionMetadataKey, WorkflowNodeExecutionStatus
 from dify_graph.node_events.base import NodeRunResult
 
 
@@ -7,14 +6,14 @@ def test_node_run_result_accepts_trigger_info_metadata() -> None:
     result = NodeRunResult(
         status=WorkflowNodeExecutionStatus.SUCCEEDED,
         metadata={
-            TRIGGER_INFO_METADATA_KEY: {
+            WorkflowNodeExecutionMetadataKey.TRIGGER_INFO: {
                 "provider_id": "provider-id",
                 "event_name": "event-name",
             }
         },
     )
 
-    assert result.metadata[TRIGGER_INFO_METADATA_KEY] == {
+    assert result.metadata[WorkflowNodeExecutionMetadataKey.TRIGGER_INFO] == {
         "provider_id": "provider-id",
         "event_name": "event-name",
     }

--- a/api/tests/unit_tests/dify_graph/node_events/test_base.py
+++ b/api/tests/unit_tests/dify_graph/node_events/test_base.py
@@ -1,0 +1,20 @@
+from core.trigger.constants import TRIGGER_INFO_METADATA_KEY
+from dify_graph.enums import WorkflowNodeExecutionStatus
+from dify_graph.node_events.base import NodeRunResult
+
+
+def test_node_run_result_accepts_trigger_info_metadata() -> None:
+    result = NodeRunResult(
+        status=WorkflowNodeExecutionStatus.SUCCEEDED,
+        metadata={
+            TRIGGER_INFO_METADATA_KEY: {
+                "provider_id": "provider-id",
+                "event_name": "event-name",
+            }
+        },
+    )
+
+    assert result.metadata[TRIGGER_INFO_METADATA_KEY] == {
+        "provider_id": "provider-id",
+        "event_name": "event-name",
+    }


### PR DESCRIPTION
## Summary

This PR fixes a `NodeRunResult.metadata` validation failure caused by the trigger plugin node writing `trigger_info` as a metadata key before that key was registered in `WorkflowNodeExecutionMetadataKey`.

It also removes the standalone `TRIGGER_INFO_METADATA_KEY` constant and standardizes all trigger metadata access through `WorkflowNodeExecutionMetadataKey.TRIGGER_INFO`.

### Root Cause

`NodeRunResult.metadata` is validated against `WorkflowNodeExecutionMetadataKey`.

The trigger plugin node wrote:

- `trigger_info`

but `WorkflowNodeExecutionMetadataKey` did not include that value yet.

As a result, Pydantic rejected the metadata payload when constructing `NodeRunResult`, causing workflow execution to fail for trigger plugin nodes.

## Changes

### Fix metadata validation
- Add `TRIGGER_INFO` to `WorkflowNodeExecutionMetadataKey`
- Update trigger plugin node metadata writing to use `WorkflowNodeExecutionMetadataKey.TRIGGER_INFO`

### Standardize metadata key usage

- Replace remaining usages of `TRIGGER_INFO_METADATA_KEY` with `WorkflowNodeExecutionMetadataKey.TRIGGER_INFO`
- Remove the `TRIGGER_INFO_METADATA_KEY` constant from `core.trigger.constants`

### Tests
- Add a minimal model-level test to verify `NodeRunResult` accepts trigger metadata under `WorkflowNodeExecutionMetadataKey.TRIGGER_INFO`
- Keep a trigger plugin node regression test to verify the node populates trigger metadata correctly

Fix #33754

## Screenshots

| Before | After |
|--------|-------|
|  <img width="430" height="456" alt="image" src="https://github.com/user-attachments/assets/dc8830ae-c5ee-4a54-8ef5-7686cdc07c07" />  | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
