### PR TITLE
fix(api): use constant-time comparison for API key validation

### DIFF
--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -2,6 +2,7 @@ from base64 import b64encode
 from collections.abc import Callable
 from functools import wraps
 from hashlib import sha1
+from hmac import compare_digest
 from hmac import new as hmac_new
 from typing import ParamSpec, TypeVar
 
@@ -22,7 +23,7 @@ def billing_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY:
+        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             abort(401)
 
         return view(*args, **kwargs)
@@ -38,7 +39,7 @@ def enterprise_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY:
+        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             abort(401)
 
         return view(*args, **kwargs)
@@ -90,7 +91,7 @@ def plugin_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY_FOR_PLUGIN:
+        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
             abort(404)
 
         return view(*args, **kwargs)

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -23,7 +23,10 @@ def billing_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY):
+        if not inner_api_key or not (
+            dify_config.INNER_API_KEY
+            and compare_digest(inner_api_key, dify_config.INNER_API_KEY)
+        ):
             abort(401)
 
         return view(*args, **kwargs)
@@ -39,7 +42,10 @@ def enterprise_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY):
+        if not inner_api_key or not (
+            dify_config.INNER_API_KEY
+            and compare_digest(inner_api_key, dify_config.INNER_API_KEY)
+        ):
             abort(401)
 
         return view(*args, **kwargs)
@@ -73,7 +79,7 @@ def enterprise_inner_api_user_auth(view: Callable[P, R]):
         signature = hmac_new(inner_api_key.encode("utf-8"), data_to_sign.encode("utf-8"), sha1)
         signature_base64 = b64encode(signature.digest()).decode("utf-8")
 
-        if signature_base64 != token:
+        if not compare_digest(signature_base64, token):
             return view(*args, **kwargs)
 
         kwargs["user"] = db.session.query(EndUser).where(EndUser.id == user_id).first()
@@ -91,7 +97,10 @@ def plugin_inner_api_only(view: Callable[P, R]):
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
+        if not inner_api_key or not (
+            dify_config.INNER_API_KEY_FOR_PLUGIN
+            and compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN)
+        ):
             abort(404)
 
         return view(*args, **kwargs)

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -24,8 +24,7 @@ def billing_inner_api_only(view: Callable[P, R]):
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
         if not inner_api_key or not (
-            dify_config.INNER_API_KEY
-            and compare_digest(inner_api_key, dify_config.INNER_API_KEY)
+            dify_config.INNER_API_KEY and compare_digest(inner_api_key, dify_config.INNER_API_KEY)
         ):
             abort(401)
 
@@ -43,8 +42,7 @@ def enterprise_inner_api_only(view: Callable[P, R]):
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
         if not inner_api_key or not (
-            dify_config.INNER_API_KEY
-            and compare_digest(inner_api_key, dify_config.INNER_API_KEY)
+            dify_config.INNER_API_KEY and compare_digest(inner_api_key, dify_config.INNER_API_KEY)
         ):
             abort(401)
 
@@ -98,8 +96,7 @@ def plugin_inner_api_only(view: Callable[P, R]):
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
         if not inner_api_key or not (
-            dify_config.INNER_API_KEY_FOR_PLUGIN
-            and compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN)
+            dify_config.INNER_API_KEY_FOR_PLUGIN and compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN)
         ):
             abort(404)
 

--- a/api/extensions/ext_login.py
+++ b/api/extensions/ext_login.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 
 import flask_login
@@ -32,7 +33,7 @@ def load_user_from_request(request_from_flask_login):
     # Check for admin API key authentication first
     if dify_config.ADMIN_API_KEY_ENABLE and auth_token:
         admin_api_key = dify_config.ADMIN_API_KEY
-        if admin_api_key and admin_api_key == auth_token:
+        if admin_api_key and hmac.compare_digest(admin_api_key, auth_token):
             workspace_id = request.headers.get("X-WORKSPACE-ID")
             if workspace_id:
                 tenant_account_join = db.session.execute(

--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -1,3 +1,4 @@
+import hmac
 import logging
 import re
 from datetime import UTC, datetime, timedelta
@@ -191,7 +192,7 @@ def check_csrf_token(request: Request, user_id: str):
     # since these APIs are post, they are already protected by SameSite: Lax, so csrf is not required.
     if dify_config.ADMIN_API_KEY_ENABLE:
         auth_token = extract_access_token(request)
-        if auth_token and auth_token == dify_config.ADMIN_API_KEY:
+        if auth_token and hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
             return
 
     def _unauthorized():

--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -192,7 +192,7 @@ def check_csrf_token(request: Request, user_id: str):
     # since these APIs are post, they are already protected by SameSite: Lax, so csrf is not required.
     if dify_config.ADMIN_API_KEY_ENABLE:
         auth_token = extract_access_token(request)
-        if auth_token and hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
+        if auth_token and dify_config.ADMIN_API_KEY and hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):
             return
 
     def _unauthorized():


### PR DESCRIPTION
## Context

Fixes timing attack vulnerability in API key validation. String comparison operators (`==`, `!=`) leak timing information proportional to the length of the matching prefix, allowing attackers to brute-force API keys byte-by-byte.

## Problem

The following locations used `==` or `!=` for secret key comparison:

- `api/libs/token.py:194` - CSRF token admin API key bypass
- `api/extensions/ext_login.py:35` - Admin API key authentication  
- `api/controllers/inner_api/wraps.py:25,41,93` - Inner API key and plugin key validation

```python
# Vulnerable pattern
if auth_token == dify_config.ADMIN_API_KEY:  # timing leak

# Fixed pattern  
if hmac.compare_digest(auth_token, dify_config.ADMIN_API_KEY):  # constant time
```

## Technical Decision

`hmac.compare_digest()` provides constant-time string comparison that:
- Returns in the same time regardless of where the mismatch occurs
- Prevents timing side-channel attacks on secret validation
- Is the standard Python library function for this purpose (stdlib `hmac`)

## Changes

| File | Change |
|------|--------|
| `api/libs/token.py` | Added `import hmac`, changed `==` to `hmac.compare_digest()` |
| `api/extensions/ext_login.py` | Added `import hmac`, changed `==` to `hmac.compare_digest()` |
| `api/controllers/inner_api/wraps.py` | Added `compare_digest` to import, changed `!=` to `not compare_digest()` (3 locations) |

## Verification

- `ruff check` passes on all modified files
- Python syntax validation passed
- Minimal, surgical change with no behavioral modification beyond security fix

## Related

Fixes #33763