### PR TITLE
chore(ci): reduce web test shard fan-out

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6]
-        shardTotal: [6]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     defaults:
       run:
         shell: bash
@@ -66,7 +66,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup web environment


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. This PR is part of #34212. It intentionally does not use `Fixes #34212` because the umbrella issue will remain open for follow-up CI optimization PRs.

## Summary

Part of #34212.

- reduce web vitest shard fan-out from 6 to 4
- remove unnecessary full-history checkout from the report merge job
- preserve merged test report and coverage behavior

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

## Validation

- YAML validation passed for `.github/workflows/web-tests.yml`
- trade-off: fewer shards reduces total runner minutes, with a modest increase in per-shard runtime while preserving merged coverage/reporting
