### PR TITLE
refactor(api): type workflow service dicts with TypedDict

### DIFF
--- a/api/services/workflow/workflow_converter.py
+++ b/api/services/workflow/workflow_converter.py
@@ -1,5 +1,7 @@
 import json
-from typing import Any, TypedDict
+from typing import Any
+
+from typing_extensions import TypedDict
 
 from core.app.app_config.entities import (
     DatasetEntity,
@@ -32,6 +34,17 @@ class _NodeType(TypedDict):
     id: str
     position: None
     data: dict[str, Any]
+
+
+class _EdgeType(TypedDict):
+    id: str
+    source: str
+    target: str
+
+
+class WorkflowGraph(TypedDict):
+    nodes: list[_NodeType]
+    edges: list[_EdgeType]
 
 
 class WorkflowConverter:
@@ -107,7 +120,7 @@ class WorkflowConverter:
         app_config = self._convert_to_app_config(app_model=app_model, app_model_config=app_model_config)
 
         # init workflow graph
-        graph: dict[str, Any] = {"nodes": [], "edges": []}
+        graph: WorkflowGraph = {"nodes": [], "edges": []}
 
         # Convert list:
         # - variables -> start
@@ -385,7 +398,7 @@ class WorkflowConverter:
         self,
         original_app_mode: AppMode,
         new_app_mode: AppMode,
-        graph: dict,
+        graph: WorkflowGraph,
         model_config: ModelConfigEntity,
         prompt_template: PromptTemplateEntity,
         file_upload: FileUploadConfig | None = None,
@@ -595,7 +608,7 @@ class WorkflowConverter:
             "data": {"title": "ANSWER", "type": BuiltinNodeTypes.ANSWER, "answer": "{{#llm.text#}}"},
         }
 
-    def _create_edge(self, source: str, target: str):
+    def _create_edge(self, source: str, target: str) -> _EdgeType:
         """
         Create Edge
         :param source: source node id
@@ -604,7 +617,7 @@ class WorkflowConverter:
         """
         return {"id": f"{source}-{target}", "source": source, "target": target}
 
-    def _append_node(self, graph: dict[str, Any], node: _NodeType):
+    def _append_node(self, graph: WorkflowGraph, node: _NodeType):
         """
         Append Node to Graph
 

--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session
+from typing_extensions import TypedDict
 
 from dify_graph.enums import WorkflowExecutionStatus
 from models import Account, App, EndUser, TenantAccountJoin, WorkflowAppLog, WorkflowArchiveLog, WorkflowRun
@@ -12,6 +13,10 @@ from models.enums import AppTriggerType, CreatorUserRole
 from models.trigger import WorkflowTriggerLog
 from services.plugin.plugin_service import PluginService
 from services.workflow.entities import TriggerMetadata
+
+
+class LogViewDetails(TypedDict):
+    trigger_metadata: dict[str, Any] | None
 
 
 # Since the workflow_app_log table has exceeded 100 million records, we use an additional details field to extend it
@@ -22,12 +27,12 @@ class LogView:
     - Proxies all other attributes to the underlying `WorkflowAppLog`
     """
 
-    def __init__(self, log: WorkflowAppLog, details: dict | None):
+    def __init__(self, log: WorkflowAppLog, details: LogViewDetails | None):
         self.log = log
         self.details_ = details
 
     @property
-    def details(self) -> dict | None:
+    def details(self) -> LogViewDetails | None:
         return self.details_
 
     def __getattr__(self, name):


### PR DESCRIPTION
## Summary
- Add `_EdgeType`, `WorkflowGraph` TypedDicts in `workflow_converter.py` and use them for graph init, `_convert_to_llm_node`, `_append_node`, and `_create_edge` return type
- Add `LogViewDetails` TypedDict in `workflow_app_service.py` and use it for `LogView` details field
- Move `TypedDict` import to `typing_extensions` for Pydantic compatibility in `workflow_converter.py`

## What this PR does NOT change
Bare `dict` params in `workflow_service.py` and `workflow_run_service.py` where dicts are opaque API-boundary inputs (e.g. `graph`, `features`, `node_data`, `args` from `model_dump()`) are intentionally left as-is since no fixed shape is known or TypedDict would cause basedpyright errors at call sites.

## Test plan
- [x] `make type-check` passes (basedpyright + pyrefly + mypy)
- [x] `ruff check` passes
- [x] Existing unit tests pass (43 passed)

Part of #32863 (workflow services portion)