### PR TITLE
fix: merge datasource blob chunks with configured file size

### DIFF
--- a/api/core/plugin/impl/datasource.py
+++ b/api/core/plugin/impl/datasource.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator, Mapping
 from typing import Any
 
+from configs import dify_config
 from core.datasource.entities.datasource_entities import (
     DatasourceMessage,
     GetOnlineDocumentPageContentRequest,
@@ -15,6 +16,7 @@ from core.plugin.entities.plugin_daemon import (
     PluginDatasourceProviderEntity,
 )
 from core.plugin.impl.base import BasePluginClient
+from core.plugin.utils.chunk_merger import merge_blob_chunks
 from core.schemas.resolver import resolve_dify_schema_refs
 from models.provider_ids import DatasourceProviderID, GenericProviderID
 from services.tools.tools_transform_service import ToolTransformService
@@ -221,7 +223,7 @@ class PluginDatasourceManager(BasePluginClient):
 
         datasource_provider_id = GenericProviderID(datasource_provider)
 
-        return self._request_with_plugin_daemon_response_stream(
+        response = self._request_with_plugin_daemon_response_stream(
             "POST",
             f"plugin/{tenant_id}/dispatch/datasource/get_online_document_page_content",
             DatasourceMessage,
@@ -239,6 +241,7 @@ class PluginDatasourceManager(BasePluginClient):
                 "Content-Type": "application/json",
             },
         )
+        return merge_blob_chunks(response, max_file_size=dify_config.PLUGIN_MAX_FILE_SIZE)
 
     def online_drive_browse_files(
         self,
@@ -310,7 +313,7 @@ class PluginDatasourceManager(BasePluginClient):
                 "Content-Type": "application/json",
             },
         )
-        yield from response
+        yield from merge_blob_chunks(response, max_file_size=dify_config.PLUGIN_MAX_FILE_SIZE)
 
     def validate_provider_credentials(
         self, tenant_id: str, user_id: str, provider: str, plugin_id: str, credentials: dict[str, Any]

--- a/api/tests/unit_tests/core/plugin/impl/test_datasource_manager.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_datasource_manager.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from configs import dify_config
 from core.datasource.entities.datasource_entities import (
     GetOnlineDocumentPageContentRequest,
     OnlineDriveBrowseFilesRequest,
@@ -155,6 +156,7 @@ class TestPluginDatasourceManager:
         manager = PluginDatasourceManager()
         stream_mock = mocker.patch.object(manager, "_request_with_plugin_daemon_response_stream")
         stream_mock.return_value = iter(["content"])
+        merge_mock = mocker.patch("core.plugin.impl.datasource.merge_blob_chunks", return_value=["merged"])
 
         assert list(
             manager.get_online_document_page_content(
@@ -166,9 +168,10 @@ class TestPluginDatasourceManager:
                 GetOnlineDocumentPageContentRequest(workspace_id="w", page_id="p", type="doc"),
                 "online_document",
             )
-        ) == ["content"]
+        ) == ["merged"]
 
         assert stream_mock.call_count == 1
+        merge_mock.assert_called_once_with(stream_mock.return_value, max_file_size=dify_config.PLUGIN_MAX_FILE_SIZE)
 
     def test_online_drive_browse_files_streaming(self, mocker):
         manager = PluginDatasourceManager()
@@ -193,6 +196,7 @@ class TestPluginDatasourceManager:
         manager = PluginDatasourceManager()
         stream_mock = mocker.patch.object(manager, "_request_with_plugin_daemon_response_stream")
         stream_mock.return_value = iter(["download"])
+        merge_mock = mocker.patch("core.plugin.impl.datasource.merge_blob_chunks", return_value=["merged"])
 
         assert list(
             manager.online_drive_download_file(
@@ -204,9 +208,10 @@ class TestPluginDatasourceManager:
                 OnlineDriveDownloadFileRequest(id="file-1"),
                 "online_drive",
             )
-        ) == ["download"]
+        ) == ["merged"]
 
         assert stream_mock.call_count == 1
+        merge_mock.assert_called_once_with(stream_mock.return_value, max_file_size=dify_config.PLUGIN_MAX_FILE_SIZE)
 
     def test_validate_provider_credentials_returns_true_when_stream_yields_result(self, mocker):
         manager = PluginDatasourceManager()


### PR DESCRIPTION
## Summary

- apply large blob chunk merging to datasource streaming paths
- use `PLUGIN_MAX_FILE_SIZE` for datasource online document / online drive file responses
- add unit tests covering datasource-path chunk merging

Fixes #34655

## Context

PR #30887 added configurable large-file handling for the tool path:

- `api/core/plugin/impl/tool.py`

But the datasource path still streamed `DatasourceMessage` responses directly without passing through `merge_blob_chunks(...)`:

- `api/core/plugin/impl/datasource.py`

That meant datasource-based plugins such as SharePoint knowledge source could still fail for larger files even on versions that already include the tool-path fix.

## Changes

- wrap `get_online_document_page_content(...)` responses with `merge_blob_chunks(...)`
- wrap `online_drive_download_file(...)` responses with `merge_blob_chunks(...)`
- use `dify_config.PLUGIN_MAX_FILE_SIZE` as the datasource-path file size limit
- extend datasource manager unit tests to assert the merge path is used

## Verification

- `uv run --group dev pytest tests/unit_tests/core/plugin/impl/test_datasource_manager.py -q -x`
