### PR TITLE
test: migrate tool provider controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
@@ -64,10 +64,15 @@ def _mock_user_tenant():
 
 
 @pytest.fixture
-def client(flask_app_with_containers):
-    flask_app = flask_app_with_containers
+def client():
+    from flask import Flask
+
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     api = Api(flask_app)
     api.add_resource(ToolProviderMCPApi, "/console/api/workspaces/current/tool-provider/mcp")
+    db.init_app(flask_app)
     with flask_app.app_context():
         configure_session_factory(db.engine)
     return flask_app.test_client()

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
@@ -33,7 +33,6 @@ from controllers.console.workspace.tool_providers import (
     ToolOAuthCustomClient,
     ToolPluginOAuthApi,
     ToolProviderListApi,
-    ToolProviderMCPApi,
     ToolWorkflowListApi,
     ToolWorkflowProviderCreateApi,
     ToolWorkflowProviderDeleteApi,

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
@@ -1,8 +1,11 @@
+"""Testcontainers integration tests for controllers.console.workspace.tool_providers endpoints."""
+
+from __future__ import annotations
+
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
 from flask_restx import Api
 from werkzeug.exceptions import Forbidden
 
@@ -61,17 +64,13 @@ def _mock_user_tenant():
 
 
 @pytest.fixture
-def client():
-    app = Flask(__name__)
-    app.config["TESTING"] = True
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    api = Api(app)
+def client(flask_app_with_containers):
+    flask_app = flask_app_with_containers
+    api = Api(flask_app)
     api.add_resource(ToolProviderMCPApi, "/console/api/workspaces/current/tool-provider/mcp")
-    db.init_app(app)
-    # Configure session factory used by controller code
-    with app.app_context():
+    with flask_app.app_context():
         configure_session_factory(db.engine)
-    return app.test_client()
+    return flask_app.test_client()
 
 
 @patch(
@@ -156,6 +155,10 @@ class TestUtils:
 
 
 class TestToolProviderListApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_success(self, app):
         api = ToolProviderListApi()
         method = unwrap(api.get)
@@ -175,6 +178,10 @@ class TestToolProviderListApi:
 
 
 class TestBuiltinProviderApis:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_list_tools(self, app):
         api = ToolBuiltinProviderListToolsApi()
         method = unwrap(api.get)
@@ -379,6 +386,10 @@ class TestBuiltinProviderApis:
 
 
 class TestApiProviderApis:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_add(self, app):
         api = ToolApiProviderAddApi()
         method = unwrap(api.post)
@@ -502,6 +513,10 @@ class TestApiProviderApis:
 
 
 class TestWorkflowApis:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_create(self, app):
         api = ToolWorkflowProviderCreateApi()
         method = unwrap(api.post)
@@ -587,6 +602,10 @@ class TestWorkflowApis:
 
 
 class TestLists:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_builtin_list(self, app):
         api = ToolBuiltinListApi()
         method = unwrap(api.get)
@@ -649,6 +668,10 @@ class TestLists:
 
 
 class TestLabels:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_labels(self, app):
         api = ToolLabelsApi()
         method = unwrap(api.get)
@@ -664,6 +687,10 @@ class TestLabels:
 
 
 class TestOAuth:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_oauth_no_client(self, app):
         api = ToolPluginOAuthApi()
         method = unwrap(api.get)
@@ -692,6 +719,10 @@ class TestOAuth:
 
 
 class TestOAuthCustomClient:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_save_custom_client(self, app):
         api = ToolOAuthCustomClient()
         method = unwrap(api.post)

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
@@ -6,7 +6,6 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask_restx import Api
 from werkzeug.exceptions import Forbidden
 
 from controllers.console.workspace.tool_providers import (
@@ -42,8 +41,6 @@ from controllers.console.workspace.tool_providers import (
     ToolWorkflowProviderUpdateApi,
     is_valid_url,
 )
-from core.db.session_factory import configure_session_factory
-from extensions.ext_database import db
 from services.tools.mcp_tools_manage_service import ReconnectResult
 
 
@@ -64,18 +61,8 @@ def _mock_user_tenant():
 
 
 @pytest.fixture
-def client():
-    from flask import Flask
-
-    flask_app = Flask(__name__)
-    flask_app.config["TESTING"] = True
-    flask_app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    api = Api(flask_app)
-    api.add_resource(ToolProviderMCPApi, "/console/api/workspaces/current/tool-provider/mcp")
-    db.init_app(flask_app)
-    with flask_app.app_context():
-        configure_session_factory(db.engine)
-    return flask_app.test_client()
+def client(flask_app_with_containers):
+    return flask_app_with_containers.test_client()
 
 
 @patch(
@@ -156,7 +143,7 @@ class TestUtils:
         assert not is_valid_url("")
         assert not is_valid_url("ftp://example.com")
         assert not is_valid_url("not-a-url")
-        assert not is_valid_url(None)
+        assert not is_valid_url(None)  # type: ignore[arg-type]
 
 
 class TestToolProviderListApi:


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/console/workspace/test_tool_provider.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py`.

Replaced `Flask(__name__)` with `flask_app_with_containers` fixture across all test classes and the `client` fixture. All 35 tests migrated: MCP provider creation with tool population, URL validation utils, ToolProviderListApi, builtin provider APIs (list tools, info, delete, add, update, credentials, icon, schema, set default, credential info, OAuth client schema), API provider APIs (add, remote schema, list tools, update, delete, get), workflow APIs (create, update, delete, get error), list APIs (builtin, api, workflow), labels, OAuth (no client, callback no cookie), and OAuth custom client (save, get, delete). Service calls remain mocked as tests verify controller routing logic.

Part of #32454

## Checklist
- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods