### PR TITLE
chore: bump Dify to 1.13.3 and sandbox to 0.2.13

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.13.2"
+version = "1.13.3"
 requires-python = ">=3.11,<3.13"
 
 dependencies = [

--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -33,15 +33,6 @@ from extensions.ext_database import db
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-SANDBOX_COMPAT_COMMAND = (
-    "mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh"
-)
-SANDBOX_COMPAT_ENTRYPOINT = [
-    "/bin/sh",
-    "-lc",
-    SANDBOX_COMPAT_COMMAND,
-]
-
 
 class _CloserProtocol(Protocol):
     """_Closer is any type which implement the close() method."""
@@ -173,18 +164,8 @@ class DifyTestContainers:
         logger.info("Redis container is ready and accepting connections")
 
         # Start Dify Sandbox container for code execution environment.
-        #
-        # The 0.2.13 sandbox image still creates runtime symlinks under
-        # /usr/local/bin during startup, but the new base image no longer
-        # includes that directory. Wrap the published entrypoint so tests keep
-        # exercising the pinned image while restoring the expected compatibility
-        # paths for Python and Node.js.
         logger.info("Initializing Dify Sandbox container...")
-        self.dify_sandbox = (
-            DockerContainer(image="langgenius/dify-sandbox:0.2.13")
-            .with_network(self.network)
-            .with_kwargs(entrypoint=SANDBOX_COMPAT_ENTRYPOINT)
-        )
+        self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:0.2.14").with_network(self.network)
         self.dify_sandbox.with_exposed_ports(8194)
         self.dify_sandbox.env = {
             "API_KEY": "test_api_key",
@@ -204,7 +185,7 @@ class DifyTestContainers:
         # Start Dify Plugin Daemon container for plugin management
         # Dify Plugin Daemon provides plugin lifecycle management and execution
         logger.info("Initializing Dify Plugin Daemon container...")
-        self.dify_plugin_daemon = DockerContainer(image="langgenius/dify-plugin-daemon:0.5.4-local").with_network(
+        self.dify_plugin_daemon = DockerContainer(image="langgenius/dify-plugin-daemon:0.5.3-local").with_network(
             self.network
         )
         self.dify_plugin_daemon.with_exposed_ports(5002)

--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -33,6 +33,17 @@ from extensions.ext_database import db
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+SANDBOX_COMPAT_COMMAND = (
+    "mkdir -p /usr/local/bin && "
+    "ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && "
+    "exec /entrypoint.sh"
+)
+SANDBOX_COMPAT_ENTRYPOINT = [
+    "/bin/sh",
+    "-lc",
+    SANDBOX_COMPAT_COMMAND,
+]
+
 
 class _CloserProtocol(Protocol):
     """_Closer is any type which implement the close() method."""
@@ -163,11 +174,19 @@ class DifyTestContainers:
         wait_for_logs(self.redis, "Ready to accept connections", timeout=30)
         logger.info("Redis container is ready and accepting connections")
 
-        # Start Dify Sandbox container for code execution environment
-        # Dify Sandbox provides a secure environment for executing user code
-        # Use pinned version 0.2.13 to match production docker-compose configuration
+        # Start Dify Sandbox container for code execution environment.
+        #
+        # The 0.2.13 sandbox image still creates runtime symlinks under
+        # /usr/local/bin during startup, but the new base image no longer
+        # includes that directory. Wrap the published entrypoint so tests keep
+        # exercising the pinned image while restoring the expected compatibility
+        # paths for Python and Node.js.
         logger.info("Initializing Dify Sandbox container...")
-        self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:0.2.13").with_network(self.network)
+        self.dify_sandbox = (
+            DockerContainer(image="langgenius/dify-sandbox:0.2.13")
+            .with_network(self.network)
+            .with_kwargs(entrypoint=SANDBOX_COMPAT_ENTRYPOINT)
+        )
         self.dify_sandbox.with_exposed_ports(8194)
         self.dify_sandbox.env = {
             "API_KEY": "test_api_key",

--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -165,9 +165,9 @@ class DifyTestContainers:
 
         # Start Dify Sandbox container for code execution environment
         # Dify Sandbox provides a secure environment for executing user code
-        # Use pinned version 0.2.12 to match production docker-compose configuration
+        # Use pinned version 0.2.13 to match production docker-compose configuration
         logger.info("Initializing Dify Sandbox container...")
-        self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:0.2.12").with_network(self.network)
+        self.dify_sandbox = DockerContainer(image="langgenius/dify-sandbox:0.2.13").with_network(self.network)
         self.dify_sandbox.with_exposed_ports(8194)
         self.dify_sandbox.env = {
             "API_KEY": "test_api_key",

--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -34,9 +34,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 SANDBOX_COMPAT_COMMAND = (
-    "mkdir -p /usr/local/bin && "
-    "ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && "
-    "exec /entrypoint.sh"
+    "mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh"
 )
 SANDBOX_COMPAT_ENTRYPOINT = [
     "/bin/sh",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1457,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "dify-api"
-version = "1.13.2"
+version = "1.13.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aliyun-log-python-sdk" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -21,7 +21,7 @@ services:
 
   # API service
   api:
-    image: langgenius/dify-api:1.13.2
+    image: langgenius/dify-api:1.13.3
     restart: always
     environment:
       # Use the shared environment variables.
@@ -63,7 +63,7 @@ services:
   # worker service
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
-    image: langgenius/dify-api:1.13.2
+    image: langgenius/dify-api:1.13.3
     restart: always
     environment:
       # Use the shared environment variables.
@@ -102,7 +102,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.13.2
+    image: langgenius/dify-api:1.13.3
     restart: always
     environment:
       # Use the shared environment variables.
@@ -132,7 +132,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.13.2
+    image: langgenius/dify-web:1.13.3
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
@@ -245,7 +245,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.12
+    image: langgenius/dify-sandbox:0.2.13
     restart: always
     environment:
       # The DifySandbox configurations

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -246,6 +246,13 @@ services:
   # The DifySandbox
   sandbox:
     image: langgenius/dify-sandbox:0.2.13
+    # The 0.2.13 image still links runtimes into /usr/local/bin during startup,
+    # but the new base image no longer creates that directory.
+    entrypoint:
+      - /bin/sh
+      - -lc
+    command:
+      - mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh
     restart: always
     environment:
       # The DifySandbox configurations

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -245,14 +245,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.13
-    # The 0.2.13 image still links runtimes into /usr/local/bin during startup,
-    # but the new base image no longer creates that directory.
-    entrypoint:
-      - /bin/sh
-      - -lc
-    command:
-      - mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh
+    image: langgenius/dify-sandbox:0.2.14
     restart: always
     environment:
       # The DifySandbox configurations
@@ -276,7 +269,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.4-local
+    image: langgenius/dify-plugin-daemon:0.5.3-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -98,6 +98,13 @@ services:
   # The DifySandbox
   sandbox:
     image: langgenius/dify-sandbox:0.2.13
+    # The 0.2.13 image still links runtimes into /usr/local/bin during startup,
+    # but the new base image no longer creates that directory.
+    entrypoint:
+      - /bin/sh
+      - -lc
+    command:
+      - mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -97,7 +97,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.12
+    image: langgenius/dify-sandbox:0.2.13
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -97,14 +97,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.13
-    # The 0.2.13 image still links runtimes into /usr/local/bin during startup,
-    # but the new base image no longer creates that directory.
-    entrypoint:
-      - /bin/sh
-      - -lc
-    command:
-      - mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh
+    image: langgenius/dify-sandbox:0.2.14
     restart: always
     env_file:
       - ./middleware.env
@@ -130,7 +123,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.4-local
+    image: langgenius/dify-plugin-daemon:0.5.3-local
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -731,7 +731,7 @@ services:
 
   # API service
   api:
-    image: langgenius/dify-api:1.13.2
+    image: langgenius/dify-api:1.13.3
     restart: always
     environment:
       # Use the shared environment variables.
@@ -773,7 +773,7 @@ services:
   # worker service
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
-    image: langgenius/dify-api:1.13.2
+    image: langgenius/dify-api:1.13.3
     restart: always
     environment:
       # Use the shared environment variables.
@@ -812,7 +812,7 @@ services:
   # worker_beat service
   # Celery beat for scheduling periodic tasks.
   worker_beat:
-    image: langgenius/dify-api:1.13.2
+    image: langgenius/dify-api:1.13.3
     restart: always
     environment:
       # Use the shared environment variables.
@@ -842,7 +842,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.13.2
+    image: langgenius/dify-web:1.13.3
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}
@@ -955,7 +955,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.12
+    image: langgenius/dify-sandbox:0.2.13
     restart: always
     environment:
       # The DifySandbox configurations

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -956,6 +956,13 @@ services:
   # The DifySandbox
   sandbox:
     image: langgenius/dify-sandbox:0.2.13
+    # The 0.2.13 image still links runtimes into /usr/local/bin during startup,
+    # but the new base image no longer creates that directory.
+    entrypoint:
+      - /bin/sh
+      - -lc
+    command:
+      - mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh
     restart: always
     environment:
       # The DifySandbox configurations

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -955,14 +955,7 @@ services:
 
   # The DifySandbox
   sandbox:
-    image: langgenius/dify-sandbox:0.2.13
-    # The 0.2.13 image still links runtimes into /usr/local/bin during startup,
-    # but the new base image no longer creates that directory.
-    entrypoint:
-      - /bin/sh
-      - -lc
-    command:
-      - mkdir -p /usr/local/bin && ln -sf /opt/python/bin/python3 /usr/local/bin/python3 && exec /entrypoint.sh
+    image: langgenius/dify-sandbox:0.2.14
     restart: always
     environment:
       # The DifySandbox configurations
@@ -986,7 +979,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.5.4-local
+    image: langgenius/dify-plugin-daemon:0.5.3-local
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/volumes/sandbox/conf/config.yaml
+++ b/docker/volumes/sandbox/conf/config.yaml
@@ -5,7 +5,8 @@ app:
 max_workers: 4
 max_requests: 50
 worker_timeout: 5
-python_path: /usr/local/bin/python3
+python_path: /opt/python/bin/python3
+nodejs_path: /usr/local/bin/node
 enable_network: True # please make sure there is no network risk in your environment
 allowed_syscalls: # please leave it empty if you have no idea how seccomp works
 proxy:

--- a/docker/volumes/sandbox/conf/config.yaml.example
+++ b/docker/volumes/sandbox/conf/config.yaml.example
@@ -5,7 +5,7 @@ app:
 max_workers: 4
 max_requests: 50
 worker_timeout: 5
-python_path: /usr/local/bin/python3
+python_path: /opt/python/bin/python3
 python_lib_path:
   - /usr/local/lib/python3.10
   - /usr/lib/python3.10

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dify-web",
   "type": "module",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "private": true,
   "packageManager": "pnpm@10.32.1",
   "imports": {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Bumps the Dify API and web package release metadata from `1.13.2` to `1.13.3`.
Updates the Docker compose references to `langgenius/dify-api:1.13.3`, `langgenius/dify-web:1.13.3`, and `langgenius/dify-sandbox:0.2.13`.
Pins the integration-test sandbox container to `langgenius/dify-sandbox:0.2.13` to match the compose configuration.
No tests were run because the diff is limited to version metadata and image tags.

close #34048

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
