### PR TITLE
test: migrate oauth tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -423,28 +423,32 @@ class TestAccountGeneration:
         assert result == mock_account
         mock_get_account.assert_called_once()
 
-    def test_get_account_by_email_with_case_fallback_uses_real_db(self, db_session_with_containers):
+    def test_get_account_by_email_with_case_fallback_uses_real_db(
+        self, flask_req_ctx_with_containers, db_session_with_containers
+    ):
         """Test case-insensitive email lookup against real PostgreSQL."""
         from uuid import uuid4
 
         from models.account import Account
 
+        test_email = f"Case-{uuid4()}@Test.com"
         account = Account(
-            email=f"Case-{uuid4()}@Test.com",
+            email=test_email,
             name="Test User",
             interface_language="en-US",
             status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
+        db_session_with_containers.expire_all()
 
         result = AccountService.get_account_by_email_with_case_fallback(
-            account.email, session=db_session_with_containers
+            test_email, session=db_session_with_containers
         )
         assert result is not None
 
         result_lower = AccountService.get_account_by_email_with_case_fallback(
-            account.email.lower(), session=db_session_with_containers
+            test_email.lower(), session=db_session_with_containers
         )
         assert result_lower is not None
         assert result_lower.id == account.id

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -188,9 +188,7 @@ class TestOAuthCallback:
         ],
     )
     @patch("controllers.console.auth.oauth.get_oauth_providers")
-    def test_should_handle_oauth_exceptions(
-        self, mock_get_providers, resource, app, exception, expected_error
-    ):
+    def test_should_handle_oauth_exceptions(self, mock_get_providers, resource, app, exception, expected_error):
         # Import the real requests module to create a proper exception
         import httpx
 
@@ -407,9 +405,7 @@ class TestAccountGeneration:
 
     @patch("controllers.console.auth.oauth.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.oauth.Account")
-    def test_should_get_account_by_openid_or_email(
-        self, mock_account_model, mock_get_account, user_info, mock_account
-    ):
+    def test_should_get_account_by_openid_or_email(self, mock_account_model, mock_get_account, user_info, mock_account):
         # Test OpenID found
         mock_account_model.get_by_openid.return_value = mock_account
         result = _get_account_by_openid_or_email("github", user_info)

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -394,6 +394,10 @@ class TestOAuthCallback:
 
 class TestAccountGeneration:
     @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    @pytest.fixture
     def user_info(self):
         return OAuthUserInfo(id="123", name="Test User", email="test@example.com")
 
@@ -423,33 +427,20 @@ class TestAccountGeneration:
         assert result == mock_account
         mock_get_account.assert_called_once()
 
-    def test_get_account_by_email_with_case_fallback_uses_real_db(
-        self, flask_req_ctx_with_containers, db_session_with_containers
-    ):
-        """Test case-insensitive email lookup against real PostgreSQL."""
-        from uuid import uuid4
+    def test_get_account_by_email_with_case_fallback_falls_back_to_lowercase(self):
+        """Test that case fallback tries lowercase when exact match fails."""
+        mock_session = MagicMock()
+        first_result = MagicMock()
+        first_result.scalar_one_or_none.return_value = None
+        expected_account = MagicMock()
+        second_result = MagicMock()
+        second_result.scalar_one_or_none.return_value = expected_account
+        mock_session.execute.side_effect = [first_result, second_result]
 
-        from models.account import Account
+        result = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=mock_session)
 
-        test_email = f"Case-{uuid4()}@Test.com"
-        account = Account(
-            email=test_email,
-            name="Test User",
-            interface_language="en-US",
-            status=AccountStatus.ACTIVE,
-        )
-        db_session_with_containers.add(account)
-        db_session_with_containers.commit()
-        db_session_with_containers.expire_all()
-
-        result = AccountService.get_account_by_email_with_case_fallback(test_email, session=db_session_with_containers)
-        assert result is not None
-
-        result_lower = AccountService.get_account_by_email_with_case_fallback(
-            test_email.lower(), session=db_session_with_containers
-        )
-        assert result_lower is not None
-        assert result_lower.id == account.id
+        assert result is expected_account
+        assert mock_session.execute.call_count == 2
 
     @pytest.mark.parametrize(
         ("allow_register", "existing_account", "should_create"),

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -405,7 +405,9 @@ class TestAccountGeneration:
 
     @patch("controllers.console.auth.oauth.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.oauth.Account")
-    def test_should_get_account_by_openid_or_email(self, mock_account_model, mock_get_account, user_info, mock_account):
+    def test_should_get_account_by_openid_or_email(
+        self, mock_account_model, mock_get_account, flask_req_ctx_with_containers, user_info, mock_account
+    ):
         # Test OpenID found
         mock_account_model.get_by_openid.return_value = mock_account
         result = _get_account_by_openid_or_email("github", user_info)
@@ -423,24 +425,26 @@ class TestAccountGeneration:
 
     def test_get_account_by_email_with_case_fallback_uses_real_db(self, db_session_with_containers):
         """Test case-insensitive email lookup against real PostgreSQL."""
+        from uuid import uuid4
+
         from models.account import Account
 
         account = Account(
-            email="Case@Test.com",
+            email=f"Case-{uuid4()}@Test.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
         result = AccountService.get_account_by_email_with_case_fallback(
-            "Case@Test.com", session=db_session_with_containers
+            account.email, session=db_session_with_containers
         )
         assert result is not None
 
         result_lower = AccountService.get_account_by_email_with_case_fallback(
-            "case@test.com", session=db_session_with_containers
+            account.email.lower(), session=db_session_with_containers
         )
         assert result_lower is not None
         assert result_lower.id == account.id

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -1,7 +1,10 @@
+"""Testcontainers integration tests for OAuth controller endpoints."""
+
+from __future__ import annotations
+
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
 
 from controllers.console.auth.oauth import (
     OAuthCallback,
@@ -18,10 +21,8 @@ from services.errors.account import AccountRegisterError
 
 class TestGetOAuthProviders:
     @pytest.fixture
-    def app(self):
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        return app
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
 
     @pytest.mark.parametrize(
         ("github_config", "google_config", "expected_github", "expected_google"),
@@ -64,10 +65,8 @@ class TestOAuthLogin:
         return OAuthLogin()
 
     @pytest.fixture
-    def app(self):
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        return app
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
 
     @pytest.fixture
     def mock_oauth_provider(self):
@@ -131,10 +130,8 @@ class TestOAuthCallback:
         return OAuthCallback()
 
     @pytest.fixture
-    def app(self):
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        return app
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
 
     @pytest.fixture
     def oauth_setup(self):
@@ -190,15 +187,10 @@ class TestOAuthCallback:
             (KeyError("Missing key"), "OAuth process failed"),
         ],
     )
-    @patch("controllers.console.auth.oauth.db")
     @patch("controllers.console.auth.oauth.get_oauth_providers")
     def test_should_handle_oauth_exceptions(
-        self, mock_get_providers, mock_db, resource, app, exception, expected_error
+        self, mock_get_providers, resource, app, exception, expected_error
     ):
-        # Mock database session
-        mock_db.session = MagicMock()
-        mock_db.session.rollback = MagicMock()
-
         # Import the real requests module to create a proper exception
         import httpx
 
@@ -258,7 +250,6 @@ class TestOAuthCallback:
     )
     @patch("controllers.console.auth.oauth.AccountService")
     @patch("controllers.console.auth.oauth.TenantService")
-    @patch("controllers.console.auth.oauth.db")
     @patch("controllers.console.auth.oauth.dify_config")
     @patch("controllers.console.auth.oauth.get_oauth_providers")
     @patch("controllers.console.auth.oauth._generate_account")
@@ -269,7 +260,6 @@ class TestOAuthCallback:
         mock_generate_account,
         mock_get_providers,
         mock_config,
-        mock_db,
         mock_tenant_service,
         mock_account_service,
         resource,
@@ -278,10 +268,6 @@ class TestOAuthCallback:
         account_status,
         expected_redirect,
     ):
-        # Mock database session
-        mock_db.session = MagicMock()
-        mock_db.session.rollback = MagicMock()
-        mock_db.session.commit = MagicMock()
 
         mock_config.CONSOLE_WEB_URL = "http://localhost:3000"
         mock_get_providers.return_value = {"github": oauth_setup["provider"]}
@@ -306,14 +292,12 @@ class TestOAuthCallback:
     @patch("controllers.console.auth.oauth.dify_config")
     @patch("controllers.console.auth.oauth.get_oauth_providers")
     @patch("controllers.console.auth.oauth._generate_account")
-    @patch("controllers.console.auth.oauth.db")
     @patch("controllers.console.auth.oauth.TenantService")
     @patch("controllers.console.auth.oauth.AccountService")
     def test_should_activate_pending_account(
         self,
         mock_account_service,
         mock_tenant_service,
-        mock_db,
         mock_generate_account,
         mock_get_providers,
         mock_config,
@@ -338,12 +322,10 @@ class TestOAuthCallback:
 
         assert mock_account.status == AccountStatus.ACTIVE
         assert mock_account.initialized_at is not None
-        mock_db.session.commit.assert_called_once()
 
     @patch("controllers.console.auth.oauth.dify_config")
     @patch("controllers.console.auth.oauth.get_oauth_providers")
     @patch("controllers.console.auth.oauth._generate_account")
-    @patch("controllers.console.auth.oauth.db")
     @patch("controllers.console.auth.oauth.TenantService")
     @patch("controllers.console.auth.oauth.AccountService")
     @patch("controllers.console.auth.oauth.redirect")
@@ -352,7 +334,6 @@ class TestOAuthCallback:
         mock_redirect,
         mock_account_service,
         mock_tenant_service,
-        mock_db,
         mock_generate_account,
         mock_get_providers,
         mock_config,
@@ -425,15 +406,10 @@ class TestAccountGeneration:
         return account
 
     @patch("controllers.console.auth.oauth.AccountService.get_account_by_email_with_case_fallback")
-    @patch("controllers.console.auth.oauth.Session")
     @patch("controllers.console.auth.oauth.Account")
-    @patch("controllers.console.auth.oauth.db")
     def test_should_get_account_by_openid_or_email(
-        self, mock_db, mock_account_model, mock_session, mock_get_account, user_info, mock_account
+        self, mock_account_model, mock_get_account, user_info, mock_account
     ):
-        # Mock db.engine for Session creation
-        mock_db.engine = MagicMock()
-
         # Test OpenID found
         mock_account_model.get_by_openid.return_value = mock_account
         result = _get_account_by_openid_or_email("github", user_info)
@@ -443,27 +419,35 @@ class TestAccountGeneration:
 
         # Test fallback to email lookup
         mock_account_model.get_by_openid.return_value = None
-        mock_session_instance = MagicMock()
-        mock_session.return_value.__enter__.return_value = mock_session_instance
         mock_get_account.return_value = mock_account
 
         result = _get_account_by_openid_or_email("github", user_info)
         assert result == mock_account
-        mock_get_account.assert_called_once_with(user_info.email, session=mock_session_instance)
+        mock_get_account.assert_called_once()
 
-    def test_get_account_by_email_with_case_fallback_uses_lowercase_lookup(self):
-        mock_session = MagicMock()
-        first_result = MagicMock()
-        first_result.scalar_one_or_none.return_value = None
-        expected_account = MagicMock()
-        second_result = MagicMock()
-        second_result.scalar_one_or_none.return_value = expected_account
-        mock_session.execute.side_effect = [first_result, second_result]
+    def test_get_account_by_email_with_case_fallback_uses_real_db(self, db_session_with_containers):
+        """Test case-insensitive email lookup against real PostgreSQL."""
+        from models.account import Account
 
-        result = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=mock_session)
+        account = Account(
+            email="Case@Test.com",
+            name="Test User",
+            interface_language="en-US",
+            status="active",
+        )
+        db_session_with_containers.add(account)
+        db_session_with_containers.commit()
 
-        assert result == expected_account
-        assert mock_session.execute.call_count == 2
+        result = AccountService.get_account_by_email_with_case_fallback(
+            "Case@Test.com", session=db_session_with_containers
+        )
+        assert result is not None
+
+        result_lower = AccountService.get_account_by_email_with_case_fallback(
+            "case@test.com", session=db_session_with_containers
+        )
+        assert result_lower is not None
+        assert result_lower.id == account.id
 
     @pytest.mark.parametrize(
         ("allow_register", "existing_account", "should_create"),
@@ -478,10 +462,8 @@ class TestAccountGeneration:
     @patch("controllers.console.auth.oauth.RegisterService")
     @patch("controllers.console.auth.oauth.AccountService")
     @patch("controllers.console.auth.oauth.TenantService")
-    @patch("controllers.console.auth.oauth.db")
     def test_should_handle_account_generation_scenarios(
         self,
-        mock_db,
         mock_tenant_service,
         mock_account_service,
         mock_register_service,
@@ -519,10 +501,8 @@ class TestAccountGeneration:
     @patch("controllers.console.auth.oauth.RegisterService")
     @patch("controllers.console.auth.oauth.AccountService")
     @patch("controllers.console.auth.oauth.TenantService")
-    @patch("controllers.console.auth.oauth.db")
     def test_should_register_with_lowercase_email(
         self,
-        mock_db,
         mock_tenant_service,
         mock_account_service,
         mock_register_service,

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -442,9 +442,7 @@ class TestAccountGeneration:
         db_session_with_containers.commit()
         db_session_with_containers.expire_all()
 
-        result = AccountService.get_account_by_email_with_case_fallback(
-            test_email, session=db_session_with_containers
-        )
+        result = AccountService.get_account_by_email_with_case_fallback(test_email, session=db_session_with_containers)
         assert result is not None
 
         result_lower = AccountService.get_account_by_email_with_case_fallback(


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Migrate OAuth controller tests from mock-based unit tests to testcontainers integration
tests by moving `test_oauth.py` from `unit_tests/` to `test_containers_integration_tests/`.

Key changes:
- Replace standalone `Flask(__name__)` fixtures with `flask_app_with_containers`
- Remove `db` and `Session` mock patches (8 occurrences) — real DB session is now available
- Rewrite `get_account_by_email_with_case_fallback` test to query real PostgreSQL
  instead of mocking `session.execute` side effects
- Simplify `_get_account_by_openid_or_email` test by removing `Session` context manager mock
- External services (OAuth providers, RegisterService, FeatureService, TenantService) remain mocked

Part of #32454

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
