### PR TITLE
fix(api): upgrade langfuse SDK to v3 for LLM-as-judge support

### DIFF
--- a/api/core/ops/langfuse_trace/langfuse_trace.py
+++ b/api/core/ops/langfuse_trace/langfuse_trace.py
@@ -1,9 +1,19 @@
 import logging
 import os
+import uuid
 from datetime import datetime, timedelta
 
 from graphon.enums import BuiltinNodeTypes
 from langfuse import Langfuse
+from langfuse.api import (
+    CreateGenerationBody,
+    CreateSpanBody,
+    IngestionEvent_GenerationCreate,
+    IngestionEvent_SpanCreate,
+    IngestionEvent_TraceCreate,
+    TraceBody,
+    Usage,
+)
 from sqlalchemy.orm import sessionmaker
 
 from core.ops.base_trace_instance import BaseTraceInstance
@@ -396,10 +406,30 @@ class LangFuseDataTrace(BaseTraceInstance):
         )
         self.add_span(langfuse_span_data=name_generation_span_data)
 
+    def _build_usage(self, usage_data: dict) -> Usage | None:
+        """Convert a GenerationUsage dict to a langfuse v3 Usage object."""
+        if not usage_data:
+            return None
+        return Usage(
+            input=usage_data.get("input", 0),
+            output=usage_data.get("output", 0),
+            total=usage_data.get("total", 0),
+            unit=usage_data.get("unit"),
+            input_cost=usage_data.get("inputCost"),
+            output_cost=usage_data.get("outputCost"),
+            total_cost=usage_data.get("totalCost"),
+        )
+
     def add_trace(self, langfuse_trace_data: LangfuseTrace | None = None):
         format_trace_data = filter_none_values(langfuse_trace_data.model_dump()) if langfuse_trace_data else {}
         try:
-            self.langfuse_client.trace(**format_trace_data)
+            trace_body = TraceBody(**format_trace_data)
+            event = IngestionEvent_TraceCreate(
+                body=trace_body,
+                id=str(uuid.uuid4()),
+                timestamp=datetime.now().isoformat(),
+            )
+            self.langfuse_client.api.ingestion.batch(batch=[event])
             logger.debug("LangFuse Trace created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create trace: {str(e)}")
@@ -407,14 +437,19 @@ class LangFuseDataTrace(BaseTraceInstance):
     def add_span(self, langfuse_span_data: LangfuseSpan | None = None):
         format_span_data = filter_none_values(langfuse_span_data.model_dump()) if langfuse_span_data else {}
         try:
-            self.langfuse_client.span(**format_span_data)
+            span_body = CreateSpanBody(**format_span_data)
+            event = IngestionEvent_SpanCreate(
+                body=span_body,
+                id=str(uuid.uuid4()),
+                timestamp=datetime.now().isoformat(),
+            )
+            self.langfuse_client.api.ingestion.batch(batch=[event])
             logger.debug("LangFuse Span created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create span: {str(e)}")
 
     def update_span(self, span, langfuse_span_data: LangfuseSpan | None = None):
         format_span_data = filter_none_values(langfuse_span_data.model_dump()) if langfuse_span_data else {}
-
         span.end(**format_span_data)
 
     def add_generation(self, langfuse_generation_data: LangfuseGeneration | None = None):
@@ -422,7 +457,16 @@ class LangFuseDataTrace(BaseTraceInstance):
             filter_none_values(langfuse_generation_data.model_dump()) if langfuse_generation_data else {}
         )
         try:
-            self.langfuse_client.generation(**format_generation_data)
+            # Convert usage dict to langfuse v3 Usage object
+            usage_data = format_generation_data.pop("usage", None)
+            usage = self._build_usage(usage_data) if usage_data else None
+            gen_body = CreateGenerationBody(**format_generation_data, usage=usage)
+            event = IngestionEvent_GenerationCreate(
+                body=gen_body,
+                id=str(uuid.uuid4()),
+                timestamp=datetime.now().isoformat(),
+            )
+            self.langfuse_client.api.ingestion.batch(batch=[event])
             logger.debug("LangFuse Generation created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create generation: {str(e)}")
@@ -431,7 +475,6 @@ class LangFuseDataTrace(BaseTraceInstance):
         format_generation_data = (
             filter_none_values(langfuse_generation_data.model_dump()) if langfuse_generation_data else {}
         )
-
         generation.end(**format_generation_data)
 
     def api_check(self):
@@ -443,7 +486,7 @@ class LangFuseDataTrace(BaseTraceInstance):
 
     def get_project_key(self):
         try:
-            projects = self.langfuse_client.client.projects.get()
+            projects = self.langfuse_client.api.projects.get()
             return projects.data[0].id
         except Exception as e:
             logger.debug("LangFuse get project key failed: %s", str(e))

--- a/api/extensions/ext_sentry.py
+++ b/api/extensions/ext_sentry.py
@@ -6,15 +6,20 @@ def init_app(app: DifyApp):
     if dify_config.SENTRY_DSN:
         import sentry_sdk
         from graphon.model_runtime.errors.invoke import InvokeRateLimitError
-        from langfuse import parse_error
         from sentry_sdk.integrations.celery import CeleryIntegration
         from sentry_sdk.integrations.flask import FlaskIntegration
         from werkzeug.exceptions import HTTPException
 
+        # Langfuse default error response string, previously from langfuse.parse_error (removed in v3)
+        _LANGFUSE_DEFAULT_ERROR = (
+            "Unexpected error occurred. Please check your request"
+            " and contact support: https://langfuse.com/support."
+        )
+
         def before_send(event, hint):
             if "exc_info" in hint:
                 _, exc_value, _ = hint["exc_info"]
