### PR TITLE
fix: ZWSP Delimiter

### DIFF
--- a/api/core/rag/splitter/fixed_text_splitter.py
+++ b/api/core/rag/splitter/fixed_text_splitter.py
@@ -53,7 +53,10 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
     def __init__(self, fixed_separator: str = "\n\n", separators: list[str] | None = None, **kwargs: Any):
         """Create a new TextSplitter."""
         super().__init__(**kwargs)
-        self._fixed_separator = codecs.decode(fixed_separator, "unicode_escape")
+        if "\\" in fixed_separator:
+            self._fixed_separator = codecs.decode(fixed_separator, "unicode_escape")
+        else:
+            self._fixed_separator = fixed_separator
         self._separators = separators or ["\n\n", "\n", "。", ". ", " ", ""]
 
     def split_text(self, text: str) -> list[str]:

--- a/api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py
+++ b/api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py
@@ -1,0 +1,192 @@
+"""
+Test for invisible Unicode delimiter support in FixedRecursiveCharacterTextSplitter.
+
+Regression test for issue #31672:
+ZWSP and other invisible Unicode characters should work as delimiters.
+"""
+
+import pytest
+
+from core.rag.splitter.fixed_text_splitter import FixedRecursiveCharacterTextSplitter
+
+
+class TestInvisibleDelimiters:
+    """Test invisible Unicode characters as delimiters."""
+
+    @pytest.fixture
+    def base_splitter_kwargs(self):
+        """Common kwargs for creating splitters."""
+        def length_function(texts: list[str]) -> list[int]:
+            return [len(text) for text in texts]
+        
+        return {
+            "chunk_size": 100,
+            "chunk_overlap": 0,
+            "length_function": length_function,
+        }
+
+    def test_zwsp_literal_delimiter(self, base_splitter_kwargs):
+        """ZWSP (U+200B) should work as a literal delimiter."""
+        zwsp = "\u200b"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator=zwsp,
+            **base_splitter_kwargs,
+        )
+
+        text = f"chunk1{zwsp}chunk2{zwsp}chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_zwnbsp_literal_delimiter(self, base_splitter_kwargs):
+        """ZWNBSP (U+FEFF) should work as a literal delimiter."""
+        zwnbsp = "\ufeff"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator=zwnbsp,
+            **base_splitter_kwargs,
+        )
+
+        text = f"chunk1{zwnbsp}chunk2{zwnbsp}chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_invisible_separator_literal(self, base_splitter_kwargs):
+        """INVISIBLE SEPARATOR (U+2063) should work as a literal delimiter."""
+        invisible_sep = "\u2063"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator=invisible_sep,
+            **base_splitter_kwargs,
+        )
+
+        text = f"chunk1{invisible_sep}chunk2{invisible_sep}chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_word_joiner_literal(self, base_splitter_kwargs):
+        """WORD JOINER (U+2060) should work as a literal delimiter."""
+        word_joiner = "\u2060"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator=word_joiner,
+            **base_splitter_kwargs,
+        )
+
+        text = f"chunk1{word_joiner}chunk2{word_joiner}chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_ltr_mark_literal(self, base_splitter_kwargs):
+        """LEFT-TO-RIGHT MARK (U+200E) should work as a literal delimiter."""
+        ltr_mark = "\u200e"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator=ltr_mark,
+            **base_splitter_kwargs,
+        )
+
+        text = f"chunk1{ltr_mark}chunk2{ltr_mark}chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_escaped_newline_still_works(self, base_splitter_kwargs):
+        """Escaped newline \\n should still be decoded properly."""
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\\n",
+            **base_splitter_kwargs,
+        )
+
+        text = "chunk1\nchunk2\nchunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_escaped_tab_still_works(self, base_splitter_kwargs):
+        """Escaped tab \\t should still be decoded properly."""
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\\t",
+            **base_splitter_kwargs,
+        )
+
+        text = "chunk1\tchunk2\tchunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_literal_newline_works(self, base_splitter_kwargs):
+        """Literal newline should work without escaping."""
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n",
+            **base_splitter_kwargs,
+        )
+
+        text = "chunk1\nchunk2\nchunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_chinese_punctuation_literal(self, base_splitter_kwargs):
+        """Chinese punctuation should work as literal delimiters (related to issue)."""
+        # Test Chinese comma
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="，",
+            **base_splitter_kwargs,
+        )
+
+        text = "chunk1，chunk2，chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]
+
+    def test_mixed_content_with_zwsp(self, base_splitter_kwargs):
+        """Test realistic content with ZWSP delimiters."""
+        zwsp = "\u200b"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator=zwsp,
+            **base_splitter_kwargs,
+        )
+
+        text = f"First paragraph with some text.{zwsp}Second paragraph with more content.{zwsp}Third paragraph here."
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert "First paragraph" in result[0]
+        assert "Second paragraph" in result[1]
+        assert "Third paragraph" in result[2]
+
+    def test_empty_separator(self, base_splitter_kwargs):
+        """Empty separator should not split."""
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="",
+            **base_splitter_kwargs,
+        )
+
+        text = "chunk1 chunk2 chunk3"
+        result = splitter.split_text(text)
+
+        # Should not split on empty separator
+        assert len(result) == 1
+
+    def test_escaped_unicode_hex_notation(self, base_splitter_kwargs):
+        """Escaped Unicode hex notation \\u200b should be decoded."""
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\\u200b",
+            **base_splitter_kwargs,
+        )
+
+        zwsp = "\u200b"
+        text = f"chunk1{zwsp}chunk2{zwsp}chunk3"
+        result = splitter.split_text(text)
+
+        assert len(result) == 3
+        assert result == ["chunk1", "chunk2", "chunk3"]

--- a/api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py
+++ b/api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py
@@ -16,9 +16,10 @@ class TestInvisibleDelimiters:
     @pytest.fixture
     def base_splitter_kwargs(self):
         """Common kwargs for creating splitters."""
+
         def length_function(texts: list[str]) -> list[int]:
             return [len(text) for text in texts]
-        
+
         return {
             "chunk_size": 100,
             "chunk_overlap": 0,

--- a/api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py
+++ b/api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py
@@ -26,97 +26,44 @@ class TestInvisibleDelimiters:
             "length_function": length_function,
         }
 
-    def test_zwsp_literal_delimiter(self, base_splitter_kwargs):
-        """ZWSP (U+200B) should work as a literal delimiter."""
-        zwsp = "\u200b"
+    @pytest.mark.parametrize(
+        "delimiter",
+        [
+            pytest.param("\u200b", id="zwsp"),
+            pytest.param("\ufeff", id="zwnbsp"),
+            pytest.param("\u2063", id="invisible_separator"),
+            pytest.param("\u2060", id="word_joiner"),
+            pytest.param("\u200e", id="ltr_mark"),
+        ],
+    )
+    def test_invisible_literal_delimiters(self, base_splitter_kwargs, delimiter):
+        """Test that various invisible Unicode characters work as literal delimiters."""
         splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator=zwsp,
+            fixed_separator=delimiter,
             **base_splitter_kwargs,
         )
 
-        text = f"chunk1{zwsp}chunk2{zwsp}chunk3"
+        text = f"chunk1{delimiter}chunk2{delimiter}chunk3"
         result = splitter.split_text(text)
 
         assert len(result) == 3
         assert result == ["chunk1", "chunk2", "chunk3"]
 
-    def test_zwnbsp_literal_delimiter(self, base_splitter_kwargs):
-        """ZWNBSP (U+FEFF) should work as a literal delimiter."""
-        zwnbsp = "\ufeff"
+    @pytest.mark.parametrize(
+        ("escaped_char", "literal_char"),
+        [
+            pytest.param("\\n", "\n", id="newline"),
+            pytest.param("\\t", "\t", id="tab"),
+        ],
+    )
+    def test_escaped_chars_still_work(self, base_splitter_kwargs, escaped_char, literal_char):
+        """Escaped characters should still be decoded properly."""
         splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator=zwnbsp,
+            fixed_separator=escaped_char,
             **base_splitter_kwargs,
         )
 
