### PR TITLE
refactor(api): type tool service dicts with TypedDict

### DIFF
--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -1,10 +1,10 @@
 import json
 import logging
-from collections.abc import Mapping
 from typing import Any, cast
 
 from httpx import get
 from sqlalchemy import select
+from typing_extensions import TypedDict
 
 from core.entities.provider_entities import ProviderConfig
 from core.tools.__base.tool_runtime import ToolRuntime
@@ -28,9 +28,16 @@ from services.tools.tools_transform_service import ToolTransformService
 logger = logging.getLogger(__name__)
 
 
+class ApiSchemaParseResult(TypedDict):
+    schema_type: str
+    parameters_schema: list[dict[str, Any]]
+    credentials_schema: list[dict[str, Any]]
+    warning: dict[str, str]
+
+
 class ApiToolManageService:
     @staticmethod
-    def parser_api_schema(schema: str) -> Mapping[str, Any]:
+    def parser_api_schema(schema: str) -> ApiSchemaParseResult:
         """
         parse api schema to tool bundle
         """
@@ -71,7 +78,7 @@ class ApiToolManageService:
             ]
 
             return cast(
-                Mapping,
+                ApiSchemaParseResult,
                 jsonable_encoder(
                     {
                         "schema_type": schema_type,

--- a/api/services/tools/mcp_tools_manage_service.py
+++ b/api/services/tools/mcp_tools_manage_service.py
@@ -18,6 +18,7 @@ from core.helper.provider_cache import NoOpProviderCredentialCache
 from core.mcp.auth.auth_flow import auth
 from core.mcp.auth_client import MCPClientWithAuthRetry
 from core.mcp.error import MCPAuthError, MCPError
+from core.mcp.types import Tool as MCPTool
 from core.tools.entities.api_entities import ToolProviderApiEntity
 from core.tools.utils.encryption import ProviderConfigEncrypter
 from models.tools import MCPToolProvider
@@ -681,7 +682,7 @@ class MCPToolManageService:
             raise ValueError(f"Failed to re-connect MCP server: {e}") from e
 
     def _build_tool_provider_response(
-        self, db_provider: MCPToolProvider, provider_entity: MCPProviderEntity, tools: list
+        self, db_provider: MCPToolProvider, provider_entity: MCPProviderEntity, tools: list[MCPTool]
     ) -> ToolProviderApiEntity:
         """Build API response for tool provider."""
         user = db_provider.load_user()


### PR DESCRIPTION
## Summary
- Add `ApiSchemaParseResult` TypedDict in `api_tools_manage_service.py` for `parser_api_schema` return type, replacing bare `Mapping[str, Any]`
- Type bare `tools: list` as `list[MCPTool]` in `mcp_tools_manage_service.py` `_build_tool_provider_response`

## What this PR does NOT change
Bare `dict` params for `icon`, `credentials`, and `parameters` across tool services are intentionally left as-is — they are opaque pass-through dicts serialized with `json.dumps()` without key access in the service layer.

## Test plan
- [x] `make type-check` passes (basedpyright + pyrefly + mypy)
- [x] `ruff check` passes
- [x] Existing unit tests pass (60 passed)

Part of #32863 (tool services portion)
