### PR TITLE
fix: disable rerank-only controls for single dataset selection 🤖🤖🤖

### DIFF
--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.spec.tsx
@@ -218,6 +218,18 @@ describe('ConfigContent', () => {
       })
       const selectedDatasets: DataSet[] = [
         createDataset({
+          id: 'dataset-1',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+        createDataset({
+          id: 'dataset-2',
           indexing_technique: 'high_quality' as IndexingType,
           provider: 'dify',
           embedding_model: 'text-embedding',
@@ -268,6 +280,18 @@ describe('ConfigContent', () => {
       })
       const selectedDatasets: DataSet[] = [
         createDataset({
+          id: 'dataset-1',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+        createDataset({
+          id: 'dataset-2',
           indexing_technique: 'high_quality' as IndexingType,
           provider: 'dify',
           embedding_model: 'text-embedding',
@@ -309,6 +333,18 @@ describe('ConfigContent', () => {
       })
       const selectedDatasets: DataSet[] = [
         createDataset({
+          id: 'dataset-1',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+        createDataset({
+          id: 'dataset-2',
           indexing_technique: 'high_quality' as IndexingType,
           provider: 'dify',
           embedding_model: 'text-embedding',
@@ -351,6 +387,18 @@ describe('ConfigContent', () => {
       })
       const selectedDatasets: DataSet[] = [
         createDataset({
+          id: 'dataset-1',
+          indexing_technique: 'economy' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+        createDataset({
+          id: 'dataset-2',
           indexing_technique: 'economy' as IndexingType,
           provider: 'dify',
           embedding_model: 'text-embedding',
@@ -382,6 +430,86 @@ describe('ConfigContent', () => {
           reranking_enable: true,
         }),
       )
+    })
+
+    it('should disable reranking-only controls when a single dataset is selected', () => {
+      // Arrange
+      const onChange = vi.fn<(configs: DatasetConfigs, isRetrievalModeChange?: boolean) => void>()
+      const datasetConfigs = createDatasetConfigs({
+        reranking_mode: RerankingModeEnum.WeightedScore,
+      })
+      const selectedDatasets: DataSet[] = [
+        createDataset({
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+      ]
+
+      // Act
+      render(
+        <ConfigContent
+          datasetConfigs={datasetConfigs}
+          onChange={onChange}
+          selectedDatasets={selectedDatasets}
+        />,
+      )
+
+      // Assert
+      expect(screen.getAllByText('dataset.singleDatasetRerankDisabled').length).toBeGreaterThan(0)
+      expect(screen.queryByText('dataset.weightedScore.title')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('dataset.weightedScore.semantic')).not.toBeInTheDocument()
+    })
+
+    it('should show reranking controls when multiple datasets are selected', () => {
+      // Arrange
+      const onChange = vi.fn<(configs: DatasetConfigs, isRetrievalModeChange?: boolean) => void>()
+      const datasetConfigs = createDatasetConfigs({
+        reranking_mode: RerankingModeEnum.WeightedScore,
+      })
+      const selectedDatasets: DataSet[] = [
+        createDataset({
+          id: 'dataset-1',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+        createDataset({
+          id: 'dataset-2',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+      ]
+
+      // Act
+      render(
+        <ConfigContent
+          datasetConfigs={datasetConfigs}
+          onChange={onChange}
+          selectedDatasets={selectedDatasets}
+        />,
+      )
+
+      // Assert
+      expect(screen.getByText('dataset.weightedScore.title')).toBeInTheDocument()
+      expect(screen.getByLabelText('dataset.weightedScore.semantic')).toBeInTheDocument()
+      expect(screen.queryByText('dataset.singleDatasetRerankDisabled')).not.toBeInTheDocument()
     })
   })
 })

--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -52,6 +52,7 @@ const ConfigContent: FC<Props> = ({
   const { t } = useTranslation()
   const selectedDatasetsMode = useSelectedDatasetsMode(selectedDatasets)
   const type = datasetConfigs.retrieval_model
+  const isSingleDataset = selectedDatasets.length === 1
 
   useEffect(() => {
     if (type === RETRIEVE_TYPE.oneWay) {
@@ -176,6 +177,7 @@ const ConfigContent: FC<Props> = ({
 
     return datasetConfigs.reranking_enable
   }, [datasetConfigs.reranking_enable, canManuallyToggleRerank])
+  const shouldShowScoreThreshold = showRerankModel || isSingleDataset
 
   const handleManuallyToggleRerank = useCallback((enable: boolean) => {
     if (!currentRerankModel && enable)
@@ -184,7 +186,7 @@ const ConfigContent: FC<Props> = ({
       ...datasetConfigs,
       reranking_enable: enable,
     })
-  }, [currentRerankModel, datasetConfigs, onChange])
+  }, [currentRerankModel, datasetConfigs, onChange, t])
 
   return (
     <div>
@@ -231,7 +233,7 @@ const ConfigContent: FC<Props> = ({
             )
           }
           {
-            showWeightedScore && (
+            showWeightedScore && !isSingleDataset && (
               <div className="flex items-center justify-between">
                 {
                   rerankingModeOptions.map(option => (
@@ -260,6 +262,13 @@ const ConfigContent: FC<Props> = ({
             )
           }
           {
+            showWeightedScore && isSingleDataset && (
+              <div className="mt-2 rounded-lg bg-background-section-burn p-3 text-text-tertiary system-xs-medium">
+                {t('singleDatasetRerankDisabled', { ns: 'dataset' })}
+              </div>
+            )
+          }
+          {
             !showWeightedScorePanel && (
               <div className="mt-2">
                 <div className="flex items-center">
@@ -269,14 +278,23 @@ const ConfigContent: FC<Props> = ({
                         size="md"
                         value={showRerankModel ?? false}
                         onChange={handleManuallyToggleRerank}
+                        disabled={isSingleDataset}
                       />
                     )
                   }
-                  <div className="ml-1 leading-[32px] text-text-secondary system-sm-semibold">{t('modelProvider.rerankModel.key', { ns: 'common' })}</div>
+                  <div className={cn(
+                    'ml-1 leading-[32px] text-text-secondary system-sm-semibold',
+                    isSingleDataset && 'text-text-tertiary',
+                  )}
+                  >
+                    {t('modelProvider.rerankModel.key', { ns: 'common' })}
+                  </div>
                   <Tooltip
                     popupContent={(
                       <div className="w-[200px]">
-                        {t('modelProvider.rerankModel.tip', { ns: 'common' })}
+                        {isSingleDataset
+                          ? t('singleDatasetRerankDisabled', { ns: 'dataset' })
+                          : t('modelProvider.rerankModel.tip', { ns: 'common' })}
                       </div>
                     )}
                     popupClassName="ml-1"
@@ -284,7 +302,7 @@ const ConfigContent: FC<Props> = ({
                   />
                 </div>
                 {
-                  showRerankModel && (
+                  showRerankModel && !isSingleDataset && (
                     <div>
                       <ModelSelector
                         defaultModel={rerankModel && { provider: rerankModel?.provider_name, model: rerankModel?.model_name }}
@@ -309,15 +327,25 @@ const ConfigContent: FC<Props> = ({
             showWeightedScorePanel
             && (
               <div className="mt-2 space-y-4">
-                <WeightedScore
-                  value={{
-                    value: [
-                      datasetConfigs.weights!.vector_setting.vector_weight,
-                      datasetConfigs.weights!.keyword_setting.keyword_weight,
-                    ],
-                  }}
-                  onChange={handleWeightedScoreChange}
-                />
+                {
+                  !isSingleDataset
+                    ? (
+                        <WeightedScore
+                          value={{
+                            value: [
+                              datasetConfigs.weights!.vector_setting.vector_weight,
+                              datasetConfigs.weights!.keyword_setting.keyword_weight,
+                            ],
+                          }}
+                          onChange={handleWeightedScoreChange}
+                        />
+                      )
+                    : (
+                        <div className="rounded-lg bg-background-section-burn p-3 text-text-tertiary system-xs-medium">
+                          {t('singleDatasetRerankDisabled', { ns: 'dataset' })}
+                        </div>
+                      )
+                }
                 <TopKItem
                   value={datasetConfigs.top_k}
                   onChange={handleParamChange}
@@ -343,7 +371,7 @@ const ConfigContent: FC<Props> = ({
                   enable={true}
                 />
                 {
-                  showRerankModel && (
+                  shouldShowScoreThreshold && (
                     <ScoreThresholdItem
                       value={datasetConfigs.score_threshold as number}
                       onChange={handleParamChange}

--- a/web/i18n/en-US/dataset.json
+++ b/web/i18n/en-US/dataset.json
@@ -175,6 +175,7 @@
   "serviceApi.disabled": "Disabled",
   "serviceApi.enabled": "Enabled",
   "serviceApi.title": "Service API",
+  "singleDatasetRerankDisabled": "Reranking settings (Rerank Model and Weighted Score) are only applied when multiple knowledge bases are selected. With a single knowledge base, only Top-K and Score Threshold are used.",
   "unavailable": "Unavailable",
   "unknownError": "Unknown error",
   "updated": "Updated",


### PR DESCRIPTION
## Summary
This PR refreshes issue #30916 with a small focused batch.

- disable rerank-only controls when exactly one dataset is selected
- keep Top-K and Score Threshold available for single-dataset retrieval
- add regression tests for single-dataset disabled behavior and multi-dataset enabled behavior

## Files
- web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
- web/app/components/app/configuration/dataset-config/params-config/config-content.spec.tsx
- web/i18n/en-US/dataset.json

## Validation
- ./node_modules/.bin/vp test run app/components/app/configuration/dataset-config/params-config/config-content.spec.tsx app/components/app/configuration/dataset-config/params-config/index.spec.tsx app/components/app/configuration/dataset-config/params-config/weighted-score.spec.tsx
- ./node_modules/.bin/vp run lint:ci app/components/app/configuration/dataset-config/params-config/config-content.tsx app/components/app/configuration/dataset-config/params-config/config-content.spec.tsx i18n/en-US/dataset.json
- ./node_modules/.bin/vp run lint:tss
- ./node_modules/.bin/vp run type-check

fixes #30916
