### PR TITLE
refactor(workspace): optimize /workspaces plan resolution for SaaS and enterprise with resilient fallback

### DIFF
--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -127,7 +127,9 @@ class TenantListApi(Resource):
         for tenant in tenants:
             plan: str = CloudPlan.SANDBOX.value
             if is_saas and not use_legacy_feature_path:
-                plan = tenant_plans.get(tenant.id, {}).get("plan", CloudPlan.SANDBOX.value)
+                tenant_plan = tenant_plans.get(tenant.id)
+                if tenant_plan:
+                    plan = tenant_plan["plan"] if tenant_plan["plan"] else CloudPlan.SANDBOX.value
             elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
                 plan = features.billing.subscription.plan or CloudPlan.SANDBOX.value

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -30,7 +30,7 @@ from libs.helper import TimestampField
 from libs.login import current_account_with_tenant, login_required
 from models.account import Tenant, TenantStatus
 from services.account_service import TenantService
-from services.billing_service import BillingService
+from services.billing_service import BillingService, SubscriptionPlan
 from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
 from services.file_service import FileService
@@ -112,7 +112,7 @@ class TenantListApi(Resource):
         tenant_dicts = []
         is_enterprise_only = dify_config.ENTERPRISE_ENABLED and not dify_config.BILLING_ENABLED
         is_saas = dify_config.EDITION == "CLOUD" and dify_config.BILLING_ENABLED
-        tenant_plans: dict[str, dict] = {}
+        tenant_plans: dict[str, SubscriptionPlan] = {}
         use_legacy_feature_path = not is_enterprise_only and not is_saas
 
         if is_saas:

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -40,14 +40,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
 
 
-def _plan_from_billing_features(tenant_id: str) -> str:
-    """Resolve plan from billing feature flags (SaaS partial-fallback path)."""
-    features = FeatureService.get_features(tenant_id)
-    if features.billing.enabled:
-        return features.billing.subscription.plan or CloudPlan.SANDBOX
-    return CloudPlan.SANDBOX
-
-
 class WorkspaceListQuery(BaseModel):
     page: int = Field(default=1, ge=1, le=99999)
     limit: int = Field(default=20, ge=1, le=100)
@@ -121,25 +113,23 @@ class TenantListApi(Resource):
         is_enterprise_only = dify_config.ENTERPRISE_ENABLED and not dify_config.BILLING_ENABLED
         is_saas = dify_config.EDITION == "CLOUD" and dify_config.BILLING_ENABLED
         tenant_plans: dict[str, SubscriptionPlan] = {}
-        use_legacy_feature_path = not is_enterprise_only and not is_saas
 
         if is_saas:
             tenant_ids = [tenant.id for tenant in tenants]
             if tenant_ids:
                 tenant_plans = BillingService.get_plan_bulk(tenant_ids)
-                # If bulk fetch returned empty for non-empty input, fall back to legacy path
                 if not tenant_plans:
                     logger.warning("get_plan_bulk returned empty result, falling back to legacy feature path")
-                    use_legacy_feature_path = True
 
         for tenant in tenants:
             plan: str = CloudPlan.SANDBOX
-            if is_saas and not use_legacy_feature_path:
+            if is_saas:
                 tenant_plan = tenant_plans.get(tenant.id)
                 if tenant_plan:
                     plan = tenant_plan["plan"] or CloudPlan.SANDBOX
                 else:
-                    plan = _plan_from_billing_features(tenant.id)
+                    features = FeatureService.get_features(tenant.id)
+                    plan = features.billing.subscription.plan or CloudPlan.SANDBOX
             elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
                 plan = features.billing.subscription.plan or CloudPlan.SANDBOX

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -125,12 +125,12 @@ class TenantListApi(Resource):
                     use_legacy_feature_path = True
 
         for tenant in tenants:
-            plan = CloudPlan.SANDBOX
+            plan: str = CloudPlan.SANDBOX.value
             if is_saas and not use_legacy_feature_path:
