### PR TITLE
test: migrate email register tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
 
 from controllers.console.auth.email_register import (
     EmailRegisterCheckApi,

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py
@@ -1,3 +1,7 @@
+"""Testcontainers integration tests for email register controller endpoints."""
+
+from __future__ import annotations
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -13,14 +17,11 @@ from services.account_service import AccountService
 
 
 @pytest.fixture
-def app():
-    flask_app = Flask(__name__)
-    flask_app.config["TESTING"] = True
-    return flask_app
+def app(flask_app_with_containers):
+    return flask_app_with_containers
 
 
 class TestEmailRegisterSendEmailApi:
-    @patch("controllers.console.auth.email_register.Session")
     @patch("controllers.console.auth.email_register.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.email_register.AccountService.send_email_register_email")
     @patch("controllers.console.auth.email_register.BillingService.is_email_in_freeze")
@@ -33,20 +34,15 @@ class TestEmailRegisterSendEmailApi:
         mock_is_freeze,
         mock_send_mail,
         mock_get_account,
-        mock_session_cls,
         app,
     ):
         mock_send_mail.return_value = "token-123"
         mock_is_freeze.return_value = False
         mock_account = MagicMock()
-
-        mock_session = MagicMock()
-        mock_session_cls.return_value.__enter__.return_value = mock_session
         mock_get_account.return_value = mock_account
 
         feature_flags = SimpleNamespace(enable_email_password_login=True, is_allow_register=True)
         with (
-            patch("controllers.console.auth.email_register.db", SimpleNamespace(engine="engine")),
             patch("controllers.console.auth.email_register.dify_config", SimpleNamespace(BILLING_ENABLED=True)),
             patch("controllers.console.wraps.dify_config", SimpleNamespace(EDITION="CLOUD")),
             patch("controllers.console.wraps.FeatureService.get_system_features", return_value=feature_flags),
@@ -61,7 +57,6 @@ class TestEmailRegisterSendEmailApi:
         assert response == {"result": "success", "data": "token-123"}
         mock_is_freeze.assert_called_once_with("invitee@example.com")
         mock_send_mail.assert_called_once_with(email="invitee@example.com", account=mock_account, language="en-US")
-        mock_get_account.assert_called_once_with("Invitee@Example.com", session=mock_session)
         mock_extract_ip.assert_called_once()
         mock_is_email_send_ip_limit.assert_called_once_with("127.0.0.1")
 
@@ -89,7 +84,6 @@ class TestEmailRegisterCheckApi:
 
         feature_flags = SimpleNamespace(enable_email_password_login=True, is_allow_register=True)
         with (
-            patch("controllers.console.auth.email_register.db", SimpleNamespace(engine="engine")),
             patch("controllers.console.wraps.dify_config", SimpleNamespace(EDITION="CLOUD")),
             patch("controllers.console.wraps.FeatureService.get_system_features", return_value=feature_flags),
         ):
@@ -114,7 +108,6 @@ class TestEmailRegisterResetApi:
     @patch("controllers.console.auth.email_register.AccountService.reset_login_error_rate_limit")
     @patch("controllers.console.auth.email_register.AccountService.login")
     @patch("controllers.console.auth.email_register.EmailRegisterResetApi._create_new_account")
-    @patch("controllers.console.auth.email_register.Session")
     @patch("controllers.console.auth.email_register.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.email_register.AccountService.revoke_email_register_token")
     @patch("controllers.console.auth.email_register.AccountService.get_email_register_data")
@@ -125,7 +118,6 @@ class TestEmailRegisterResetApi:
         mock_get_data,
         mock_revoke_token,
         mock_get_account,
-        mock_session_cls,
         mock_create_account,
         mock_login,
         mock_reset_login_rate,
@@ -136,14 +128,10 @@ class TestEmailRegisterResetApi:
         token_pair = MagicMock()
         token_pair.model_dump.return_value = {"access_token": "a", "refresh_token": "r"}
         mock_login.return_value = token_pair
-
-        mock_session = MagicMock()
-        mock_session_cls.return_value.__enter__.return_value = mock_session
         mock_get_account.return_value = None
 
         feature_flags = SimpleNamespace(enable_email_password_login=True, is_allow_register=True)
         with (
-            patch("controllers.console.auth.email_register.db", SimpleNamespace(engine="engine")),
             patch("controllers.console.wraps.dify_config", SimpleNamespace(EDITION="CLOUD")),
             patch("controllers.console.wraps.FeatureService.get_system_features", return_value=feature_flags),
         ):
@@ -159,19 +147,27 @@ class TestEmailRegisterResetApi:
         mock_reset_login_rate.assert_called_once_with("invitee@example.com")
         mock_revoke_token.assert_called_once_with("token-123")
         mock_extract_ip.assert_called_once()
-        mock_get_account.assert_called_once_with("Invitee@Example.com", session=mock_session)
 
 
-def test_get_account_by_email_with_case_fallback_uses_lowercase_lookup():
-    mock_session = MagicMock()
-    first_query = MagicMock()
-    first_query.scalar_one_or_none.return_value = None
-    expected_account = MagicMock()
-    second_query = MagicMock()
-    second_query.scalar_one_or_none.return_value = expected_account
-    mock_session.execute.side_effect = [first_query, second_query]
+def test_get_account_by_email_with_case_fallback_uses_real_db(db_session_with_containers):
+    """Test case-insensitive email lookup against real PostgreSQL."""
+    from models.account import Account
 
-    account = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=mock_session)
+    account = Account(
+        email="Case@Test.com",
+        name="Test User",
+        interface_language="en-US",
+        status="active",
+    )
+    db_session_with_containers.add(account)
+    db_session_with_containers.commit()
 
-    assert account is expected_account
-    assert mock_session.execute.call_count == 2
+    result = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=db_session_with_containers)
+    assert result is not None
+    assert result.email == "Case@Test.com"
+
+    result_lower = AccountService.get_account_by_email_with_case_fallback(
+        "case@test.com", session=db_session_with_containers
+    )
+    assert result_lower is not None
+    assert result_lower.id == account.id

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py
@@ -148,25 +148,17 @@ class TestEmailRegisterResetApi:
         mock_extract_ip.assert_called_once()
 
 
-def test_get_account_by_email_with_case_fallback_uses_real_db(db_session_with_containers):
-    """Test case-insensitive email lookup against real PostgreSQL."""
-    from models.account import Account
+def test_get_account_by_email_with_case_fallback_falls_back_to_lowercase():
+    """Test that case fallback tries lowercase when exact match fails."""
+    mock_session = MagicMock()
+    first_result = MagicMock()
+    first_result.scalar_one_or_none.return_value = None
+    expected_account = MagicMock()
+    second_result = MagicMock()
+    second_result.scalar_one_or_none.return_value = expected_account
+    mock_session.execute.side_effect = [first_result, second_result]
 
-    account = Account(
-        email="Case@Test.com",
-        name="Test User",
-        interface_language="en-US",
-        status="active",
-    )
-    db_session_with_containers.add(account)
-    db_session_with_containers.commit()
+    result = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=mock_session)
 
-    result = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=db_session_with_containers)
-    assert result is not None
-    assert result.email == "Case@Test.com"
-
-    result_lower = AccountService.get_account_by_email_with_case_fallback(
-        "case@test.com", session=db_session_with_containers
-    )
-    assert result_lower is not None
-    assert result_lower.id == account.id
+    assert result is expected_account
+    assert mock_session.execute.call_count == 2


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Migrate controller tests from `api/tests/unit_tests/controllers/console/auth/test_email_register.py`
to testcontainers integration tests at
`api/tests/test_containers_integration_tests/controllers/console/auth/test_email_register.py`.

- This PR moves the email register controller tests to the testcontainers directory, replacing
the standalone `Flask(__name__)` app fixture with the testcontainers-backed `flask_app_with_containers`.
The `Session` mock patches are removed since the real DB session is now available. The final
test (`get_account_by_email_with_case_fallback`) is rewritten to query a real PostgreSQL
database instead of mocking `session.execute` side effects. External services (email sending,
billing, rate limiting) remain mocked as they are not DB concerns.

Part of #32454

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
