### PR TITLE
fix(models): handle legacy model_type values in EnumText.process_result_value

### DIFF
--- a/api/models/types.py
+++ b/api/models/types.py
@@ -143,6 +143,13 @@ class EnumText[T: enum.StrEnum](TypeDecorator[T | None]):
     def process_result_value(self, value: str | None, dialect: Dialect) -> T | None:
         if value is None or value == "":
             return None
+        # Use value_of() when available to handle legacy database values
+        # (e.g. "embeddings" -> ModelType.TEXT_EMBEDDING, "reranking" -> ModelType.RERANK).
+        if hasattr(self._enum_class, "value_of"):
+            try:
+                return self._enum_class.value_of(value)  # type: ignore[attr-defined]
+            except (ValueError, KeyError):
+                pass
         # Type annotation guarantees value is str at this point
         return self._enum_class(value)
 


### PR DESCRIPTION
## Summary

Fixes #34365

### Problem

PR #34300 migrated `model_type` columns from `String(40)` to `EnumText(ModelType, length=40)`. However, older Dify databases still store legacy values:

| DB value | Expected ModelType |
|---|---|
| `embeddings` | `ModelType.TEXT_EMBEDDING` (`text-embedding`) |
| `reranking` | `ModelType.RERANK` (`rerank`) |
| `text-generation` | `ModelType.LLM` (`llm`) |

`EnumText.process_result_value` called `self._enum_class(value)` directly, which uses `StrEnum.__new__` and requires an exact `.value` match. Legacy values like `"embeddings"` don't match any `.value` → `ValueError`.

### Fix

`ModelType` already provides a `value_of()` classmethod that maps legacy DB strings to the correct enum member. `EnumText.process_result_value` now calls `value_of()` first when the enum class provides it, falling back to direct construction for enums without a `value_of()` method.

This is backward-compatible: enums without `value_of()` (e.g. `AccountStatus`) are unaffected.

### Files changed

- `api/models/types.py` — `EnumText.process_result_value`: try `value_of()` before direct construction