### PR TITLE
refactor(api): type aliyun trace utils with TypedDict and tighten return types

### DIFF
--- a/api/core/ops/aliyun_trace/utils.py
+++ b/api/core/ops/aliyun_trace/utils.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypedDict
 
 from graphon.entities import WorkflowNodeExecution
 from graphon.enums import WorkflowNodeExecutionStatus
@@ -56,10 +56,22 @@ def create_links_from_trace_id(trace_id: str | None) -> list[Link]:
     return links
 
 
-def extract_retrieval_documents(documents: list[Document]) -> list[dict[str, Any]]:
-    documents_data = []
+class RetrievalDocumentMetadataDict(TypedDict):
+    dataset_id: Any
+    doc_id: Any
+    document_id: Any
+
+
+class RetrievalDocumentDict(TypedDict):
+    content: str
+    metadata: RetrievalDocumentMetadataDict
+    score: Any
+
+
+def extract_retrieval_documents(documents: list[Document]) -> list[RetrievalDocumentDict]:
+    documents_data: list[RetrievalDocumentDict] = []
     for document in documents:
-        document_data = {
+        document_data: RetrievalDocumentDict = {
             "content": document.page_content,
             "metadata": {
                 "dataset_id": document.metadata.get("dataset_id"),
@@ -83,7 +95,7 @@ def create_common_span_attributes(
     framework: str = DEFAULT_FRAMEWORK_NAME,
     inputs: str = "",
     outputs: str = "",
-) -> dict[str, Any]:
+) -> dict[str, str]:
     return {
         GEN_AI_SESSION_ID: session_id,
         GEN_AI_USER_ID: user_id,


### PR DESCRIPTION
## Summary
- Add `RetrievalDocumentDict` and `RetrievalDocumentMetadataDict` TypedDicts for `extract_retrieval_documents` return type
- Tighten `create_common_span_attributes` return from `dict[str, Any]` to `dict[str, str]` (all values are strings)

## Why this change
`extract_retrieval_documents` constructs dicts with 3 fixed keys (`content`, `metadata`, `score`) and a nested metadata dict with 3 fixed keys (`dataset_id`, `doc_id`, `document_id`). `create_common_span_attributes` returns 6 string values but was typed as `dict[str, Any]`.

## Changes
- `core/ops/aliyun_trace/utils.py`: Define 2 TypedDicts, update 1 function return type to TypedDict, tighten 1 function return type to `dict[str, str]`

## Test plan
- [x] `ruff check` passes

Part of #32863 (`core/ops/aliyun_trace/utils.py`)
