### PR TITLE
refactor: use EnumText for credential_type in TriggerSubscription

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -37,7 +37,6 @@ from core.agent.entities import AgentToolEntity
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.helper.module_import_helper import load_single_subclass_from_source
 from core.helper.position_helper import is_filtered
-from core.plugin.entities.plugin_daemon import CredentialType
 from core.tools.__base.tool import Tool
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
 from core.tools.builtin_tool.providers._positions import BuiltinToolProviderSort
@@ -326,7 +325,7 @@ class ToolManager:
                     tenant_id=tenant_id,
                     user_id=user_id,
                     credentials=dict(decrypted_credentials),
-                    credential_type=CredentialType.of(builtin_provider.credential_type),
+                    credential_type=builtin_provider.credential_type,
                     runtime_parameters={},
                     invoke_from=invoke_from,
                     tool_invoke_from=tool_invoke_from,

--- a/api/models/tools.py
+++ b/api/models/tools.py
@@ -11,6 +11,7 @@ from deprecated import deprecated
 from sqlalchemy import ForeignKey, String, func, select
 from sqlalchemy.orm import Mapped, mapped_column
 
+from core.plugin.entities.plugin_daemon import CredentialType
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_bundle import ApiToolBundle
 from core.tools.entities.tool_entities import (
@@ -109,8 +110,11 @@ class BuiltinToolProvider(TypeBase):
     )
     is_default: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"), default=False)
     # credential type, e.g., "api-key", "oauth2"
-    credential_type: Mapped[str] = mapped_column(
-        String(32), nullable=False, server_default=sa.text("'api-key'"), default="api-key"
+    credential_type: Mapped[CredentialType] = mapped_column(
+        EnumText(CredentialType, length=32),
+        nullable=False,
+        server_default=sa.text("'api-key'"),
+        default=CredentialType.API_KEY,
     )
     expires_at: Mapped[int] = mapped_column(sa.BigInteger, nullable=False, server_default=sa.text("-1"), default=-1)
 

--- a/api/models/trigger.py
+++ b/api/models/trigger.py
@@ -102,7 +102,9 @@ class TriggerSubscription(TypeBase):
     credentials: Mapped[TriggerCredentials] = mapped_column(
         sa.JSON, nullable=False, comment="Subscription credentials JSON"
     )
-    credential_type: Mapped[str] = mapped_column(String(50), nullable=False, comment="oauth or api_key")
+    credential_type: Mapped[CredentialType] = mapped_column(
+        EnumText(CredentialType, length=50), nullable=False, comment="oauth or api_key"
+    )
     credential_expires_at: Mapped[int] = mapped_column(
         Integer, default=-1, comment="OAuth token expiration timestamp, -1 for never"
     )
@@ -144,7 +146,7 @@ class TriggerSubscription(TypeBase):
             endpoint=generate_plugin_trigger_endpoint_url(self.endpoint_id),
             parameters=self.parameters,
             properties=self.properties,
-            credential_type=CredentialType(self.credential_type),
+            credential_type=self.credential_type,
             credentials=self.credentials,
             workflows_in_use=-1,
         )

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -275,7 +275,7 @@ class BuiltinToolManageService:
                         user_id=user_id,
                         provider=provider,
                         encrypted_credentials=json.dumps(encrypter.encrypt(credentials)),
-                        credential_type=api_type.value,
+                        credential_type=api_type,
                         name=name,
                         expires_at=expires_at if expires_at is not None else -1,
                     )
@@ -314,7 +314,7 @@ class BuiltinToolManageService:
             .filter_by(
                 tenant_id=tenant_id,
                 provider=provider,
-                credential_type=credential_type.value,
+                credential_type=credential_type,
             )
             .order_by(BuiltinToolProvider.created_at.desc())
             .all()

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -423,7 +423,7 @@ class ToolTransformService:
             id=provider.id,
             name=provider.name,
             provider=provider.provider,
-            credential_type=CredentialType.of(provider.credential_type),
+            credential_type=provider.credential_type,
             is_default=provider.is_default,
             credentials=credentials,
         )

--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -198,7 +198,7 @@ class TriggerProviderService:
                         credentials=dict(credential_encrypter.encrypt(dict(credentials)))
                         if credential_encrypter
                         else {},
-                        credential_type=credential_type.value,
+                        credential_type=credential_type,
                         credential_expires_at=credential_expires_at,
                         expires_at=expires_at,
                     )

--- a/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
@@ -66,7 +66,7 @@ class TestGetDynamicSelectOptionsTool:
             provider="google",
             name="API KEY 1",
             encrypted_credentials=json.dumps({"api_key": "encrypted"}),
-            credential_type="api_key",
+            credential_type="api-key",
         )
         db_session_with_containers.add(db_record)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
@@ -12,9 +12,9 @@ from uuid import uuid4
 
 import pytest
 
+from core.plugin.entities.plugin_daemon import CredentialType
 from models.tools import BuiltinToolProvider
 from services.plugin.plugin_parameter_service import PluginParameterService
-from core.plugin.entities.plugin_daemon import CredentialType
 
 
 class TestGetDynamicSelectOptionsTool:

--- a/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
@@ -66,7 +66,7 @@ class TestGetDynamicSelectOptionsTool:
             provider="google",
             name="API KEY 1",
             encrypted_credentials=json.dumps({"api_key": "encrypted"}),
-            credential_type="api-key",
+            credential_type=CredentialType.API_KEY,
         )
         db_session_with_containers.add(db_record)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
@@ -14,6 +14,7 @@ import pytest
 
 from models.tools import BuiltinToolProvider
 from services.plugin.plugin_parameter_service import PluginParameterService
+from core.plugin.entities.plugin_daemon import CredentialType
 
 
 class TestGetDynamicSelectOptionsTool:


### PR DESCRIPTION
## Summary
- Convert `TriggerSubscription.credential_type` and `BuiltinToolProvider.credential_type` from `Mapped[str] + String` to `Mapped[CredentialType] + EnumText(CredentialType)`
- Remove redundant `.value` calls and `CredentialType.of()` / `CredentialType()` wrappers at call sites
- Remove unused `CredentialType` import in `tool_manager.py`

Related to #33294.

## Test plan
- [x] basedpyright: 0 errors
- [x] mypy: 0 errors
- [x] 119 unit tests pass (trigger provider service, tool models, builtin tools manage service)