### PR TITLE
fix: default online drive prefix to root

### DIFF
--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -360,7 +360,7 @@ class OnlineDriveBrowseFilesRequest(BaseModel):
     """
 
     bucket: str | None = Field(None, description="The file bucket")
-    prefix: str = Field(..., description="The parent folder ID")
+    prefix: str = Field(default="", description="The prefix to browse. An empty string means the root folder.")
     max_keys: int = Field(20, description="Page size for pagination")
     next_page_parameters: dict | None = Field(None, description="Parameters for fetching the next page")
 

--- a/api/tests/unit_tests/core/datasource/entities/test_datasource_entities.py
+++ b/api/tests/unit_tests/core/datasource/entities/test_datasource_entities.py
@@ -256,6 +256,9 @@ def test_online_drive_models():
     bucket = OnlineDriveFileBucket(bucket="b1", files=[file], is_truncated=False, next_page_parameters=None)
     assert bucket.bucket == "b1"
 
+    req_default = OnlineDriveBrowseFilesRequest()
+    assert req_default.prefix == ""
+
     req = OnlineDriveBrowseFilesRequest(bucket="b1", prefix="folder1", max_keys=10, next_page_parameters=None)
     assert req.prefix == "folder1"
 

--- a/api/tests/unit_tests/core/datasource/entities/test_datasource_entities.py
+++ b/api/tests/unit_tests/core/datasource/entities/test_datasource_entities.py
@@ -257,7 +257,10 @@ def test_online_drive_models():
     assert bucket.bucket == "b1"
 
     req_default = OnlineDriveBrowseFilesRequest()
+    assert req_default.bucket is None
     assert req_default.prefix == ""
+    assert req_default.max_keys == 20
+    assert req_default.next_page_parameters is None
 
     req = OnlineDriveBrowseFilesRequest(bucket="b1", prefix="folder1", max_keys=10, next_page_parameters=None)
     assert req.prefix == "folder1"


### PR DESCRIPTION
## Summary
- default `OnlineDriveBrowseFilesRequest.prefix` to an empty string so callers can omit it when browsing the root folder
- clarify the field description to match the actual behavior
- add a focused unit test for the empty-prefix case

## Testing
- `python -m pytest tests/unit_tests/core/datasource/entities/test_datasource_entities.py`
- `python -m pytest tests/unit_tests/core/plugin/impl/test_datasource_manager.py`

Closes #31761