### PR TITLE
test: migrate web conversation controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/web/test_conversation.py
+++ b/api/tests/test_containers_integration_tests/controllers/web/test_conversation.py
@@ -1,4 +1,4 @@
-"""Unit tests for controllers.web.conversation endpoints."""
+"""Testcontainers integration tests for controllers.web.conversation endpoints."""
 
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from flask import Flask
 from werkzeug.exceptions import NotFound
 
 from controllers.web.conversation import (
@@ -33,18 +32,19 @@ def _end_user() -> SimpleNamespace:
     return SimpleNamespace(id="eu-1")
 
 
-# ---------------------------------------------------------------------------
-# ConversationListApi
-# ---------------------------------------------------------------------------
 class TestConversationListApi:
-    def test_non_chat_mode_raises(self, app: Flask) -> None:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_non_chat_mode_raises(self, app) -> None:
         with app.test_request_context("/conversations"):
             with pytest.raises(NotChatAppError):
                 ConversationListApi().get(_completion_app(), _end_user())
 
     @patch("controllers.web.conversation.WebConversationService.pagination_by_last_id")
     @patch("controllers.web.conversation.db")
-    def test_happy_path(self, mock_db: MagicMock, mock_paginate: MagicMock, app: Flask) -> None:
+    def test_happy_path(self, mock_db: MagicMock, mock_paginate: MagicMock, app) -> None:
         conv_id = str(uuid4())
         conv = SimpleNamespace(
             id=conv_id,
@@ -73,17 +73,18 @@ class TestConversationListApi:
         assert result["has_more"] is False
 
 
-# ---------------------------------------------------------------------------
-# ConversationApi (delete)
-# ---------------------------------------------------------------------------
 class TestConversationApi:
-    def test_non_chat_mode_raises(self, app: Flask) -> None:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_non_chat_mode_raises(self, app) -> None:
         with app.test_request_context(f"/conversations/{uuid4()}"):
             with pytest.raises(NotChatAppError):
                 ConversationApi().delete(_completion_app(), _end_user(), uuid4())
 
     @patch("controllers.web.conversation.ConversationService.delete")
-    def test_delete_success(self, mock_delete: MagicMock, app: Flask) -> None:
+    def test_delete_success(self, mock_delete: MagicMock, app) -> None:
         c_id = uuid4()
         with app.test_request_context(f"/conversations/{c_id}"):
             result, status = ConversationApi().delete(_chat_app(), _end_user(), c_id)
@@ -92,25 +93,26 @@ class TestConversationApi:
         assert result["result"] == "success"
 
     @patch("controllers.web.conversation.ConversationService.delete", side_effect=ConversationNotExistsError())
-    def test_delete_not_found(self, mock_delete: MagicMock, app: Flask) -> None:
+    def test_delete_not_found(self, mock_delete: MagicMock, app) -> None:
         c_id = uuid4()
         with app.test_request_context(f"/conversations/{c_id}"):
             with pytest.raises(NotFound, match="Conversation Not Exists"):
                 ConversationApi().delete(_chat_app(), _end_user(), c_id)
 
 
-# ---------------------------------------------------------------------------
-# ConversationRenameApi
-# ---------------------------------------------------------------------------
 class TestConversationRenameApi:
-    def test_non_chat_mode_raises(self, app: Flask) -> None:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_non_chat_mode_raises(self, app) -> None:
         with app.test_request_context(f"/conversations/{uuid4()}/name", method="POST", json={"name": "x"}):
             with pytest.raises(NotChatAppError):
                 ConversationRenameApi().post(_completion_app(), _end_user(), uuid4())
 
     @patch("controllers.web.conversation.ConversationService.rename")
     @patch("controllers.web.conversation.web_ns")
-    def test_rename_success(self, mock_ns: MagicMock, mock_rename: MagicMock, app: Flask) -> None:
+    def test_rename_success(self, mock_ns: MagicMock, mock_rename: MagicMock, app) -> None:
         c_id = uuid4()
         mock_ns.payload = {"name": "New Name", "auto_generate": False}
         conv = SimpleNamespace(
@@ -134,7 +136,7 @@ class TestConversationRenameApi:
         side_effect=ConversationNotExistsError(),
     )
     @patch("controllers.web.conversation.web_ns")
-    def test_rename_not_found(self, mock_ns: MagicMock, mock_rename: MagicMock, app: Flask) -> None:
+    def test_rename_not_found(self, mock_ns: MagicMock, mock_rename: MagicMock, app) -> None:
         c_id = uuid4()
         mock_ns.payload = {"name": "X", "auto_generate": False}
 
@@ -143,17 +145,18 @@ class TestConversationRenameApi:
                 ConversationRenameApi().post(_chat_app(), _end_user(), c_id)
 
 
-# ---------------------------------------------------------------------------
-# ConversationPinApi / ConversationUnPinApi
-# ---------------------------------------------------------------------------
 class TestConversationPinApi:
-    def test_non_chat_mode_raises(self, app: Flask) -> None:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_non_chat_mode_raises(self, app) -> None:
         with app.test_request_context(f"/conversations/{uuid4()}/pin", method="PATCH"):
             with pytest.raises(NotChatAppError):
                 ConversationPinApi().patch(_completion_app(), _end_user(), uuid4())
 
     @patch("controllers.web.conversation.WebConversationService.pin")
-    def test_pin_success(self, mock_pin: MagicMock, app: Flask) -> None:
+    def test_pin_success(self, mock_pin: MagicMock, app) -> None:
         c_id = uuid4()
         with app.test_request_context(f"/conversations/{c_id}/pin", method="PATCH"):
             result = ConversationPinApi().patch(_chat_app(), _end_user(), c_id)
@@ -161,7 +164,7 @@ class TestConversationPinApi:
         assert result["result"] == "success"
 
     @patch("controllers.web.conversation.WebConversationService.pin", side_effect=ConversationNotExistsError())
-    def test_pin_not_found(self, mock_pin: MagicMock, app: Flask) -> None:
+    def test_pin_not_found(self, mock_pin: MagicMock, app) -> None:
         c_id = uuid4()
         with app.test_request_context(f"/conversations/{c_id}/pin", method="PATCH"):
             with pytest.raises(NotFound):
@@ -169,13 +172,17 @@ class TestConversationPinApi:
 
 
 class TestConversationUnPinApi:
-    def test_non_chat_mode_raises(self, app: Flask) -> None:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_non_chat_mode_raises(self, app) -> None:
         with app.test_request_context(f"/conversations/{uuid4()}/unpin", method="PATCH"):
             with pytest.raises(NotChatAppError):
                 ConversationUnPinApi().patch(_completion_app(), _end_user(), uuid4())
 
     @patch("controllers.web.conversation.WebConversationService.unpin")
-    def test_unpin_success(self, mock_unpin: MagicMock, app: Flask) -> None:
+    def test_unpin_success(self, mock_unpin: MagicMock, app) -> None:
         c_id = uuid4()
         with app.test_request_context(f"/conversations/{c_id}/unpin", method="PATCH"):
             result = ConversationUnPinApi().patch(_chat_app(), _end_user(), c_id)

--- a/api/tests/test_containers_integration_tests/controllers/web/test_conversation.py
+++ b/api/tests/test_containers_integration_tests/controllers/web/test_conversation.py
@@ -43,8 +43,7 @@ class TestConversationListApi:
                 ConversationListApi().get(_completion_app(), _end_user())
 
     @patch("controllers.web.conversation.WebConversationService.pagination_by_last_id")
-    @patch("controllers.web.conversation.db")
-    def test_happy_path(self, mock_db: MagicMock, mock_paginate: MagicMock, app) -> None:
+    def test_happy_path(self, mock_paginate: MagicMock, app) -> None:
         conv_id = str(uuid4())
         conv = SimpleNamespace(
             id=conv_id,
@@ -56,17 +55,8 @@ class TestConversationListApi:
             updated_at=1700000000,
         )
         mock_paginate.return_value = SimpleNamespace(limit=20, has_more=False, data=[conv])
-        mock_db.engine = "engine"
 
-        session_mock = MagicMock()
-        session_ctx = MagicMock()
-        session_ctx.__enter__ = MagicMock(return_value=session_mock)
-        session_ctx.__exit__ = MagicMock(return_value=False)
-
-        with (
-            app.test_request_context("/conversations?limit=20"),
-            patch("controllers.web.conversation.Session", return_value=session_ctx),
-        ):
+        with app.test_request_context("/conversations?limit=20"):
             result = ConversationListApi().get(_chat_app(), _end_user())
 
         assert result["limit"] == 20


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/web/test_conversation.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/web/test_conversation.py`.

Replaced `Flask(__name__)` with `flask_app_with_containers` fixture for proper app context. All 13 tests migrated: ConversationListApi (non-chat mode rejection, happy path pagination), ConversationApi (delete success, not found), ConversationRenameApi (rename success, not found), ConversationPinApi/UnPinApi (pin/unpin success, not found, non-chat mode rejection). Service layer calls remain mocked as they test controller routing logic.

Part of #32454

## Checklist
- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods