### PR TITLE
fix: bridge Dify design tokens for streamdown table fullscreen

### DIFF
--- a/web/app/styles/markdown.css
+++ b/web/app/styles/markdown.css
@@ -582,6 +582,44 @@
   background-color: var(--color-components-menu-item-bg-hover);
 }
 
+[data-streamdown="table-fullscreen"] {
+  background-color: var(--color-components-panel-bg);
+  color: var(--color-text-primary);
+}
+
+[data-streamdown="table-fullscreen"] button {
+  color: var(--color-text-tertiary);
+}
+
+[data-streamdown="table-fullscreen"] button:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-background-section-burn);
+}
+
+[data-streamdown="table-fullscreen"] table[data-streamdown="table"] {
+  border-color: var(--color-divider-regular);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-header"] {
+  background-color: var(--color-background-section-burn);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-header"] th {
+  color: var(--color-text-tertiary);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-body"] {
+  border-color: var(--color-divider-subtle);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-body"] > tr {
+  border-color: var(--color-divider-subtle);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-body"] td {
+  color: var(--color-text-secondary);
+}
+
 .markdown-body table img {
   background-color: transparent;
 }


### PR DESCRIPTION
Made-with: Cursor

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Streamdown's table fullscreen uses `createPortal` to `document.body`, with shadcn/ui Tailwind classes (`bg-background`, `bg-muted`, `border-border`, etc.) that don't resolve in Dify's design system — resulting in missing background, borders, and text colors.
- Added CSS overrides for `[data-streamdown="table-fullscreen"]` in `markdown.css`, following the same pattern already used for `[data-streamdown="table-wrapper"]`.
fixes #34182
## Screenshots

| Before | After |
|--------|-------|
| <img width="532" height="400" alt="image" src="https://github.com/user-attachments/assets/d66fd964-ea59-4256-acb6-e369314b80d5" />| <img width="1909" height="370" alt="image" src="https://github.com/user-attachments/assets/7f61409c-0ffa-49ea-9cc2-5259b606bb7e" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
