### PR TITLE
fix: Unblock CI with docker env defaults and stream chunked agent text

### DIFF
--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -36,11 +36,13 @@ _file_access_controller = DatabaseFileAccessController()
 _AGENT_SINGLE_TEXT_STREAM_CHUNK_SIZE = 64
 
 
-def _split_text_for_agent_stream(text: str) -> list[str]:
+def _split_text_for_agent_stream(text: str) -> Generator[str, None, None]:
     max_len = _AGENT_SINGLE_TEXT_STREAM_CHUNK_SIZE
     if len(text) <= max_len:
-        return [text]
-    return [text[i : i + max_len] for i in range(0, len(text), max_len)]
+        yield text
+        return
+    for i in range(0, len(text), max_len):
+        yield text[i : i + max_len]
 
 
 class AgentMessageTransformer:

--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -30,6 +30,18 @@ from .exceptions import AgentNodeError, AgentVariableTypeError, ToolFileNotFound
 
 _file_access_controller = DatabaseFileAccessController()
 
+# Plugin agent strategies often return the full model reply in a single TEXT frame when the
+# upstream LLM call is non-streaming. Downstream workflow SSE then looks like "one message at
+# the end". Split large frames so clients still receive incremental `message` events.
+_AGENT_SINGLE_TEXT_STREAM_CHUNK_SIZE = 64
+
+
+def _split_text_for_agent_stream(text: str) -> list[str]:
+    max_len = _AGENT_SINGLE_TEXT_STREAM_CHUNK_SIZE
+    if len(text) <= max_len:
+        return [text]
+    return [text[i : i + max_len] for i in range(0, len(text), max_len)]
+
 
 class AgentMessageTransformer:
     def transform(
@@ -125,12 +137,14 @@ class AgentMessageTransformer:
                 )
             elif message.type == ToolInvokeMessage.MessageType.TEXT:
                 assert isinstance(message.message, ToolInvokeMessage.TextMessage)
-                text += message.message.text
-                yield StreamChunkEvent(
-                    selector=[node_id, "text"],
-                    chunk=message.message.text,
-                    is_final=False,
-                )
+                raw_text = message.message.text
+                text += raw_text
+                for piece in _split_text_for_agent_stream(raw_text):
+                    yield StreamChunkEvent(
+                        selector=[node_id, "text"],
+                        chunk=piece,
+                        is_final=False,
+                    )
             elif message.type == ToolInvokeMessage.MessageType.JSON:
                 assert isinstance(message.message, ToolInvokeMessage.JsonMessage)
                 if node_type == BuiltinNodeTypes.AGENT:

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
 from graphon.enums import BuiltinNodeTypes
+from graphon.node_events import StreamChunkEvent
 
+from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.utils.message_transformer import ToolFileMessageTransformer
 from core.workflow.nodes.agent.message_transformer import AgentMessageTransformer
 
@@ -32,3 +34,41 @@ def test_transform_passes_conversation_id_to_tool_file_message_transformer() -> 
         tenant_id="tenant-id",
         conversation_id="conversation-id",
     )
+
+
+def test_transform_splits_long_single_text_into_multiple_stream_chunks() -> None:
+    long_text = "a" * 200
+    plugin_messages = [
+        ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.TEXT,
+            message=ToolInvokeMessage.TextMessage(text=long_text),
+        )
+    ]
+    transformer = AgentMessageTransformer()
+
+    with patch.object(
+        ToolFileMessageTransformer,
+        "transform_tool_invoke_messages",
+        return_value=iter(plugin_messages),
+    ):
+        events = list(
+            transformer.transform(
+                messages=iter(()),
+                tool_info={},
+                parameters_for_log={},
+                user_id="user-id",
+                tenant_id="tenant-id",
+                conversation_id="conversation-id",
+                node_type=BuiltinNodeTypes.AGENT,
+                node_id="node-id",
+                node_execution_id="execution-id",
+            )
+        )
+
+    text_chunks = [
+        e
+        for e in events
+        if isinstance(e, StreamChunkEvent) and e.selector == ["node-id", "text"] and not e.is_final and e.chunk
+    ]
+    assert len(text_chunks) == 4
+    assert "".join(e.chunk for e in text_chunks) == long_text


### PR DESCRIPTION
Part of #34395.

## Summary

- Split large single `TEXT` frames from agent tool/plugin messages into multiple smaller `StreamChunkEvents`.
- Make `_split_text_for_agent_stream ` a generator so chunking doesn’t build a full list in memory.
- Add a unit test to ensure long agent text is emitted as multiple incremental stream chunks.

## Why this change

In self-hosted setups, some agent strategies/plugins return the full model reply in one non-streaming `TEXT` message. That makes workflow SSE look like “one message at the end”, even though the UI expects incremental `message` events.

Chunking that single large frame improves perceived streaming by emitting multiple `StreamChunkEvents` progressively, without changing the final output text.

## Changes

- `api/core/workflow/nodes/agent/message_transformer.py`:

   - Add `_split_text_for_agent_stream` (generator) and use it when handling `ToolInvokeMessage.MessageType.TEXT`.
   - Emit multiple `StreamChunkEvents` for a long `raw_text` instead of a single large chunk.

- `api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py`:

   - Add coverage to assert a long single text message becomes multiple stream chunks and reassembles to the original text.

## Test plan

- `uv run --project api pytest api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py`
- CI unit tests pass
