### PR TITLE
refactor(api): clean up AssistantPromptMessage typing in CotChatAgentRunner

### DIFF
--- a/api/core/agent/cot_chat_agent_runner.py
+++ b/api/core/agent/cot_chat_agent_runner.py
@@ -79,21 +79,18 @@ class CotChatAgentRunner(CotAgentRunner):
         if not agent_scratchpad:
             assistant_messages = []
         else:
-            assistant_message = AssistantPromptMessage(content="")
-            assistant_message.content = ""  # FIXME: type check tell mypy that assistant_message.content is str
+            content = ""
             for unit in agent_scratchpad:
                 if unit.is_final():
-                    assert isinstance(assistant_message.content, str)
-                    assistant_message.content += f"Final Answer: {unit.agent_response}"
+                    content += f"Final Answer: {unit.agent_response}"
                 else:
-                    assert isinstance(assistant_message.content, str)
-                    assistant_message.content += f"Thought: {unit.thought}\n\n"
+                    content += f"Thought: {unit.thought}\n\n"
                     if unit.action_str:
-                        assistant_message.content += f"Action: {unit.action_str}\n\n"
+                        content += f"Action: {unit.action_str}\n\n"
                     if unit.observation:
-                        assistant_message.content += f"Observation: {unit.observation}\n\n"
+                        content += f"Observation: {unit.observation}\n\n"
 
-            assistant_messages = [assistant_message]
+            assistant_messages = [AssistantPromptMessage(content=content)]
 
         # query messages
         query_messages = self._organize_user_query(self._query, [])


### PR DESCRIPTION
### Summary
Resolves a `FIXME` and removes unnecessary `isinstance` assertions in the CoT Chat Agent runner by building the message content using a local variable.

### Why this change
Modifying `AssistantPromptMessage.content` (typed as `str | list`) directly inside a loop forced multiple `isinstance` checks to satisfy the type-checker. By accumulating the content in a lightweight string first and instantiating the model once at the end, we naturally satisfy strict type analysis (mypy) and simplify the code.

### Changes
**`api/core/agent/cot_chat_agent_runner.py`**:
- Removed the top-level `AssistantPromptMessage` empty instantiation and the associated `FIXME` comment.
- Created a local `content` string variable to accumulate the agent scratchpad responses.
- Removed two `assert isinstance(assistant_message.content, str)` lines that are no longer necessary and Instantiated `AssistantPromptMessage(content=content)` once at the end of the loop with the finalized string.

### Test Plan
- `ruff check` and `basedpyright`- Passed