### PR TITLE
refactor(api): enforce strict typing on retrieval_model to resolve FIXME

### DIFF
--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -44,7 +44,7 @@ class HitTestingService:
         dataset: Dataset,
         query: str,
         account: Account,
-        retrieval_model: Any,  # FIXME drop this any
+        retrieval_model: dict | None,
         external_retrieval_model: dict,
         attachment_ids: list | None = None,
         limit: int = 10,
@@ -54,6 +54,7 @@ class HitTestingService:
         # get retrieval model , if the model is not setting , using default
         if not retrieval_model:
             retrieval_model = dataset.retrieval_model or default_retrieval_model
+        assert isinstance(retrieval_model, dict)
         document_ids_filter = None
         metadata_filtering_conditions = retrieval_model.get("metadata_filtering_conditions", {})
         if metadata_filtering_conditions and query:


### PR DESCRIPTION
## Summary
Replaced the loose `Any` type hint with `dict | None` for `retrieval_model` to align with the project's strict typing rules.
Inserted an `assert isinstance()` check to explicitly narrow the type for static analyzers, it ensures strict safety for all downstream `.get()` method calls.

### Why this change
A `# FIXME drop this any` comment was left on the `retrieval_model` parameter. Enforcing the dictionary type and logically asserting it prevents `reportOptionalMemberAccess` errors from static analyzers and ensures strict safety for all downstream `.get()` property lookups.

## Changes
`api/services/hit_testing_service.py`: Update `retrieve` method signature and add `assert isinstance` execution.

### Test plan
 `basedpyright` and `ruff check`  passes successfully.