### PR TITLE
fix: simplify pre-commit hook flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,4 @@
 - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
 - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
 - [x] I've updated the documentation accordingly.
-- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
+- [x] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -95,31 +95,5 @@ if $web_modified; then
         exit 1
     fi
 
-    echo "Running unit tests check"
-    modified_files=$(git diff --cached --name-only -- utils | grep -v '\.spec\.ts$' || true)
-
-    if [ -n "$modified_files" ]; then
-        for file in $modified_files; do
-            test_file="${file%.*}.spec.ts"
-            echo "Checking for test file: $test_file"
-
-            # check if the test file exists
-            if [ -f "../$test_file" ]; then
-                echo "Detected changes in $file, running corresponding unit tests..."
-                pnpm run test "../$test_file"
-
-                if [ $? -ne 0 ]; then
-                    echo "Unit tests failed. Please fix the errors before committing."
-                    exit 1
-                fi
-                echo "Unit tests for $file passed."
-            else
-                echo "Warning: $file does not have a corresponding test file."
-            fi
-
-        done
-        echo "All unit tests for modified web/utils files have passed."
-    fi
-
     cd ../
 fi

--- a/web/docs/lint.md
+++ b/web/docs/lint.md
@@ -38,7 +38,7 @@ Treat this as an escape hatch—fix these errors when time permits.
 ### The Auto-Fix Workflow and Suppression Strategy
 
 To streamline your development process, we recommend configuring your editor to automatically fix lint errors on save.
-As a fallback, any remaining autofixable errors will be corrected automatically when you commit.
+As a fallback, the commit hook runs `vp staged`, which applies autofixable ESLint changes to staged files before the commit continues.
 To prevent workflow disruptions, these commit hooks are intentionally bypassed when you are merging branches, rebasing, or cherry-picking.
 
 Additionally, we currently track many existing legacy errors in eslint-suppressions.json.


### PR DESCRIPTION
## Summary

This PR removes a low-signal unit-test special case from the pre-commit hook and updates the related documentation to match the current Vite+ hook workflow.

## What Changed

- removed the `web/utils` file-to-spec test runner from `.vite-hooks/pre-commit`
- updated the PR template to reference `cd web && pnpm exec vp staged` instead of the obsolete `npx lint-staged`
- updated the web lint documentation to describe the current `vp staged` commit-hook behavior

## Why

The current pre-commit flow already runs staged ESLint fixes, TypeScript checks for staged TS changes, and `knip`. The extra `web/utils` test special case added noise and maintenance burden without providing a consistent repository-wide policy.

The docs were also stale after the migration from older hook tooling to Vite+.

## Validation

- simulated a staged `web/utils` change and ran `.vite-hooks/pre-commit`
- confirmed the hook now runs `vp staged`, `type-check:tsgo` when applicable, and `knip`, without the removed special-case test step
- committed the change successfully through the active pre-commit hook
