### PR TITLE
refactor(api): type I18nObject.to_dict with I18nObjectDict TypedDict

### DIFF
--- a/api/core/datasource/entities/common_entities.py
+++ b/api/core/datasource/entities/common_entities.py
@@ -1,4 +1,13 @@
+from typing import TypedDict
+
 from pydantic import BaseModel, Field, model_validator
+
+
+class I18nObjectDict(TypedDict):
+    zh_Hans: str | None
+    en_US: str
+    pt_BR: str | None
+    ja_JP: str | None
 
 
 class I18nObject(BaseModel):
@@ -18,5 +27,11 @@ class I18nObject(BaseModel):
         self.ja_JP = self.ja_JP or self.en_US
         return self
 
-    def to_dict(self) -> dict:
-        return {"zh_Hans": self.zh_Hans, "en_US": self.en_US, "pt_BR": self.pt_BR, "ja_JP": self.ja_JP}
+    def to_dict(self) -> I18nObjectDict:
+        result: I18nObjectDict = {
+            "zh_Hans": self.zh_Hans,
+            "en_US": self.en_US,
+            "pt_BR": self.pt_BR,
+            "ja_JP": self.ja_JP,
+        }
+        return result

--- a/api/core/tools/entities/common_entities.py
+++ b/api/core/tools/entities/common_entities.py
@@ -1,4 +1,13 @@
+from typing import TypedDict
+
 from pydantic import BaseModel, Field, model_validator
+
+
+class I18nObjectDict(TypedDict):
+    zh_Hans: str | None
+    en_US: str
+    pt_BR: str | None
+    ja_JP: str | None
 
 
 class I18nObject(BaseModel):
@@ -18,5 +27,11 @@ class I18nObject(BaseModel):
         self.ja_JP = self.ja_JP or self.en_US
         return self
 
-    def to_dict(self):
-        return {"zh_Hans": self.zh_Hans, "en_US": self.en_US, "pt_BR": self.pt_BR, "ja_JP": self.ja_JP}
+    def to_dict(self) -> I18nObjectDict:
+        result: I18nObjectDict = {
+            "zh_Hans": self.zh_Hans,
+            "en_US": self.en_US,
+            "pt_BR": self.pt_BR,
+            "ja_JP": self.ja_JP,
+        }
+        return result


### PR DESCRIPTION
Part of #32863 (`api/core/tools/entities/`, `api/core/datasource/entities/`)

## Summary
- Add `I18nObjectDict` TypedDict in `tools/entities/common_entities.py`, annotate `I18nObject.to_dict`
- Add `I18nObjectDict` TypedDict in `datasource/entities/common_entities.py`, annotate `I18nObject.to_dict`

## Why this change
Both `I18nObject.to_dict` implementations return an identical fixed-key dict (`zh_Hans`, `en_US`, `pt_BR`, `ja_JP`) but had no return type annotation (or bare `-> dict`). The TypedDict makes the i18n shape explicit and checkable.

## Changes
- `api/core/tools/entities/common_entities.py`: Define `I18nObjectDict`, annotate `to_dict`
- `api/core/datasource/entities/common_entities.py`: Define `I18nObjectDict`, annotate `to_dict`
