### PR TITLE
refactor: migrate services layer to sessionmaker pattern

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -12,7 +12,6 @@ from sqlalchemy import delete, func, select, update
 from sqlalchemy.orm import Session, sessionmaker
 
 
-
 class InvitationData(TypedDict):
     account_id: str
     email: str

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -12,6 +12,7 @@ from sqlalchemy import delete, func, select, update
 from sqlalchemy.orm import Session, sessionmaker
 
 
+
 class InvitationData(TypedDict):
     account_id: str
     email: str

--- a/api/services/clear_free_plan_tenant_expired_logs.py
+++ b/api/services/clear_free_plan_tenant_expired_logs.py
@@ -120,7 +120,7 @@ class ClearFreePlanTenantExpiredLogs:
             apps = db.session.scalars(select(App).where(App.tenant_id == tenant_id)).all()
             app_ids = [app.id for app in apps]
             while True:
-                with Session(db.engine).no_autoflush as session:
+                with sessionmaker(db.engine, autoflush=False).begin() as session:
                     messages = (
                         session.query(Message)
                         .where(
@@ -152,7 +152,6 @@ class ClearFreePlanTenantExpiredLogs:
                     ).delete(synchronize_session=False)
 
                     cls._clear_message_related_tables(session, tenant_id, message_ids)
-                    session.commit()
 
                     click.echo(
                         click.style(
@@ -161,7 +160,7 @@ class ClearFreePlanTenantExpiredLogs:
                     )
 
             while True:
-                with Session(db.engine).no_autoflush as session:
+                with sessionmaker(db.engine, autoflush=False).begin() as session:
                     conversations = (
                         session.query(Conversation)
                         .where(
@@ -190,7 +189,6 @@ class ClearFreePlanTenantExpiredLogs:
                     session.query(Conversation).where(
                         Conversation.id.in_(conversation_ids),
                     ).delete(synchronize_session=False)
-                    session.commit()
 
                     click.echo(
                         click.style(
@@ -294,7 +292,7 @@ class ClearFreePlanTenantExpiredLogs:
                     break
 
             while True:
-                with Session(db.engine).no_autoflush as session:
+                with sessionmaker(db.engine, autoflush=False).begin() as session:
                     workflow_app_logs = (
                         session.query(WorkflowAppLog)
                         .where(
@@ -326,7 +324,6 @@ class ClearFreePlanTenantExpiredLogs:
                     session.query(WorkflowAppLog).where(WorkflowAppLog.id.in_(workflow_app_log_ids)).delete(
                         synchronize_session=False
                     )
-                    session.commit()
 
                     click.echo(
                         click.style(

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3017,7 +3017,7 @@ class DocumentService:
                         document = update_info["document"]
                         indexing_cache_key = f"document_{document.id}_indexing"
                         redis_client.setex(indexing_cache_key, 600, 1)
-                except Exception as e:
+                except Exception:
                     # Log the error but do not rollback the transaction
                     logger.exception("Error setting cache for document %s", update_info["document"].id)
             # Raise any propagation error after all updates

--- a/api/services/datasource_provider_service.py
+++ b/api/services/datasource_provider_service.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from graphon.model_runtime.entities.provider_entities import FormType
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from configs import dify_config
 from constants import HIDDEN_VALUE, UNKNOWN_VALUE
@@ -53,13 +53,12 @@ class DatasourceProviderService:
         """
         remove oauth custom client params
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             session.query(DatasourceOauthTenantParamConfig).filter_by(
                 tenant_id=tenant_id,
                 provider=datasource_provider_id.provider_name,
                 plugin_id=datasource_provider_id.plugin_id,
             ).delete()
-            session.commit()
 
     def decrypt_datasource_provider_credentials(
         self,
@@ -109,7 +108,7 @@ class DatasourceProviderService:
         """
         get credential by id
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             if credential_id:
                 datasource_provider = (
                     session.query(DatasourceProvider).filter_by(tenant_id=tenant_id, id=credential_id).first()
@@ -156,7 +155,6 @@ class DatasourceProviderService:
                     datasource_provider=datasource_provider,
                 )
                 datasource_provider.expires_at = refreshed_credentials.expires_at
-                session.commit()
 
             return self.decrypt_datasource_provider_credentials(
                 tenant_id=tenant_id,
@@ -174,7 +172,7 @@ class DatasourceProviderService:
         """
         get all datasource credentials by provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             datasource_providers = (
                 session.query(DatasourceProvider)
                 .filter_by(tenant_id=tenant_id, provider=provider, plugin_id=plugin_id)
@@ -224,7 +222,6 @@ class DatasourceProviderService:
                     provider=provider,
                 )
                 real_credentials_list.append(real_credentials)
-            session.commit()
 
             return real_credentials_list
 
@@ -234,7 +231,7 @@ class DatasourceProviderService:
         """
         update datasource provider name
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             target_provider = (
                 session.query(DatasourceProvider)
                 .filter_by(
@@ -266,7 +263,6 @@ class DatasourceProviderService:
                 raise ValueError("Authorization name is already exists")
 
             target_provider.name = name
-            session.commit()
         return
 
     def set_default_datasource_provider(
@@ -275,7 +271,7 @@ class DatasourceProviderService:
         """
         set default datasource provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             # get provider
             target_provider = (
                 session.query(DatasourceProvider)
@@ -300,7 +296,6 @@ class DatasourceProviderService:
 
             # set new default provider
             target_provider.is_default = True
-            session.commit()
         return {"result": "success"}
 
     def setup_oauth_custom_client_params(
@@ -315,7 +310,7 @@ class DatasourceProviderService:
         """
         if client_params is None and enabled is None:
             return
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             tenant_oauth_client_params = (
                 session.query(DatasourceOauthTenantParamConfig)
                 .filter_by(
@@ -349,13 +344,12 @@ class DatasourceProviderService:
 
             if enabled is not None:
                 tenant_oauth_client_params.enabled = enabled
-            session.commit()
 
     def is_system_oauth_params_exist(self, datasource_provider_id: DatasourceProviderID) -> bool:
         """
         check if system oauth params exist
         """
-        with Session(db.engine).no_autoflush as session:
+        with sessionmaker(db.engine, autoflush=False).begin() as session:
             return (
                 session.query(DatasourceOauthParamConfig)
                 .filter_by(provider=datasource_provider_id.provider_name, plugin_id=datasource_provider_id.plugin_id)
@@ -427,7 +421,7 @@ class DatasourceProviderService:
         """
         provider = datasource_provider_id.provider_name
         plugin_id = datasource_provider_id.plugin_id
-        with Session(db.engine).no_autoflush as session:
+        with sessionmaker(db.engine, autoflush=False).begin() as session:
             # get tenant oauth client params
             tenant_oauth_client_params = (
                 session.query(DatasourceOauthTenantParamConfig)
@@ -488,7 +482,7 @@ class DatasourceProviderService:
         """
         update datasource oauth provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             lock = f"datasource_provider_create_lock:{tenant_id}_{provider_id}_{CredentialType.OAUTH2.value}"
             with redis_client.lock(lock, timeout=20):
                 target_provider = (
@@ -535,7 +529,6 @@ class DatasourceProviderService:
                 target_provider.expires_at = expire_at
                 target_provider.encrypted_credentials = credentials
                 target_provider.avatar_url = avatar_url or target_provider.avatar_url
-                session.commit()
 
     def add_datasource_oauth_provider(
         self,
@@ -550,7 +543,7 @@ class DatasourceProviderService:
         add datasource oauth provider
         """
         credential_type = CredentialType.OAUTH2
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             lock = f"datasource_provider_create_lock:{tenant_id}_{provider_id}_{credential_type.value}"
             with redis_client.lock(lock, timeout=60):
                 db_provider_name = name
@@ -604,7 +597,6 @@ class DatasourceProviderService:
                     expires_at=expire_at,
                 )
                 session.add(datasource_provider)
-                session.commit()
 
     def add_datasource_api_key_provider(
         self,
@@ -623,7 +615,7 @@ class DatasourceProviderService:
         provider_name = provider_id.provider_name
         plugin_id = provider_id.plugin_id
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             lock = f"datasource_provider_create_lock:{tenant_id}_{provider_id}_{CredentialType.API_KEY}"
             with redis_client.lock(lock, timeout=20):
                 db_provider_name = name or self.generate_next_datasource_provider_name(
@@ -670,7 +662,6 @@ class DatasourceProviderService:
                     encrypted_credentials=credentials,
                 )
                 session.add(datasource_provider)
-                session.commit()
 
     def extract_secret_variables(self, tenant_id: str, provider_id: str, credential_type: CredentialType) -> list[str]:
         """
@@ -926,7 +917,7 @@ class DatasourceProviderService:
         update datasource credentials.
         """
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             datasource_provider = (
                 session.query(DatasourceProvider)
                 .filter_by(tenant_id=tenant_id, id=auth_id, provider=provider, plugin_id=plugin_id)
@@ -980,7 +971,6 @@ class DatasourceProviderService:
                         encrypted_credentials[key] = value
 
                 datasource_provider.encrypted_credentials = encrypted_credentials
-            session.commit()
 
     def remove_datasource_credentials(self, tenant_id: str, auth_id: str, provider: str, plugin_id: str) -> None:
         """

--- a/api/services/plugin/plugin_auto_upgrade_service.py
+++ b/api/services/plugin/plugin_auto_upgrade_service.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from extensions.ext_database import db
 from models.account import TenantPluginAutoUpgradeStrategy
@@ -7,7 +7,7 @@ from models.account import TenantPluginAutoUpgradeStrategy
 class PluginAutoUpgradeService:
     @staticmethod
     def get_strategy(tenant_id: str) -> TenantPluginAutoUpgradeStrategy | None:
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             return (
                 session.query(TenantPluginAutoUpgradeStrategy)
                 .where(TenantPluginAutoUpgradeStrategy.tenant_id == tenant_id)
@@ -23,7 +23,7 @@ class PluginAutoUpgradeService:
         exclude_plugins: list[str],
         include_plugins: list[str],
     ) -> bool:
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             exist_strategy = (
                 session.query(TenantPluginAutoUpgradeStrategy)
                 .where(TenantPluginAutoUpgradeStrategy.tenant_id == tenant_id)
@@ -46,12 +46,11 @@ class PluginAutoUpgradeService:
                 exist_strategy.exclude_plugins = exclude_plugins
                 exist_strategy.include_plugins = include_plugins
 
-            session.commit()
             return True
 
     @staticmethod
     def exclude_plugin(tenant_id: str, plugin_id: str) -> bool:
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             exist_strategy = (
                 session.query(TenantPluginAutoUpgradeStrategy)
                 .where(TenantPluginAutoUpgradeStrategy.tenant_id == tenant_id)
@@ -83,5 +82,4 @@ class PluginAutoUpgradeService:
                     exist_strategy.upgrade_mode = TenantPluginAutoUpgradeStrategy.UpgradeMode.EXCLUDE
                     exist_strategy.exclude_plugins = [plugin_id]
 
-                session.commit()
                 return True

--- a/api/services/plugin/plugin_migration.py
+++ b/api/services/plugin/plugin_migration.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 import tqdm
 from flask import Flask, current_app
 from pydantic import TypeAdapter
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from core.agent.entities import AgentToolEntity
 from core.helper import marketplace
@@ -65,7 +65,7 @@ class PluginMigration:
         started_at = datetime.datetime(2023, 4, 3, 8, 59, 24)
         current_time = started_at
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             total_tenant_count = session.query(Tenant.id).count()
 
         click.echo(click.style(f"Total tenant count: {total_tenant_count}", fg="white"))
@@ -109,7 +109,7 @@ class PluginMigration:
             # Initial interval of 1 day, will be dynamically adjusted based on tenant count
             interval = datetime.timedelta(days=1)
             # Process tenants in this batch
-            with Session(db.engine) as session:
+            with sessionmaker(db.engine).begin() as session:
                 # Calculate tenant count in next batch with current interval
                 # Try different intervals until we find one with a reasonable tenant count
                 test_intervals = [
@@ -218,7 +218,7 @@ class PluginMigration:
         """
         Extract model table.
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             rs = session.execute(
                 sa.text(f"SELECT DISTINCT {column} FROM {table} WHERE tenant_id = :tenant_id"), {"tenant_id": tenant_id}
             )
@@ -234,7 +234,7 @@ class PluginMigration:
         """
         Extract tool tables.
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             rs = session.query(BuiltinToolProvider).where(BuiltinToolProvider.tenant_id == tenant_id).all()
             result = []
             for row in rs:
@@ -248,7 +248,7 @@ class PluginMigration:
         Extract workflow tables, only ToolNode is required.
         """
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             rs = session.query(Workflow).where(Workflow.tenant_id == tenant_id).all()
             result = []
             for row in rs:
@@ -271,7 +271,7 @@ class PluginMigration:
         """
         Extract app tables.
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             apps = session.query(App).where(App.tenant_id == tenant_id).all()
             if not apps:
                 return []

--- a/api/services/plugin/plugin_migration.py
+++ b/api/services/plugin/plugin_migration.py
@@ -15,6 +15,7 @@ from flask import Flask, current_app
 from pydantic import TypeAdapter
 from sqlalchemy.orm import sessionmaker
 
+
 from core.agent.entities import AgentToolEntity
 from core.helper import marketplace
 from core.plugin.entities.plugin import PluginInstallationSource

--- a/api/services/plugin/plugin_migration.py
+++ b/api/services/plugin/plugin_migration.py
@@ -15,7 +15,6 @@ from flask import Flask, current_app
 from pydantic import TypeAdapter
 from sqlalchemy.orm import sessionmaker
 
-
 from core.agent.entities import AgentToolEntity
 from core.helper import marketplace
 from core.plugin.entities.plugin import PluginInstallationSource

--- a/api/services/plugin/plugin_parameter_service.py
+++ b/api/services/plugin/plugin_parameter_service.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from core.plugin.entities.parameters import PluginParameterOption
 from core.plugin.entities.plugin_daemon import CredentialType
@@ -55,7 +55,7 @@ class PluginParameterService:
                     credentials = {}
                 else:
                     # fetch credentials from db
-                    with Session(db.engine) as session:
+                    with sessionmaker(db.engine).begin() as session:
                         if credential_id:
                             db_record = session.scalar(
                                 select(BuiltinToolProvider)

--- a/api/services/plugin/plugin_permission_service.py
+++ b/api/services/plugin/plugin_permission_service.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from extensions.ext_database import db
 from models.account import TenantPluginPermission
@@ -7,7 +7,7 @@ from models.account import TenantPluginPermission
 class PluginPermissionService:
     @staticmethod
     def get_permission(tenant_id: str) -> TenantPluginPermission | None:
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             return session.query(TenantPluginPermission).where(TenantPluginPermission.tenant_id == tenant_id).first()
 
     @staticmethod
@@ -16,7 +16,7 @@ class PluginPermissionService:
         install_permission: TenantPluginPermission.InstallPermission,
         debug_permission: TenantPluginPermission.DebugPermission,
     ):
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             permission = (
                 session.query(TenantPluginPermission).where(TenantPluginPermission.tenant_id == tenant_id).first()
             )
@@ -30,5 +30,4 @@ class PluginPermissionService:
                 permission.install_permission = install_permission
                 permission.debug_permission = debug_permission
 
-            session.commit()
             return True

--- a/api/services/plugin/plugin_service.py
+++ b/api/services/plugin/plugin_service.py
@@ -4,7 +4,7 @@ from mimetypes import guess_type
 
 from pydantic import BaseModel
 from sqlalchemy import delete, select, update
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 from yarl import URL
 
 from configs import dify_config
@@ -530,7 +530,7 @@ class PluginService:
                     plugin_unique_identifier=plugin.plugin_unique_identifier,
                 )
             )
-        with Session(db.engine) as session, session.begin():
+        with sessionmaker(db.engine).begin() as session:
             plugin_id = plugin.plugin_id
             logger.info("Deleting credentials for plugin: %s", plugin_id)
 

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import exists, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from configs import dify_config
 from constants import HIDDEN_VALUE, UNKNOWN_VALUE
@@ -46,13 +46,12 @@ class BuiltinToolManageService:
         delete custom oauth client params
         """
         tool_provider = ToolProviderID(provider)
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             session.query(ToolOAuthTenantClient).filter_by(
                 tenant_id=tenant_id,
                 provider=tool_provider.provider_name,
                 plugin_id=tool_provider.plugin_id,
             ).delete()
-            session.commit()
         return {"result": "success"}
 
     @staticmethod
@@ -150,7 +149,7 @@ class BuiltinToolManageService:
         """
         update builtin tool provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             # get if the provider exists
             db_provider = (
                 session.query(BuiltinToolProvider)
@@ -202,10 +201,7 @@ class BuiltinToolManageService:
                         raise ValueError(f"the credential name '{name}' is already used")
 
                     db_provider.name = name
-
-                session.commit()
             except Exception as e:
-                session.rollback()
                 raise ValueError(str(e))
         return {"result": "success"}
 
@@ -222,7 +218,7 @@ class BuiltinToolManageService:
         """
         add builtin tool provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             try:
                 lock = f"builtin_tool_provider_create_lock:{tenant_id}_{provider}"
                 with redis_client.lock(lock, timeout=20):
@@ -281,9 +277,7 @@ class BuiltinToolManageService:
                     )
 
                     session.add(db_provider)
-                    session.commit()
             except Exception as e:
-                session.rollback()
                 raise ValueError(str(e))
 
         return {"result": "success"}
@@ -379,7 +373,7 @@ class BuiltinToolManageService:
         """
         delete tool provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             db_provider = (
                 session.query(BuiltinToolProvider)
                 .where(
@@ -393,7 +387,6 @@ class BuiltinToolManageService:
                 raise ValueError(f"you have not added provider {provider}")
 
             session.delete(db_provider)
-            session.commit()
 
             # delete cache
             provider_controller = ToolManager.get_builtin_provider(provider, tenant_id)
@@ -409,7 +402,7 @@ class BuiltinToolManageService:
         """
         set default provider
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             # get provider
             target_provider = session.query(BuiltinToolProvider).filter_by(id=id, tenant_id=tenant_id).first()
             if target_provider is None:
@@ -422,7 +415,6 @@ class BuiltinToolManageService:
 
             # set new default provider
             target_provider.is_default = True
-            session.commit()
 
         return {"result": "success"}
 
@@ -432,7 +424,7 @@ class BuiltinToolManageService:
         check if oauth system client exists
         """
         tool_provider = ToolProviderID(provider_name)
-        with Session(db.engine, autoflush=False) as session:
+        with sessionmaker(db.engine, autoflush=False).begin() as session:
             system_client: ToolOAuthSystemClient | None = (
                 session.query(ToolOAuthSystemClient)
                 .filter_by(plugin_id=tool_provider.plugin_id, provider=tool_provider.provider_name)
@@ -446,7 +438,7 @@ class BuiltinToolManageService:
         check if oauth custom client is enabled
         """
         tool_provider = ToolProviderID(provider)
-        with Session(db.engine, autoflush=False) as session:
+        with sessionmaker(db.engine, autoflush=False).begin() as session:
             user_client: ToolOAuthTenantClient | None = (
                 session.query(ToolOAuthTenantClient)
                 .filter_by(
@@ -471,7 +463,7 @@ class BuiltinToolManageService:
             config=[x.to_basic_provider_config() for x in provider_controller.get_oauth_client_schema()],
             cache=NoOpProviderCredentialCache(),
         )
-        with Session(db.engine, autoflush=False) as session:
+        with sessionmaker(db.engine, autoflush=False).begin() as session:
             user_client: ToolOAuthTenantClient | None = (
                 session.query(ToolOAuthTenantClient)
                 .filter_by(
@@ -582,7 +574,7 @@ class BuiltinToolManageService:
         1.if the default provider exists, return the default provider
         2.if the default provider does not exist, return the oldest provider
         """
-        with Session(db.engine, autoflush=False) as session:
+        with sessionmaker(db.engine, autoflush=False).begin() as session:
             try:
                 full_provider_name = provider_name
                 provider_id_entity = ToolProviderID(provider_name)
@@ -654,7 +646,7 @@ class BuiltinToolManageService:
         if not isinstance(provider_controller, (BuiltinToolProviderController, PluginToolProviderController)):
             raise ValueError(f"Provider {provider} is not a builtin or plugin provider")
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             custom_client_params = (
                 session.query(ToolOAuthTenantClient)
                 .filter_by(
@@ -690,7 +682,6 @@ class BuiltinToolManageService:
             if enable_oauth_custom_client is not None:
                 custom_client_params.enabled = enable_oauth_custom_client
 
-            session.commit()
         return {"result": "success"}
 
     @staticmethod
@@ -698,7 +689,7 @@ class BuiltinToolManageService:
         """
         get custom oauth client params
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             tool_provider = ToolProviderID(provider)
             custom_oauth_client_params: ToolOAuthTenantClient | None = (
                 session.query(ToolOAuthTenantClient)

--- a/api/services/trigger/app_trigger_service.py
+++ b/api/services/trigger/app_trigger_service.py
@@ -8,7 +8,7 @@ This service centralizes all AppTrigger-related business logic.
 import logging
 
 from sqlalchemy import update
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from extensions.ext_database import db
 from models.enums import AppTriggerStatus
@@ -34,13 +34,12 @@ class AppTriggerService:
 
         """
         try:
-            with Session(db.engine) as session:
+            with sessionmaker(db.engine).begin() as session:
                 session.execute(
                     update(AppTrigger)
                     .where(AppTrigger.tenant_id == tenant_id, AppTrigger.status == AppTriggerStatus.ENABLED)
                     .values(status=AppTriggerStatus.RATE_LIMITED)
                 )
-                session.commit()
                 logger.info("Marked all enabled triggers as rate limited for tenant %s", tenant_id)
         except Exception:
             logger.exception("Failed to mark all enabled triggers as rate limited for tenant %s", tenant_id)

--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -678,7 +678,6 @@ class TriggerProviderService:
             if enabled is not None:
                 custom_client.enabled = enabled
 
-
         return {"result": "success"}
 
     @classmethod

--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from sqlalchemy import desc, func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from configs import dify_config
 from constants import HIDDEN_VALUE, UNKNOWN_VALUE
@@ -67,7 +67,7 @@ class TriggerProviderService:
         """List all trigger subscriptions for the current tenant"""
         subscriptions: list[TriggerProviderSubscriptionApiEntity] = []
         workflows_in_use_map: dict[str, int] = {}
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             # Get all subscriptions
             subscriptions_db = (
                 session.query(TriggerSubscription)
@@ -146,7 +146,7 @@ class TriggerProviderService:
         """
         try:
             provider_controller = TriggerManager.get_trigger_provider(tenant_id, provider_id)
-            with Session(db.engine, expire_on_commit=False) as session:
+            with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
                 # Use distributed lock to prevent race conditions
                 lock_key = f"trigger_provider_create_lock:{tenant_id}_{provider_id}"
                 with redis_client.lock(lock_key, timeout=20):
@@ -205,7 +205,6 @@ class TriggerProviderService:
                     subscription.id = subscription_id or str(uuid.uuid4())
 
                     session.add(subscription)
-                    session.commit()
 
                     return {
                         "result": "success",
@@ -241,7 +240,7 @@ class TriggerProviderService:
         :param expires_at: Optional new expiration timestamp
         :return: Success response with updated subscription info
         """
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             # Use distributed lock to prevent race conditions on the same subscription
             lock_key = f"trigger_subscription_update_lock:{tenant_id}_{subscription_id}"
             with redis_client.lock(lock_key, timeout=20):
@@ -302,8 +301,6 @@ class TriggerProviderService:
                 if expires_at is not None:
                     subscription.expires_at = expires_at
 
-                session.commit()
-
                 # Clear subscription cache
                 delete_cache_for_subscription(
                     tenant_id=tenant_id,
@@ -316,7 +313,7 @@ class TriggerProviderService:
         """
         Get a trigger subscription by the ID.
         """
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             subscription: TriggerSubscription | None = None
             if subscription_id:
                 subscription = (
@@ -404,7 +401,7 @@ class TriggerProviderService:
         :param subscription_id: Subscription instance ID
         :return: New token info
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             subscription = session.query(TriggerSubscription).filter_by(tenant_id=tenant_id, id=subscription_id).first()
 
             if not subscription:
@@ -448,7 +445,6 @@ class TriggerProviderService:
             # Update credentials
             subscription.credentials = dict(encrypter.encrypt(dict(refreshed_credentials.credentials)))
             subscription.credential_expires_at = refreshed_credentials.expires_at
-            session.commit()
 
             # Clear cache
             cache.delete()
@@ -478,7 +474,7 @@ class TriggerProviderService:
         """
         now_ts: int = int(now if now is not None else _time.time())
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             subscription: TriggerSubscription | None = (
                 session.query(TriggerSubscription).filter_by(tenant_id=tenant_id, id=subscription_id).first()
             )
@@ -531,7 +527,6 @@ class TriggerProviderService:
             # Persist refreshed properties and expires_at
             subscription.properties = dict(properties_encrypter.encrypt(dict(refreshed.properties)))
             subscription.expires_at = int(refreshed.expires_at)
-            session.commit()
             properties_cache.delete()
 
             logger.info(
@@ -556,7 +551,7 @@ class TriggerProviderService:
         provider_controller: PluginTriggerProviderController = TriggerManager.get_trigger_provider(
             tenant_id=tenant_id, provider_id=provider_id
         )
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             tenant_client: TriggerOAuthTenantClient | None = (
                 session.query(TriggerOAuthTenantClient)
                 .filter_by(
@@ -606,7 +601,7 @@ class TriggerProviderService:
         is_verified = PluginService.is_plugin_verified(tenant_id, provider_controller.plugin_unique_identifier)
         if not is_verified:
             return False
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             system_client: TriggerOAuthSystemClient | None = (
                 session.query(TriggerOAuthSystemClient)
                 .filter_by(plugin_id=provider_id.plugin_id, provider=provider_id.provider_name)
@@ -639,7 +634,7 @@ class TriggerProviderService:
             tenant_id=tenant_id, provider_id=provider_id
         )
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             # Find existing custom client params
             custom_client = (
                 session.query(TriggerOAuthTenantClient)
@@ -683,7 +678,6 @@ class TriggerProviderService:
             if enabled is not None:
                 custom_client.enabled = enabled
 
-            session.commit()
 
         return {"result": "success"}
 
@@ -696,7 +690,7 @@ class TriggerProviderService:
         :param provider_id: Provider identifier
         :return: Masked OAuth client parameters
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             custom_client = (
                 session.query(TriggerOAuthTenantClient)
                 .filter_by(
@@ -733,13 +727,12 @@ class TriggerProviderService:
         :param provider_id: Provider identifier
         :return: Success response
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             session.query(TriggerOAuthTenantClient).filter_by(
                 tenant_id=tenant_id,
                 provider=provider_id.provider_name,
                 plugin_id=provider_id.plugin_id,
             ).delete()
-            session.commit()
 
         return {"result": "success"}
 
@@ -752,7 +745,7 @@ class TriggerProviderService:
         :param provider_id: Provider identifier
         :return: True if enabled, False otherwise
         """
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             custom_client = (
                 session.query(TriggerOAuthTenantClient)
                 .filter_by(
@@ -770,7 +763,7 @@ class TriggerProviderService:
         """
         Get a trigger subscription by the endpoint ID.
         """
-        with Session(db.engine, expire_on_commit=False) as session:
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             subscription = session.query(TriggerSubscription).filter_by(endpoint_id=endpoint_id).first()
             if not subscription:
                 return None

--- a/api/services/trigger/trigger_service.py
+++ b/api/services/trigger/trigger_service.py
@@ -8,7 +8,7 @@ from flask import Request, Response
 from graphon.entities.graph_config import NodeConfigDict
 from pydantic import BaseModel
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.entities.request import TriggerDispatchResponse, TriggerInvokeEventResponse
@@ -215,7 +215,7 @@ class TriggerService:
                 not_found_in_cache.append(node_info)
                 continue
 
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             try:
                 # lock the concurrent plugin trigger creation
                 redis_client.lock(f"{cls.__PLUGIN_TRIGGER_NODE_CACHE_KEY__}:apps:{app.id}:lock", timeout=10)
@@ -260,7 +260,6 @@ class TriggerService:
                         cache.model_dump_json(),
                         ex=60 * 60,
                     )
-                session.commit()
 
                 # Update existing records if subscription_id changed
                 for node_info in nodes_in_graph:
@@ -290,14 +289,12 @@ class TriggerService:
                                 cache.model_dump_json(),
                                 ex=60 * 60,
                             )
-                session.commit()
 
                 # delete the nodes not found in the graph
                 for node_id in nodes_id_in_db:
                     if node_id not in nodes_id_in_graph:
                         session.delete(nodes_id_in_db[node_id])
                         redis_client.delete(f"{cls.__PLUGIN_TRIGGER_NODE_CACHE_KEY__}:{app.id}:{node_id}")
-                session.commit()
             except Exception:
                 logger.exception("Failed to sync plugin trigger relationships for app %s", app.id)
                 raise

--- a/api/services/trigger/webhook_service.py
+++ b/api/services/trigger/webhook_service.py
@@ -12,7 +12,7 @@ from graphon.file import FileTransferMethod
 from graphon.variables.types import ArrayValidation, SegmentType
 from pydantic import BaseModel
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import RequestEntityTooLarge
 
@@ -102,7 +102,7 @@ class WebhookService:
         Raises:
             ValueError: If webhook not found, app trigger not found, trigger disabled, or workflow not found
         """
-        with Session(db.engine) as session:
+        with sessionmaker(db.engine).begin() as session:
             # Get webhook trigger
             webhook_trigger = (
                 session.query(WorkflowWebhookTrigger).where(WorkflowWebhookTrigger.webhook_id == webhook_id).first()
@@ -781,7 +781,7 @@ class WebhookService:
             Exception: If workflow execution fails
         """
         try:
-            with Session(db.engine) as session:
+            with sessionmaker(db.engine).begin() as session:
                 # Prepare inputs for the webhook node
                 # The webhook node expects webhook_data in the inputs
                 workflow_inputs = cls.build_workflow_inputs(webhook_data)
@@ -912,7 +912,7 @@ class WebhookService:
                 logger.warning("Failed to acquire lock for webhook sync, app %s", app.id)
                 raise RuntimeError("Failed to acquire lock for webhook trigger synchronization")
 
-            with Session(db.engine) as session:
+            with sessionmaker(db.engine).begin() as session:
                 # fetch the non-cached nodes from DB
                 all_records = session.scalars(
                     select(WorkflowWebhookTrigger).where(
@@ -941,14 +941,12 @@ class WebhookService:
                     redis_client.set(
                         f"{cls.__WEBHOOK_NODE_CACHE_KEY__}:{app.id}:{node_id}", cache.model_dump_json(), ex=60 * 60
                     )
-                session.commit()
 
                 # delete the nodes not found in the graph
                 for node_id in nodes_id_in_db:
                     if node_id not in nodes_id_in_graph:
                         session.delete(nodes_id_in_db[node_id])
                         redis_client.delete(f"{cls.__WEBHOOK_NODE_CACHE_KEY__}:{app.id}:{node_id}")
-                session.commit()
         except Exception:
             logger.exception("Failed to sync webhook relationships for app %s", app.id)
             raise

--- a/api/tests/unit_tests/services/test_datasource_provider_service.py
+++ b/api/tests/unit_tests/services/test_datasource_provider_service.py
@@ -39,8 +39,13 @@ class TestDatasourceProviderService:
         Robust, chainable query mock.
         q returns itself for .filter_by(), .order_by(), .where() so any
         SQLAlchemy chaining pattern works without multiple brittle sub-mocks.
+
+        Patches ``sessionmaker`` so that
+        ``sessionmaker(db.engine).begin().__enter__()`` and
+        ``sessionmaker(db.engine, autoflush=False).begin().__enter__()``
+        both return this same mock session.
         """
-        with patch("services.datasource_provider_service.Session") as mock_cls:
+        with patch("services.datasource_provider_service.sessionmaker") as mock_sm:
             sess = MagicMock(spec=Session)
 
             q = MagicMock()
@@ -61,8 +66,9 @@ class TestDatasourceProviderService:
             sess.scalar.return_value = None
             sess.scalars.return_value.all.return_value = []
 
-            mock_cls.return_value.__enter__.return_value = sess
-            mock_cls.return_value.no_autoflush.__enter__.return_value = sess
+            # sessionmaker(db.engine).begin().__enter__() -> sess
+            mock_sm.return_value.begin.return_value.__enter__ = MagicMock(return_value=sess)
+            mock_sm.return_value.begin.return_value.__exit__ = MagicMock(return_value=False)
 
             yield sess
 
@@ -266,7 +272,6 @@ class TestDatasourceProviderService:
             patch.object(service, "decrypt_datasource_provider_credentials", return_value={"tok": "plain"}),
         ):
             service.get_datasource_credentials("t1", "prov", "org/plug")
-        mock_db_session.commit.assert_called_once()
 
     def test_should_return_decrypted_credentials_when_api_key_not_expired(self, service, mock_db_session, mock_user):
         """API key credentials with expires_at=-1 skip refresh and return directly."""
@@ -333,7 +338,6 @@ class TestDatasourceProviderService:
         p.name = "same"
         mock_db_session.query().first.return_value = p
         service.update_datasource_provider_name("t1", make_id(), "same", "cred-id")
-        mock_db_session.commit.assert_not_called()
 
     def test_should_raise_value_error_when_name_already_exists(self, service, mock_db_session):
         p = MagicMock(spec=DatasourceProvider)
@@ -352,7 +356,6 @@ class TestDatasourceProviderService:
         mock_db_session.query().count.return_value = 0
         service.update_datasource_provider_name("t1", make_id(), "new_name", "some-id")
         assert p.name == "new_name"
-        mock_db_session.commit.assert_called_once()
 
     # -----------------------------------------------------------------------
     # set_default_datasource_provider (lines 277-303)
@@ -370,7 +373,6 @@ class TestDatasourceProviderService:
         mock_db_session.query().first.return_value = target
         service.set_default_datasource_provider("t1", make_id(), "new-id")
         assert target.is_default is True
-        mock_db_session.commit.assert_called_once()
 
     # -----------------------------------------------------------------------
     # get_oauth_encrypter (lines 404-420)
@@ -460,7 +462,6 @@ class TestDatasourceProviderService:
         with patch.object(service, "extract_secret_variables", return_value=[]):
             service.add_datasource_oauth_provider("new", "t1", make_id(), "http://cb", 9999, {})
         mock_db_session.add.assert_called_once()
-        mock_db_session.commit.assert_called_once()
 
     def test_should_auto_rename_when_oauth_provider_name_conflicts(self, service, mock_db_session):
         """Conflict on name results in auto-incremented name, not an error."""
@@ -512,7 +513,6 @@ class TestDatasourceProviderService:
         mock_db_session.query().count.return_value = 0
         with patch.object(service, "extract_secret_variables", return_value=[]):
             service.reauthorize_datasource_oauth_provider("n", "t1", make_id(), "u", 1, {}, "oid")
-        mock_db_session.commit.assert_called_once()
 
     def test_should_auto_rename_when_reauth_name_conflicts(self, service, mock_db_session):
         p = MagicMock(spec=DatasourceProvider)
@@ -523,7 +523,6 @@ class TestDatasourceProviderService:
             service.reauthorize_datasource_oauth_provider(
                 "conflict_name", "t1", make_id(), "u", 9999, {"tok": "v"}, "cred-id"
             )
-        mock_db_session.commit.assert_called_once()
 
     def test_should_encrypt_secret_fields_when_reauthorizing(self, service, mock_db_session):
         p = MagicMock(spec=DatasourceProvider)
@@ -571,7 +570,6 @@ class TestDatasourceProviderService:
         ):
             service.add_datasource_api_key_provider(None, "t1", make_id(), {"sk": "v"})
         mock_db_session.add.assert_called_once()
-        mock_db_session.commit.assert_called_once()
 
     def test_should_acquire_redis_lock_when_adding_api_key_provider(self, service, mock_db_session, mock_user):
         mock_db_session.query().count.return_value = 0
@@ -746,8 +744,6 @@ class TestDatasourceProviderService:
             service.update_datasource_credentials("t1", "id", "prov", "org/plug", {"sk": "new_val"}, "name")
         # encrypter must have been called with the new secret value
         self._enc.encrypt_token.assert_called()
-        # commit must be called exactly once
-        mock_db_session.commit.assert_called_once()
 
     # -----------------------------------------------------------------------
     # remove_datasource_credentials (lines 980-997)

--- a/api/tests/unit_tests/services/test_trigger_provider_service.py
+++ b/api/tests/unit_tests/services/test_trigger_provider_service.py
@@ -229,7 +229,6 @@ def test_add_trigger_subscription_should_create_subscription_successfully_for_ap
     mock_session.add.assert_called_once()
 
 
-
 def test_add_trigger_subscription_should_store_empty_credentials_for_unauthorized_type(
     mocker: MockerFixture,
     mock_session: MagicMock,
@@ -855,7 +854,6 @@ def test_save_custom_oauth_client_params_should_create_record_and_clear_params_w
     mock_session.add.assert_called_once_with(fake_model)
 
 
-
 def test_save_custom_oauth_client_params_should_merge_hidden_values_and_delete_cache(
     mocker: MockerFixture,
     mock_session: MagicMock,
@@ -885,7 +883,6 @@ def test_save_custom_oauth_client_params_should_merge_hidden_values_and_delete_c
     assert result == {"result": "success"}
     assert json.loads(custom_client.encrypted_oauth_params) == {"client_id": "new-id"}
     cache.delete.assert_called_once()
-
 
 
 def test_get_custom_oauth_client_params_should_return_empty_when_record_missing(
@@ -936,7 +933,6 @@ def test_delete_custom_oauth_client_params_should_delete_record_and_commit(
 
     # Assert
     assert result == {"result": "success"}
-
 
 
 @pytest.mark.parametrize("exists", [True, False])

--- a/api/tests/unit_tests/services/test_trigger_provider_service.py
+++ b/api/tests/unit_tests/services/test_trigger_provider_service.py
@@ -56,13 +56,28 @@ def mock_db_engine(mocker: MockerFixture) -> SimpleNamespace:
 
 @pytest.fixture
 def mock_session(mocker: MockerFixture) -> MagicMock:
-    """Mocks the database session context manager used by TriggerProviderService."""
+    """Mocks the database session context manager used by TriggerProviderService.
+
+    The production code uses ``sessionmaker(db.engine, ...).begin()`` as a
+    context manager.  We patch ``sessionmaker`` so that calling it returns a
+    factory whose ``.begin()`` yields our mock session.
+    """
     # Arrange
     mock_session_instance = MagicMock()
-    mock_session_cm = MagicMock()
-    mock_session_cm.__enter__.return_value = mock_session_instance
-    mock_session_cm.__exit__.return_value = False
-    mocker.patch("services.trigger.trigger_provider_service.Session", return_value=mock_session_cm)
+
+    # .begin() returns a context-manager that yields the session
+    mock_begin_cm = MagicMock()
+    mock_begin_cm.__enter__ = MagicMock(return_value=mock_session_instance)
+    mock_begin_cm.__exit__ = MagicMock(return_value=False)
+
+    # sessionmaker(...) returns a factory; factory.begin() returns the cm
+    mock_factory = MagicMock()
+    mock_factory.begin.return_value = mock_begin_cm
+
+    mocker.patch(
+        "services.trigger.trigger_provider_service.sessionmaker",
+        return_value=mock_factory,
+    )
     return mock_session_instance
 
 
@@ -212,7 +227,7 @@ def test_add_trigger_subscription_should_create_subscription_successfully_for_ap
     # Assert
     assert result["result"] == "success"
     mock_session.add.assert_called_once()
-    mock_session.commit.assert_called_once()
+
 
 
 def test_add_trigger_subscription_should_store_empty_credentials_for_unauthorized_type(
@@ -406,7 +421,7 @@ def test_update_trigger_subscription_should_update_fields_and_clear_cache(
     assert subscription.credentials == {"api_key": "new-key"}
     assert subscription.credential_expires_at == 100
     assert subscription.expires_at == 200
-    mock_session.commit.assert_called_once()
+
     mock_delete_cache.assert_called_once()
 
 
@@ -593,7 +608,7 @@ def test_refresh_oauth_token_should_refresh_and_persist_new_credentials(
     assert result == {"result": "success", "expires_at": 12345}
     assert subscription.credentials == {"access_token": "new"}
     assert subscription.credential_expires_at == 12345
-    mock_session.commit.assert_called_once()
+
     cache.delete.assert_called_once()
 
 
@@ -664,7 +679,7 @@ def test_refresh_subscription_should_refresh_and_persist_properties(
     assert result == {"result": "success", "expires_at": 999}
     assert subscription.properties == {"p": "new-enc"}
     assert subscription.expires_at == 999
-    mock_session.commit.assert_called_once()
+
     prop_cache.delete.assert_called_once()
 
 
@@ -838,7 +853,7 @@ def test_save_custom_oauth_client_params_should_create_record_and_clear_params_w
     assert fake_model.encrypted_oauth_params == "{}"
     assert fake_model.enabled is True
     mock_session.add.assert_called_once_with(fake_model)
-    mock_session.commit.assert_called_once()
+
 
 
 def test_save_custom_oauth_client_params_should_merge_hidden_values_and_delete_cache(
@@ -870,7 +885,7 @@ def test_save_custom_oauth_client_params_should_merge_hidden_values_and_delete_c
     assert result == {"result": "success"}
     assert json.loads(custom_client.encrypted_oauth_params) == {"client_id": "new-id"}
     cache.delete.assert_called_once()
-    mock_session.commit.assert_called_once()
+
 
 
 def test_get_custom_oauth_client_params_should_return_empty_when_record_missing(
@@ -921,7 +936,7 @@ def test_delete_custom_oauth_client_params_should_delete_record_and_commit(
 
     # Assert
     assert result == {"result": "success"}
-    mock_session.commit.assert_called_once()
+
 
 
 @pytest.mark.parametrize("exists", [True, False])

--- a/api/tests/unit_tests/services/tools/test_builtin_tools_manage_service.py
+++ b/api/tests/unit_tests/services/tools/test_builtin_tools_manage_service.py
@@ -7,25 +7,24 @@ from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 MODULE = "services.tools.builtin_tools_manage_service"
 
 
-def _mock_session(mock_session_cls):
-    """Helper: set up a Session context manager mock and return the inner session."""
+def _mock_sessionmaker(mock_sessionmaker_cls):
+    """Helper: set up a sessionmaker().begin() context manager mock and return the inner session."""
     session = MagicMock()
-    mock_session_cls.return_value.__enter__ = MagicMock(return_value=session)
-    mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+    mock_sessionmaker_cls.return_value.begin.return_value.__enter__ = MagicMock(return_value=session)
+    mock_sessionmaker_cls.return_value.begin.return_value.__exit__ = MagicMock(return_value=False)
     return session
 
 
 class TestDeleteCustomOauthClientParams:
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_deletes_and_returns_success(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_deletes_and_returns_success(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
 
         result = BuiltinToolManageService.delete_custom_oauth_client_params("tenant-1", "google")
 
         assert result == {"result": "success"}
         session.query.return_value.filter_by.return_value.delete.assert_called_once()
-        session.commit.assert_called_once()
 
 
 class TestListBuiltinToolProviderTools:
@@ -100,36 +99,36 @@ class TestGetBuiltinToolProviderIcon:
 
 
 class TestIsOauthSystemClientExists:
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_true_when_exists(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_true_when_exists(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
 
         assert BuiltinToolManageService.is_oauth_system_client_exists("google") is True
 
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_false_when_missing(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_false_when_missing(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.filter_by.return_value.first.return_value = None
 
         assert BuiltinToolManageService.is_oauth_system_client_exists("google") is False
 
 
 class TestIsOauthCustomClientEnabled:
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_true_when_enabled(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_true_when_enabled(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.filter_by.return_value.first.return_value = MagicMock(enabled=True)
 
         assert BuiltinToolManageService.is_oauth_custom_client_enabled("t", "g") is True
 
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_false_when_none(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_false_when_none(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.filter_by.return_value.first.return_value = None
 
         assert BuiltinToolManageService.is_oauth_custom_client_enabled("t", "g") is False
@@ -138,10 +137,10 @@ class TestIsOauthCustomClientEnabled:
 class TestDeleteBuiltinToolProvider:
     @patch(f"{MODULE}.BuiltinToolManageService.create_tool_encrypter")
     @patch(f"{MODULE}.ToolManager")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_raises_when_not_found(self, mock_db, mock_session_cls, mock_tm, mock_enc):
-        session = _mock_session(mock_session_cls)
+    def test_raises_when_not_found(self, mock_db, mock_sessionmaker_cls, mock_tm, mock_enc):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.where.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="you have not added provider"):
@@ -149,10 +148,10 @@ class TestDeleteBuiltinToolProvider:
 
     @patch(f"{MODULE}.BuiltinToolManageService.create_tool_encrypter")
     @patch(f"{MODULE}.ToolManager")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_deletes_provider_and_clears_cache(self, mock_db, mock_session_cls, mock_tm, mock_enc):
-        session = _mock_session(mock_session_cls)
+    def test_deletes_provider_and_clears_cache(self, mock_db, mock_sessionmaker_cls, mock_tm, mock_enc):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         db_provider = MagicMock()
         session.query.return_value.where.return_value.first.return_value = db_provider
         mock_cache = MagicMock()
@@ -162,24 +161,23 @@ class TestDeleteBuiltinToolProvider:
 
         assert result == {"result": "success"}
         session.delete.assert_called_once_with(db_provider)
-        session.commit.assert_called_once()
         mock_cache.delete.assert_called_once()
 
 
 class TestSetDefaultProvider:
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_raises_when_not_found(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_raises_when_not_found(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.filter_by.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="provider not found"):
             BuiltinToolManageService.set_default_provider("t", "u", "p", "id")
 
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_sets_default_and_clears_old(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_sets_default_and_clears_old(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         target = MagicMock()
         session.query.return_value.filter_by.return_value.first.return_value = target
 
@@ -187,14 +185,13 @@ class TestSetDefaultProvider:
 
         assert result == {"result": "success"}
         assert target.is_default is True
-        session.commit.assert_called_once()
 
 
 class TestUpdateBuiltinToolProvider:
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_raises_when_provider_not_exists(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_raises_when_provider_not_exists(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.where.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="you have not added provider"):
@@ -203,10 +200,10 @@ class TestUpdateBuiltinToolProvider:
     @patch(f"{MODULE}.BuiltinToolManageService.create_tool_encrypter")
     @patch(f"{MODULE}.CredentialType")
     @patch(f"{MODULE}.ToolManager")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_updates_credentials_and_commits(self, mock_db, mock_session_cls, mock_tm, mock_cred_type, mock_enc):
-        session = _mock_session(mock_session_cls)
+    def test_updates_credentials_and_commits(self, mock_db, mock_sessionmaker_cls, mock_tm, mock_cred_type, mock_enc):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         db_provider = MagicMock(credential_type="api_key", credentials="{}")
         session.query.return_value.where.return_value.first.return_value = db_provider
 
@@ -227,7 +224,6 @@ class TestUpdateBuiltinToolProvider:
         result = BuiltinToolManageService.update_builtin_tool_provider("u", "t", "p", "c", credentials={"key": "val"})
 
         assert result == {"result": "success"}
-        session.commit.assert_called_once()
         mock_cache.delete.assert_called_once()
 
 
@@ -255,12 +251,12 @@ class TestGetOauthClient:
     @patch(f"{MODULE}.PluginService")
     @patch(f"{MODULE}.create_provider_encrypter")
     @patch(f"{MODULE}.ToolManager")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
     def test_returns_user_client_params_when_exists(
-        self, mock_db, mock_session_cls, mock_tm, mock_create_enc, mock_plugin
+        self, mock_db, mock_sessionmaker_cls, mock_tm, mock_create_enc, mock_plugin
     ):
-        session = _mock_session(mock_session_cls)
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         mock_controller = MagicMock()
         mock_controller.get_oauth_client_schema.return_value = []
         mock_tm.get_builtin_provider.return_value = mock_controller
@@ -280,12 +276,12 @@ class TestGetOauthClient:
     @patch(f"{MODULE}.PluginService")
     @patch(f"{MODULE}.create_provider_encrypter")
     @patch(f"{MODULE}.ToolManager")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
     def test_falls_back_to_system_client(
-        self, mock_db, mock_session_cls, mock_tm, mock_create_enc, mock_plugin, mock_decrypt
+        self, mock_db, mock_sessionmaker_cls, mock_tm, mock_create_enc, mock_plugin, mock_decrypt
     ):
-        session = _mock_session(mock_session_cls)
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         mock_controller = MagicMock()
         mock_controller.get_oauth_client_schema.return_value = []
         mock_tm.get_builtin_provider.return_value = mock_controller
@@ -317,10 +313,10 @@ class TestSaveCustomOauthClientParams:
 
 
 class TestGetCustomOauthClientParams:
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_returns_empty_when_none(self, mock_db, mock_session_cls):
-        session = _mock_session(mock_session_cls)
+    def test_returns_empty_when_none(self, mock_db, mock_sessionmaker_cls):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         session.query.return_value.filter_by.return_value.first.return_value = None
 
         result = BuiltinToolManageService.get_custom_oauth_client_params("t", "p")
@@ -381,10 +377,10 @@ class TestGetBuiltinToolProviderCredentials:
 
 class TestGetBuiltinProvider:
     @patch(f"{MODULE}.ToolProviderID")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_returns_none_when_not_found(self, mock_db, mock_session_cls, mock_prov_id):
-        session = _mock_session(mock_session_cls)
+    def test_returns_none_when_not_found(self, mock_db, mock_sessionmaker_cls, mock_prov_id):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         mock_prov_id.return_value.provider_name = "google"
         mock_prov_id.return_value.organization = "langgenius"
         session.query.return_value.where.return_value.order_by.return_value.first.return_value = None
@@ -394,10 +390,10 @@ class TestGetBuiltinProvider:
         assert result is None
 
     @patch(f"{MODULE}.ToolProviderID")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_returns_provider_for_langgenius_org(self, mock_db, mock_session_cls, mock_prov_id):
-        session = _mock_session(mock_session_cls)
+    def test_returns_provider_for_langgenius_org(self, mock_db, mock_sessionmaker_cls, mock_prov_id):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         mock_prov_id.return_value.provider_name = "google"
         mock_prov_id.return_value.organization = "langgenius"
         db_provider = MagicMock(provider="google")
@@ -420,10 +416,10 @@ class TestGetBuiltinProvider:
         assert result is db_provider
 
     @patch(f"{MODULE}.ToolProviderID")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_returns_provider_for_non_langgenius_org(self, mock_db, mock_session_cls, mock_prov_id):
-        session = _mock_session(mock_session_cls)
+    def test_returns_provider_for_non_langgenius_org(self, mock_db, mock_sessionmaker_cls, mock_prov_id):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
 
         def prov_id_side_effect(name):
             m = MagicMock()
@@ -442,10 +438,10 @@ class TestGetBuiltinProvider:
         assert result is db_provider
 
     @patch(f"{MODULE}.ToolProviderID")
-    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.sessionmaker")
     @patch(f"{MODULE}.db")
-    def test_falls_back_on_exception(self, mock_db, mock_session_cls, mock_prov_id):
-        session = _mock_session(mock_session_cls)
+    def test_falls_back_on_exception(self, mock_db, mock_sessionmaker_cls, mock_prov_id):
+        session = _mock_sessionmaker(mock_sessionmaker_cls)
         mock_prov_id.side_effect = Exception("parse error")
         fallback = MagicMock()
         session.query.return_value.where.return_value.order_by.return_value.first.return_value = fallback


### PR DESCRIPTION
## Summary
Part of #24245. Migrate `Session(db.engine)` + manual `session.commit()` to `sessionmaker(db.engine).begin()` context manager in the services layer.

Continues the migration after #34379 (service_api + inner_api controllers).

## Changes
- Replace `Session(db.engine)` with `sessionmaker(db.engine).begin()`
- Replace `Session(db.engine).no_autoflush` with `sessionmaker(db.engine, autoflush=False).begin()`
- Replace `Session(db.engine, autoflush=False)` with `sessionmaker(db.engine, autoflush=False).begin()`
- Replace `Session(db.engine, expire_on_commit=False)` with `sessionmaker(db.engine, expire_on_commit=False).begin()`
- Replace `Session(db.engine) as session, session.begin()` with `sessionmaker(db.engine).begin()`
- Remove manual `session.commit()` calls (handled automatically by the context manager)
- Remove manual `session.rollback()` calls (handled automatically on exception)
- Preserve `Session` import where used as type annotation

### Files modified (19 files in `api/services/`)
- `account_service.py`
- `async_workflow_service.py`
- `clear_free_plan_tenant_expired_logs.py`
- `credit_pool_service.py`
- `dataset_service.py`
- `datasource_provider_service.py`
- `oauth_server.py`
- `plugin/plugin_auto_upgrade_service.py`
- `plugin/plugin_migration.py`
- `plugin/plugin_parameter_service.py`
- `plugin/plugin_permission_service.py`
- `plugin/plugin_service.py`
- `rag_pipeline/rag_pipeline.py`
- `tools/builtin_tools_manage_service.py`
- `trigger/app_trigger_service.py`
- `trigger/trigger_provider_service.py`
- `trigger/trigger_service.py`
- `trigger/webhook_service.py`
- `workflow_service.py`

Closes part of #24245