### PR TITLE
fix: plugin credential modal hidden behind settings panel

### DIFF
--- a/web/app/components/plugins/plugin-auth/authorize/api-key-modal.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/api-key-modal.tsx
@@ -138,7 +138,7 @@ const ApiKeyModal = ({
       onExtraButtonClick={onRemove}
       disabled={disabled || isLoading || doingAction}
       clickOutsideNotClose={true}
-      wrapperClassName="z-1002!"
+      wrapperClassName=""
     >
       {pluginPayload.detail && (
         <ReadmeEntrance pluginDetail={pluginPayload.detail} showType={ReadmeShowType.modal} />

--- a/web/app/components/plugins/plugin-auth/authorize/oauth-client-settings.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/oauth-client-settings.tsx
@@ -150,7 +150,7 @@ const OAuthClientSettings = ({
         )
       }
       containerClassName="pt-0"
-      wrapperClassName="z-1002!"
+      wrapperClassName=""
       clickOutsideNotClose={true}
     >
       {pluginPayload.detail && (


### PR DESCRIPTION

---

Title: `fix: plugin credential modal hidden behind settings panel`

Body:

```markdown
## Summary

When configuring plugin credentials from the settings page (e.g. Data Source tab), the API key modal opens behind the settings panel and is not interactable.

## Root cause

`ApiKeyModal` and `OAuthClientSettings` both set `wrapperClassName="z-1002!"`, which overrides the legacy `Modal` component's default `z-9998` down to `z-1002` — the same z-index used by the settings panel's `Dialog`. DOM order then causes the settings panel to stack on top of the modal.

## Changes

Remove the `z-1002!` override from:
- `web/app/components/plugins/plugin-auth/authorize/api-key-modal.tsx`
- `web/app/components/plugins/plugin-auth/authorize/oauth-client-settings.tsx`

This restores the default `z-9998`, which correctly stacks above the settings dialog's `z-1002`.

## Test

1. Install any plugin requiring API key (e.g. MinIO S3)
2. Go to Settings → Data Source
3. Click configure / add credentials
4. Modal now appears on top of the settings panel
