### PR TITLE
refactor(api): type orphaned draft variable stats with TypedDict

### DIFF
--- a/api/commands/retention.py
+++ b/api/commands/retention.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import time
-from typing import Any
+from typing import TypedDict
 
 import click
 import sqlalchemy as sa
@@ -503,7 +503,19 @@ def _find_orphaned_draft_variables(batch_size: int = 1000) -> list[str]:
         return [row[0] for row in result]
 
 
-def _count_orphaned_draft_variables() -> dict[str, Any]:
+class _AppOrphanCounts(TypedDict):
+    variables: int
+    files: int
+
+
+class OrphanedDraftVariableStatsDict(TypedDict):
+    total_orphaned_variables: int
+    total_orphaned_files: int
+    orphaned_app_count: int
+    orphaned_by_app: dict[str, _AppOrphanCounts]
+
+
+def _count_orphaned_draft_variables() -> OrphanedDraftVariableStatsDict:
     """
     Count orphaned draft variables by app, including associated file counts.
 
@@ -526,7 +538,7 @@ def _count_orphaned_draft_variables() -> dict[str, Any]:
 
     with db.engine.connect() as conn:
         result = conn.execute(sa.text(variables_query))
-        orphaned_by_app = {}
+        orphaned_by_app: dict[str, _AppOrphanCounts] = {}
         total_files = 0
 
         for row in result:


### PR DESCRIPTION
## Summary
- Add `OrphanedDraftVariableStatsDict` and `_AppOrphanCounts` TypedDicts
- Annotate return type of `_count_orphaned_draft_variables` (was `dict[str, Any]`)
- Remove unused `Any` import

## Why this change
`_count_orphaned_draft_variables` returns a dict with 4 fixed keys (`total_orphaned_variables`, `total_orphaned_files`, `orphaned_app_count`, `orphaned_by_app`) and a nested per-app dict with `variables`/`files`. All callers access keys by literal name. The TypedDict makes the stats contract explicit.

## Changes
- `commands/retention.py`: Define 2 TypedDicts, update function return type

## Test plan
- [x] `ruff check` passes

Part of #32863 (`commands/retention.py`)
