### PR TITLE
Add OSOP workflow example — portable format for Dify workflows

### DIFF
--- a/examples/osop/README.md
+++ b/examples/osop/README.md
@@ -1,0 +1,37 @@
+# OSOP Workflow Examples for Dify
+
+[OSOP](https://github.com/osopcloud/osop-spec) (Open Standard for Orchestration Protocols) is a YAML-based workflow definition format that provides a portable, platform-agnostic way to describe AI agent pipelines.
+
+## Why OSOP + Dify?
+
+Dify workflows are powerful but live inside the Dify platform. OSOP lets you describe those same workflows in a standard YAML format so they can be:
+
+- **Shared** across teams without requiring Dify access
+- **Compared** with workflows built in other tools (n8n, LangGraph, CrewAI, etc.)
+- **Version-controlled** as plain text alongside your application code
+- **Validated** using the OSOP CLI before import
+
+## Files in this directory
+
+| File | Description |
+|------|-------------|
+| `dify-rag-chatbot.osop.yaml` | A retrieval-augmented generation chatbot pipeline: question → vector retrieval → rerank → cited answer → feedback loop |
+
+## Quick start
+
+```bash
+# Install the OSOP CLI
+pip install osop
+
+# Validate the workflow
+osop validate dify-rag-chatbot.osop.yaml
+
+# Render a visual graph
+osop render dify-rag-chatbot.osop.yaml -o workflow.png
+```
+
+## Learn more
+
+- [OSOP Specification](https://github.com/osopcloud/osop-spec)
+- [OSOP Examples](https://github.com/osopcloud/osop-examples) — 30+ workflow templates
+- [OSOP Visual Editor](https://github.com/osopcloud/osop-editor)

--- a/examples/osop/README.md
+++ b/examples/osop/README.md
@@ -1,6 +1,6 @@
 # OSOP Workflow Examples for Dify
 
-[OSOP](https://github.com/osopcloud/osop-spec) (Open Standard for Orchestration Protocols) is a YAML-based workflow definition format that provides a portable, platform-agnostic way to describe AI agent pipelines.
+[OSOP](https://github.com/Archie0125/osop-spec) (Open Standard for Orchestration Protocols) is a YAML-based workflow definition format that provides a portable, platform-agnostic way to describe AI agent pipelines.
 
 ## Why OSOP + Dify?
 
@@ -32,6 +32,6 @@ osop render dify-rag-chatbot.osop.yaml -o workflow.png
 
 ## Learn more
 
-- [OSOP Specification](https://github.com/osopcloud/osop-spec)
-- [OSOP Examples](https://github.com/osopcloud/osop-examples) — 30+ workflow templates
-- [OSOP Visual Editor](https://github.com/osopcloud/osop-editor)
+- [OSOP Specification](https://github.com/Archie0125/osop-spec)
+- [OSOP Examples](https://github.com/Archie0125/osop-examples) — 30+ workflow templates
+- [OSOP Visual Editor](https://github.com/Archie0125/osop-editor)

--- a/examples/osop/dify-rag-chatbot.osop.yaml
+++ b/examples/osop/dify-rag-chatbot.osop.yaml
@@ -1,0 +1,87 @@
+# Dify RAG Chatbot — OSOP Portable Workflow
+#
+# Retrieval-augmented generation pipeline: receive a user question,
+# retrieve relevant chunks from a vector store, rerank for relevance,
+# generate a cited answer, and collect user feedback for fine-tuning.
+#
+# Build in Dify or validate: osop validate dify-rag-chatbot.osop.yaml
+
+osop_version: "1.0"
+id: "dify-rag-chatbot"
+name: "RAG Chatbot Pipeline"
+description: "Question → retrieve → rerank → generate answer with citations → feedback."
+version: "1.0.0"
+tags: [dify, rag, chatbot, vector-search, llm]
+
+nodes:
+  - id: "receive_question"
+    type: "api"
+    subtype: "webhook"
+    name: "Receive Question"
+    description: "User submits a question via chat interface or API."
+
+  - id: "retrieve_docs"
+    type: "db"
+    name: "Vector Retrieval"
+    description: "Embed the query and retrieve top-k chunks from the vector store."
+    config:
+      store: "pinecone"
+      top_k: 20
+      embedding_model: "text-embedding-3-small"
+
+  - id: "rerank"
+    type: "agent"
+    subtype: "llm"
+    name: "Rerank Results"
+    description: "Cross-encoder reranking to select the most relevant 5 chunks."
+    config:
+      model: "cohere-rerank-v3"
+      top_n: 5
+
+  - id: "generate_answer"
+    type: "agent"
+    subtype: "llm"
+    name: "Generate Answer"
+    description: "Produce a grounded answer using retrieved context with inline citations."
+    config:
+      model: "gpt-4o"
+      temperature: 0.3
+      system_prompt: "Answer using ONLY the provided context. Cite sources as [1], [2], etc."
+
+  - id: "format_citations"
+    type: "cli"
+    subtype: "script"
+    name: "Format Citations"
+    description: "Map inline citation markers to source document metadata."
+
+  - id: "collect_feedback"
+    type: "human"
+    name: "User Feedback"
+    description: "Thumbs up/down and optional comment for answer quality tracking."
+
+  - id: "log_for_finetuning"
+    type: "db"
+    name: "Log to Training Set"
+    description: "Store high-rated Q&A pairs for future model fine-tuning."
+
+edges:
+  - from: "receive_question"
+    to: "retrieve_docs"
+    mode: "sequential"
+  - from: "retrieve_docs"
+    to: "rerank"
+    mode: "sequential"
+  - from: "rerank"
+    to: "generate_answer"
+    mode: "sequential"
+  - from: "generate_answer"
+    to: "format_citations"
+    mode: "sequential"
+  - from: "format_citations"
+    to: "collect_feedback"
+    mode: "sequential"
+  - from: "collect_feedback"
+    to: "log_for_finetuning"
+    mode: "conditional"
+    when: "feedback == 'positive'"
+    label: "Good answer — save for training"


### PR DESCRIPTION
## Summary

- Adds an [OSOP](https://github.com/osopcloud/osop-spec) (Open Standard for Orchestration Protocols) workflow example representing a Dify RAG chatbot pipeline
- OSOP is a YAML-based workflow definition format that enables cross-platform portability — describe Dify workflows as plain text for version control, sharing, and comparison with other orchestration tools
- Includes a README explaining the integration and a complete RAG chatbot pipeline example (question → vector retrieval → rerank → cited answer → feedback)

## Details

This PR is **non-invasive and additive only** — it creates a new `examples/osop/` directory with two files:

| File | Purpose |
|------|---------|
| `examples/osop/README.md` | Explains what OSOP is and how it relates to Dify workflows |
| `examples/osop/dify-rag-chatbot.osop.yaml` | A 7-node RAG chatbot pipeline defined in OSOP format |

The OSOP workflow mirrors a typical Dify RAG chatbot: receive a question, retrieve from vector store, rerank results, generate a cited answer, collect feedback, and log positive examples for fine-tuning.

No existing files are modified.

## Test plan

- [x] YAML is valid and parseable
- [x] Workflow validates with `osop validate dify-rag-chatbot.osop.yaml`
- [x] No existing files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)