### PR TITLE
fix(ci): update setup-vp action to fix node-version-file warning

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Setup Vite+
-      uses: voidzero-dev/setup-vp@4a524139920f87f9f7080d3b8545acac019e1852 # v1.0.0
+      uses: voidzero-dev/setup-vp@906b5821fc79472a80264736a266e06643cca1fc # v1
       with:
         node-version-file: web/.nvmrc
         cache: true


### PR DESCRIPTION
## Summary

- Updates the pinned SHA for `voidzero-dev/setup-vp` in `.github/actions/setup-web/action.yml` from `4a524139` (v1.0.0) to `906b5821` (current v1 tag)
- The old SHA was from a commit that did not have `node-version-file` as a declared input, causing the CI warning: `Unexpected input(s) 'node-version-file'`
- The new SHA is the latest v1 release which properly declares `node-version-file` and also fixes the "No cache directories found" warning

## Test plan

- [x] CI should no longer show `Unexpected input(s) 'node-version-file'` warning
- [x] CI should no longer show `No cache directories found. Skipping cache restore.` warning
- [x] Web setup step continues to work as expected

Fixes #33948