### PR TITLE
fix:  lighten the health checks for the Worker and Worker Beat services, and disable them by default

### DIFF
--- a/api/celery_healthcheck.py
+++ b/api/celery_healthcheck.py
@@ -1,0 +1,18 @@
+# This module provides a lightweight Celery instance for use in Docker health checks.
+# Unlike celery_entrypoint.py, this does NOT import app.py and therefore avoids
+# initializing all Flask extensions (DB, Redis, storage, blueprints, etc.).
+# Using this module keeps the health check fast and low-cost.
+from celery import Celery
+
+from configs import dify_config
+from extensions.ext_celery import get_celery_broker_transport_options, get_celery_ssl_options
+
+celery = Celery(broker=dify_config.CELERY_BROKER_URL)
+
+broker_transport_options = get_celery_broker_transport_options()
+if broker_transport_options:
+    celery.conf.update(broker_transport_options=broker_transport_options)
+
+ssl_options = get_celery_ssl_options()
+if ssl_options:
+    celery.conf.update(broker_use_ssl=ssl_options)

--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -10,7 +10,7 @@ from configs import dify_config
 from dify_app import DifyApp
 
 
-def _get_celery_ssl_options() -> dict[str, Any] | None:
+def get_celery_ssl_options() -> dict[str, Any] | None:
     """Get SSL configuration for Celery broker/backend connections."""
     # Only apply SSL if we're using Redis as broker/backend
     if not dify_config.BROKER_USE_SSL:
@@ -43,6 +43,19 @@ def _get_celery_ssl_options() -> dict[str, Any] | None:
     return ssl_options
 
 
+def get_celery_broker_transport_options() -> dict[str, Any]:
+    """Get broker transport options (e.g. Redis Sentinel) for Celery connections."""
+    if dify_config.CELERY_USE_SENTINEL:
+        return {
+            "master_name": dify_config.CELERY_SENTINEL_MASTER_NAME,
+            "sentinel_kwargs": {
+                "socket_timeout": dify_config.CELERY_SENTINEL_SOCKET_TIMEOUT,
+                "password": dify_config.CELERY_SENTINEL_PASSWORD,
+            },
+        }
+    return {}
+
+
 def init_app(app: DifyApp) -> Celery:
     class FlaskTask(Task):
         def __call__(self, *args: object, **kwargs: object) -> object:
@@ -53,16 +66,7 @@ def init_app(app: DifyApp) -> Celery:
                 init_request_context()
                 return self.run(*args, **kwargs)
 
-    broker_transport_options = {}
-
-    if dify_config.CELERY_USE_SENTINEL:
-        broker_transport_options = {
-            "master_name": dify_config.CELERY_SENTINEL_MASTER_NAME,
-            "sentinel_kwargs": {
-                "socket_timeout": dify_config.CELERY_SENTINEL_SOCKET_TIMEOUT,
-                "password": dify_config.CELERY_SENTINEL_PASSWORD,
-            },
-        }
+    broker_transport_options = get_celery_broker_transport_options()
 
     celery_app = Celery(
         app.name,
@@ -89,7 +93,7 @@ def init_app(app: DifyApp) -> Celery:
         )
 
     # Apply SSL configuration if enabled
-    ssl_options = _get_celery_ssl_options()
+    ssl_options = get_celery_ssl_options()
     if ssl_options:
         celery_app.conf.update(
             broker_use_ssl=ssl_options,

--- a/api/tests/unit_tests/extensions/test_celery_ssl.py
+++ b/api/tests/unit_tests/extensions/test_celery_ssl.py
@@ -14,9 +14,9 @@ class TestCelerySSLConfiguration:
         dify_config = DifyConfig(CELERY_BROKER_URL="redis://localhost:6379/0")
 
         with patch("extensions.ext_celery.dify_config", dify_config):
-            from extensions.ext_celery import _get_celery_ssl_options
+            from extensions.ext_celery import get_celery_ssl_options
 
-            result = _get_celery_ssl_options()
+            result = get_celery_ssl_options()
             assert result is None
 
     def test_get_celery_ssl_options_when_broker_not_redis(self):
@@ -25,9 +25,9 @@ class TestCelerySSLConfiguration:
         mock_config.CELERY_BROKER_URL = "amqp://localhost:5672"
 
         with patch("extensions.ext_celery.dify_config", mock_config):
-            from extensions.ext_celery import _get_celery_ssl_options
+            from extensions.ext_celery import get_celery_ssl_options
 
-            result = _get_celery_ssl_options()
+            result = get_celery_ssl_options()
             assert result is None
 
     def test_get_celery_ssl_options_with_cert_none(self):
@@ -40,9 +40,9 @@ class TestCelerySSLConfiguration:
         mock_config.REDIS_SSL_KEYFILE = None
 
         with patch("extensions.ext_celery.dify_config", mock_config):
-            from extensions.ext_celery import _get_celery_ssl_options
+            from extensions.ext_celery import get_celery_ssl_options
 
-            result = _get_celery_ssl_options()
+            result = get_celery_ssl_options()
             assert result is not None
             assert result["ssl_cert_reqs"] == ssl.CERT_NONE
             assert result["ssl_ca_certs"] is None
@@ -59,9 +59,9 @@ class TestCelerySSLConfiguration:
         mock_config.REDIS_SSL_KEYFILE = "/path/to/client.key"
 
         with patch("extensions.ext_celery.dify_config", mock_config):
-            from extensions.ext_celery import _get_celery_ssl_options
+            from extensions.ext_celery import get_celery_ssl_options
 
-            result = _get_celery_ssl_options()
+            result = get_celery_ssl_options()
             assert result is not None
             assert result["ssl_cert_reqs"] == ssl.CERT_REQUIRED
             assert result["ssl_ca_certs"] == "/path/to/ca.crt"
@@ -78,9 +78,9 @@ class TestCelerySSLConfiguration:
         mock_config.REDIS_SSL_KEYFILE = None
 
         with patch("extensions.ext_celery.dify_config", mock_config):
-            from extensions.ext_celery import _get_celery_ssl_options
+            from extensions.ext_celery import get_celery_ssl_options
 
-            result = _get_celery_ssl_options()
+            result = get_celery_ssl_options()
             assert result is not None
             assert result["ssl_cert_reqs"] == ssl.CERT_OPTIONAL
             assert result["ssl_ca_certs"] == "/path/to/ca.crt"
@@ -95,9 +95,9 @@ class TestCelerySSLConfiguration:
         mock_config.REDIS_SSL_KEYFILE = None
 
         with patch("extensions.ext_celery.dify_config", mock_config):
-            from extensions.ext_celery import _get_celery_ssl_options
+            from extensions.ext_celery import get_celery_ssl_options
 
-            result = _get_celery_ssl_options()
+            result = get_celery_ssl_options()
             assert result is not None
             assert result["ssl_cert_reqs"] == ssl.CERT_NONE  # Should default to CERT_NONE
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -395,6 +395,16 @@ CELERY_SENTINEL_SOCKET_TIMEOUT=0.1
 # e.g. {"tasks.add": {"rate_limit": "10/s"}}
 CELERY_TASK_ANNOTATIONS=null
 
+# Worker health check configuration
+# Set to false to enable the health check for worker and worker_beat services.
+# Note: enabling the health check may cause periodic CPU spikes and increased load,
+# as it initializes a Celery connection on every check interval.
+WORKER_HEALTHCHECK_DISABLED=true
+# Interval between health checks (e.g. 30s, 1m)
+WORKER_HEALTHCHECK_INTERVAL=30s
+# Timeout for each health check (e.g. 30s, 1m)
+WORKER_HEALTHCHECK_TIMEOUT=30s
+
 # ------------------------------
 # CORS Configuration
 # Used to set the front-end cross-domain access policy.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -395,16 +395,6 @@ CELERY_SENTINEL_SOCKET_TIMEOUT=0.1
 # e.g. {"tasks.add": {"rate_limit": "10/s"}}
 CELERY_TASK_ANNOTATIONS=null
 
-# Worker health check configuration
-# Set to false to enable the health check for worker and worker_beat services.
-# Note: enabling the health check may cause periodic CPU spikes and increased load,
-# as it initializes a Celery connection on every check interval.
-WORKER_HEALTHCHECK_DISABLED=true
-# Interval between health checks (e.g. 30s, 1m)
-WORKER_HEALTHCHECK_INTERVAL=30s
-# Timeout for each health check (e.g. 30s, 1m)
-WORKER_HEALTHCHECK_TIMEOUT=30s
-
 # ------------------------------
 # CORS Configuration
 # Used to set the front-end cross-domain access policy.
@@ -1367,6 +1357,18 @@ SSRF_POOL_KEEPALIVE_EXPIRY=5.0
 # if you want to use unstructured, add ',unstructured' to the end
 # ------------------------------
 COMPOSE_PROFILES=${VECTOR_STORE:-weaviate},${DB_TYPE:-postgresql}
+
+# ------------------------------
+# Worker health check configuration for worker and worker_beat services.
+# Set to false to enable the health check.
+# Note: enabling the health check may cause periodic CPU spikes and increased load,
+# as it establishes a broker connection and sends a Celery ping on every check interval.
+# ------------------------------
+COMPOSE_WORKER_HEALTHCHECK_DISABLED=true
+# Interval between health checks (e.g. 30s, 1m)
+COMPOSE_WORKER_HEALTHCHECK_INTERVAL=30s
+# Timeout for each health check (e.g. 30s, 1m)
+COMPOSE_WORKER_HEALTHCHECK_TIMEOUT=30s
 
 # ------------------------------
 # Docker Compose Service Expose Host Port Configurations

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -103,10 +103,11 @@ services:
       - ./volumes/app/storage:/app/api/storage
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: 30s
-      timeout: 30s
+      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
+      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default
@@ -140,10 +141,11 @@ services:
         condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: 30s
-      timeout: 30s
+      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
+      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -103,11 +103,11 @@ services:
       - ./volumes/app/storage:/app/api/storage
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
-      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
+      interval: ${COMPOSE_WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${COMPOSE_WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
-      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
+      disable: ${COMPOSE_WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default
@@ -141,11 +141,11 @@ services:
         condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
-      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
+      interval: ${COMPOSE_WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${COMPOSE_WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
-      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
+      disable: ${COMPOSE_WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -102,9 +102,9 @@ services:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
     healthcheck:
-      test: ["CMD-SHELL", "celery -A celery_entrypoint.celery inspect ping"]
+      test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 60s
     networks:
@@ -139,9 +139,9 @@ services:
       redis:
         condition: service_started
     healthcheck:
-      test: ["CMD-SHELL", "celery -A app.celery inspect ping"]
+      test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 60s
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -812,11 +812,11 @@ services:
       - ./volumes/app/storage:/app/api/storage
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
-      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
+      interval: ${COMPOSE_WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${COMPOSE_WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
-      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
+      disable: ${COMPOSE_WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default
@@ -850,11 +850,11 @@ services:
         condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
-      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
+      interval: ${COMPOSE_WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${COMPOSE_WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
-      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
+      disable: ${COMPOSE_WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -811,9 +811,9 @@ services:
       # Mount the storage directory to the container, for storing user files.
       - ./volumes/app/storage:/app/api/storage
     healthcheck:
-      test: ["CMD-SHELL", "celery -A celery_entrypoint.celery inspect ping"]
+      test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 60s
     networks:
@@ -848,9 +848,9 @@ services:
       redis:
         condition: service_started
     healthcheck:
-      test: ["CMD-SHELL", "celery -A app.celery inspect ping"]
+      test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 60s
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -812,10 +812,11 @@ services:
       - ./volumes/app/storage:/app/api/storage
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: 30s
-      timeout: 30s
+      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
+      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default
@@ -849,10 +850,11 @@ services:
         condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "celery -A celery_healthcheck.celery inspect ping"]
-      interval: 30s
-      timeout: 30s
+      interval: ${WORKER_HEALTHCHECK_INTERVAL:-30s}
+      timeout: ${WORKER_HEALTHCHECK_TIMEOUT:-30s}
       retries: 3
       start_period: 60s
+      disable: ${WORKER_HEALTHCHECK_DISABLED:-true}
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/generate_docker_compose
+++ b/docker/generate_docker_compose
@@ -3,6 +3,20 @@ import os
 import re
 import sys
 
+# Variables that exist only for Docker Compose orchestration and must NOT be
+# injected into containers as environment variables.
+SHARED_ENV_EXCLUDE = frozenset(
+    [
+        # Docker Compose profile selection
+        "COMPOSE_PROFILES",
+        # Worker health check orchestration flags (consumed by docker-compose,
+        # not by the application running inside the container)
+        "WORKER_HEALTHCHECK_DISABLED",
+        "WORKER_HEALTHCHECK_INTERVAL",
+        "WORKER_HEALTHCHECK_TIMEOUT",
+    ]
+)
+
 
 def parse_env_example(file_path):
     """
@@ -37,7 +51,7 @@ def generate_shared_env_block(env_vars, anchor_name="shared-api-worker-env"):
     """
     lines = [f"x-shared-env: &{anchor_name}"]
     for key, default in env_vars.items():
-        if key == "COMPOSE_PROFILES":
+        if key in SHARED_ENV_EXCLUDE:
             continue
         # If default value is empty, use ${KEY:-}
         if default == "":
@@ -54,6 +68,7 @@ def insert_shared_env(template_path, output_path, shared_env_block, header_comme
     """
     Inserts the shared environment variables block and header comments into the template file,
     removing any existing x-shared-env anchors, and generates the final docker-compose.yaml file.
+    Always writes with LF line endings.
     """
     with open(template_path, "r", encoding="utf-8") as f:
         template_content = f.read()
@@ -69,7 +84,7 @@ def insert_shared_env(template_path, output_path, shared_env_block, header_comme
     # Prepare the final content with header comments and shared env block
     final_content = f"{header_comments}\n{shared_env_block}\n\n{template_content}"
 
-    with open(output_path, "w", encoding="utf-8") as f:
+    with open(output_path, "w", encoding="utf-8", newline="\n") as f:
         f.write(final_content)
     print(f"Generated {output_path}")
 

--- a/docker/generate_docker_compose
+++ b/docker/generate_docker_compose
@@ -11,9 +11,9 @@ SHARED_ENV_EXCLUDE = frozenset(
         "COMPOSE_PROFILES",
         # Worker health check orchestration flags (consumed by docker-compose,
         # not by the application running inside the container)
-        "WORKER_HEALTHCHECK_DISABLED",
-        "WORKER_HEALTHCHECK_INTERVAL",
-        "WORKER_HEALTHCHECK_TIMEOUT",
+        "COMPOSE_WORKER_HEALTHCHECK_DISABLED",
+        "COMPOSE_WORKER_HEALTHCHECK_INTERVAL",
+        "COMPOSE_WORKER_HEALTHCHECK_TIMEOUT",
     ]
 )
 


### PR DESCRIPTION
## Summary

This PR addresses an issue where the health checks for the worker service were consuming excessive host CPU by making the following changes:

- The health checks for the worker and worker beat services are now disabled by default, and can be enabled via environment variables.
- The interval and timeout for health checks can also be configured through environment variables.
- A new lightweight Celery entry point for health checks has been added.

More specifically, the following modifications have been made:

- A new lightweight Celery entry point for health checks has been added.
  - To support Sentinel and SSL connections when connecting to the broker, an existing function for configuring connection options based on settings has been made public and reused.
  - Function names used in tests have also been updated.
- The health checks for the worker and worker beat services are now disabled by default, and can be enabled with environment variables.
  - The user can now change `healthcheck.disable`.
  - Similarly, the health check interval and timeout can be changed.
  - When generating the compose file from the template, environment variables that should not be passed to containers are now maintained in a list to prevent them from being included.
  - The compose file generated from the template will always use LF for line endings.

Closes #34546

## Screenshots

### Before

- Periodic high CPU load
- Every health checks take 7 seconds or more

<img width="1396" height="690" alt="Image" src="https://github.com/user-attachments/assets/bc68e10e-5298-4282-90da-4142c06954a1" />

```bash
dify@20b4144e993b:/app/api$ start=$(date +%s%3N); celery -A celery_entrypoint.celery inspect ping; echo "Elapsed: $(( $(date +%s%3N) - start ))ms"
gRPC patched with gevent.
psycopg2 patched with gevent.
Warning! You didn't set docs_url, redoc_url or openapi_url.
API Documentation will be skipped.
->  celery@8046cd2bd0ba: OK
        pong

1 node online.
Elapsed: 7567ms     👈👈👈
```

### After

If the health checks are disabled, it does not consume any resources at all.
If they are enabled:

- There is a periodic small CPU spike
- Each health check takes 2 seconds

<img width="707" height="385" alt="image" src="https://github.com/user-attachments/assets/b303ca48-d44c-4439-9afe-924f42ca5e9f" />

```bash
dify@cf80cabeee53:/app/api$ start=$(date +%s%3N); celery -A celery_healthcheck.celery inspect ping; echo "Elapsed: $(( $(date +%s%3N) - start ))ms"
->  celery@cf80cabeee53: OK
        pong

1 node online.
Elapsed: 2449ms     👈👈👈
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
