### PR TITLE
fix(web): prevent PortalSelect dropdown from being obscured in dialogs 🤖🤖🤖

### DIFF
--- a/web/app/components/base/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/select/__tests__/index.spec.tsx
@@ -599,6 +599,22 @@ describe('PortalSelect', () => {
       expect(screen.getByTitle('Banana')).toBeInTheDocument()
     })
 
+    it('should render portal popup above legacy dialog layers', async () => {
+      const user = userEvent.setup()
+      render(
+        <PortalSelect
+          value=""
+          items={items}
+          onSelect={vi.fn()}
+        />,
+      )
+
+      await user.click(screen.getByText(/select/i))
+
+      const popupLayer = document.querySelector('[class*="z-[1001]"]')
+      expect(popupLayer).toBeInTheDocument()
+    })
+
     it('should render with custom placeholder', () => {
       render(
         <PortalSelect

--- a/web/app/components/base/select/index.tsx
+++ b/web/app/components/base/select/index.tsx
@@ -400,7 +400,7 @@ const PortalSelect: FC<PortalSelectProps> = ({
             )}
 
       </PortalToFollowElemTrigger>
-      <PortalToFollowElemContent className={`z-20 ${popupClassName}`}>
+      <PortalToFollowElemContent className={`z-[1001] ${popupClassName}`}>
         <div
           className={cn('max-h-60 overflow-auto rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg px-1 py-1 text-base shadow-lg focus:outline-none sm:text-sm', popupInnerClassName)}
         >


### PR DESCRIPTION
## Summary
- raise legacy `PortalSelect` popup layer to `z-[1001]` so dropdown options render above dialog content layers
- add a regression test to ensure the portal popup keeps the expected overlay z-index

## Why
Issue #27581 reports dropdown options being obscured when opened inside dialog contexts.
The previous `z-20` layer can be lower than current dialog migration layers.

## Files
- `web/app/components/base/select/index.tsx`
- `web/app/components/base/select/__tests__/index.spec.tsx`

## Verification
- `./node_modules/.bin/vp test run app/components/base/select/__tests__/index.spec.tsx`
- `./node_modules/.bin/vp run lint:ci app/components/base/select/index.tsx app/components/base/select/__tests__/index.spec.tsx`
- `./node_modules/.bin/vp run lint:tss`
- `./node_modules/.bin/vp run type-check`

fixes #27581
