### PR TITLE
fix: prevent full-page loading when switching app tabs 🤖🤖🤖

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -128,7 +128,7 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     }).finally(() => {
       setIsLoadingAppDetail(false)
     })
-  }, [appId, pathname])
+  }, [appId])
 
   useEffect(() => {
     if (!appDetailRes || !currentWorkspace.id || isLoadingCurrentWorkspace || isLoadingAppDetail)
@@ -150,7 +150,7 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
       setAppDetail({ ...res, enable_sso: false })
       setNavigation(getNavigationConfig(appId, isCurrentWorkspaceEditor, res.mode))
     }
-  }, [appDetailRes, isCurrentWorkspaceEditor, isLoadingAppDetail, isLoadingCurrentWorkspace])
+  }, [appDetailRes, isCurrentWorkspaceEditor, isLoadingAppDetail, isLoadingCurrentWorkspace, pathname])
 
   useUnmount(() => {
     setAppDetail()


### PR DESCRIPTION
## Summary
This PR fixes the tab-switch loading flash in app detail pages.

- fetch app detail only when appId changes (not on every pathname tab switch)
- keep pathname-sensitive redirect checks by including pathname in the redirect effect dependencies

## File
- web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx

## Validation
- ./node_modules/.bin/vp run lint:ci app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
- ./node_modules/.bin/vp run lint:tss
- ./node_modules/.bin/vp run type-check
- ./node_modules/.bin/vp test run app/components/app-sidebar/app-info/__tests__/app-info-detail-panel.spec.tsx

fixes #31171
