### PR TITLE
chore(ci): remove Python 3.11 from CI test workflows

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
           - "3.12"
 
     steps:

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
           - "3.12"
 
     steps:


### PR DESCRIPTION
## Summary

- Removes Python 3.11 from the CI test workflow matrices in `api-tests.yml` and `vdb-tests.yml`
- Keeps Python 3.12 as the sole test baseline

Closes #34125

## Test plan

- [x] Verified only Python 3.11 references are removed
- [x] Python 3.12 version retained
- [x] No other workflow logic changed