### PR TITLE
test: add e2e scenarios for app creation and sign-out

### DIFF
--- a/e2e/features/apps/create-chatbot-app.feature
+++ b/e2e/features/apps/create-chatbot-app.feature
@@ -1,0 +1,11 @@
+@apps @authenticated
+Feature: Create Chatbot app
+  Scenario: Create a new Chatbot app and redirect to the configuration page
+    Given I am signed in as the default E2E admin
+    When I open the apps console
+    And I start creating a blank app
+    And I expand the beginner app types
+    And I select the "Chatbot" app type
+    And I enter a unique E2E app name
+    And I confirm app creation
+    Then I should land on the app configuration page

--- a/e2e/features/apps/create-workflow-app.feature
+++ b/e2e/features/apps/create-workflow-app.feature
@@ -1,0 +1,10 @@
+@apps @authenticated
+Feature: Create Workflow app
+  Scenario: Create a new Workflow app and redirect to the workflow editor
+    Given I am signed in as the default E2E admin
+    When I open the apps console
+    And I start creating a blank app
+    And I select the "Workflow" app type
+    And I enter a unique E2E app name
+    And I confirm app creation
+    Then I should land on the workflow editor

--- a/e2e/features/auth/sign-out.feature
+++ b/e2e/features/auth/sign-out.feature
@@ -1,0 +1,8 @@
+@auth @authenticated
+Feature: Sign out
+  Scenario: Sign out from the apps console
+    Given I am signed in as the default E2E admin
+    When I open the apps console
+    And I open the account menu
+    And I sign out
+    Then I should be on the sign-in page

--- a/e2e/features/step-definitions/apps/create-app.steps.ts
+++ b/e2e/features/step-definitions/apps/create-app.steps.ts
@@ -24,6 +24,29 @@ When('I confirm app creation', async function (this: DifyWorld) {
   await createButton.click()
 })
 
+When('I select the {string} app type', async function (this: DifyWorld, appType: string) {
+  const page = this.getPage()
+
+  await expect(page.getByText(appType, { exact: true }).first()).toBeVisible()
+  await page.getByText(appType, { exact: true }).first().click()
+})
+
+When('I expand the beginner app types', async function (this: DifyWorld) {
+  const page = this.getPage()
+  const toggle = page.getByRole('button', { name: 'More basic app types' })
+
+  await expect(toggle).toBeVisible()
+  await toggle.click()
+})
+
 Then('I should land on the app editor', async function (this: DifyWorld) {
   await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/(workflow|configuration)(?:\?.*)?$/)
+})
+
+Then('I should land on the workflow editor', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/workflow(?:\?.*)?$/)
+})
+
+Then('I should land on the app configuration page', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/configuration(?:\?.*)?$/)
 })

--- a/e2e/features/step-definitions/apps/create-app.steps.ts
+++ b/e2e/features/step-definitions/apps/create-app.steps.ts
@@ -26,7 +26,9 @@ When('I confirm app creation', async function (this: DifyWorld) {
 
 When('I select the {string} app type', async function (this: DifyWorld, appType: string) {
   const dialog = this.getPage().getByRole('dialog')
-  const appTypeCard = dialog.locator('.cursor-pointer', { hasText: appType })
+  const appTypeCard = dialog.locator('.cursor-pointer').filter({
+    has: dialog.locator('.system-sm-semibold', { hasText: new RegExp(`^${appType}$`) }),
+  })
 
   await expect(appTypeCard).toBeVisible()
   await appTypeCard.click()

--- a/e2e/features/step-definitions/apps/create-app.steps.ts
+++ b/e2e/features/step-definitions/apps/create-app.steps.ts
@@ -26,12 +26,10 @@ When('I confirm app creation', async function (this: DifyWorld) {
 
 When('I select the {string} app type', async function (this: DifyWorld, appType: string) {
   const dialog = this.getPage().getByRole('dialog')
-  const appTypeCard = dialog.locator('.cursor-pointer').filter({
-    has: dialog.locator('.system-sm-semibold', { hasText: new RegExp(`^${appType}$`) }),
-  })
+  const appTypeTitle = dialog.getByText(appType, { exact: true })
 
-  await expect(appTypeCard).toBeVisible()
-  await appTypeCard.click()
+  await expect(appTypeTitle).toBeVisible()
+  await appTypeTitle.click()
 })
 
 When('I expand the beginner app types', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/apps/create-app.steps.ts
+++ b/e2e/features/step-definitions/apps/create-app.steps.ts
@@ -26,9 +26,10 @@ When('I confirm app creation', async function (this: DifyWorld) {
 
 When('I select the {string} app type', async function (this: DifyWorld, appType: string) {
   const dialog = this.getPage().getByRole('dialog')
+  const appTypeCard = dialog.locator('.cursor-pointer', { hasText: appType })
 
-  await expect(dialog.getByText(appType, { exact: true }).first()).toBeVisible()
-  await dialog.getByText(appType, { exact: true }).first().click()
+  await expect(appTypeCard).toBeVisible()
+  await appTypeCard.click()
 })
 
 When('I expand the beginner app types', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/apps/create-app.steps.ts
+++ b/e2e/features/step-definitions/apps/create-app.steps.ts
@@ -25,10 +25,10 @@ When('I confirm app creation', async function (this: DifyWorld) {
 })
 
 When('I select the {string} app type', async function (this: DifyWorld, appType: string) {
-  const page = this.getPage()
+  const dialog = this.getPage().getByRole('dialog')
 
-  await expect(page.getByText(appType, { exact: true }).first()).toBeVisible()
-  await page.getByText(appType, { exact: true }).first().click()
+  await expect(dialog.getByText(appType, { exact: true }).first()).toBeVisible()
+  await dialog.getByText(appType, { exact: true }).first().click()
 })
 
 When('I expand the beginner app types', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/auth/sign-out.steps.ts
+++ b/e2e/features/step-definitions/auth/sign-out.steps.ts
@@ -1,0 +1,25 @@
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import type { DifyWorld } from '../../support/world'
+
+When('I open the account menu', async function (this: DifyWorld) {
+  const page = this.getPage()
+  const trigger = page.getByRole('button', { name: 'Account' })
+
+  await expect(trigger).toBeVisible()
+  await trigger.click()
+})
+
+When('I sign out', async function (this: DifyWorld) {
+  const page = this.getPage()
+
+  await expect(page.getByText('Log out')).toBeVisible()
+  await page.getByText('Log out').click()
+})
+
+Then('I should be on the sign-in page', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/signin/)
+  await expect(this.getPage().getByRole('button', { name: 'Sign In' })).toBeVisible({
+    timeout: 30_000,
+  })
+})

--- a/e2e/features/step-definitions/auth/sign-out.steps.ts
+++ b/e2e/features/step-definitions/auth/sign-out.steps.ts
@@ -19,7 +19,7 @@ When('I sign out', async function (this: DifyWorld) {
 
 Then('I should be on the sign-in page', async function (this: DifyWorld) {
   await expect(this.getPage()).toHaveURL(/\/signin/)
-  await expect(this.getPage().getByRole('button', { name: 'Sign In' })).toBeVisible({
+  await expect(this.getPage().getByRole('button', { name: /^Sign in$/i })).toBeVisible({
     timeout: 30_000,
   })
 })


### PR DESCRIPTION
part of #34278

> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Adds 3 new e2e test scenarios using the Cucumber BDD + Playwright infra from #34193:

- **Create Workflow app** (`create-workflow-app.feature`) — signs in, creates a blank Workflow app, asserts landing on the workflow editor (`/app/[id]/workflow`)
- **Create Chatbot app** (`create-chatbot-app.feature`) — signs in, expands beginner app types, creates a Chatbot, asserts landing on the configuration page (`/app/[id]/configuration`)
- **Sign out** (`sign-out.feature`) — signs in, opens the account menu, clicks sign out, asserts redirect to `/signin`

New step definitions follow the existing `DifyWorld` typing pattern and are organized by domain (`apps/`, `auth/`). Reuses shared steps like `I am signed in as the default E2E admin` and `I open the apps console`.

`pnpm -C e2e check` passes (formatting + linting + type-check).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods