### PR TITLE
test: migrate trigger providers controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_trigger_providers.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_trigger_providers.py
@@ -1,3 +1,7 @@
+"""Testcontainers integration tests for controllers.console.workspace.trigger_providers endpoints."""
+
+from __future__ import annotations
+
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -40,6 +44,10 @@ def mock_user():
 
 
 class TestTriggerProviderApis:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_icon_success(self, app):
         api = TriggerProviderIconApi()
         method = unwrap(api.get)
@@ -84,6 +92,10 @@ class TestTriggerProviderApis:
 
 
 class TestTriggerSubscriptionListApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_list_success(self, app):
         api = TriggerSubscriptionListApi()
         method = unwrap(api.get)
@@ -115,6 +127,10 @@ class TestTriggerSubscriptionListApi:
 
 
 class TestTriggerSubscriptionBuilderApis:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_create_builder(self, app):
         api = TriggerSubscriptionBuilderCreateApi()
         method = unwrap(api.post)
@@ -219,6 +235,10 @@ class TestTriggerSubscriptionBuilderApis:
 
 
 class TestTriggerSubscriptionCrud:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_update_rename_only(self, app):
         api = TriggerSubscriptionUpdateApi()
         method = unwrap(api.post)
@@ -321,6 +341,10 @@ class TestTriggerSubscriptionCrud:
 
 
 class TestTriggerOAuthApis:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_oauth_authorize_success(self, app):
         api = TriggerOAuthAuthorizeApi()
         method = unwrap(api.get)
@@ -455,6 +479,10 @@ class TestTriggerOAuthApis:
 
 
 class TestTriggerOAuthClientManageApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_get_client(self, app):
         api = TriggerOAuthClientManageApi()
         method = unwrap(api.get)
@@ -527,6 +555,10 @@ class TestTriggerOAuthClientManageApi:
 
 
 class TestTriggerSubscriptionVerifyApi:
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
     def test_verify_success(self, app):
         api = TriggerSubscriptionVerifyApi()
         method = unwrap(api.post)


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/console/workspace/test_trigger_providers.py`.

Replaced `Flask(__name__)` with `flask_app_with_containers` fixture across all 7 test classes. All 28 tests migrated: TriggerProviderApis (icon, list, info), TriggerSubscriptionListApi (success, invalid provider), TriggerSubscriptionBuilderApis (create, get, verify, verify error, update, logs, build), TriggerSubscriptionCrud (update rename/not found/rebuild, delete success/value error), TriggerOAuthApis (authorize success/no client, callback forbidden/success/no client/empty credentials), TriggerOAuthClientManageApi (get/post/delete client, post value error), TriggerSubscriptionVerifyApi (success, parametrized errors). Service calls remain mocked as tests verify controller routing logic.

Part of #32454

## Checklist
- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods