### PR TITLE
fix(tests): correct keyword arguments in tool provider test constructors

### DIFF
--- a/api/tests/test_containers_integration_tests/services/tools/test_tools_transform_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_tools_transform_service.py
@@ -48,41 +48,42 @@ class TestToolTransformService:
                 name=fake.company(),
                 description=fake.text(max_nb_chars=100),
                 icon='{"background": "#FF6B6B", "content": "🔧"}',
-                icon_dark='{"background": "#252525", "content": "🔧"}',
                 tenant_id="test_tenant_id",
                 user_id="test_user_id",
-                credentials={"auth_type": "api_key_header", "api_key": "test_key"},
-                provider_type="api",
+                credentials_str='{"auth_type": "api_key_header", "api_key": "test_key"}',
+                schema="{}",
+                schema_type_str="openapi",
+                tools_str="[]",
             )
         elif provider_type == "builtin":
             provider = BuiltinToolProvider(
                 name=fake.company(),
-                description=fake.text(max_nb_chars=100),
-                icon="🔧",
-                icon_dark="🔧",
                 tenant_id="test_tenant_id",
+                user_id="test_user_id",
                 provider="test_provider",
                 credential_type="api_key",
-                credentials={"api_key": "test_key"},
+                encrypted_credentials='{"api_key": "test_key"}',
             )
         elif provider_type == "workflow":
             provider = WorkflowToolProvider(
                 name=fake.company(),
                 description=fake.text(max_nb_chars=100),
                 icon='{"background": "#FF6B6B", "content": "🔧"}',
-                icon_dark='{"background": "#252525", "content": "🔧"}',
                 tenant_id="test_tenant_id",
                 user_id="test_user_id",
-                workflow_id="test_workflow_id",
+                app_id="test_workflow_id",
+                label="Test Workflow",
+                version="1.0.0",
+                parameter_configuration="[]",
             )
         elif provider_type == "mcp":
             provider = MCPToolProvider(
                 name=fake.company(),
-                description=fake.text(max_nb_chars=100),
-                provider_icon='{"background": "#FF6B6B", "content": "🔧"}',
+                icon='{"background": "#FF6B6B", "content": "🔧"}',
                 tenant_id="test_tenant_id",
                 user_id="test_user_id",
                 server_url="https://mcp.example.com",
+                server_url_hash="test_server_url_hash",
                 server_identifier="test_server",
                 tools='[{"name": "test_tool", "description": "Test tool"}]',
                 authed=True,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #32592

Fix unexpected keyword argument errors in the `_create_test_tool_provider` helper method in `test_tools_transform_service.py` by aligning constructor arguments with the actual SQLAlchemy model definitions in `api/models/tools.py`.

Changes per provider:

- **ApiToolProvider**: remove `icon_dark` and `provider_type`; rename `credentials` to `credentials_str`; add required `schema`, `schema_type_str`, `tools_str`
- **BuiltinToolProvider**: remove `description`, `icon`, `icon_dark`; rename `credentials` to `encrypted_credentials`; add required `user_id`
- **WorkflowToolProvider**: remove `icon_dark`; rename `workflow_id` to `app_id`; add required `label`, `version`, `parameter_configuration`
- **MCPToolProvider**: remove `description`; rename `provider_icon` to `icon`; add required `server_url_hash`

The corrected field names are consistent with usage elsewhere in the test file (e.g., `test_api_provider_to_controller_success` at line 652) and in `api/tests/unit_tests/models/test_tool_models.py`.

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods