### PR TITLE
fix: fix omitted app icon_type updates

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -95,54 +95,27 @@ class CreateAppPayload(BaseModel):
     name: str = Field(..., min_length=1, description="App name")
     description: str | None = Field(default=None, description="App description (max 400 chars)", max_length=400)
     mode: Literal["chat", "agent-chat", "advanced-chat", "workflow", "completion"] = Field(..., description="App mode")
-    icon_type: str | None = Field(default=None, description="Icon type")
+    icon_type: IconType | None = Field(default=None, description="Icon type")
     icon: str | None = Field(default=None, description="Icon")
     icon_background: str | None = Field(default=None, description="Icon background color")
-
-    @field_validator("icon_type")
-    @classmethod
-    def validate_icon_type(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-
-        IconType(value)
-        return value
 
 
 class UpdateAppPayload(BaseModel):
     name: str = Field(..., min_length=1, description="App name")
     description: str | None = Field(default=None, description="App description (max 400 chars)", max_length=400)
-    icon_type: str | None = Field(default=None, description="Icon type")
+    icon_type: IconType | None = Field(default=None, description="Icon type")
     icon: str | None = Field(default=None, description="Icon")
     icon_background: str | None = Field(default=None, description="Icon background color")
     use_icon_as_answer_icon: bool | None = Field(default=None, description="Use icon as answer icon")
     max_active_requests: int | None = Field(default=None, description="Maximum active requests")
 
-    @field_validator("icon_type")
-    @classmethod
-    def validate_icon_type(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-
-        IconType(value)
-        return value
-
 
 class CopyAppPayload(BaseModel):
     name: str | None = Field(default=None, description="Name for the copied app")
     description: str | None = Field(default=None, description="Description for the copied app", max_length=400)
-    icon_type: str | None = Field(default=None, description="Icon type")
+    icon_type: IconType | None = Field(default=None, description="Icon type")
     icon: str | None = Field(default=None, description="Icon")
     icon_background: str | None = Field(default=None, description="Icon background color")
-
-    @field_validator("icon_type")
-    @classmethod
-    def validate_icon_type(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-
-        IconType(value)
-        return value
 
 
 class AppExportQuery(BaseModel):

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -99,6 +99,15 @@ class CreateAppPayload(BaseModel):
     icon: str | None = Field(default=None, description="Icon")
     icon_background: str | None = Field(default=None, description="Icon background color")
 
+    @field_validator("icon_type")
+    @classmethod
+    def validate_icon_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        IconType(value)
+        return value
+
 
 class UpdateAppPayload(BaseModel):
     name: str = Field(..., min_length=1, description="App name")
@@ -109,6 +118,15 @@ class UpdateAppPayload(BaseModel):
     use_icon_as_answer_icon: bool | None = Field(default=None, description="Use icon as answer icon")
     max_active_requests: int | None = Field(default=None, description="Maximum active requests")
 
+    @field_validator("icon_type")
+    @classmethod
+    def validate_icon_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        IconType(value)
+        return value
+
 
 class CopyAppPayload(BaseModel):
     name: str | None = Field(default=None, description="Name for the copied app")
@@ -116,6 +134,15 @@ class CopyAppPayload(BaseModel):
     icon_type: str | None = Field(default=None, description="Icon type")
     icon: str | None = Field(default=None, description="Icon")
     icon_background: str | None = Field(default=None, description="Icon background color")
+
+    @field_validator("icon_type")
+    @classmethod
+    def validate_icon_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        IconType(value)
+        return value
 
 
 class AppExportQuery(BaseModel):

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -594,7 +594,7 @@ class AppApi(Resource):
         args_dict: AppService.ArgsDict = {
             "name": args.name,
             "description": args.description or "",
-            "icon_type": args.icon_type or "",
+            "icon_type": args.icon_type,
             "icon": args.icon or "",
             "icon_background": args.icon_background or "",
             "use_icon_as_answer_icon": args.use_icon_as_answer_icon or False,

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -241,7 +241,7 @@ class AppService:
     class ArgsDict(TypedDict):
         name: str
         description: str
-        icon_type: str | None
+        icon_type: IconType | str | None
         icon: str
         icon_background: str
         use_icon_as_answer_icon: bool

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -260,8 +260,6 @@ class AppService:
         icon_type = args.get("icon_type")
         if icon_type is None:
             resolved_icon_type = app.icon_type
-        elif icon_type == "":
-            resolved_icon_type = app.icon_type or IconType.EMOJI
         else:
             resolved_icon_type = IconType(icon_type)
 

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -241,7 +241,7 @@ class AppService:
     class ArgsDict(TypedDict):
         name: str
         description: str
-        icon_type: str
+        icon_type: str | None
         icon: str
         icon_background: str
         use_icon_as_answer_icon: bool
@@ -257,7 +257,15 @@ class AppService:
         assert current_user is not None
         app.name = args["name"]
         app.description = args["description"]
-        app.icon_type = IconType(args["icon_type"]) if args["icon_type"] else None
+        icon_type = args.get("icon_type")
+        if icon_type is None:
+            resolved_icon_type = app.icon_type
+        elif icon_type == "":
+            resolved_icon_type = app.icon_type or IconType.EMOJI
+        else:
+            resolved_icon_type = IconType(icon_type)
+
+        app.icon_type = resolved_icon_type
         app.icon = args["icon"]
         app.icon_background = args["icon_background"]
         app.use_icon_as_answer_icon = args.get("use_icon_as_answer_icon", False)

--- a/api/tests/test_containers_integration_tests/services/test_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from constants.model_template import default_app_templates
 from models import Account
-from models.model import App, Site
+from models.model import App, IconType, Site
 from services.account_service import AccountService, TenantService
 from tests.test_containers_integration_tests.helpers import generate_valid_password
 
@@ -462,6 +462,58 @@ class TestAppService:
         assert updated_app.mode == app.mode
         assert updated_app.tenant_id == app.tenant_id
         assert updated_app.created_by == app.created_by
+
+    def test_update_app_should_preserve_icon_type_when_omitted(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """
+        Test update_app keeps the persisted icon_type when the update payload omits it.
+        """
+        fake = Faker()
+
+        account = AccountService.create_account(
+            email=fake.email(),
+            name=fake.name(),
+            interface_language="en-US",
+            password=generate_valid_password(fake),
+        )
+        TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
+        tenant = account.current_tenant
+
+        from services.app_service import AppService
+
+        app_service = AppService()
+        app = app_service.create_app(
+            tenant.id,
+            {
+                "name": fake.company(),
+                "description": fake.text(max_nb_chars=100),
+                "mode": "chat",
+                "icon_type": "emoji",
+                "icon": "🎯",
+                "icon_background": "#45B7D1",
+            },
+            account,
+        )
+
+        mock_current_user = create_autospec(Account, instance=True)
+        mock_current_user.id = account.id
+        mock_current_user.current_tenant_id = account.current_tenant_id
+
+        with patch("services.app_service.current_user", mock_current_user):
+            updated_app = app_service.update_app(
+                app,
+                {
+                    "name": "Updated App Name",
+                    "description": "Updated app description",
+                    "icon_type": None,
+                    "icon": "🔄",
+                    "icon_background": "#FF8C42",
+                    "use_icon_as_answer_icon": True,
+                },
+            )
+
+        assert updated_app.icon_type == IconType.EMOJI
 
     def test_update_app_name_success(self, db_session_with_containers: Session, mock_external_service_dependencies):
         """

--- a/api/tests/test_containers_integration_tests/services/test_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_service.py
@@ -515,6 +515,57 @@ class TestAppService:
 
         assert updated_app.icon_type == IconType.EMOJI
 
+    def test_update_app_should_reject_empty_icon_type(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """
+        Test update_app rejects an explicit empty icon_type.
+        """
+        fake = Faker()
+
+        account = AccountService.create_account(
+            email=fake.email(),
+            name=fake.name(),
+            interface_language="en-US",
+            password=generate_valid_password(fake),
+        )
+        TenantService.create_owner_tenant_if_not_exist(account, name=fake.company())
+        tenant = account.current_tenant
+
+        from services.app_service import AppService
+
+        app_service = AppService()
+        app = app_service.create_app(
+            tenant.id,
+            {
+                "name": fake.company(),
+                "description": fake.text(max_nb_chars=100),
+                "mode": "chat",
+                "icon_type": "emoji",
+                "icon": "🎯",
+                "icon_background": "#45B7D1",
+            },
+            account,
+        )
+
+        mock_current_user = create_autospec(Account, instance=True)
+        mock_current_user.id = account.id
+        mock_current_user.current_tenant_id = account.current_tenant_id
+
+        with patch("services.app_service.current_user", mock_current_user):
+            with pytest.raises(ValueError):
+                app_service.update_app(
+                    app,
+                    {
+                        "name": "Updated App Name",
+                        "description": "Updated app description",
+                        "icon_type": "",
+                        "icon": "🔄",
+                        "icon_background": "#FF8C42",
+                        "use_icon_as_answer_icon": True,
+                    },
+                )
+
     def test_update_app_name_success(self, db_session_with_containers: Session, mock_external_service_dependencies):
         """
         Test successful app name update.

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -7,13 +7,17 @@ from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from werkzeug.exceptions import BadRequest, NotFound
 
+from controllers.console import console_ns
 from controllers.console.app import (
     annotation as annotation_module,
+)
+from controllers.console.app import (
+    app as app_module,
 )
 from controllers.console.app import (
     completion as completion_module,
@@ -201,6 +205,35 @@ class TestCompletionEndpoints:
         ):
             with pytest.raises(completion_module.ProviderQuotaExceededError):
                 method(app_model=MagicMock(id="app-1"))
+
+
+class TestAppEndpoints:
+    """Tests for app endpoints."""
+
+    def test_app_put_should_preserve_icon_type_when_payload_omits_it(self, app, monkeypatch):
+        api = app_module.AppApi()
+        method = _unwrap(api.put)
+        payload = {
+            "name": "Updated App",
+            "description": "Updated description",
+            "icon": "🤖",
+            "icon_background": "#FFFFFF",
+        }
+        app_service = MagicMock()
+        app_service.update_app.return_value = SimpleNamespace()
+        response_model = MagicMock()
+        response_model.model_dump.return_value = {"id": "app-1"}
+
+        monkeypatch.setattr(app_module, "AppService", lambda: app_service)
+        monkeypatch.setattr(app_module.AppDetailWithSite, "model_validate", MagicMock(return_value=response_model))
+
+        with app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload), patch.object(
+            type(console_ns), "payload", payload
+        ):
+            response = method(app_model=SimpleNamespace(icon_type=app_module.IconType.EMOJI))
+
+        assert response == {"id": "app-1"}
+        assert app_service.update_app.call_args.args[1]["icon_type"] is None
 
 
 # ========== OpsTrace Tests ==========

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -228,9 +228,8 @@ class TestAppEndpoints:
         monkeypatch.setattr(app_module, "AppService", lambda: app_service)
         monkeypatch.setattr(app_module.AppDetailWithSite, "model_validate", MagicMock(return_value=response_model))
 
-        with (
-            app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload),
-            patch.object(type(console_ns), "payload", payload),
+        with app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload), patch.object(
+            type(console_ns), "payload", payload
         ):
             response = method(app_model=SimpleNamespace(icon_type=app_module.IconType.EMOJI))
 

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 from werkzeug.exceptions import BadRequest, NotFound
 
 from controllers.console import console_ns
@@ -227,14 +228,25 @@ class TestAppEndpoints:
         monkeypatch.setattr(app_module, "AppService", lambda: app_service)
         monkeypatch.setattr(app_module.AppDetailWithSite, "model_validate", MagicMock(return_value=response_model))
 
-        with (
-            app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload),
-            patch.object(type(console_ns), "payload", payload),
+        with app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload), patch.object(
+            type(console_ns), "payload", payload
         ):
             response = method(app_model=SimpleNamespace(icon_type=app_module.IconType.EMOJI))
 
         assert response == {"id": "app-1"}
         assert app_service.update_app.call_args.args[1]["icon_type"] is None
+
+    def test_update_app_payload_should_reject_empty_icon_type(self):
+        with pytest.raises(ValidationError):
+            app_module.UpdateAppPayload.model_validate(
+                {
+                    "name": "Updated App",
+                    "description": "Updated description",
+                    "icon_type": "",
+                    "icon": "🤖",
+                    "icon_background": "#FFFFFF",
+                }
+            )
 
 
 # ========== OpsTrace Tests ==========

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -228,8 +228,9 @@ class TestAppEndpoints:
         monkeypatch.setattr(app_module, "AppService", lambda: app_service)
         monkeypatch.setattr(app_module.AppDetailWithSite, "model_validate", MagicMock(return_value=response_model))
 
-        with app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload), patch.object(
-            type(console_ns), "payload", payload
+        with (
+            app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload),
+            patch.object(type(console_ns), "payload", payload),
         ):
             response = method(app_model=SimpleNamespace(icon_type=app_module.IconType.EMOJI))
 

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -227,8 +227,9 @@ class TestAppEndpoints:
         monkeypatch.setattr(app_module, "AppService", lambda: app_service)
         monkeypatch.setattr(app_module.AppDetailWithSite, "model_validate", MagicMock(return_value=response_model))
 
-        with app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload), patch.object(
-            type(console_ns), "payload", payload
+        with (
+            app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload),
+            patch.object(type(console_ns), "payload", payload),
         ):
             response = method(app_model=SimpleNamespace(icon_type=app_module.IconType.EMOJI))
 

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -9,7 +9,7 @@ import pytest
 
 from core.errors.error import ProviderTokenNotInitError
 from models import Account, Tenant
-from models.model import App, AppMode
+from models.model import App, AppMode, IconType
 from services.app_service import AppService
 
 
@@ -411,6 +411,7 @@ class TestAppServiceGetAndUpdate:
 
             # Assert
             assert updated is app
+            assert updated.icon_type == IconType.IMAGE
             assert renamed is app
             assert iconed is app
             assert site_same is app
@@ -418,6 +419,45 @@ class TestAppServiceGetAndUpdate:
             assert site_changed is app
             assert api_changed is app
             assert mock_db.session.commit.call_count >= 5
+
+    def test_update_app_should_preserve_icon_type_when_not_provided(self, service: AppService) -> None:
+        """Test update_app keeps the existing icon_type when the payload omits it."""
+        # Arrange
+        app = cast(
+            App,
+            SimpleNamespace(
+                name="old",
+                description="old",
+                icon_type=IconType.EMOJI,
+                icon="a",
+                icon_background="#111",
+                use_icon_as_answer_icon=False,
+                max_active_requests=1,
+            ),
+        )
+        args = {
+            "name": "new",
+            "description": "new-desc",
+            "icon_type": None,
+            "icon": "new-icon",
+            "icon_background": "#222",
+            "use_icon_as_answer_icon": True,
+            "max_active_requests": 5,
+        }
+        user = SimpleNamespace(id="user-1")
+
+        with (
+            patch("services.app_service.current_user", user),
+            patch("services.app_service.db") as mock_db,
+            patch("services.app_service.naive_utc_now", return_value="now"),
+        ):
+            # Act
+            updated = service.update_app(app, args)
+
+            # Assert
+            assert updated is app
+            assert updated.icon_type == IconType.EMOJI
+            mock_db.session.commit.assert_called_once()
 
 
 class TestAppServiceDeleteAndMeta:

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -459,6 +459,40 @@ class TestAppServiceGetAndUpdate:
             assert updated.icon_type == IconType.EMOJI
             mock_db.session.commit.assert_called_once()
 
