### PR TITLE
test: add onBlur behavior test for PromptEditor component

### DIFF
--- a/web/app/components/base/prompt-editor/__tests__/index.spec.tsx
+++ b/web/app/components/base/prompt-editor/__tests__/index.spec.tsx
@@ -272,6 +272,28 @@ describe('PromptEditor', () => {
       expect(onFocus).toHaveBeenCalledTimes(1)
       expect(onBlur).toHaveBeenCalledTimes(1)
     })
+
+    it('should not call onBlur when blur target is var-search-input', () => {
+      const onBlur = vi.fn()
+      const onFocus = vi.fn()
+
+      render(
+        <PromptEditor
+          onFocus={onFocus}
+          onBlur={onBlur}
+        />,
+      )
+
+      const blurHandler = mocks.commandHandlers.get(BLUR_COMMAND)
+      expect(blurHandler).toBeDefined()
+
+      const varInput = document.createElement('input')
+      varInput.classList.add('var-search-input')
+
+      blurHandler?.({ relatedTarget: varInput } as unknown as ReactFocusEvent<Element>)
+
+      expect(onBlur).not.toHaveBeenCalled()
+    })
   })
 
   // Prop typing guard for shortcut popup shape without any-casts.


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
