### PR TITLE
refactor: use EnumText for DocumentSegment.type

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -43,6 +43,7 @@ from .enums import (
     IndexingStatus,
     ProcessRuleMode,
     SegmentStatus,
+    SegmentType,
     SummaryStatus,
 )
 from .model import App, Tag, TagBinding, UploadFile
@@ -998,7 +999,9 @@ class ChildChunk(Base):
     # indexing fields
     index_node_id = mapped_column(String(255), nullable=True)
     index_node_hash = mapped_column(String(255), nullable=True)
-    type = mapped_column(String(255), nullable=False, server_default=sa.text("'automatic'"))
+    type: Mapped[SegmentType] = mapped_column(
+        EnumText(SegmentType, length=255), nullable=False, server_default=sa.text("'automatic'")
+    )
     created_by = mapped_column(StringUUID, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=sa.func.current_timestamp())
     updated_by = mapped_column(StringUUID, nullable=True)

--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -222,6 +222,13 @@ class DatasetMetadataType(StrEnum):
     TIME = "time"
 
 
+class SegmentType(StrEnum):
+    """Document segment type"""
+
+    AUTOMATIC = "automatic"
+    CUSTOMIZED = "customized"
+
+
 class SegmentStatus(StrEnum):
     """Document segment status"""
 

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -58,6 +58,7 @@ from models.enums import (
     IndexingStatus,
     ProcessRuleMode,
     SegmentStatus,
+    SegmentType,
 )
 from models.model import UploadFile
 from models.provider_ids import ModelProviderID
@@ -3786,7 +3787,7 @@ class SegmentService:
                         child_chunk.word_count = len(child_chunk.content)
                         child_chunk.updated_by = current_user.id
                         child_chunk.updated_at = naive_utc_now()
-                        child_chunk.type = "customized"
+                        child_chunk.type = SegmentType.CUSTOMIZED
                         update_child_chunks.append(child_chunk)
             else:
                 new_child_chunks_args.append(child_chunk_update_args)
@@ -3845,7 +3846,7 @@ class SegmentService:
             child_chunk.word_count = len(content)
             child_chunk.updated_by = current_user.id
             child_chunk.updated_at = naive_utc_now()
-            child_chunk.type = "customized"
+            child_chunk.type = SegmentType.CUSTOMIZED
             db.session.add(child_chunk)
             VectorService.update_child_chunk_vector([], [child_chunk], [], dataset)
             db.session.commit()

--- a/api/tests/unit_tests/services/segment_service.py
+++ b/api/tests/unit_tests/services/segment_service.py
@@ -4,6 +4,7 @@ import pytest
 
 from models.account import Account
 from models.dataset import ChildChunk, Dataset, Document, DocumentSegment
+from models.enums import SegmentType
 from services.dataset_service import SegmentService
 from services.entities.knowledge_entities.knowledge_entities import SegmentUpdateArgs
 from services.errors.chunk import ChildChunkDeleteIndexError, ChildChunkIndexingError
@@ -77,7 +78,7 @@ class SegmentTestDataFactory:
         chunk.word_count = word_count
         chunk.index_node_id = f"node-{chunk_id}"
         chunk.index_node_hash = "hash-123"
-        chunk.type = "automatic"
+        chunk.type = SegmentType.AUTOMATIC
         chunk.created_by = "user-123"
         chunk.updated_by = None
         chunk.updated_at = None


### PR DESCRIPTION
## Summary
- Create new `SegmentType` enum with `AUTOMATIC` and `CUSTOMIZED` values
- Replace `sa.String` with `EnumText(SegmentType)` for `DocumentSegment.type`
- Replace string literals with enum values in service and test files

Continues #33294

## Details
| Model | Column | Before | After |
|-------|--------|--------|-------|
| `DocumentSegment.type` | `String(255)` | `EnumText(SegmentType)` |

## Test plan
- [x] `make type-check` passes (0 errors across basedpyright + pyrefly + mypy)
- [x] `basedpyright` passes (0 errors on changed files)
