### PR TITLE
fix(api): agent node tracing in Langfuse (#33923)

### DIFF
--- a/api/core/ops/langfuse_trace/langfuse_trace.py
+++ b/api/core/ops/langfuse_trace/langfuse_trace.py
@@ -26,7 +26,7 @@ from core.ops.langfuse_trace.entities.langfuse_trace_entity import (
     LevelEnum,
     UnitEnum,
 )
-from core.ops.utils import filter_none_values
+from core.ops.utils import filter_none_values, should_trace_as_llm
 from core.repositories import DifyCoreRepositoryFactory
 from dify_graph.enums import NodeType
 from extensions.ext_database import db
@@ -174,8 +174,8 @@ class LangFuseDataTrace(BaseTraceInstance):
                     }
                 )
 
-            # add generation span
-            if process_data and process_data.get("model_mode") == "chat":
+            # add generation span for LLM and agent nodes
+            if should_trace_as_llm(node_type, process_data):
                 total_token = metadata.get("total_tokens", 0)
                 prompt_tokens = 0
                 completion_tokens = 0

--- a/api/core/ops/langsmith_trace/langsmith_trace.py
+++ b/api/core/ops/langsmith_trace/langsmith_trace.py
@@ -26,7 +26,7 @@ from core.ops.langsmith_trace.entities.langsmith_trace_entity import (
     LangSmithRunType,
     LangSmithRunUpdateModel,
 )
-from core.ops.utils import filter_none_values, generate_dotted_order
+from core.ops.utils import filter_none_values, generate_dotted_order, should_trace_as_llm
 from core.repositories import DifyCoreRepositoryFactory
 from dify_graph.enums import NodeType, WorkflowNodeExecutionMetadataKey
 from extensions.ext_database import db
@@ -189,7 +189,7 @@ class LangSmithDataTrace(BaseTraceInstance):
 
             process_data = node_execution.process_data or {}
 
-            if process_data and process_data.get("model_mode") == "chat":
+            if should_trace_as_llm(node_type, process_data):
                 run_type = LangSmithRunType.llm
                 metadata.update(
                     {

--- a/api/core/ops/opik_trace/opik_trace.py
+++ b/api/core/ops/opik_trace/opik_trace.py
@@ -22,6 +22,7 @@ from core.ops.entities.trace_entity import (
     TraceTaskName,
     WorkflowTraceInfo,
 )
+from core.ops.utils import should_trace_as_llm
 from core.repositories import DifyCoreRepositoryFactory
 from dify_graph.enums import NodeType, WorkflowNodeExecutionMetadataKey
 from extensions.ext_database import db
@@ -218,7 +219,7 @@ class OpikDataTrace(BaseTraceInstance):
             completion_tokens = 0
             prompt_tokens = 0
 
-            if process_data and process_data.get("model_mode") == "chat":
+            if should_trace_as_llm(node_type, process_data):
                 run_type = "llm"
                 provider = process_data.get("model_provider", None)
                 model = process_data.get("model_name", "")

--- a/api/core/ops/utils.py
+++ b/api/core/ops/utils.py
@@ -5,8 +5,20 @@ from urllib.parse import urlparse
 
 from sqlalchemy import select
 
+from dify_graph.enums import NodeType
 from models.engine import db
 from models.model import Message
+
+
+def should_trace_as_llm(node_type: NodeType, process_data: dict[str, Any] | None) -> bool:
+    """Determine whether a workflow node should be traced as an LLM generation.
+
+    Returns True for LLM nodes (identified by model_mode == "chat" in process_data)
+    and for agent nodes (which wrap LLM calls internally).
+    """
+    is_llm_generation = bool(process_data and process_data.get("model_mode") == "chat")
+    is_agent_node = node_type == NodeType.AGENT
+    return is_llm_generation or is_agent_node
 
 
 def filter_none_values(data: dict[str, Any]) -> dict[str, Any]:

--- a/api/core/ops/weave_trace/weave_trace.py
+++ b/api/core/ops/weave_trace/weave_trace.py
@@ -29,6 +29,7 @@ from core.ops.entities.trace_entity import (
     TraceTaskName,
     WorkflowTraceInfo,
 )
+from core.ops.utils import should_trace_as_llm
 from core.ops.weave_trace.entities.weave_trace_entity import WeaveTraceModel
 from core.repositories import DifyCoreRepositoryFactory
 from dify_graph.enums import NodeType, WorkflowNodeExecutionMetadataKey
@@ -200,7 +201,7 @@ class WeaveDataTrace(BaseTraceInstance):
             )
 
             process_data = node_execution.process_data or {}
-            if process_data and process_data.get("model_mode") == "chat":
+            if should_trace_as_llm(node_type, process_data):
                 attributes.update(
                     {
                         "ls_provider": process_data.get("model_provider", ""),

--- a/api/dify_graph/nodes/agent/agent_node.py
+++ b/api/dify_graph/nodes/agent/agent_node.py
@@ -114,6 +114,18 @@ class AgentNode(Node[AgentNodeData]):
             for_log=True,
             strategy=strategy,
         )
+
+        # Extract model provider and model name from the first MODEL_SELECTOR parameter
+        model_provider = ""
+        model_name = ""
+        for param in agent_parameters:
+            if param.type == AgentStrategyParameter.AgentStrategyParameterType.MODEL_SELECTOR:
+                model_selector_value = parameters.get(param.name)
+                if isinstance(model_selector_value, dict):
+                    model_provider = model_selector_value.get("provider", "")
+                    model_name = model_selector_value.get("model", "")
+                break
+
         credentials = self._generate_credentials(parameters=parameters)
 
         # get conversation id
@@ -151,6 +163,8 @@ class AgentNode(Node[AgentNodeData]):
                 node_type=self.node_type,
                 node_id=self._node_id,
                 node_execution_id=self.id,
+                model_provider=model_provider,
+                model_name=model_name,
             )
         except PluginDaemonClientSideError as e:
             transform_error = AgentMessageTransformError(
@@ -492,6 +506,8 @@ class AgentNode(Node[AgentNodeData]):
         node_type: NodeType,
         node_id: str,
         node_execution_id: str,
+        model_provider: str = "",
+        model_name: str = "",
     ) -> Generator[NodeEventBase, None, None]:
         """
         Convert ToolInvokeMessages into tuple[plain_text, files]
@@ -741,6 +757,15 @@ class AgentNode(Node[AgentNodeData]):
                 is_final=True,
             )
 
+        process_data: dict[str, Any] = {
+            "usage": jsonable_encoder(llm_usage),
+        }
+        if model_provider or model_name:
+            # Assume chat mode since agent strategies typically use chat-based LLMs
+            process_data["model_mode"] = "chat"
+            process_data["model_provider"] = model_provider
+            process_data["model_name"] = model_name
+
         yield StreamCompletedEvent(
             node_run_result=NodeRunResult(
                 status=WorkflowNodeExecutionStatus.SUCCEEDED,
@@ -751,8 +776,12 @@ class AgentNode(Node[AgentNodeData]):
                     "json": json_output,
                     **variables,
                 },
+                process_data=process_data,
                 metadata={
                     **agent_execution_metadata,
+                    WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: llm_usage.total_tokens,
+                    WorkflowNodeExecutionMetadataKey.TOTAL_PRICE: llm_usage.total_price,
+                    WorkflowNodeExecutionMetadataKey.CURRENCY: llm_usage.currency,
                     WorkflowNodeExecutionMetadataKey.TOOL_INFO: tool_info,
                     WorkflowNodeExecutionMetadataKey.AGENT_LOG: agent_logs,
                 },


### PR DESCRIPTION
## Summary
- Agent nodes in workflows now appear as **GENERATIONs** (not SPANs) in Langfuse, LangSmith, Opik, and Weave, with proper token usage and cost tracking.
- Extracts model provider/name from the agent's `MODEL_SELECTOR` parameter and populates `process_data` on `NodeRunResult`, mirroring the LLM node pattern.
- Adds `should_trace_as_llm()` helper in all four tracing providers so agent nodes are always recognized as generation-type operations.
- Includes `TOTAL_TOKENS`, `TOTAL_PRICE`, and `CURRENCY` in agent node execution metadata.

Closes #33923
Related: #24361

## Test plan
- [ ] Set up a workflow with an agent node, enable Langfuse tracing, verify the agent node appears as a GENERATION with token usage, model name, and cost
- [ ] Verify LLM nodes still traced correctly as GENERATIONs
- [ ] Repeat with LangSmith, Opik, Weave to confirm consistent behavior