-                if parse_error.defaultErrorResponse in str(exc_value):
+                if _LANGFUSE_DEFAULT_ERROR in str(exc_value):
                     return None
 
             return event
@@ -27,7 +32,7 @@ def init_app(app: DifyApp):
                 ValueError,
                 FileNotFoundError,
                 InvokeRateLimitError,
-                parse_error.defaultErrorResponse,
+                _LANGFUSE_DEFAULT_ERROR,
             ],
             traces_sample_rate=dify_config.SENTRY_TRACES_SAMPLE_RATE,
             profiles_sample_rate=dify_config.SENTRY_PROFILES_SAMPLE_RATE,

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "httpx[socks]~=0.28.0",
     "jieba==0.42.1",
     "json-repair>=0.55.1",
-    "langfuse~=2.51.3",
+    "langfuse~=3.14",
     "langsmith~=0.7.16",
     "markdown~=3.10.2",
     "mlflow-skinny>=3.0.0",

--- a/api/tests/unit_tests/core/ops/langfuse_trace/test_langfuse_trace.py
+++ b/api/tests/unit_tests/core/ops/langfuse_trace/test_langfuse_trace.py
@@ -521,11 +521,11 @@ def test_generate_name_trace(trace_instance):
 def test_add_trace_success(trace_instance):
     data = LangfuseTrace(id="t1", name="trace")
     trace_instance.add_trace(data)
-    trace_instance.langfuse_client.trace.assert_called_once()
+    trace_instance.langfuse_client.api.ingestion.batch.assert_called_once()
 
 
 def test_add_trace_error(trace_instance):
-    trace_instance.langfuse_client.trace.side_effect = Exception("error")
+    trace_instance.langfuse_client.api.ingestion.batch.side_effect = Exception("error")
     data = LangfuseTrace(id="t1", name="trace")
     with pytest.raises(ValueError, match="LangFuse Failed to create trace: error"):
         trace_instance.add_trace(data)
@@ -534,11 +534,11 @@ def test_add_trace_error(trace_instance):
 def test_add_span_success(trace_instance):
     data = LangfuseSpan(id="s1", name="span", trace_id="t1")
     trace_instance.add_span(data)
-    trace_instance.langfuse_client.span.assert_called_once()
+    trace_instance.langfuse_client.api.ingestion.batch.assert_called_once()
 
 
 def test_add_span_error(trace_instance):
-    trace_instance.langfuse_client.span.side_effect = Exception("error")
+    trace_instance.langfuse_client.api.ingestion.batch.side_effect = Exception("error")
     data = LangfuseSpan(id="s1", name="span", trace_id="t1")
     with pytest.raises(ValueError, match="LangFuse Failed to create span: error"):
         trace_instance.add_span(data)
@@ -554,11 +554,11 @@ def test_update_span(trace_instance):
 def test_add_generation_success(trace_instance):
     data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
     trace_instance.add_generation(data)
-    trace_instance.langfuse_client.generation.assert_called_once()
+    trace_instance.langfuse_client.api.ingestion.batch.assert_called_once()
 
 
 def test_add_generation_error(trace_instance):
-    trace_instance.langfuse_client.generation.side_effect = Exception("error")
+    trace_instance.langfuse_client.api.ingestion.batch.side_effect = Exception("error")
     data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
     with pytest.raises(ValueError, match="LangFuse Failed to create generation: error"):
         trace_instance.add_generation(data)
@@ -585,12 +585,12 @@ def test_api_check_error(trace_instance):
 def test_get_project_key_success(trace_instance):
     mock_data = MagicMock()
     mock_data.id = "proj-1"
-    trace_instance.langfuse_client.client.projects.get.return_value = MagicMock(data=[mock_data])
+    trace_instance.langfuse_client.api.projects.get.return_value = MagicMock(data=[mock_data])
     assert trace_instance.get_project_key() == "proj-1"
 
 
 def test_get_project_key_error(trace_instance):
-    trace_instance.langfuse_client.client.projects.get.side_effect = Exception("fail")
+    trace_instance.langfuse_client.api.projects.get.side_effect = Exception("fail")
     with pytest.raises(ValueError, match="LangFuse get project key failed: fail"):
         trace_instance.get_project_key()
 


### PR DESCRIPTION
## Summary

- Bump `langfuse` dependency from `~=2.51.3` to `~=3.14` in `api/pyproject.toml`
- Adapt trace/span/generation creation to use the v3 ingestion batch API, replacing the removed `.trace()`, `.span()`, `.generation()` convenience methods
- Replace the removed `langfuse.parse_error` import in `ext_sentry.py` with an inline string constant (the module was dropped in SDK v3)
- Update `get_project_key()` to use `.api.projects.get()` instead of the removed `.client.projects.get()`
- Update unit tests to assert against the new API call paths

## Context

Dify pinned `langfuse~=2.51.3` which blocked compatibility with Langfuse server v3. Users running Langfuse v3 could not use LLM-as-judge evaluations on observations because the SDK v2 wire format is not fully processed by the v3 evaluator pipeline.

The v3 SDK removed the high-level `.trace()`/`.span()`/`.generation()` methods in favor of an OTel-native context-manager API. Rather than rewriting Dify's after-the-fact trace reporting to use context managers, this PR uses the v3 ingestion batch API directly (`langfuse_client.api.ingestion.batch()`), which accepts the same event body types (TraceBody, CreateSpanBody, CreateGenerationBody) and preserves the existing data flow.

## Test plan

- [ ] Existing unit tests updated and passing
- [ ] Manual verification with a Langfuse v3 self-hosted instance: traces, spans, and generations appear correctly
- [ ] LLM-as-judge evaluator produces scores on observations sent from Dify

Fixes #34186