### PR TITLE
fix: remove legacy z-index overrides on model config popup

### DIFF
--- a/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
+++ b/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
@@ -298,7 +298,6 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
           <div>
             <ModelParameterModal
               popupClassName="!w-[520px]"
-              portalToFollowElemContentClassName="z-[1000]"
               isAdvancedMode={true}
               provider={model.provider}
               completionParams={model.completion_params}

--- a/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
+++ b/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
@@ -214,7 +214,6 @@ export const GetCodeGeneratorResModal: FC<IGetCodeGeneratorResProps> = (
           <div className="mb-4">
             <ModelParameterModal
               popupClassName="!w-[520px]"
-              portalToFollowElemContentClassName="z-[1000]"
               isAdvancedMode={true}
               provider={model.provider}
               completionParams={model.completion_params}

--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -370,7 +370,6 @@ const ConfigContent: FC<Props> = ({
           <ModelParameterModal
             isInWorkflow={isInWorkflow}
             popupClassName="!w-[387px]"
-            portalToFollowElemContentClassName="!z-[1002]"
             isAdvancedMode={true}
             provider={model?.provider}
             completionParams={model?.completion_params}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -32,7 +32,6 @@ import Trigger from './trigger'
 
 export type ModelParameterModalProps = {
   popupClassName?: string
-  portalToFollowElemContentClassName?: string
   isAdvancedMode: boolean
   modelId: string
   provider: string
@@ -50,7 +49,6 @@ export type ModelParameterModalProps = {
 
 const ModelParameterModal: FC<ModelParameterModalProps> = ({
   popupClassName,
-  portalToFollowElemContentClassName,
   isAdvancedMode,
   modelId,
   provider,
@@ -161,7 +159,6 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
       <PopoverContent
         placement={isInWorkflow ? 'left' : (renderTrigger ? 'bottom-end' : 'left-start')}
         sideOffset={4}
-        className={portalToFollowElemContentClassName}
         popupClassName={cn(popupClassName, 'w-[400px] rounded-2xl')}
         positionerProps={!renderTrigger ? { anchor: settingsIconRef } : undefined}
       >

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-filter/index.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-filter/index.tsx
@@ -80,7 +80,6 @@ const MetadataFilter = ({
               </div>
               <div className="mt-1 px-4">
                 <ModelParameterModal
-                  portalToFollowElemContentClassName="z-[50]"
                   popupClassName="!w-[387px]"
                   isInWorkflow
                   isAdvancedMode={true}

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/prompt-editor.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/prompt-editor.tsx
@@ -63,7 +63,6 @@ const PromptEditor: FC<PromptEditorProps> = ({
         </div>
         <ModelParameterModal
           popupClassName="!w-[448px]"
-          portalToFollowElemContentClassName="z-[1000]"
           isAdvancedMode={true}
           provider={model.provider}
           completionParams={model.completion_params}


### PR DESCRIPTION
Fixes #33745

## Summary

- Remove legacy `portalToFollowElemContentClassName` z-index values that override the Popover component's default `z-[1002]` via `tailwind-merge`, causing the model configuration popup to render behind other UI elements
- The most critical case was `metadata-filter/index.tsx` passing `z-[50]`, which placed the popup far below other overlays
- Other callers passed `z-[1000]` or `!z-[1002]`, which were unnecessary since the new Popover primitive already uses `z-[1002]` by default
- Remove the now-unused `portalToFollowElemContentClassName` prop from `ModelParameterModal`

### Root cause

When the `ModelParameterModal` was migrated from `PortalToFollowElem` (default `z-[60]`) to the new `Popover` primitive (default `z-[1002]`), callers still passed legacy z-index overrides through `portalToFollowElemContentClassName`. Since `cn()` uses `tailwind-merge`, these values override the Popover's default `z-[1002]`, breaking the stacking order. This is consistent with the [overlay migration guide](https://github.com/langgenius/dify/blob/main/web/docs/overlay-migration.md) which states: "`portalToFollowElemContentClassName` with z-index values should be deleted when the surrounding legacy container is migrated."

## Screenshots

| Before | After |
|--------|-------|
| Model config popup hidden behind other panels due to z-[50] override | Popup correctly appears on top with default z-[1002] |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods