### PR TITLE
refactor(api): extract shared RAG domain entities into core/rag/entity

### DIFF
--- a/api/core/rag/entities/__init__.py
+++ b/api/core/rag/entities/__init__.py
@@ -1,0 +1,15 @@
+from core.rag.entities.citation_metadata import RetrievalSourceMetadata
+from core.rag.entities.context_entities import DocumentContext
+from core.rag.entities.processing_entities import ParentMode, PreProcessingRule, Rule, Segmentation
+from core.rag.entities.retrieval_settings import KeywordSetting, VectorSetting
+
+__all__ = [
+    "DocumentContext",
+    "KeywordSetting",
+    "ParentMode",
+    "PreProcessingRule",
+    "RetrievalSourceMetadata",
+    "Rule",
+    "Segmentation",
+    "VectorSetting",
+]

--- a/api/core/rag/entities/processing_entities.py
+++ b/api/core/rag/entities/processing_entities.py
@@ -1,0 +1,27 @@
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ParentMode(StrEnum):
+    FULL_DOC = "full-doc"
+    PARAGRAPH = "paragraph"
+
+
+class PreProcessingRule(BaseModel):
+    id: str
+    enabled: bool
+
+
+class Segmentation(BaseModel):
+    separator: str = "\n"
+    max_tokens: int
+    chunk_overlap: int = 0
+
+
+class Rule(BaseModel):
+    pre_processing_rules: list[PreProcessingRule] | None = None
+    segmentation: Segmentation | None = None
+    parent_mode: Literal["full-doc", "paragraph"] | None = None
+    subchunk_segmentation: Segmentation | None = None

--- a/api/core/rag/entities/retrieval_settings.py
+++ b/api/core/rag/entities/retrieval_settings.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class VectorSetting(BaseModel):
+    """
+    Vector Setting.
+    """
+
+    vector_weight: float
+    embedding_provider_name: str
+    embedding_model_name: str
+
+
+class KeywordSetting(BaseModel):
+    """
+    Keyword Setting.
+    """
+
+    keyword_weight: float


### PR DESCRIPTION
Part of #32385, Follow up PRs are coming.
The deletion of duplicates will be a separate PR.

## Summary
- Add `processing_entities.py` with `ParentMode`, `PreProcessingRule`, `Segmentation`, and `Rule` models
- Add `retrieval_settings.py` with `VectorSetting` and `KeywordSetting` models
- Add `__init__.py` re-exporting all RAG domain entities for convenient `from core.rag.entities import ...` usage

## Why this change
`VectorSetting`, `KeywordSetting`, `Rule`, `Segmentation`, and related processing types are duplicated across `knowledge_retrieval/entities.py`, `knowledge_index/entities.py`, and `rerank/entity/weight.py`. Extracting them into a single shared location (`core/rag/entities/`) removes the duplication and establishes a canonical import path.

This PR only introduces the shared definitions. Consumer migration to the new import paths follows in a stacked PR.

## Changes
- `core/rag/entities/__init__.py`: New file — re-exports all entities
- `core/rag/entities/processing_entities.py`: New file — `ParentMode`, `PreProcessingRule`, `Segmentation`, `Rule`
- `core/rag/entities/retrieval_settings.py`: New file — `VectorSetting`, `KeywordSetting`

## Test plan
- [x] `ruff check` passes

