### PR TITLE
test: migrate explore conversation controller tests to testcontainers

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/explore/test_conversation.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/explore/test_conversation.py
@@ -1,7 +1,10 @@
+"""Testcontainers integration tests for controllers.console.explore.conversation endpoints."""
+
+from __future__ import annotations
+
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask
 from werkzeug.exceptions import NotFound
 
 import controllers.console.explore.conversation as conversation_module
@@ -48,24 +51,12 @@ def user():
     return user
 
 
-@pytest.fixture(autouse=True)
-def mock_db_and_session():
-    with (
-        patch.object(
-            conversation_module,
-            "db",
-            MagicMock(session=MagicMock(), engine=MagicMock()),
-        ),
-        patch(
-            "controllers.console.explore.conversation.Session",
-            MagicMock(),
-        ),
-    ):
-        yield
-
-
 class TestConversationListApi:
-    def test_get_success(self, app: Flask, chat_app, user):
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_get_success(self, app, chat_app, user):
         api = conversation_module.ConversationListApi()
         method = unwrap(api.get)
 
@@ -90,7 +81,7 @@ class TestConversationListApi:
         assert result["has_more"] is False
         assert len(result["data"]) == 2
 
-    def test_last_conversation_not_exists(self, app: Flask, chat_app, user):
+    def test_last_conversation_not_exists(self, app, chat_app, user):
         api = conversation_module.ConversationListApi()
         method = unwrap(api.get)
 
@@ -106,7 +97,7 @@ class TestConversationListApi:
             with pytest.raises(NotFound):
                 method(chat_app)
 
-    def test_wrong_app_mode(self, app: Flask, non_chat_app):
+    def test_wrong_app_mode(self, app, non_chat_app):
         api = conversation_module.ConversationListApi()
         method = unwrap(api.get)
 
@@ -116,7 +107,11 @@ class TestConversationListApi:
 
 
 class TestConversationApi:
-    def test_delete_success(self, app: Flask, chat_app, user):
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_delete_success(self, app, chat_app, user):
         api = conversation_module.ConversationApi()
         method = unwrap(api.delete)
 
@@ -134,7 +129,7 @@ class TestConversationApi:
         assert status == 204
         assert body["result"] == "success"
 
-    def test_delete_not_found(self, app: Flask, chat_app, user):
+    def test_delete_not_found(self, app, chat_app, user):
         api = conversation_module.ConversationApi()
         method = unwrap(api.delete)
 
@@ -150,7 +145,7 @@ class TestConversationApi:
             with pytest.raises(NotFound):
                 method(chat_app, "cid")
 
-    def test_delete_wrong_app_mode(self, app: Flask, non_chat_app):
+    def test_delete_wrong_app_mode(self, app, non_chat_app):
         api = conversation_module.ConversationApi()
         method = unwrap(api.delete)
 
@@ -160,7 +155,11 @@ class TestConversationApi:
 
 
 class TestConversationRenameApi:
-    def test_rename_success(self, app: Flask, chat_app, user):
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_rename_success(self, app, chat_app, user):
         api = conversation_module.ConversationRenameApi()
         method = unwrap(api.post)
 
@@ -179,7 +178,7 @@ class TestConversationRenameApi:
 
         assert result["id"] == "cid"
 
-    def test_rename_not_found(self, app: Flask, chat_app, user):
+    def test_rename_not_found(self, app, chat_app, user):
         api = conversation_module.ConversationRenameApi()
         method = unwrap(api.post)
 
@@ -197,7 +196,11 @@ class TestConversationRenameApi:
 
 
 class TestConversationPinApi:
-    def test_pin_success(self, app: Flask, chat_app, user):
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_pin_success(self, app, chat_app, user):
         api = conversation_module.ConversationPinApi()
         method = unwrap(api.patch)
 
@@ -215,7 +218,11 @@ class TestConversationPinApi:
 
 
 class TestConversationUnPinApi:
-    def test_unpin_success(self, app: Flask, chat_app, user):
+    @pytest.fixture
+    def app(self, flask_app_with_containers):
+        return flask_app_with_containers
+
+    def test_unpin_success(self, app, chat_app, user):
         api = conversation_module.ConversationUnPinApi()
         method = unwrap(api.patch)
 


### PR DESCRIPTION
## Summary

Migrate tests from `api/tests/unit_tests/controllers/console/explore/test_conversation.py` to testcontainers integration tests at `api/tests/test_containers_integration_tests/controllers/console/explore/test_conversation.py`.

Part of #32454

## Checklist
- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods