### PR TITLE
chore(api): remove backend utcnow usage

### DIFF
--- a/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
+++ b/api/tests/test_containers_integration_tests/helpers/execution_extra_content.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import uuid4
 
 from graphon.nodes.human_input.entities import FormDefinition, UserAction
+from libs.datetime_utils import naive_utc_now
 from models.account import Account, Tenant, TenantAccountJoin
 from models.enums import ConversationFromSource, InvokeFrom
 from models.execution_extra_content import HumanInputContent
@@ -117,7 +118,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         inputs=[],
         user_actions=[UserAction(id=action_id, title=action_text)],
         rendered_content="Rendered block",
-        expiration_time=datetime.utcnow() + timedelta(days=1),
+        expiration_time=naive_utc_now() + timedelta(days=1),
         node_title=node_title,
         display_in_ui=True,
     )
@@ -129,7 +130,7 @@ def create_human_input_message_fixture(db_session) -> HumanInputMessageFixture:
         form_definition=form_definition.model_dump_json(),
         rendered_content="Rendered block",
         status=HumanInputFormStatus.SUBMITTED,
-        expiration_time=datetime.utcnow() + timedelta(days=1),
+        expiration_time=naive_utc_now() + timedelta(days=1),
         selected_action_id=action_id,
     )
     db_session.add(form)

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_execution_extra_content_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_execution_extra_content_repository.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import uuid4
 
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from graphon.nodes.human_input.entities import FormDefinition, UserAction
 from graphon.nodes.human_input.enums import HumanInputFormStatus
+from libs.datetime_utils import naive_utc_now
 from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from models.enums import ConversationFromSource, InvokeFrom
 from models.execution_extra_content import ExecutionExtraContent, HumanInputContent
@@ -174,7 +175,7 @@ def _create_submitted_form(
     action_title: str = "Approve",
     node_title: str = "Approval",
 ) -> HumanInputForm:
