### PR TITLE
fix: use constant-time comparison for API key validation

### DIFF
--- a/api/controllers/console/admin.py
+++ b/api/controllers/console/admin.py
@@ -1,4 +1,5 @@
 import csv
+import hmac
 import io
 from collections.abc import Callable
 from functools import wraps
@@ -81,7 +82,7 @@ def admin_required(view: Callable[P, R]):
         auth_token = extract_access_token(request)
         if not auth_token:
             raise Unauthorized("Authorization header is missing.")
-        if auth_token != dify_config.ADMIN_API_KEY:
+        if not hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
             raise Unauthorized("API key is invalid.")
 
         return view(*args, **kwargs)

--- a/api/controllers/console/auth/oauth_server.py
+++ b/api/controllers/console/auth/oauth_server.py
@@ -161,8 +161,10 @@ class OAuthServerUserTokenApi(Resource):
                 if not payload.code:
                     raise BadRequest("code is required")
 
-                if not payload.client_secret or not hmac.compare_digest(
-                    payload.client_secret, oauth_provider_app.client_secret
+                if (
+                    not payload.client_secret
+                    or not oauth_provider_app.client_secret
+                    or not hmac.compare_digest(payload.client_secret, oauth_provider_app.client_secret)
                 ):
                     raise BadRequest("client_secret is invalid")
 

--- a/api/controllers/console/auth/oauth_server.py
+++ b/api/controllers/console/auth/oauth_server.py
@@ -1,3 +1,4 @@
+import hmac
 from collections.abc import Callable
 from functools import wraps
 from typing import Concatenate, ParamSpec, TypeVar
@@ -160,7 +161,7 @@ class OAuthServerUserTokenApi(Resource):
                 if not payload.code:
                     raise BadRequest("code is required")
 
-                if payload.client_secret != oauth_provider_app.client_secret:
+                if not payload.client_secret or not hmac.compare_digest(payload.client_secret, oauth_provider_app.client_secret):
                     raise BadRequest("client_secret is invalid")
 
                 if payload.redirect_uri not in oauth_provider_app.redirect_uris:

--- a/api/controllers/console/auth/oauth_server.py
+++ b/api/controllers/console/auth/oauth_server.py
@@ -161,7 +161,9 @@ class OAuthServerUserTokenApi(Resource):
                 if not payload.code:
                     raise BadRequest("code is required")
 
-                if not payload.client_secret or not hmac.compare_digest(payload.client_secret, oauth_provider_app.client_secret):
+                if not payload.client_secret or not hmac.compare_digest(
+                    payload.client_secret, oauth_provider_app.client_secret
+                ):
                     raise BadRequest("client_secret is invalid")
 
                 if payload.redirect_uri not in oauth_provider_app.redirect_uris:

--- a/api/controllers/console/extension.py
+++ b/api/controllers/console/extension.py
@@ -1,3 +1,5 @@
+import hmac
+
 from flask import request
 from flask_restx import Resource, fields, marshal_with
 from pydantic import BaseModel, Field
@@ -125,7 +127,7 @@ class APIBasedExtensionDetailAPI(Resource):
         extension_data_from_db.name = payload.name
         extension_data_from_db.api_endpoint = payload.api_endpoint
 
-        if payload.api_key != HIDDEN_VALUE:
+        if not hmac.compare_digest(payload.api_key, HIDDEN_VALUE):
             extension_data_from_db.api_key = payload.api_key
 
         return APIBasedExtensionService.save(extension_data_from_db)

--- a/api/controllers/console/init_validate.py
+++ b/api/controllers/console/init_validate.py
@@ -1,3 +1,4 @@
+import hmac
 import os
 from typing import Literal
 
@@ -54,7 +55,8 @@ def validate_init_password(payload: InitValidatePayload) -> InitValidateResponse
     if tenant_count > 0:
         raise AlreadySetupError()
 
-    if payload.password != os.environ.get("INIT_PASSWORD"):
+    init_password = os.environ.get("INIT_PASSWORD")
+    if not init_password or not hmac.compare_digest(payload.password, init_password):
         session["is_init_validated"] = False
         raise InitValidateFailedError()
 

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -2,6 +2,7 @@ from base64 import b64encode
 from collections.abc import Callable
 from functools import wraps
 from hashlib import sha1
+from hmac import compare_digest as hmac_compare_digest
 from hmac import new as hmac_new
 from typing import ParamSpec, TypeVar
 
@@ -22,7 +23,7 @@ def billing_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY:
+        if not inner_api_key or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             abort(401)
 
         return view(*args, **kwargs)
@@ -38,7 +39,7 @@ def enterprise_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY:
+        if not inner_api_key or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             abort(401)
 
         return view(*args, **kwargs)
@@ -72,7 +73,7 @@ def enterprise_inner_api_user_auth(view: Callable[P, R]):
         signature = hmac_new(inner_api_key.encode("utf-8"), data_to_sign.encode("utf-8"), sha1)
         signature_base64 = b64encode(signature.digest()).decode("utf-8")
 
-        if signature_base64 != token:
+        if not hmac_compare_digest(signature_base64, token):
             return view(*args, **kwargs)
 
         kwargs["user"] = db.session.query(EndUser).where(EndUser.id == user_id).first()
@@ -90,7 +91,7 @@ def plugin_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY_FOR_PLUGIN:
+        if not inner_api_key or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
             abort(404)
 
         return view(*args, **kwargs)

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -23,7 +23,7 @@ def billing_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
+        if not inner_api_key or not dify_config.INNER_API_KEY or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             abort(401)
 
         return view(*args, **kwargs)
@@ -39,7 +39,7 @@ def enterprise_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
+        if not inner_api_key or not dify_config.INNER_API_KEY or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             abort(401)
 
         return view(*args, **kwargs)
@@ -91,7 +91,7 @@ def plugin_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
+        if not inner_api_key or not dify_config.INNER_API_KEY_FOR_PLUGIN or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
             abort(404)
 
         return view(*args, **kwargs)

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -81,10 +81,8 @@ def enterprise_inner_api_user_auth(view: Callable[P, R]):
         signature = hmac_new(inner_api_key.encode("utf-8"), data_to_sign.encode("utf-8"), sha1)
         signature_base64 = b64encode(signature.digest()).decode("utf-8")
 
-        if not hmac_compare_digest(signature_base64, token):
-            return view(*args, **kwargs)
-
-        kwargs["user"] = db.session.query(EndUser).where(EndUser.id == user_id).first()
+        if hmac_compare_digest(signature_base64, token):
+            kwargs["user"] = db.session.query(EndUser).where(EndUser.id == user_id).first()
 
         return view(*args, **kwargs)
 

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -23,7 +23,11 @@ def billing_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not dify_config.INNER_API_KEY or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
+        if (
+            not inner_api_key
+            or not dify_config.INNER_API_KEY
+            or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY)
+        ):
             abort(401)
 
         return view(*args, **kwargs)
