### PR TITLE
refactor(web): convert file-local Step enum to as-const in website crawlers 🤖🤖🤖

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2449,9 +2449,6 @@
     }
   },
   "web/app/components/datasets/create/website/firecrawl/index.tsx": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "no-console": {
       "count": 1
     },
@@ -2468,9 +2465,6 @@
     }
   },
   "web/app/components/datasets/create/website/jina-reader/index.tsx": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "no-console": {
       "count": 1
     },
@@ -2487,9 +2481,6 @@
     }
   },
   "web/app/components/datasets/create/website/watercrawl/index.tsx": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "no-console": {
       "count": 1
     },

--- a/web/app/components/datasets/create/website/firecrawl/index.tsx
+++ b/web/app/components/datasets/create/website/firecrawl/index.tsx
@@ -27,11 +27,12 @@ type Props = {
   crawlOptions: CrawlOptions
   onCrawlOptionsChange: (payload: CrawlOptions) => void
 }
-enum Step {
-  init = 'init',
-  running = 'running',
-  finished = 'finished',
-}
+const Step = {
+  init: 'init',
+  running: 'running',
+  finished: 'finished',
+} as const
+type Step = typeof Step[keyof typeof Step]
 type CrawlState = {
   current: number
   total: number

--- a/web/app/components/datasets/create/website/jina-reader/index.tsx
+++ b/web/app/components/datasets/create/website/jina-reader/index.tsx
@@ -27,11 +27,12 @@ type Props = {
   crawlOptions: CrawlOptions
   onCrawlOptionsChange: (payload: CrawlOptions) => void
 }
-enum Step {
-  init = 'init',
-  running = 'running',
-  finished = 'finished',
-}
+const Step = {
+  init: 'init',
+  running: 'running',
+  finished: 'finished',
+} as const
+type Step = typeof Step[keyof typeof Step]
 const JinaReader: FC<Props> = ({ onPreview, checkedCrawlResult, onCheckedCrawlResultChange, onJobIdChange, crawlOptions, onCrawlOptionsChange }) => {
   const { t } = useTranslation()
   const [step, setStep] = useState<Step>(Step.init)

--- a/web/app/components/datasets/create/website/watercrawl/index.tsx
+++ b/web/app/components/datasets/create/website/watercrawl/index.tsx
@@ -27,11 +27,12 @@ type Props = {
   crawlOptions: CrawlOptions
   onCrawlOptionsChange: (payload: CrawlOptions) => void
 }
-enum Step {
-  init = 'init',
-  running = 'running',
-  finished = 'finished',
-}
+const Step = {
+  init: 'init',
+  running: 'running',
+  finished: 'finished',
+} as const
+type Step = typeof Step[keyof typeof Step]
 const WaterCrawl: FC<Props> = ({ onPreview, checkedCrawlResult, onCheckedCrawlResultChange, onJobIdChange, crawlOptions, onCrawlOptionsChange }) => {
   const { t } = useTranslation()
   const [step, setStep] = useState<Step>(Step.init)


### PR DESCRIPTION
## Summary

Converts the file-local `Step` enum to an `as const` object with a companion type alias in three website crawler components (`firecrawl`, `jina-reader`, `watercrawl`). All three files declared an identical 3-value `Step` enum (`init` / `running` / `finished`) used for local crawl-state tracking.

Partially addresses #27998.

## Why this is safe

- `Step` is **file-local** in each component — never exported, never imported cross-file.
- All call sites use value lookup (`Step.init`, `Step.running`, `Step.finished`) or type position (`useState<Step>`), so the `as const` object produces identical runtime values and compile-time types.
- No runtime reflection (`Object.values`/`Object.keys`/iteration), so none of the special-case patterns from dosubot's comment on #27998 apply.

## Pattern

Matches the convention from the merged batches (e.g. #33960, #33834):

```ts
const Step = {
  init: 'init',
  running: 'running',
  finished: 'finished',
} as const
type Step = typeof Step[keyof typeof Step]
```

## Checklist

- [x] Ran `npx eslint` on the three touched files — 0 errors
- [x] Ran `npx tsc --noEmit -p tsconfig.json` — 0 errors
- [x] Ran `npx knip` — 0 errors
- [x] Removed the three `erasable-syntax-only/enums` suppressions from `web/eslint-suppressions.json` (other suppressions for these files left intact)