### PR TITLE
fix: datetime.utcnow() deprecation warnings for Python 3.12+

### DIFF
--- a/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
+++ b/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from uuid import uuid4
 
@@ -117,7 +117,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         inputs=[],
         user_actions=[UserAction(id=action_id, title=action_text)],
         rendered_content="Rendered block",
-        expiration_time=datetime.now(tz=timezone.utc) + timedelta(days=1),
+        expiration_time=datetime.now(tz=UTC) + timedelta(days=1),
         node_title=node_title,
         display_in_ui=True,
     )
@@ -129,7 +129,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         form_definition=form_definition.model_dump_json(),
         rendered_content="Rendered block",
         status=HumanInputFormStatus.SUBMITTED,
-        expiration_time=datetime.now(tz=timezone.utc) + timedelta(days=1),
+        expiration_time=datetime.now(tz=UTC) + timedelta(days=1),
         selected_action_id=action_id,
     )
     db_session.add(form)

--- a/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
+++ b/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
 
@@ -117,7 +117,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         inputs=[],
         user_actions=[UserAction(id=action_id, title=action_text)],
         rendered_content="Rendered block",
-        expiration_time=datetime.utcnow() + timedelta(days=1),
+        expiration_time=datetime.now(tz=timezone.utc) + timedelta(days=1),
         node_title=node_title,
         display_in_ui=True,
     )
@@ -129,7 +129,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         form_definition=form_definition.model_dump_json(),
         rendered_content="Rendered block",
         status=HumanInputFormStatus.SUBMITTED,
-        expiration_time=datetime.utcnow() + timedelta(days=1),
+        expiration_time=datetime.now(tz=timezone.utc) + timedelta(days=1),
         selected_action_id=action_id,
     )
     db_session.add(form)

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_execution_extra_content_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_execution_extra_content_repository.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from uuid import uuid4
 
@@ -174,7 +174,7 @@ def _create_submitted_form(
     action_title: str = "Approve",
     node_title: str = "Approval",
 ) -> HumanInputForm:
-    expiration_time = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    expiration_time = datetime.now(tz=UTC) + timedelta(days=1)
     form_definition = FormDefinition(
         form_content="content",
         inputs=[],
@@ -207,7 +207,7 @@ def _create_waiting_form(
     workflow_run_id: str,
     default_values: dict | None = None,
 ) -> HumanInputForm:
-    expiration_time = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    expiration_time = datetime.now(tz=UTC) + timedelta(days=1)
     form_definition = FormDefinition(
         form_content="content",
         inputs=[],

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_execution_extra_content_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_execution_extra_content_repository.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
 
@@ -174,7 +174,7 @@ def _create_submitted_form(
     action_title: str = "Approve",
     node_title: str = "Approval",
 ) -> HumanInputForm:
-    expiration_time = datetime.utcnow() + timedelta(days=1)
+    expiration_time = datetime.now(tz=timezone.utc) + timedelta(days=1)
     form_definition = FormDefinition(
         form_content="content",
         inputs=[],
@@ -207,7 +207,7 @@ def _create_waiting_form(
     workflow_run_id: str,
     default_values: dict | None = None,
 ) -> HumanInputForm:
-    expiration_time = datetime.utcnow() + timedelta(days=1)
+    expiration_time = datetime.now(tz=timezone.utc) + timedelta(days=1)
     form_definition = FormDefinition(
         form_content="content",
         inputs=[],

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -372,7 +372,7 @@ class TestPublishedPipelineApis:
 
         workflow = MagicMock(
             id="w1",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         session = MagicMock()

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -372,7 +372,7 @@ class TestPublishedPipelineApis:
 
         workflow = MagicMock(
             id="w1",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         session = MagicMock()

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -54,8 +54,8 @@ def _segment():
         disabled_by=None,
         status="normal",
         created_by="u1",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(tz=timezone.utc),
+        updated_at=datetime.now(tz=timezone.utc),
         updated_by="u1",
         indexing_at=None,
         completed_at=None,

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -54,8 +54,8 @@ def _segment():
         disabled_by=None,
         status="normal",
         created_by="u1",
-        created_at=datetime.now(tz=timezone.utc),
-        updated_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
         updated_by="u1",
         indexing_at=None,
         completed_at=None,

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -44,13 +44,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         with (
@@ -97,13 +97,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         features_t2 = MagicMock()
@@ -152,13 +152,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         features = MagicMock()
@@ -204,7 +204,7 @@ class TestTenantListApi:
             id="t1",
             name="Tenant",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         features = MagicMock()
@@ -243,13 +243,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         with (
@@ -305,7 +305,7 @@ class TestWorkspaceListApi:
         api = WorkspaceListApi()
         method = unwrap(api.get)
 
-        tenant = MagicMock(id="t1", name="T", status="active", created_at=datetime.utcnow())
+        tenant = MagicMock(id="t1", name="T", status="active", created_at=datetime.now(tz=timezone.utc))
 
         paginate_result = MagicMock(
             items=[tenant],
@@ -331,7 +331,7 @@ class TestWorkspaceListApi:
             id="t1",
             name="T",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         paginate_result = MagicMock(

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -44,13 +44,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         with (
@@ -97,13 +97,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         features_t2 = MagicMock()
@@ -152,13 +152,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         features = MagicMock()
@@ -204,7 +204,7 @@ class TestTenantListApi:
             id="t1",
             name="Tenant",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         features = MagicMock()
@@ -243,13 +243,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         with (
@@ -305,7 +305,7 @@ class TestWorkspaceListApi:
         api = WorkspaceListApi()
         method = unwrap(api.get)
 
-        tenant = MagicMock(id="t1", name="T", status="active", created_at=datetime.now(tz=timezone.utc))
+        tenant = MagicMock(id="t1", name="T", status="active", created_at=datetime.now(tz=UTC))
 
         paginate_result = MagicMock(
             items=[tenant],
@@ -331,7 +331,7 @@ class TestWorkspaceListApi:
             id="t1",
             name="T",
             status="active",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
         )
 
         paginate_result = MagicMock(

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -75,7 +75,7 @@ def _make_pipeline():
     message = SimpleNamespace(
         id="message-id",
         query="hello",
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(tz=timezone.utc),
         status=MessageStatus.NORMAL,
         answer="",
     )
@@ -256,7 +256,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         iter_next = QueueIterationNextEvent(
@@ -272,7 +272,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         loop_start = QueueLoopStartEvent(
@@ -280,7 +280,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         loop_next = QueueLoopNextEvent(
@@ -296,7 +296,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
 
@@ -359,7 +359,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             inputs={},
             outputs={},
             process_data={},
@@ -369,7 +369,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             inputs={},
             outputs={},
             process_data={},
@@ -472,7 +472,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="title",
-            expiration_time=datetime.utcnow(),
+            expiration_time=datetime.now(tz=timezone.utc),
         )
 
         assert list(pipeline._handle_human_input_form_filled_event(filled_event)) == ["filled"]
@@ -590,7 +590,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             inputs={},
             outputs={},
             process_data={},

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -75,7 +75,7 @@ def _make_pipeline():
     message = SimpleNamespace(
         id="message-id",
         query="hello",
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
         status=MessageStatus.NORMAL,
         answer="",
     )
@@ -256,7 +256,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         iter_next = QueueIterationNextEvent(
@@ -272,7 +272,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         loop_start = QueueLoopStartEvent(
@@ -280,7 +280,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         loop_next = QueueLoopNextEvent(
@@ -296,7 +296,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
 
@@ -359,7 +359,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             inputs={},
             outputs={},
             process_data={},
@@ -369,7 +369,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             inputs={},
             outputs={},
             process_data={},
@@ -472,7 +472,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="title",
-            expiration_time=datetime.now(tz=timezone.utc),
+            expiration_time=datetime.now(tz=UTC),
         )
 
         assert list(pipeline._handle_human_input_form_filled_event(filled_event)) == ["filled"]
@@ -590,7 +590,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             inputs={},
             outputs={},
             process_data={},

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -195,7 +195,7 @@ class TestWorkflowBasedAppRunner:
                 node_id="node",
                 node_type=BuiltinNodeTypes.START,
                 node_title="Start",
-                start_at=datetime.now(tz=timezone.utc),
+                start_at=datetime.now(tz=UTC),
             ),
         )
         runner._handle_event(
@@ -232,7 +232,7 @@ class TestWorkflowBasedAppRunner:
                 node_id="node",
                 node_type=BuiltinNodeTypes.LLM,
                 node_title="Iter",
-                start_at=datetime.now(tz=timezone.utc),
+                start_at=datetime.now(tz=UTC),
                 inputs={},
                 outputs={"ok": True},
                 metadata={},
@@ -246,7 +246,7 @@ class TestWorkflowBasedAppRunner:
                 node_id="node",
                 node_type=BuiltinNodeTypes.LLM,
                 node_title="Loop",
-                start_at=datetime.now(tz=timezone.utc),
+                start_at=datetime.now(tz=UTC),
                 inputs={},
                 outputs={},
                 metadata={},

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -195,7 +195,7 @@ class TestWorkflowBasedAppRunner:
                 node_id="node",
                 node_type=BuiltinNodeTypes.START,
                 node_title="Start",
-                start_at=datetime.utcnow(),
+                start_at=datetime.now(tz=timezone.utc),
             ),
         )
         runner._handle_event(
@@ -232,7 +232,7 @@ class TestWorkflowBasedAppRunner:
                 node_id="node",
                 node_type=BuiltinNodeTypes.LLM,
                 node_title="Iter",
-                start_at=datetime.utcnow(),
+                start_at=datetime.now(tz=timezone.utc),
                 inputs={},
                 outputs={"ok": True},
                 metadata={},
@@ -246,7 +246,7 @@ class TestWorkflowBasedAppRunner:
                 node_id="node",
                 node_type=BuiltinNodeTypes.LLM,
                 node_title="Loop",
-                start_at=datetime.utcnow(),
+                start_at=datetime.now(tz=timezone.utc),
                 inputs={},
                 outputs={},
                 metadata={},

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -191,7 +191,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             inputs={},
             outputs={},
             process_data={},
@@ -244,7 +244,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             inputs={},
             outputs={},
             process_data={},
@@ -302,7 +302,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         iter_next = QueueIterationNextEvent(
@@ -318,7 +318,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         loop_start = QueueLoopStartEvent(
@@ -326,7 +326,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         loop_next = QueueLoopNextEvent(
@@ -342,7 +342,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             node_run_index=1,
         )
         filled_event = QueueHumanInputFormFilledEvent(
@@ -358,7 +358,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="title",
-            expiration_time=datetime.now(tz=timezone.utc),
+            expiration_time=datetime.now(tz=UTC),
         )
         agent_event = QueueAgentLogEvent(
             id="log",
@@ -647,7 +647,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_title="title",
             node_type=BuiltinNodeTypes.LLM,
             node_run_index=1,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             provider_type="provider",
             provider_id="provider-id",
             error="error",
@@ -659,7 +659,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_title="title",
             node_type=BuiltinNodeTypes.LLM,
             node_run_index=1,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             provider_type="provider",
             provider_id="provider-id",
         )
@@ -684,7 +684,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec-id",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             inputs={},
             outputs={},
             process_data={},
@@ -857,7 +857,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node-id",
             node_type=BuiltinNodeTypes.START,
             in_loop_id="loop-id",
-            start_at=datetime.now(tz=timezone.utc),
+            start_at=datetime.now(tz=UTC),
             process_data={"k": "v"},
             outputs={"out": 1},
         )

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -191,7 +191,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             inputs={},
             outputs={},
             process_data={},
@@ -244,7 +244,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             inputs={},
             outputs={},
             process_data={},
@@ -302,7 +302,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         iter_next = QueueIterationNextEvent(
@@ -318,7 +318,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         loop_start = QueueLoopStartEvent(
@@ -326,7 +326,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         loop_next = QueueLoopNextEvent(
@@ -342,7 +342,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             node_run_index=1,
         )
         filled_event = QueueHumanInputFormFilledEvent(
@@ -358,7 +358,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="title",
-            expiration_time=datetime.utcnow(),
+            expiration_time=datetime.now(tz=timezone.utc),
         )
         agent_event = QueueAgentLogEvent(
             id="log",
@@ -647,7 +647,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_title="title",
             node_type=BuiltinNodeTypes.LLM,
             node_run_index=1,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             provider_type="provider",
             provider_id="provider-id",
             error="error",
@@ -659,7 +659,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_title="title",
             node_type=BuiltinNodeTypes.LLM,
             node_run_index=1,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             provider_type="provider",
             provider_id="provider-id",
         )
@@ -684,7 +684,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec-id",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             inputs={},
             outputs={},
             process_data={},
@@ -857,7 +857,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node-id",
             node_type=BuiltinNodeTypes.START,
             in_loop_id="loop-id",
-            start_at=datetime.utcnow(),
+            start_at=datetime.now(tz=timezone.utc),
             process_data={"k": "v"},
             outputs={"out": 1},
         )

--- a/api/tests/unit_tests/core/app/layers/test_conversation_variable_persist_layer.py
+++ b/api/tests/unit_tests/core/app/layers/test_conversation_variable_persist_layer.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import Mock
 
 from core.app.layers.conversation_variable_persist_layer import ConversationVariablePersistenceLayer
@@ -51,7 +51,7 @@ def _build_node_run_succeeded_event(
         id="node-exec-id",
         node_id="assigner",
         node_type=node_type,
-        start_at=datetime.utcnow(),
+        start_at=datetime.now(tz=timezone.utc),
         node_run_result=NodeRunResult(
             status=WorkflowNodeExecutionStatus.SUCCEEDED,
             outputs=outputs or {},

--- a/api/tests/unit_tests/core/app/layers/test_conversation_variable_persist_layer.py
+++ b/api/tests/unit_tests/core/app/layers/test_conversation_variable_persist_layer.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import Mock
 
 from core.app.layers.conversation_variable_persist_layer import ConversationVariablePersistenceLayer
@@ -51,7 +51,7 @@ def _build_node_run_succeeded_event(
         id="node-exec-id",
         node_id="assigner",
         node_type=node_type,
-        start_at=datetime.now(tz=timezone.utc),
+        start_at=datetime.now(tz=UTC),
         node_run_result=NodeRunResult(
             status=WorkflowNodeExecutionStatus.SUCCEEDED,
             outputs=outputs or {},

--- a/api/tests/unit_tests/core/repositories/test_human_input_form_repository_impl.py
+++ b/api/tests/unit_tests/core/repositories/test_human_input_form_repository_impl.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -272,7 +272,7 @@ def _make_form_definition() -> str:
         inputs=[],
         user_actions=[UserAction(id="submit", title="Submit")],
         rendered_content="<p>hello</p>",
-        expiration_time=datetime.now(tz=timezone.utc),
+        expiration_time=datetime.now(tz=UTC),
     ).model_dump_json()
 
 

--- a/api/tests/unit_tests/core/repositories/test_human_input_form_repository_impl.py
+++ b/api/tests/unit_tests/core/repositories/test_human_input_form_repository_impl.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -272,7 +272,7 @@ def _make_form_definition() -> str:
         inputs=[],
         user_actions=[UserAction(id="submit", title="Submit")],
         rendered_content="<p>hello</p>",
-        expiration_time=datetime.utcnow(),
+        expiration_time=datetime.now(tz=timezone.utc),
     ).model_dump_json()
 
 

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_dispatcher_pause_drain.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_dispatcher_pause_drain.py
@@ -1,5 +1,5 @@
 import queue
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from dify_graph.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
 from dify_graph.graph_engine.orchestration.dispatcher import Dispatcher
@@ -52,7 +52,7 @@ def test_dispatcher_drains_events_when_paused() -> None:
         id="exec-1",
         node_id="node-1",
         node_type=BuiltinNodeTypes.START,
-        start_at=datetime.now(tz=timezone.utc),
+        start_at=datetime.now(tz=UTC),
         node_run_result=NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED),
     )
     event_queue.put(event)

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_dispatcher_pause_drain.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_dispatcher_pause_drain.py
@@ -1,5 +1,5 @@
 import queue
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dify_graph.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
 from dify_graph.graph_engine.orchestration.dispatcher import Dispatcher
@@ -52,7 +52,7 @@ def test_dispatcher_drains_events_when_paused() -> None:
         id="exec-1",
         node_id="node-1",
         node_type=BuiltinNodeTypes.START,
-        start_at=datetime.utcnow(),
+        start_at=datetime.now(tz=timezone.utc),
         node_run_result=NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED),
     )
     event_queue.put(event)

--- a/api/tests/unit_tests/libs/_human_input/support.py
+++ b/api/tests/unit_tests/libs/_human_input/support.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from dify_graph.nodes.human_input.entities import FormInput
@@ -61,7 +61,7 @@ class HumanInputForm:
 
     @property
     def is_expired(self) -> bool:
-        return self.expires_at is not None and datetime.now(tz=timezone.utc) > self.expires_at
+        return self.expires_at is not None and datetime.now(tz=UTC) > self.expires_at
 
     @property
     def is_submitted(self) -> bool:
@@ -70,7 +70,7 @@ class HumanInputForm:
     def mark_submitted(self, inputs: dict[str, Any], action: str) -> None:
         self.submitted_data = inputs
         self.submitted_action = action
-        self.submitted_at = datetime.now(tz=timezone.utc)
+        self.submitted_at = datetime.now(tz=UTC)
 
     def submit(self, inputs: dict[str, Any], action: str) -> None:
         self.mark_submitted(inputs, action)

--- a/api/tests/unit_tests/libs/_human_input/support.py
+++ b/api/tests/unit_tests/libs/_human_input/support.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from dify_graph.nodes.human_input.entities import FormInput
@@ -61,7 +61,7 @@ class HumanInputForm:
 
     @property
     def is_expired(self) -> bool:
-        return self.expires_at is not None and datetime.utcnow() > self.expires_at
+        return self.expires_at is not None and datetime.now(tz=timezone.utc) > self.expires_at
 
     @property
     def is_submitted(self) -> bool:
@@ -70,7 +70,7 @@ class HumanInputForm:
     def mark_submitted(self, inputs: dict[str, Any], action: str) -> None:
         self.submitted_data = inputs
         self.submitted_action = action
-        self.submitted_at = datetime.utcnow()
+        self.submitted_at = datetime.now(tz=timezone.utc)
 
     def submit(self, inputs: dict[str, Any], action: str) -> None:
         self.mark_submitted(inputs, action)

--- a/api/tests/unit_tests/libs/_human_input/test_form_service.py
+++ b/api/tests/unit_tests/libs/_human_input/test_form_service.py
@@ -2,7 +2,7 @@
 Unit tests for FormService.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -142,7 +142,7 @@ class TestFormService:
 
         # Manually expire the form by modifying expiry time
         form = form_service.get_form_by_id("form-123")
-        form.expires_at = datetime.utcnow() - timedelta(hours=1)
+        form.expires_at = datetime.now(tz=timezone.utc) - timedelta(hours=1)
         form_service.repository.save(form)
 
         # Should raise FormExpiredError
@@ -227,7 +227,7 @@ class TestFormService:
 
         # Manually expire the form
         form = form_service.get_form_by_id("form-123")
-        form.expires_at = datetime.utcnow() - timedelta(hours=1)
+        form.expires_at = datetime.now(tz=timezone.utc) - timedelta(hours=1)
         form_service.repository.save(form)
 
         # Try to submit expired form

--- a/api/tests/unit_tests/libs/_human_input/test_form_service.py
+++ b/api/tests/unit_tests/libs/_human_input/test_form_service.py
@@ -2,7 +2,7 @@
 Unit tests for FormService.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -142,7 +142,7 @@ class TestFormService:
 
         # Manually expire the form by modifying expiry time
         form = form_service.get_form_by_id("form-123")
-        form.expires_at = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        form.expires_at = datetime.now(tz=UTC) - timedelta(hours=1)
         form_service.repository.save(form)
 
         # Should raise FormExpiredError
@@ -227,7 +227,7 @@ class TestFormService:
 
         # Manually expire the form
         form = form_service.get_form_by_id("form-123")
-        form.expires_at = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        form.expires_at = datetime.now(tz=UTC) - timedelta(hours=1)
         form_service.repository.save(form)
 
         # Try to submit expired form

--- a/api/tests/unit_tests/libs/_human_input/test_models.py
+++ b/api/tests/unit_tests/libs/_human_input/test_models.py
@@ -2,7 +2,7 @@
 Unit tests for human input form models.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -83,7 +83,7 @@ class TestHumanInputForm:
     def test_form_expiry_property_expired(self, sample_form_data):
         """Test is_expired property for expired form."""
         # Create form with past expiry
-        past_time = datetime.utcnow() - timedelta(hours=1)
+        past_time = datetime.now(tz=timezone.utc) - timedelta(hours=1)
         sample_form_data["created_at"] = past_time
 
         form = HumanInputForm(**sample_form_data)
@@ -111,9 +111,9 @@ class TestHumanInputForm:
         """Test form submit method."""
         form = HumanInputForm(**sample_form_data)
 
-        submission_time_before = datetime.utcnow()
+        submission_time_before = datetime.now(tz=timezone.utc)
         form.submit({"input": "test value"}, "submit")
-        submission_time_after = datetime.utcnow()
+        submission_time_after = datetime.now(tz=timezone.utc)
 
         assert form.is_submitted
         assert form.submitted_data == {"input": "test value"}
@@ -213,11 +213,11 @@ class TestFormSubmissionData:
 
     def test_submission_data_timestamps(self):
         """Test submission data timestamp handling."""
-        before_time = datetime.utcnow()
+        before_time = datetime.now(tz=timezone.utc)
 
         submission_data = FormSubmissionData(form_id="form-123", inputs={"test": "value"}, action="submit")
 
-        after_time = datetime.utcnow()
+        after_time = datetime.now(tz=timezone.utc)
 
         assert before_time <= submission_data.submitted_at <= after_time
 

--- a/api/tests/unit_tests/libs/_human_input/test_models.py
+++ b/api/tests/unit_tests/libs/_human_input/test_models.py
@@ -2,7 +2,7 @@
 Unit tests for human input form models.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -83,7 +83,7 @@ class TestHumanInputForm:
     def test_form_expiry_property_expired(self, sample_form_data):
         """Test is_expired property for expired form."""
         # Create form with past expiry
-        past_time = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        past_time = datetime.now(tz=UTC) - timedelta(hours=1)
         sample_form_data["created_at"] = past_time
 
         form = HumanInputForm(**sample_form_data)
@@ -111,9 +111,9 @@ class TestHumanInputForm:
         """Test form submit method."""
         form = HumanInputForm(**sample_form_data)
 
-        submission_time_before = datetime.now(tz=timezone.utc)
+        submission_time_before = datetime.now(tz=UTC)
         form.submit({"input": "test value"}, "submit")
-        submission_time_after = datetime.now(tz=timezone.utc)
+        submission_time_after = datetime.now(tz=UTC)
 
         assert form.is_submitted
         assert form.submitted_data == {"input": "test value"}
@@ -213,11 +213,11 @@ class TestFormSubmissionData:
 
     def test_submission_data_timestamps(self):
         """Test submission data timestamp handling."""
-        before_time = datetime.now(tz=timezone.utc)
+        before_time = datetime.now(tz=UTC)
 
         submission_data = FormSubmissionData(form_id="form-123", inputs={"test": "value"}, action="submit")
 
-        after_time = datetime.now(tz=timezone.utc)
+        after_time = datetime.now(tz=UTC)
 
         assert before_time <= submission_data.submitted_at <= after_time
 

--- a/api/tests/unit_tests/services/test_conversation_service.py
+++ b/api/tests/unit_tests/services/test_conversation_service.py
@@ -6,7 +6,7 @@ Tests are organized by functionality and include edge cases, error handling,
 and both positive and negative test scenarios.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import pytest
@@ -122,8 +122,8 @@ class ConversationServiceTestDataFactory:
         conversation.is_deleted = kwargs.get("is_deleted", False)
         conversation.name = kwargs.get("name", "Test Conversation")
         conversation.status = kwargs.get("status", "normal")
-        conversation.created_at = kwargs.get("created_at", datetime.now(tz=timezone.utc))
-        conversation.updated_at = kwargs.get("updated_at", datetime.now(tz=timezone.utc))
+        conversation.created_at = kwargs.get("created_at", datetime.now(tz=UTC))
+        conversation.updated_at = kwargs.get("updated_at", datetime.now(tz=UTC))
         for key, value in kwargs.items():
             setattr(conversation, key, value)
         return conversation
@@ -152,7 +152,7 @@ class ConversationServiceTestDataFactory:
         message.conversation_id = conversation_id
         message.app_id = app_id
         message.query = kwargs.get("query", "Test message content")
-        message.created_at = kwargs.get("created_at", datetime.now(tz=timezone.utc))
+        message.created_at = kwargs.get("created_at", datetime.now(tz=UTC))
         for key, value in kwargs.items():
             setattr(message, key, value)
         return message
@@ -181,8 +181,8 @@ class ConversationServiceTestDataFactory:
         variable.conversation_id = conversation_id
         variable.app_id = app_id
         variable.data = {"name": kwargs.get("name", "test_var"), "value": kwargs.get("value", "test_value")}
-        variable.created_at = kwargs.get("created_at", datetime.now(tz=timezone.utc))
-        variable.updated_at = kwargs.get("updated_at", datetime.now(tz=timezone.utc))
+        variable.created_at = kwargs.get("created_at", datetime.now(tz=UTC))
+        variable.updated_at = kwargs.get("updated_at", datetime.now(tz=UTC))
 
         # Mock to_variable method
         mock_variable = Mock()
@@ -302,7 +302,7 @@ class TestConversationServiceHelpers:
         """
         # Arrange
         mock_conversation = ConversationServiceTestDataFactory.create_conversation_mock()
-        mock_conversation.updated_at = datetime.now(tz=timezone.utc)
+        mock_conversation.updated_at = datetime.now(tz=UTC)
 
         # Act
         condition = ConversationService._build_filter_condition(
@@ -323,7 +323,7 @@ class TestConversationServiceHelpers:
         """
         # Arrange
         mock_conversation = ConversationServiceTestDataFactory.create_conversation_mock()
-        mock_conversation.created_at = datetime.now(tz=timezone.utc)
+        mock_conversation.created_at = datetime.now(tz=UTC)
 
         # Act
         condition = ConversationService._build_filter_condition(
@@ -668,9 +668,9 @@ class TestConversationServiceConversationalVariable:
         mock_session_factory.create_session.return_value.__enter__.return_value = mock_session
 
         last_variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(
-            created_at=datetime.now(tz=timezone.utc) - timedelta(hours=1)
+            created_at=datetime.now(tz=UTC) - timedelta(hours=1)
         )
-        variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(created_at=datetime.now(tz=timezone.utc))
+        variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(created_at=datetime.now(tz=UTC))
 
         mock_session.scalar.return_value = last_variable
         mock_session.scalars.return_value.all.return_value = [variable]

--- a/api/tests/unit_tests/services/test_conversation_service.py
+++ b/api/tests/unit_tests/services/test_conversation_service.py
@@ -6,7 +6,7 @@ Tests are organized by functionality and include edge cases, error handling,
 and both positive and negative test scenarios.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import pytest
@@ -122,8 +122,8 @@ class ConversationServiceTestDataFactory:
         conversation.is_deleted = kwargs.get("is_deleted", False)
         conversation.name = kwargs.get("name", "Test Conversation")
         conversation.status = kwargs.get("status", "normal")
-        conversation.created_at = kwargs.get("created_at", datetime.utcnow())
-        conversation.updated_at = kwargs.get("updated_at", datetime.utcnow())
+        conversation.created_at = kwargs.get("created_at", datetime.now(tz=timezone.utc))
+        conversation.updated_at = kwargs.get("updated_at", datetime.now(tz=timezone.utc))
         for key, value in kwargs.items():
             setattr(conversation, key, value)
         return conversation
@@ -152,7 +152,7 @@ class ConversationServiceTestDataFactory:
         message.conversation_id = conversation_id
         message.app_id = app_id
         message.query = kwargs.get("query", "Test message content")
-        message.created_at = kwargs.get("created_at", datetime.utcnow())
+        message.created_at = kwargs.get("created_at", datetime.now(tz=timezone.utc))
         for key, value in kwargs.items():
             setattr(message, key, value)
         return message
@@ -181,8 +181,8 @@ class ConversationServiceTestDataFactory:
         variable.conversation_id = conversation_id
         variable.app_id = app_id
         variable.data = {"name": kwargs.get("name", "test_var"), "value": kwargs.get("value", "test_value")}
-        variable.created_at = kwargs.get("created_at", datetime.utcnow())
-        variable.updated_at = kwargs.get("updated_at", datetime.utcnow())
+        variable.created_at = kwargs.get("created_at", datetime.now(tz=timezone.utc))
+        variable.updated_at = kwargs.get("updated_at", datetime.now(tz=timezone.utc))
 
         # Mock to_variable method
         mock_variable = Mock()
@@ -302,7 +302,7 @@ class TestConversationServiceHelpers:
         """
         # Arrange
         mock_conversation = ConversationServiceTestDataFactory.create_conversation_mock()
-        mock_conversation.updated_at = datetime.utcnow()
+        mock_conversation.updated_at = datetime.now(tz=timezone.utc)
 
         # Act
         condition = ConversationService._build_filter_condition(
@@ -323,7 +323,7 @@ class TestConversationServiceHelpers:
         """
         # Arrange
         mock_conversation = ConversationServiceTestDataFactory.create_conversation_mock()
-        mock_conversation.created_at = datetime.utcnow()
+        mock_conversation.created_at = datetime.now(tz=timezone.utc)
 
         # Act
         condition = ConversationService._build_filter_condition(
@@ -668,9 +668,9 @@ class TestConversationServiceConversationalVariable:
         mock_session_factory.create_session.return_value.__enter__.return_value = mock_session
 
         last_variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(
-            created_at=datetime.utcnow() - timedelta(hours=1)
+            created_at=datetime.now(tz=timezone.utc) - timedelta(hours=1)
         )
-        variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(created_at=datetime.utcnow())
+        variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(created_at=datetime.now(tz=timezone.utc))
 
         mock_session.scalar.return_value = last_variable
         mock_session.scalars.return_value.all.return_value = [variable]

--- a/api/tests/unit_tests/services/test_human_input_service.py
+++ b/api/tests/unit_tests/services/test_human_input_service.py
@@ -1,5 +1,5 @@
 import dataclasses
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -51,11 +51,11 @@ def sample_form_record():
             inputs=[],
             user_actions=[UserAction(id="submit", title="Submit")],
             rendered_content="<p>hello</p>",
-            expiration_time=datetime.utcnow() + timedelta(hours=1),
+            expiration_time=datetime.now(tz=timezone.utc) + timedelta(hours=1),
         ),
         rendered_content="<p>hello</p>",
-        created_at=datetime.utcnow(),
-        expiration_time=datetime.utcnow() + timedelta(hours=1),
+        created_at=datetime.now(tz=timezone.utc),
+        expiration_time=datetime.now(tz=timezone.utc) + timedelta(hours=1),
         status=HumanInputFormStatus.WAITING,
         selected_action_id=None,
         submitted_data=None,
@@ -101,8 +101,8 @@ def test_ensure_form_active_respects_global_timeout(monkeypatch, sample_form_rec
     service = HumanInputService(session_factory)
     expired_record = dataclasses.replace(
         sample_form_record,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        expiration_time=datetime.utcnow() + timedelta(hours=2),
+        created_at=datetime.now(tz=timezone.utc) - timedelta(hours=2),
+        expiration_time=datetime.now(tz=timezone.utc) + timedelta(hours=2),
     )
     monkeypatch.setattr(human_input_service_module.dify_config, "HUMAN_INPUT_GLOBAL_TIMEOUT_SECONDS", 3600)
 
@@ -391,7 +391,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
     service = HumanInputService(session_factory)
 
     # Submitted
-    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.utcnow())
+    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.now(tz=timezone.utc))
     with pytest.raises(human_input_service_module.FormSubmittedError):
         service.ensure_form_active(Form(submitted_record))
 
@@ -402,7 +402,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
 
     # Expired time
     expired_time_record = dataclasses.replace(
-        sample_form_record, expiration_time=datetime.utcnow() - timedelta(minutes=1)
+        sample_form_record, expiration_time=datetime.now(tz=timezone.utc) - timedelta(minutes=1)
     )
     with pytest.raises(FormExpiredError):
         service.ensure_form_active(Form(expired_time_record))
@@ -411,7 +411,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
 def test_ensure_not_submitted_raises(sample_form_record, mock_session_factory):
     session_factory, _ = mock_session_factory
     service = HumanInputService(session_factory)
-    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.utcnow())
+    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.now(tz=timezone.utc))
 
     with pytest.raises(human_input_service_module.FormSubmittedError):
         service._ensure_not_submitted(Form(submitted_record))

--- a/api/tests/unit_tests/services/test_human_input_service.py
+++ b/api/tests/unit_tests/services/test_human_input_service.py
@@ -1,5 +1,5 @@
 import dataclasses
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -51,11 +51,11 @@ def sample_form_record():
             inputs=[],
             user_actions=[UserAction(id="submit", title="Submit")],
             rendered_content="<p>hello</p>",
-            expiration_time=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            expiration_time=datetime.now(tz=UTC) + timedelta(hours=1),
         ),
         rendered_content="<p>hello</p>",
-        created_at=datetime.now(tz=timezone.utc),
-        expiration_time=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+        created_at=datetime.now(tz=UTC),
+        expiration_time=datetime.now(tz=UTC) + timedelta(hours=1),
         status=HumanInputFormStatus.WAITING,
         selected_action_id=None,
         submitted_data=None,
@@ -101,8 +101,8 @@ def test_ensure_form_active_respects_global_timeout(monkeypatch, sample_form_rec
     service = HumanInputService(session_factory)
     expired_record = dataclasses.replace(
         sample_form_record,
-        created_at=datetime.now(tz=timezone.utc) - timedelta(hours=2),
-        expiration_time=datetime.now(tz=timezone.utc) + timedelta(hours=2),
+        created_at=datetime.now(tz=UTC) - timedelta(hours=2),
+        expiration_time=datetime.now(tz=UTC) + timedelta(hours=2),
     )
     monkeypatch.setattr(human_input_service_module.dify_config, "HUMAN_INPUT_GLOBAL_TIMEOUT_SECONDS", 3600)
 
@@ -391,7 +391,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
     service = HumanInputService(session_factory)
 
     # Submitted
-    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.now(tz=timezone.utc))
+    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.now(tz=UTC))
     with pytest.raises(human_input_service_module.FormSubmittedError):
         service.ensure_form_active(Form(submitted_record))
 
@@ -402,7 +402,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
 
     # Expired time
     expired_time_record = dataclasses.replace(
-        sample_form_record, expiration_time=datetime.now(tz=timezone.utc) - timedelta(minutes=1)
+        sample_form_record, expiration_time=datetime.now(tz=UTC) - timedelta(minutes=1)
     )
     with pytest.raises(FormExpiredError):
         service.ensure_form_active(Form(expired_time_record))
@@ -411,7 +411,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
 def test_ensure_not_submitted_raises(sample_form_record, mock_session_factory):
     session_factory, _ = mock_session_factory
     service = HumanInputService(session_factory)
-    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.now(tz=timezone.utc))
+    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.now(tz=UTC))
 
     with pytest.raises(human_input_service_module.FormSubmittedError):
         service._ensure_not_submitted(Form(submitted_record))


### PR DESCRIPTION
## Summary

- Replaces all 70 occurrences of deprecated `datetime.utcnow()` with `datetime.now(tz=timezone.utc)` across 16 test files
- Adds `timezone` import where needed
- Resolves `DeprecationWarning` in Python 3.12+ as `datetime.utcnow()` is scheduled for removal in Python 3.14

Closes #33977