### PR TITLE
feat: Improve validation feedback in Conversation Opener modal when opener message is empty #34474

### DIFF
--- a/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx
@@ -212,7 +212,13 @@ const OpeningSettingModal = ({
         <div className="mt-1.5 h-8 w-8 shrink-0 rounded-lg border-components-panel-border bg-util-colors-orange-dark-orange-dark-500 p-1.5">
           <span className="i-ri-asterisk h-5 w-5 text-text-primary-on-surface" />
         </div>
-        <div className="grow rounded-2xl border-t border-divider-subtle bg-chat-bubble-bg p-3 shadow-xs">
+        <div
+          aria-invalid={isSaveDisabled}
+          className={cn(
+            'grow rounded-2xl border-t border-divider-subtle bg-chat-bubble-bg p-3 shadow-xs',
+            isSaveDisabled && 'border border-components-input-border-destructive',
+          )}
+        >
           <PromptEditor
             value={tempValue}
             onChange={setTempValue}


### PR DESCRIPTION

## Summary

close #34474

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
