### PR TITLE
refactor(web): convert 8 enums to as-const objects (batch 6)

### DIFF
--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -9892,16 +9892,6 @@
       "count": 1
     }
   },
-  "models/access-control.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 2
-    }
-  },
-  "models/app.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 2
-    }
-  },
   "models/common.ts": {
     "erasable-syntax-only/enums": {
       "count": 3
@@ -9919,17 +9909,11 @@
     }
   },
   "models/debug.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 4
     }
   },
   "models/log.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 7
     }
@@ -10012,9 +9996,6 @@
     }
   },
   "service/share.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 3
     }

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -36,6 +36,7 @@ export default antfu(
       overrides: {
         'ts/consistent-type-definitions': ['error', 'type'],
         'ts/no-explicit-any': 'error',
+        'ts/no-redeclare': 'off',
       },
       erasableOnly: true,
     },

--- a/web/models/access-control.ts
+++ b/web/models/access-control.ts
@@ -1,14 +1,16 @@
-export enum SubjectType {
-  GROUP = 'group',
-  ACCOUNT = 'account',
-}
+export const SubjectType = {
+  GROUP: 'group',
+  ACCOUNT: 'account',
+} as const
+export type SubjectType = typeof SubjectType[keyof typeof SubjectType]
 
-export enum AccessMode {
-  PUBLIC = 'public',
-  SPECIFIC_GROUPS_MEMBERS = 'private',
-  ORGANIZATION = 'private_all',
-  EXTERNAL_MEMBERS = 'sso_verified',
-}
+export const AccessMode = {
+  PUBLIC: 'public',
+  SPECIFIC_GROUPS_MEMBERS: 'private',
+  ORGANIZATION: 'private_all',
+  EXTERNAL_MEMBERS: 'sso_verified',
+} as const
+export type AccessMode = typeof AccessMode[keyof typeof AccessMode]
 
 export type AccessControlGroup = {
   id: 'string'

--- a/web/models/app.ts
+++ b/web/models/app.ts
@@ -14,17 +14,19 @@ import type {
 import type { Dependency } from '@/app/components/plugins/types'
 import type { App, AppModeEnum, AppTemplate, SiteConfig } from '@/types/app'
 
-export enum DSLImportMode {
-  YAML_CONTENT = 'yaml-content',
-  YAML_URL = 'yaml-url',
-}
+export const DSLImportMode = {
+  YAML_CONTENT: 'yaml-content',
+  YAML_URL: 'yaml-url',
+} as const
+export type DSLImportMode = typeof DSLImportMode[keyof typeof DSLImportMode]
 
-export enum DSLImportStatus {
-  COMPLETED = 'completed',
-  COMPLETED_WITH_WARNINGS = 'completed-with-warnings',
-  PENDING = 'pending',
-  FAILED = 'failed',
-}
+export const DSLImportStatus = {
+  COMPLETED: 'completed',
+  COMPLETED_WITH_WARNINGS: 'completed-with-warnings',
+  PENDING: 'pending',
+  FAILED: 'failed',
+} as const
+export type DSLImportStatus = typeof DSLImportStatus[keyof typeof DSLImportStatus]
 
 export type AppListResponse = {
   data: App[]

--- a/web/models/debug.ts
+++ b/web/models/debug.ts
@@ -13,10 +13,11 @@ import type { AgentStrategy, ModelModeType, RETRIEVE_TYPE, ToolItem, TtsAutoPlay
 
 export type Inputs = Record<string, string | number | object | boolean>
 
-export enum PromptMode {
-  simple = 'simple',
-  advanced = 'advanced',
-}
+export const PromptMode = {
+  simple: 'simple',
+  advanced: 'advanced',
+} as const
+export type PromptMode = typeof PromptMode[keyof typeof PromptMode]
 
 export type PromptItem = {
   role?: PromptRole
@@ -42,11 +43,12 @@ export type BlockStatus = {
   query: boolean
 }
 
-export enum PromptRole {
-  system = 'system',
-  user = 'user',
-  assistant = 'assistant',
-}
+export const PromptRole = {
+  system: 'system',
+  user: 'user',
+  assistant: 'assistant',
+} as const
+export type PromptRole = typeof PromptRole[keyof typeof PromptRole]
 
 export type PromptVariable = {
   key: string

--- a/web/models/log.ts
+++ b/web/models/log.ts
@@ -211,15 +211,16 @@ export type AnnotationsCountResponse = {
   count: number
 }
 
-export enum WorkflowRunTriggeredFrom {
-  DEBUGGING = 'debugging',
-  APP_RUN = 'app-run',
-  RAG_PIPELINE_RUN = 'rag-pipeline-run',
-  RAG_PIPELINE_DEBUGGING = 'rag-pipeline-debugging',
-  WEBHOOK = 'webhook',
-  SCHEDULE = 'schedule',
-  PLUGIN = 'plugin',
-}
+export const WorkflowRunTriggeredFrom = {
+  DEBUGGING: 'debugging',
+  APP_RUN: 'app-run',
+  RAG_PIPELINE_RUN: 'rag-pipeline-run',
+  RAG_PIPELINE_DEBUGGING: 'rag-pipeline-debugging',
+  WEBHOOK: 'webhook',
+  SCHEDULE: 'schedule',
+  PLUGIN: 'plugin',
+} as const
+export type WorkflowRunTriggeredFrom = typeof WorkflowRunTriggeredFrom[keyof typeof WorkflowRunTriggeredFrom]
 
 export type TriggerMetadata = {
   type?: string

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -29,11 +29,12 @@ import {
 } from './base'
 import { getWebAppAccessToken } from './webapp-auth'
 
-export enum AppSourceType {
-  webApp = 'webApp',
-  installedApp = 'installedApp',
-  tryApp = 'tryApp',
-}
+export const AppSourceType = {
+  webApp: 'webApp',
+  installedApp: 'installedApp',
+  tryApp: 'tryApp',
+} as const
+export type AppSourceType = typeof AppSourceType[keyof typeof AppSourceType]
 
 const apiPrefix = {
   [AppSourceType.webApp]: '',


### PR DESCRIPTION
## Summary

Converts 8 TypeScript enums across model and service files to `as const` objects with companion type aliases, continuing the work tracked in #27998.

**Files changed:**
- `web/models/access-control.ts` — `SubjectType`, `AccessMode`
- `web/models/debug.ts` — `PromptMode`, `PromptRole`
- `web/models/app.ts` — `DSLImportMode`, `DSLImportStatus`
- `web/models/log.ts` — `WorkflowRunTriggeredFrom`
- `web/service/share.ts` — `AppSourceType`
- `web/eslint.config.mjs` — disable `ts/no-redeclare` globally (TypeScript handles redeclaration checking natively)

**Pattern used:**
```ts
// Before
export enum SubjectType {
  GROUP = 'group',
  ACCOUNT = 'account',
}

// After
export const SubjectType = {
  GROUP: 'group',
  ACCOUNT: 'account',
} as const
export type SubjectType = typeof SubjectType[keyof typeof SubjectType]
```

## Test plan

- [x] `npm run lint` passes with 0 errors
- [x] All existing consumers of these types continue to work (type aliases are structurally identical)
- [x] No inline eslint-disable comments added

Closes part of #27998