### PR TITLE
refactor: use EnumText for Conversation/Message invoke_from and from_source

### DIFF
--- a/api/core/app/apps/message_based_app_generator.py
+++ b/api/core/app/apps/message_based_app_generator.py
@@ -33,7 +33,7 @@ from extensions.ext_redis import get_pubsub_broadcast_channel
 from libs.broadcast_channel.channel import Topic
 from libs.datetime_utils import naive_utc_now
 from models import Account
-from models.enums import CreatorUserRole, MessageFileBelongsTo
+from models.enums import ConversationFromSource, CreatorUserRole, MessageFileBelongsTo
 from models.model import App, AppMode, AppModelConfig, Conversation, EndUser, Message, MessageFile
 from services.errors.app_model_config import AppModelConfigBrokenError
 from services.errors.conversation import ConversationNotExistsError
@@ -130,10 +130,10 @@ class MessageBasedAppGenerator(BaseAppGenerator):
         end_user_id = None
         account_id = None
         if application_generate_entity.invoke_from in {InvokeFrom.WEB_APP, InvokeFrom.SERVICE_API}:
-            from_source = "api"
+            from_source = ConversationFromSource.API
             end_user_id = application_generate_entity.user_id
         else:
-            from_source = "console"
+            from_source = ConversationFromSource.CONSOLE
             account_id = application_generate_entity.user_id
 
         if isinstance(application_generate_entity, AdvancedChatAppGenerateEntity):

--- a/api/core/app/features/annotation_reply/annotation_reply.py
+++ b/api/core/app/features/annotation_reply/annotation_reply.py
@@ -6,7 +6,7 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from core.rag.datasource.vdb.vector_factory import Vector
 from extensions.ext_database import db
 from models.dataset import Dataset
-from models.enums import CollectionBindingType
+from models.enums import CollectionBindingType, ConversationFromSource
 from models.model import App, AppAnnotationSetting, Message, MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.dataset_service import DatasetCollectionBindingService
@@ -68,9 +68,9 @@ class AnnotationReplyFeature:
                 annotation = AppAnnotationService.get_annotation_by_id(annotation_id)
                 if annotation:
                     if invoke_from in {InvokeFrom.SERVICE_API, InvokeFrom.WEB_APP}:
-                        from_source = "api"
+                        from_source = ConversationFromSource.API
                     else:
-                        from_source = "console"
+                        from_source = ConversationFromSource.CONSOLE
 
                     # insert annotation history
                     AppAnnotationService.add_annotation_history(

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -34,10 +34,12 @@ from .enums import (
     AppMCPServerStatus,
     AppStatus,
     BannerStatus,
+    ConversationFromSource,
     ConversationStatus,
     CreatorUserRole,
     FeedbackFromSource,
     FeedbackRating,
+    InvokeFrom,
     MessageChainType,
     MessageFileBelongsTo,
     MessageStatus,
@@ -1022,10 +1024,14 @@ class Conversation(Base):
     #
     # Its value corresponds to the members of `InvokeFrom`.
     # (api/core/app/entities/app_invoke_entities.py)
-    invoke_from = mapped_column(String(255), nullable=True)
+    invoke_from: Mapped[InvokeFrom | None] = mapped_column(
+        EnumText(InvokeFrom, length=255), nullable=True
+    )
 
     # ref: ConversationSource.
-    from_source: Mapped[str] = mapped_column(String(255), nullable=False)
+    from_source: Mapped[ConversationFromSource] = mapped_column(
+        EnumText(ConversationFromSource, length=255), nullable=False
+    )
     from_end_user_id = mapped_column(StringUUID)
     from_account_id = mapped_column(StringUUID)
     read_at = mapped_column(sa.DateTime)
@@ -1374,8 +1380,10 @@ class Message(Base):
     )
     error: Mapped[str | None] = mapped_column(LongText)
     message_metadata: Mapped[str | None] = mapped_column(LongText)
-    invoke_from: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    from_source: Mapped[str] = mapped_column(String(255), nullable=False)
+    invoke_from: Mapped[InvokeFrom | None] = mapped_column(EnumText(InvokeFrom, length=255), nullable=True)
+    from_source: Mapped[ConversationFromSource] = mapped_column(
+        EnumText(ConversationFromSource, length=255), nullable=False
+    )
     from_end_user_id: Mapped[str | None] = mapped_column(StringUUID)
     from_account_id: Mapped[str | None] = mapped_column(StringUUID)
     created_at: Mapped[datetime] = mapped_column(sa.DateTime, server_default=func.current_timestamp())

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1024,9 +1024,7 @@ class Conversation(Base):
     #
     # Its value corresponds to the members of `InvokeFrom`.
     # (api/core/app/entities/app_invoke_entities.py)
-    invoke_from: Mapped[InvokeFrom | None] = mapped_column(
-        EnumText(InvokeFrom, length=255), nullable=True
-    )
+    invoke_from: Mapped[InvokeFrom | None] = mapped_column(EnumText(InvokeFrom, length=255), nullable=True)
 
     # ref: ConversationSource.
     from_source: Mapped[ConversationFromSource] = mapped_column(

--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -35,7 +35,7 @@ from factories.variable_factory import build_segment, segment_to_variable
 from libs.datetime_utils import naive_utc_now
 from libs.uuid_utils import uuidv7
 from models import Account, App, Conversation
-from models.enums import DraftVariableType
+from models.enums import ConversationFromSource, DraftVariableType
 from models.workflow import Workflow, WorkflowDraftVariable, WorkflowDraftVariableFile, is_system_variable_editable
 from repositories.factory import DifyAPIRepositoryFactory
 from services.file_service import FileService
@@ -601,7 +601,7 @@ class WorkflowDraftVariableService:
             system_instruction_tokens=0,
             status="normal",
             invoke_from=InvokeFrom.DEBUGGER,
-            from_source="console",
+            from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,
             from_account_id=account_id,
         )

--- a/api/tests/integration_tests/controllers/console/app/test_chat_message_permissions.py
+++ b/api/tests/integration_tests/controllers/console/app/test_chat_message_permissions.py
@@ -13,6 +13,7 @@ from controllers.console.app import wraps
 from libs.datetime_utils import naive_utc_now
 from models import App, Tenant
 from models.account import Account, TenantAccountJoin, TenantAccountRole
+from models.enums import ConversationFromSource
 from models.model import AppMode
 from services.app_generate_service import AppGenerateService
 
@@ -154,7 +155,7 @@ class TestChatMessageApiPermissions:
             re_sign_file_url_answer="",
             answer_tokens=0,
             provider_response_latency=0.0,
-            from_source="console",
+            from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,
             from_account_id=mock_account.id,
             feedbacks=[],

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
@@ -13,7 +13,7 @@ from libs.datetime_utils import naive_utc_now
 from libs.token import _real_cookie_name, generate_csrf_token
 from models import Account, DifySetup, Tenant, TenantAccountJoin
 from models.account import AccountStatus, TenantAccountRole
-from models.enums import CreatorUserRole
+from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import App, AppMode, Conversation, Message
 from models.workflow import WorkflowRun
 from services.account_service import AccountService
@@ -75,7 +75,7 @@ def _create_conversation(db_session: Session, app_id: str, account_id: str) -> C
         inputs={},
         status="normal",
         mode=AppMode.CHAT,
-        from_source=CreatorUserRole.ACCOUNT,
+        from_source=ConversationFromSource.CONSOLE,
         from_account_id=account_id,
     )
     db_session.add(conversation)
@@ -124,7 +124,7 @@ def _create_message(
         answer_price_unit=0.001,
         currency="USD",
         status="normal",
-        from_source=CreatorUserRole.ACCOUNT,
+        from_source=ConversationFromSource.CONSOLE,
         from_account_id=account_id,
         workflow_run_id=workflow_run_id,
         inputs={"query": "Hello"},

--- a/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
+++ b/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from dify_graph.nodes.human_input.entities import FormDefinition, UserAction
 from models.account import Account, Tenant, TenantAccountJoin
+from models.enums import ConversationFromSource, InvokeFrom
 from models.execution_extra_content import HumanInputContent
 from models.human_input import HumanInputForm, HumanInputFormStatus
 from models.model import App, Conversation, Message
@@ -78,8 +79,8 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         introduction="",
         system_instruction="",
         status="normal",
-        invoke_from="console",
-        from_source="console",
+        invoke_from=InvokeFrom.EXPLORE,
+        from_source=ConversationFromSource.CONSOLE,
         from_account_id=account.id,
         from_end_user_id=None,
     )
@@ -101,7 +102,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         answer_unit_price=Decimal("0.001"),
         provider_response_latency=0.5,
         currency="USD",
-        from_source="console",
+        from_source=ConversationFromSource.CONSOLE,
         from_account_id=account.id,
         workflow_run_id=workflow_run_id,
     )

--- a/api/tests/test_containers_integration_tests/services/test_agent_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_agent_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from core.plugin.impl.exc import PluginDaemonClientSideError
 from models import Account
-from models.enums import MessageFileBelongsTo
+from models.enums import ConversationFromSource, MessageFileBelongsTo
 from models.model import AppModelConfig, Conversation, EndUser, Message, MessageAgentThought
 from services.account_service import AccountService, TenantService
 from services.agent_service import AgentService
@@ -165,7 +165,7 @@ class TestAgentService:
             inputs={},
             status="normal",
             mode="chat",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(conversation)
         db_session_with_containers.commit()
@@ -204,7 +204,7 @@ class TestAgentService:
             answer_unit_price=0.001,
             provider_response_latency=1.5,
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(message)
         db_session_with_containers.commit()
@@ -406,7 +406,7 @@ class TestAgentService:
             inputs={},
             status="normal",
             mode="chat",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(conversation)
         db_session_with_containers.commit()
@@ -445,7 +445,7 @@ class TestAgentService:
             answer_unit_price=0.001,
             provider_response_latency=1.5,
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(message)
         db_session_with_containers.commit()
@@ -478,7 +478,7 @@ class TestAgentService:
             inputs={},
             status="normal",
             mode="chat",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(conversation)
         db_session_with_containers.commit()
@@ -517,7 +517,7 @@ class TestAgentService:
             answer_unit_price=0.001,
             provider_response_latency=1.5,
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(message)
         db_session_with_containers.commit()
@@ -624,7 +624,7 @@ class TestAgentService:
             inputs={},
             status="normal",
             mode="chat",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             app_model_config_id=None,  # Explicitly set to None
         )
         db_session_with_containers.add(conversation)
@@ -647,7 +647,7 @@ class TestAgentService:
             answer_unit_price=0.001,
             provider_response_latency=1.5,
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         db_session_with_containers.add(message)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/test_annotation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_annotation_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from models import Account
+from models.enums import ConversationFromSource, InvokeFrom
 from models.model import MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.app_service import AppService
@@ -136,8 +137,8 @@ class TestAnnotationService:
             system_instruction="",
             system_instruction_tokens=0,
             status="normal",
-            invoke_from="console",
-            from_source="console",
+            invoke_from=InvokeFrom.EXPLORE,
+            from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,
             from_account_id=account.id,
         )
@@ -174,8 +175,8 @@ class TestAnnotationService:
             provider_response_latency=0,
             total_price=0,
             currency="USD",
-            invoke_from="console",
-            from_source="console",
+            invoke_from=InvokeFrom.EXPLORE,
+            from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,
             from_account_id=account.id,
         )
@@ -721,7 +722,7 @@ class TestAnnotationService:
                 query=f"Query {i}: {fake.sentence()}",
                 user_id=account.id,
                 message_id=fake.uuid4(),
-                from_source="console",
+                from_source=ConversationFromSource.CONSOLE,
                 score=0.8 + (i * 0.1),
             )
 
@@ -772,7 +773,7 @@ class TestAnnotationService:
             query=query,
             user_id=account.id,
             message_id=message_id,
-            from_source="console",
+            from_source=ConversationFromSource.CONSOLE,
             score=score,
         )
 

--- a/api/tests/test_containers_integration_tests/services/test_conversation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_conversation_service.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from models.account import Account, Tenant, TenantAccountJoin
+from models.enums import ConversationFromSource
 from models.model import App, Conversation, EndUser, Message, MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.conversation_service import ConversationService
@@ -107,7 +108,7 @@ class ConversationServiceIntegrationTestDataFactory:
             system_instruction_tokens=0,
             status="normal",
             invoke_from=invoke_from.value,
-            from_source="api" if isinstance(user, EndUser) else "console",
+            from_source=ConversationFromSource.API if isinstance(user, EndUser) else ConversationFromSource.CONSOLE,
             from_end_user_id=user.id if isinstance(user, EndUser) else None,
             from_account_id=user.id if isinstance(user, Account) else None,
             dialogue_count=0,
@@ -154,7 +155,7 @@ class ConversationServiceIntegrationTestDataFactory:
             currency="USD",
             status="normal",
             invoke_from=InvokeFrom.WEB_APP.value,
-            from_source="api" if isinstance(user, EndUser) else "console",
+            from_source=ConversationFromSource.API if isinstance(user, EndUser) else ConversationFromSource.CONSOLE,
             from_end_user_id=user.id if isinstance(user, EndUser) else None,
             from_account_id=user.id if isinstance(user, Account) else None,
         )

--- a/api/tests/test_containers_integration_tests/services/test_message_export_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_export_service.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
-from models.enums import FeedbackFromSource, FeedbackRating
+from models.enums import ConversationFromSource, FeedbackFromSource, FeedbackRating
 from models.model import (
     App,
     AppAnnotationHitHistory,
@@ -94,7 +94,7 @@ class TestAppMessageExportServiceIntegration:
             name="conv",
             inputs={"seed": 1},
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid.uuid4()),
         )
         session.add(conversation)
@@ -129,7 +129,7 @@ class TestAppMessageExportServiceIntegration:
             total_price=Decimal("0.003"),
             currency="USD",
             message_metadata=message_metadata,
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=conversation.from_end_user_id,
             created_at=created_at,
         )

--- a/api/tests/test_containers_integration_tests/services/test_message_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_service.py
@@ -4,7 +4,7 @@ import pytest
 from faker import Faker
 from sqlalchemy.orm import Session
 
-from models.enums import FeedbackRating
+from models.enums import ConversationFromSource, FeedbackRating, InvokeFrom
 from models.model import MessageFeedback
 from services.app_service import AppService
 from services.errors.message import (
@@ -149,8 +149,8 @@ class TestMessageService:
             system_instruction="",
             system_instruction_tokens=0,
             status="normal",
-            invoke_from="console",
-            from_source="console",
+            invoke_from=InvokeFrom.EXPLORE,
+            from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,
             from_account_id=account.id,
         )
@@ -187,8 +187,8 @@ class TestMessageService:
             provider_response_latency=0,
             total_price=0,
             currency="USD",
-            invoke_from="console",
-            from_source="console",
+            invoke_from=InvokeFrom.EXPLORE,
+            from_source=ConversationFromSource.CONSOLE,
             from_end_user_id=None,
             from_account_id=account.id,
         )

--- a/api/tests/test_containers_integration_tests/services/test_message_service_extra_contents.py
+++ b/api/tests/test_containers_integration_tests/services/test_message_service_extra_contents.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 import pytest
 
