### PR TITLE
fix(api): add spacing around human input form urls

### DIFF
--- a/api/dify_graph/nodes/human_input/entities.py
+++ b/api/dify_graph/nodes/human_input/entities.py
@@ -60,6 +60,7 @@ class EmailDeliveryConfig(BaseModel):
     """Configuration for email delivery method."""
 
     URL_PLACEHOLDER: ClassVar[str] = "{{#url#}}"
+    _URL_PLACEHOLDER_PATTERN: ClassVar[re.Pattern[str]] = re.compile(re.escape("{{#url#}}"))
     _SUBJECT_NEWLINE_PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"[\r\n]+")
     _ALLOWED_HTML_TAGS: ClassVar[list[str]] = [
         "a",
@@ -116,8 +117,23 @@ class EmailDeliveryConfig(BaseModel):
 
     @classmethod
     def replace_url_placeholder(cls, body: str, url: str | None) -> str:
-        """Replace the url placeholder with provided value."""
-        return body.replace(cls.URL_PLACEHOLDER, url or "")
+        """Replace the url placeholder with provided value.
+
+        If the placeholder is adjacent to non-whitespace characters, a space is
+        inserted so the resulting URL is not concatenated with surrounding text.
+        """
+        if cls.URL_PLACEHOLDER not in body:
+            return body
+        if not url:
+            return body.replace(cls.URL_PLACEHOLDER, "")
+
+        def _replace(match: re.Match[str]) -> str:
+            start, end = match.span()
+            prefix = "" if start == 0 or body[start - 1].isspace() else " "
+            suffix = "" if end == len(body) or body[end].isspace() else " "
+            return f"{prefix}{url}{suffix}"
+
+        return cls._URL_PLACEHOLDER_PATTERN.sub(_replace, body)
 
     @classmethod
     def render_body_template(

--- a/api/tests/unit_tests/core/workflow/nodes/human_input/test_email_delivery_config.py
+++ b/api/tests/unit_tests/core/workflow/nodes/human_input/test_email_delivery_config.py
@@ -16,6 +16,30 @@ def test_render_body_template_replaces_variable_values():
     assert result == "Hello World https://example.com"
 
 
+def test_render_body_template_inserts_spacing_around_url_placeholder():
+    config = EmailDeliveryConfig(
+        recipients=EmailRecipients(),
+        subject="Subject",
+        body="Approval:{{#url#}}Hi",
+    )
+
+    result = config.render_body_template(body=config.body, url="https://example.com", variable_pool=None)
+
+    assert result == "Approval: https://example.com Hi"
+
+
+def test_render_body_template_preserves_existing_whitespace_around_url_placeholder():
+    config = EmailDeliveryConfig(
+        recipients=EmailRecipients(),
+        subject="Subject",
+        body="Approval:\n{{#url#}}\n\nHi",
+    )
+
+    result = config.render_body_template(body=config.body, url="https://example.com", variable_pool=None)
+
+    assert result == "Approval:\nhttps://example.com\n\nHi"
+
+
 def test_render_markdown_body_renders_markdown_to_html():
     rendered = EmailDeliveryConfig.render_markdown_body("**Bold** and [link](https://example.com)")
 


### PR DESCRIPTION
When {{#url#}} is adjacent to non-whitespace text in a Human Input email delivery body, the rendered URL was concatenated directly with surrounding characters, producing broken links (e.g. "Approval:https://...").

Fix by replacing the simple str.replace call with a regex substitution that inspects the characters immediately before and after the placeholder and inserts a space where none exists.

Fixes langgenius/dify#34160

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
![img_v3_02106_4658da88-55e5-41e7-b467-fec069431d3g](https://github.com/user-attachments/assets/0b09289e-746d-47ad-a356-469e6a7617c8)


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
