### PR TITLE
test: migrate mcp controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py
+++ b/api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import types
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from flask import Response
@@ -30,8 +31,13 @@ def fake_payload(data):
     module.mcp_ns.payload = data
 
 
+_TENANT_ID = str(uuid4())
+_APP_ID = str(uuid4())
+_SERVER_ID = str(uuid4())
+
+
 class DummyServer:
-    def __init__(self, status, app_id="app-1", tenant_id="tenant-1", server_id="srv-1"):
+    def __init__(self, status, app_id=_APP_ID, tenant_id=_TENANT_ID, server_id=_SERVER_ID):
         self.status = status
         self.app_id = app_id
         self.tenant_id = tenant_id
@@ -40,8 +46,8 @@ class DummyServer:
 
 class DummyApp:
     def __init__(self, mode, workflow=None, app_model_config=None):
-        self.id = "app-1"
-        self.tenant_id = "tenant-1"
+        self.id = _APP_ID
+        self.tenant_id = _TENANT_ID
         self.mode = mode
         self.workflow = workflow
         self.app_model_config = app_model_config

--- a/api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py
+++ b/api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py
@@ -62,6 +62,7 @@ class DummyResult:
         return {"jsonrpc": "2.0", "result": "ok", "id": 1}
 
 
+@pytest.mark.usefixtures("flask_req_ctx_with_containers")
 class TestMCPAppApi:
     @patch.object(module, "handle_mcp_request", return_value=DummyResult(), autospec=True)
     def test_success_request(self, mock_handle):

--- a/api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py
+++ b/api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py
@@ -1,3 +1,7 @@
+"""Testcontainers integration tests for controllers.mcp.mcp endpoints."""
+
+from __future__ import annotations
+
 import types
 from unittest.mock import MagicMock, patch
 
@@ -12,24 +16,6 @@ def unwrap(func):
     while hasattr(func, "__wrapped__"):
         func = func.__wrapped__
     return func
-
-
-@pytest.fixture(autouse=True)
-def mock_db():
-    module.db = types.SimpleNamespace(engine=object())
-
-
-@pytest.fixture
-def fake_session():
-    session = MagicMock()
-    session.__enter__.return_value = session
-    session.__exit__.return_value = False
-    return session
-
-
-@pytest.fixture(autouse=True)
-def mock_session(fake_session):
-    module.Session = MagicMock(return_value=fake_session)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/mcp/test_mcp.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/mcp/test_mcp.py`.

Removed `mock_db` and `mock_session` autouse fixtures that were replacing `module.db` and `module.Session` with fakes - the controller now uses real `Session(db.engine)` from the testcontainers PostgreSQL instance. All 17 tests migrated: MCP request handling (success, notification initialized, invalid notification, inactive server, invalid payload, missing request ID, no response), server/app lookup (server not found, app not found), app availability (no workflow, no model config), app modes (workflow with user input form, chat with model config), invalid request format, server status validation, user input form conversion, and invalid user input form validation.

Part of #32454