### PR TITLE
fix(workflow): enable source handle connector on End node

### DIFF
--- a/web/app/components/workflow/hooks/__tests__/use-available-blocks.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-available-blocks.spec.ts
@@ -81,9 +81,10 @@ describe('useAvailableBlocks', () => {
       expect(result.current.availableNextBlocks).toEqual([])
     })
 
-    it('should return empty array for End node', () => {
+    it('should return available blocks for End node (same as regular nodes)', () => {
       const { result } = renderWorkflowHook(() => useAvailableBlocks(BlockEnum.End), { hooksStoreProps })
-      expect(result.current.availableNextBlocks).toEqual([])
+      expect(result.current.availableNextBlocks.length).toBeGreaterThan(0)
+      expect(result.current.availableNextBlocks).toContain(BlockEnum.LLM)
     })
 
     it('should return empty array for LoopEnd node', () => {
@@ -143,12 +144,19 @@ describe('useAvailableBlocks', () => {
       expect(blocks.availablePrevBlocks).toEqual([])
     })
 
-    it('should return empty nextBlocks for End/LoopEnd/KnowledgeBase', () => {
+    it('should return empty nextBlocks for LoopEnd/KnowledgeBase', () => {
       const { result } = renderWorkflowHook(() => useAvailableBlocks(BlockEnum.LLM), { hooksStoreProps })
 
-      expect(result.current.getAvailableBlocks(BlockEnum.End).availableNextBlocks).toEqual([])
       expect(result.current.getAvailableBlocks(BlockEnum.LoopEnd).availableNextBlocks).toEqual([])
       expect(result.current.getAvailableBlocks(BlockEnum.KnowledgeBase).availableNextBlocks).toEqual([])
+    })
+
+    it('should return available nextBlocks for End node (same as regular nodes)', () => {
+      const { result } = renderWorkflowHook(() => useAvailableBlocks(BlockEnum.LLM), { hooksStoreProps })
+      const blocks = result.current.getAvailableBlocks(BlockEnum.End)
+
+      expect(blocks.availableNextBlocks.length).toBeGreaterThan(0)
+      expect(blocks.availableNextBlocks).toContain(BlockEnum.LLM)
     })
 
     it('should filter by inContainer when provided', () => {

--- a/web/app/components/workflow/hooks/use-available-blocks.ts
+++ b/web/app/components/workflow/hooks/use-available-blocks.ts
@@ -30,7 +30,7 @@ export const useAvailableBlocks = (nodeType?: BlockEnum, inContainer?: boolean) 
     return availableNodesType
   }, [availableNodesType, nodeType])
   const availableNextBlocks = useMemo(() => {
-    if (!nodeType || nodeType === BlockEnum.End || nodeType === BlockEnum.LoopEnd || nodeType === BlockEnum.KnowledgeBase)
+    if (!nodeType || nodeType === BlockEnum.LoopEnd || nodeType === BlockEnum.KnowledgeBase)
       return []
 
     return availableNodesType
@@ -42,7 +42,7 @@ export const useAvailableBlocks = (nodeType?: BlockEnum, inContainer?: boolean) 
       availablePrevBlocks = []
 
     let availableNextBlocks = availableNodesType
-    if (!nodeType || nodeType === BlockEnum.End || nodeType === BlockEnum.LoopEnd || nodeType === BlockEnum.KnowledgeBase)
+    if (!nodeType || nodeType === BlockEnum.LoopEnd || nodeType === BlockEnum.KnowledgeBase)
       availableNextBlocks = []
 
     return {


### PR DESCRIPTION
## Problem

The End (Output) node had its source handle `+` button permanently hidden. This happened because `useAvailableBlocks` returned `availableNextBlocks = []` for `BlockEnum.End`, making `isConnectable = false` in `NodeSourceHandle`, which prevented the `BlockSelector` from rendering.

Unlike every other regular node, users had no way to click `+` on the End node's right side to add a new connection — even though `BaseNode` already renders a `NodeSourceHandle` for it.

## Fix

Remove `BlockEnum.End` from the empty-list guard in both the `availableNextBlocks` memo and the `getAvailableBlocks` callback in `use-available-blocks.ts`.

The `availableBlocksFilter` that prevents End nodes from being placed inside Iteration/Loop containers is unchanged.

## Changes

- `web/app/components/workflow/hooks/use-available-blocks.ts` — 2 lines

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
- [x] The change is frontend-only, no backend impact
- [ ] I have written tests for this change