### PR TITLE
fix: web app user avatar display incorrect black

### DIFF
--- a/web/app/components/base/chat/chat/__tests__/question.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/question.spec.tsx
@@ -501,6 +501,16 @@ describe('Question component', () => {
     expect(onRegenerate).toHaveBeenCalled()
   })
 
+  it('should render default question avatar icon when questionIcon is not provided', () => {
+    const { container } = renderWithProvider(
+      makeItem(),
+      vi.fn() as unknown as OnRegenerate,
+    )
+
+    const defaultIcon = container.querySelector('.question-default-user-icon')
+    expect(defaultIcon).toBeInTheDocument()
+  })
+
   it('should render custom questionIcon when provided', () => {
     const { container } = renderWithProvider(
       makeItem(),
@@ -509,7 +519,7 @@ describe('Question component', () => {
     )
 
     expect(screen.getByTestId('custom-question-icon')).toBeInTheDocument()
-    const defaultIcon = container.querySelector('.i-custom-public-avatar-user')
+    const defaultIcon = container.querySelector('.question-default-user-icon')
     expect(defaultIcon).not.toBeInTheDocument()
   })
 

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -15,6 +15,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import Textarea from 'react-textarea-autosize'
 import { FileList } from '@/app/components/base/file-uploader'
+import { User } from '@/app/components/base/icons/src/public/avatar'
 import { Markdown } from '@/app/components/base/markdown'
 import { cn } from '@/utils/classnames'
 import ActionButton from '../../action-button'
@@ -243,7 +244,7 @@ const Question: FC<QuestionProps> = ({
           {
             questionIcon || (
               <div className="h-full w-full rounded-full border-[0.5px] border-black/5">
-                <div className="i-custom-public-avatar-user h-full w-full" />
+                <User className="question-default-user-icon h-full w-full" />
               </div>
             )
           }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/34554

The black user avatar regression was introduced by https://github.com/langgenius/dify/pull/34453 
After that refactor, we started using the pre-generated Iconify collection (`custom-public/icons.json`) for `i-custom-public-avatar-user`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
