### PR TITLE
refactor(web): replace native useContext with use in shared components 🤖🤖🤖

### DIFF
--- a/web/app/components/base/carousel/index.tsx
+++ b/web/app/components/base/carousel/index.tsx
@@ -29,7 +29,7 @@ type CarouselContextValue = {
 const CarouselContext = React.createContext<CarouselContextValue | null>(null)
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.use(CarouselContext)
 
   if (!context)
     throw new Error('useCarousel must be used within a <Carousel />')

--- a/web/app/components/base/pagination/pagination.tsx
+++ b/web/app/components/base/pagination/pagination.tsx
@@ -33,7 +33,7 @@ const PrevButton = ({
   as = <button type="button" />,
   ...buttonProps
 }: ButtonProps) => {
-  const pagination = React.useContext(PaginationContext)
+  const pagination = React.use(PaginationContext)
   const previous = () => {
     if (pagination.currentPage + 1 > 1)
       pagination.setCurrentPage(pagination.currentPage - 1)
@@ -68,7 +68,7 @@ const NextButton = ({
   as = <button type="button" />,
   ...buttonProps
 }: ButtonProps) => {
-  const pagination = React.useContext(PaginationContext)
+  const pagination = React.use(PaginationContext)
   const next = () => {
     if (pagination.currentPage + 1 < pagination.pages.length)
       pagination.setCurrentPage(pagination.currentPage + 1)
@@ -101,7 +101,7 @@ type ITruncableElementProps = {
 }
 
 const TruncableElement = ({ prev }: ITruncableElementProps) => {
-  const pagination: IPagination = React.useContext(PaginationContext)
+  const pagination: IPagination = React.use(PaginationContext)
 
   const {
     isPreviousTruncable,
@@ -126,7 +126,7 @@ const PageButton = ({
   inactiveClassName,
   renderExtraProps,
 }: PageButtonProps) => {
-  const pagination: IPagination = React.useContext(PaginationContext)
+  const pagination: IPagination = React.use(PaginationContext)
 
   const renderPageButton = (page: number) => (
     <li key={page}>

--- a/web/app/components/base/portal-to-follow-elem/index.tsx
+++ b/web/app/components/base/portal-to-follow-elem/index.tsx
@@ -115,7 +115,7 @@ type ContextType = ReturnType<typeof usePortalToFollowElem> | null
 const PortalToFollowElemContext = React.createContext<ContextType>(null)
 
 function usePortalToFollowElemContext() {
-  const context = React.useContext(PortalToFollowElemContext)
+  const context = React.use(PortalToFollowElemContext)
 
   if (context == null)
     throw new Error('PortalToFollowElem components must be wrapped in <PortalToFollowElem />')


### PR DESCRIPTION
## Summary

This PR contributes a small non-overlapping batch for #25193.

- replace remaining React native `useContext` calls with `use` in three shared base components
- keep behavior unchanged
- avoid touching `use-context-selector` usage

## Scope

- `web/app/components/base/carousel/index.tsx`
- `web/app/components/base/pagination/pagination.tsx`
- `web/app/components/base/portal-to-follow-elem/index.tsx`

## Validation

- `pnpm exec vp test run app/components/base/carousel/__tests__/index.spec.tsx app/components/base/pagination/__tests__/pagination.spec.tsx app/components/base/portal-to-follow-elem/__tests__/index.spec.tsx`
- `pnpm run lint:ci app/components/base/carousel/index.tsx app/components/base/pagination/pagination.tsx app/components/base/portal-to-follow-elem/index.tsx`
- `pnpm run type-check`
- `pnpm run lint:tss`

fixes #25193