-    expiration_time = datetime.utcnow() + timedelta(days=1)
+    expiration_time = naive_utc_now() + timedelta(days=1)
     form_definition = FormDefinition(
         form_content="content",
         inputs=[],
@@ -207,7 +208,7 @@ def _create_waiting_form(
     workflow_run_id: str,
     default_values: dict | None = None,
 ) -> HumanInputForm:
-    expiration_time = datetime.utcnow() + timedelta(days=1)
+    expiration_time = naive_utc_now() + timedelta(days=1)
     form_definition = FormDefinition(
         form_content="content",
         inputs=[],

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
@@ -26,6 +26,7 @@ from controllers.console.datasets.rag_pipeline.rag_pipeline_workflow import (
     RagPipelineWorkflowLastRunApi,
 )
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
+from libs.datetime_utils import naive_utc_now
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
 from services.errors.llm import InvokeRateLimitError
 
@@ -372,7 +373,7 @@ class TestPublishedPipelineApis:
 
         workflow = MagicMock(
             id="w1",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         session = MagicMock()

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +24,7 @@ from controllers.console.datasets.error import (
 )
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.rag.index_processor.constant.index_type import IndexStructureType
+from libs.datetime_utils import naive_utc_now
 from models.dataset import ChildChunk, DocumentSegment
 from models.model import UploadFile
 
@@ -54,8 +54,8 @@ def _segment():
         disabled_by=None,
         status="normal",
         created_by="u1",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=naive_utc_now(),
+        updated_at=naive_utc_now(),
         updated_by="u1",
         indexing_at=None,
         completed_at=None,

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +25,7 @@ from controllers.console.workspace.workspace import (
     WorkspacePermissionApi,
 )
 from enums.cloud_plan import CloudPlan
+from libs.datetime_utils import naive_utc_now
 from models.account import TenantStatus
 
 
@@ -44,13 +44,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         with (
@@ -97,13 +97,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         features_t2 = MagicMock()
@@ -152,13 +152,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         features = MagicMock()
@@ -204,7 +204,7 @@ class TestTenantListApi:
             id="t1",
             name="Tenant",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         features = MagicMock()
@@ -243,13 +243,13 @@ class TestTenantListApi:
             id="t1",
             name="Tenant 1",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
         tenant2 = MagicMock(
             id="t2",
             name="Tenant 2",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         with (
@@ -305,7 +305,7 @@ class TestWorkspaceListApi:
         api = WorkspaceListApi()
         method = unwrap(api.get)
 
-        tenant = MagicMock(id="t1", name="T", status="active", created_at=datetime.utcnow())
+        tenant = MagicMock(id="t1", name="T", status="active", created_at=naive_utc_now())
 
         paginate_result = MagicMock(
             items=[tenant],
@@ -331,7 +331,7 @@ class TestWorkspaceListApi:
             id="t1",
             name="T",
             status="active",
-            created_at=datetime.utcnow(),
+            created_at=naive_utc_now(),
         )
 
         paginate_result = MagicMock(

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
@@ -45,6 +44,7 @@ from core.base.tts.app_generator_tts_publisher import AudioTrunk
 from core.workflow.system_variables import build_system_variables
 from graphon.enums import BuiltinNodeTypes
 from graphon.runtime import GraphRuntimeState, VariablePool
+from libs.datetime_utils import naive_utc_now
 from models.enums import MessageStatus
 from models.model import AppMode, EndUser
 from tests.workflow_test_utils import build_test_variable_pool
@@ -76,7 +76,7 @@ def _make_pipeline():
     message = SimpleNamespace(
         id="message-id",
         query="hello",
-        created_at=datetime.utcnow(),
+        created_at=naive_utc_now(),
         status=MessageStatus.NORMAL,
         answer="",
     )
@@ -257,7 +257,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         iter_next = QueueIterationNextEvent(
@@ -273,7 +273,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         loop_start = QueueLoopStartEvent(
@@ -281,7 +281,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         loop_next = QueueLoopNextEvent(
@@ -297,7 +297,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
 
@@ -360,7 +360,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             inputs={},
             outputs={},
             process_data={},
@@ -370,7 +370,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             inputs={},
             outputs={},
             process_data={},
@@ -473,7 +473,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="title",
-            expiration_time=datetime.utcnow(),
+            expiration_time=naive_utc_now(),
         )
 
         assert list(pipeline._handle_human_input_form_filled_event(filled_event)) == ["filled"]
@@ -591,7 +591,7 @@ class TestAdvancedChatGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             inputs={},
             outputs={},
             process_data={},

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
@@ -47,6 +46,7 @@ from core.base.tts.app_generator_tts_publisher import AudioTrunk
 from core.workflow.system_variables import build_system_variables, system_variables_to_mapping
 from graphon.enums import BuiltinNodeTypes, WorkflowExecutionStatus
 from graphon.runtime import GraphRuntimeState, VariablePool
+from libs.datetime_utils import naive_utc_now
 from models.enums import CreatorUserRole
 from models.model import AppMode, EndUser
 from tests.workflow_test_utils import build_test_variable_pool
@@ -192,7 +192,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             inputs={},
             outputs={},
             process_data={},
@@ -245,7 +245,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             inputs={},
             outputs={},
             process_data={},
@@ -303,7 +303,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         iter_next = QueueIterationNextEvent(
@@ -319,7 +319,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         loop_start = QueueLoopStartEvent(
@@ -327,7 +327,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         loop_next = QueueLoopNextEvent(
@@ -343,7 +343,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="LLM",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             node_run_index=1,
         )
         filled_event = QueueHumanInputFormFilledEvent(
@@ -359,7 +359,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node",
             node_type=BuiltinNodeTypes.LLM,
             node_title="title",
-            expiration_time=datetime.utcnow(),
+            expiration_time=naive_utc_now(),
         )
         agent_event = QueueAgentLogEvent(
             id="log",
@@ -648,7 +648,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_title="title",
             node_type=BuiltinNodeTypes.LLM,
             node_run_index=1,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             provider_type="provider",
             provider_id="provider-id",
             error="error",
@@ -660,7 +660,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_title="title",
             node_type=BuiltinNodeTypes.LLM,
             node_run_index=1,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             provider_type="provider",
             provider_id="provider-id",
         )
@@ -685,7 +685,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_execution_id="exec-id",
             node_id="node",
             node_type=BuiltinNodeTypes.START,
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             inputs={},
             outputs={},
             process_data={},
@@ -836,7 +836,7 @@ class TestWorkflowGenerateTaskPipeline:
             node_id="node-id",
             node_type=BuiltinNodeTypes.START,
             in_loop_id="loop-id",
-            start_at=datetime.utcnow(),
+            start_at=naive_utc_now(),
             process_data={"k": "v"},
             outputs={"out": 1},
         )

--- a/api/tests/unit_tests/core/app/layers/test_conversation_variable_persist_layer.py
+++ b/api/tests/unit_tests/core/app/layers/test_conversation_variable_persist_layer.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from datetime import datetime
 from unittest.mock import Mock
 
 from core.app.layers.conversation_variable_persist_layer import ConversationVariablePersistenceLayer
@@ -12,6 +11,7 @@ from graphon.node_events import NodeRunResult
 from graphon.runtime.graph_runtime_state_protocol import ReadOnlyGraphRuntimeState
 from graphon.variables import StringVariable
 from graphon.variables.segments import Segment, StringSegment
+from libs.datetime_utils import naive_utc_now
 
 
 class MockReadOnlyVariablePool:
@@ -48,7 +48,7 @@ def _build_node_run_succeeded_event() -> NodeRunSucceededEvent:
         id="node-exec-id",
         node_id="assigner",
         node_type=BuiltinNodeTypes.LLM,
-        start_at=datetime.utcnow(),
+        start_at=naive_utc_now(),
         node_run_result=NodeRunResult(
             status=WorkflowNodeExecutionStatus.SUCCEEDED,
             outputs={},

--- a/api/tests/unit_tests/core/repositories/test_human_input_form_repository_impl.py
+++ b/api/tests/unit_tests/core/repositories/test_human_input_form_repository_impl.py
@@ -274,7 +274,7 @@ def _make_form_definition() -> str:
         inputs=[],
         user_actions=[UserAction(id="submit", title="Submit")],
         rendered_content="<p>hello</p>",
-        expiration_time=datetime.utcnow(),
+        expiration_time=naive_utc_now(),
     ).model_dump_json()
 
 

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_dispatcher_pause_drain.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_dispatcher_pause_drain.py
@@ -1,10 +1,10 @@
 import queue
-from datetime import datetime
 
 from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
 from graphon.graph_engine.orchestration.dispatcher import Dispatcher
 from graphon.graph_events import NodeRunSucceededEvent
 from graphon.node_events import NodeRunResult
+from libs.datetime_utils import naive_utc_now
 
 
 class StubExecutionCoordinator:
@@ -52,7 +52,7 @@ def test_dispatcher_drains_events_when_paused() -> None:
         id="exec-1",
         node_id="node-1",
         node_type=BuiltinNodeTypes.START,
-        start_at=datetime.utcnow(),
+        start_at=naive_utc_now(),
         node_run_result=NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED),
     )
     event_queue.put(event)

--- a/api/tests/unit_tests/libs/_human_input/support.py
+++ b/api/tests/unit_tests/libs/_human_input/support.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from graphon.nodes.human_input.entities import FormInput
 from graphon.nodes.human_input.enums import TimeoutUnit
+from libs.datetime_utils import naive_utc_now
 
 
 # Exceptions
@@ -49,7 +50,7 @@ class HumanInputForm:
     timeout: int
     timeout_unit: TimeoutUnit
     form_token: str | None = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=naive_utc_now)
     expires_at: datetime | None = None
     submitted_at: datetime | None = None
     submitted_data: dict[str, Any] | None = None
@@ -61,7 +62,7 @@ class HumanInputForm:
 
     @property
     def is_expired(self) -> bool:
-        return self.expires_at is not None and datetime.utcnow() > self.expires_at
+        return self.expires_at is not None and naive_utc_now() > self.expires_at
 
     @property
     def is_submitted(self) -> bool:
@@ -70,7 +71,7 @@ class HumanInputForm:
     def mark_submitted(self, inputs: dict[str, Any], action: str) -> None:
         self.submitted_data = inputs
         self.submitted_action = action
-        self.submitted_at = datetime.utcnow()
+        self.submitted_at = naive_utc_now()
 
     def submit(self, inputs: dict[str, Any], action: str) -> None:
         self.mark_submitted(inputs, action)
@@ -107,7 +108,7 @@ class FormSubmissionData:
     form_id: str
     inputs: dict[str, Any]
     action: str
-    submitted_at: datetime = field(default_factory=datetime.utcnow)
+    submitted_at: datetime = field(default_factory=naive_utc_now)
 
     @classmethod
     def from_request(cls, form_id: str, request: FormSubmissionRequest) -> FormSubmissionData:  # type: ignore

--- a/api/tests/unit_tests/libs/_human_input/test_form_service.py
+++ b/api/tests/unit_tests/libs/_human_input/test_form_service.py
@@ -2,7 +2,7 @@
 Unit tests for FormService.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 
@@ -142,7 +142,7 @@ class TestFormService:
 
         # Manually expire the form by modifying expiry time
         form = form_service.get_form_by_id("form-123")
-        form.expires_at = datetime.utcnow() - timedelta(hours=1)
+        form.expires_at = naive_utc_now() - timedelta(hours=1)
         form_service.repository.save(form)
 
         # Should raise FormExpiredError
@@ -227,7 +227,7 @@ class TestFormService:
 
         # Manually expire the form
         form = form_service.get_form_by_id("form-123")
-        form.expires_at = datetime.utcnow() - timedelta(hours=1)
+        form.expires_at = naive_utc_now() - timedelta(hours=1)
         form_service.repository.save(form)
 
         # Try to submit expired form

--- a/api/tests/unit_tests/libs/_human_input/test_models.py
+++ b/api/tests/unit_tests/libs/_human_input/test_models.py
@@ -14,6 +14,7 @@ from graphon.nodes.human_input.enums import (
     FormInputType,
     TimeoutUnit,
 )
+from libs.datetime_utils import naive_utc_now
 
 from .support import FormSubmissionData, FormSubmissionRequest, HumanInputForm
 
@@ -83,7 +84,7 @@ class TestHumanInputForm:
     def test_form_expiry_property_expired(self, sample_form_data):
         """Test is_expired property for expired form."""
         # Create form with past expiry
-        past_time = datetime.utcnow() - timedelta(hours=1)
+        past_time = naive_utc_now() - timedelta(hours=1)
         sample_form_data["created_at"] = past_time
 
         form = HumanInputForm(**sample_form_data)
@@ -111,9 +112,9 @@ class TestHumanInputForm:
         """Test form submit method."""
         form = HumanInputForm(**sample_form_data)
 
-        submission_time_before = datetime.utcnow()
+        submission_time_before = naive_utc_now()
         form.submit({"input": "test value"}, "submit")
-        submission_time_after = datetime.utcnow()
+        submission_time_after = naive_utc_now()
 
         assert form.is_submitted
         assert form.submitted_data == {"input": "test value"}
@@ -213,11 +214,11 @@ class TestFormSubmissionData:
 
     def test_submission_data_timestamps(self):
         """Test submission data timestamp handling."""
-        before_time = datetime.utcnow()
+        before_time = naive_utc_now()
 
         submission_data = FormSubmissionData(form_id="form-123", inputs={"test": "value"}, action="submit")
 
-        after_time = datetime.utcnow()
+        after_time = naive_utc_now()
 
         assert before_time <= submission_data.submitted_at <= after_time
 

--- a/api/tests/unit_tests/services/test_conversation_service.py
+++ b/api/tests/unit_tests/services/test_conversation_service.py
@@ -6,13 +6,14 @@ Tests are organized by functionality and include edge cases, error handling,
 and both positive and negative test scenarios.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import pytest
 from sqlalchemy import asc, desc
 
 from core.app.entities.app_invoke_entities import InvokeFrom
+from libs.datetime_utils import naive_utc_now
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from models import Account, ConversationVariable
 from models.enums import ConversationFromSource
@@ -122,8 +123,8 @@ class ConversationServiceTestDataFactory:
         conversation.is_deleted = kwargs.get("is_deleted", False)
         conversation.name = kwargs.get("name", "Test Conversation")
         conversation.status = kwargs.get("status", "normal")
-        conversation.created_at = kwargs.get("created_at", datetime.utcnow())
-        conversation.updated_at = kwargs.get("updated_at", datetime.utcnow())
+        conversation.created_at = kwargs.get("created_at", naive_utc_now())
+        conversation.updated_at = kwargs.get("updated_at", naive_utc_now())
         for key, value in kwargs.items():
             setattr(conversation, key, value)
         return conversation
@@ -152,7 +153,7 @@ class ConversationServiceTestDataFactory:
         message.conversation_id = conversation_id
         message.app_id = app_id
         message.query = kwargs.get("query", "Test message content")
-        message.created_at = kwargs.get("created_at", datetime.utcnow())
+        message.created_at = kwargs.get("created_at", naive_utc_now())
         for key, value in kwargs.items():
             setattr(message, key, value)
         return message
@@ -181,8 +182,8 @@ class ConversationServiceTestDataFactory:
         variable.conversation_id = conversation_id
         variable.app_id = app_id
         variable.data = {"name": kwargs.get("name", "test_var"), "value": kwargs.get("value", "test_value")}
-        variable.created_at = kwargs.get("created_at", datetime.utcnow())
-        variable.updated_at = kwargs.get("updated_at", datetime.utcnow())
+        variable.created_at = kwargs.get("created_at", naive_utc_now())
+        variable.updated_at = kwargs.get("updated_at", naive_utc_now())
 
         # Mock to_variable method
         mock_variable = Mock()
@@ -302,7 +303,7 @@ class TestConversationServiceHelpers:
         """
         # Arrange
         mock_conversation = ConversationServiceTestDataFactory.create_conversation_mock()
-        mock_conversation.updated_at = datetime.utcnow()
+        mock_conversation.updated_at = naive_utc_now()
 
         # Act
         condition = ConversationService._build_filter_condition(
@@ -323,7 +324,7 @@ class TestConversationServiceHelpers:
         """
         # Arrange
         mock_conversation = ConversationServiceTestDataFactory.create_conversation_mock()
-        mock_conversation.created_at = datetime.utcnow()
+        mock_conversation.created_at = naive_utc_now()
 
         # Act
         condition = ConversationService._build_filter_condition(
@@ -668,9 +669,9 @@ class TestConversationServiceConversationalVariable:
         mock_session_factory.create_session.return_value.__enter__.return_value = mock_session
 
         last_variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(
-            created_at=datetime.utcnow() - timedelta(hours=1)
+            created_at=naive_utc_now() - timedelta(hours=1)
         )
-        variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(created_at=datetime.utcnow())
+        variable = ConversationServiceTestDataFactory.create_conversation_variable_mock(created_at=naive_utc_now())
 
         mock_session.scalar.return_value = last_variable
         mock_session.scalars.return_value.all.return_value = [variable]

--- a/api/tests/unit_tests/services/test_human_input_service.py
+++ b/api/tests/unit_tests/services/test_human_input_service.py
@@ -15,6 +15,7 @@ from graphon.nodes.human_input.entities import (
     UserAction,
 )
 from graphon.nodes.human_input.enums import FormInputType, HumanInputFormKind, HumanInputFormStatus
+from libs.datetime_utils import naive_utc_now
 from models.human_input import RecipientType
 from services.human_input_service import (
     Form,
@@ -51,11 +52,11 @@ def sample_form_record():
             inputs=[],
             user_actions=[UserAction(id="submit", title="Submit")],
             rendered_content="<p>hello</p>",
-            expiration_time=datetime.utcnow() + timedelta(hours=1),
+            expiration_time=naive_utc_now() + timedelta(hours=1),
         ),
         rendered_content="<p>hello</p>",
-        created_at=datetime.utcnow(),
-        expiration_time=datetime.utcnow() + timedelta(hours=1),
+        created_at=naive_utc_now(),
+        expiration_time=naive_utc_now() + timedelta(hours=1),
         status=HumanInputFormStatus.WAITING,
         selected_action_id=None,
         submitted_data=None,
@@ -101,8 +102,8 @@ def test_ensure_form_active_respects_global_timeout(monkeypatch, sample_form_rec
     service = HumanInputService(session_factory)
     expired_record = dataclasses.replace(
         sample_form_record,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        expiration_time=datetime.utcnow() + timedelta(hours=2),
+        created_at=naive_utc_now() - timedelta(hours=2),
+        expiration_time=naive_utc_now() + timedelta(hours=2),
     )
     monkeypatch.setattr(human_input_service_module.dify_config, "HUMAN_INPUT_GLOBAL_TIMEOUT_SECONDS", 3600)
 
@@ -391,7 +392,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
     service = HumanInputService(session_factory)
 
     # Submitted
-    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.utcnow())
+    submitted_record = dataclasses.replace(sample_form_record, submitted_at=naive_utc_now())
     with pytest.raises(human_input_service_module.FormSubmittedError):
         service.ensure_form_active(Form(submitted_record))
 
@@ -402,7 +403,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
 
     # Expired time
     expired_time_record = dataclasses.replace(
-        sample_form_record, expiration_time=datetime.utcnow() - timedelta(minutes=1)
+        sample_form_record, expiration_time=naive_utc_now() - timedelta(minutes=1)
     )
     with pytest.raises(FormExpiredError):
         service.ensure_form_active(Form(expired_time_record))
@@ -411,7 +412,7 @@ def test_ensure_form_active_errors(sample_form_record, mock_session_factory):
 def test_ensure_not_submitted_raises(sample_form_record, mock_session_factory):
     session_factory, _ = mock_session_factory
     service = HumanInputService(session_factory)
-    submitted_record = dataclasses.replace(sample_form_record, submitted_at=datetime.utcnow())
+    submitted_record = dataclasses.replace(sample_form_record, submitted_at=naive_utc_now())
 
     with pytest.raises(human_input_service_module.FormSubmittedError):
         service._ensure_not_submitted(Form(submitted_record))


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #33977.

Remove backend `utcnow()` usage.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