-        text = f"chunk1{zwnbsp}chunk2{zwnbsp}chunk3"
-        result = splitter.split_text(text)
-
-        assert len(result) == 3
-        assert result == ["chunk1", "chunk2", "chunk3"]
-
-    def test_invisible_separator_literal(self, base_splitter_kwargs):
-        """INVISIBLE SEPARATOR (U+2063) should work as a literal delimiter."""
-        invisible_sep = "\u2063"
-        splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator=invisible_sep,
-            **base_splitter_kwargs,
-        )
-
-        text = f"chunk1{invisible_sep}chunk2{invisible_sep}chunk3"
-        result = splitter.split_text(text)
-
-        assert len(result) == 3
-        assert result == ["chunk1", "chunk2", "chunk3"]
-
-    def test_word_joiner_literal(self, base_splitter_kwargs):
-        """WORD JOINER (U+2060) should work as a literal delimiter."""
-        word_joiner = "\u2060"
-        splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator=word_joiner,
-            **base_splitter_kwargs,
-        )
-
-        text = f"chunk1{word_joiner}chunk2{word_joiner}chunk3"
-        result = splitter.split_text(text)
-
-        assert len(result) == 3
-        assert result == ["chunk1", "chunk2", "chunk3"]
-
-    def test_ltr_mark_literal(self, base_splitter_kwargs):
-        """LEFT-TO-RIGHT MARK (U+200E) should work as a literal delimiter."""
-        ltr_mark = "\u200e"
-        splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator=ltr_mark,
-            **base_splitter_kwargs,
-        )
-
-        text = f"chunk1{ltr_mark}chunk2{ltr_mark}chunk3"
-        result = splitter.split_text(text)
-
-        assert len(result) == 3
-        assert result == ["chunk1", "chunk2", "chunk3"]
-
-    def test_escaped_newline_still_works(self, base_splitter_kwargs):
-        """Escaped newline \\n should still be decoded properly."""
-        splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator="\\n",
-            **base_splitter_kwargs,
-        )
-
-        text = "chunk1\nchunk2\nchunk3"
-        result = splitter.split_text(text)
-
-        assert len(result) == 3
-        assert result == ["chunk1", "chunk2", "chunk3"]
-
-    def test_escaped_tab_still_works(self, base_splitter_kwargs):
-        """Escaped tab \\t should still be decoded properly."""
-        splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator="\\t",
-            **base_splitter_kwargs,
-        )
-
-        text = "chunk1\tchunk2\tchunk3"
+        text = f"chunk1{literal_char}chunk2{literal_char}chunk3"
         result = splitter.split_text(text)
 
         assert len(result) == 3


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixes #31672

Zero-width space (ZWSP) and other invisible Unicode delimiters stopped working. The delimiters were being corrupted during text splitting, causing no chunks to be created.

It was because `codecs.decode(fixed_separator, "unicode_escape")` in `fixed_text_splitter.py` corrupts literal Unicode characters.

I fixed by applying `codecs.decode()` when the string contains backslash escape sequences.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Test

```
# New invisible delimiter tests
uv run --project api pytest api/tests/unit_tests/core/rag/splitter/test_fixed_text_splitter_invisible_delimiters.py -v

# Existing parent-child tests  
uv run --project api pytest api/tests/unit_tests/core/rag/indexing/processor/test_parent_child_index_processor.py -v
```


## Screenshots

| Before 

```
Input text: 'chunk1\u200bchunk2\u200bchunk3'
Result: ['chunk1\u200bchunk2\u200bchunk3']
Number of chunks: 1
```
Only 1 chunk instead of 3. ZWSP delimiter was corrupted to 'â\x80\x8b' and didn't match the text.

| After

```
# Same code with fixed splitter
zwsp = "\u200b"  # Zero-width space literal
text = f"chunk1{zwsp}chunk2{zwsp}chunk3"

splitter = FixedRecursiveCharacterTextSplitter(fixed_separator=zwsp)
result = splitter.split_text(text)

print(f"Input text: {repr(text)}")
print(f"Result: {result}")
print(f"Number of chunks: {len(result)}")
```
Fixed: Correctly splits into 3 chunks. ZWSP delimiter preserved as '\u200b'.


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
