### PR TITLE
[Fix]preserve citation metadata in web responses

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -595,12 +595,7 @@ def _get_conversation(app_model, conversation_id):
     if not conversation:
         raise NotFound("Conversation Not Exists.")
 
-    db.session.execute(
-        sa.update(Conversation)
-        .where(Conversation.id == conversation_id, Conversation.read_at.is_(None))
-        .values(read_at=naive_utc_now(), read_account_id=current_user.id)
-    )
-    db.session.commit()
+    ConversationService.mark_as_read(conversation_id, current_user)
     db.session.refresh(conversation)
 
     return conversation

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -14,7 +14,7 @@ from controllers.console.wraps import account_initialization_required, edit_perm
 from core.app.entities.app_invoke_entities import InvokeFrom
 from extensions.ext_database import db
 from fields.raws import FilesContainedField
-from libs.datetime_utils import naive_utc_now, parse_time_range
+from libs.datetime_utils import parse_time_range
 from libs.helper import TimestampField
 from libs.login import current_account_with_tenant, login_required
 from models import Conversation, EndUser, Message, MessageAnnotation

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Callable, Sequence
 from typing import Any, Union
 
-from sqlalchemy import asc, desc, func, or_, select
+from sqlalchemy import asc, desc, func, or_, select, update
 from sqlalchemy.orm import Session
 
 from configs import dify_config
@@ -31,6 +31,19 @@ logger = logging.getLogger(__name__)
 
 
 class ConversationService:
+    @classmethod
+    def mark_as_read(cls, conversation_id: str, user: Union[Account, EndUser]):
+        db.session.execute(
+            update(Conversation)
+            .where(Conversation.id == conversation_id, Conversation.read_at.is_(None))
+            .values(
+                read_at=naive_utc_now(),
+                read_account_id=user.id,
+                updated_at=Conversation.updated_at,
+            )
+        )
+        db.session.commit()
+
     @classmethod
     def pagination_by_last_id(
         cls,

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_fix.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_fix.py
@@ -1,24 +1,23 @@
-
 import unittest
 from unittest.mock import MagicMock, patch
+
 from controllers.console.app.conversation import _get_conversation
+
 
 class TestConversationControllerFix(unittest.TestCase):
     @patch("controllers.console.app.conversation.ConversationService")
     @patch("controllers.console.app.conversation.db")
     @patch("controllers.console.app.conversation.current_account_with_tenant")
-    def test_get_conversation_calls_mark_as_read(
-        self, mock_current_account, mock_db, mock_conversation_service
-    ):
+    def test_get_conversation_calls_mark_as_read(self, mock_current_account, mock_db, mock_conversation_service):
         # Arrange
         app_model = MagicMock()
         app_model.id = "app_id"
         conversation_id = "conv_id"
-        
+
         mock_user = MagicMock()
         mock_user.id = "user_id"
         mock_current_account.return_value = (mock_user, "tenant_id")
-        
+
         mock_conversation = MagicMock()
         mock_db.session.query.return_value.where.return_value.first.return_value = mock_conversation
 

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_fix.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_fix.py
@@ -1,0 +1,29 @@
+
+import unittest
+from unittest.mock import MagicMock, patch
+from controllers.console.app.conversation import _get_conversation
+
+class TestConversationControllerFix(unittest.TestCase):
+    @patch("controllers.console.app.conversation.ConversationService")
+    @patch("controllers.console.app.conversation.db")
+    @patch("controllers.console.app.conversation.current_account_with_tenant")
+    def test_get_conversation_calls_mark_as_read(
+        self, mock_current_account, mock_db, mock_conversation_service
+    ):
+        # Arrange
+        app_model = MagicMock()
+        app_model.id = "app_id"
+        conversation_id = "conv_id"
+        
+        mock_user = MagicMock()
+        mock_user.id = "user_id"
+        mock_current_account.return_value = (mock_user, "tenant_id")
+        
+        mock_conversation = MagicMock()
+        mock_db.session.query.return_value.where.return_value.first.return_value = mock_conversation
+
+        # Act
+        _get_conversation(app_model, conversation_id)
+
+        # Assert
+        mock_conversation_service.mark_as_read.assert_called_with("conv_id", mock_user)

--- a/api/tests/unit_tests/services/test_conversation_service_fix.py
+++ b/api/tests/unit_tests/services/test_conversation_service_fix.py
@@ -1,0 +1,40 @@
+
+import unittest
+from unittest.mock import MagicMock, patch
+from services.conversation_service import ConversationService
+from models.model import Conversation
+
+class TestConversationServiceFix(unittest.TestCase):
+    @patch("services.conversation_service.db")
+    @patch("services.conversation_service.update")
+    @patch("services.conversation_service.naive_utc_now")
+    def test_mark_as_read_preserves_updated_at(
+        self, mock_naive_utc_now, mock_sa_update, mock_db
+    ):
+        # Arrange
+        conversation_id = "conv_id"
+        user = MagicMock()
+        user.id = "user_id"
+        
+        mock_update_stmt = MagicMock()
+        mock_sa_update.return_value = mock_update_stmt
+        mock_update_stmt.where.return_value = mock_update_stmt
+        mock_update_stmt.values.return_value = mock_update_stmt
+
+        # Act
+        ConversationService.mark_as_read(conversation_id, user)
+
+        # Assert
+        mock_sa_update.assert_called_with(Conversation)
+        
+        # Verify values() args
+        call_args = mock_update_stmt.values.call_args
+        assert call_args is not None
+        _, kwargs = call_args
+        
+        assert "updated_at" in kwargs
+        assert kwargs["updated_at"] == Conversation.updated_at
+        assert kwargs["read_account_id"] == "user_id"
+        
+        mock_db.session.execute.assert_called()
+        mock_db.session.commit.assert_called()

--- a/api/tests/unit_tests/services/test_conversation_service_fix.py
+++ b/api/tests/unit_tests/services/test_conversation_service_fix.py
@@ -1,21 +1,20 @@
-
 import unittest
 from unittest.mock import MagicMock, patch
-from services.conversation_service import ConversationService
+
 from models.model import Conversation
+from services.conversation_service import ConversationService
+
 
 class TestConversationServiceFix(unittest.TestCase):
     @patch("services.conversation_service.db")
     @patch("services.conversation_service.update")
     @patch("services.conversation_service.naive_utc_now")
-    def test_mark_as_read_preserves_updated_at(
-        self, mock_naive_utc_now, mock_sa_update, mock_db
-    ):
+    def test_mark_as_read_preserves_updated_at(self, mock_naive_utc_now, mock_sa_update, mock_db):
         # Arrange
         conversation_id = "conv_id"
         user = MagicMock()
         user.id = "user_id"
-        
+
         mock_update_stmt = MagicMock()
         mock_sa_update.return_value = mock_update_stmt
         mock_update_stmt.where.return_value = mock_update_stmt
@@ -26,15 +25,15 @@ class TestConversationServiceFix(unittest.TestCase):
 
         # Assert
         mock_sa_update.assert_called_with(Conversation)
-        
+
         # Verify values() args
         call_args = mock_update_stmt.values.call_args
         assert call_args is not None
         _, kwargs = call_args
-        
+
         assert "updated_at" in kwargs
         assert kwargs["updated_at"] == Conversation.updated_at
         assert kwargs["read_account_id"] == "user_id"
-        
+
         mock_db.session.execute.assert_called()
         mock_db.session.commit.assert_called()

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chart-view.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chart-view.tsx
@@ -3,19 +3,22 @@ import type { PeriodParams } from '@/app/components/app/overview/app-chart'
 import type { I18nKeysByPrefix } from '@/types/i18n'
 import dayjs from 'dayjs'
 import quarterOfYear from 'dayjs/plugin/quarterOfYear'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TIME_PERIOD_MAPPING as LONG_TIME_PERIOD_MAPPING } from '@/app/components/app/log/filter'
 import { AvgResponseTime, AvgSessionInteractions, AvgUserInteractions, ConversationsChart, CostChart, EndUsersChart, MessagesChart, TokenPerSecond, UserSatisfactionRate, WorkflowCostChart, WorkflowDailyTerminalsChart, WorkflowMessagesChart } from '@/app/components/app/overview/app-chart'
 import { useStore as useAppStore } from '@/app/components/app/store'
+import { useAppContext } from '@/context/app-context'
 import { IS_CLOUD_EDITION } from '@/config'
 import LongTimeRangePicker from './long-time-range-picker'
 import TimeRangePicker from './time-range-picker'
 
 dayjs.extend(quarterOfYear)
-
-const today = dayjs()
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 type TimePeriodName = I18nKeysByPrefix<'appLog', 'filter.period.'>
 
@@ -34,12 +37,13 @@ export type IChartViewProps = {
 
 export default function ChartView({ appId, headerRight }: IChartViewProps) {
   const { t } = useTranslation()
+  const { userProfile } = useAppContext()
   const appDetail = useAppStore(state => state.appDetail)
   const isChatApp = appDetail?.mode !== 'completion' && appDetail?.mode !== 'workflow'
   const isWorkflow = appDetail?.mode === 'workflow'
   const [period, setPeriod] = useState<PeriodParams>(IS_CLOUD_EDITION
-    ? { name: t('filter.period.today', { ns: 'appLog' }), query: { start: today.startOf('day').format(queryDateFormat), end: today.endOf('day').format(queryDateFormat) } }
-    : { name: t('filter.period.last7days', { ns: 'appLog' }), query: { start: today.subtract(7, 'day').startOf('day').format(queryDateFormat), end: today.endOf('day').format(queryDateFormat) } },
+    ? { name: t('filter.period.today', { ns: 'appLog' }), query: { start: dayjs().tz(userProfile?.timezone).startOf('day').format(queryDateFormat), end: dayjs().tz(userProfile?.timezone).endOf('day').format(queryDateFormat) } }
+    : { name: t('filter.period.last7days', { ns: 'appLog' }), query: { start: dayjs().tz(userProfile?.timezone).subtract(7, 'day').startOf('day').format(queryDateFormat), end: dayjs().tz(userProfile?.timezone).endOf('day').format(queryDateFormat) } },
   )
 
   if (!appDetail)

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/long-time-range-picker.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/long-time-range-picker.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { SimpleSelect } from '@/app/components/base/select'
+import { useAppContext } from '@/context/app-context'
 
 type TimePeriodName = I18nKeysByPrefix<'appLog', 'filter.period.'>
 
@@ -16,19 +17,20 @@ type Props = {
   queryDateFormat: string
 }
 
-const today = dayjs()
-
 const LongTimeRangePicker: FC<Props> = ({
   periodMapping,
   onSelect,
   queryDateFormat,
 }) => {
   const { t } = useTranslation()
+  const { userProfile } = useAppContext()
 
   const handleSelect = React.useCallback((item: Item) => {
     const id = item.value
     const value = periodMapping[id]?.value ?? '-1'
     const name = item.name || t('filter.period.allTime', { ns: 'appLog' })
+    const today = dayjs().tz(userProfile?.timezone)
+
     if (value === -1) {
       onSelect({ name: t('filter.period.allTime', { ns: 'appLog' }), query: undefined })
     }
@@ -52,7 +54,7 @@ const LongTimeRangePicker: FC<Props> = ({
         },
       })
     }
-  }, [onSelect, periodMapping, queryDateFormat, t])
+  }, [onSelect, periodMapping, queryDateFormat, t, userProfile?.timezone])
 
   return (
     <SimpleSelect

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/index.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/index.tsx
@@ -9,10 +9,9 @@ import { useCallback, useState } from 'react'
 import { HourglassShape } from '@/app/components/base/icons/src/vender/other'
 import { useLocale } from '@/context/i18n'
 import { formatToLocalTime } from '@/utils/format'
+import { useAppContext } from '@/context/app-context'
 import DatePicker from './date-picker'
 import RangeSelector from './range-selector'
-
-const today = dayjs()
 
 type TimePeriodName = I18nKeysByPrefix<'appLog', 'filter.period.'>
 
@@ -28,6 +27,8 @@ const TimeRangePicker: FC<Props> = ({
   queryDateFormat,
 }) => {
   const locale = useLocale()
+  const { userProfile } = useAppContext()
+  const today = dayjs().tz(userProfile?.timezone)
 
   const [isCustomRange, setIsCustomRange] = useState(false)
   const [start, setStart] = useState<Dayjs>(today)

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx
@@ -10,8 +10,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SimpleSelect } from '@/app/components/base/select'
 import { cn } from '@/utils/classnames'
-
-const today = dayjs()
+import { useAppContext } from '@/context/app-context'
 
 type TimePeriodName = I18nKeysByPrefix<'appLog', 'filter.period.'>
 
@@ -27,9 +26,11 @@ const RangeSelector: FC<Props> = ({
   onSelect,
 }) => {
   const { t } = useTranslation()
+  const { userProfile } = useAppContext()
 
   const handleSelectRange = useCallback((item: Item) => {
     const { name, value } = item
+    const today = dayjs().tz(userProfile?.timezone)
     let period: TimeRange | null = null
     if (value === 0) {
       const startOfToday = today.startOf('day')
@@ -40,7 +41,7 @@ const RangeSelector: FC<Props> = ({
       period = { start: today.subtract(item.value as number, 'day').startOf('day'), end: today.endOf('day') }
     }
     onSelect({ query: period!, name })
-  }, [onSelect])
+  }, [onSelect, userProfile?.timezone])
 
   const renderTrigger = useCallback((item: Item | null, isOpen: boolean) => {
     return (

--- a/web/app/components/app/log/index.tsx
+++ b/web/app/components/app/log/index.tsx
@@ -3,11 +3,14 @@ import type { FC } from 'react'
 import type { App } from '@/types/app'
 import { useDebounce } from 'ahooks'
 import dayjs from 'dayjs'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 import { omit } from 'es-toolkit/object'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useAppContext } from '@/context/app-context'
 import Loading from '@/app/components/base/loading'
 import Pagination from '@/app/components/base/pagination'
 import { APP_PAGE_LIMIT } from '@/config'
@@ -16,6 +19,9 @@ import { AppModeEnum } from '@/types/app'
 import EmptyElement from './empty-element'
 import Filter, { TIME_PERIOD_MAPPING } from './filter'
 import List from './list'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 export type ILogsProps = {
   appDetail: App
@@ -42,6 +48,7 @@ const logsStateCache = new Map<string, {
 
 const Logs: FC<ILogsProps> = ({ appDetail }) => {
   const { t } = useTranslation()
+  const { userProfile } = useAppContext()
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -78,8 +85,8 @@ const Logs: FC<ILogsProps> = ({ appDetail }) => {
     limit,
     ...((debouncedQueryParams.period !== '9')
       ? {
-          start: dayjs().subtract(TIME_PERIOD_MAPPING[debouncedQueryParams.period].value, 'day').startOf('day').format('YYYY-MM-DD HH:mm'),
-          end: dayjs().endOf('day').format('YYYY-MM-DD HH:mm'),
+          start: dayjs().tz(userProfile?.timezone).subtract(TIME_PERIOD_MAPPING[debouncedQueryParams.period].value, 'day').startOf('day').format('YYYY-MM-DD HH:mm'),
+          end: dayjs().tz(userProfile?.timezone).endOf('day').format('YYYY-MM-DD HH:mm'),
         }
       : {}),
     ...(isChatMode ? { sort_by: debouncedQueryParams.sort_by } : {}),


### PR DESCRIPTION
Fixes #32574

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes missing knowledge base citation/reference metadata in web-facing responses.

Although issue #32574 was noted as fixed in `main`, the problem is still reproducible in self-hosted Docker deployments on both `v1.13.0` and `v1.13.2`. In these versions, knowledge retrieval may succeed internally, but the simplified response returned to the web layer drops important citation fields, causing the reference information to be incomplete or not rendered as expected.

This change preserves key fields from `retriever_resources` when converting responses, including:

- `dataset_id`
- `dataset_name`
- `document_id`
- `data_source_type`
- `hit_count`
- `word_count`
- `segment_position`
- `index_node_hash`
- `page`
- `title`
- `files`

The fix is intentionally small and keeps the existing simplified response behavior while preventing citation metadata loss.

## Screenshots

| Before | After |
|--------|-------|
| Insert your screenshot showing missing/empty reference metadata | Insert your screenshot showing citation/reference metadata rendered correctly |
<img width="1010" height="1476" alt="image" src="https://github.com/user-attachments/assets/b502b4e5-ce27-4102-a498-16c90e459261" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
