### PR TITLE
fix: extract 4 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/pyrefly-diff.yml
+++ b/.github/workflows/pyrefly-diff.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Prepare diagnostics extractor
         run: |
-          git show ${{ github.event.pull_request.head.sha }}:api/libs/pyrefly_diagnostics.py > /tmp/pyrefly_diagnostics.py
+          git show ${PR_HEAD_SHA}:api/libs/pyrefly_diagnostics.py > /tmp/pyrefly_diagnostics.py
 
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Run pyrefly on PR branch
         run: |
           uv run --directory api --dev pyrefly check 2>&1 \

--- a/.github/workflows/translate-i18n-claude.yml
+++ b/.github/workflows/translate-i18n-claude.yml
@@ -56,15 +56,15 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             # Manual trigger
-            if [ -n "${{ github.event.inputs.files }}" ]; then
-              echo "CHANGED_FILES=${{ github.event.inputs.files }}" >> $GITHUB_OUTPUT
+            if [ -n "${INPUT_FILES}" ]; then
+              echo "CHANGED_FILES=${INPUT_FILES}" >> $GITHUB_OUTPUT
             else
               # Get all JSON files in en-US directory
               files=$(ls web/i18n/en-US/*.json 2>/dev/null | xargs -n1 basename | sed 's/.json$//' | tr '\n' ' ')
               echo "CHANGED_FILES=$files" >> $GITHUB_OUTPUT
             fi
-            echo "TARGET_LANGS=${{ github.event.inputs.languages }}" >> $GITHUB_OUTPUT
-            echo "SYNC_MODE=${{ github.event.inputs.mode || 'incremental' }}" >> $GITHUB_OUTPUT
+            echo "TARGET_LANGS=${INPUT_LANGUAGES}" >> $GITHUB_OUTPUT
+            echo "SYNC_MODE=${INPUT_MODE}" >> $GITHUB_OUTPUT
 
             # For manual trigger with incremental mode, get diff from last commit
             # For full mode, we'll do a complete check anyway
@@ -118,6 +118,10 @@ jobs:
 
           echo "Detected files: $(cat $GITHUB_OUTPUT | grep CHANGED_FILES || echo 'none')"
 
+        env:
+          INPUT_FILES: ${{ github.event.inputs.files }}
+          INPUT_LANGUAGES: ${{ github.event.inputs.languages }}
+          INPUT_MODE: ${{ github.event.inputs.mode || 'incremental' }}
       - name: Run Claude Code for Translation Sync
         if: steps.detect_changes.outputs.CHANGED_FILES != ''
         uses: anthropics/claude-code-action@ff9acae5886d41a99ed4ec14b7dc147d55834722 # v1.0.77


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/pyrefly-diff.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/translate-i18n-claude.yml` | Extracted 3 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/deploy-agent-dev.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/deploy-dev.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/deploy-enterprise.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/deploy-hitl.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/pyrefly-diff-comment.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/pyrefly-diff-comment.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/pyrefly-diff-comment.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-014 | high | `.github/workflows/translate-i18n-claude.yml` | Expression Injection via workflow_dispatch Input |
| RGS-005 | medium | `.github/workflows/labeler.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.