### PR TITLE
fix: test error by matching pkg versioin with docker compose

### DIFF
--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -165,8 +165,10 @@ class DifyTestContainers:
 
         # Start Dify Sandbox container for code execution environment
         # Dify Sandbox provides a secure environment for executing user code
+        # Use pinned version 0.2.12 to match production docker-compose configuration
+        # and prevent test failures when latest tag is updated with breaking changes
         logger.info("Initializing Dify Sandbox container...")
-        self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:latest").with_network(self.network)
+        self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:0.2.12").with_network(self.network)
         self.dify_sandbox.with_exposed_ports(8194)
         self.dify_sandbox.env = {
             "API_KEY": "test_api_key",

--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -166,7 +166,6 @@ class DifyTestContainers:
         # Start Dify Sandbox container for code execution environment
         # Dify Sandbox provides a secure environment for executing user code
         # Use pinned version 0.2.12 to match production docker-compose configuration
-        # and prevent test failures when latest tag is updated with breaking changes
         logger.info("Initializing Dify Sandbox container...")
         self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:0.2.12").with_network(self.network)
         self.dify_sandbox.with_exposed_ports(8194)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #33839
Fixed test case.
how to reproduce
```
cd /home/loki/projects/dify/api
uv run pytest tests/test_containers_integration_tests/workflow/nodes/code_executor/test_code_javascript.py::TestJavaScriptCodeExecutor::test_javascript_plain -v
```

## Screenshots

| Before
```
FAILED test_javascript_plain - CodeExecutionError: Got error code: -500. 
Got error msg: fork/exec /usr/local/bin/node: no such file or directory
 
FAILED test_javascript_json - (same error)
FAILED test_javascript_with_code_template - (same error)
```
| After
```
===================== 4 passed, 13 warnings in 36.18s =====================
```
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
