### PR TITLE
refactor: migrate uncovered React useContext calls to use (batch 1) 🤖🤖🤖

### DIFF
--- a/web/app/components/base/features/__tests__/context.spec.tsx
+++ b/web/app/components/base/features/__tests__/context.spec.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import * as React from 'react'
-import { useContext } from 'react'
+import { use } from 'react'
 import { FeaturesContext, FeaturesProvider } from '../context'
 
 const TestConsumer = () => {
-  const store = useContext(FeaturesContext)
+  const store = use(FeaturesContext)
   if (!store)
     return <div>no store</div>
 
@@ -34,10 +34,10 @@ describe('FeaturesProvider', () => {
   })
 
   it('should maintain the same store reference across re-renders', () => {
-    const storeRefs: Array<ReturnType<typeof useContext>> = []
+    const storeRefs: Array<React.ContextType<typeof FeaturesContext>> = []
 
     const StoreRefCollector = () => {
-      const store = useContext(FeaturesContext)
+      const store = use(FeaturesContext)
       storeRefs.push(store)
       return null
     }

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { useContext } from 'react'
+import { use } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DataSourceProvider, { DataSourceContext } from '../provider'
 
@@ -11,7 +11,7 @@ vi.mock('../', () => ({
 
 // Test consumer component that reads from context
 function ContextConsumer() {
-  const store = useContext(DataSourceContext)
+  const store = use(DataSourceContext)
   return (
     <div data-testid="context-value" data-has-store={store !== null}>
       {store ? 'has-store' : 'no-store'}
@@ -65,7 +65,7 @@ describe('DataSourceProvider', () => {
       const storeValues: Array<typeof mockStore | null> = []
 
       function StoreCapture() {
-        const store = useContext(DataSourceContext)
+        const store = use(DataSourceContext)
         storeValues.push(store as typeof mockStore | null)
         return null
       }

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/store/index.ts
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/store/index.ts
@@ -3,7 +3,7 @@ import type { LocalFileSliceShape } from './slices/local-file'
 import type { OnlineDocumentSliceShape } from './slices/online-document'
 import type { OnlineDriveSliceShape } from './slices/online-drive'
 import type { WebsiteCrawlSliceShape } from './slices/website-crawl'
-import { useContext } from 'react'
+import { use } from 'react'
 import { createStore, useStore } from 'zustand'
 import { DataSourceContext } from './provider'
 import { createCommonSlice } from './slices/common'
@@ -29,7 +29,7 @@ export const createDataSourceStore = () => {
 }
 
 export const useDataSourceStoreWithSelector = <T>(selector: (state: DataSourceShape) => T): T => {
-  const store = useContext(DataSourceContext)
+  const store = use(DataSourceContext)
   if (!store)
     throw new Error('Missing DataSourceContext.Provider in the tree')
 
@@ -37,7 +37,7 @@ export const useDataSourceStoreWithSelector = <T>(selector: (state: DataSourceSh
 }
 
 export const useDataSourceStore = () => {
-  const store = useContext(DataSourceContext)
+  const store = use(DataSourceContext)
   if (!store)
     throw new Error('Missing DataSourceContext.Provider in the tree')
 

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/system-quota-card.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/system-quota-card.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import { cn } from '@/utils/classnames'
 import styles from './quota-panel.module.css'
 
@@ -41,7 +41,7 @@ const SystemQuotaCard = ({
 }
 
 const Label = ({ children, className }: { children: ReactNode, className?: string }) => {
-  const variant = useContext(VariantContext)
+  const variant = use(VariantContext)
   return (
     <div className={cn(
       'relative z-[1] flex items-center gap-1 truncate px-1.5 pt-1 system-xs-medium',

--- a/web/app/components/workflow/hooks-store/__tests__/provider.spec.tsx
+++ b/web/app/components/workflow/hooks-store/__tests__/provider.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import { useContext } from 'react'
+import { use } from 'react'
 import { HooksStoreContext, HooksStoreContextProvider } from '../provider'
 
 const mockRefreshAll = vi.fn()
@@ -27,7 +27,7 @@ vi.mock('../store', async () => {
 })
 
 const Consumer = () => {
-  const store = useContext(HooksStoreContext)
+  const store = use(HooksStoreContext)
   return <div>{store ? 'has-hooks-store' : 'missing-hooks-store'}</div>
 }
 

--- a/web/app/components/workflow/nodes/_base/components/mcp-tool-availability.tsx
+++ b/web/app/components/workflow/nodes/_base/components/mcp-tool-availability.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { ReactNode } from 'react'
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 
 type MCPToolAvailabilityContextValue = {
   versionSupported?: boolean
@@ -26,7 +26,7 @@ export const MCPToolAvailabilityProvider = ({
 )
 
 export const useMCPToolAvailability = (): MCPToolAvailability => {
-  const context = useContext(MCPToolAvailabilityContext)
+  const context = use(MCPToolAvailabilityContext)
   if (context === undefined)
     return { allowed: true }
 


### PR DESCRIPTION
## Summary
This PR delivers a small non-overlapping batch for #25193.

- Replaced React native useContext with use in files not covered by open PR #25548
- Kept behavior unchanged
- Did not touch use-context-selector usage

## Scope (batch 1)
- web/app/components/datasets/documents/create-from-pipeline/data-source/store/index.ts
- web/app/components/workflow/nodes/_base/components/mcp-tool-availability.tsx
- web/app/components/header/account-setting/model-provider-page/provider-added-card/system-quota-card.tsx
- web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx
- web/app/components/workflow/hooks-store/__tests__/provider.spec.tsx
- web/app/components/base/features/__tests__/context.spec.tsx

## Validation
- ./node_modules/.bin/vp test run app/components/base/features/__tests__/context.spec.tsx app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx app/components/workflow/hooks-store/__tests__/provider.spec.tsx
- ./node_modules/.bin/vp run lint:ci app/components/datasets/documents/create-from-pipeline/data-source/store/index.ts app/components/workflow/nodes/_base/components/mcp-tool-availability.tsx app/components/header/account-setting/model-provider-page/provider-added-card/system-quota-card.tsx app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx app/components/workflow/hooks-store/__tests__/provider.spec.tsx app/components/base/features/__tests__/context.spec.tsx
- ./node_modules/.bin/vp run lint:tss
- ./node_modules/.bin/vp run type-check

fixes #25193
