### PR TITLE
refactor(api): reuse IdentityDict TypedDict in logging filters

### DIFF
--- a/api/core/logging/filters.py
+++ b/api/core/logging/filters.py
@@ -6,6 +6,7 @@ import logging
 import flask
 
 from core.logging.context import get_request_id, get_trace_id
+from core.logging.structured_formatter import IdentityDict
 
 
 class TraceContextFilter(logging.Filter):
@@ -60,7 +61,7 @@ class IdentityContextFilter(logging.Filter):
         record.user_type = identity.get("user_type", "")
         return True
 
-    def _extract_identity(self) -> dict[str, str]:
+    def _extract_identity(self) -> IdentityDict:
         """Extract identity from current_user if in request context."""
         try:
             if not flask.has_request_context():
@@ -77,7 +78,7 @@ class IdentityContextFilter(logging.Filter):
             from models import Account
             from models.model import EndUser
 
-            identity: dict[str, str] = {}
+            identity: IdentityDict = {}
 
             if isinstance(user, Account):
                 if user.current_tenant_id:


### PR DESCRIPTION
## Summary
- Reuse `IdentityDict` TypedDict (from `structured_formatter.py`) in `filters.py`
- Annotate `_extract_identity` return type and local variable

## Why this change
`IdentityDict` was introduced in #34485 for the structured formatter's `_extract_identity`. The logging filter's `_extract_identity` returns the exact same shape (`tenant_id`, `user_id`, `user_type`) but was still typed as `dict[str, str]`. Reusing the existing TypedDict keeps the identity contract consistent across both logging components.

## Changes
- `core/logging/filters.py`: Import `IdentityDict`, update return type and local variable annotation

## Test plan
- [x] `ruff check` passes
- [x] No circular imports

Part of #32863 (`core/logging/filters.py`)
