### PR TITLE
feat(docker): add healthcheck for api, worker, and worker_beat services

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -56,6 +56,12 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     networks:
       - ssrf_proxy_network
       - default
@@ -95,6 +101,12 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A celery_entrypoint.celery inspect ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - ssrf_proxy_network
       - default
@@ -126,6 +138,12 @@ services:
         required: false
       redis:
         condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A app.celery inspect ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -765,6 +765,12 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     networks:
       - ssrf_proxy_network
       - default
@@ -804,6 +810,12 @@ services:
     volumes:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A celery_entrypoint.celery inspect ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - ssrf_proxy_network
       - default
@@ -835,6 +847,12 @@ services:
         required: false
       redis:
         condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A app.celery inspect ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - ssrf_proxy_network
       - default


### PR DESCRIPTION
## Summary
- Add healthcheck to `api` service: HTTP check against `/health` on port 5001
- Add healthcheck to `worker` service: `celery inspect ping` via `celery_entrypoint.celery`
- Add healthcheck to `worker_beat` service: `celery inspect ping` via `app.celery`

Closes #34320

## Details
The `api`, `worker`, and `worker_beat` services in `docker-compose.yaml` lack healthcheck definitions, while other services (redis, db, sandbox, etc.) already have them.

This PR adds healthcheck blocks following the existing patterns in the file:

- **api**: Uses `curl -f http://localhost:5001/health` matching the sandbox service pattern. The `/health` endpoint is defined in `api/extensions/ext_app_metrics.py`. `curl` is installed in the `dify-api` Docker image.
- **worker**: Uses `celery -A celery_entrypoint.celery inspect ping` matching the Celery app name from `api/docker/entrypoint.sh:66`.
- **worker_beat**: Uses `celery -A app.celery inspect ping` matching the Celery app name from `api/docker/entrypoint.sh:72`.

## Test plan
- [x] YAML syntax validated: `docker compose -f docker/docker-compose.yaml config --quiet` passes
- [x] Regeneration consistent: `./generate_docker_compose` produces matching output
- [ ] Manual: `docker compose up -d api worker worker_beat` then `docker inspect --format='{{json .State.Health}}' docker-api-1`