### PR TITLE
fix: add tenant/dataset ownership checks to prevent IDOR vulnerabilities

### DIFF
--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -175,7 +175,9 @@ class ExternalApiTemplateApi(Resource):
     def get(self, external_knowledge_api_id):
         _, current_tenant_id = current_account_with_tenant()
         external_knowledge_api_id = str(external_knowledge_api_id)
-        external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(external_knowledge_api_id, current_tenant_id)
+        external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(
+            external_knowledge_api_id, current_tenant_id
+        )
         if external_knowledge_api is None:
             raise NotFound("API template not found.")
 

--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -173,8 +173,9 @@ class ExternalApiTemplateApi(Resource):
     @login_required
     @account_initialization_required
     def get(self, external_knowledge_api_id):
+        _, current_tenant_id = current_account_with_tenant()
         external_knowledge_api_id = str(external_knowledge_api_id)
-        external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(external_knowledge_api_id)
+        external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(external_knowledge_api_id, current_tenant_id)
         if external_knowledge_api is None:
             raise NotFound("API template not found.")
 

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -274,7 +274,9 @@ class DatasetService:
         db.session.flush()
 
         if provider == "external" and external_knowledge_api_id:
-            external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(external_knowledge_api_id, tenant_id)
+            external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(
+                external_knowledge_api_id, tenant_id
+            )
             if not external_knowledge_api:
                 raise ValueError("External API template not found.")
             if external_knowledge_id is None:

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -274,7 +274,7 @@ class DatasetService:
         db.session.flush()
 
         if provider == "external" and external_knowledge_api_id:
-            external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(external_knowledge_api_id)
+            external_knowledge_api = ExternalDatasetService.get_external_knowledge_api(external_knowledge_api_id, tenant_id)
             if not external_knowledge_api:
                 raise ValueError("External API template not found.")
             if external_knowledge_id is None:

--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -102,9 +102,9 @@ class ExternalDatasetService:
             raise ValueError(f"Forbidden: Authorization failed with api_key: {api_key}")
 
     @staticmethod
-    def get_external_knowledge_api(external_knowledge_api_id: str) -> ExternalKnowledgeApis:
+    def get_external_knowledge_api(external_knowledge_api_id: str, tenant_id: str) -> ExternalKnowledgeApis:
         external_knowledge_api: ExternalKnowledgeApis | None = (
-            db.session.query(ExternalKnowledgeApis).filter_by(id=external_knowledge_api_id).first()
+            db.session.query(ExternalKnowledgeApis).filter_by(id=external_knowledge_api_id, tenant_id=tenant_id).first()
         )
         if external_knowledge_api is None:
             raise ValueError("api template not found")

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -65,7 +65,7 @@ class MetadataService:
                 raise ValueError("Metadata name already exists in Built-in fields.")
         try:
             MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)
-            metadata = db.session.query(DatasetMetadata).filter_by(id=metadata_id).first()
+            metadata = db.session.query(DatasetMetadata).filter_by(id=metadata_id, dataset_id=dataset_id).first()
             if metadata is None:
                 raise ValueError("Metadata not found.")
             old_name = metadata.name
@@ -101,7 +101,7 @@ class MetadataService:
         lock_key = f"dataset_metadata_lock_{dataset_id}"
         try:
             MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)
-            metadata = db.session.query(DatasetMetadata).filter_by(id=metadata_id).first()
+            metadata = db.session.query(DatasetMetadata).filter_by(id=metadata_id, dataset_id=dataset_id).first()
             if metadata is None:
                 raise ValueError("Metadata not found.")
             db.session.delete(metadata)

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -411,7 +411,7 @@ class BuiltinToolManageService:
         """
         with Session(db.engine) as session:
             # get provider
-            target_provider = session.query(BuiltinToolProvider).filter_by(id=id).first()
+            target_provider = session.query(BuiltinToolProvider).filter_by(id=id, tenant_id=tenant_id).first()
             if target_provider is None:
                 raise ValueError("provider not found")
 

--- a/api/tests/unit_tests/services/external_dataset_service.py
+++ b/api/tests/unit_tests/services/external_dataset_service.py
@@ -294,7 +294,7 @@ class TestExternalDatasetServiceCrudExternalKnowledgeApi:
         api = Mock(spec=ExternalKnowledgeApis)
         mock_db_session.query.return_value.filter_by.return_value.first.return_value = api
 
-        result = ExternalDatasetService.get_external_knowledge_api("api-id")
+        result = ExternalDatasetService.get_external_knowledge_api("api-id", "tenant-id")
         assert result is api
 
     def test_get_external_knowledge_api_not_found_raises(self, mock_db_session: MagicMock):
@@ -305,7 +305,7 @@ class TestExternalDatasetServiceCrudExternalKnowledgeApi:
         mock_db_session.query.return_value.filter_by.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="api template not found"):
-            ExternalDatasetService.get_external_knowledge_api("missing-id")
+            ExternalDatasetService.get_external_knowledge_api("missing-id", "tenant-id")
 
     def test_update_external_knowledge_api_success_with_hidden_api_key(self, mock_db_session: MagicMock):
         """

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -805,11 +805,12 @@ class TestExternalDatasetServiceGetAPI:
         mock_query.first.return_value = expected_api
 
         # Act
-        result = ExternalDatasetService.get_external_knowledge_api(api_id)
+        tenant_id = "tenant-123"
+        result = ExternalDatasetService.get_external_knowledge_api(api_id, tenant_id)
 
         # Assert
         assert result.id == api_id
-        mock_query.filter_by.assert_called_once_with(id=api_id)
+        mock_query.filter_by.assert_called_once_with(id=api_id, tenant_id=tenant_id)
 
     @patch("services.external_knowledge_service.db")
     def test_get_external_knowledge_api_not_found(self, mock_db, factory):
@@ -822,7 +823,7 @@ class TestExternalDatasetServiceGetAPI:
 
         # Act & Assert
         with pytest.raises(ValueError, match="api template not found"):
-            ExternalDatasetService.get_external_knowledge_api("nonexistent-id")
+            ExternalDatasetService.get_external_knowledge_api("nonexistent-id", "tenant-123")
 
 
 class TestExternalDatasetServiceUpdateAPI:


### PR DESCRIPTION
## Summary
Add missing authorization filters to queries that fetch resources by ID without verifying ownership, preventing authenticated users from accessing or modifying resources belonging to other tenants/datasets:

- `ExternalDatasetService.get_external_knowledge_api`: add `tenant_id` to `filter_by`
- `MetadataService.update_metadata_name`: add `dataset_id` to `filter_by`
- `MetadataService.delete_metadata`: add `dataset_id` to `filter_by`
- `BuiltinToolsManageService.set_default_provider`: add `tenant_id` to `filter_by`

Other methods in the same files (e.g., `update_external_knowledge_api`, `delete_external_knowledge_api`) already include these ownership checks — these four were the ones missing them.

## Test plan
- Updated existing unit tests for `get_external_knowledge_api` to pass `tenant_id`
- Verified `filter_by` assertions include ownership parameters

Fixes #31839