+from models.enums import ConversationFromSource
 from models.model import Message
 from services import message_service
 from tests.test_containers_integration_tests.helpers.execution_extra_content import (
@@ -36,7 +37,7 @@ def test_attach_message_extra_contents_assigns_serialized_payload(db_session_wit
         total_price=Decimal(0),
         currency="USD",
         status="normal",
-        from_source="console",
+        from_source=ConversationFromSource.CONSOLE,
         from_account_id=fixture.account.id,
     )
     db_session_with_containers.add(message_without_extra_content)

--- a/api/tests/test_containers_integration_tests/services/test_messages_clean_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_messages_clean_service.py
@@ -11,7 +11,14 @@ from sqlalchemy.orm import Session
 from enums.cloud_plan import CloudPlan
 from extensions.ext_redis import redis_client
 from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
-from models.enums import DataSourceType, FeedbackFromSource, FeedbackRating, MessageChainType, MessageFileBelongsTo
+from models.enums import (
+    ConversationFromSource,
+    DataSourceType,
+    FeedbackFromSource,
+    FeedbackRating,
+    MessageChainType,
+    MessageFileBelongsTo,
+)
 from models.model import (
     App,
     AppAnnotationHitHistory,
@@ -166,7 +173,7 @@ class TestMessagesCleanServiceIntegration:
             name="Test conversation",
             inputs={},
             status="normal",
-            from_source=FeedbackFromSource.USER,
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid.uuid4()),
         )
         db_session_with_containers.add(conversation)
@@ -196,7 +203,7 @@ class TestMessagesCleanServiceIntegration:
             answer_unit_price=Decimal("0.002"),
             total_price=Decimal("0.003"),
             currency="USD",
-            from_source=FeedbackFromSource.USER,
+            from_source=ConversationFromSource.API,
             from_account_id=conversation.from_end_user_id,
             created_at=created_at,
         )

--- a/api/tests/test_containers_integration_tests/services/test_saved_message_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_saved_message_service.py
@@ -4,6 +4,7 @@ import pytest
 from faker import Faker
 from sqlalchemy.orm import Session
 
+from models.enums import ConversationFromSource
 from models.model import EndUser, Message
 from models.web import SavedMessage
 from services.app_service import AppService
@@ -132,11 +133,14 @@ class TestSavedMessageService:
         # Create a simple conversation first
         from models.model import Conversation
 
