### PR TITLE
test: migrate forgot password tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_forgot_password.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_forgot_password.py
@@ -162,7 +162,9 @@ def test_get_account_by_email_with_case_fallback_uses_real_db(db_session_with_co
     db_session_with_containers.add(account)
     db_session_with_containers.commit()
 
-    result = AccountService.get_account_by_email_with_case_fallback("Mixed@Test.com", session=db_session_with_containers)
+    result = AccountService.get_account_by_email_with_case_fallback(
+        "Mixed@Test.com", session=db_session_with_containers
+    )
     assert result is not None
     assert result.email == "Mixed@Test.com"
 

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_forgot_password.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_forgot_password.py
@@ -149,27 +149,19 @@ class TestForgotPasswordResetApi:
         mock_update_account.assert_called_once()
 
 
-def test_get_account_by_email_with_case_fallback_uses_real_db(db_session_with_containers):
-    """Test case-insensitive email lookup against real PostgreSQL."""
-    from models.account import Account
+def test_get_account_by_email_with_case_fallback_falls_back_to_lowercase():
+    """Test that case fallback tries lowercase when exact match fails."""
+    from unittest.mock import MagicMock
 
-    account = Account(
-        email="Mixed@Test.com",
-        name="Test User",
-        interface_language="en-US",
-        status="active",
-    )
-    db_session_with_containers.add(account)
-    db_session_with_containers.commit()
+    mock_session = MagicMock()
+    first_result = MagicMock()
+    first_result.scalar_one_or_none.return_value = None
+    expected_account = MagicMock()
+    second_result = MagicMock()
+    second_result.scalar_one_or_none.return_value = expected_account
+    mock_session.execute.side_effect = [first_result, second_result]
 
-    result = AccountService.get_account_by_email_with_case_fallback(
-        "Mixed@Test.com", session=db_session_with_containers
-    )
-    assert result is not None
-    assert result.email == "Mixed@Test.com"
+    result = AccountService.get_account_by_email_with_case_fallback("Mixed@Test.com", session=mock_session)
 
-    result_lower = AccountService.get_account_by_email_with_case_fallback(
-        "mixed@test.com", session=db_session_with_containers
-    )
-    assert result_lower is not None
-    assert result_lower.id == account.id
+    assert result is expected_account
+    assert mock_session.execute.call_count == 2

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_forgot_password.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_forgot_password.py
@@ -1,8 +1,11 @@
+"""Testcontainers integration tests for forgot password controller endpoints."""
+
+from __future__ import annotations
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
 
 from controllers.console.auth.forgot_password import (
     ForgotPasswordCheckApi,
@@ -13,14 +16,11 @@ from services.account_service import AccountService
 
 
 @pytest.fixture
-def app():
-    flask_app = Flask(__name__)
-    flask_app.config["TESTING"] = True
-    return flask_app
+def app(flask_app_with_containers):
+    return flask_app_with_containers
 
 
 class TestForgotPasswordSendEmailApi:
-    @patch("controllers.console.auth.forgot_password.Session")
     @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.forgot_password.AccountService.send_reset_password_email")
     @patch("controllers.console.auth.forgot_password.AccountService.is_email_send_ip_limit", return_value=False)
@@ -31,19 +31,15 @@ class TestForgotPasswordSendEmailApi:
         mock_is_ip_limit,
         mock_send_email,
         mock_get_account,
-        mock_session_cls,
         app,
     ):
         mock_account = MagicMock()
         mock_get_account.return_value = mock_account
         mock_send_email.return_value = "token-123"
-        mock_session = MagicMock()
-        mock_session_cls.return_value.__enter__.return_value = mock_session
 
         wraps_features = SimpleNamespace(enable_email_password_login=True, is_allow_register=True)
         controller_features = SimpleNamespace(is_allow_register=True)
         with (
-            patch("controllers.console.auth.forgot_password.db", SimpleNamespace(engine="engine")),
             patch(
                 "controllers.console.auth.forgot_password.FeatureService.get_system_features",
                 return_value=controller_features,
@@ -59,7 +55,6 @@ class TestForgotPasswordSendEmailApi:
                 response = ForgotPasswordSendEmailApi().post()
 
         assert response == {"result": "success", "data": "token-123"}
-        mock_get_account.assert_called_once_with("User@Example.com", session=mock_session)
         mock_send_email.assert_called_once_with(
             account=mock_account,
             email="user@example.com",
@@ -117,7 +112,6 @@ class TestForgotPasswordCheckApi:
 
 class TestForgotPasswordResetApi:
     @patch("controllers.console.auth.forgot_password.ForgotPasswordResetApi._update_existing_account")
-    @patch("controllers.console.auth.forgot_password.Session")
     @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.forgot_password.AccountService.revoke_reset_password_token")
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
@@ -126,7 +120,6 @@ class TestForgotPasswordResetApi:
         mock_get_reset_data,
         mock_revoke_token,
         mock_get_account,
-        mock_session_cls,
         mock_update_account,
         app,
     ):
@@ -134,12 +127,8 @@ class TestForgotPasswordResetApi:
         mock_account = MagicMock()
         mock_get_account.return_value = mock_account
 
-        mock_session = MagicMock()
-        mock_session_cls.return_value.__enter__.return_value = mock_session
-
         wraps_features = SimpleNamespace(enable_email_password_login=True)
         with (
-            patch("controllers.console.auth.forgot_password.db", SimpleNamespace(engine="engine")),
             patch("controllers.console.wraps.dify_config", SimpleNamespace(EDITION="CLOUD")),
             patch("controllers.console.wraps.FeatureService.get_system_features", return_value=wraps_features),
         ):
@@ -157,20 +146,28 @@ class TestForgotPasswordResetApi:
         assert response == {"result": "success"}
         mock_get_reset_data.assert_called_once_with("token-123")
         mock_revoke_token.assert_called_once_with("token-123")
-        mock_get_account.assert_called_once_with("User@Example.com", session=mock_session)
         mock_update_account.assert_called_once()
 
 
-def test_get_account_by_email_with_case_fallback_uses_lowercase_lookup():
-    mock_session = MagicMock()
-    first_query = MagicMock()
-    first_query.scalar_one_or_none.return_value = None
-    expected_account = MagicMock()
-    second_query = MagicMock()
-    second_query.scalar_one_or_none.return_value = expected_account
-    mock_session.execute.side_effect = [first_query, second_query]
+def test_get_account_by_email_with_case_fallback_uses_real_db(db_session_with_containers):
+    """Test case-insensitive email lookup against real PostgreSQL."""
+    from models.account import Account
 
-    account = AccountService.get_account_by_email_with_case_fallback("Mixed@Test.com", session=mock_session)
+    account = Account(
+        email="Mixed@Test.com",
+        name="Test User",
+        interface_language="en-US",
+        status="active",
+    )
+    db_session_with_containers.add(account)
+    db_session_with_containers.commit()
 
-    assert account is expected_account
-    assert mock_session.execute.call_count == 2
+    result = AccountService.get_account_by_email_with_case_fallback("Mixed@Test.com", session=db_session_with_containers)
+    assert result is not None
+    assert result.email == "Mixed@Test.com"
+
+    result_lower = AccountService.get_account_by_email_with_case_fallback(
+        "mixed@test.com", session=db_session_with_containers
+    )
+    assert result_lower is not None
+    assert result_lower.id == account.id


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Migrate controller tests for forgot password from mock-based unit tests to testcontainers
integration tests by moving `test_forgot_password.py` from `unit_tests/` to
`test_containers_integration_tests/`.

Key changes:
- Replace standalone `Flask(__name__)` fixture with `flask_app_with_containers`
- Remove `Session` and `db` mock patches — real DB session is now available
- Rewrite `get_account_by_email_with_case_fallback` test to query real PostgreSQL
  instead of mocking `session.execute` side effects
- External services (email sending, rate limiting) remain mocked

Part of #32454

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
