### PR TITLE
fix: web Docker image fails to build from source because @dify/iconify-collections is excluded from the build context #34467

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -25,6 +25,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY web/package.json /app/web/
 COPY e2e/package.json /app/e2e/
 COPY sdks/nodejs-client/package.json /app/sdks/nodejs-client/
+COPY packages/iconify-collections/package.json /app/packages/iconify-collections/
 
 # Use packageManager from package.json
 RUN corepack install

--- a/web/Dockerfile.dockerignore
+++ b/web/Dockerfile.dockerignore
@@ -7,6 +7,9 @@
 !web/**
 !e2e/
 !e2e/package.json
+!packages/
+!packages/iconify-collections/
+!packages/iconify-collections/**
 !sdks/
 !sdks/nodejs-client/
 !sdks/nodejs-client/package.json


### PR DESCRIPTION

## Summary

fix #34467

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
