### PR TITLE
fix(i18n): translate "nodes.note.addNote" as "メモを追加" in ja-JP

### DIFF
--- a/web/i18n/ja-JP/workflow.json
+++ b/web/i18n/ja-JP/workflow.json
@@ -818,7 +818,7 @@
   "nodes.loop.setLoopVariables": "ループスコープ内で変数を設定",
   "nodes.loop.totalLoopCount": "総ループ回数：{{count}}",
   "nodes.loop.variableName": "変数名",
-  "nodes.note.addNote": "コメントを追加",
+  "nodes.note.addNote": "メモを追加",
   "nodes.note.editor.bold": "太字",
   "nodes.note.editor.bulletList": "リスト",
   "nodes.note.editor.enterUrl": "リンク入力中...",


### PR DESCRIPTION
"Note" is more accurately translated as "メモ" rather than "コメント" in Japanese. The note feature is for personal memos/annotations on workflow nodes, not comments directed at others. This aligns with common Japanese UI conventions (e.g., macOS Notes app is "メモ").

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix Japanese translation of nodes.note.addNote from "コメントを追加" (Add Comment) to "メモを追加" (Add Note).

"Note" should be translated as "メモ" rather than "コメント" in Japanese. The note feature is for personal　memos/annotations on workflow nodes, not comments directed at others. This
  aligns with common Japanese UI conventions (e.g., macOS Notes app is "メモ").

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
