### PR TITLE
refactor(api): type app parameter feature toggles with FeatureToggleD…

### DIFF
--- a/api/core/app/app_config/common/parameters_mapping/__init__.py
+++ b/api/core/app/app_config/common/parameters_mapping/__init__.py
@@ -5,6 +5,10 @@ from configs import dify_config
 from constants import DEFAULT_FILE_NUMBER_LIMITS
 
 
+class FeatureToggleDict(TypedDict):
+    enabled: bool
+
+
 class SystemParametersDict(TypedDict):
     image_file_size_limit: int
     video_file_size_limit: int
@@ -16,12 +20,12 @@ class SystemParametersDict(TypedDict):
 class AppParametersDict(TypedDict):
     opening_statement: str | None
     suggested_questions: list[str]
-    suggested_questions_after_answer: dict[str, Any]
-    speech_to_text: dict[str, Any]
-    text_to_speech: dict[str, Any]
-    retriever_resource: dict[str, Any]
-    annotation_reply: dict[str, Any]
-    more_like_this: dict[str, Any]
+    suggested_questions_after_answer: FeatureToggleDict
+    speech_to_text: FeatureToggleDict
+    text_to_speech: FeatureToggleDict
+    retriever_resource: FeatureToggleDict
+    annotation_reply: FeatureToggleDict
+    more_like_this: FeatureToggleDict
     user_input_form: list[dict[str, Any]]
     sensitive_word_avoidance: dict[str, Any]
     file_upload: dict[str, Any]


### PR DESCRIPTION
## Summary
- Add `FeatureToggleDict` TypedDict with key `enabled` (bool)
- Tighten 6 fields in `AppParametersDict` from `dict[str, Any]` to `FeatureToggleDict`: `suggested_questions_after_answer`, `speech_to_text`, `text_to_speech`, `retriever_resource`, `annotation_reply`, `more_like_this`

## Why this change
These 6 fields all follow the same `{"enabled": bool}` pattern — the function constructs them with `features_dict.get("...", {"enabled": False})`. Using `dict[str, Any]` hides this common structure. `FeatureToggleDict` makes the toggle pattern explicit and reusable.

`sensitive_word_avoidance` and `file_upload` are left as `dict[str, Any]` since they have additional nested keys beyond `enabled`.

## Changes
- `core/app/app_config/common/parameters_mapping/__init__.py`: Define `FeatureToggleDict`, update 6 fields in `AppParametersDict`

## Test plan
- [x] `ruff check` passes

Part of #32863 (`core/app/app_config/common/parameters_mapping/__init__.py`)
