### PR TITLE
refactor(api): type WorkflowAppLog.to_dict with WorkflowAppLogDict TypedDict

### DIFF
--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -1196,6 +1196,18 @@ class WorkflowAppLogCreatedFrom(StrEnum):
         raise ValueError(f"invalid workflow app log created from value {value}")
 
 
+class WorkflowAppLogDict(TypedDict):
+    id: str
+    tenant_id: str
+    app_id: str
+    workflow_id: str
+    workflow_run_id: str
+    created_from: WorkflowAppLogCreatedFrom
+    created_by_role: CreatorUserRole
+    created_by: str
+    created_at: datetime
+
+
 class WorkflowAppLog(TypeBase):
     """
     Workflow App execution log, excluding workflow debugging records.
@@ -1273,8 +1285,8 @@ class WorkflowAppLog(TypeBase):
         created_by_role = CreatorUserRole(self.created_by_role)
         return db.session.get(EndUser, self.created_by) if created_by_role == CreatorUserRole.END_USER else None
 
-    def to_dict(self):
-        return {
+    def to_dict(self) -> WorkflowAppLogDict:
+        result: WorkflowAppLogDict = {
             "id": self.id,
             "tenant_id": self.tenant_id,
             "app_id": self.app_id,
@@ -1285,6 +1297,7 @@ class WorkflowAppLog(TypeBase):
             "created_by": self.created_by,
             "created_at": self.created_at,
         }
+        return result
 
 
 class WorkflowArchiveLog(TypeBase):


### PR DESCRIPTION
Part of #32863 (`api/models/workflow.py`)

## Summary
- Add `WorkflowAppLogDict` TypedDict in `models/workflow.py`, annotate `WorkflowAppLog.to_dict`

## Why this change
`WorkflowAppLog.to_dict` returns a fixed-key dict (9 keys) but had no return type annotation. The TypedDict makes the serialized shape explicit and checkable.

## Changes
- `api/models/workflow.py`: Define `WorkflowAppLogDict` (`id`, `tenant_id`, `app_id`, `workflow_id`, `workflow_run_id`, `created_from`, `created_by_role`, `created_by`, `created_at`), annotate `to_dict`