### PR TITLE
refactor(api-tools): decouple db.session in ToolLabelManager, ApiToolManageService, WorkflowToolManageService

### DIFF
--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -1,5 +1,5 @@
 from sqlalchemy import delete, select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
 
 from core.tools.__base.tool_provider import ToolProviderController
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
@@ -20,12 +20,13 @@ class ToolLabelManager:
         return list(set(tool_labels))
 
     @classmethod
-    def update_tool_labels(cls, controller: ToolProviderController, labels: list[str]) -> None:
+    def update_tool_labels(cls, controller: ToolProviderController, labels: list[str], session: Session | None = None) -> None:
         """
         Update tool labels
 
         :param controller: tool provider controller
         :param labels: list of tool labels
+        :param session: database session, if None, a new session will be created
         :return: None
         """
 
@@ -36,16 +37,26 @@ class ToolLabelManager:
         else:
             raise ValueError("Unsupported tool type")
 
-        # keep the atomicity of delete and insert operations
-        with sessionmaker(db.engine).begin() as _session:
+        if session is not None:
             # delete old labels
-            _session.execute(delete(ToolLabelBinding).where(ToolLabelBinding.tool_id == provider_id))
+            session.execute(delete(ToolLabelBinding).where(ToolLabelBinding.tool_id == provider_id))
 
             # insert new labels
             for label in labels:
-                _session.add(
+                session.add(
                     ToolLabelBinding(tool_id=provider_id, tool_type=controller.provider_type, label_name=label)
                 )
+
+        else:
+            with sessionmaker(db.engine).begin() as _session:
+                # delete old labels
+                _session.execute(delete(ToolLabelBinding).where(ToolLabelBinding.tool_id == provider_id))
+
+                # insert new labels
+                for label in labels:
+                    _session.add(
+                        ToolLabelBinding(tool_id=provider_id, tool_type=controller.provider_type, label_name=label)
+                    )
 
     @classmethod
     def get_tool_labels(cls, controller: ToolProviderController) -> list[str]:

--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -1,5 +1,5 @@
 from sqlalchemy import delete, select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from core.tools.__base.tool_provider import ToolProviderController
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
@@ -20,9 +20,7 @@ class ToolLabelManager:
         return list(set(tool_labels))
 
     @classmethod
-    def update_tool_labels(
-        cls, controller: ToolProviderController, labels: list[str]
-    ) -> None:
+    def update_tool_labels(cls, controller: ToolProviderController, labels: list[str]) -> None:
         """
         Update tool labels
 
@@ -41,19 +39,12 @@ class ToolLabelManager:
         # keep the atomicity of delete and insert operations
         with sessionmaker(db.engine).begin() as _session:
             # delete old labels
-            _session.execute(
-                delete(ToolLabelBinding)
-                .where(ToolLabelBinding.tool_id == provider_id)
-            )
+            _session.execute(delete(ToolLabelBinding).where(ToolLabelBinding.tool_id == provider_id))
 
             # insert new labels
             for label in labels:
                 _session.add(
-                    ToolLabelBinding(
-                        tool_id=provider_id,
-                        tool_type=controller.provider_type,
-                        label_name=label
-                    )
+                    ToolLabelBinding(tool_id=provider_id, tool_type=controller.provider_type, label_name=label)
                 )
 
     @classmethod
@@ -107,12 +98,7 @@ class ToolLabelManager:
 
         labels: list[ToolLabelBinding] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            labels = _session.scalars(
-                select(ToolLabelBinding).
-                where(
-                    ToolLabelBinding.tool_id.in_(provider_ids)
-                )
-            ).all()
+            labels = _session.scalars(select(ToolLabelBinding).where(ToolLabelBinding.tool_id.in_(provider_ids))).all()
 
         tool_labels: dict[str, list[str]] = {label.tool_id: [] for label in labels}
 

--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -20,8 +20,9 @@ class ToolLabelManager:
         return list(set(tool_labels))
 
     @classmethod
-    def update_tool_labels(cls, controller: ToolProviderController,
-                           labels: list[str], session: Session | None = None) -> None:
+    def update_tool_labels(
+        cls, controller: ToolProviderController, labels: list[str], session: Session | None = None
+    ) -> None:
         """
         Update tool labels
 
@@ -44,9 +45,7 @@ class ToolLabelManager:
 
             # insert new labels
             for label in labels:
-                session.add(
-                    ToolLabelBinding(tool_id=provider_id, tool_type=controller.provider_type, label_name=label)
-                )
+                session.add(ToolLabelBinding(tool_id=provider_id, tool_type=controller.provider_type, label_name=label))
 
         else:
             with sessionmaker(db.engine).begin() as _session:
@@ -109,8 +108,9 @@ class ToolLabelManager:
 
         labels: list[ToolLabelBinding] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            labels = list(_session.scalars(select(ToolLabelBinding)
-            .where(ToolLabelBinding.tool_id.in_(provider_ids))).all())
+            labels = list(
+                _session.scalars(select(ToolLabelBinding).where(ToolLabelBinding.tool_id.in_(provider_ids))).all()
+            )
 
         tool_labels: dict[str, list[str]] = {label.tool_id: [] for label in labels}
 

--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -1,4 +1,3 @@
-from typing import Any
 from sqlalchemy import delete, select
 from sqlalchemy.orm import sessionmaker, Session
 

--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -1,3 +1,4 @@
+from typing import Any
 from sqlalchemy import delete, select
 from sqlalchemy.orm import sessionmaker, Session
 
@@ -78,11 +79,10 @@ class ToolLabelManager:
             ToolLabelBinding.tool_type == controller.provider_type,
         )
 
-        labels: list[str] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            labels = _session.scalars(stmt).all()
+            labels: list[str] = list(_session.scalars(stmt).all())
 
-        return list(labels)
+        return labels
 
     @classmethod
     def get_tools_labels(cls, tool_providers: list[ToolProviderController]) -> dict[str, list[str]]:
@@ -102,14 +102,14 @@ class ToolLabelManager:
             if not isinstance(controller, ApiToolProviderController | WorkflowToolProviderController):
                 raise ValueError("Unsupported tool type")
 
-        provider_ids = []
+        provider_ids: list[str] = []
         for controller in tool_providers:
             assert isinstance(controller, ApiToolProviderController | WorkflowToolProviderController)
             provider_ids.append(controller.provider_id)
 
         labels: list[ToolLabelBinding] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            labels = _session.scalars(select(ToolLabelBinding).where(ToolLabelBinding.tool_id.in_(provider_ids))).all()
+            labels = list(_session.scalars(select(ToolLabelBinding).where(ToolLabelBinding.tool_id.in_(provider_ids))).all())
 
         tool_labels: dict[str, list[str]] = {label.tool_id: [] for label in labels}
 

--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -1,5 +1,5 @@
 from sqlalchemy import delete, select
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.tools.__base.tool_provider import ToolProviderController
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
@@ -20,7 +20,8 @@ class ToolLabelManager:
         return list(set(tool_labels))
 
     @classmethod
