### PR TITLE
refactor(api): type messages cleanup stats with MessagesCleanStatsDict TypedDict

### DIFF
--- a/api/services/retention/conversation/messages_clean_service.py
+++ b/api/services/retention/conversation/messages_clean_service.py
@@ -3,7 +3,7 @@ import logging
 import random
 import time
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import sqlalchemy as sa
 from sqlalchemy import delete, select, tuple_
@@ -158,6 +158,13 @@ class MessagesCleanupMetrics:
         self._record(self._job_duration_seconds, job_duration_seconds, attributes)
 
 
+class MessagesCleanStatsDict(TypedDict):
+    batches: int
+    total_messages: int
+    filtered_messages: int
+    total_deleted: int
+
+
 class MessagesCleanService:
     """
     Service for cleaning expired messages based on retention policies.
@@ -299,7 +306,7 @@ class MessagesCleanService:
             task_label=task_label,
         )
 
-    def run(self) -> dict[str, int]:
+    def run(self) -> MessagesCleanStatsDict:
         """
         Execute the message cleanup operation.
 
@@ -319,7 +326,7 @@ class MessagesCleanService:
                 job_duration_seconds=time.monotonic() - run_start,
             )
 
-    def _clean_messages_by_time_range(self) -> dict[str, int]:
+    def _clean_messages_by_time_range(self) -> MessagesCleanStatsDict:
         """
         Clean messages within a time range using cursor-based pagination.
 
@@ -334,7 +341,7 @@ class MessagesCleanService:
         Returns:
             Dict with statistics: batches, filtered_messages, total_deleted
         """
-        stats = {
+        stats: MessagesCleanStatsDict = {
             "batches": 0,
             "total_messages": 0,
             "filtered_messages": 0,


### PR DESCRIPTION
## Summary
- Add `MessagesCleanStatsDict` TypedDict with keys `batches`, `total_messages`, `filtered_messages`, `total_deleted`
- Annotate return types of `run` and `_clean_messages_by_time_range`, and the local `stats` variable

## Why this change
Both methods return a stats dict with 4 fixed integer keys but were typed as `dict[str, int]`. The TypedDict makes the statistics contract explicit so callers and tests can rely on the key names.

## Changes
- `services/retention/conversation/messages_clean_service.py`: Define `MessagesCleanStatsDict`, update 2 method return types and 1 local variable annotation

## Test plan
- [x] `ruff check` passes

Part of #32863 (`services/retention/conversation/messages_clean_service.py`)
