### PR TITLE
refactor(api): type upload file serialization with UploadFileDict TypedDict

### DIFF
--- a/api/controllers/service_api/dataset/rag_pipeline/serializers.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/serializers.py
@@ -4,13 +4,23 @@ Serialization helpers for Service API knowledge pipeline endpoints.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from models.model import UploadFile
 
 
-def serialize_upload_file(upload_file: UploadFile) -> dict[str, Any]:
+class UploadFileDict(TypedDict):
+    id: str
+    name: str
+    size: int
+    extension: str
+    mime_type: str | None
+    created_by: str
+    created_at: str | None
+
+
+def serialize_upload_file(upload_file: UploadFile) -> UploadFileDict:
     return {
         "id": upload_file.id,
         "name": upload_file.name,


### PR DESCRIPTION
Part of #32863 (`api/controllers/service_api/dataset/rag_pipeline/serializers.py`)

## Summary
- Add `UploadFileDict` TypedDict with keys `id`, `name`, `size`, `extension`, `mime_type`, `created_by`, `created_at`
- Annotate return type of `serialize_upload_file`

## Why this change
`serialize_upload_file` returns a dict with 7 well-known fixed keys but was typed as `dict[str, Any]`.
The TypedDict makes the shape explicit.

## Changes
- `api/controllers/service_api/dataset/rag_pipeline/serializers.py`: Define `UploadFileDict`, update `serialize_upload_file` return type
