### PR TITLE
fix(agent): expose text variable from file tool in knowledge pipeline

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
@@ -1,0 +1,217 @@
+import type { StructuredOutput } from '@/app/components/workflow/nodes/llm/types'
+import type { Node, ToolWithProvider, Var } from '@/app/components/workflow/types'
+import type { SchemaTypeDefinition } from '@/service/use-common'
+import { CollectionType } from '@/app/components/tools/types'
+import { OUTPUT_FILE_SUB_VARIABLES } from '@/app/components/workflow/nodes/constants'
+import { Type } from '@/app/components/workflow/nodes/llm/types'
+import ToolNodeDefault from '@/app/components/workflow/nodes/tool/default'
+import { BlockEnum, VarType } from '@/app/components/workflow/types'
+import { toNodeAvailableVars } from '../utils'
+
+const localizedText = {
+  en_US: 'test',
+  zh_Hans: 'test',
+}
+
+const fileSchemaDefinition = {
+  name: 'file',
+  schema: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      size: { type: 'number' },
+      type: { type: 'string' },
+      extension: { type: 'string' },
+      mime_type: { type: 'string' },
+      transfer_method: { type: 'string' },
+      url: { type: 'string' },
+      related_id: { type: 'string' },
+    },
+  },
+} as unknown as SchemaTypeDefinition
+
+const createToolNode = (): Node => {
+  return {
+    id: 'tool-node',
+    position: { x: 0, y: 0 },
+    data: {
+      type: BlockEnum.Tool,
+      title: 'File Tool',
+      provider_id: 'provider',
+      provider_type: CollectionType.builtIn,
+      provider_name: 'Provider',
+      tool_name: 'file_tool',
+      tool_label: 'File Tool',
+      tool_parameters: {},
+      tool_configurations: {},
+      tool_node_version: '2',
+    },
+  } as unknown as Node
+}
+
+const createToolCollection = (outputSchema: Record<string, unknown>): ToolWithProvider => {
+  return {
+    id: 'provider',
+    name: 'Provider',
+    author: 'Dify',
+    description: localizedText,
+    icon: '',
+    label: localizedText,
+    type: CollectionType.builtIn,
+    team_credentials: {},
+    is_team_authorization: false,
+    allow_delete: false,
+    labels: [],
+    tools: [
+      {
+        name: 'file_tool',
+        author: 'Dify',
+        label: localizedText,
+        description: 'Test tool',
+        parameters: [],
+        labels: [],
+        output_schema: outputSchema,
+      },
+    ],
+    meta: {
+      version: '',
+    },
+  }
+}
+
+const createPluginInfoList = (outputSchema: Record<string, unknown>) => {
+  return {
+    buildInTools: [createToolCollection(outputSchema)],
+    customTools: [],
+    workflowTools: [],
+    mcpTools: [],
+    dataSourceList: [],
+  }
+}
+
+const getToolOutputVar = (outputSchema: Record<string, unknown>, variable: string) => {
+  const nodeVars = toNodeAvailableVars({
+    beforeNodes: [createToolNode()],
+    isChatMode: false,
+    filterVar: () => true,
+    allPluginInfoList: createPluginInfoList(outputSchema),
+    schemaTypeDefinitions: [fileSchemaDefinition],
+  }).find(item => item.nodeId === 'tool-node')
+
+  return nodeVars?.vars.find(v => v.variable === variable)
+}
+
+const getChildVariables = (variable?: Var) => {
+  if (!variable || !Array.isArray(variable.children))
+    return []
+
+  return variable.children.map(child => child.variable)
+}
+
+const createFileStructuredOutput = (
+  extraProperties: StructuredOutput['schema']['properties'] = {},
+): StructuredOutput => {
+  return {
+    schema: {
+      type: Type.object,
+      properties: {
+        name: { type: Type.string },
+        size: { type: Type.number },
+        type: { type: Type.string },
+        extension: { type: Type.string },
+        mime_type: { type: Type.string },
+        transfer_method: { type: Type.string },
+        url: { type: Type.string },
+        related_id: { type: Type.string },
+        ...extraProperties,
+      },
+      additionalProperties: false,
+    },
+  }
+}
+
+describe('toNodeAvailableVars', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('file-like outputs', () => {
+    it('should keep the standard file children when no extra fields exist', () => {
+      const fileVar = getToolOutputVar({
+        type: 'object',
+        properties: {
+          artifact: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              size: { type: 'number' },
+              type: { type: 'string' },
+              extension: { type: 'string' },
+              mime_type: { type: 'string' },
+              transfer_method: { type: 'string' },
+              url: { type: 'string' },
+              related_id: { type: 'string' },
+            },
+          },
+        },
+      }, 'artifact')
+
+      const childVariables = getChildVariables(fileVar)
+
+      expect(fileVar?.type).toBe(VarType.file)
+      expect(childVariables).toEqual([...OUTPUT_FILE_SUB_VARIABLES, 'transfer_method'])
+      expect(new Set(childVariables).size).toBe(childVariables.length)
+    })
+
+    it('should expose extra text children without duplicating standard file fields', () => {
+      vi.spyOn(ToolNodeDefault, 'getOutputVars').mockReturnValue([
+        {
+          variable: 'artifact',
+          type: VarType.file,
+          children: createFileStructuredOutput({
+            text: { type: Type.string },
+          }),
+        },
+      ])
+
+      const fileVar = getToolOutputVar({}, 'artifact')
+
+      const childVariables = getChildVariables(fileVar)
+
+      expect(fileVar?.type).toBe(VarType.file)
+      expect(childVariables).toContain('text')
+      expect(childVariables).toContain('transfer_method')
+      expect(childVariables).toEqual([...OUTPUT_FILE_SUB_VARIABLES, 'transfer_method', 'text'])
+      expect(new Set(childVariables).size).toBe(childVariables.length)
+    })
+  })
+
+  describe('non-file outputs', () => {
+    it('should keep non-file object children unchanged', () => {
+      const objectVar = getToolOutputVar({
+        type: 'object',
+        properties: {
+          metadata: {
+            type: 'object',
+            properties: {
+              summary: { type: 'string' },
+              count: { type: 'number' },
+            },
+          },
+        },
+      }, 'metadata')
+
+      expect(objectVar?.type).toBe(VarType.object)
+      expect(objectVar?.children).toEqual({
+        schema: {
+          type: 'object',
+          properties: {
+            summary: { type: 'string' },
+            count: { type: 'number' },
+          },
+          additionalProperties: false,
+        },
+      })
+    })
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -150,6 +150,65 @@ const structTypeToVarType = (type: Type, isArray?: boolean): VarType => {
   )
 }
 
+const getDefaultFileChildren = (): Var[] => {
+  return OUTPUT_FILE_SUB_VARIABLES.map((key) => {
+    const def = FILE_STRUCT.find(c => c.variable === key)
+    return {
+      variable: key,
+      type: def?.type || VarType.string,
+    }
+  })
+}
+
+const structuredFieldToVar = (variable: string, field: StructField): Var => {
+  const isArray = field.type === Type.array
+  const arrayType = field.items?.type
+
+  return {
+    variable,
+    type: structTypeToVarType(isArray ? arrayType! : field.type, isArray),
+    des: field.description,
+    schemaType: field.schemaType,
+    children: field.type === Type.object && field.properties
+      ? {
+          schema: {
+            type: Type.object,
+            properties: field.properties,
+            additionalProperties: false,
+          },
+        }
+      : undefined,
+  }
+}
+
+const getFileChildren = (children?: Var[] | StructuredOutput): Var[] => {
+  const defaultChildren = getDefaultFileChildren()
+  const extraChildren = (() => {
+    if (Array.isArray(children))
+      return children.filter(child => !OUTPUT_FILE_SUB_VARIABLES.includes(child.variable))
+
+    if (children?.schema?.properties) {
+      return Object.entries(children.schema.properties)
+        .filter(([variable]) => !OUTPUT_FILE_SUB_VARIABLES.includes(variable))
+        .map(([variable, field]) => structuredFieldToVar(variable, field))
+    }
+
+    return []
+  })()
+
+  const existingVariables = new Set(defaultChildren.map(child => child.variable))
+  return [
+    ...defaultChildren,
+    ...extraChildren.filter((child) => {
+      if (existingVariables.has(child.variable))
+        return false
+
+      existingVariables.add(child.variable)
+      return true
+    }),
+  ]
+}
+
 export const varTypeToStructType = (type: VarType): Type => {
   return (
     (
@@ -721,15 +780,9 @@ const formatItem = (
 
       const isFile = v.type === VarType.file
       const children = (() => {
-        if (isFile) {
-          return OUTPUT_FILE_SUB_VARIABLES.map((key) => {
-            const def = FILE_STRUCT.find(c => c.variable === key)
-            return {
-              variable: key,
-              type: def?.type || VarType.string,
-            }
-          })
-        }
+        if (isFile)
+          return getFileChildren(v.children)
+
         return v.children
       })()
       if (!children)
@@ -748,13 +801,7 @@ const formatItem = (
       const { children } = (() => {
         if (isFile) {
           return {
-            children: OUTPUT_FILE_SUB_VARIABLES.map((key) => {
-              const def = FILE_STRUCT.find(c => c.variable === key)
-              return {
-                variable: key,
-                type: def?.type || VarType.string,
-              }
-            }),
+            children: getFileChildren(v.children),
           }
         }
         return v


### PR DESCRIPTION
Fixes #33541

## Summary

This PR fixes the workflow variable exposure chain for file-like outputs in knowledge pipeline flows.

Previously, when a tool returned a file-like object with both standard file metadata and an extra `text` field, downstream Agent / VLM variable selectors only exposed the standard file fields. The `text` field was dropped before reaching `availableVars`.

This change preserves the default file sub-fields while also exposing additional schema-defined fields such as `text`.

### Root cause

During variable preparation, file-like outputs were normalized to `VarType.file`, and their children were replaced with a fixed list of standard file sub-fields. As a result, any extra schema-defined fields were discarded before the selector was built.

### Fix

- add a shared helper to build file children from:
  - the standard file sub-fields
  - extra fields defined in the original schema
- deduplicate merged children by variable name
- reuse the same helper in both the filtering and mapping stages
- keep non-file behavior unchanged

## Screenshots

N/A — this is a logic-only frontend fix for variable exposure in the selector chain.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://docs.dify.ai/)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods