### PR TITLE
refactor: convert ProviderQuotaType if/elif to match/case (#30001)

### DIFF
--- a/api/events/event_handlers/update_provider_when_message_created.py
+++ b/api/events/event_handlers/update_provider_when_message_created.py
@@ -160,7 +160,9 @@ def handle(sender: Message, **kwargs):
                             provider_type=ProviderType.SYSTEM.value,
                             quota_type=provider_configuration.system_configuration.current_quota_type,
                         ),
-                        values=_ProviderUpdateValues(quota_used=Provider.quota_used + used_quota, last_used=current_time),
+                        values=_ProviderUpdateValues(
+                            quota_used=Provider.quota_used + used_quota, last_used=current_time
+                        ),
                         additional_filters=_ProviderUpdateAdditionalFilters(
                             quota_limit_check=True  # Provider.quota_limit > Provider.quota_used
                         ),

--- a/api/events/event_handlers/update_provider_when_message_created.py
+++ b/api/events/event_handlers/update_provider_when_message_created.py
@@ -135,37 +135,38 @@ def handle(sender: Message, **kwargs):
             model_name=model_config.model,
         )
         if used_quota is not None:
-            if provider_configuration.system_configuration.current_quota_type == ProviderQuotaType.TRIAL:
-                from services.credit_pool_service import CreditPoolService
+            match provider_configuration.system_configuration.current_quota_type:
+                case ProviderQuotaType.TRIAL:
+                    from services.credit_pool_service import CreditPoolService
 
-                CreditPoolService.check_and_deduct_credits(
-                    tenant_id=tenant_id,
-                    credits_required=used_quota,
-                    pool_type="trial",
-                )
-            elif provider_configuration.system_configuration.current_quota_type == ProviderQuotaType.PAID:
-                from services.credit_pool_service import CreditPoolService
-
-                CreditPoolService.check_and_deduct_credits(
-                    tenant_id=tenant_id,
-                    credits_required=used_quota,
-                    pool_type="paid",
-                )
-            else:
-                quota_update = _ProviderUpdateOperation(
-                    filters=_ProviderUpdateFilters(
+                    CreditPoolService.check_and_deduct_credits(
                         tenant_id=tenant_id,
-                        provider_name=ModelProviderID(model_config.provider).provider_name,
-                        provider_type=ProviderType.SYSTEM.value,
-                        quota_type=provider_configuration.system_configuration.current_quota_type,
-                    ),
-                    values=_ProviderUpdateValues(quota_used=Provider.quota_used + used_quota, last_used=current_time),
-                    additional_filters=_ProviderUpdateAdditionalFilters(
-                        quota_limit_check=True  # Provider.quota_limit > Provider.quota_used
-                    ),
-                    description="quota_deduction_update",
-                )
-                updates_to_perform.append(quota_update)
+                        credits_required=used_quota,
+                        pool_type="trial",
+                    )
+                case ProviderQuotaType.PAID:
+                    from services.credit_pool_service import CreditPoolService
+
+                    CreditPoolService.check_and_deduct_credits(
+                        tenant_id=tenant_id,
+                        credits_required=used_quota,
+                        pool_type="paid",
+                    )
+                case ProviderQuotaType.FREE:
+                    quota_update = _ProviderUpdateOperation(
+                        filters=_ProviderUpdateFilters(
+                            tenant_id=tenant_id,
+                            provider_name=ModelProviderID(model_config.provider).provider_name,
+                            provider_type=ProviderType.SYSTEM.value,
+                            quota_type=provider_configuration.system_configuration.current_quota_type,
+                        ),
+                        values=_ProviderUpdateValues(quota_used=Provider.quota_used + used_quota, last_used=current_time),
+                        additional_filters=_ProviderUpdateAdditionalFilters(
+                            quota_limit_check=True  # Provider.quota_limit > Provider.quota_used
+                        ),
+                        description="quota_deduction_update",
+                    )
+                    updates_to_perform.append(quota_update)
 
     # Execute all updates
     start_time = time_module.perf_counter()


### PR DESCRIPTION
## Summary
Part of #30001. Split from #34412 per review feedback.

Converts `ProviderQuotaType` (`TRIAL`/`PAID`/`FREE`) dispatch in `update_provider_when_message_created.py` from `if/elif` to `match/case`.

## Changes
- `api/events/event_handlers/update_provider_when_message_created.py`: 3 explicit enum cases, no `case _:` wildcard

## Testing
- pyrefly-diff ✅
- API Unit Tests ✅
- Python Style ✅