### PR TITLE
refactor(api): type storage statistics with StorageStatisticsDict TypedDict

### DIFF
--- a/api/extensions/storage/clickzetta_volume/file_lifecycle.py
+++ b/api/extensions/storage/clickzetta_volume/file_lifecycle.py
@@ -13,13 +13,24 @@ import operator
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import StrEnum, auto
-from typing import Any
+from typing import Any, TypedDict
 
 from pydantic import TypeAdapter
 
 logger = logging.getLogger(__name__)
 
 _metadata_adapter: TypeAdapter[dict[str, Any]] = TypeAdapter(dict[str, Any])
+
+
+class StorageStatisticsDict(TypedDict):
+    total_files: int
+    active_files: int
+    archived_files: int
+    deleted_files: int
+    total_size: int
+    versions_count: int
+    oldest_file: str | None
+    newest_file: str | None
 
 
 class FileStatus(StrEnum):
@@ -384,7 +395,7 @@ class FileLifecycleManager:
             logger.exception("Failed to cleanup old versions")
             return 0
 
-    def get_storage_statistics(self) -> dict[str, Any]:
+    def get_storage_statistics(self) -> StorageStatisticsDict:
         """Get storage statistics
 
         Returns:
@@ -393,16 +404,16 @@ class FileLifecycleManager:
         try:
             metadata_dict = self._load_metadata()
 
-            stats: dict[str, Any] = {
-                "total_files": len(metadata_dict),
-                "active_files": 0,
-                "archived_files": 0,
-                "deleted_files": 0,
-                "total_size": 0,
-                "versions_count": 0,
-                "oldest_file": None,
-                "newest_file": None,
-            }
+            stats = StorageStatisticsDict(
+                total_files=len(metadata_dict),
+                active_files=0,
+                archived_files=0,
+                deleted_files=0,
+                total_size=0,
+                versions_count=0,
+                oldest_file=None,
+                newest_file=None,
+            )
 
             oldest_date = None
             newest_date = None
@@ -437,7 +448,10 @@ class FileLifecycleManager:
 
         except Exception:
             logger.exception("Failed to get storage statistics")
-            return {}
+            return StorageStatisticsDict(
+                total_files=0, active_files=0, archived_files=0, deleted_files=0,
+                total_size=0, versions_count=0, oldest_file=None, newest_file=None,
+            )
 
     def _create_version_backup(self, filename: str, metadata: dict):
         """Create version backup"""

--- a/api/extensions/storage/clickzetta_volume/file_lifecycle.py
+++ b/api/extensions/storage/clickzetta_volume/file_lifecycle.py
@@ -449,8 +449,14 @@ class FileLifecycleManager:
         except Exception:
             logger.exception("Failed to get storage statistics")
             return StorageStatisticsDict(
-                total_files=0, active_files=0, archived_files=0, deleted_files=0,
-                total_size=0, versions_count=0, oldest_file=None, newest_file=None,
+                total_files=0,
+                active_files=0,
+                archived_files=0,
+                deleted_files=0,
+                total_size=0,
+                versions_count=0,
+                oldest_file=None,
+                newest_file=None,
             )
 
     def _create_version_backup(self, filename: str, metadata: dict):


### PR DESCRIPTION
## Summary
- Add `StorageStatisticsDict` TypedDict with 8 keys (`total_files`, `active_files`, `archived_files`, `deleted_files`, `total_size`, `versions_count`, `oldest_file`, `newest_file`)
- Annotate return type of `get_storage_statistics` and use TypedDict constructor for both the normal and error fallback paths

## Why this change
`get_storage_statistics` constructs a dict with 8 fixed keys but was typed as `dict[str, Any]`. The TypedDict makes the statistics shape explicit and provides correct per-field types (`int` vs `str | None`).

## Changes
- `extensions/storage/clickzetta_volume/file_lifecycle.py`: Define `StorageStatisticsDict`, update method return type and both return paths

## Test plan
- [x] `ruff check` passes

Part of #32863 (`extensions/storage/clickzetta_volume/file_lifecycle.py`)