### PR TITLE
refactor: use EnumText for prompt_type and customize_token_strategy

### DIFF
--- a/api/events/event_handlers/create_site_record_when_app_created.py
+++ b/api/events/event_handlers/create_site_record_when_app_created.py
@@ -1,5 +1,6 @@
 from events.app_event import app_was_created
 from extensions.ext_database import db
+from models.enums import CustomizeTokenStrategy
 from models.model import Site
 
 
@@ -16,7 +17,7 @@ def handle(sender, **kwargs):
             icon=app.icon,
             icon_background=app.icon_background,
             default_language=account.interface_language,
-            customize_token_strategy="not_allow",
+            customize_token_strategy=CustomizeTokenStrategy.NOT_ALLOW,
             code=Site.generate_code(16),
             created_by=app.created_by,
             updated_by=app.updated_by,

--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -158,6 +158,15 @@ class FeedbackFromSource(StrEnum):
     ADMIN = "admin"
 
 
+class CustomizeTokenStrategy(StrEnum):
+    """Site token customization strategy"""
+
+    MUST = "must"
+    ALLOW = "allow"
+    NOT_ALLOW = "not_allow"
+    UUID = "uuid"
+
+
 class FeedbackRating(StrEnum):
     """MessageFeedback rating"""
 
@@ -312,6 +321,13 @@ class MessageChainType(StrEnum):
     """Message chain type"""
 
     SYSTEM = "system"
+
+
+class PromptType(StrEnum):
+    """Prompt configuration type"""
+
+    SIMPLE = "simple"
+    ADVANCED = "advanced"
 
 
 class ProviderQuotaType(StrEnum):

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -40,12 +40,14 @@ from .enums import (
     ConversationFromSource,
     ConversationStatus,
     CreatorUserRole,
+    CustomizeTokenStrategy,
     FeedbackFromSource,
     FeedbackRating,
     InvokeFrom,
     MessageChainType,
     MessageFileBelongsTo,
     MessageStatus,
+    PromptType,
     ProviderQuotaType,
     TagType,
 )
@@ -649,8 +651,11 @@ class AppModelConfig(TypeBase):
     agent_mode: Mapped[str | None] = mapped_column(LongText, default=None)
     sensitive_word_avoidance: Mapped[str | None] = mapped_column(LongText, default=None)
     retriever_resource: Mapped[str | None] = mapped_column(LongText, default=None)
-    prompt_type: Mapped[str] = mapped_column(
-        String(255), nullable=False, server_default=sa.text("'simple'"), default="simple"
+    prompt_type: Mapped[PromptType] = mapped_column(
+        EnumText(PromptType, length=255),
+        nullable=False,
+        server_default=sa.text("'simple'"),
+        default=PromptType.SIMPLE,
     )
     chat_prompt_config: Mapped[str | None] = mapped_column(LongText, default=None)
     completion_prompt_config: Mapped[str | None] = mapped_column(LongText, default=None)
@@ -802,7 +807,7 @@ class AppModelConfig(TypeBase):
             "dataset_query_variable": self.dataset_query_variable,
             "pre_prompt": self.pre_prompt,
             "agent_mode": self.agent_mode_dict,
-            "prompt_type": self.prompt_type,
+            "prompt_type": self.prompt_type.value if isinstance(self.prompt_type, PromptType) else self.prompt_type,
             "chat_prompt_config": self.chat_prompt_config_dict,
             "completion_prompt_config": self.completion_prompt_config_dict,
             "dataset_configs": self.dataset_configs_dict,
@@ -846,7 +851,7 @@ class AppModelConfig(TypeBase):
         self.retriever_resource = (
             json.dumps(model_config.get("retriever_resource")) if model_config.get("retriever_resource") else None
         )
-        self.prompt_type = model_config.get("prompt_type", "simple")
+        self.prompt_type = PromptType(model_config.get("prompt_type", "simple"))
         self.chat_prompt_config = (
             json.dumps(model_config.get("chat_prompt_config")) if model_config.get("chat_prompt_config") else None
         )
@@ -2084,7 +2089,9 @@ class Site(Base):
     use_icon_as_answer_icon: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     _custom_disclaimer: Mapped[str] = mapped_column("custom_disclaimer", LongText, default="")
     customize_domain = mapped_column(String(255))
-    customize_token_strategy: Mapped[str] = mapped_column(String(255), nullable=False)
+    customize_token_strategy: Mapped[CustomizeTokenStrategy] = mapped_column(
+        EnumText(CustomizeTokenStrategy, length=255), nullable=False
+    )
     prompt_public: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     status: Mapped[AppStatus] = mapped_column(
         EnumText(AppStatus, length=255), nullable=False, server_default=sa.text("'normal'"), default=AppStatus.NORMAL


### PR DESCRIPTION
## Summary
- Create `PromptType` and `CustomizeTokenStrategy` enums in `models/enums.py`
- Convert `AppModelConfig.prompt_type` from `Mapped[str] + String` to `Mapped[PromptType] + EnumText(PromptType)`
- Convert `Site.customize_token_strategy` from `Mapped[str] + String` to `Mapped[CustomizeTokenStrategy] + EnumText(CustomizeTokenStrategy)`
- Replace string literal in `create_site_record_when_app_created.py`

Related to #33294.

## Test plan
- [x] basedpyright: 0 errors
- [x] mypy: 0 errors
- [x] 53 unit tests pass (app models)
