### PR TITLE
test: migrate data source controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/datasets/test_data_source.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/datasets/test_data_source.py
@@ -1,3 +1,7 @@
+"""Testcontainers integration tests for controllers.console.datasets.data_source endpoints."""
+
+from __future__ import annotations
+
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -46,6 +50,10 @@ def mock_engine():
 
 
 class TestDataSourceApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_success(self, app, patch_tenant):
         api = DataSourceApi()
         method = unwrap(api.get)
@@ -179,6 +187,10 @@ class TestDataSourceApi:
 
 
 class TestDataSourceNotionListApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_credential_not_found(self, app, patch_tenant):
         api = DataSourceNotionListApi()
         method = unwrap(api.get)
@@ -310,6 +322,10 @@ class TestDataSourceNotionListApi:
 
 
 class TestDataSourceNotionApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_preview_success(self, app, patch_tenant):
         api = DataSourceNotionApi()
         method = unwrap(api.get)
@@ -364,6 +380,10 @@ class TestDataSourceNotionApi:
 
 
 class TestDataSourceNotionDatasetSyncApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_success(self, app, patch_tenant):
         api = DataSourceNotionDatasetSyncApi()
         method = unwrap(api.get)
@@ -403,6 +423,10 @@ class TestDataSourceNotionDatasetSyncApi:
 
 
 class TestDataSourceNotionDocumentSyncApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_success(self, app, patch_tenant):
         api = DataSourceNotionDocumentSyncApi()
         method = unwrap(api.get)


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/console/datasets/test_data_source.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/console/datasets/test_data_source.py`.

Replaced `Flask(__name__)` with `flask_app_with_containers` fixture. All 16 tests migrated: DataSourceApi (get success/no bindings, patch enable/disable/not found/already enabled/disabled), DataSourceNotionListApi (credential not found, success with/without dataset_id, invalid dataset type), DataSourceNotionApi (preview success, indexing estimate), DataSourceNotionDatasetSyncApi (success, dataset not found), DataSourceNotionDocumentSyncApi (success, document not found). External services and DB sessions remain mocked as tests verify controller routing logic.

Part of #32454

## Checklist
- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods