### PR TITLE
fix(security): add tenant_id validation to prevent IDOR in data source binding

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -158,10 +158,11 @@ class DataSourceApi(Resource):
     @login_required
     @account_initialization_required
     def patch(self, binding_id, action: Literal["enable", "disable"]):
+        _, current_tenant_id = current_account_with_tenant()
         binding_id = str(binding_id)
         with Session(db.engine) as session:
             data_source_binding = session.execute(
-                select(DataSourceOauthBinding).filter_by(id=binding_id)
+                select(DataSourceOauthBinding).filter_by(id=binding_id, tenant_id=current_tenant_id)
             ).scalar_one_or_none()
         if data_source_binding is None:
             raise NotFound("Data source binding not found.")


### PR DESCRIPTION
## Summary
Fixes #31839. Add `tenant_id` filter when querying `DataSourceOauthBinding` in the PATCH method to prevent Insecure Direct Object Reference (IDOR).

## Changes
- Add `tenant_id=current_tenant_id` filter to the `DataSourceOauthBinding` query in `DataSourceApi.patch()`
- Users can now only enable/disable data source bindings belonging to their own tenant
- Returns 404 instead of allowing cross-tenant access

## Security Impact
Without this fix, an authenticated user could enable/disable data source bindings belonging to other tenants by providing arbitrary binding IDs. The GET method already correctly filters by `tenant_id` (line 117), but the PATCH method was missing this check.