### PR TITLE
fix(web): avoid prehydration script in slider

### DIFF
--- a/web/app/components/base/ui/slider/__tests__/index.spec.tsx
+++ b/web/app/components/base/ui/slider/__tests__/index.spec.tsx
@@ -70,4 +70,10 @@ describe('Slider', () => {
     const sliderWrapper = container.querySelector('.outer-test')
     expect(sliderWrapper).toBeInTheDocument()
   })
+
+  it('should not render prehydration script tags', () => {
+    const { container } = render(<Slider value={10} onValueChange={vi.fn()} aria-label="Value" />)
+
+    expect(container.querySelector('script')).not.toBeInTheDocument()
+  })
 })

--- a/web/app/components/base/ui/slider/index.tsx
+++ b/web/app/components/base/ui/slider/index.tsx
@@ -82,7 +82,7 @@ export function Slider({
       step={step}
       disabled={disabled}
       name={name}
-      thumbAlignment="edge"
+      thumbAlignment="edge-client-only"
       className={cn(sliderRootClassName, className)}
     >
       <BaseSlider.Control className={sliderControlClassName}>


### PR DESCRIPTION
## Summary
- switch the shared Base UI slider wrapper from `thumbAlignment="edge"` to `thumbAlignment="edge-client-only"`
- keep the edge-aligned visual behavior while avoiding Base UI's prehydration inline script path
- add a regression test to assert the slider wrapper no longer renders `<script>` tags

## Root Cause
Base UI's `thumbAlignment="edge"` mode enables a prehydration positioning path that renders an inline `<script>` inside `Slider.Thumb`. In the current `Next.js 16.2.2 + React 19` client rendering path, that triggers the runtime error about encountering a script tag while rendering a React component.

## Validation
- `pnpm --dir web test app/components/base/ui/slider/__tests__/index.spec.tsx`
