### PR TITLE
refactor(web): convert enums to as-const in subscription-list 🤖🤖🤖

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3415,16 +3415,6 @@
       "count": 1
     }
   },
-  "web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/use-common-modal-state.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    }
-  },
-  "web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/use-oauth-client-state.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 2
-    }
-  },
   "web/app/components/plugins/plugin-detail-panel/subscription-list/create/index.tsx": {
     "no-barrel-files/no-barrel-files": {
       "count": 3
@@ -3438,15 +3428,7 @@
       "count": 1
     }
   },
-  "web/app/components/plugins/plugin-detail-panel/subscription-list/create/types.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    }
-  },
   "web/app/components/plugins/plugin-detail-panel/subscription-list/edit/apikey-edit-modal.tsx": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -3472,9 +3454,6 @@
     }
   },
   "web/app/components/plugins/plugin-detail-panel/subscription-list/log-viewer.tsx": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 2
     }
@@ -3486,11 +3465,6 @@
   },
   "web/app/components/plugins/plugin-detail-panel/subscription-list/subscription-card.tsx": {
     "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/components/plugins/plugin-detail-panel/subscription-list/types.ts": {
-    "erasable-syntax-only/enums": {
       "count": 1
     }
   },

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/index.spec.tsx
@@ -1437,7 +1437,7 @@ describe('CreateSubscriptionButton', () => {
 
   // ==================== Export Verification ====================
   describe('Export Verification', () => {
-    it('should export CreateButtonType enum', () => {
+    it('should export CreateButtonType constant', () => {
       // Assert
       expect(CreateButtonType.FULL_BUTTON).toBe('full-button')
       expect(CreateButtonType.ICON_BUTTON).toBe('icon-button')

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/__tests__/use-oauth-client-state.spec.ts
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/__tests__/use-oauth-client-state.spec.ts
@@ -714,7 +714,7 @@ describe('useOAuthClientState', () => {
   })
 })
 
-describe('Enum Exports', () => {
+describe('Constant Exports', () => {
   it('should export AuthorizationStatusEnum', () => {
     expect(AuthorizationStatusEnum.Pending).toBe('pending')
     expect(AuthorizationStatusEnum.Success).toBe('success')

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/use-common-modal-state.ts
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/use-common-modal-state.ts
@@ -33,10 +33,11 @@ import {
 // Types
 // ============================================================================
 
-export enum ApiKeyStep {
-  Verify = 'verify',
-  Configuration = 'configuration',
-}
+export const ApiKeyStep = {
+  Verify: 'verify',
+  Configuration: 'configuration',
+} as const
+export type ApiKeyStep = typeof ApiKeyStep[keyof typeof ApiKeyStep]
 
 const CREDENTIAL_TYPE_MAP: Record<SupportedCreationMethods, TriggerCredentialTypeEnum> = {
   [SupportedCreationMethods.APIKEY]: TriggerCredentialTypeEnum.ApiKey,

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/use-oauth-client-state.ts
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/hooks/use-oauth-client-state.ts
@@ -13,16 +13,18 @@ import {
   useVerifyAndUpdateTriggerSubscriptionBuilder,
 } from '@/service/use-triggers'
 
-export enum AuthorizationStatusEnum {
-  Pending = 'pending',
-  Success = 'success',
-  Failed = 'failed',
-}
+export const AuthorizationStatusEnum = {
+  Pending: 'pending',
+  Success: 'success',
+  Failed: 'failed',
+} as const
+export type AuthorizationStatusEnum = typeof AuthorizationStatusEnum[keyof typeof AuthorizationStatusEnum]
 
-export enum ClientTypeEnum {
-  Default = 'default',
-  Custom = 'custom',
-}
+export const ClientTypeEnum = {
+  Default: 'default',
+  Custom: 'custom',
+} as const
+export type ClientTypeEnum = typeof ClientTypeEnum[keyof typeof ClientTypeEnum]
 
 const POLL_INTERVAL_MS = 3000
 

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/types.ts
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/types.ts
@@ -1,6 +1,7 @@
-export enum CreateButtonType {
-  FULL_BUTTON = 'full-button',
-  ICON_BUTTON = 'icon-button',
-}
+export const CreateButtonType = {
+  FULL_BUTTON: 'full-button',
+  ICON_BUTTON: 'icon-button',
+} as const
+export type CreateButtonType = typeof CreateButtonType[keyof typeof CreateButtonType]
 
 export const DEFAULT_METHOD = 'default'

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/apikey-edit-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/apikey-edit-modal.tsx
@@ -23,10 +23,11 @@ type Props = {
   pluginDetail?: PluginDetail
 }
 
-enum EditStep {
-  EditCredentials = 'edit_credentials',
-  EditConfiguration = 'edit_configuration',
-}
+const EditStep = {
+  EditCredentials: 'edit_credentials',
+  EditConfiguration: 'edit_configuration',
+} as const
+type EditStep = typeof EditStep[keyof typeof EditStep]
 
 const normalizeFormType = (type: string): FormTypeEnum => {
   switch (type) {

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/log-viewer.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/log-viewer.tsx
@@ -21,10 +21,11 @@ type Props = {
   className?: string
 }
 
-enum LogTypeEnum {
-  REQUEST = 'request',
-  RESPONSE = 'response',
-}
+const LogTypeEnum = {
+  REQUEST: 'request',
+  RESPONSE: 'response',
+} as const
+type LogTypeEnum = typeof LogTypeEnum[keyof typeof LogTypeEnum]
 
 const LogViewer = ({ logs, className }: Props) => {
   const { t } = useTranslation()

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/types.ts
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/types.ts
@@ -1,7 +1,8 @@
-export enum SubscriptionListMode {
-  PANEL = 'panel',
-  SELECTOR = 'selector',
-}
+export const SubscriptionListMode = {
+  PANEL: 'panel',
+  SELECTOR: 'selector',
+} as const
+export type SubscriptionListMode = typeof SubscriptionListMode[keyof typeof SubscriptionListMode]
 
 export type SimpleSubscription = {
   id: string


### PR DESCRIPTION
## Summary

Converts 7 TypeScript enums in the `plugins/plugin-detail-panel/subscription-list` component tree to `as const` objects with companion type aliases:

| Enum | File | Scope |
|------|------|-------|
| `SubscriptionListMode` | `subscription-list/types.ts` | exported |
| `CreateButtonType` | `subscription-list/create/types.ts` | exported |
| `AuthorizationStatusEnum` | `create/hooks/use-oauth-client-state.ts` | exported |
| `ClientTypeEnum` | `create/hooks/use-oauth-client-state.ts` | exported |
| `ApiKeyStep` | `create/hooks/use-common-modal-state.ts` | exported |
| `LogTypeEnum` | `subscription-list/log-viewer.tsx` | file-local |
| `EditStep` | `subscription-list/edit/apikey-edit-modal.tsx` | file-local |

Partially addresses #27998.

## Why this is safe

- All consumers use either `EnumName.MEMBER` as a value or `EnumName` as a type. The `as const` object + type alias pattern preserves both the exported name and the set of string values, so the public API is identical.
- No runtime reflection on any of these enums (`Object.values`/`Object.keys`/iteration) — checked with grep across the repo, so the special-case patterns from the dosubot comment on #27998 don't apply.
- No string-to-enum coercion (e.g. `Status[key as keyof typeof Status]`) — all accesses are static member references.

## Pattern

Matches the convention from the merged batches (e.g. #33960, #33834) and my prior PR #34565:

```ts
export const AuthorizationStatusEnum = {
  Pending: 'pending',
  Success: 'success',
  Failed: 'failed',
} as const
export type AuthorizationStatusEnum = typeof AuthorizationStatusEnum[keyof typeof AuthorizationStatusEnum]
```

## Checklist

- [x] `pnpm run type-check` — 0 errors
- [x] `pnpm run lint:ci` — 0 errors (3174 pre-existing warnings, none introduced)
- [x] Tests pass — `pnpm run test` on the 10 affected test files (294 tests across `subscription-list/**/__tests__/`)
- [x] Removed the 7 `erasable-syntax-only/enums` entries from `web/eslint-suppressions.json`; left other suppressions for those files intact; dropped 4 file entries that became empty.
- [x] Husky pre-commit hook passed (ESLint, tsgo, knip, unit tests)
- [x] Avoids conflict with @mahmoodhamdi's open PR #33962 (different file set)