### PR TITLE
fix: resolve SADeprecationWarning for callable default in remaining TypeBase models

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -940,7 +940,9 @@ class AccountTrialAppRecord(Base):
 class ExporleBanner(TypeBase):
     __tablename__ = "exporle_banners"
     __table_args__ = (sa.PrimaryKeyConstraint("id", name="exporler_banner_pkey"),)
-    id: Mapped[str] = mapped_column(StringUUID, default=gen_uuidv4_string, init=False)
+    id: Mapped[str] = mapped_column(
+        StringUUID, insert_default=gen_uuidv4_string, default_factory=gen_uuidv4_string, init=False
+    )
     content: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
     link: Mapped[str] = mapped_column(String(255), nullable=False)
     sort: Mapped[int] = mapped_column(sa.Integer, nullable=False)
@@ -1849,7 +1851,9 @@ class AppAnnotationHitHistory(TypeBase):
         sa.Index("app_annotation_hit_histories_message_idx", "message_id"),
     )
 
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()), init=False)
+    id: Mapped[str] = mapped_column(
+        StringUUID, insert_default=lambda: str(uuid4()), default_factory=lambda: str(uuid4()), init=False
+    )
     app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     annotation_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     source: Mapped[str] = mapped_column(LongText, nullable=False)


### PR DESCRIPTION
## Summary
- Fixes the `SADeprecationWarning` for callable objects passed to the `default` parameter in ORM-mapped Dataclass (`TypeBase`) models
- Replaces deprecated `default=callable` with `insert_default` + `default_factory` in the **2 remaining** TypeBase models: `ExporleBanner` and `AppAnnotationHitHistory`
- Follows the same pattern established by PR #33980 which fixed `AppModelConfig`

## Context
SQLAlchemy warns that passing a callable to `default` in a `MappedAsDataclass` context is ambiguous. The fix uses:
- `insert_default`: generates the UUID at database INSERT time
- `default_factory`: generates the UUID at Python dataclass instantiation time

All other TypeBase models in the codebase have already been migrated to the correct pattern.

Closes #33978

## Test plan
- [ ] Verify no `SADeprecationWarning` is raised when importing or instantiating `ExporleBanner` or `AppAnnotationHitHistory`
- [ ] Confirm existing tests pass with `uv run --project api pytest`