### PR TITLE
test: migrate web forgot password controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/web/test_web_forgot_password.py
+++ b/api/tests/test_containers_integration_tests/controllers/web/test_web_forgot_password.py
@@ -1,22 +1,18 @@
+"""Testcontainers integration tests for controllers.web.forgot_password endpoints."""
+
+from __future__ import annotations
+
 import base64
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
 
 from controllers.web.forgot_password import (
     ForgotPasswordCheckApi,
     ForgotPasswordResetApi,
     ForgotPasswordSendEmailApi,
 )
-
-
-@pytest.fixture
-def app():
-    flask_app = Flask(__name__)
-    flask_app.config["TESTING"] = True
-    return flask_app
 
 
 @pytest.fixture(autouse=True)
@@ -33,6 +29,10 @@ def _patch_wraps():
 
 
 class TestForgotPasswordSendEmailApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     @patch("controllers.web.forgot_password.AccountService.send_reset_password_email")
     @patch("controllers.web.forgot_password.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.web.forgot_password.AccountService.is_email_send_ip_limit", return_value=False)
@@ -69,6 +69,10 @@ class TestForgotPasswordSendEmailApi:
 
 
 class TestForgotPasswordCheckApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     @patch("controllers.web.forgot_password.AccountService.reset_forgot_password_error_rate_limit")
     @patch("controllers.web.forgot_password.AccountService.generate_reset_password_token")
     @patch("controllers.web.forgot_password.AccountService.revoke_reset_password_token")
@@ -143,6 +147,10 @@ class TestForgotPasswordCheckApi:
 
 
 class TestForgotPasswordResetApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     @patch("controllers.web.forgot_password.ForgotPasswordResetApi._update_existing_account")
     @patch("controllers.web.forgot_password.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.web.forgot_password.Session")


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/web/test_web_forgot_password.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/web/test_web_forgot_password.py`.

Replaced `Flask(__name__)` with `flask_app_with_containers` fixture. All 5 tests migrated: email normalization before sending reset email, email normalization for validity checks, token email case preservation, account fetching with case fallback, and password update with commit verification. External services (AccountService, Session, db) remain mocked as tests verify controller routing and email normalization logic.

Part of #32454

## Checklist
- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods