### PR TITLE
refactor: select in remaining console app controllers

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -458,9 +458,7 @@ class ChatConversationApi(Resource):
         args = ChatConversationQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
 
         subquery = (
-            sa.select(
-                Conversation.id.label("conversation_id"), EndUser.session_id.label("from_end_user_session_id")
-            )
+            sa.select(Conversation.id.label("conversation_id"), EndUser.session_id.label("from_end_user_session_id"))
             .outerjoin(EndUser, Conversation.from_end_user_id == EndUser.id)
             .subquery()
         )

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -458,7 +458,7 @@ class ChatConversationApi(Resource):
         args = ChatConversationQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
 
         subquery = (
-            db.session.query(
+            sa.select(
                 Conversation.id.label("conversation_id"), EndUser.session_id.label("from_end_user_session_id")
             )
             .outerjoin(EndUser, Conversation.from_end_user_id == EndUser.id)
@@ -595,10 +595,8 @@ class ChatConversationDetailApi(Resource):
 
 def _get_conversation(app_model, conversation_id):
     current_user, _ = current_account_with_tenant()
-    conversation = (
-        db.session.query(Conversation)
-        .where(Conversation.id == conversation_id, Conversation.app_id == app_model.id)
-        .first()
+    conversation = db.session.scalar(
+        sa.select(Conversation).where(Conversation.id == conversation_id, Conversation.app_id == app_model.id).limit(1)
     )
 
     if not conversation:

--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -168,7 +168,7 @@ class InstructionGenerateApi(Resource):
         try:
             # Generate from nothing for a workflow node
             if (args.current in (code_template, "")) and args.node_id != "":
-                app = db.session.query(App).where(App.id == args.flow_id).first()
+                app = db.session.get(App, args.flow_id)
                 if not app:
                     return {"error": f"app {args.flow_id} not found"}, 400
                 workflow = WorkflowService().get_draft_workflow(app_model=app)

--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -2,6 +2,7 @@ import json
 
 from flask_restx import Resource, marshal_with
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from werkzeug.exceptions import NotFound
 
 from controllers.console import console_ns
@@ -47,7 +48,7 @@ class AppMCPServerController(Resource):
     @get_app_model
     @marshal_with(app_server_model)
     def get(self, app_model):
-        server = db.session.query(AppMCPServer).where(AppMCPServer.app_id == app_model.id).first()
+        server = db.session.scalar(select(AppMCPServer).where(AppMCPServer.app_id == app_model.id).limit(1))
         return server
 
     @console_ns.doc("create_app_mcp_server")
@@ -98,7 +99,7 @@ class AppMCPServerController(Resource):
     @edit_permission_required
     def put(self, app_model):
         payload = MCPServerUpdatePayload.model_validate(console_ns.payload or {})
-        server = db.session.query(AppMCPServer).where(AppMCPServer.id == payload.id).first()
+        server = db.session.get(AppMCPServer, payload.id)
         if not server:
             raise NotFound()
 
@@ -135,11 +136,10 @@ class AppMCPServerRefreshController(Resource):
     @edit_permission_required
     def get(self, server_id):
         _, current_tenant_id = current_account_with_tenant()
-        server = (
-            db.session.query(AppMCPServer)
-            .where(AppMCPServer.id == server_id)
-            .where(AppMCPServer.tenant_id == current_tenant_id)
-            .first()
+        server = db.session.scalar(
+            select(AppMCPServer)
+            .where(AppMCPServer.id == server_id, AppMCPServer.tenant_id == current_tenant_id)
+            .limit(1)
         )
         if not server:
             raise NotFound()

--- a/api/controllers/console/app/model_config.py
+++ b/api/controllers/console/app/model_config.py
@@ -69,9 +69,7 @@ class ModelConfigResource(Resource):
 
         if app_model.mode == AppMode.AGENT_CHAT or app_model.is_agent:
             # get original app model config
-            original_app_model_config = (
-                db.session.query(AppModelConfig).where(AppModelConfig.id == app_model.app_model_config_id).first()
-            )
+            original_app_model_config = db.session.get(AppModelConfig, app_model.app_model_config_id)
             if original_app_model_config is None:
                 raise ValueError("Original app model config not found")
             agent_mode = original_app_model_config.agent_mode_dict

--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from flask_restx import Resource, marshal_with
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
 from werkzeug.exceptions import NotFound
 
 from constants.languages import supported_language
@@ -75,7 +76,7 @@ class AppSite(Resource):
     def post(self, app_model):
         args = AppSiteUpdatePayload.model_validate(console_ns.payload or {})
         current_user, _ = current_account_with_tenant()
-        site = db.session.query(Site).where(Site.app_id == app_model.id).first()
+        site = db.session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
         if not site:
             raise NotFound
 
@@ -124,7 +125,7 @@ class AppSiteAccessTokenReset(Resource):
     @marshal_with(app_site_model)
     def post(self, app_model):
         current_user, _ = current_account_with_tenant()
-        site = db.session.query(Site).where(Site.app_id == app_model.id).first()
+        site = db.session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
 
         if not site:
             raise NotFound

--- a/api/controllers/console/app/wraps.py
+++ b/api/controllers/console/app/wraps.py
@@ -2,6 +2,8 @@ from collections.abc import Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar, Union
 
+from sqlalchemy import select
+
 from controllers.console.app.error import AppNotFoundError
 from extensions.ext_database import db
 from libs.login import current_account_with_tenant
@@ -15,16 +17,14 @@ R1 = TypeVar("R1")
 
 def _load_app_model(app_id: str) -> App | None:
     _, current_tenant_id = current_account_with_tenant()
-    app_model = (
-        db.session.query(App)
-        .where(App.id == app_id, App.tenant_id == current_tenant_id, App.status == "normal")
-        .first()
+    app_model = db.session.scalar(
+        select(App).where(App.id == app_id, App.tenant_id == current_tenant_id, App.status == "normal").limit(1)
     )
     return app_model
 
 
 def _load_app_model_with_trial(app_id: str) -> App | None:
-    app_model = db.session.query(App).where(App.id == app_id, App.status == "normal").first()
+    app_model = db.session.scalar(select(App).where(App.id == app_id, App.status == "normal").limit(1))
     return app_model
 
 

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -281,12 +281,10 @@ class TestSiteEndpoints:
         method = _unwrap(api.post)
 
         site = MagicMock()
-        query = MagicMock()
-        query.where.return_value.first.return_value = site
         monkeypatch.setattr(
             site_module.db,
             "session",
-            MagicMock(query=lambda *_args, **_kwargs: query, commit=lambda: None),
+            MagicMock(scalar=lambda *_args, **_kwargs: site, commit=lambda: None),
         )
         monkeypatch.setattr(
             site_module,
@@ -305,12 +303,10 @@ class TestSiteEndpoints:
         method = _unwrap(api.post)
 
         site = MagicMock()
-        query = MagicMock()
-        query.where.return_value.first.return_value = site
         monkeypatch.setattr(
             site_module.db,
             "session",
-            MagicMock(query=lambda *_args, **_kwargs: query, commit=lambda: None),
+            MagicMock(scalar=lambda *_args, **_kwargs: site, commit=lambda: None),
         )
         monkeypatch.setattr(site_module.Site, "generate_code", lambda *_args, **_kwargs: "code")
         monkeypatch.setattr(

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
@@ -82,12 +82,8 @@ def test_chat_conversation_list_advanced_chat_calls_paginate(app, monkeypatch: p
 def test_get_conversation_updates_read_at(monkeypatch: pytest.MonkeyPatch) -> None:
     conversation = SimpleNamespace(id="c1", app_id="app-1")
 
-    query = MagicMock()
-    query.where.return_value = query
-    query.first.return_value = conversation
-
     session = MagicMock()
-    session.query.return_value = query
+    session.scalar.return_value = conversation
 
     monkeypatch.setattr(conversation_module, "current_account_with_tenant", lambda: (_make_account(), "t1"))
     monkeypatch.setattr(conversation_module.db, "session", session)
@@ -101,12 +97,8 @@ def test_get_conversation_updates_read_at(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_get_conversation_missing_raises_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    query = MagicMock()
-    query.where.return_value = query
-    query.first.return_value = None
-
     session = MagicMock()
-    session.query.return_value = query
+    session.scalar.return_value = None
 
     monkeypatch.setattr(conversation_module, "current_account_with_tenant", lambda: (_make_account(), "t1"))
     monkeypatch.setattr(conversation_module.db, "session", session)

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_read_timestamp.py
@@ -24,7 +24,7 @@ def test_get_conversation_mark_read_keeps_updated_at_unchanged():
         ),
         patch("controllers.console.app.conversation.db.session", autospec=True) as mock_session,
     ):
-        mock_session.query.return_value.where.return_value.first.return_value = conversation
+        mock_session.scalar.return_value = conversation
 
         _get_conversation(app_model, "conversation-id")
 

--- a/api/tests/unit_tests/controllers/console/app/test_generator_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_generator_api.py
@@ -73,8 +73,7 @@ def test_instruction_generate_app_not_found(app, monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(generator_module, "current_account_with_tenant", lambda: (None, "t1"))
 
-    query = SimpleNamespace(where=lambda *_args, **_kwargs: query, first=lambda: None)
-    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(query=lambda *_args, **_kwargs: query))
+    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(get=lambda *_args, **_kwargs: None))
 
     with app.test_request_context(
         "/console/api/instruction-generate",
@@ -99,8 +98,7 @@ def test_instruction_generate_workflow_not_found(app, monkeypatch: pytest.Monkey
     monkeypatch.setattr(generator_module, "current_account_with_tenant", lambda: (None, "t1"))
 
     app_model = SimpleNamespace(id="app-1")
-    query = SimpleNamespace(where=lambda *_args, **_kwargs: query, first=lambda: app_model)
-    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(query=lambda *_args, **_kwargs: query))
+    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(get=lambda *_args, **_kwargs: app_model))
     _install_workflow_service(monkeypatch, workflow=None)
 
     with app.test_request_context(
@@ -126,8 +124,7 @@ def test_instruction_generate_node_missing(app, monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(generator_module, "current_account_with_tenant", lambda: (None, "t1"))
 
     app_model = SimpleNamespace(id="app-1")
-    query = SimpleNamespace(where=lambda *_args, **_kwargs: query, first=lambda: app_model)
-    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(query=lambda *_args, **_kwargs: query))
+    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(get=lambda *_args, **_kwargs: app_model))
 
     workflow = SimpleNamespace(graph_dict={"nodes": []})
     _install_workflow_service(monkeypatch, workflow=workflow)
@@ -155,8 +152,7 @@ def test_instruction_generate_code_node(app, monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(generator_module, "current_account_with_tenant", lambda: (None, "t1"))
 
     app_model = SimpleNamespace(id="app-1")
-    query = SimpleNamespace(where=lambda *_args, **_kwargs: query, first=lambda: app_model)
-    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(query=lambda *_args, **_kwargs: query))
+    monkeypatch.setattr(generator_module.db, "session", SimpleNamespace(get=lambda *_args, **_kwargs: app_model))
 
     workflow = SimpleNamespace(
         graph_dict={

--- a/api/tests/unit_tests/controllers/console/app/test_model_config_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_model_config_api.py
@@ -92,10 +92,7 @@ def test_post_encrypts_agent_tool_parameters(app, monkeypatch: pytest.MonkeyPatc
     )
 
     session = MagicMock()
-    query = MagicMock()
-    query.where.return_value = query
-    query.first.return_value = original_config
-    session.query.return_value = query
+    session.get.return_value = original_config
     monkeypatch.setattr(model_config_module.db, "session", session)
 
     monkeypatch.setattr(

--- a/api/tests/unit_tests/controllers/console/app/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/app/test_wraps.py
@@ -11,10 +11,8 @@ from models.model import AppMode
 
 def test_get_app_model_injects_model(monkeypatch: pytest.MonkeyPatch) -> None:
     app_model = SimpleNamespace(id="app-1", mode=AppMode.CHAT.value, status="normal", tenant_id="t1")
-    query = SimpleNamespace(where=lambda *_args, **_kwargs: query, first=lambda: app_model)
-
     monkeypatch.setattr(wraps_module, "current_account_with_tenant", lambda: (None, "t1"))
-    monkeypatch.setattr(wraps_module.db, "session", SimpleNamespace(query=lambda *_args, **_kwargs: query))
+    monkeypatch.setattr(wraps_module.db, "session", SimpleNamespace(scalar=lambda *_args, **_kwargs: app_model))
 
     @wraps_module.get_app_model
     def handler(app_model):
@@ -25,10 +23,8 @@ def test_get_app_model_injects_model(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_get_app_model_rejects_wrong_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     app_model = SimpleNamespace(id="app-1", mode=AppMode.CHAT.value, status="normal", tenant_id="t1")
-    query = SimpleNamespace(where=lambda *_args, **_kwargs: query, first=lambda: app_model)
-
     monkeypatch.setattr(wraps_module, "current_account_with_tenant", lambda: (None, "t1"))
-    monkeypatch.setattr(wraps_module.db, "session", SimpleNamespace(query=lambda *_args, **_kwargs: query))
+    monkeypatch.setattr(wraps_module.db, "session", SimpleNamespace(scalar=lambda *_args, **_kwargs: app_model))
 
     @wraps_module.get_app_model(mode=[AppMode.COMPLETION])
     def handler(app_model):


### PR DESCRIPTION
## Summary
- Migrate 11 `db.session.query()` calls to SQLAlchemy 2.0 `select()` style across 6 remaining files in `controllers/console/app/`
- Update 2 test files to match the new query patterns
- After this PR, `controllers/console/app/` has zero `db.session.query` occurrences

Part of #22668

## Changes
| File | Occurrences | Pattern |
|---|---|---|
| `wraps.py` | 2 | `.first()` → `scalar(select().where().limit(1))` |
| `conversation.py` | 2 | 1 subquery → `sa.select().subquery()`, 1 `.first()` → `scalar()` |
| `mcp_server.py` | 3 | 1 PK lookup → `session.get()`, 2 → `scalar(select().where().limit(1))` |
| `site.py` | 2 | `.first()` → `scalar(select().where().limit(1))` |
| `model_config.py` | 1 | PK lookup → `session.get()` |
| `generator.py` | 1 | PK lookup → `session.get()` |
| `test_wraps.py` | — | mock updated: `session.query` → `session.scalar` |
| `test_conversation_read_timestamp.py` | — | mock updated: `session.query` → `session.scalar` |

## Test plan
- [x] `ruff check` passes on all modified files
- [x] `test_wraps.py` (3 tests) pass
- [x] `test_conversation_read_timestamp.py` (1 test) passes
