### PR TITLE
fix: QA index processor preview key error

### DIFF
--- a/api/core/rag/index_processor/processor/qa_index_processor.py
+++ b/api/core/rag/index_processor/processor/qa_index_processor.py
@@ -237,7 +237,7 @@ class QAIndexProcessor(BaseIndexProcessor):
             preview.append({"question": qa_chunk.question, "answer": qa_chunk.answer})
         return {
             "chunk_structure": IndexStructureType.QA_INDEX,
-            "qa_preview": preview,
+            "preview": preview,
             "total_segments": len(qa_chunks.qa_chunks),
         }
 

--- a/api/tests/unit_tests/core/rag/indexing/processor/test_qa_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/processor/test_qa_index_processor.py
@@ -314,7 +314,7 @@ class TestQAIndexProcessor:
             with pytest.raises(ValueError, match="must be high quality"):
                 processor.index(dataset, dataset_document, {"qa_chunks": []})
 
-    def test_format_preview_returns_qa_preview(self, processor: QAIndexProcessor) -> None:
+    def test_format_preview_returns_preview_items(self, processor: QAIndexProcessor) -> None:
         qa_chunks = SimpleNamespace(qa_chunks=[SimpleNamespace(question="Q1", answer="A1")])
 
         with patch(
@@ -325,7 +325,7 @@ class TestQAIndexProcessor:
 
         assert preview["chunk_structure"] == "qa_model"
         assert preview["total_segments"] == 1
-        assert preview["qa_preview"] == [{"question": "Q1", "answer": "A1"}]
+        assert preview["preview"] == [{"question": "Q1", "answer": "A1"}]
 
     def test_generate_summary_preview_returns_input(self, processor: QAIndexProcessor) -> None:
         preview_items = [PreviewDetail(content="Q1")]


### PR DESCRIPTION
## Summary

Fixed a KeyError that occurred when using QA blocks in knowledge base workflows.

## Root Cause

The `QAIndexProcessor.format_preview` method was returning a dictionary with the key `'qa_preview'`, but the parent `IndexProcessor.format_preview` method expected the key `'preview'`. This caused a `KeyError: 'preview'` when iterating through the preview items.

## Changes

- `api/core/rag/index_processor/processor/qa_index_processor.py`: Changed the return key from `'qa_preview'` to `'preview'` to match the expected interface.

## Testing

This fix ensures that QA blocks in knowledge base workflows can be previewed without errors.

Fixes #34144