### PR TITLE
docs: correct keyword scoring method description from BM25 to TF-IDF

### DIFF
--- a/api/core/rag/rerank/weight_rerank.py
+++ b/api/core/rag/rerank/weight_rerank.py
@@ -74,7 +74,7 @@ class WeightRerankRunner(BaseRerankRunner):
 
     def _calculate_keyword_score(self, query: str, documents: list[Document]) -> list[float]:
         """
-        Calculate BM25 scores
+        Calculate keyword scores using TF-IDF and cosine similarity
         :param query: search query
         :param documents: documents for reranking
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Fixed an incorrect docstring in `_calculate_keyword_score`. The implementation uses TF-IDF and cosine similarity, but the comment incorrectly referenced BM25.

## Screenshots

| Before | After |
|--------|-------|
| Calculate BM25 scores | Calculate keyword scores using TF-IDF and cosine similarity |

## Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've updated the documentation accordingly.
