### PR TITLE
fix(dev): load middleware env in start-docker-compose

### DIFF
--- a/dev/start-docker-compose
+++ b/dev/start-docker-compose
@@ -5,4 +5,4 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$ROOT/docker"
-docker compose -f docker-compose.middleware.yaml --profile postgresql --profile weaviate -p dify up -d
+docker compose --env-file middleware.env -f docker-compose.middleware.yaml --profile postgresql --profile weaviate -p dify up -d

--- a/dev/start-docker-compose
+++ b/dev/start-docker-compose
@@ -5,4 +5,4 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$ROOT/docker"
-docker compose --env-file middleware.env -f docker-compose.middleware.yaml --profile postgresql --profile weaviate -p dify up -d
+docker compose --env-file middleware.env -f docker-compose.middleware.yaml -p dify up -d


### PR DESCRIPTION
## Summary
- load docker/middleware.env in dev/start-docker-compose
- keep the helper script consistent with other middleware startup commands in the repo
- make custom middleware ports and compose variables generated during setup take effect when using the dev script

## Test plan
- [x] verify the script diff only adds --env-file middleware.env
- [x] docker compose --env-file middleware.env -f docker-compose.middleware.yaml -p dify config