### PR TITLE
refactor(api): Extract shared ResponseModel

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -7,7 +7,7 @@ from flask import request
 from flask_restx import Resource
 from graphon.enums import WorkflowExecutionStatus
 from graphon.file import helpers as file_helpers
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, computed_field, field_validator
 from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import BadRequest
@@ -29,6 +29,7 @@ from core.ops.ops_trace_manager import OpsTraceManager
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from core.trigger.constants import TRIGGER_NODE_TYPES
 from extensions.ext_database import db
+from fields.base import ResponseModel
 from libs.login import current_account_with_tenant, login_required
 from models import App, DatasetPermissionEnum, Workflow
 from models.model import IconType
@@ -153,16 +154,6 @@ class AppTracePayload(BaseModel):
 
 
 type JSONValue = Any
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
 
 
 def _to_timestamp(value: datetime | int | None) -> int | None:

--- a/api/fields/annotation_fields.py
+++ b/api/fields/annotation_fields.py
@@ -2,23 +2,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
+
+from fields.base import ResponseModel
 
 
 def _to_timestamp(value: datetime | int | None) -> int | None:
     if isinstance(value, datetime):
         return int(value.timestamp())
     return value
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
 
 
 class Annotation(ResponseModel):

--- a/api/fields/base.py
+++ b/api/fields/base.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ResponseModel(BaseModel):
+    model_config = ConfigDict(
+        from_attributes=True,
+        extra="ignore",
+        populate_by_name=True,
+        serialize_by_alias=True,
+        protected_namespaces=(),
+    )

--- a/api/fields/conversation_fields.py
+++ b/api/fields/conversation_fields.py
@@ -4,19 +4,11 @@ from datetime import datetime
 from typing import Any
 
 from graphon.file import File
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
+
+from fields.base import ResponseModel
 
 type JSONValue = Any
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
 
 
 class MessageFile(ResponseModel):

--- a/api/fields/end_user_fields.py
+++ b/api/fields/end_user_fields.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 
 from flask_restx import fields
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
+
+from fields.base import ResponseModel
 
 simple_end_user_fields = {
     "id": fields.String,
@@ -24,16 +26,6 @@ end_user_detail_fields = {
     "created_at": fields.DateTime,
     "updated_at": fields.DateTime,
 }
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
 
 
 class SimpleEndUser(ResponseModel):

--- a/api/fields/file_fields.py
+++ b/api/fields/file_fields.py
@@ -2,17 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import field_validator
 
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
+from fields.base import ResponseModel
 
 
 def _to_timestamp(value: datetime | int | None) -> int | None:

--- a/api/fields/member_fields.py
+++ b/api/fields/member_fields.py
@@ -4,7 +4,9 @@ from datetime import datetime
 
 from flask_restx import fields
 from graphon.file import helpers as file_helpers
-from pydantic import BaseModel, ConfigDict, computed_field, field_validator
+from pydantic import computed_field, field_validator
+
+from fields.base import ResponseModel
 
 simple_account_fields = {
     "id": fields.String,
@@ -25,16 +27,6 @@ def _build_avatar_url(avatar: str | None) -> str | None:
     if avatar.startswith(("http://", "https://")):
         return avatar
     return file_helpers.get_signed_file_url(avatar)
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
 
 
 class SimpleAccount(ResponseModel):

--- a/api/fields/tag_fields.py
+++ b/api/fields/tag_fields.py
@@ -1,16 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(
-        from_attributes=True,
-        extra="ignore",
-        populate_by_name=True,
-        serialize_by_alias=True,
-        protected_namespaces=(),
-    )
+from fields.base import ResponseModel
 
 
 class DataSetTag(ResponseModel):


### PR DESCRIPTION
Part of  #32385
Note: There will be follow up PRs. This PR is one split to reduce size of PR.

## Summary
- Add `ResponseModel` base class in `fields/base.py` with shared `ConfigDict` (from_attributes, extra="ignore", populate_by_name, serialize_by_alias, protected_namespaces)
- Remove 7 identical `ResponseModel` definitions from `annotation_fields`, `conversation_fields`, `end_user_fields`, `file_fields`, `member_fields`, `tag_fields`, and `controllers/console/app/app.py`
- Update all 7 files to import from `fields.base`

## Why this change
The same `ResponseModel(BaseModel)` with identical `ConfigDict` was copy-pasted across 7 files. A single canonical definition makes the Pydantic config contract explicit and avoids silent config drift if one copy is updated but others are not.

## Test plan
- [ ] `ruff check` passes
- [ ] No behavioral change — `fields/message_fields.py` intentionally keeps its own `ResponseModel` (different config: only `from_attributes=True, extra="ignore"`)

