### PR TITLE
refactor(api): type hit testing retrieve responses with TypedDict

### DIFF
--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, TypedDict
 
 from graphon.model_runtime.entities import LLMMode
 
@@ -17,6 +17,16 @@ from models.dataset import Dataset, DatasetQuery
 from models.enums import CreatorUserRole, DatasetQuerySource
 
 logger = logging.getLogger(__name__)
+
+
+class QueryDict(TypedDict):
+    content: str
+
+
+class RetrieveResponseDict(TypedDict):
+    query: QueryDict
+    records: list[dict[str, Any]]
+
 
 default_retrieval_model = {
     "search_method": RetrievalMethod.SEMANTIC_SEARCH,
@@ -150,7 +160,7 @@ class HitTestingService:
         return dict(cls.compact_external_retrieve_response(dataset, query, all_documents))
 
     @classmethod
-    def compact_retrieve_response(cls, query: str, documents: list[Document]) -> dict[Any, Any]:
+    def compact_retrieve_response(cls, query: str, documents: list[Document]) -> RetrieveResponseDict:
         records = RetrievalService.format_retrieval_documents(documents)
 
         return {
@@ -161,7 +171,7 @@ class HitTestingService:
         }
 
     @classmethod
-    def compact_external_retrieve_response(cls, dataset: Dataset, query: str, documents: list) -> dict[Any, Any]:
+    def compact_external_retrieve_response(cls, dataset: Dataset, query: str, documents: list) -> RetrieveResponseDict:
         records = []
         if dataset.provider == "external":
             for document in documents:


### PR DESCRIPTION
## Summary
- Add `QueryDict` and `RetrieveResponseDict` TypedDicts to `hit_testing_service.py`
- Annotate return types of `compact_retrieve_response` and `compact_external_retrieve_response` (previously `dict[Any, Any]`)

## Why this change
Both methods construct dicts with the same fixed shape (`query.content` + `records` list) but were typed as `dict[Any, Any]` — the weakest possible dict annotation. A TypedDict makes the response contract explicit.

## Changes
- `hit_testing_service.py`: Define 2 TypedDicts, update 2 method return types

## Test plan
- [x] `ruff check` passes

Part of #32863 (`services/hit_testing_service.py`)
