### PR TITLE
ci: detect icon package changes for web checks

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -65,6 +65,7 @@ jobs:
               - 'docker/volumes/sandbox/conf/**'
             web:
               - 'web/**'
+              - 'packages/iconify-collections/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -77,6 +78,7 @@ jobs:
               - 'api/uv.lock'
               - 'e2e/**'
               - 'web/**'
+              - 'packages/iconify-collections/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'


### PR DESCRIPTION
## Summary
- include the packages/iconify-collections path in the main CI filters for web checks
- trigger both web and e2e jobs when the shared icon workspace package changes
- keep the scope narrow to the package currently consumed by the web workspace

## Testing
- git diff --check

Fixes #34533
