### PR TITLE
refactor(api): type indexing result with IndexingResultDict TypedDict

### DIFF
--- a/api/core/rag/index_processor/index_processor.py
+++ b/api/core/rag/index_processor/index_processor.py
@@ -12,7 +12,7 @@ from core.db.session_factory import session_factory
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
 from core.rag.index_processor.index_processor_base import SummaryIndexSettingDict
 from core.workflow.nodes.knowledge_index.exc import KnowledgeIndexNodeError
-from core.workflow.nodes.knowledge_index.protocols import Preview, PreviewItem, QaPreview
+from core.workflow.nodes.knowledge_index.protocols import IndexingResultDict, Preview, PreviewItem, QaPreview
 from models.dataset import Dataset, Document, DocumentSegment
 
 from .index_processor_factory import IndexProcessorFactory
@@ -61,7 +61,7 @@ class IndexProcessor:
         chunks: Mapping[str, Any],
         batch: Any,
         summary_index_setting: SummaryIndexSettingDict | None = None,
-    ):
+    ) -> IndexingResultDict:
         with session_factory.create_session() as session:
             document = session.query(Document).filter_by(id=document_id).first()
             if not document:
@@ -129,7 +129,7 @@ class IndexProcessor:
                 }
             )
 
-        return {
+        result: IndexingResultDict = {
             "dataset_id": dataset_id,
             "dataset_name": dataset_name_value,
             "batch": batch,
@@ -138,6 +138,7 @@ class IndexProcessor:
             "created_at": created_at_value.timestamp(),
             "display_status": "completed",
         }
+        return result
 
     def get_preview_output(
         self,

--- a/api/core/workflow/nodes/knowledge_index/protocols.py
+++ b/api/core/workflow/nodes/knowledge_index/protocols.py
@@ -1,7 +1,17 @@
 from collections.abc import Mapping
-from typing import Any, Protocol
+from typing import Any, Protocol, TypedDict
 
 from pydantic import BaseModel, Field
+
+
+class IndexingResultDict(TypedDict):
+    dataset_id: str
+    dataset_name: str
+    batch: Any
+    document_id: str
+    document_name: str
+    created_at: float
+    display_status: str
 
 
 class PreviewItem(BaseModel):
@@ -34,7 +44,7 @@ class IndexProcessorProtocol(Protocol):
         chunks: Mapping[str, Any],
         batch: Any,
         summary_index_setting: dict | None = None,
-    ) -> dict[str, Any]: ...
+    ) -> IndexingResultDict: ...
 
     def get_preview_output(
         self, chunks: Any, dataset_id: str, document_id: str, chunk_structure: str, summary_index_setting: dict | None


### PR DESCRIPTION
Part of #32863 (`api/core/rag/index_processor/index_processor.py`)

## Summary
- Add `IndexingResultDict` TypedDict with keys `dataset_id`, `dataset_name`, `batch`, `document_id`, `document_name`, `created_at`, `display_status`
- Annotate return type of `IndexProcessor.index_and_clean`
- Update `IndexProcessorProtocol.index_and_clean` return type

## Why this change
`index_and_clean` returns a dict with 7 well-known fixed keys but was untyped. The TypedDict makes the shape explicit for callers.

## Changes
- `api/core/workflow/nodes/knowledge_index/protocols.py`: Define `IndexingResultDict`, update protocol return type
- `api/core/rag/index_processor/index_processor.py`: Import `IndexingResultDict`, annotate return type and local variable
