### PR TITLE
fix(workflow): handle file-preview URLs in node output display

### DIFF
--- a/web/app/components/workflow/run/node.tsx
+++ b/web/app/components/workflow/run/node.tsx
@@ -255,6 +255,7 @@ const NodePanel: FC<Props> = ({
               <div className={cn('mb-1')}>
                 <CodeEditor
                   readOnly
+                  showFileList
                   title={<div>{processDataTitle}</div>}
                   language={CodeLanguage.json}
                   value={nodeInfo.process_data}
@@ -266,6 +267,7 @@ const NodePanel: FC<Props> = ({
               <div>
                 <CodeEditor
                   readOnly
+                  showFileList
                   title={<div>{outputTitle}</div>}
                   language={CodeLanguage.json}
                   value={nodeInfo.outputs}

--- a/web/app/components/workflow/run/result-panel.tsx
+++ b/web/app/components/workflow/run/result-panel.tsx
@@ -140,6 +140,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
         {process_data && (
           <CodeEditor
             readOnly
+            showFileList
             title={<div>{t('common.processData', { ns: 'workflow' }).toLocaleUpperCase()}</div>}
             language={CodeLanguage.json}
             value={process_data}
@@ -150,6 +151,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
         {(outputs || status === 'running') && (
           <CodeEditor
             readOnly
+            showFileList
             title={<div>{t('common.output', { ns: 'workflow' }).toLocaleUpperCase()}</div>}
             language={CodeLanguage.json}
             value={outputs}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our contribution guidelines
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #34006.

The `CodeEditor` component already extracts file objects from JSON data via `getFilesInLogs` and builds a file list, but the `showFileList` prop was not enabled on the process data and output editors in `node.tsx` and `result-panel.tsx`. This meant file-preview URLs were only visible as raw text in the JSON viewer and could not be clicked or downloaded.

This adds `showFileList` to the CodeEditor instances for process data and outputs in both the node panel (used in workflow run logs) and the result panel (used in the side panel detail view), matching the existing behavior in `output-panel.tsx` which already had this prop set.

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. [Contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `cd web && npx lint-staged` to appease the lint gods