### PR TITLE
refactor(api): type load balancing config dicts with TypedDict

### DIFF
--- a/api/services/model_load_balancing_service.py
+++ b/api/services/model_load_balancing_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Union
+from typing import Any, TypedDict, Union
 
 from graphon.model_runtime.entities.model_entities import ModelType
 from graphon.model_runtime.entities.provider_entities import (
@@ -23,6 +23,23 @@ from models.enums import CredentialSourceType
 from models.provider import LoadBalancingModelConfig, ProviderCredential, ProviderModelCredential
 
 logger = logging.getLogger(__name__)
+
+
+class LoadBalancingConfigDetailDict(TypedDict):
+    id: str
+    name: str
+    credentials: dict[str, Any]
+    enabled: bool
+
+
+class LoadBalancingConfigSummaryDict(TypedDict):
+    id: str
+    name: str
+    credentials: dict[str, Any]
+    credential_id: str | None
+    enabled: bool
+    in_cooldown: bool
+    ttl: int
 
 
 class ModelLoadBalancingService:
@@ -74,7 +91,7 @@ class ModelLoadBalancingService:
 
     def get_load_balancing_configs(
         self, tenant_id: str, provider: str, model: str, model_type: str, config_from: str = ""
-    ) -> tuple[bool, list[dict]]:
+    ) -> tuple[bool, list[LoadBalancingConfigSummaryDict]]:
         """
         Get load balancing configurations.
         :param tenant_id: workspace id
@@ -214,7 +231,7 @@ class ModelLoadBalancingService:
 
     def get_load_balancing_config(
         self, tenant_id: str, provider: str, model: str, model_type: str, config_id: str
-    ) -> dict | None:
+    ) -> LoadBalancingConfigDetailDict | None:
         """
         Get load balancing configuration.
         :param tenant_id: workspace id

--- a/api/services/model_load_balancing_service.py
+++ b/api/services/model_load_balancing_service.py
@@ -173,7 +173,7 @@ class ModelLoadBalancingService:
         decoding_rsa_key, decoding_cipher_rsa = encrypter.get_decrypt_decoding(tenant_id)
 
         # fetch status and ttl for each config
-        datas = []
+        datas: list[LoadBalancingConfigSummaryDict] = []
         for load_balancing_config in load_balancing_configs:
             in_cooldown, ttl = LBModelManager.get_config_in_cooldown_and_ttl(
                 tenant_id=tenant_id,
@@ -284,12 +284,13 @@ class ModelLoadBalancingService:
             credentials=credentials, credential_form_schemas=credential_schemas.credential_form_schemas
         )
 
-        return {
+        result: LoadBalancingConfigDetailDict = {
             "id": load_balancing_model_config.id,
             "name": load_balancing_model_config.name,
             "credentials": credentials,
             "enabled": load_balancing_model_config.enabled,
         }
+        return result
 
     def _init_inherit_config(
         self, tenant_id: str, provider: str, model: str, model_type: ModelType

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -3,10 +3,7 @@ import logging
 import time
 import uuid
 from collections.abc import Callable, Generator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, cast
-
-if TYPE_CHECKING:
-    from services.model_load_balancing_service import LoadBalancingConfigSummaryDict
+from typing import Any, cast
 
 from graphon.entities import GraphInitParams, WorkflowNodeExecution
 from graphon.entities.graph_config import NodeConfigDict
@@ -638,9 +635,7 @@ class WorkflowService:
             # If we can't determine the status, assume load balancing is not enabled
             return False
 
-    def _get_load_balancing_configs(
-        self, tenant_id: str, provider: str, model_name: str
-    ) -> list[LoadBalancingConfigSummaryDict]:
+    def _get_load_balancing_configs(self, tenant_id: str, provider: str, model_name: str) -> list[dict]:
         """
         Get all load balancing configurations for a model.
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -659,7 +659,7 @@ class WorkflowService:
             _, custom_configs = model_load_balancing_service.get_load_balancing_configs(
                 tenant_id=tenant_id, provider=provider, model=model_name, model_type="llm", config_from="custom-model"
             )
-            all_configs: list[dict[str, Any]] = configs + custom_configs
+            all_configs = cast(list[dict[str, Any]], configs) + cast(list[dict[str, Any]], custom_configs)
 
             return [config for config in all_configs if config.get("credential_id")]
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -635,7 +635,7 @@ class WorkflowService:
             # If we can't determine the status, assume load balancing is not enabled
             return False
 
-    def _get_load_balancing_configs(self, tenant_id: str, provider: str, model_name: str) -> list[dict]:
+    def _get_load_balancing_configs(self, tenant_id: str, provider: str, model_name: str) -> list[dict[str, Any]]:
         """
         Get all load balancing configurations for a model.
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -659,7 +659,7 @@ class WorkflowService:
             _, custom_configs = model_load_balancing_service.get_load_balancing_configs(
                 tenant_id=tenant_id, provider=provider, model=model_name, model_type="llm", config_from="custom-model"
             )
-            all_configs = configs + custom_configs
+            all_configs: list[dict[str, Any]] = configs + custom_configs
 
             return [config for config in all_configs if config.get("credential_id")]
 

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -3,7 +3,10 @@ import logging
 import time
 import uuid
 from collections.abc import Callable, Generator, Mapping, Sequence
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from services.model_load_balancing_service import LoadBalancingConfigSummaryDict
 
 from graphon.entities import GraphInitParams, WorkflowNodeExecution
 from graphon.entities.graph_config import NodeConfigDict
@@ -635,7 +638,9 @@ class WorkflowService:
             # If we can't determine the status, assume load balancing is not enabled
             return False
 
-    def _get_load_balancing_configs(self, tenant_id: str, provider: str, model_name: str) -> list[dict]:
+    def _get_load_balancing_configs(
+        self, tenant_id: str, provider: str, model_name: str
+    ) -> list[LoadBalancingConfigSummaryDict]:
         """
         Get all load balancing configurations for a model.
 


### PR DESCRIPTION
Part of #32863 (`api/services/model_load_balancing_service.py`)

## Summary
- Add `LoadBalancingConfigDetailDict` TypedDict with keys `id`, `name`, `credentials`, `enabled`
- Add `LoadBalancingConfigSummaryDict` TypedDict with keys `id`, `name`, `credentials`, `credential_id`, `enabled`, `in_cooldown`, `ttl`
- Annotate return types of `get_load_balancing_configs` and `get_load_balancing_config`

## Why this change
Both methods return dicts with well-known fixed keys but were typed as `list[dict]` and `dict | None`.
The TypedDicts make the shape explicit.

## Changes
- `api/services/model_load_balancing_service.py`: Define 2 TypedDicts, update 2 method signatures