-                plan = tenant_plans.get(tenant.id, {}).get("plan", CloudPlan.SANDBOX)
+                plan = tenant_plans.get(tenant.id, {}).get("plan", CloudPlan.SANDBOX.value)
             elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
-                plan = features.billing.subscription.plan or CloudPlan.SANDBOX
+                plan = features.billing.subscription.plan or CloudPlan.SANDBOX.value
 
             # Create a dictionary with tenant attributes
             tenant_dict = {

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -130,7 +130,7 @@ class TenantListApi(Resource):
                 plan = tenant_plans.get(tenant.id, {}).get("plan", CloudPlan.SANDBOX)
             elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
-                plan = features.billing.subscription.plan if features.billing.enabled else CloudPlan.SANDBOX
+                plan = features.billing.subscription.plan or CloudPlan.SANDBOX
 
             # Create a dictionary with tenant attributes
             tenant_dict = {

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -118,10 +118,10 @@ class TenantListApi(Resource):
         if is_saas:
             tenant_ids = [tenant.id for tenant in tenants]
             if tenant_ids:
-                try:
-                    tenant_plans = BillingService.get_plan_bulk(tenant_ids)
-                except Exception:
-                    logger.exception("failed to fetch workspace plans in bulk, falling back to legacy feature path")
+                tenant_plans = BillingService.get_plan_bulk(tenant_ids)
+                # If bulk fetch returned empty for non-empty input, fall back to legacy path
+                if not tenant_plans:
+                    logger.warning("get_plan_bulk returned empty result, falling back to legacy feature path")
                     use_legacy_feature_path = True
 
         for tenant in tenants:

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from werkzeug.exceptions import Unauthorized
 
 import services
+from configs import dify_config
 from controllers.common.errors import (
     FilenameNotExistsError,
     FileTooLargeError,
@@ -108,9 +109,13 @@ class TenantListApi(Resource):
         current_user, current_tenant_id = current_account_with_tenant()
         tenants = TenantService.get_join_tenants(current_user)
         tenant_dicts = []
+        is_enterprise_only = dify_config.ENTERPRISE_ENABLED and not dify_config.BILLING_ENABLED
 
         for tenant in tenants:
-            features = FeatureService.get_features(tenant.id)
+            plan = CloudPlan.SANDBOX
+            if not is_enterprise_only:
+                features = FeatureService.get_features(tenant.id)
+                plan = features.billing.subscription.plan if features.billing.enabled else CloudPlan.SANDBOX
 
             # Create a dictionary with tenant attributes
             tenant_dict = {
@@ -118,7 +123,7 @@ class TenantListApi(Resource):
                 "name": tenant.name,
                 "status": tenant.status,
                 "created_at": tenant.created_at,
-                "plan": features.billing.subscription.plan if features.billing.enabled else CloudPlan.SANDBOX,
+                "plan": plan,
                 "current": tenant.id == current_tenant_id if current_tenant_id else False,
             }
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -30,6 +30,7 @@ from libs.helper import TimestampField
 from libs.login import current_account_with_tenant, login_required
 from models.account import Tenant, TenantStatus
 from services.account_service import TenantService
+from services.billing_service import BillingService
 from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
 from services.file_service import FileService
@@ -110,10 +111,24 @@ class TenantListApi(Resource):
         tenants = TenantService.get_join_tenants(current_user)
         tenant_dicts = []
         is_enterprise_only = dify_config.ENTERPRISE_ENABLED and not dify_config.BILLING_ENABLED
+        is_saas = dify_config.EDITION == "CLOUD" and dify_config.BILLING_ENABLED
+        tenant_plans: dict[str, dict] = {}
+        use_legacy_feature_path = not is_enterprise_only and not is_saas
+
+        if is_saas:
+            tenant_ids = [tenant.id for tenant in tenants]
+            if tenant_ids:
+                try:
+                    tenant_plans = BillingService.get_plan_bulk(tenant_ids)
+                except Exception:
+                    logger.exception("failed to fetch workspace plans in bulk, falling back to legacy feature path")
+                    use_legacy_feature_path = True
 
         for tenant in tenants:
             plan = CloudPlan.SANDBOX
-            if not is_enterprise_only:
+            if is_saas and not use_legacy_feature_path:
+                plan = tenant_plans.get(tenant.id, {}).get("plan", CloudPlan.SANDBOX)
+            elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
                 plan = features.billing.subscription.plan if features.billing.enabled else CloudPlan.SANDBOX
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -125,14 +125,14 @@ class TenantListApi(Resource):
                     use_legacy_feature_path = True
 
         for tenant in tenants:
-            plan: str = CloudPlan.SANDBOX.value
+            plan: str = CloudPlan.SANDBOX
             if is_saas and not use_legacy_feature_path:
                 tenant_plan = tenant_plans.get(tenant.id)
                 if tenant_plan:
-                    plan = tenant_plan["plan"] if tenant_plan["plan"] else CloudPlan.SANDBOX.value
+                    plan = tenant_plan["plan"] or CloudPlan.SANDBOX
             elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
-                plan = features.billing.subscription.plan or CloudPlan.SANDBOX.value
+                plan = features.billing.subscription.plan or CloudPlan.SANDBOX
 
             # Create a dictionary with tenant attributes
             tenant_dict = {

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
 
 
+def _plan_from_billing_features(tenant_id: str) -> str:
+    """Resolve plan from billing feature flags (SaaS partial-fallback path)."""
+    features = FeatureService.get_features(tenant_id)
+    if features.billing.enabled:
+        return features.billing.subscription.plan or CloudPlan.SANDBOX
+    return CloudPlan.SANDBOX
+
+
 class WorkspaceListQuery(BaseModel):
     page: int = Field(default=1, ge=1, le=99999)
     limit: int = Field(default=20, ge=1, le=100)
@@ -130,6 +138,8 @@ class TenantListApi(Resource):
                 tenant_plan = tenant_plans.get(tenant.id)
                 if tenant_plan:
                     plan = tenant_plan["plan"] or CloudPlan.SANDBOX
+                else:
+                    plan = _plan_from_billing_features(tenant.id)
             elif not is_enterprise_only:
                 features = FeatureService.get_features(tenant.id)
                 plan = features.billing.subscription.plan or CloudPlan.SANDBOX

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -84,7 +84,8 @@ class TestTenantListApi:
         get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
         get_features_mock.assert_not_called()
 
-    def test_get_saas_path_falls_back_to_sandbox_for_missing_tenant(self, app):
+    def test_get_saas_path_partial_fallback_for_missing_tenant_billing_disabled(self, app):
+        """Bulk omits a tenant: only that tenant uses FeatureService; billing off -> SANDBOX."""
         api = TenantListApi()
         method = unwrap(api.get)
 
@@ -100,6 +101,10 @@ class TestTenantListApi:
             status="active",
             created_at=datetime.utcnow(),
         )
+
+        features_t2 = MagicMock()
+        features_t2.billing.enabled = False
+        features_t2.billing.subscription.plan = CloudPlan.PROFESSIONAL
 
         with (
             app.test_request_context("/workspaces"),
@@ -117,7 +122,10 @@ class TestTenantListApi:
                 "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
                 return_value={"t1": {"plan": CloudPlan.TEAM, "expiration_date": 0}},
             ) as get_plan_bulk_mock,
-            patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
+            patch(
+                "controllers.console.workspace.workspace.FeatureService.get_features",
+                return_value=features_t2,
+            ) as get_features_mock,
         ):
             result, status = method(api)
 
@@ -125,7 +133,58 @@ class TestTenantListApi:
         assert result["workspaces"][0]["plan"] == CloudPlan.TEAM
         assert result["workspaces"][1]["plan"] == CloudPlan.SANDBOX
         get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
-        get_features_mock.assert_not_called()
+        get_features_mock.assert_called_once_with("t2")
+
+    def test_get_saas_path_partial_fallback_for_missing_tenant_billing_enabled(self, app):
+        """Bulk omits a tenant: FeatureService supplies plan when billing.enabled is true."""
+        api = TenantListApi()
+        method = unwrap(api.get)
+
+        tenant1 = MagicMock(
+            id="t1",
+            name="Tenant 1",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+        tenant2 = MagicMock(
+            id="t2",
+            name="Tenant 2",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+
+        features_t2 = MagicMock()
+        features_t2.billing.enabled = True
+        features_t2.billing.subscription.plan = CloudPlan.PROFESSIONAL
+
+        with (
+            app.test_request_context("/workspaces"),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t1")
+            ),
+            patch(
+                "controllers.console.workspace.workspace.TenantService.get_join_tenants",
+                return_value=[tenant1, tenant2],
+            ),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", True),
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "CLOUD"),
+            patch(
+                "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
+                return_value={"t1": {"plan": CloudPlan.TEAM, "expiration_date": 0}},
+            ) as get_plan_bulk_mock,
+            patch(
+                "controllers.console.workspace.workspace.FeatureService.get_features",
+                return_value=features_t2,
+            ) as get_features_mock,
+        ):
+            result, status = method(api)
+
+        assert status == 200
+        assert result["workspaces"][0]["plan"] == CloudPlan.TEAM
+        assert result["workspaces"][1]["plan"] == CloudPlan.PROFESSIONAL
+        get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
+        get_features_mock.assert_called_once_with("t2")
 
     def test_get_saas_path_falls_back_to_legacy_feature_path_on_bulk_error(self, app):
         """Test fallback to FeatureService when bulk billing returns empty result.

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -84,8 +84,8 @@ class TestTenantListApi:
         get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
         get_features_mock.assert_not_called()
 
-    def test_get_saas_path_partial_fallback_for_missing_tenant_billing_disabled(self, app):
-        """Bulk omits a tenant: only that tenant uses FeatureService; billing off -> SANDBOX."""
+    def test_get_saas_path_partial_fallback_for_missing_tenant_ignores_billing_enabled_mock(self, app):
+        """Bulk omits a tenant: plan comes from subscription only (SaaS billing.enabled is always true)."""
         api = TenantListApi()
         method = unwrap(api.get)
 
@@ -104,57 +104,6 @@ class TestTenantListApi:
 
         features_t2 = MagicMock()
         features_t2.billing.enabled = False
-        features_t2.billing.subscription.plan = CloudPlan.PROFESSIONAL
-
-        with (
-            app.test_request_context("/workspaces"),
-            patch(
-                "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t1")
-            ),
-            patch(
-                "controllers.console.workspace.workspace.TenantService.get_join_tenants",
-                return_value=[tenant1, tenant2],
-            ),
-            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
-            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", True),
-            patch("controllers.console.workspace.workspace.dify_config.EDITION", "CLOUD"),
-            patch(
-                "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
-                return_value={"t1": {"plan": CloudPlan.TEAM, "expiration_date": 0}},
-            ) as get_plan_bulk_mock,
-            patch(
-                "controllers.console.workspace.workspace.FeatureService.get_features",
-                return_value=features_t2,
-            ) as get_features_mock,
-        ):
-            result, status = method(api)
-
-        assert status == 200
-        assert result["workspaces"][0]["plan"] == CloudPlan.TEAM
-        assert result["workspaces"][1]["plan"] == CloudPlan.SANDBOX
-        get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
-        get_features_mock.assert_called_once_with("t2")
-
-    def test_get_saas_path_partial_fallback_for_missing_tenant_billing_enabled(self, app):
-        """Bulk omits a tenant: FeatureService supplies plan when billing.enabled is true."""
-        api = TenantListApi()
-        method = unwrap(api.get)
-
-        tenant1 = MagicMock(
-            id="t1",
-            name="Tenant 1",
-            status="active",
-            created_at=datetime.utcnow(),
-        )
-        tenant2 = MagicMock(
-            id="t2",
-            name="Tenant 2",
-            status="active",
-            created_at=datetime.utcnow(),
-        )
-
-        features_t2 = MagicMock()
-        features_t2.billing.enabled = True
         features_t2.billing.subscription.plan = CloudPlan.PROFESSIONAL
 
         with (

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -36,7 +36,7 @@ def unwrap(func):
 
 
 class TestTenantListApi:
-    def test_get_success(self, app):
+    def test_get_success_saas_path(self, app):
         api = TenantListApi()
         method = unwrap(api.get)
 
@@ -66,15 +66,21 @@ class TestTenantListApi:
                 "controllers.console.workspace.workspace.TenantService.get_join_tenants",
                 return_value=[tenant1, tenant2],
             ),
-            patch("controllers.console.workspace.workspace.FeatureService.get_features", return_value=features),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", True),
+            patch("controllers.console.workspace.workspace.FeatureService.get_features", return_value=features) as get_features_mock,
         ):
             result, status = method(api)
 
         assert status == 200
         assert len(result["workspaces"]) == 2
         assert result["workspaces"][0]["current"] is True
+        assert result["workspaces"][0]["plan"] == CloudPlan.SANDBOX
+        assert get_features_mock.call_count == 2
+        get_features_mock.assert_any_call("t1")
+        get_features_mock.assert_any_call("t2")
 
-    def test_get_billing_disabled(self, app):
+    def test_get_billing_disabled_community_path(self, app):
         api = TenantListApi()
         method = unwrap(api.get)
 
@@ -98,15 +104,80 @@ class TestTenantListApi:
                 "controllers.console.workspace.workspace.TenantService.get_join_tenants",
                 return_value=[tenant],
             ),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", False),
             patch(
                 "controllers.console.workspace.workspace.FeatureService.get_features",
                 return_value=features,
-            ),
+            ) as get_features_mock,
         ):
             result, status = method(api)
 
         assert status == 200
         assert result["workspaces"][0]["plan"] == CloudPlan.SANDBOX
+        get_features_mock.assert_called_once_with("t1")
+
+    def test_get_enterprise_only_skips_feature_service(self, app):
+        api = TenantListApi()
+        method = unwrap(api.get)
+
+        tenant1 = MagicMock(
+            id="t1",
+            name="Tenant 1",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+        tenant2 = MagicMock(
+            id="t2",
+            name="Tenant 2",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+
+        with (
+            app.test_request_context("/workspaces"),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t2")
+            ),
+            patch(
+                "controllers.console.workspace.workspace.TenantService.get_join_tenants",
+                return_value=[tenant1, tenant2],
+            ),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", True),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", False),
+            patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
+        ):
+            result, status = method(api)
+
+        assert status == 200
+        assert result["workspaces"][0]["plan"] == CloudPlan.SANDBOX
+        assert result["workspaces"][1]["plan"] == CloudPlan.SANDBOX
+        assert result["workspaces"][0]["current"] is False
+        assert result["workspaces"][1]["current"] is True
+        get_features_mock.assert_not_called()
+
+    def test_get_enterprise_only_with_empty_tenants(self, app):
+        api = TenantListApi()
+        method = unwrap(api.get)
+
+        with (
+            app.test_request_context("/workspaces"),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), None)
+            ),
+            patch(
+                "controllers.console.workspace.workspace.TenantService.get_join_tenants",
+                return_value=[],
+            ),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", True),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", False),
+            patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
+        ):
+            result, status = method(api)
+
+        assert status == 200
+        assert result["workspaces"] == []
+        get_features_mock.assert_not_called()
 
 
 class TestWorkspaceListApi:

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -84,8 +84,12 @@ class TestTenantListApi:
         get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
         get_features_mock.assert_not_called()
 
-    def test_get_saas_path_partial_fallback_for_missing_tenant_ignores_billing_enabled_mock(self, app):
-        """Bulk omits a tenant: plan comes from subscription only (SaaS billing.enabled is always true)."""
+    def test_get_saas_path_partial_fallback_does_not_gate_plan_on_billing_enabled(self, app):
+        """Bulk omits a tenant: resolve plan via subscription.plan only; billing.enabled is not used.
+
+        billing.enabled is mocked False to prove the endpoint does not gate on it for this path
+        (SaaS contract treats enabled as on; display follows subscription.plan).
+        """
         api = TenantListApi()
         method = unwrap(api.get)
 

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -128,6 +128,11 @@ class TestTenantListApi:
         get_features_mock.assert_not_called()
 
     def test_get_saas_path_falls_back_to_legacy_feature_path_on_bulk_error(self, app):
+        """Test fallback to FeatureService when bulk billing returns empty result.
+
+        BillingService.get_plan_bulk catches exceptions internally and returns empty dict,
+        so we simulate the real failure mode by returning empty dict for non-empty input.
+        """
         api = TenantListApi()
         method = unwrap(api.get)
 
@@ -162,13 +167,13 @@ class TestTenantListApi:
             patch("controllers.console.workspace.workspace.dify_config.EDITION", "CLOUD"),
             patch(
                 "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
-                side_effect=RuntimeError("billing down"),
+                return_value={},  # Simulates real failure: empty result for non-empty input
             ) as get_plan_bulk_mock,
             patch(
                 "controllers.console.workspace.workspace.FeatureService.get_features",
                 return_value=features,
             ) as get_features_mock,
-            patch("controllers.console.workspace.workspace.logger.exception") as logger_exception_mock,
+            patch("controllers.console.workspace.workspace.logger.warning") as logger_warning_mock,
         ):
             result, status = method(api)
 
@@ -177,7 +182,7 @@ class TestTenantListApi:
         assert result["workspaces"][1]["plan"] == CloudPlan.TEAM
         get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
         assert get_features_mock.call_count == 2
-        logger_exception_mock.assert_called_once()
+        logger_warning_mock.assert_called_once()
 
     def test_get_billing_disabled_community_path(self, app):
         api = TenantListApi()
@@ -192,6 +197,7 @@ class TestTenantListApi:
 
         features = MagicMock()
         features.billing.enabled = False
+        features.billing.subscription.plan = CloudPlan.SANDBOX
 
         with (
             app.test_request_context("/workspaces"),

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -53,9 +53,53 @@ class TestTenantListApi:
             created_at=datetime.utcnow(),
         )
 
-        features = MagicMock()
-        features.billing.enabled = True
-        features.billing.subscription.plan = CloudPlan.SANDBOX
+        with (
+            app.test_request_context("/workspaces"),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t1")
+            ),
+            patch(
+                "controllers.console.workspace.workspace.TenantService.get_join_tenants",
+                return_value=[tenant1, tenant2],
+            ),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", True),
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "CLOUD"),
+            patch(
+                "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
+                return_value={
+                    "t1": {"plan": CloudPlan.TEAM, "expiration_date": 0},
+                    "t2": {"plan": CloudPlan.PROFESSIONAL, "expiration_date": 0},
+                },
+            ) as get_plan_bulk_mock,
+            patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
+        ):
+            result, status = method(api)
+
+        assert status == 200
+        assert len(result["workspaces"]) == 2
+        assert result["workspaces"][0]["current"] is True
+        assert result["workspaces"][0]["plan"] == CloudPlan.TEAM
+        assert result["workspaces"][1]["plan"] == CloudPlan.PROFESSIONAL
+        get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
+        get_features_mock.assert_not_called()
+
+    def test_get_saas_path_falls_back_to_sandbox_for_missing_tenant(self, app):
+        api = TenantListApi()
+        method = unwrap(api.get)
+
+        tenant1 = MagicMock(
+            id="t1",
+            name="Tenant 1",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+        tenant2 = MagicMock(
+            id="t2",
+            name="Tenant 2",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
 
         with (
             app.test_request_context("/workspaces"),
@@ -68,17 +112,72 @@ class TestTenantListApi:
             ),
             patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
             patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", True),
-            patch("controllers.console.workspace.workspace.FeatureService.get_features", return_value=features) as get_features_mock,
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "CLOUD"),
+            patch(
+                "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
+                return_value={"t1": {"plan": CloudPlan.TEAM, "expiration_date": 0}},
+            ) as get_plan_bulk_mock,
+            patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
         ):
             result, status = method(api)
 
         assert status == 200
-        assert len(result["workspaces"]) == 2
-        assert result["workspaces"][0]["current"] is True
-        assert result["workspaces"][0]["plan"] == CloudPlan.SANDBOX
+        assert result["workspaces"][0]["plan"] == CloudPlan.TEAM
+        assert result["workspaces"][1]["plan"] == CloudPlan.SANDBOX
+        get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
+        get_features_mock.assert_not_called()
+
+    def test_get_saas_path_falls_back_to_legacy_feature_path_on_bulk_error(self, app):
+        api = TenantListApi()
+        method = unwrap(api.get)
+
+        tenant1 = MagicMock(
+            id="t1",
+            name="Tenant 1",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+        tenant2 = MagicMock(
+            id="t2",
+            name="Tenant 2",
+            status="active",
+            created_at=datetime.utcnow(),
+        )
+
+        features = MagicMock()
+        features.billing.enabled = True
+        features.billing.subscription.plan = CloudPlan.TEAM
+
+        with (
+            app.test_request_context("/workspaces"),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t2")
+            ),
+            patch(
+                "controllers.console.workspace.workspace.TenantService.get_join_tenants",
+                return_value=[tenant1, tenant2],
+            ),
+            patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", True),
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "CLOUD"),
+            patch(
+                "controllers.console.workspace.workspace.BillingService.get_plan_bulk",
+                side_effect=RuntimeError("billing down"),
+            ) as get_plan_bulk_mock,
+            patch(
+                "controllers.console.workspace.workspace.FeatureService.get_features",
+                return_value=features,
+            ) as get_features_mock,
+            patch("controllers.console.workspace.workspace.logger.exception") as logger_exception_mock,
+        ):
+            result, status = method(api)
+
+        assert status == 200
+        assert result["workspaces"][0]["plan"] == CloudPlan.TEAM
+        assert result["workspaces"][1]["plan"] == CloudPlan.TEAM
+        get_plan_bulk_mock.assert_called_once_with(["t1", "t2"])
         assert get_features_mock.call_count == 2
-        get_features_mock.assert_any_call("t1")
-        get_features_mock.assert_any_call("t2")
+        logger_exception_mock.assert_called_once()
 
     def test_get_billing_disabled_community_path(self, app):
         api = TenantListApi()
@@ -106,6 +205,7 @@ class TestTenantListApi:
             ),
             patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", False),
             patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "SELF_HOSTED"),
             patch(
                 "controllers.console.workspace.workspace.FeatureService.get_features",
                 return_value=features,
@@ -145,6 +245,7 @@ class TestTenantListApi:
             ),
             patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", True),
             patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "SELF_HOSTED"),
             patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
         ):
             result, status = method(api)
@@ -171,6 +272,7 @@ class TestTenantListApi:
             ),
             patch("controllers.console.workspace.workspace.dify_config.ENTERPRISE_ENABLED", True),
             patch("controllers.console.workspace.workspace.dify_config.BILLING_ENABLED", False),
+            patch("controllers.console.workspace.workspace.dify_config.EDITION", "SELF_HOSTED"),
             patch("controllers.console.workspace.workspace.FeatureService.get_features") as get_features_mock,
         ):
             result, status = method(api)

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -145,7 +145,7 @@ class TestTenantListApi:
         )
 
         features = MagicMock()
-        features.billing.enabled = True
+        features.billing.enabled = False
         features.billing.subscription.plan = CloudPlan.TEAM
 
         with (


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

Fixes #33718

## Summary

Optimizes the console **`GET /workspaces`** (`TenantListApi`) plan resolution by **deployment mode** (SaaS vs enterprise-only vs community/self-hosted). On the **SaaS happy path**, it replaces per-tenant `FeatureService.get_features` with a single `BillingService.get_plan_bulk` call. It adds **tiered fallbacks** when bulk billing data is **partially missing** or **empty**.

## Motivation

Previously, every joined workspace triggered `FeatureService.get_features(tenant_id)` mainly to derive `plan`, increasing fan-out into billing-related resolution. SaaS benefits from bulk plan fetch; enterprise-only deployments (`ENTERPRISE_ENABLED` + `!BILLING_ENABLED`) do not need billing-backed feature resolution for this field.

## What changed

### 1. Explicit deployment-path branching

- `is_enterprise_only = ENTERPRISE_ENABLED && !BILLING_ENABLED`
- `is_saas = EDITION == "CLOUD" && BILLING_ENABLED`

Plan resolution is chosen deterministically by these flags for clarity and testability.

### 2. SaaS: bulk plan retrieval (happy path)

- In SaaS mode, collect all joined `tenant_id`s and call `BillingService.get_plan_bulk(tenant_ids)` **once**.
- For tenants present in the bulk map, `plan` comes from bulk (`plan` with `CloudPlan.SANDBOX` when empty).

### 3. SaaS: partial fallback (tenant missing from bulk map)

- If bulk returns a **non-empty** map but **omits** some tenant IDs, only those missing tenants call `FeatureService.get_features` via `_plan_from_billing_features`.
- Partial path semantics: **`billing.enabled` gates** plan display — disabled → `CloudPlan.SANDBOX`; enabled → `subscription.plan or CloudPlan.SANDBOX`.

### 4. SaaS: full fallback (empty bulk for non-empty input)

- `get_plan_bulk` may swallow errors internally and return `{}`. When `tenant_ids` is non-empty but the merged bulk result is **empty**, log a **warning** and use the **legacy per-tenant** path for **all** tenants.

### 5. Legacy / community (and SaaS full fallback)

- Uses `features.billing.subscription.plan or CloudPlan.SANDBOX` (**no** `billing.enabled` gate on this path).

### 6. Enterprise-only shortcut

- When `is_enterprise_only`, skip `FeatureService`; `plan` remains `CloudPlan.SANDBOX` (consistent with prior behavior for this endpoint).

## Files changed

- `api/controllers/console/workspace/workspace.py`
- `api/tests/unit_tests/controllers/console/workspace/test_workspace.py`

## Test coverage

- SaaS happy path: `get_plan_bulk` called once; `FeatureService` not used when all tenants are covered by bulk.
- SaaS partial omission: `FeatureService` called **only** for missing tenant(s); covers `billing.enabled` true/false.
- SaaS empty bulk: full legacy path; per-tenant `FeatureService`; warning logged.
- Community (`BILLING_ENABLED=false`, self-hosted): expectations unchanged.
- Enterprise-only: no `FeatureService`; default plan; empty tenant list covered.

## Risk / notes for reviewers

- Bulk `plan` is still assumed to match product expectations when billing would be “enabled”; partial fallback re-applies `billing.enabled` **only** for tenant IDs **omitted** from bulk.
- `get_plan_bulk` error handling lives inside `BillingService`; the controller treats an **empty aggregate result** as the signal for full fallback.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added tests for the paths introduced/changed.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) as required by the repo