-    def update_tool_labels(cls, controller: ToolProviderController, labels: list[str], session: Session | None = None) -> None:
+    def update_tool_labels(cls, controller: ToolProviderController,
+                           labels: list[str], session: Session | None = None) -> None:
         """
         Update tool labels
 
@@ -108,7 +109,8 @@ class ToolLabelManager:
 
         labels: list[ToolLabelBinding] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            labels = list(_session.scalars(select(ToolLabelBinding).where(ToolLabelBinding.tool_id.in_(provider_ids))).all())
+            labels = list(_session.scalars(select(ToolLabelBinding)
+            .where(ToolLabelBinding.tool_id.in_(provider_ids))).all())
 
         tool_labels: dict[str, list[str]] = {label.tool_id: [] for label in labels}
 

--- a/api/core/tools/tool_label_manager.py
+++ b/api/core/tools/tool_label_manager.py
@@ -1,4 +1,5 @@
 from sqlalchemy import delete, select
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.tools.__base.tool_provider import ToolProviderController
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
@@ -19,10 +20,17 @@ class ToolLabelManager:
         return list(set(tool_labels))
 
     @classmethod
-    def update_tool_labels(cls, controller: ToolProviderController, labels: list[str]):
+    def update_tool_labels(
+        cls, controller: ToolProviderController, labels: list[str]
+    ) -> None:
         """
         Update tool labels
+
+        :param controller: tool provider controller
+        :param labels: list of tool labels
+        :return: None
         """
+
         labels = cls.filter_tool_labels(labels)
 
         if isinstance(controller, ApiToolProviderController | WorkflowToolProviderController):
@@ -30,26 +38,33 @@ class ToolLabelManager:
         else:
             raise ValueError("Unsupported tool type")
 
-        # delete old labels
-        db.session.execute(delete(ToolLabelBinding).where(ToolLabelBinding.tool_id == provider_id))
-
-        # insert new labels
-        for label in labels:
-            db.session.add(
-                ToolLabelBinding(
-                    tool_id=provider_id,
-                    tool_type=controller.provider_type,
-                    label_name=label,
-                )
+        # keep the atomicity of delete and insert operations
+        with sessionmaker(db.engine).begin() as _session:
+            # delete old labels
+            _session.execute(
+                delete(ToolLabelBinding)
+                .where(ToolLabelBinding.tool_id == provider_id)
             )
 
-        db.session.commit()
+            # insert new labels
+            for label in labels:
+                _session.add(
+                    ToolLabelBinding(
+                        tool_id=provider_id,
+                        tool_type=controller.provider_type,
+                        label_name=label
+                    )
+                )
 
     @classmethod
     def get_tool_labels(cls, controller: ToolProviderController) -> list[str]:
         """
         Get tool labels
+
+        :param controller: tool provider controller
+        :return: list of tool labels (str)
         """
+
         if isinstance(controller, ApiToolProviderController | WorkflowToolProviderController):
             provider_id = controller.provider_id
         elif isinstance(controller, BuiltinToolProviderController):
@@ -60,7 +75,10 @@ class ToolLabelManager:
             ToolLabelBinding.tool_id == provider_id,
             ToolLabelBinding.tool_type == controller.provider_type,
         )
-        labels = db.session.scalars(stmt).all()
+
+        labels: list[str] = []
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            labels = _session.scalars(stmt).all()
 
         return list(labels)
 
@@ -87,7 +105,14 @@ class ToolLabelManager:
             assert isinstance(controller, ApiToolProviderController | WorkflowToolProviderController)
             provider_ids.append(controller.provider_id)
 
-        labels = db.session.scalars(select(ToolLabelBinding).where(ToolLabelBinding.tool_id.in_(provider_ids))).all()
+        labels: list[ToolLabelBinding] = []
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            labels = _session.scalars(
+                select(ToolLabelBinding).
+                where(
+                    ToolLabelBinding.tool_id.in_(provider_ids)
+                )
+            ).all()
 
         tool_labels: dict[str, list[str]] = {label.tool_id: [] for label in labels}
 

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -459,7 +459,7 @@ class ApiToolManageService:
                 .limit(1)
             )
 
-        if provider is not None:
+        if provider is None:
             # create a fake db provider
             provider = ApiToolProvider(
                 tenant_id="",

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -5,7 +5,7 @@ from typing import Any, TypedDict, cast
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from httpx import get
 from sqlalchemy import select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from core.entities.provider_entities import ProviderConfig
 from core.tools.__base.tool_runtime import ToolRuntime
@@ -311,7 +311,7 @@ class ApiToolManageService:
             )
         if provider is None:
             raise ValueError(f"api provider {provider_name} does not exists")
-        
+
         # parse openapi to tool bundle
         extra_info: dict[str, str] = {}
         # extra info like description will be set here
@@ -525,10 +525,7 @@ class ApiToolManageService:
         # create new session with automatic transaction management
         providers: list[ApiToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            providers = _session.scalars(
-                select(ApiToolProvider).
-                where(ApiToolProvider.tenant_id == tenant_id)
-            ).all()
+            providers = _session.scalars(select(ApiToolProvider).where(ApiToolProvider.tenant_id == tenant_id)).all()
 
         result: list[ToolProviderApiEntity] = []
         for provider in providers:

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -525,7 +525,7 @@ class ApiToolManageService:
         # create new session with automatic transaction management
         providers: list[ApiToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            providers = _session.scalars(select(ApiToolProvider).where(ApiToolProvider.tenant_id == tenant_id)).all()
+            providers = list(_session.scalars(select(ApiToolProvider).where(ApiToolProvider.tenant_id == tenant_id)).all())
 
         result: list[ToolProviderApiEntity] = []
         for provider in providers:

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -525,8 +525,9 @@ class ApiToolManageService:
         # create new session with automatic transaction management
         providers: list[ApiToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            providers = list(_session.scalars(select(ApiToolProvider)
-            .where(ApiToolProvider.tenant_id == tenant_id)).all())
+            providers = list(
+                _session.scalars(select(ApiToolProvider).where(ApiToolProvider.tenant_id == tenant_id)).all()
+            )
 
         result: list[ToolProviderApiEntity] = []
         for provider in providers:

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -5,6 +5,7 @@ from typing import Any, TypedDict, cast
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from httpx import get
 from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.entities.provider_entities import ProviderConfig
 from core.tools.__base.tool_runtime import ToolRuntime
@@ -116,22 +117,37 @@ class ApiToolManageService:
         privacy_policy: str,
         custom_disclaimer: str,
         labels: list[str],
-    ):
+    ) -> dict[str, Any]:
         """
-        create api tool provider
+        Create a new API tool provider.
+
+        :param user_id: The ID of the user creating the provider.
+        :param tenant_id: The ID of the workspace/tenant.
+        :param provider_name: The name of the API tool provider.
+        :param icon: The icon configuration for the provider.
+        :param credentials: The credentials for the provider.
+        :param schema_type: The type of schema (e.g., OpenAPI).
+        :param schema: The raw schema string.
+        :param privacy_policy: The privacy policy URL or text.
+        :param custom_disclaimer: Custom disclaimer text.
+        :param labels: A list of labels for the provider.
+        :return: A dictionary indicating the result status.
         """
+
         provider_name = provider_name.strip()
 
         # check if the provider exists
-        provider = db.session.scalar(
-            select(ApiToolProvider)
-            .where(
-                ApiToolProvider.tenant_id == tenant_id,
-                ApiToolProvider.name == provider_name,
+        # Create new session with automatic transaction management
+        provider: ApiToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            provider = _session.scalar(
+                select(ApiToolProvider)
+                .where(
+                    ApiToolProvider.tenant_id == tenant_id,
+                    ApiToolProvider.name == provider_name,
+                )
+                .limit(1)
             )
-            .limit(1)
-        )
-
         if provider is not None:
             raise ValueError(f"provider {provider_name} already exists")
 
@@ -176,8 +192,8 @@ class ApiToolManageService:
         )
         db_provider.credentials_str = json.dumps(encrypter.encrypt(credentials))
 
-        db.session.add(db_provider)
-        db.session.commit()
+        with sessionmaker(db.engine).begin() as _session:
+            _session.add(db_provider)
 
         # update labels
         ToolLabelManager.update_tool_labels(provider_controller, labels)
@@ -212,16 +228,25 @@ class ApiToolManageService:
     @staticmethod
     def list_api_tool_provider_tools(user_id: str, tenant_id: str, provider_name: str) -> list[ToolApiEntity]:
         """
-        list api tool provider tools
+        List tools provided by a specific API tool provider.
+
+        :param user_id: The ID of the user requesting the list.
+        :param tenant_id: The ID of the workspace/tenant.
+        :param provider_name: The name of the API tool provider.
+        :return: A list of ToolApiEntity objects.
         """
-        provider: ApiToolProvider | None = db.session.scalar(
-            select(ApiToolProvider)
-            .where(
-                ApiToolProvider.tenant_id == tenant_id,
-                ApiToolProvider.name == provider_name,
+
+        # create new session with automatic transaction management
+        provider: ApiToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            provider = _session.scalar(
+                select(ApiToolProvider)
+                .where(
+                    ApiToolProvider.tenant_id == tenant_id,
+                    ApiToolProvider.name == provider_name,
+                )
+                .limit(1)
             )
-            .limit(1)
-        )
 
         if provider is None:
             raise ValueError(f"you have not added provider {provider_name}")
@@ -251,24 +276,42 @@ class ApiToolManageService:
         privacy_policy: str | None,
         custom_disclaimer: str,
         labels: list[str],
-    ):
+    ) -> dict[str, Any]:
         """
-        update api tool provider
+        Update an existing API tool provider.
+
+        :param user_id: The ID of the user updating the provider.
+        :param tenant_id: The ID of the workspace/tenant.
+        :param provider_name: The new name of the API tool provider.
+        :param original_provider: The original name of the API tool provider.
+        :param icon: The icon configuration for the provider.
+        :param credentials: The credentials for the provider.
+        :param _schema_type: The type of schema (e.g., OpenAPI).
+        :param schema: The raw schema string.
+        :param privacy_policy: The privacy policy URL or text.
+        :param custom_disclaimer: Custom disclaimer text.
+        :param labels: A list of labels for the provider.
+        :param session: Optional SQLAlchemy session.
+        :return: A dictionary indicating the result status.
         """
+
         provider_name = provider_name.strip()
 
         # check if the provider exists
-        provider = db.session.scalar(
-            select(ApiToolProvider)
-            .where(
-                ApiToolProvider.tenant_id == tenant_id,
-                ApiToolProvider.name == original_provider,
+        # create new session with automatic transaction management
+        provider: ApiToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            provider = _session.scalar(
+                select(ApiToolProvider)
+                .where(
+                    ApiToolProvider.tenant_id == tenant_id,
+                    ApiToolProvider.name == original_provider,
+                )
+                .limit(1)
             )
-            .limit(1)
-        )
-
         if provider is None:
             raise ValueError(f"api provider {provider_name} does not exists")
+        
         # parse openapi to tool bundle
         extra_info: dict[str, str] = {}
         # extra info like description will be set here
@@ -311,8 +354,8 @@ class ApiToolManageService:
         credentials = dict(encrypter.encrypt(credentials))
         provider.credentials_str = json.dumps(credentials)
 
-        db.session.add(provider)
-        db.session.commit()
+        with sessionmaker(db.engine).begin() as _session:
+            _session.add(provider)
 
         # delete cache
         cache.delete()
@@ -325,29 +368,45 @@ class ApiToolManageService:
     @staticmethod
     def delete_api_tool_provider(user_id: str, tenant_id: str, provider_name: str):
         """
-        delete tool provider
+        Delete an API tool provider.
+
+        :param user_id: The ID of the user performing the deletion operation.
+        :param tenant_id: The ID of the workspace/tenant where the provider belongs.
+        :param provider_name: The unique name of the API tool provider to be deleted.
+        :raises ValueError: If the specified provider does not exist in the tenant.
+        :return: A dictionary indicating the result status.
         """
-        provider = db.session.scalar(
-            select(ApiToolProvider)
-            .where(
-                ApiToolProvider.tenant_id == tenant_id,
-                ApiToolProvider.name == provider_name,
+
+        # create new session with automatic transaction management
+        provider: ApiToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            provider = _session.scalar(
+                select(ApiToolProvider)
+                .where(
+                    ApiToolProvider.tenant_id == tenant_id,
+                    ApiToolProvider.name == provider_name,
+                )
+                .limit(1)
             )
-            .limit(1)
-        )
 
         if provider is None:
             raise ValueError(f"you have not added provider {provider_name}")
 
-        db.session.delete(provider)
-        db.session.commit()
+        # create new session with automatic transaction management to delete the provider
+        with sessionmaker(db.engine).begin() as _session:
+            _session.delete(provider)
 
         return {"result": "success"}
 
     @staticmethod
-    def get_api_tool_provider(user_id: str, tenant_id: str, provider: str):
+    def get_api_tool_provider(user_id: str, tenant_id: str, provider: str) -> dict[str, Any]:
         """
-        get api tool provider
+        Get API tool provider details.
+
+        :param user_id: The ID of the user requesting the provider.
+        :param tenant_id: The ID of the workspace/tenant.
+        :param provider: The name of the API tool provider.
+        :return: A dictionary containing the provider details.
         """
         return ToolManager.user_get_api_provider(provider=provider, tenant_id=tenant_id)
 
@@ -360,10 +419,21 @@ class ApiToolManageService:
         parameters: dict,
         schema_type: ApiProviderSchemaType,
         schema: str,
-    ):
+    ) -> dict[str, Any]:
         """
-        test api tool before adding api tool provider
+        Test an API tool before adding the API tool provider.
+
+        :param tenant_id: The ID of the workspace/tenant.
+        :param provider_name: The name of the API tool provider.
+        :param tool_name: The name of the specific tool to test.
+        :param credentials: The credentials for the provider.
+        :param parameters: The parameters to pass to the tool.
+        :param schema_type: The type of schema (e.g., OpenAPI).
+        :param schema: The raw schema string.
+        :param session: Optional SQLAlchemy session.
+        :return: A dictionary containing the result or error message.
         """
+
         if schema_type not in [member.value for member in ApiProviderSchemaType]:
             raise ValueError(f"invalid schema type {schema_type}")
 
@@ -377,18 +447,21 @@ class ApiToolManageService:
         if tool_bundle is None:
             raise ValueError(f"invalid tool name {tool_name}")
 
-        db_provider = db.session.scalar(
-            select(ApiToolProvider)
-            .where(
-                ApiToolProvider.tenant_id == tenant_id,
-                ApiToolProvider.name == provider_name,
+        # create new session with automatic transaction management to get the provider
+        provider: ApiToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            provider = _session.scalar(
+                select(ApiToolProvider)
+                .where(
+                    ApiToolProvider.tenant_id == tenant_id,
+                    ApiToolProvider.name == provider_name,
+                )
+                .limit(1)
             )
-            .limit(1)
-        )
 
-        if not db_provider:
+        if provider is not None:
             # create a fake db provider
-            db_provider = ApiToolProvider(
+            provider = ApiToolProvider(
                 tenant_id="",
                 user_id="",
                 name="",
@@ -407,12 +480,12 @@ class ApiToolManageService:
         auth_type = ApiProviderAuthType.value_of(credentials["auth_type"])
 
         # create provider entity
-        provider_controller = ApiToolProviderController.from_db(db_provider, auth_type)
+        provider_controller = ApiToolProviderController.from_db(provider, auth_type)
         # load tools into provider entity
         provider_controller.load_bundled_tools(tool_bundles)
 
         # decrypt credentials
-        if db_provider.id:
+        if provider.id:
             encrypter, _ = create_tool_provider_encrypter(
                 tenant_id=tenant_id,
                 controller=provider_controller,
@@ -443,14 +516,22 @@ class ApiToolManageService:
     @staticmethod
     def list_api_tools(tenant_id: str) -> list[ToolProviderApiEntity]:
         """
-        list api tools
+        List all API tools for a specific tenant.
+
+        :param tenant_id: The ID of the workspace/tenant.
+        :return: A list of ToolProviderApiEntity objects.
         """
         # get all api providers
-        db_providers = db.session.scalars(select(ApiToolProvider).where(ApiToolProvider.tenant_id == tenant_id)).all()
+        # create new session with automatic transaction management
+        providers: list[ApiToolProvider] = []
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            providers = _session.scalars(
+                select(ApiToolProvider).
+                where(ApiToolProvider.tenant_id == tenant_id)
+            ).all()
 
         result: list[ToolProviderApiEntity] = []
-
-        for provider in db_providers:
+        for provider in providers:
             # convert provider controller to user provider
             provider_controller = ToolTransformService.api_provider_to_controller(db_provider=provider)
             labels = ToolLabelManager.get_tool_labels(provider_controller)

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -525,7 +525,8 @@ class ApiToolManageService:
         # create new session with automatic transaction management
         providers: list[ApiToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            providers = list(_session.scalars(select(ApiToolProvider).where(ApiToolProvider.tenant_id == tenant_id)).all())
+            providers = list(_session.scalars(select(ApiToolProvider)
+            .where(ApiToolProvider.tenant_id == tenant_id)).all())
 
         result: list[ToolProviderApiEntity] = []
         for provider in providers:

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -147,8 +147,7 @@ class WorkflowToolManageService:
                     WorkflowToolProvider.tenant_id == tenant_id,
                     WorkflowToolProvider.name == name,
                     WorkflowToolProvider.id != workflow_tool_id,
-                )
-                .limit(1)
+                ).limit(1)
             )
 
         # if the name exists raise error
@@ -160,8 +159,10 @@ class WorkflowToolManageService:
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             workflow_tool_provider = _session.scalar(
                 select(WorkflowToolProvider)
-                .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
-                .limit(1)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    WorkflowToolProvider.id == workflow_tool_id
+                ).limit(1)
             )
 
         # if not found raise error
@@ -172,7 +173,11 @@ class WorkflowToolManageService:
         app: App | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             app = _session.scalar(
-                select(App).where(App.id == workflow_tool_provider.app_id, App.tenant_id == tenant_id).limit(1)
+                select(App)
+                .where(
+                    App.id == workflow_tool_provider.app_id,
+                    App.tenant_id == tenant_id
+                ).limit(1)
             )
 
         # if not found raise error
@@ -189,25 +194,30 @@ class WorkflowToolManageService:
         # check if workflow configuration is synced
         WorkflowToolConfigurationUtils.ensure_no_human_input_nodes(workflow.graph_dict)
 
-        # update workflow tool provider
-        workflow_tool_provider.name = name
-        workflow_tool_provider.label = label
-        workflow_tool_provider.icon = json.dumps(icon)
-        workflow_tool_provider.description = description
-        workflow_tool_provider.parameter_configuration = json.dumps([p.model_dump() for p in parameters])
-        workflow_tool_provider.privacy_policy = privacy_policy
-        workflow_tool_provider.version = workflow.version
-        workflow_tool_provider.updated_at = datetime.now()
+        with sessionmaker(db.engine).begin() as _session:
+            _session.add(workflow_tool_provider)
 
-        try:
-            WorkflowToolProviderController.from_db(workflow_tool_provider)
-        except Exception as e:
-            raise ValueError(str(e))
+            # update workflow tool provider
+            workflow_tool_provider.name = name
+            workflow_tool_provider.label = label
+            workflow_tool_provider.icon = json.dumps(icon)
+            workflow_tool_provider.description = description
+            workflow_tool_provider.parameter_configuration = json.dumps([p.model_dump() for p in parameters])
+            workflow_tool_provider.privacy_policy = privacy_policy
+            workflow_tool_provider.version = workflow.version
+            workflow_tool_provider.updated_at = datetime.now()
 
-        if labels is not None:
-            ToolLabelManager.update_tool_labels(
-                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider), labels
-            )
+            try:
+                WorkflowToolProviderController.from_db(workflow_tool_provider)
+            except Exception as e:
+                raise ValueError(str(e))
+
+            if labels is not None:
+                ToolLabelManager.update_tool_labels(
+                    ToolTransformService.workflow_provider_to_controller(workflow_tool_provider),
+                    labels,
+                    session=_session
+                )
 
         return {"result": "success"}
 

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -233,9 +233,9 @@ class WorkflowToolManageService:
 
         providers: list[WorkflowToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            providers = _session.scalars(
+            providers = list(_session.scalars(
                 select(WorkflowToolProvider).where(WorkflowToolProvider.tenant_id == tenant_id)
-            ).all()
+            ).all())
 
         # Create a mapping from provider_id to app_id
         provider_id_to_app_id = {provider.id: provider.app_id for provider in providers}

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -205,7 +205,7 @@ class WorkflowToolManageService:
                 # skip deleted tools
                 logger.exception("Failed to load workflow tool provider %s", provider.id)
 
-        labels = ToolLabelManager.get_tools_labels([t for t in tools if isinstance(t, ToolProviderController)])
+        labels = ToolLabelManager.get_tools_labels([tool for tool in tools if isinstance(tool, ToolProviderController)])
 
         result = []
 

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -322,7 +322,6 @@ class WorkflowToolManageService:
         :return: the tool
         """
 
-        tool_provider: WorkflowToolProvider | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             tool_provider: WorkflowToolProvider | None = _session.scalar(
                 select(WorkflowToolProvider)

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -50,13 +50,11 @@ class WorkflowToolManageService:
                 .where(
                     WorkflowToolProvider.tenant_id == tenant_id,
                     # name or app_id
-                    or_(
-                        WorkflowToolProvider.name == name,
-                        WorkflowToolProvider.app_id == workflow_app_id
-                    ),
-                ).limit(1)
+                    or_(WorkflowToolProvider.name == name, WorkflowToolProvider.app_id == workflow_app_id),
+                )
+                .limit(1)
             )
-            
+
         # if the name or app_id exists raise error
         if existing_workflow_tool_provider is not None:
             raise ValueError(f"Tool with name {name} or app_id {workflow_app_id} already exists")
@@ -64,14 +62,7 @@ class WorkflowToolManageService:
         # query the app
         app: App | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            app= _session.scalar(
-                select(App)
-                .where(
-                    App.id == workflow_app_id,
-                    App.tenant_id == tenant_id
-                )
-                .limit(1)
-            )
+            app = _session.scalar(select(App).where(App.id == workflow_app_id, App.tenant_id == tenant_id).limit(1))
 
         # if not found raise error
         if app is None:
@@ -112,8 +103,7 @@ class WorkflowToolManageService:
         # keep the session open to make orm instances in the same session
         if labels is not None:
             ToolLabelManager.update_tool_labels(
-                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider),
-                labels
+                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider), labels
             )
 
         return {"result": "success"}
@@ -170,10 +160,7 @@ class WorkflowToolManageService:
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             workflow_tool_provider = _session.scalar(
                 select(WorkflowToolProvider)
-                .where(
-                    WorkflowToolProvider.tenant_id == tenant_id,
-                    WorkflowToolProvider.id == workflow_tool_id
-                )
+                .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
                 .limit(1)
             )
 
@@ -185,11 +172,7 @@ class WorkflowToolManageService:
         app: App | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             app = _session.scalar(
-                select(App).
-                where(
-                    App.id == workflow_tool_provider.app_id,
-                    App.tenant_id == tenant_id
-                ).limit(1)
+                select(App).where(App.id == workflow_tool_provider.app_id, App.tenant_id == tenant_id).limit(1)
             )
 
         # if not found raise error
