### PR TITLE
fix: apply Baidu Vector DB connection timeout when initializing Mochow client

### DIFF
--- a/api/core/rag/datasource/vdb/baidu/baidu_vector.py
+++ b/api/core/rag/datasource/vdb/baidu/baidu_vector.py
@@ -200,7 +200,11 @@ class BaiduVector(BaseVector):
                 raise
 
     def _init_client(self, config) -> MochowClient:
-        config = Configuration(credentials=BceCredentials(config.account, config.api_key), endpoint=config.endpoint)
+        config = Configuration(
+            credentials=BceCredentials(config.account, config.api_key),
+            endpoint=config.endpoint,
+            connection_timeout_in_mills=config.connection_timeout_in_mills,
+        )
         client = MochowClient(config)
         return client
 

--- a/api/tests/unit_tests/core/rag/datasource/vdb/baidu/test_baidu_vector.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/baidu/test_baidu_vector.py
@@ -381,13 +381,22 @@ def test_init_client_constructs_configuration_and_client(baidu_module, monkeypat
     monkeypatch.setattr(baidu_module, "MochowClient", client_cls)
 
     vector = baidu_module.BaiduVector.__new__(baidu_module.BaiduVector)
-    config = SimpleNamespace(account="account", api_key="key", endpoint="https://endpoint")
+    config = SimpleNamespace(
+        account="account",
+        api_key="key",
+        endpoint="https://endpoint",
+        connection_timeout_in_mills=12_345,
+    )
 
     client = vector._init_client(config)
 
     assert client == "client"
     credentials.assert_called_once_with("account", "key")
-    configuration.assert_called_once_with(credentials="credentials", endpoint="https://endpoint")
+    configuration.assert_called_once_with(
+        credentials="credentials",
+        endpoint="https://endpoint",
+        connection_timeout_in_mills=12_345,
+    )
     client_cls.assert_called_once_with("configuration")
 
 


### PR DESCRIPTION
## Summary

This PR fixes a Baidu Vector DB configuration issue in Dify.

BAIDU_VECTOR_DB_CONNECTION_TIMEOUT_MS is already exposed in the config and passed into BaiduConfig, but it was not forwarded when initializing the Mochow client. As a result, updating this env var had no effect.

This PR wires the timeout through to pymochow.Configuration and adds regression coverage.

## Changes

- pass connection_timeout_in_mills to pymochow.Configuration in Baidu Vector DB client initialization
- add a regression test to verify the timeout value is forwarded correctly

## Related Issue

- Closes #34374

## Why

Dify already exposes this config in .env.example, BaiduConfig, and BaiduVectorFactory, but the client initialization path ignored it, so the actual runtime behavior did not match the configured behavior.

## Validation

Ran the Baidu Vector DB unit tests successfully:

    cd api
    ./.venv/bin/pytest tests/unit_tests/core/rag/datasource/vdb/baidu/test_baidu_vector.py

Result:

    19 passed in 0.95s