+    def test_update_app_should_reject_empty_icon_type(self, service: AppService) -> None:
+        """Test update_app rejects an explicit empty icon_type."""
+        app = cast(
+            App,
+            SimpleNamespace(
+                name="old",
+                description="old",
+                icon_type=IconType.EMOJI,
+                icon="a",
+                icon_background="#111",
+                use_icon_as_answer_icon=False,
+                max_active_requests=1,
+            ),
+        )
+        args = {
+            "name": "new",
+            "description": "new-desc",
+            "icon_type": "",
+            "icon": "new-icon",
+            "icon_background": "#222",
+            "use_icon_as_answer_icon": True,
+            "max_active_requests": 5,
+        }
+        user = SimpleNamespace(id="user-1")
+
+        with (
+            patch("services.app_service.current_user", user),
+            patch("services.app_service.db") as mock_db,
+        ):
+            with pytest.raises(ValueError):
+                service.update_app(app, args)
+
+        mock_db.session.commit.assert_not_called()
+
 
 class TestAppServiceDeleteAndMeta:
     """Test suite for delete and metadata methods."""


### PR DESCRIPTION
## Summary

**This PR is drafted by gpt-5.4(high) and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**

This PR fixes the app update path so `PUT /console/api/apps/{app_id}` no longer clears `icon_type` when the field is omitted.

The root cause for invalid enumeration is still unknown. After reviewing the data, I found that the rows with invalid values were updated over a period of several months. This suggests the issue is unlikely to be caused by a recent bug.

Closes #33987.

## What Changed

- keep `icon_type` as `None` in the controller when the request omits the field
- preserve the existing `app.icon_type` in `AppService.update_app` when `icon_type` is not provided
- reject explicit invalid `icon_type` values, including `""`, instead of treating them as a fallback signal
- add unit and container integration regression coverage for both the omitted-field and invalid-empty-string cases

## Validation

- `uv sync --dev --all-extras`
- `uv run --project api pytest api/tests/unit_tests/services/test_app_service.py api/tests/unit_tests/controllers/console/app/test_app_apis.py -q`
- `uv run --project api pytest api/tests/test_containers_integration_tests/services/test_app_service.py -k 'update_app_success or preserve_icon_type or reject_empty_icon_type' -q`
- `uv run --project api ruff check api/controllers/console/app/app.py api/services/app_service.py api/tests/unit_tests/services/test_app_service.py api/tests/unit_tests/controllers/console/app/test_app_apis.py api/tests/test_containers_integration_tests/services/test_app_service.py`
