### PR TITLE
fix(web): restore ui select public exports

### DIFF
--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -1,16 +1,6 @@
-import { Select as BaseSelect } from '@base-ui/react/select'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectGroupLabel,
-  SelectItem,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from '../index'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../index'
 
 const renderOpenSelect = ({
   rootProps = {},
@@ -51,14 +41,6 @@ const renderOpenSelect = ({
 }
 
 describe('Select wrappers', () => {
-  describe('alias exports', () => {
-    it('should map group-related aliases to the corresponding BaseSelect primitives', () => {
-      expect(SelectGroup).toBe(BaseSelect.Group)
-      expect(SelectGroupLabel).toBe(BaseSelect.GroupLabel)
-      expect(SelectSeparator).toBe(BaseSelect.Separator)
-    })
-  })
-
   describe('SelectTrigger', () => {
     it('should render clear button when clearable is true and loading is false', () => {
       renderOpenSelect({

--- a/web/app/components/base/ui/select/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/select/__tests__/index.spec.tsx
@@ -1,6 +1,16 @@
+import { Select as BaseSelect } from '@base-ui/react/select'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../index'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '../index'
 
 const renderOpenSelect = ({
   rootProps = {},
@@ -41,6 +51,14 @@ const renderOpenSelect = ({
 }
 
 describe('Select wrappers', () => {
+  describe('alias exports', () => {
+    it('should map group-related aliases to the corresponding BaseSelect primitives', () => {
+      expect(SelectGroup).toBe(BaseSelect.Group)
+      expect(SelectGroupLabel).toBe(BaseSelect.GroupLabel)
+      expect(SelectSeparator).toBe(BaseSelect.Separator)
+    })
+  })
+
   describe('SelectTrigger', () => {
     it('should render clear button when clearable is true and loading is false', () => {
       renderOpenSelect({

--- a/web/app/components/base/ui/select/index.tsx
+++ b/web/app/components/base/ui/select/index.tsx
@@ -10,8 +10,11 @@ import { cn } from '@/utils/classnames'
 
 export const Select = BaseSelect.Root
 export const SelectValue = BaseSelect.Value
+/** @public */
 export const SelectGroup = BaseSelect.Group
+/** @public */
 export const SelectGroupLabel = BaseSelect.GroupLabel
+/** @public */
 export const SelectSeparator = BaseSelect.Separator
 
 const selectTriggerVariants = cva(

--- a/web/app/components/base/ui/select/index.tsx
+++ b/web/app/components/base/ui/select/index.tsx
@@ -10,6 +10,9 @@ import { cn } from '@/utils/classnames'
 
 export const Select = BaseSelect.Root
 export const SelectValue = BaseSelect.Value
+export const SelectGroup = BaseSelect.Group
+export const SelectGroupLabel = BaseSelect.GroupLabel
+export const SelectSeparator = BaseSelect.Separator
 
 const selectTriggerVariants = cva(
   '',


### PR DESCRIPTION
## Summary
- restore `SelectGroup`, `SelectGroupLabel`, and `SelectSeparator` in the `base/ui/select` wrapper
- add an alias export spec so these public wrapper exports stay protected from future knip cleanup

## Why
`base/ui/select` is the replacement primitive for legacy select during overlay migration, so its group-related exports should remain part of the public API even if current call sites have not migrated yet.

## Validation
- `pnpm exec vp test app/components/base/ui/select/__tests__/index.spec.tsx`
- `pnpm exec knip`