### PR TITLE
fix(api): avoid OpenSearch import collision with local events package

### DIFF
--- a/api/events/__init__.py
+++ b/api/events/__init__.py
@@ -7,7 +7,10 @@ class _EventHook:
         return self
 
     def __isub__(self, handler):
-        self._handlers.remove(handler)
+        try:
+            self._handlers.remove(handler)
+        except ValueError:
+            pass
         return self
 
     def __call__(self, *args, **kwargs):

--- a/api/events/__init__.py
+++ b/api/events/__init__.py
@@ -1,0 +1,22 @@
+class _EventHook:
+    def __init__(self):
+        self._handlers = []
+
+    def __iadd__(self, handler):
+        self._handlers.append(handler)
+        return self
+
+    def __isub__(self, handler):
+        self._handlers.remove(handler)
+        return self
+
+    def __call__(self, *args, **kwargs):
+        for handler in list(self._handlers):
+            handler(*args, **kwargs)
+
+
+class Events:
+    def __getattr__(self, name):
+        hook = _EventHook()
+        setattr(self, name, hook)
+        return hook

--- a/api/tests/unit_tests/events/test_events_compat.py
+++ b/api/tests/unit_tests/events/test_events_compat.py
@@ -1,0 +1,16 @@
+def test_local_events_exports_compat_events_class():
+    import events
+
+    evt = events.Events()
+    called = []
+
+    evt.request_start += lambda *args, **kwargs: called.append((args, kwargs))
+    evt.request_start("GET", "/_search")
+
+    assert len(called) == 1
+
+
+def test_opensearch_import_works_with_local_events_package():
+    from opensearchpy import OpenSearch
+
+    assert OpenSearch is not None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #33818.

This PR fixes an import collision between Dify's local `events` package and `opensearch-py`.

When OpenSearch support is imported inside Dify's `api` package, Python resolves `events`
to Dify's local `api/events` package instead of the third-party `Events` library expected
by `opensearch-py`, which causes:

`ImportError: cannot import name 'Events' from 'events'`

This change adds a minimal compatibility `Events` implementation in `api/events/__init__.py`
and includes regression tests to verify that importing `OpenSearch` works correctly in the
presence of Dify's local `events` package.

## Screenshots

N/A (backend-only fix, no UI changes)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods