### PR TITLE
fix: refresh MCP tool/provider lists after mutations 🤖🤖🤖

### DIFF
--- a/web/app/components/tools/mcp/__tests__/create-card.spec.tsx
+++ b/web/app/components/tools/mcp/__tests__/create-card.spec.tsx
@@ -7,12 +7,16 @@ import NewMCPCard from '../create-card'
 
 // Track the mock functions
 const mockCreateMCP = vi.fn().mockResolvedValue({ id: 'new-mcp-id', name: 'New MCP' })
+const mockInvalidateAllMCPTools = vi.fn()
+const mockInvalidateAllToolProviders = vi.fn()
 
 // Mock the service
 vi.mock('@/service/use-tools', () => ({
   useCreateMCP: () => ({
     mutateAsync: mockCreateMCP,
   }),
+  useInvalidateAllMCPTools: () => mockInvalidateAllMCPTools,
+  useInvalidateAllToolProviders: () => mockInvalidateAllToolProviders,
 }))
 
 // Mock the MCP Modal
@@ -87,6 +91,8 @@ describe('NewMCPCard', () => {
 
   beforeEach(() => {
     mockCreateMCP.mockClear()
+    mockInvalidateAllMCPTools.mockClear()
+    mockInvalidateAllToolProviders.mockClear()
     mockIsCurrentWorkspaceManager = true
   })
 
@@ -189,6 +195,8 @@ describe('NewMCPCard', () => {
             name: 'Test MCP',
             server_url: 'https://test.com',
           })
+          expect(mockInvalidateAllMCPTools).toHaveBeenCalled()
+          expect(mockInvalidateAllToolProviders).toHaveBeenCalled()
           expect(handleCreate).toHaveBeenCalled()
         })
       }

--- a/web/app/components/tools/mcp/create-card.tsx
+++ b/web/app/components/tools/mcp/create-card.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppContext } from '@/context/app-context'
 import { useDocLink } from '@/context/i18n'
-import { useCreateMCP } from '@/service/use-tools'
+import { useCreateMCP, useInvalidateAllMCPTools, useInvalidateAllToolProviders } from '@/service/use-tools'
 import MCPModal from './modal'
 
 type Props = {
@@ -22,9 +22,13 @@ const NewMCPCard = ({ handleCreate }: Props) => {
   const { isCurrentWorkspaceManager } = useAppContext()
 
   const { mutateAsync: createMCP } = useCreateMCP()
+  const invalidateAllMCPTools = useInvalidateAllMCPTools()
+  const invalidateAllToolProviders = useInvalidateAllToolProviders()
 
   const create = async (info: any) => {
     const provider = await createMCP(info)
+    invalidateAllMCPTools()
+    invalidateAllToolProviders()
     handleCreate(provider)
   }
 

--- a/web/app/components/tools/mcp/detail/__tests__/content.spec.tsx
+++ b/web/app/components/tools/mcp/detail/__tests__/content.spec.tsx
@@ -12,6 +12,8 @@ const mockAuthorizeMcp = vi.fn().mockResolvedValue({ result: 'success' })
 const mockUpdateMCP = vi.fn().mockResolvedValue({ result: 'success' })
 const mockDeleteMCP = vi.fn().mockResolvedValue({ result: 'success' })
 const mockInvalidateMCPTools = vi.fn()
+const mockInvalidateAllMCPTools = vi.fn()
+const mockInvalidateAllToolProviders = vi.fn()
 const mockOpenOAuthPopup = vi.fn()
 
 // Mutable mock state
@@ -33,6 +35,8 @@ vi.mock('@/service/use-tools', () => ({
     isFetching: mockIsFetching,
   }),
   useInvalidateMCPTools: () => mockInvalidateMCPTools,
+  useInvalidateAllMCPTools: () => mockInvalidateAllMCPTools,
+  useInvalidateAllToolProviders: () => mockInvalidateAllToolProviders,
   useUpdateMCPTools: () => ({
     mutateAsync: mockUpdateTools,
     isPending: mockIsUpdating,
@@ -191,6 +195,8 @@ describe('MCPDetailContent', () => {
     mockUpdateMCP.mockClear()
     mockDeleteMCP.mockClear()
     mockInvalidateMCPTools.mockClear()
+    mockInvalidateAllMCPTools.mockClear()
+    mockInvalidateAllToolProviders.mockClear()
     mockOpenOAuthPopup.mockClear()
 
     // Reset mock return values
@@ -523,6 +529,8 @@ describe('MCPDetailContent', () => {
 
       await waitFor(() => {
         expect(mockUpdateTools).toHaveBeenCalledWith('mcp-1')
+        expect(mockInvalidateAllMCPTools).toHaveBeenCalled()
+        expect(mockInvalidateAllToolProviders).toHaveBeenCalled()
         expect(mockInvalidateMCPTools).toHaveBeenCalledWith('mcp-1')
         expect(onUpdate).toHaveBeenCalled()
       })
@@ -599,6 +607,8 @@ describe('MCPDetailContent', () => {
           server_url: 'https://updated.com',
           provider_id: 'mcp-1',
         })
+        expect(mockInvalidateAllMCPTools).toHaveBeenCalled()
+        expect(mockInvalidateAllToolProviders).toHaveBeenCalled()
         expect(onUpdate).toHaveBeenCalled()
       })
     })
@@ -678,6 +688,8 @@ describe('MCPDetailContent', () => {
 
       await waitFor(() => {
         expect(mockDeleteMCP).toHaveBeenCalledWith('mcp-1')
+        expect(mockInvalidateAllMCPTools).toHaveBeenCalled()
+        expect(mockInvalidateAllToolProviders).toHaveBeenCalled()
         expect(onUpdate).toHaveBeenCalledWith(true)
       })
     })

--- a/web/app/components/tools/mcp/detail/content.tsx
+++ b/web/app/components/tools/mcp/detail/content.tsx
@@ -22,6 +22,8 @@ import { openOAuthPopup } from '@/hooks/use-oauth'
 import {
   useAuthorizeMCP,
   useDeleteMCP,
+  useInvalidateAllMCPTools,
+  useInvalidateAllToolProviders,
   useInvalidateMCPTools,
   useMCPTools,
   useUpdateMCP,
@@ -52,6 +54,8 @@ const MCPDetailContent: FC<Props> = ({
   const { isCurrentWorkspaceManager } = useAppContext()
 
   const { data, isFetching: isGettingTools } = useMCPTools(detail.is_team_authorization ? detail.id : '')
+  const invalidateAllMCPTools = useInvalidateAllMCPTools()
+  const invalidateAllToolProviders = useInvalidateAllToolProviders()
   const invalidateMCPTools = useInvalidateMCPTools()
   const { mutateAsync: updateTools, isPending: isUpdating } = useUpdateMCPTools()
   const { mutateAsync: authorizeMcp, isPending: isAuthorizing } = useAuthorizeMCP()
@@ -67,9 +71,11 @@ const MCPDetailContent: FC<Props> = ({
     if (!detail)
       return
     await updateTools(detail.id)
+    invalidateAllMCPTools()
+    invalidateAllToolProviders()
     invalidateMCPTools(detail.id)
     onUpdate()
-  }, [detail, hideUpdateConfirm, invalidateMCPTools, onUpdate, updateTools])
+  }, [detail, hideUpdateConfirm, invalidateAllMCPTools, invalidateAllToolProviders, invalidateMCPTools, onUpdate, updateTools])
 
   const { mutateAsync: updateMCP } = useUpdateMCP({})
   const { mutateAsync: deleteMCP } = useDeleteMCP({})
@@ -129,10 +135,12 @@ const MCPDetailContent: FC<Props> = ({
     })
     if ((res as any)?.result === 'success') {
       hideUpdateModal()
+      invalidateAllMCPTools()
+      invalidateAllToolProviders()
       onUpdate()
       handleAuthorize()
     }
-  }, [detail, updateMCP, hideUpdateModal, onUpdate, handleAuthorize])
+  }, [detail, updateMCP, hideUpdateModal, invalidateAllMCPTools, invalidateAllToolProviders, onUpdate, handleAuthorize])
 
   const handleDelete = useCallback(async () => {
     if (!detail)
@@ -142,9 +150,11 @@ const MCPDetailContent: FC<Props> = ({
     hideDeleting()
     if ((res as any)?.result === 'success') {
       hideDeleteConfirm()
+      invalidateAllMCPTools()
+      invalidateAllToolProviders()
       onUpdate(true)
     }
-  }, [detail, showDeleting, deleteMCP, hideDeleting, hideDeleteConfirm, onUpdate])
+  }, [detail, showDeleting, deleteMCP, hideDeleting, hideDeleteConfirm, invalidateAllMCPTools, invalidateAllToolProviders, onUpdate])
 
   useEffect(() => {
     if (isTriggerAuthorize)


### PR DESCRIPTION
## Summary
This PR delivers a focused MCP-only refresh for #31372.

- invalidate MCP and tool-provider list queries after MCP create
- invalidate MCP and tool-provider list queries after MCP update/delete/update-tools actions
- add/update MCP tests to cover query invalidation behavior

## Files
- web/app/components/tools/mcp/create-card.tsx
- web/app/components/tools/mcp/detail/content.tsx
- web/app/components/tools/mcp/__tests__/create-card.spec.tsx
- web/app/components/tools/mcp/detail/__tests__/content.spec.tsx

## Validation
- ./node_modules/.bin/vp test run app/components/tools/mcp/__tests__/create-card.spec.tsx app/components/tools/mcp/detail/__tests__/content.spec.tsx
- ./node_modules/.bin/vp run lint:ci app/components/tools/mcp/create-card.tsx app/components/tools/mcp/detail/content.tsx app/components/tools/mcp/__tests__/create-card.spec.tsx app/components/tools/mcp/detail/__tests__/content.spec.tsx
- ./node_modules/.bin/vp run lint:tss
- ./node_modules/.bin/vp run type-check

fixes #31372
