### PR TITLE
fix: resolve SADeprecationWarning for Callable default in DefaultFieldsMixin

### DIFF
--- a/api/models/base.py
+++ b/api/models/base.py
@@ -27,24 +27,29 @@ class DefaultFieldsMixin:
     id: Mapped[str] = mapped_column(
         StringUUID,
         primary_key=True,
-        # NOTE: The default serve as fallback mechanisms.
+        # NOTE: The insert_default serves as a fallback mechanism for INSERT.
         # The application can generate the `id` before saving to optimize
         # the insertion process (especially for interdependent models)
         # and reduce database roundtrips.
-        default=lambda: str(uuidv7()),
+        # Use insert_default + default_factory to avoid SADeprecationWarning
+        # when used in MappedAsDataclass (TypeBase) contexts.
+        insert_default=lambda: str(uuidv7()),
+        default_factory=lambda: str(uuidv7()),
     )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=naive_utc_now,
+        insert_default=naive_utc_now,
+        default_factory=naive_utc_now,
         server_default=func.current_timestamp(),
     )
 
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=naive_utc_now,
+        insert_default=naive_utc_now,
+        default_factory=naive_utc_now,
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
     )


### PR DESCRIPTION
## Summary

Replace deprecated `default=callable` with `insert_default` + `default_factory` in `DefaultFieldsMixin` to resolve `SADeprecationWarning` when used in `MappedAsDataclass` (TypeBase) contexts.

This is a follow-up to #33980 which fixed the same warning in `AppModelConfig` (`model.py`). This PR addresses the shared `DefaultFieldsMixin` in `base.py`, which is inherited by 6 models across `human_input.py`, `workflow.py`, and `execution_extra_content.py`.

## Problem

SQLAlchemy raises `SADeprecationWarning` when a callable is passed to the `default` parameter in an ORM-mapped dataclass context:

```
SADeprecationWarning: Callable object passed to the ``default`` parameter
for attribute 'id' in a ORM-mapped Dataclasses context is ambiguous,
and this use will raise an error in a future release.
```

## Fix

For each affected field in `DefaultFieldsMixin`:
- `insert_default=callable` for database-level INSERT defaults
- `default_factory=callable` for dataclass instance-level defaults

This is the same pattern already used throughout the codebase in `web.py`, `tools.py`, `trigger.py`, and `model.py` (via #33980).

## Changes

- `api/models/base.py`: Updated 3 field declarations in `DefaultFieldsMixin` (`id`, `created_at`, `updated_at`)

Closes #33978