### PR TITLE
refactor(api): type plugin migration results with TypedDict

### DIFF
--- a/api/services/plugin/plugin_migration.py
+++ b/api/services/plugin/plugin_migration.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TypedDict
 from uuid import uuid4
 
 import click
@@ -40,6 +40,16 @@ class _TenantPluginRecord(TypedDict):
 
 
 _tenant_plugin_adapter: TypeAdapter[_TenantPluginRecord] = TypeAdapter(_TenantPluginRecord)
+
+
+class ExtractedPluginsDict(TypedDict):
+    plugins: dict[str, str]
+    plugin_not_exist: list[str]
+
+
+class PluginInstallResultDict(TypedDict):
+    success: list[str]
+    failed: list[str]
 
 
 class PluginMigration:
@@ -310,7 +320,7 @@ class PluginMigration:
         Path(output_file).write_text(json.dumps(cls.extract_unique_plugins(extracted_plugins)))
 
     @classmethod
-    def extract_unique_plugins(cls, extracted_plugins: str) -> Mapping[str, Any]:
+    def extract_unique_plugins(cls, extracted_plugins: str) -> ExtractedPluginsDict:
         plugins: dict[str, str] = {}
         plugin_ids = []
         plugin_not_exist = []
@@ -524,7 +534,7 @@ class PluginMigration:
     @classmethod
     def handle_plugin_instance_install(
         cls, tenant_id: str, plugin_identifiers_map: Mapping[str, str]
-    ) -> Mapping[str, Any]:
+    ) -> PluginInstallResultDict:
         """
         Install plugins for a tenant.
         """


### PR DESCRIPTION
Part of #32863 (`api/services/plugin/plugin_migration.py`)

## Summary
- Add `ExtractedPluginsDict` TypedDict with keys `plugins`, `plugin_not_exist`
- Add `PluginInstallResultDict` TypedDict with keys `success`, `failed`
- Annotate return types of `PluginMigration.extract_unique_plugins` and `PluginMigration.handle_plugin_instance_install`

## Why this change
Both methods return dicts with well-known fixed keys but were typed as `Mapping[str, Any]`.
The TypedDicts make the shape explicit.

## Changes
- `api/services/plugin/plugin_migration.py`: Define 2 TypedDicts, update 2 method signatures, remove unused `Any` import
