### PR TITLE
fix: invalidate MCP tool cache on provider update to refresh descriptions

### DIFF
--- a/web/app/components/tools/mcp/detail/content.tsx
+++ b/web/app/components/tools/mcp/detail/content.tsx
@@ -130,9 +130,10 @@ const MCPDetailContent: FC<Props> = ({
     if ((res as any)?.result === 'success') {
       hideUpdateModal()
       onUpdate()
+      invalidateMCPTools(detail.id)
       handleAuthorize()
     }
-  }, [detail, updateMCP, hideUpdateModal, onUpdate, handleAuthorize])
+  }, [detail, updateMCP, hideUpdateModal, onUpdate, invalidateMCPTools, handleAuthorize])
 
   const handleDelete = useCallback(async () => {
     if (!detail)


### PR DESCRIPTION
## Summary

Fixes #31372

When updating an MCP provider configuration through the Studio UI (e.g., changing the server URL via MCPModal), the per-provider tool list cache (`useMCPTools(providerID)`) was not invalidated. This caused tool descriptions to remain stale even after the provider config was successfully updated.

## Root Cause

In `web/app/components/tools/mcp/detail/content.tsx`, the `handleUpdate` callback calls `onUpdate()` after a successful `updateMCP`, which refreshes the provider list via `useAllToolProviders`. However, it did **not** invalidate the individual provider's tool cache (`useMCPTools`), so the cached tool names and descriptions persisted.

The sibling `handleUpdateTools` callback already correctly calls `invalidateMCPTools(detail.id)` after updating tools — `handleUpdate` simply needed the same invalidation.

## Fix

Added `invalidateMCPTools(detail.id)` in the `handleUpdate` callback (and its dependency array) to force tool descriptions to refresh when the provider configuration changes.

This is a minimal one-line change with no side effects — `invalidateMCPTools` was already imported and used elsewhere in the same component.