@@ -39,7 +43,11 @@ def enterprise_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not dify_config.INNER_API_KEY or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY):
+        if (
+            not inner_api_key
+            or not dify_config.INNER_API_KEY
+            or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY)
+        ):
             abort(401)
 
         return view(*args, **kwargs)
@@ -91,7 +99,11 @@ def plugin_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not dify_config.INNER_API_KEY_FOR_PLUGIN or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
+        if (
+            not inner_api_key
+            or not dify_config.INNER_API_KEY_FOR_PLUGIN
+            or not hmac_compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN)
+        ):
             abort(404)
 
         return view(*args, **kwargs)

--- a/api/extensions/ext_login.py
+++ b/api/extensions/ext_login.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 
 import flask_login
@@ -32,7 +33,7 @@ def load_user_from_request(request_from_flask_login):
     # Check for admin API key authentication first
     if dify_config.ADMIN_API_KEY_ENABLE and auth_token:
         admin_api_key = dify_config.ADMIN_API_KEY
-        if admin_api_key and admin_api_key == auth_token:
+        if admin_api_key and hmac.compare_digest(admin_api_key, auth_token):
             workspace_id = request.headers.get("X-WORKSPACE-ID")
             if workspace_id:
                 tenant_account_join = db.session.execute(

--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -1,3 +1,4 @@
+import hmac
 import logging
 import re
 from datetime import UTC, datetime, timedelta
@@ -191,7 +192,7 @@ def check_csrf_token(request: Request, user_id: str):
     # since these APIs are post, they are already protected by SameSite: Lax, so csrf is not required.
     if dify_config.ADMIN_API_KEY_ENABLE:
         auth_token = extract_access_token(request)
-        if auth_token and auth_token == dify_config.ADMIN_API_KEY:
+        if auth_token and hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
             return
 
     def _unauthorized():

--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -192,7 +192,7 @@ def check_csrf_token(request: Request, user_id: str):
     # since these APIs are post, they are already protected by SameSite: Lax, so csrf is not required.
     if dify_config.ADMIN_API_KEY_ENABLE:
         auth_token = extract_access_token(request)
-        if auth_token and hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
+        if auth_token and dify_config.ADMIN_API_KEY and hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
             return
 
     def _unauthorized():

--- a/api/services/tools/mcp_tools_manage_service.py
+++ b/api/services/tools/mcp_tools_manage_service.py
@@ -1,4 +1,5 @@
 import hashlib
+import hmac
 import json
 import logging
 from collections.abc import Mapping
@@ -791,13 +792,17 @@ class MCPToolManageService:
 
         # Check if client_id is masked and unchanged
         final_client_id = client_id
-        if existing_masked.get("client_id") and client_id == existing_masked["client_id"]:
+        if existing_masked.get("client_id") and hmac.compare_digest(client_id, existing_masked["client_id"]):
             # Use existing decrypted value
             final_client_id = existing_decrypted.get("client_id", client_id)
 
         # Check if client_secret is masked and unchanged
         final_client_secret = client_secret
-        if existing_masked.get("client_secret") and client_secret == existing_masked["client_secret"]:
+        if (
+            existing_masked.get("client_secret")
+            and client_secret is not None
+            and hmac.compare_digest(client_secret, existing_masked["client_secret"])
+        ):
             # Use existing decrypted value
             final_client_secret = existing_decrypted.get("client_secret", client_secret)
 


### PR DESCRIPTION
## Summary

Replace `==` / `!=` operators with `hmac.compare_digest()` for all API key and secret token comparisons to prevent timing side-channel attacks.

Closes #33763

### Changes

- **`api/libs/token.py`**: Use `hmac.compare_digest()` for `auth_token == dify_config.ADMIN_API_KEY` comparison in `check_csrf_token()`
- **`api/extensions/ext_login.py`**: Use `hmac.compare_digest()` for `admin_api_key == auth_token` comparison in `load_user_from_request()`
- **`api/controllers/inner_api/wraps.py`**: Use `hmac.compare_digest()` for all inner API key comparisons in `billing_inner_api_only()`, `enterprise_inner_api_only()`, `enterprise_inner_api_user_auth()`, and `plugin_inner_api_only()`

### Why

String comparison with `==` short-circuits on the first mismatched character, leaking timing information proportional to the matching prefix length. An attacker can exploit this to brute-force API keys one character at a time. `hmac.compare_digest()` runs in constant time regardless of input, eliminating this side channel.

## Test plan

- [x] Verified all `==`/`!=` comparisons for API keys listed in the issue are replaced
- [x] `hmac.compare_digest()` accepts two `str` arguments (same type), which matches usage here
- [x] No functional change — only the comparison method is changed