### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
         <img alt="LFX Contributors" src="https://insights.linuxfoundation.org/api/badge/contributors?project=langgenius-dify"></a>
     <a href="https://insights.linuxfoundation.org/project/langgenius-dify" target="_blank">
         <img alt="LFX Active Contributors" src="https://insights.linuxfoundation.org/api/badge/active-contributors?project=langgenius-dify"></a>
+    <a href="https://gitcgr.com/langgenius/dify">
+      <img src="https://gitcgr.com/badge/langgenius/dify.svg" alt="gitcgr" />
+    </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/langgenius/dify.svg)](https://gitcgr.com/langgenius/dify)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).