### PR TITLE
refactor(api): type log identity dict with IdentityDict TypedDict

### DIFF
--- a/api/core/logging/structured_formatter.py
+++ b/api/core/logging/structured_formatter.py
@@ -3,11 +3,17 @@
 import logging
 import traceback
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, TypedDict
 
 import orjson
 
 from configs import dify_config
+
+
+class IdentityDict(TypedDict, total=False):
+    tenant_id: str
+    user_id: str
+    user_type: str
 
 
 class StructuredJSONFormatter(logging.Formatter):
@@ -84,7 +90,7 @@ class StructuredJSONFormatter(logging.Formatter):
 
         return log_dict
 
-    def _extract_identity(self, record: logging.LogRecord) -> dict[str, str] | None:
+    def _extract_identity(self, record: logging.LogRecord) -> IdentityDict | None:
         tenant_id = getattr(record, "tenant_id", None)
         user_id = getattr(record, "user_id", None)
         user_type = getattr(record, "user_type", None)
@@ -92,7 +98,7 @@ class StructuredJSONFormatter(logging.Formatter):
         if not any([tenant_id, user_id, user_type]):
             return None
 
-        identity: dict[str, str] = {}
+        identity: IdentityDict = {}
         if tenant_id:
             identity["tenant_id"] = tenant_id
         if user_id:


### PR DESCRIPTION
## Summary
- Add `IdentityDict` TypedDict (`total=False`) with keys `tenant_id`, `user_id`, `user_type`
- Annotate return type of `_extract_identity` and its local variable

## Why this change
`_extract_identity` returns a dict with 3 well-known optional keys but was typed as `dict[str, str] | None`. The TypedDict with `total=False` documents exactly which keys can appear, matching the structured JSON log schema documented in the class docstring.

## Changes
- `core/logging/structured_formatter.py`: Define `IdentityDict`, update return type and local variable annotation

## Test plan
- [x] `ruff check` passes

Part of #32863 (`core/logging/structured_formatter.py`)
