### PR TITLE
refactor(api): type Chroma and AnalyticDB config params dicts with TypedDicts

### DIFF
--- a/api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py
+++ b/api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, model_validator
 
@@ -11,6 +11,13 @@ _import_err_msg = (
 from core.rag.datasource.vdb.field import parse_metadata_json
 from core.rag.models.document import Document
 from extensions.ext_redis import redis_client
+
+
+class AnalyticdbClientParamsDict(TypedDict):
+    access_key_id: str
+    access_key_secret: str
+    region_id: str
+    read_timeout: int
 
 
 class AnalyticdbVectorOpenAPIConfig(BaseModel):
@@ -44,13 +51,14 @@ class AnalyticdbVectorOpenAPIConfig(BaseModel):
             raise ValueError("config ANALYTICDB_NAMESPACE_PASSWORD is required")
         return values
 
-    def to_analyticdb_client_params(self):
-        return {
+    def to_analyticdb_client_params(self) -> AnalyticdbClientParamsDict:
+        result: AnalyticdbClientParamsDict = {
             "access_key_id": self.access_key_id,
             "access_key_secret": self.access_key_secret,
             "region_id": self.region_id,
             "read_timeout": self.read_timeout,
         }
+        return result
 
 
 class AnalyticdbVectorOpenAPI:

--- a/api/core/rag/datasource/vdb/chroma/chroma_vector.py
+++ b/api/core/rag/datasource/vdb/chroma/chroma_vector.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, TypedDict
 
 import chromadb
 from chromadb import QueryResult, Settings
@@ -15,6 +15,15 @@ from extensions.ext_redis import redis_client
 from models.dataset import Dataset
 
 
+class ChromaParamsDict(TypedDict):
+    host: str
+    port: int
+    ssl: bool
+    tenant: str
+    database: str
+    settings: Settings
+
+
 class ChromaConfig(BaseModel):
     host: str
     port: int
@@ -23,14 +32,13 @@ class ChromaConfig(BaseModel):
     auth_provider: str | None = None
     auth_credentials: str | None = None
 
-    def to_chroma_params(self):
+    def to_chroma_params(self) -> ChromaParamsDict:
         settings = Settings(
             # auth
             chroma_client_auth_provider=self.auth_provider,
             chroma_client_auth_credentials=self.auth_credentials,
         )
-
-        return {
+        result: ChromaParamsDict = {
             "host": self.host,
             "port": self.port,
             "ssl": False,
@@ -38,6 +46,7 @@ class ChromaConfig(BaseModel):
             "database": self.database,
             "settings": settings,
         }
+        return result
 
 
 class ChromaVector(BaseVector):


### PR DESCRIPTION
Part of #32863 (`api/core/rag/datasource/vdb/`)

## Summary
- Add `ChromaParamsDict` TypedDict in `chroma_vector.py`, annotate `ChromaConfig.to_chroma_params`
- Add `AnalyticdbClientParamsDict` TypedDict in `analyticdb_vector_openapi.py`, annotate `AnalyticdbVectorOpenAPIConfig.to_analyticdb_client_params`

## Why this change
Both `to_chroma_params` and `to_analyticdb_client_params` return fixed-key dicts with no conditional keys but had no return type annotation. The TypedDicts make the connection parameter shapes explicit and checkable.

## Changes
- `api/core/rag/datasource/vdb/chroma/chroma_vector.py`: Define `ChromaParamsDict` (`host`, `port`, `ssl`, `tenant`, `database`, `settings`), annotate `to_chroma_params`
- `api/core/rag/datasource/vdb/analyticdb/analyticdb_vector_openapi.py`: Define `AnalyticdbClientParamsDict` (`access_key_id`, `access_key_secret`, `region_id`, `read_timeout`), annotate `to_analyticdb_client_params`
