### PR TITLE
refactor(web): replace MediaType enum with const object

### DIFF
--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -9712,11 +9712,6 @@
       "count": 6
     }
   },
-  "hooks/use-breakpoints.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    }
-  },
   "hooks/use-format-time-from-now.spec.ts": {
     "regexp/no-dupe-disjunctions": {
       "count": 5

--- a/web/hooks/use-breakpoints.ts
+++ b/web/hooks/use-breakpoints.ts
@@ -1,11 +1,13 @@
 'use client'
 import * as React from 'react'
 
-export enum MediaType {
-  mobile = 'mobile',
-  tablet = 'tablet',
-  pc = 'pc',
-}
+export const MediaType = {
+  mobile: 'mobile',
+  tablet: 'tablet',
+  pc: 'pc',
+} as const
+
+export type MediaTypeValue = (typeof MediaType)[keyof typeof MediaType]
 
 const useBreakpoints = () => {
   const [width, setWidth] = React.useState(globalThis.innerWidth)

--- a/web/hooks/use-breakpoints.ts
+++ b/web/hooks/use-breakpoints.ts
@@ -1,6 +1,10 @@
 'use client'
 import * as React from 'react'
 
+/**
+ * MediaType is defined as a const object to avoid non-erasable enum emit.
+ * This approach aligns with the erasable-syntax-only setup.
+ */
 export const MediaType = {
   mobile: 'mobile',
   tablet: 'tablet',

--- a/web/hooks/use-breakpoints.ts
+++ b/web/hooks/use-breakpoints.ts
@@ -7,9 +7,9 @@ export const MediaType = {
   pc: 'pc',
 } as const
 
-export type MediaTypeValue = (typeof MediaType)[keyof typeof MediaType]
+type MediaTypeValue = (typeof MediaType)[keyof typeof MediaType]
 
-const useBreakpoints = () => {
+const useBreakpoints = (): MediaTypeValue => {
   const [width, setWidth] = React.useState(globalThis.innerWidth)
   const media = (() => {
     if (width <= 640)

--- a/web/hooks/use-breakpoints.ts
+++ b/web/hooks/use-breakpoints.ts
@@ -1,10 +1,6 @@
 'use client'
 import * as React from 'react'
 
-/**
- * MediaType is defined as a const object to avoid non-erasable enum emit.
- * This approach aligns with the erasable-syntax-only setup.
- */
 export const MediaType = {
   mobile: 'mobile',
   tablet: 'tablet',


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Replace the `MediaType` string `enum` in `web/hooks/use-breakpoints.ts` with an `as const` object plus an exported union type alias (`MediaTypeValue`), avoiding non-erasable enum emit and matching the direction in #27998 / the `erasable-syntax-only` setup from #31487.
- Remove the corresponding `erasable-syntax-only/enums` suppression for `hooks/use-breakpoints.ts` in `web/eslint-suppressions.json`.
- Call sites keep using `MediaType.mobile` / `.tablet` / `.pc`; no UI or behavior change intended.

**Relates to #27998** 

## Screenshots

| Before | After |
|--------|-------|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods