### PR TITLE
test(web): enable async leak detection and stabilize common-modal specs

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/common-modal.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/common-modal.spec.tsx
@@ -1333,12 +1333,9 @@ describe('CommonCreateModal', () => {
       mockVerifyCredentials.mockImplementation((params, { onSuccess }) => {
         onSuccess()
       })
+      const builder = createMockSubscriptionBuilder()
 
-      render(<CommonCreateModal {...defaultProps} />)
-
-      await waitFor(() => {
-        expect(mockCreateBuilder).toHaveBeenCalled()
-      })
+      render(<CommonCreateModal {...defaultProps} builder={builder} />)
 
       fireEvent.click(screen.getByTestId('modal-confirm'))
 
@@ -1975,8 +1972,8 @@ describe('CommonCreateModal', () => {
       })
       mockUsePluginStore.mockReturnValue(detailWithCredentials)
 
-      // Make createBuilder slow
-      mockCreateBuilder.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 1000)))
+      const createBuilderPromise = Promise.withResolvers<{ subscription_builder: TriggerSubscriptionBuilder }>()
+      mockCreateBuilder.mockImplementation(() => createBuilderPromise.promise)
 
       render(<CommonCreateModal {...defaultProps} />)
 
@@ -1985,6 +1982,14 @@ describe('CommonCreateModal', () => {
 
       // Should still attempt to verify
       expect(screen.getByTestId('modal')).toBeInTheDocument()
+
+      createBuilderPromise.resolve({
+        subscription_builder: createMockSubscriptionBuilder(),
+      })
+
+      await waitFor(() => {
+        expect(mockCreateBuilder).toHaveBeenCalled()
+      })
     })
   })
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig(({ mode }) => {
     test: {
       environment: 'jsdom',
       globals: true,
+      detectAsyncLeaks: true,
       setupFiles: ['./vitest.setup.ts'],
       coverage: {
         provider: 'v8',


### PR DESCRIPTION
### Motivation

- Enable Vitest async leak detection to catch resource/promise leaks early in CI by setting `detectAsyncLeaks: true` in the shared test config. 
- Fix flaky/async-leak failures in the subscription modal tests that were intermittently failing under the stricter leak checks.

### Description

- Enabled async leak detection by adding `detectAsyncLeaks: true` to the `test` section in `web/vite.config.ts`.
- Stabilized `Verify Success Flow` in `web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/common-modal.spec.tsx` by passing an initialized builder to the component so the verify path no longer races builder creation.
- Replaced a timer-based slow `createBuilder` mock with a controllable promise using `Promise.withResolvers` and explicitly `resolve(...)` in-test to avoid leaked timers/promises and make the test deterministic.

### Testing

- Ran the targeted spec: `pnpm test --run app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/common-modal.spec.tsx` and it passed (`95 tests`).
- Ran the two-spec combination: `pnpm test --run app/components/datasets/documents/create-from-pipeline/__tests__/index.spec.tsx app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/common-modal.spec.tsx` and both files passed (`230 tests` total).
- Pre-commit checks (`eslint --fix` and `pnpm type-check:tsgo`) ran successfully during commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbcea156ac8327a62331e9294b0286)