### PR TITLE
refactor(api): migrate dict returns to TypedDict in workflow run counts

### DIFF
--- a/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
+++ b/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
@@ -29,7 +29,7 @@ from extensions.logstore.sql_escape import escape_identifier, escape_logstore_qu
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.workflow import WorkflowRun, WorkflowType
-from repositories.api_workflow_run_repository import APIWorkflowRunRepository
+from repositories.api_workflow_run_repository import APIWorkflowRunRepository, WorkflowRunCountsDict
 from repositories.types import (
     AverageInteractionStats,
     DailyRunsStats,
@@ -454,7 +454,7 @@ class LogstoreAPIWorkflowRunRepository(APIWorkflowRunRepository):
         triggered_from: str,
         status: str | None = None,
         time_range: str | None = None,
-    ) -> dict[str, int]:
+    ) -> WorkflowRunCountsDict:
         """
         Get workflow runs count statistics grouped by status.
 
@@ -567,7 +567,8 @@ class LogstoreAPIWorkflowRunRepository(APIWorkflowRunRepository):
             )
 
             # Build response
-            status_counts = {
+            status_counts: WorkflowRunCountsDict = {
+                "total": 0,
                 "running": 0,
                 "succeeded": 0,
                 "failed": 0,
@@ -580,7 +581,7 @@ class LogstoreAPIWorkflowRunRepository(APIWorkflowRunRepository):
                 status_val = result.get("status")
                 count = result.get("count", 0)
                 if status_val in status_counts:
-                    status_counts[status_val] = count
+                    status_counts[status_val] = count  # type: ignore[literal-required]
                     total += count
 
             # Add running count
@@ -588,7 +589,8 @@ class LogstoreAPIWorkflowRunRepository(APIWorkflowRunRepository):
             status_counts["running"] = running_count
             total += running_count
 
-            return {"total": total} | status_counts
+            status_counts["total"] = total
+            return status_counts
 
         except Exception:
             logger.exception("Failed to get workflow runs count")

--- a/api/repositories/api_workflow_run_repository.py
+++ b/api/repositories/api_workflow_run_repository.py
@@ -55,6 +55,19 @@ from repositories.types import (
 )
 
 
+WorkflowRunCountsDict = TypedDict(
+    "WorkflowRunCountsDict",
+    {
+        "total": int,
+        "running": int,
+        "succeeded": int,
+        "failed": int,
+        "stopped": int,
+        "partial-succeeded": int,
+    },
+)
+
+
 class RunsWithRelatedCountsDict(TypedDict):
     runs: int
     node_executions: int
@@ -163,7 +176,7 @@ class APIWorkflowRunRepository(WorkflowExecutionRepository, Protocol):
         triggered_from: str,
         status: str | None = None,
         time_range: str | None = None,
-    ) -> dict[str, int]:
+    ) -> WorkflowRunCountsDict:
         """
         Get workflow runs count statistics.
 
@@ -179,7 +192,7 @@ class APIWorkflowRunRepository(WorkflowExecutionRepository, Protocol):
                        Filters records based on created_at field
 
         Returns:
-            Dictionary containing:
+            WorkflowRunCountsDict containing:
             - total: Total count of all workflow runs (or filtered by status)
             - running: Count of workflow runs with status "running"
             - succeeded: Count of workflow runs with status "succeeded"

--- a/api/repositories/sqlalchemy_api_workflow_run_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_run_repository.py
@@ -45,7 +45,11 @@ from libs.uuid_utils import uuidv7
 from models.enums import WorkflowRunTriggeredFrom
 from models.human_input import HumanInputForm
 from models.workflow import WorkflowAppLog, WorkflowArchiveLog, WorkflowPause, WorkflowPauseReason, WorkflowRun
-from repositories.api_workflow_run_repository import APIWorkflowRunRepository, RunsWithRelatedCountsDict
+from repositories.api_workflow_run_repository import (
+    APIWorkflowRunRepository,
+    RunsWithRelatedCountsDict,
+    WorkflowRunCountsDict,
+)
 from repositories.entities.workflow_pause import WorkflowPauseEntity
 from repositories.types import (
     AverageInteractionStats,
@@ -214,11 +218,12 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
         triggered_from: str,
         status: str | None = None,
         time_range: str | None = None,
-    ) -> dict[str, int]:
+    ) -> WorkflowRunCountsDict:
         """
         Get workflow runs count statistics grouped by status.
         """
-        _initial_status_counts = {
+        _initial_status_counts: WorkflowRunCountsDict = {
+            "total": 0,
             "running": 0,
             "succeeded": 0,
             "failed": 0,
@@ -245,11 +250,11 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
                 count_stmt = select(func.count(WorkflowRun.id)).where(*base_conditions, WorkflowRun.status == status)
                 total = session.scalar(count_stmt) or 0
 
-                result = {"total": total} | _initial_status_counts
+                result: WorkflowRunCountsDict = {**_initial_status_counts, "total": total}
 
                 # Set the count for the filtered status
                 if status in result:
-                    result[status] = total
+                    result[status] = total  # type: ignore[literal-required]
 
                 return result
 
@@ -264,15 +269,16 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
             results = session.execute(base_stmt).all()
 
             # Build response dictionary
-            status_counts = _initial_status_counts.copy()
+            status_counts = {**_initial_status_counts}
 
             total = 0
             for status_val, count in results:
                 total += count
                 if status_val in status_counts:
-                    status_counts[status_val] = count
+                    status_counts[status_val] = count  # type: ignore[literal-required]
 
-            return {"total": total} | status_counts
+            status_counts["total"] = total
+            return status_counts
 
     def get_expired_runs_batch(
         self,

--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -15,7 +15,7 @@ from models import (
     WorkflowRun,
     WorkflowRunTriggeredFrom,
 )
-from repositories.api_workflow_run_repository import APIWorkflowRunRepository
+from repositories.api_workflow_run_repository import APIWorkflowRunRepository, WorkflowRunCountsDict
 from repositories.factory import DifyAPIRepositoryFactory
 
 
@@ -114,7 +114,7 @@ class WorkflowRunService:
         status: str | None = None,
         time_range: str | None = None,
         triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING,
-    ) -> dict[str, int]:
+    ) -> WorkflowRunCountsDict:
         """
         Get workflow runs count statistics
 
@@ -122,7 +122,7 @@ class WorkflowRunService:
         :param status: optional status filter
         :param time_range: optional time range filter (e.g., "7d", "4h", "30m", "30s")
         :param triggered_from: workflow run triggered from (default: DEBUGGING)
-        :return: dict with total and status counts
+        :return: WorkflowRunCountsDict with total and status counts
         """
         return self._workflow_run_repo.get_workflow_runs_count(
             tenant_id=app_model.tenant_id,


### PR DESCRIPTION
## Summary

Replace `dict[str, int]` return type with a `WorkflowRunCountsDict` TypedDict for `get_workflow_runs_count` across:

- `api/repositories/api_workflow_run_repository.py` — protocol definition + new TypedDict
- `api/repositories/sqlalchemy_api_workflow_run_repository.py` — SQLAlchemy implementation
- `api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py` — LogStore implementation
- `api/services/workflow_run_service.py` — service layer

### TypedDict added

```python
WorkflowRunCountsDict = TypedDict(
    "WorkflowRunCountsDict",
    {
        "total": int,
        "running": int,
        "succeeded": int,
        "failed": int,
        "stopped": int,
        "partial-succeeded": int,
    },
)
```

Uses the functional TypedDict form because the `partial-succeeded` key is not a valid Python identifier.

Part of #32863