@@ -223,8 +206,7 @@ class WorkflowToolManageService:
 
         if labels is not None:
             ToolLabelManager.update_tool_labels(
-                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider),
-                labels
+                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider), labels
             )
 
         return {"result": "success"}
@@ -242,8 +224,7 @@ class WorkflowToolManageService:
         providers: list[WorkflowToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             providers = _session.scalars(
-                select(WorkflowToolProvider)
-                .where(WorkflowToolProvider.tenant_id == tenant_id)
+                select(WorkflowToolProvider).where(WorkflowToolProvider.tenant_id == tenant_id)
             ).all()
 
         # Create a mapping from provider_id to app_id
@@ -289,13 +270,11 @@ class WorkflowToolManageService:
         :param tenant_id: the tenant id
         :param workflow_tool_id: the workflow tool id
         """
-        
+
         with sessionmaker(db.engine).begin() as _session:
             _session.execute(
-                delete(WorkflowToolProvider)
-                .where(
-                    WorkflowToolProvider.tenant_id == tenant_id,
-                    WorkflowToolProvider.id == workflow_tool_id
+                delete(WorkflowToolProvider).where(
+                    WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id
                 )
             )
 
@@ -316,10 +295,7 @@ class WorkflowToolManageService:
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             tool_provider = _session.scalar(
                 select(WorkflowToolProvider)
-                .where(
-                    WorkflowToolProvider.tenant_id == tenant_id,
-                    WorkflowToolProvider.id == workflow_tool_id
-                )
+                .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
                 .limit(1)
             )
 
@@ -360,12 +336,7 @@ class WorkflowToolManageService:
         workflow_app: App | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             workflow_app = _session.scalar(
-                select(App)
-                .where(
-                    App.id == db_tool.app_id,
-                    App.tenant_id == db_tool.tenant_id
-                )
-                .limit(1)
+                select(App).where(App.id == db_tool.app_id, App.tenant_id == db_tool.tenant_id).limit(1)
             )
 
         if workflow_app is None:
@@ -417,10 +388,7 @@ class WorkflowToolManageService:
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             provider = _session.scalar(
                 select(WorkflowToolProvider)
-                .where(
-                    WorkflowToolProvider.tenant_id == tenant_id,
-                    WorkflowToolProvider.id == workflow_tool_id
-                )
+                .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
                 .limit(1)
             )
 

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from sqlalchemy import delete, or_, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 
 from core.tools.__base.tool_provider import ToolProviderController
 from core.tools.entities.api_entities import ToolApiEntity, ToolProviderApiEntity
@@ -42,32 +42,52 @@ class WorkflowToolManageService:
         labels: list[str] | None = None,
     ):
         # check if the name is unique
-        existing_workflow_tool_provider = db.session.scalar(
-            select(WorkflowToolProvider)
-            .where(
-                WorkflowToolProvider.tenant_id == tenant_id,
-                # name or app_id
-                or_(WorkflowToolProvider.name == name, WorkflowToolProvider.app_id == workflow_app_id),
+        existing_workflow_tool_provider: WorkflowToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            # query if the name or app_id exists
+            existing_workflow_tool_provider = _session.scalar(
+                select(WorkflowToolProvider)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    # name or app_id
+                    or_(
+                        WorkflowToolProvider.name == name,
+                        WorkflowToolProvider.app_id == workflow_app_id
+                    ),
+                ).limit(1)
             )
-            .limit(1)
-        )
-
+            
+        # if the name or app_id exists raise error
         if existing_workflow_tool_provider is not None:
             raise ValueError(f"Tool with name {name} or app_id {workflow_app_id} already exists")
 
-        app: App | None = db.session.scalar(
-            select(App).where(App.id == workflow_app_id, App.tenant_id == tenant_id).limit(1)
-        )
+        # query the app
+        app: App | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            app= _session.scalar(
+                select(App)
+                .where(
+                    App.id == workflow_app_id,
+                    App.tenant_id == tenant_id
+                )
+                .limit(1)
+            )
 
+        # if not found raise error
         if app is None:
             raise ValueError(f"App {workflow_app_id} not found")
 
+        # query the workflow
         workflow: Workflow | None = app.workflow
+
+        # if not found raise error
         if workflow is None:
             raise ValueError(f"Workflow not found for app {workflow_app_id}")
 
+        # check if workflow configuration is synced
         WorkflowToolConfigurationUtils.ensure_no_human_input_nodes(workflow.graph_dict)
 
+        # create workflow tool provider
         workflow_tool_provider = WorkflowToolProvider(
             tenant_id=tenant_id,
             user_id=user_id,
@@ -86,13 +106,16 @@ class WorkflowToolManageService:
         except Exception as e:
             raise ValueError(str(e))
 
-        with Session(db.engine, expire_on_commit=False) as session, session.begin():
-            session.add(workflow_tool_provider)
+        with sessionmaker(db.engine).begin() as _session:
+            _session.add(workflow_tool_provider)
 
+        # keep the session open to make orm instances in the same session
         if labels is not None:
             ToolLabelManager.update_tool_labels(
-                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider), labels
+                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider),
+                labels
             )
+
         return {"result": "success"}
 
     @classmethod
@@ -111,6 +134,7 @@ class WorkflowToolManageService:
     ):
         """
         Update a workflow tool.
+
         :param user_id: the user id
         :param tenant_id: the tenant id
         :param workflow_tool_id: workflow tool id
@@ -123,42 +147,66 @@ class WorkflowToolManageService:
         :param labels: labels
         :return: the updated tool
         """
-        # check if the name is unique
-        existing_workflow_tool_provider = db.session.scalar(
-            select(WorkflowToolProvider)
-            .where(
-                WorkflowToolProvider.tenant_id == tenant_id,
-                WorkflowToolProvider.name == name,
-                WorkflowToolProvider.id != workflow_tool_id,
-            )
-            .limit(1)
-        )
 
+        existing_workflow_tool_provider: WorkflowToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            # query if the name exists for other tools
+            existing_workflow_tool_provider = _session.scalar(
+                select(WorkflowToolProvider)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    WorkflowToolProvider.name == name,
+                    WorkflowToolProvider.id != workflow_tool_id,
+                )
+                .limit(1)
+            )
+
+        # if the name exists raise error
         if existing_workflow_tool_provider is not None:
             raise ValueError(f"Tool with name {name} already exists")
 
-        workflow_tool_provider: WorkflowToolProvider | None = db.session.scalar(
-            select(WorkflowToolProvider)
-            .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
-            .limit(1)
-        )
+        # query the workflow tool provider
+        workflow_tool_provider: WorkflowToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            workflow_tool_provider = _session.scalar(
+                select(WorkflowToolProvider)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    WorkflowToolProvider.id == workflow_tool_id
+                )
+                .limit(1)
+            )
 
+        # if not found raise error
         if workflow_tool_provider is None:
             raise ValueError(f"Tool {workflow_tool_id} not found")
 
-        app: App | None = db.session.scalar(
-            select(App).where(App.id == workflow_tool_provider.app_id, App.tenant_id == tenant_id).limit(1)
-        )
+        # query the app
+        app: App | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            app = _session.scalar(
+                select(App).
+                where(
+                    App.id == workflow_tool_provider.app_id,
+                    App.tenant_id == tenant_id
+                ).limit(1)
+            )
 
+        # if not found raise error
         if app is None:
             raise ValueError(f"App {workflow_tool_provider.app_id} not found")
 
+        # query the workflow
         workflow: Workflow | None = app.workflow
+
+        # if not found raise error
         if workflow is None:
             raise ValueError(f"Workflow not found for app {workflow_tool_provider.app_id}")
 
+        # check if workflow configuration is synced
         WorkflowToolConfigurationUtils.ensure_no_human_input_nodes(workflow.graph_dict)
 
+        # update workflow tool provider
         workflow_tool_provider.name = name
         workflow_tool_provider.label = label
         workflow_tool_provider.icon = json.dumps(icon)
@@ -173,11 +221,10 @@ class WorkflowToolManageService:
         except Exception as e:
             raise ValueError(str(e))
 
-        db.session.commit()
-
         if labels is not None:
             ToolLabelManager.update_tool_labels(
-                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider), labels
+                ToolTransformService.workflow_provider_to_controller(workflow_tool_provider),
+                labels
             )
 
         return {"result": "success"}
@@ -186,19 +233,24 @@ class WorkflowToolManageService:
     def list_tenant_workflow_tools(cls, user_id: str, tenant_id: str) -> list[ToolProviderApiEntity]:
         """
         List workflow tools.
+
         :param user_id: the user id
         :param tenant_id: the tenant id
         :return: the list of tools
         """
-        db_tools = db.session.scalars(
-            select(WorkflowToolProvider).where(WorkflowToolProvider.tenant_id == tenant_id)
-        ).all()
+
+        providers: list[WorkflowToolProvider] = []
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            providers = _session.scalars(
+                select(WorkflowToolProvider)
+                .where(WorkflowToolProvider.tenant_id == tenant_id)
+            ).all()
 
         # Create a mapping from provider_id to app_id
-        provider_id_to_app_id = {provider.id: provider.app_id for provider in db_tools}
+        provider_id_to_app_id = {provider.id: provider.app_id for provider in providers}
 
         tools: list[WorkflowToolProviderController] = []
-        for provider in db_tools:
+        for provider in providers:
             try:
                 tools.append(ToolTransformService.workflow_provider_to_controller(provider))
             except Exception:
@@ -207,7 +259,7 @@ class WorkflowToolManageService:
 
         labels = ToolLabelManager.get_tools_labels([tool for tool in tools if isinstance(tool, ToolProviderController)])
 
-        result = []
+        result: list[ToolProviderApiEntity] = []
 
         for tool in tools:
             workflow_app_id = provider_id_to_app_id.get(tool.provider_id)
@@ -232,17 +284,20 @@ class WorkflowToolManageService:
     def delete_workflow_tool(cls, user_id: str, tenant_id: str, workflow_tool_id: str):
         """
         Delete a workflow tool.
+
         :param user_id: the user id
         :param tenant_id: the tenant id
         :param workflow_tool_id: the workflow tool id
         """
-        db.session.execute(
-            delete(WorkflowToolProvider).where(
-                WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id
+        
+        with sessionmaker(db.engine).begin() as _session:
+            _session.execute(
+                delete(WorkflowToolProvider)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    WorkflowToolProvider.id == workflow_tool_id
+                )
             )
-        )
-
-        db.session.commit()
 
         return {"result": "success"}
 
@@ -250,47 +305,68 @@ class WorkflowToolManageService:
     def get_workflow_tool_by_tool_id(cls, user_id: str, tenant_id: str, workflow_tool_id: str):
         """
         Get a workflow tool.
+
         :param user_id: the user id
         :param tenant_id: the tenant id
         :param workflow_tool_id: the workflow tool id
         :return: the tool
         """
-        db_tool: WorkflowToolProvider | None = db.session.scalar(
-            select(WorkflowToolProvider)
-            .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
-            .limit(1)
-        )
-        return cls._get_workflow_tool(tenant_id, db_tool)
+
+        tool_provider: WorkflowToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            tool_provider = _session.scalar(
+                select(WorkflowToolProvider)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    WorkflowToolProvider.id == workflow_tool_id
+                )
+                .limit(1)
+            )
+
+        return cls._get_workflow_tool(tenant_id, tool_provider)
 
     @classmethod
     def get_workflow_tool_by_app_id(cls, user_id: str, tenant_id: str, workflow_app_id: str):
         """
         Get a workflow tool.
+
         :param user_id: the user id
         :param tenant_id: the tenant id
         :param workflow_app_id: the workflow app id
         :return: the tool
         """
-        db_tool: WorkflowToolProvider | None = db.session.scalar(
-            select(WorkflowToolProvider)
-            .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.app_id == workflow_app_id)
-            .limit(1)
-        )
-        return cls._get_workflow_tool(tenant_id, db_tool)
+
+        tool_provider: WorkflowToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            tool_provider: WorkflowToolProvider | None = _session.scalar(
+                select(WorkflowToolProvider)
+                .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.app_id == workflow_app_id)
+                .limit(1)
+            )
+
+        return cls._get_workflow_tool(tenant_id, tool_provider)
 
     @classmethod
     def _get_workflow_tool(cls, tenant_id: str, db_tool: WorkflowToolProvider | None):
         """
         Get a workflow tool.
+
         :db_tool: the database tool
         :return: the tool
         """
         if db_tool is None:
             raise ValueError("Tool not found")
 
-        workflow_app: App | None = db.session.scalar(
-            select(App).where(App.id == db_tool.app_id, App.tenant_id == db_tool.tenant_id).limit(1)
-        )
+        workflow_app: App | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            workflow_app = _session.scalar(
+                select(App)
+                .where(
+                    App.id == db_tool.app_id,
+                    App.tenant_id == db_tool.tenant_id
+                )
+                .limit(1)
+            )
 
         if workflow_app is None:
             raise ValueError(f"App {db_tool.app_id} not found")
@@ -330,28 +406,35 @@ class WorkflowToolManageService:
     def list_single_workflow_tools(cls, user_id: str, tenant_id: str, workflow_tool_id: str) -> list[ToolApiEntity]:
         """
         List workflow tool provider tools.
+
         :param user_id: the user id
         :param tenant_id: the tenant id
         :param workflow_tool_id: the workflow tool id
         :return: the list of tools
         """
-        db_tool: WorkflowToolProvider | None = db.session.scalar(
-            select(WorkflowToolProvider)
-            .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
-            .limit(1)
-        )
 
-        if db_tool is None:
+        provider: WorkflowToolProvider | None = None
+        with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
+            provider = _session.scalar(
+                select(WorkflowToolProvider)
+                .where(
+                    WorkflowToolProvider.tenant_id == tenant_id,
+                    WorkflowToolProvider.id == workflow_tool_id
+                )
+                .limit(1)
+            )
+
+        if provider is None:
             raise ValueError(f"Tool {workflow_tool_id} not found")
 
-        tool = ToolTransformService.workflow_provider_to_controller(db_tool)
+        tool = ToolTransformService.workflow_provider_to_controller(provider)
         workflow_tools: list[WorkflowTool] = tool.get_tools(tenant_id)
         if len(workflow_tools) == 0:
             raise ValueError(f"Tool {workflow_tool_id} not found")
 
         return [
             ToolTransformService.convert_tool_entity_to_api_entity(
-                tool=tool.get_tools(db_tool.tenant_id)[0],
+                tool=tool.get_tools(provider.tenant_id)[0],
                 labels=ToolLabelManager.get_tool_labels(tool),
                 tenant_id=tenant_id,
             )

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -147,7 +147,8 @@ class WorkflowToolManageService:
                     WorkflowToolProvider.tenant_id == tenant_id,
                     WorkflowToolProvider.name == name,
                     WorkflowToolProvider.id != workflow_tool_id,
-                ).limit(1)
+                )
+                .limit(1)
             )
 
         # if the name exists raise error
@@ -159,10 +160,8 @@ class WorkflowToolManageService:
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             workflow_tool_provider = _session.scalar(
                 select(WorkflowToolProvider)
-                .where(
-                    WorkflowToolProvider.tenant_id == tenant_id,
-                    WorkflowToolProvider.id == workflow_tool_id
-                ).limit(1)
+                .where(WorkflowToolProvider.tenant_id == tenant_id, WorkflowToolProvider.id == workflow_tool_id)
+                .limit(1)
             )
 
         # if not found raise error
@@ -173,11 +172,7 @@ class WorkflowToolManageService:
         app: App | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             app = _session.scalar(
-                select(App)
-                .where(
-                    App.id == workflow_tool_provider.app_id,
-                    App.tenant_id == tenant_id
-                ).limit(1)
+                select(App).where(App.id == workflow_tool_provider.app_id, App.tenant_id == tenant_id).limit(1)
             )
 
         # if not found raise error
@@ -216,7 +211,7 @@ class WorkflowToolManageService:
                 ToolLabelManager.update_tool_labels(
                     ToolTransformService.workflow_provider_to_controller(workflow_tool_provider),
                     labels,
-                    session=_session
+                    session=_session,
                 )
 
         return {"result": "success"}
@@ -233,9 +228,9 @@ class WorkflowToolManageService:
 
         providers: list[WorkflowToolProvider] = []
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
-            providers = list(_session.scalars(
-                select(WorkflowToolProvider).where(WorkflowToolProvider.tenant_id == tenant_id)
-            ).all())
+            providers = list(
+                _session.scalars(select(WorkflowToolProvider).where(WorkflowToolProvider.tenant_id == tenant_id)).all()
+            )
 
         # Create a mapping from provider_id to app_id
         provider_id_to_app_id = {provider.id: provider.app_id for provider in providers}

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -138,7 +138,8 @@ def test_inner_api_config_exist(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DB_DATABASE", "dify")
     monkeypatch.setenv("INNER_API_KEY", "test-inner-api-key")
 
-    config = DifyConfig()
+    # Disable `.env` loading to ensure test stability across environments
+    config = DifyConfig(_env_file=None)
     assert config.INNER_API is False
     assert isinstance(config.INNER_API_KEY, str)
     assert len(config.INNER_API_KEY) > 0
@@ -156,7 +157,8 @@ def test_db_extras_options_merging(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DB_EXTRAS", "options=-c search_path=myschema")
 
     # Create config
-    config = DifyConfig()
+    # Disable `.env` loading to ensure test stability across environments
+    config = DifyConfig(_env_file=None)
 
     # Get engine options
     engine_options = config.SQLALCHEMY_ENGINE_OPTIONS
@@ -184,7 +186,8 @@ def test_pubsub_redis_url_default(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("REDIS_DB", "2")
     monkeypatch.setenv("REDIS_USE_SSL", "true")
 
-    config = DifyConfig()
+    # Disable `.env` loading to ensure test stability across environments
+    config = DifyConfig(_env_file=None)
 
     assert config.normalized_pubsub_redis_url == "rediss://user:pass%40word@redis.example.com:6380/2"
     assert config.PUBSUB_REDIS_CHANNEL_TYPE == "pubsub"
@@ -202,7 +205,8 @@ def test_pubsub_redis_url_override(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DB_DATABASE", "dify")
     monkeypatch.setenv("PUBSUB_REDIS_URL", "redis://pubsub-host:6381/5")
 
-    config = DifyConfig()
+    # Disable `.env` loading to ensure test stability across environments
+    config = DifyConfig(_env_file=None)
 
     assert config.normalized_pubsub_redis_url == "redis://pubsub-host:6381/5"
 
@@ -219,8 +223,9 @@ def test_pubsub_redis_url_required_when_default_unavailable(monkeypatch: pytest.
     monkeypatch.setenv("DB_DATABASE", "dify")
     monkeypatch.setenv("REDIS_HOST", "")
 
+    # Disable `.env` loading to ensure test stability across environments
     with pytest.raises(ValueError, match="PUBSUB_REDIS_URL must be set"):
-        _ = DifyConfig().normalized_pubsub_redis_url
+        _ = DifyConfig(_env_file=None).normalized_pubsub_redis_url
 
 
 @pytest.mark.parametrize(
@@ -274,7 +279,8 @@ def test_celery_broker_url_with_special_chars_password(
     monkeypatch.setenv("CELERY_BROKER_URL", broker_url)
 
     # Create config and verify the URL is stored correctly
-    config = DifyConfig()
+    # Disable `.env` loading to ensure test stability across environments
+    config = DifyConfig(_env_file=None)
     assert broker_url == config.CELERY_BROKER_URL
 
     # Test actual parsing behavior using kombu's parse_url (same as production)

--- a/api/tests/unit_tests/core/tools/test_tool_label_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_label_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -11,12 +11,12 @@ from core.tools.custom_tool.provider import ApiToolProviderController
 from core.tools.tool_label_manager import ToolLabelManager
 from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
 
-
+# Create a mock class for testing abstract/base classes
 class _ConcreteBuiltinToolProviderController(BuiltinToolProviderController):
     def _validate_credentials(self, user_id: str, credentials: dict[str, Any]):
         return None
 
-
+# Factory function to create a "lightweight" controller for testing
 def _api_controller(provider_id: str = "api-1") -> ApiToolProviderController:
     controller = object.__new__(ApiToolProviderController)
     controller.provider_id = provider_id
@@ -28,30 +28,37 @@ def _workflow_controller(provider_id: str = "wf-1") -> WorkflowToolProviderContr
     controller.provider_id = provider_id
     return controller
 
-
+# Test pure logic: filtering and deduplication
 def test_tool_label_manager_filter_tool_labels():
     filtered = ToolLabelManager.filter_tool_labels(["search", "search", "invalid", "news"])
     assert set(filtered) == {"search", "news"}
     assert len(filtered) == 2
 
-
+# Test database update logic with Session Mocking
 def test_tool_label_manager_update_tool_labels_db():
     controller = _api_controller("api-1")
-    with patch("core.tools.tool_label_manager.db") as mock_db:
+
+    # Patch 'db' to avoid Flask context issues, and 'sessionmaker' to intercept DB calls
+    with patch("core.tools.tool_label_manager.db"), \
+         patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker:
+
+        # Mocking the chain: sessionmaker(engine).begin().__enter__ -> session
+        mock_session = MagicMock()
+        mock_sessionmaker.return_value.begin.return_value.__enter__.return_value = mock_session
+        
         ToolLabelManager.update_tool_labels(controller, ["search", "search", "invalid"])
 
-        mock_db.session.execute.assert_called_once()
-        # only one valid unique label should be inserted.
-        assert mock_db.session.add.call_count == 1
-        mock_db.session.commit.assert_called_once()
+        # Verify if the execute method (DELETE SQL) was called
+        mock_session.execute.assert_called_once()
 
-
+# Test error handling
 def test_tool_label_manager_update_tool_labels_unsupported():
     with pytest.raises(ValueError, match="Unsupported tool type"):
         ToolLabelManager.update_tool_labels(object(), ["search"])  # type: ignore[arg-type]
 
-
+# Test retrieval logic
 def test_tool_label_manager_get_tool_labels_for_builtin_and_db():
+    # Mocking a property (@property) using PropertyMock
     with patch.object(
         _ConcreteBuiltinToolProviderController,
         "tool_labels",
@@ -62,29 +69,42 @@ def test_tool_label_manager_get_tool_labels_for_builtin_and_db():
         assert ToolLabelManager.get_tool_labels(builtin) == ["search", "news"]
 
     api = _api_controller("api-1")
-    with patch("core.tools.tool_label_manager.db") as mock_db:
-        mock_db.session.scalars.return_value.all.return_value = ["search", "news"]
+    with patch("core.tools.tool_label_manager.db"), \
+         patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker:
+        
+        mock_session = MagicMock()
+        mock_sessionmaker.return_value.begin.return_value.__enter__.return_value = mock_session
+        
+        # Inject mock data into the query result: session.scalars(stmt).all()
+        mock_session.scalars.return_value.all.return_value = ["search", "news"]
+        
         labels = ToolLabelManager.get_tool_labels(api)
-    assert labels == ["search", "news"]
+        assert labels == ["search", "news"]
 
-    with pytest.raises(ValueError, match="Unsupported tool type"):
-        ToolLabelManager.get_tool_labels(object())  # type: ignore[arg-type]
-
-
+# Test batch processing and mapping
 def test_tool_label_manager_get_tools_labels_batch():
     assert ToolLabelManager.get_tools_labels([]) == {}
 
     api = _api_controller("api-1")
     wf = _workflow_controller("wf-1")
+
+    # SimpleNamespace is a quick way to simulate SQLAlchemy row objects
     records = [
         SimpleNamespace(tool_id="api-1", label_name="search"),
         SimpleNamespace(tool_id="api-1", label_name="news"),
         SimpleNamespace(tool_id="wf-1", label_name="utilities"),
     ]
-    with patch("core.tools.tool_label_manager.db") as mock_db:
-        mock_db.session.scalars.return_value.all.return_value = records
-        labels = ToolLabelManager.get_tools_labels([api, wf])
-    assert labels == {"api-1": ["search", "news"], "wf-1": ["utilities"]}
 
-    with pytest.raises(ValueError, match="Unsupported tool type"):
-        ToolLabelManager.get_tools_labels([api, object()])  # type: ignore[list-item]
+    with patch("core.tools.tool_label_manager.db"), \
+         patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker:
+        
+        mock_session = MagicMock()
+        mock_sessionmaker.return_value.begin.return_value.__enter__.return_value = mock_session
+        
+        # Simulating the batch query result
+        mock_session.scalars.return_value.all.return_value = records
+        
+        labels = ToolLabelManager.get_tools_labels([api, wf])
+
+    # Verify the final dictionary mapping    
+    assert labels == {"api-1": ["search", "news"], "wf-1": ["utilities"]}

--- a/api/tests/unit_tests/core/tools/test_tool_label_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_label_manager.py
@@ -11,10 +11,12 @@ from core.tools.custom_tool.provider import ApiToolProviderController
 from core.tools.tool_label_manager import ToolLabelManager
 from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
 
+
 # Create a mock class for testing abstract/base classes
 class _ConcreteBuiltinToolProviderController(BuiltinToolProviderController):
     def _validate_credentials(self, user_id: str, credentials: dict[str, Any]):
         return None
+
 
 # Factory function to create a "lightweight" controller for testing
 def _api_controller(provider_id: str = "api-1") -> ApiToolProviderController:
@@ -28,11 +30,13 @@ def _workflow_controller(provider_id: str = "wf-1") -> WorkflowToolProviderContr
     controller.provider_id = provider_id
     return controller
 
+
 # Test pure logic: filtering and deduplication
 def test_tool_label_manager_filter_tool_labels():
     filtered = ToolLabelManager.filter_tool_labels(["search", "search", "invalid", "news"])
     assert set(filtered) == {"search", "news"}
     assert len(filtered) == 2
+
 
 # Test database update logic with Session Mocking
 def test_tool_label_manager_update_tool_labels_db():
@@ -51,10 +55,12 @@ def test_tool_label_manager_update_tool_labels_db():
         # Verify if the execute method (DELETE SQL) was called
         mock_session.execute.assert_called_once()
 
+
 # Test error handling
 def test_tool_label_manager_update_tool_labels_unsupported():
     with pytest.raises(ValueError, match="Unsupported tool type"):
         ToolLabelManager.update_tool_labels(object(), ["search"])  # type: ignore[arg-type]
+
 
 # Test retrieval logic
 def test_tool_label_manager_get_tool_labels_for_builtin_and_db():
@@ -80,6 +86,7 @@ def test_tool_label_manager_get_tool_labels_for_builtin_and_db():
         
         labels = ToolLabelManager.get_tool_labels(api)
         assert labels == ["search", "news"]
+
 
 # Test batch processing and mapping
 def test_tool_label_manager_get_tools_labels_batch():

--- a/api/tests/unit_tests/core/tools/test_tool_label_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_label_manager.py
@@ -43,13 +43,14 @@ def test_tool_label_manager_update_tool_labels_db():
     controller = _api_controller("api-1")
 
     # Patch 'db' to avoid Flask context issues, and 'sessionmaker' to intercept DB calls
-    with patch("core.tools.tool_label_manager.db"), \
-         patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker:
-
+    with (
+        patch("core.tools.tool_label_manager.db"),
+        patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker,
+    ):
         # Mocking the chain: sessionmaker(engine).begin().__enter__ -> session
         mock_session = MagicMock()
         mock_sessionmaker.return_value.begin.return_value.__enter__.return_value = mock_session
-        
+
         ToolLabelManager.update_tool_labels(controller, ["search", "search", "invalid"])
 
         # Verify if the execute method (DELETE SQL) was called
@@ -75,15 +76,16 @@ def test_tool_label_manager_get_tool_labels_for_builtin_and_db():
         assert ToolLabelManager.get_tool_labels(builtin) == ["search", "news"]
 
     api = _api_controller("api-1")
-    with patch("core.tools.tool_label_manager.db"), \
-         patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker:
-        
+    with (
+        patch("core.tools.tool_label_manager.db"),
+        patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker,
+    ):
         mock_session = MagicMock()
         mock_sessionmaker.return_value.begin.return_value.__enter__.return_value = mock_session
-        
+
         # Inject mock data into the query result: session.scalars(stmt).all()
         mock_session.scalars.return_value.all.return_value = ["search", "news"]
-        
+
         labels = ToolLabelManager.get_tool_labels(api)
         assert labels == ["search", "news"]
 
@@ -102,16 +104,17 @@ def test_tool_label_manager_get_tools_labels_batch():
         SimpleNamespace(tool_id="wf-1", label_name="utilities"),
     ]
 
-    with patch("core.tools.tool_label_manager.db"), \
-         patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker:
-        
+    with (
+        patch("core.tools.tool_label_manager.db"),
+        patch("core.tools.tool_label_manager.sessionmaker") as mock_sessionmaker,
+    ):
         mock_session = MagicMock()
         mock_sessionmaker.return_value.begin.return_value.__enter__.return_value = mock_session
-        
+
         # Simulating the batch query result
         mock_session.scalars.return_value.all.return_value = records
-        
+
         labels = ToolLabelManager.get_tools_labels([api, wf])
 
-    # Verify the final dictionary mapping    
+    # Verify the final dictionary mapping
     assert labels == {"api-1": ["search", "news"], "wf-1": ["utilities"]}


### PR DESCRIPTION
#24115


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Ref #<issue number>`.

## Summary

**Motivation & Context:**
Currently, `ToolLabelManager, ApiToolManageService, WorkflowToolManageService` tightly couples database operations with the global `db.session` and auto-commits. This prevents external transaction control (e.g., executing multiple service methods within a single atomic transaction) and makes unit testing difficult without a real database connection.

**Changes in this Draft PR:**
- refactored using `with sessionmaker`
- Ensured transactions atomicity
- Added comprehensive Sphinx/reST style docstrings.

## Screenshots

N/A - Backend architectural refactoring only.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods