### PR TITLE
chore(ci): move full VDB matrix off the PR path

### DIFF
--- a/.github/workflows/vdb-tests-full.yml
+++ b/.github/workflows/vdb-tests-full.yml
@@ -1,15 +1,21 @@
-name: Run VDB Smoke Tests
+name: Run Full VDB Tests
 
 on:
-  workflow_call:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
-  group: vdb-tests-${{ github.head_ref || github.run_id }}
+  group: vdb-tests-full-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   test:
-    name: VDB Smoke Tests
+    name: Full VDB Tests
+    if: github.repository == 'langgenius/dify'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -58,18 +64,23 @@ jobs:
 #            tidb
 #            tiflash
 
-      - name: Set up Vector Stores for Smoke Coverage
+      - name: Set up Full Vector Store Matrix
         uses: hoverkraft-tech/compose-action@4894d2492015c1774ee5a13a95b1072093087ec3 # v2.5.0
         with:
           compose-file: |
             docker/docker-compose.yaml
           services: |
-            db_postgres
-            redis
             weaviate
             qdrant
+            couchbase-server
+            etcd
+            minio
+            milvus-standalone
+            pgvecto-rs
             pgvector
             chroma
+            elasticsearch
+            oceanbase
 
       - name: setup test config
         run: |
@@ -81,9 +92,4 @@ jobs:
 #        run: uv run --project api python api/tests/integration_tests/vdb/tidb_vector/check_tiflash_ready.py
 
       - name: Test Vector Stores
-        run: |
-          uv run --project api pytest --timeout "${PYTEST_TIMEOUT:-180}" \
-            api/tests/integration_tests/vdb/chroma \
-            api/tests/integration_tests/vdb/pgvector \
-            api/tests/integration_tests/vdb/qdrant \
-            api/tests/integration_tests/vdb/weaviate
+        run: uv run --project api bash dev/pytest/pytest_vdb.sh

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -3,6 +3,9 @@ name: Run VDB Smoke Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: vdb-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. This PR is part of #34212. It intentionally does not use `Fixes #34212` because the umbrella issue will remain open for follow-up CI optimization PRs.

## Summary

Part of #34212.
- turn the reusable PR-time VDB workflow into a smaller smoke lane
- add a separate scheduled/manual full VDB workflow for the complete provider matrix
- preserve lightweight validation on the PR path while moving heavy coverage off the critical path

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods

## Validation

- YAML parse only for `.github/workflows/vdb-tests.yml` and `.github/workflows/vdb-tests-full.yml`
- `main-ci` trigger tightening is handled in a separate PR