### PR TITLE
[codex] Force Node 24 for legacy GitHub Actions runtimes

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: api-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   autofix:
     if: github.repository == 'langgenius/dify'

--- a/.github/workflows/db-migration-test.yml
+++ b/.github/workflows/db-migration-test.yml
@@ -3,6 +3,9 @@ name: DB Migration Test
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: db-migration-test-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -16,6 +16,9 @@ permissions:
   checks: write
   statuses: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: main-ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/vdb-tests.yml
+++ b/.github/workflows/vdb-tests.yml
@@ -3,6 +3,9 @@ name: Run VDB Tests
 on:
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: vdb-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
## What changed
- add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the workflows that still invoke third-party JavaScript actions pinned to Node 20
- cover `main-ci.yml`, `autofix.yml`, `api-tests.yml`, `db-migration-test.yml`, and `vdb-tests.yml`

## Why
GitHub Actions is deprecating the Node 20 runtime for JavaScript actions. Dify `main` no longer uses `oven-sh/setup-bun`, but it still relies on these actions that currently run on Node 20:
- `fkirc/skip-duplicate-actions`
- `autofix-ci/action`
- `hoverkraft-tech/compose-action`

The latest public refs currently used by upstream still declare `runs.using: node20`, so bumping SHAs alone would not remove the platform warning. This switches the affected workflows to the GitHub-supported Node 24 compatibility path without changing workflow logic.

## Impact
- removes Node 20 deprecation exposure for the affected workflows
- keeps existing SHA pinning and behavior intact
- avoids waiting on upstream action maintainers to publish Node 24 releases

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/main-ci.yml .github/workflows/autofix.yml .github/workflows/api-tests.yml .github/workflows/db-migration-test.yml .github/workflows/vdb-tests.yml`
- `git diff --check -- .github/workflows/main-ci.yml .github/workflows/autofix.yml .github/workflows/api-tests.yml .github/workflows/db-migration-test.yml .github/workflows/vdb-tests.yml`
