### PR TITLE
refactor(api): type get_knowledge_rate_limit with KnowledgeRateLimitD…

### DIFF
--- a/api/services/billing_service.py
+++ b/api/services/billing_service.py
@@ -33,6 +33,11 @@ class SubscriptionPlan(TypedDict):
     expiration_date: int
 
 
+class KnowledgeRateLimitDict(TypedDict):
+    limit: int
+    subscription_plan: str
+
+
 class BillingService:
     base_url = os.environ.get("BILLING_API_URL", "BILLING_API_URL")
     secret_key = os.environ.get("BILLING_API_SECRET_KEY", "BILLING_API_SECRET_KEY")
@@ -59,7 +64,7 @@ class BillingService:
         return usage_info
 
     @classmethod
-    def get_knowledge_rate_limit(cls, tenant_id: str):
+    def get_knowledge_rate_limit(cls, tenant_id: str) -> KnowledgeRateLimitDict:
         params = {"tenant_id": tenant_id}
 
         knowledge_rate_limit = cls._send_request("GET", "/subscription/knowledge-rate-limit", params=params)


### PR DESCRIPTION
## Summary
- Add `KnowledgeRateLimitDict` TypedDict with `limit` (int) and `subscription_plan` (str) keys
- Annotate return type of `BillingService.get_knowledge_rate_limit`

## Why this change
`get_knowledge_rate_limit` constructs a dict with two fixed keys but had no return type annotation. The TypedDict makes the shape explicit alongside the existing `SubscriptionPlan` TypedDict already in the file.

## Changes
- `billing_service.py`: Define `KnowledgeRateLimitDict`, add return type annotation

## Test plan
- [x] `ruff check` passes

Part of #32863 (`services/billing_service.py`)
