### PR TITLE
fix(#34467): include @dify/iconify-collections in Docker build context

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -25,6 +25,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY web/package.json /app/web/
 COPY e2e/package.json /app/e2e/
 COPY sdks/nodejs-client/package.json /app/sdks/nodejs-client/
+COPY packages/iconify-collections/package.json /app/packages/iconify-collections/
 COPY packages /app/packages
 
 # Use packageManager from package.json

--- a/web/Dockerfile.dockerignore
+++ b/web/Dockerfile.dockerignore
@@ -10,6 +10,7 @@
 !packages/
 !packages/**/
 !packages/**/package.json
+!packages/iconify-collections/**
 !sdks/
 !sdks/nodejs-client/
 !sdks/nodejs-client/package.json


### PR DESCRIPTION
## Fix
Web Docker build fails because `@dify/iconify-collections` workspace package is excluded from the build context.

## Root Cause
`web/Dockerfile` only copies a subset of workspace `package.json` files into the install stage, missing `packages/iconify-collections`. `web/Dockerfile.dockerignore` excludes the entire package via the top-level `**` wildcard — the existing `!packages/**/package.json` exception only covers `package.json`, not source files needed at build time.

## Change
- `web/Dockerfile`: add `COPY packages/iconify-collections/package.json` in the install stage
- `web/Dockerfile.dockerignore`: add `!packages/iconify-collections/**` to allow source files into context

## Scope
2 files, 2 lines added. No side effects.

Fixes #34467