### PR TITLE
fix(api): add missing error handling in Notion table rows extractor

### DIFF
--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -291,17 +291,24 @@ class NotionExtractor(BaseExtractor):
         while not done:
             query_dict: dict[str, Any] = {} if not start_cursor else {"start_cursor": start_cursor}
 
-            res = httpx.request(
-                "GET",
-                block_url,
-                headers={
-                    "Authorization": "Bearer " + self._notion_access_token,
-                    "Content-Type": "application/json",
-                    "Notion-Version": "2022-06-28",
-                },
-                params=query_dict,
-            )
-            data = res.json()
+            try:
+                res = httpx.request(
+                    "GET",
+                    block_url,
+                    headers={
+                        "Authorization": "Bearer " + self._notion_access_token,
+                        "Content-Type": "application/json",
+                        "Notion-Version": "2022-06-28",
+                    },
+                    params=query_dict,
+                )
+                if res.status_code != 200:
+                    raise ValueError(f"Error fetching Notion table rows: {res.text}")
+                data = res.json()
+            except httpx.HTTPError as e:
+                raise ValueError("Error fetching Notion table rows") from e
+            if "results" not in data or not isinstance(data["results"], list) or len(data["results"]) == 0:
+                break
             # get table headers text
             table_header_cell_texts = []
             table_header_cells = data["results"][0]["table_row"]["cells"]

--- a/api/tests/unit_tests/core/datasource/test_notion_provider.py
+++ b/api/tests/unit_tests/core/datasource/test_notion_provider.py
@@ -599,7 +599,9 @@ class TestNotionExtractorTableParsing:
             "next_cursor": None,
             "has_more": False,
         }
-        mock_request.return_value = Mock(json=lambda: mock_data)
+        mock_response = Mock(json=lambda: mock_data)
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
 
         # Act
         result = extractor._read_table_rows("table-block-123")
@@ -631,7 +633,9 @@ class TestNotionExtractorTableParsing:
             "next_cursor": None,
             "has_more": False,
         }
-        mock_request.return_value = Mock(json=lambda: mock_data)
+        mock_response = Mock(json=lambda: mock_data)
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
 
         # Act
         result = extractor._read_table_rows("table-block-123")
@@ -670,7 +674,11 @@ class TestNotionExtractorTableParsing:
             "next_cursor": None,
             "has_more": False,
         }
-        mock_request.side_effect = [Mock(json=lambda: first_page), Mock(json=lambda: second_page)]
+        first_mock = Mock(json=lambda: first_page)
+        first_mock.status_code = 200
+        second_mock = Mock(json=lambda: second_page)
+        second_mock.status_code = 200
+        mock_request.side_effect = [first_mock, second_mock]
 
         # Act
         result = extractor._read_table_rows("table-block-123")

--- a/api/tests/unit_tests/core/datasource/test_notion_provider.py
+++ b/api/tests/unit_tests/core/datasource/test_notion_provider.py
@@ -1662,7 +1662,9 @@ class TestNotionExtractorTableAdvanced:
             "next_cursor": None,
             "has_more": False,
         }
-        mock_request.return_value = Mock(json=lambda: mock_data)
+        mock_response = Mock(json=lambda: mock_data)
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
 
         # Act
         result = extractor._read_table_rows("table-block-123")

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
@@ -381,6 +381,58 @@ class TestNotionBlocks:
         assert "| H1 |  |" in markdown
         assert "| R2C1 | R2C2 |" in markdown
 
+    def test_read_table_rows_raises_on_http_error(self, mocker: MockerFixture):
+        extractor = notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type="page",
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+        mocker.patch("httpx.request", return_value=_mock_response({}, status_code=401, text="Unauthorized"))
+        with pytest.raises(ValueError, match="Error fetching Notion table rows"):
+            extractor._read_table_rows("tbl-1")
+
+    def test_read_table_rows_raises_on_network_error(self, mocker: MockerFixture):
+        extractor = notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type="page",
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+        mocker.patch("httpx.request", side_effect=httpx.HTTPError("connection failed"))
+        with pytest.raises(ValueError, match="Error fetching Notion table rows"):
+            extractor._read_table_rows("tbl-1")
+
+    def test_read_table_rows_returns_empty_on_missing_results(self, mocker: MockerFixture):
+        extractor = notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type="page",
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+        mocker.patch("httpx.request", return_value=_mock_response({"results": [], "next_cursor": None}))
+        assert extractor._read_table_rows("tbl-1") == ""
+
+    def test_read_table_rows_returns_empty_on_error_response_body(self, mocker: MockerFixture):
+        extractor = notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type="page",
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+        # Simulate Notion API error wrapped in 200 (some edge cases)
+        error_body = {"object": "error", "status": 400, "message": "Invalid block"}
+        mocker.patch("httpx.request", return_value=_mock_response(error_body))
+        assert extractor._read_table_rows("tbl-1") == ""
+
 
 class TestNotionMetadataAndCredentialMethods:
     def test_update_last_edited_time_no_document_model(self):


### PR DESCRIPTION
I noticed that `_read_table_rows` in `notion_extractor.py` is the only method in the Notion extractor that doesn't validate the HTTP response before processing. Its sibling methods `_get_notion_block_data` (lines 171-188) and `_read_block` (line 245) both check the status code and validate the response structure, but `_read_table_rows` goes straight to `data["results"][0]` without any checks.

This crashes in two situations:

1. **Notion API returns an error** (401 expired token, 429 rate limit, 500 server error): The response body has no `"results"` key, so `data["results"]` raises `KeyError`.

2. **Empty table results**: If the results array is empty, `data["results"][0]` raises `IndexError`.

Both are easy to reproduce:
```python
# Error response (expired token):
data = {"object": "error", "status": 401, "code": "unauthorized"}
data["results"][0]  # → KeyError: 'results'

# Empty results:
data = {"results": [], "next_cursor": None}
data["results"][0]  # → IndexError: list index out of range
```

The fix adds the same validation pattern already used by `_get_notion_block_data`:
- HTTP status code check with `ValueError` on non-200
- `httpx.HTTPError` catch for network failures
- `"results"` key and empty-list check before indexing

**Tests added:** Four test cases covering HTTP error, network error, empty results, and error-in-200-body scenarios.