+        is_account = hasattr(user, "current_tenant")
+        from_source = ConversationFromSource.CONSOLE if is_account else ConversationFromSource.API
+
         conversation = Conversation(
             app_id=app.id,
-            from_source="account" if hasattr(user, "current_tenant") else "end_user",
-            from_end_user_id=user.id if not hasattr(user, "current_tenant") else None,
-            from_account_id=user.id if hasattr(user, "current_tenant") else None,
+            from_source=from_source,
+            from_end_user_id=user.id if not is_account else None,
+            from_account_id=user.id if is_account else None,
             name=fake.sentence(nb_words=3),
             inputs={},
             status="normal",
@@ -150,9 +154,9 @@ class TestSavedMessageService:
         message = Message(
             app_id=app.id,
             conversation_id=conversation.id,
-            from_source="account" if hasattr(user, "current_tenant") else "end_user",
-            from_end_user_id=user.id if not hasattr(user, "current_tenant") else None,
-            from_account_id=user.id if hasattr(user, "current_tenant") else None,
+            from_source=from_source,
+            from_end_user_id=user.id if not is_account else None,
+            from_account_id=user.id if is_account else None,
             inputs={},
             query=fake.sentence(nb_words=5),
             message=fake.text(max_nb_chars=100),

--- a/api/tests/test_containers_integration_tests/services/test_web_conversation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_web_conversation_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from models import Account
+from models.enums import ConversationFromSource
 from models.model import Conversation, EndUser
 from models.web import PinnedConversation
 from services.account_service import AccountService, TenantService
@@ -145,7 +146,7 @@ class TestWebConversationService:
             system_instruction_tokens=50,
             status="normal",
             invoke_from=InvokeFrom.WEB_APP,
-            from_source="console" if isinstance(user, Account) else "api",
+            from_source=ConversationFromSource.CONSOLE if isinstance(user, Account) else ConversationFromSource.API,
             from_end_user_id=user.id if isinstance(user, EndUser) else None,
             from_account_id=user.id if isinstance(user, Account) else None,
             dialogue_count=0,

--- a/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
@@ -7,7 +7,7 @@ import pytest
 from faker import Faker
 from sqlalchemy.orm import Session
 
-from models.enums import CreatorUserRole
+from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import (
     Message,
 )
@@ -165,7 +165,7 @@ class TestWorkflowRunService:
             inputs={},
             status="normal",
             mode="chat",
-            from_source=CreatorUserRole.ACCOUNT,
+            from_source=ConversationFromSource.CONSOLE,
             from_account_id=account.id,
         )
         db_session_with_containers.add(conversation)
@@ -186,7 +186,7 @@ class TestWorkflowRunService:
         message.answer_price_unit = 0.001
         message.currency = "USD"
         message.status = "normal"
-        message.from_source = CreatorUserRole.ACCOUNT
+        message.from_source = ConversationFromSource.CONSOLE
         message.from_account_id = account.id
         message.workflow_run_id = workflow_run.id
         message.inputs = {"input": "test input"}

--- a/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
@@ -11,6 +11,7 @@ from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, InvokeFrom
 from core.app.task_pipeline import message_cycle_manager
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
+from models.enums import ConversationFromSource
 from models.model import AppMode, Conversation, Message
 
 
@@ -92,7 +93,7 @@ def test_init_generate_records_marks_existing_conversation():
         system_instruction_tokens=0,
         status="normal",
         invoke_from=InvokeFrom.WEB_APP.value,
-        from_source="api",
+        from_source=ConversationFromSource.API,
         from_end_user_id="user-id",
         from_account_id=None,
     )

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 
+from models.enums import ConversationFromSource
 from models.model import (
     App,
     AppAnnotationHitHistory,
@@ -324,7 +325,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=from_end_user_id,
         )
 
@@ -345,7 +346,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
         )
         conversation._inputs = inputs
@@ -364,7 +365,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
         )
         inputs = {"query": "Hello", "context": "test"}
@@ -383,7 +384,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
             summary="Test summary",
         )
@@ -402,7 +403,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
             summary=None,
         )
@@ -425,7 +426,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
             override_model_configs='{"model": "gpt-4"}',
         )
@@ -446,7 +447,7 @@ class TestConversationModel:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=from_end_user_id,
             dialogue_count=5,
         )
@@ -487,7 +488,7 @@ class TestMessageModel:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
 
         # Assert
@@ -511,7 +512,7 @@ class TestMessageModel:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         message._inputs = inputs
 
@@ -533,7 +534,7 @@ class TestMessageModel:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         inputs = {"query": "Hello", "context": "test"}
 
@@ -555,7 +556,7 @@ class TestMessageModel:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             override_model_configs='{"model": "gpt-4"}',
         )
 
@@ -578,7 +579,7 @@ class TestMessageModel:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             message_metadata=json.dumps(metadata),
         )
 
@@ -600,7 +601,7 @@ class TestMessageModel:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             message_metadata=None,
         )
 
@@ -627,7 +628,7 @@ class TestMessageModel:
             answer_unit_price=Decimal("0.0002"),
             total_price=Decimal("0.0003"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             status="normal",
         )
         message.id = str(uuid4())
@@ -988,7 +989,7 @@ class TestModelIntegration:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
             from_end_user_id=str(uuid4()),
         )
         conversation.id = conversation_id
@@ -1003,7 +1004,7 @@ class TestModelIntegration:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         message.id = message_id
 
@@ -1064,7 +1065,7 @@ class TestModelIntegration:
             message_unit_price=Decimal("0.0001"),
             answer_unit_price=Decimal("0.0002"),
             currency="USD",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         message.id = message_id
 
@@ -1158,7 +1159,7 @@ class TestConversationStatusCount:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         conversation.id = str(uuid4())
 
@@ -1183,7 +1184,7 @@ class TestConversationStatusCount:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
 
@@ -1215,7 +1216,7 @@ class TestConversationStatusCount:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
 
@@ -1307,7 +1308,7 @@ class TestConversationStatusCount:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
 
@@ -1361,7 +1362,7 @@ class TestConversationStatusCount:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
 
@@ -1418,7 +1419,7 @@ class TestConversationStatusCount:
             mode=AppMode.CHAT,
             name="Test Conversation",
             status="normal",
-            from_source="api",
+            from_source=ConversationFromSource.API,
         )
         conversation.id = conversation_id
 

--- a/api/tests/unit_tests/services/test_conversation_service.py
+++ b/api/tests/unit_tests/services/test_conversation_service.py
@@ -15,6 +15,7 @@ from sqlalchemy import asc, desc
 from core.app.entities.app_invoke_entities import InvokeFrom
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from models import Account, ConversationVariable
+from models.enums import ConversationFromSource
 from models.model import App, Conversation, EndUser, Message
 from services.conversation_service import ConversationService
 from services.errors.conversation import (
@@ -350,7 +351,7 @@ class TestConversationServiceGetConversation:
         app_model = ConversationServiceTestDataFactory.create_app_mock()
         user = ConversationServiceTestDataFactory.create_account_mock()
         conversation = ConversationServiceTestDataFactory.create_conversation_mock(
-            from_account_id=user.id, from_source="console"
+            from_account_id=user.id, from_source=ConversationFromSource.CONSOLE
         )
 
         mock_query = mock_db_session.query.return_value
@@ -374,7 +375,7 @@ class TestConversationServiceGetConversation:
         app_model = ConversationServiceTestDataFactory.create_app_mock()
         user = ConversationServiceTestDataFactory.create_end_user_mock()
         conversation = ConversationServiceTestDataFactory.create_conversation_mock(
-            from_end_user_id=user.id, from_source="api"
+            from_end_user_id=user.id, from_source=ConversationFromSource.API
         )
 
         mock_query = mock_db_session.query.return_value
@@ -1111,7 +1112,7 @@ class TestConversationServiceEdgeCases:
         mock_session_factory.create_session.return_value.__enter__.return_value = mock_session
 
         conversation = ConversationServiceTestDataFactory.create_conversation_mock(
-            from_source="api", from_end_user_id="user-123"
+            from_source=ConversationFromSource.API, from_end_user_id="user-123"
         )
         mock_session.scalars.return_value.all.return_value = [conversation]
 
@@ -1143,7 +1144,7 @@ class TestConversationServiceEdgeCases:
         mock_session_factory.create_session.return_value.__enter__.return_value = mock_session
 
         conversation = ConversationServiceTestDataFactory.create_conversation_mock(
-            from_source="console", from_account_id="account-123"
+            from_source=ConversationFromSource.CONSOLE, from_account_id="account-123"
         )
         mock_session.scalars.return_value.all.return_value = [conversation]
 


### PR DESCRIPTION
## Summary
- Replace `sa.String` with `EnumText(InvokeFrom)` for `Conversation.invoke_from` and `Message.invoke_from`
- Replace `sa.String` with `EnumText(ConversationFromSource)` for `Conversation.from_source` and `Message.from_source`
- Replace all string literal assignments with enum values across 4 source files and 12 test files

Continues #33294 (model domain — invoke_from + from_source)

## Details
| Model | Column | Before | After |
|-------|--------|--------|-------|
| `Conversation.invoke_from` | `String(255)` | `EnumText(InvokeFrom)` |
| `Conversation.from_source` | `String(255)` | `EnumText(ConversationFromSource)` |
| `Message.invoke_from` | `String(255)` | `EnumText(InvokeFrom)` |
| `Message.from_source` | `String(255)` | `EnumText(ConversationFromSource)` |

## Test plan
- [x] `basedpyright` passes (0 errors on changed files)
- [x] 89 unit tests pass