### PR TITLE
fix(api): preserve citation metadata in web responses

### DIFF
--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -74,11 +74,22 @@ class AppGenerateResponseConverter(ABC):
             for resource in metadata["retriever_resources"]:
                 updated_resources.append(
                     {
+                        "dataset_id": resource.get("dataset_id"),
+                        "dataset_name": resource.get("dataset_name"),
+                        "document_id": resource.get("document_id"),
                         "segment_id": resource.get("segment_id", ""),
                         "position": resource["position"],
+                        "data_source_type": resource.get("data_source_type"),
                         "document_name": resource["document_name"],
                         "score": resource["score"],
+                        "hit_count": resource.get("hit_count"),
+                        "word_count": resource.get("word_count"),
+                        "segment_position": resource.get("segment_position"),
+                        "index_node_hash": resource.get("index_node_hash"),
                         "content": resource["content"],
+                        "page": resource.get("page"),
+                        "title": resource.get("title"),
+                        "files": resource.get("files"),
                         "summary": resource.get("summary"),
                     }
                 )

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py
@@ -44,11 +44,22 @@ class TestAgentChatAppGenerateResponseConverterBlocking:
                 metadata={
                     "retriever_resources": [
                         {
+                            "dataset_id": "dataset-1",
+                            "dataset_name": "Dataset 1",
+                            "document_id": "document-1",
                             "segment_id": "s1",
                             "position": 1,
+                            "data_source_type": "file",
                             "document_name": "doc",
                             "score": 0.9,
+                            "hit_count": 2,
+                            "word_count": 128,
+                            "segment_position": 3,
+                            "index_node_hash": "abc1234",
                             "content": "content",
+                            "page": 5,
+                            "title": "Citation Title",
+                            "files": [{"id": "file-1"}],
                         }
                     ],
                     "annotation_reply": {"id": "a"},
@@ -107,11 +118,22 @@ class TestAgentChatAppGenerateResponseConverterStream:
                     metadata={
                         "retriever_resources": [
                             {
+                                "dataset_id": "dataset-1",
+                                "dataset_name": "Dataset 1",
+                                "document_id": "document-1",
                                 "segment_id": "s1",
                                 "position": 1,
+                                "data_source_type": "file",
                                 "document_name": "doc",
                                 "score": 0.9,
+                                "hit_count": 2,
+                                "word_count": 128,
+                                "segment_position": 3,
+                                "index_node_hash": "abc1234",
                                 "content": "content",
+                                "page": 5,
+                                "title": "Citation Title",
+                                "files": [{"id": "file-1"}],
                                 "summary": "summary",
                                 "extra": "ignored",
                             }
@@ -151,11 +173,22 @@ class TestAgentChatAppGenerateResponseConverterStream:
         assert "usage" not in metadata
         assert metadata["retriever_resources"] == [
             {
+                "dataset_id": "dataset-1",
+                "dataset_name": "Dataset 1",
+                "document_id": "document-1",
                 "segment_id": "s1",
                 "position": 1,
+                "data_source_type": "file",
                 "document_name": "doc",
                 "score": 0.9,
+                "hit_count": 2,
+                "word_count": 128,
+                "segment_position": 3,
+                "index_node_hash": "abc1234",
                 "content": "content",
+                "page": 5,
+                "title": "Citation Title",
+                "files": [{"id": "file-1"}],
                 "summary": "summary",
             }
         ]

--- a/api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py
+++ b/api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py
@@ -38,11 +38,22 @@ class TestCompletionAppGenerateResponseConverter:
         metadata = {
             "retriever_resources": [
                 {
+                    "dataset_id": "dataset-1",
+                    "dataset_name": "Dataset 1",
+                    "document_id": "document-1",
                     "segment_id": "s",
                     "position": 1,
+                    "data_source_type": "file",
                     "document_name": "doc",
                     "score": 0.9,
+                    "hit_count": 2,
+                    "word_count": 128,
+                    "segment_position": 3,
+                    "index_node_hash": "abc1234",
                     "content": "c",
+                    "page": 5,
+                    "title": "Citation Title",
+                    "files": [{"id": "file-1"}],
                     "summary": "sum",
                     "extra": "x",
                 }
@@ -66,7 +77,12 @@ class TestCompletionAppGenerateResponseConverter:
 
         assert "annotation_reply" not in result["metadata"]
         assert "usage" not in result["metadata"]
+        assert result["metadata"]["retriever_resources"][0]["dataset_id"] == "dataset-1"
+        assert result["metadata"]["retriever_resources"][0]["document_id"] == "document-1"
         assert result["metadata"]["retriever_resources"][0]["segment_id"] == "s"
+        assert result["metadata"]["retriever_resources"][0]["data_source_type"] == "file"
+        assert result["metadata"]["retriever_resources"][0]["segment_position"] == 3
+        assert result["metadata"]["retriever_resources"][0]["index_node_hash"] == "abc1234"
         assert "extra" not in result["metadata"]["retriever_resources"][0]
 
     def test_convert_blocking_simple_response_metadata_not_dict(self):


### PR DESCRIPTION
Fixes #32574 

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes missing knowledge base citation/reference metadata in web-facing responses.

Although issue #32574 was noted as fixed in `main`, the problem is still reproducible in self-hosted Docker deployments on both `v1.13.0` and `v1.13.2`. In these versions, knowledge retrieval may succeed internally, but the simplified response returned to the web layer drops important citation fields, causing the reference information to be incomplete or not rendered as expected.

This change preserves key fields from `retriever_resources` when converting responses, including:

- `dataset_id`
- `dataset_name`
- `document_id`
- `data_source_type`
- `hit_count`
- `word_count`
- `segment_position`
- `index_node_hash`
- `page`
- `title`
- `files`

The fix is intentionally small and keeps the existing simplified response behavior while preventing citation metadata loss.

## Screenshots

| Before | After |
|--------|-------|
<img width="1010" height="1476" alt="image" src="https://github.com/user-attachments/assets/da840ffd-ea53-49d9-86f9-d0de812ec97e" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
