### PR TITLE
refactor(api): deduplicate RAG index entities and consolidate import paths

### DIFF
--- a/api/core/rag/entities/__init__.py
+++ b/api/core/rag/entities/__init__.py
@@ -1,12 +1,20 @@
 from core.rag.entities.citation_metadata import RetrievalSourceMetadata
 from core.rag.entities.context_entities import DocumentContext
+from core.rag.entities.event import DatasourceCompletedEvent, DatasourceErrorEvent, DatasourceProcessingEvent
+from core.rag.entities.index_entities import EconomySetting, EmbeddingSetting, IndexMethod
 from core.rag.entities.metadata_entities import Condition, MetadataFilteringCondition, SupportedComparisonOperator
 from core.rag.entities.processing_entities import ParentMode, PreProcessingRule, Rule, Segmentation
-from core.rag.entities.retrieval_settings import KeywordSetting, VectorSetting
+from core.rag.entities.retrieval_settings import KeywordSetting, VectorSetting, WeightedScoreConfig
 
 __all__ = [
     "Condition",
+    "DatasourceCompletedEvent",
+    "DatasourceErrorEvent",
+    "DatasourceProcessingEvent",
     "DocumentContext",
+    "EconomySetting",
+    "EmbeddingSetting",
+    "IndexMethod",
     "KeywordSetting",
     "MetadataFilteringCondition",
     "ParentMode",
@@ -16,4 +24,5 @@ __all__ = [
     "Segmentation",
     "SupportedComparisonOperator",
     "VectorSetting",
+    "WeightedScoreConfig",
 ]

--- a/api/core/rag/entities/index_entities.py
+++ b/api/core/rag/entities/index_entities.py
@@ -1,0 +1,30 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class EmbeddingSetting(BaseModel):
+    """
+    Embedding Setting.
+    """
+
+    embedding_provider_name: str
+    embedding_model_name: str
+
+
+class EconomySetting(BaseModel):
+    """
+    Economy Setting.
+    """
+
+    keyword_number: int
+
+
+class IndexMethod(BaseModel):
+    """
+    Knowledge Index Setting.
+    """
+
+    indexing_technique: Literal["high_quality", "economy"]
+    embedding_setting: EmbeddingSetting
+    economy_setting: EconomySetting

--- a/api/core/rag/entities/retrieval_settings.py
+++ b/api/core/rag/entities/retrieval_settings.py
@@ -17,3 +17,12 @@ class KeywordSetting(BaseModel):
     """
 
     keyword_weight: float
+
+
+class WeightedScoreConfig(BaseModel):
+    """
+    Weighted score Config.
+    """
+
+    vector_setting: VectorSetting
+    keyword_setting: KeywordSetting

--- a/api/core/workflow/nodes/knowledge_index/entities.py
+++ b/api/core/workflow/nodes/knowledge_index/entities.py
@@ -1,10 +1,10 @@
-from typing import Literal, Union
+from typing import Union
 
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.enums import NodeType
 from pydantic import BaseModel
 
-from core.rag.entities import KeywordSetting, VectorSetting
+from core.rag.entities import WeightedScoreConfig
 from core.rag.index_processor.index_processor_base import SummaryIndexSettingDict
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from core.workflow.nodes.knowledge_index import KNOWLEDGE_INDEX_NODE_TYPE
@@ -17,32 +17,6 @@ class RerankingModelConfig(BaseModel):
 
     reranking_provider_name: str
     reranking_model_name: str
-
-
-class WeightedScoreConfig(BaseModel):
-    """
-    Weighted score Config.
-    """
-
-    vector_setting: VectorSetting
-    keyword_setting: KeywordSetting
-
-
-class EmbeddingSetting(BaseModel):
-    """
-    Embedding Setting.
-    """
-
-    embedding_provider_name: str
-    embedding_model_name: str
-
-
-class EconomySetting(BaseModel):
-    """
-    Economy Setting.
-    """
-
-    keyword_number: int
 
 
 class RetrievalSetting(BaseModel):
@@ -58,16 +32,6 @@ class RetrievalSetting(BaseModel):
     reranking_enable: bool = True
     reranking_model: RerankingModelConfig | None = None
     weights: WeightedScoreConfig | None = None
-
-
-class IndexMethod(BaseModel):
-    """
-    Knowledge Index Setting.
-    """
-
-    indexing_technique: Literal["high_quality", "economy"]
-    embedding_setting: EmbeddingSetting
-    economy_setting: EconomySetting
 
 
 class FileInfo(BaseModel):

--- a/api/core/workflow/nodes/knowledge_retrieval/entities.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/entities.py
@@ -5,7 +5,7 @@ from graphon.enums import BuiltinNodeTypes, NodeType
 from graphon.nodes.llm.entities import ModelConfig, VisionConfig
 from pydantic import BaseModel, Field
 
-from core.rag.entities import Condition, KeywordSetting, MetadataFilteringCondition, VectorSetting
+from core.rag.entities import Condition, MetadataFilteringCondition, WeightedScoreConfig
 
 __all__ = ["Condition"]
 
@@ -17,15 +17,6 @@ class RerankingModelConfig(BaseModel):
 
     provider: str
     model: str
-
-
-class WeightedScoreConfig(BaseModel):
-    """
-    Weighted score Config.
-    """
-
-    vector_setting: VectorSetting
-    keyword_setting: KeywordSetting
 
 
 class MultipleRetrievalConfig(BaseModel):

--- a/api/services/entities/knowledge_entities/rag_pipeline_entities.py
+++ b/api/services/entities/knowledge_entities/rag_pipeline_entities.py
@@ -46,23 +46,6 @@ class WeightedScoreConfig(BaseModel):
     keyword_setting: KeywordSetting | None
 
 
-class EmbeddingSetting(BaseModel):
-    """
-    Embedding Setting.
-    """
-
-    embedding_provider_name: str
-    embedding_model_name: str
-
-
-class EconomySetting(BaseModel):
-    """
-    Economy Setting.
-    """
-
-    keyword_number: int
-
-
 class RetrievalSetting(BaseModel):
     """
     Retrieval Setting.
@@ -76,16 +59,6 @@ class RetrievalSetting(BaseModel):
     reranking_enable: bool | None = True
     reranking_model: RerankingModelConfig | None = None
     weights: WeightedScoreConfig | None = None
-
-
-class IndexMethod(BaseModel):
-    """
-    Knowledge Index Setting.
-    """
-
-    indexing_technique: Literal["high_quality", "economy"]
-    embedding_setting: EmbeddingSetting
-    economy_setting: EconomySetting
 
 
 class KnowledgeConfiguration(BaseModel):

--- a/api/services/rag_pipeline/rag_pipeline.py
+++ b/api/services/rag_pipeline/rag_pipeline.py
@@ -38,11 +38,7 @@ from core.datasource.online_document.online_document_plugin import OnlineDocumen
 from core.datasource.online_drive.online_drive_plugin import OnlineDriveDatasourcePlugin
 from core.datasource.website_crawl.website_crawl_plugin import WebsiteCrawlDatasourcePlugin
 from core.helper import marketplace
-from core.rag.entities.event import (
-    DatasourceCompletedEvent,
-    DatasourceErrorEvent,
-    DatasourceProcessingEvent,
-)
+from core.rag.entities import DatasourceCompletedEvent, DatasourceErrorEvent, DatasourceProcessingEvent
 from core.repositories.factory import DifyCoreRepositoryFactory, OrderConfig
 from core.repositories.sqlalchemy_workflow_node_execution_repository import SQLAlchemyWorkflowNodeExecutionRepository
 from core.workflow.node_factory import LATEST_VERSION, get_node_type_classes_mapping


### PR DESCRIPTION
Part of #32385. 
## Summary
- Consolidate `WeightedScoreConfig` from `knowledge_retrieval/entities.py` and `knowledge_index/entities.py` into `core/rag/entities/retrieval_settings.py`
- Consolidate identical `EmbeddingSetting`, `EconomySetting`, and `IndexMethod` from `knowledge_index/entities.py` and `rag_pipeline_entities.py` into `core/rag/entities/index_entities.py`
- Re-export datasource event classes (`DatasourceCompletedEvent`, `DatasourceErrorEvent`, `DatasourceProcessingEvent`) from `core/rag/entities/__init__.py`
- Fix remaining `PluginCredentialType` import in test file to use canonical `core.entities` path

## Why this change
`WeightedScoreConfig`, `EmbeddingSetting`, `EconomySetting`, and `IndexMethod` had identical definitions duplicated across 2–3 files. Consolidating them into `core/rag/entities/` establishes a single source of truth and aligns with the existing pattern of re-exporting shared RAG domain entities from the package `__init__.py`.

The services-layer `WeightedScoreConfig` and `RerankingModelConfig` variants are intentionally left separate — they have different field types (`| None`) reflecting looser validation at the API boundary.

## Changes
- `core/rag/entities/retrieval_settings.py`: Add canonical `WeightedScoreConfig`
- `core/rag/entities/index_entities.py`: New file — canonical `EmbeddingSetting`, `EconomySetting`, `IndexMethod`
- `core/rag/entities/__init__.py`: Re-export new entities and datasource event classes
- `core/workflow/nodes/knowledge_index/entities.py`: Remove duplicates, import from `core.rag.entities`
- `core/workflow/nodes/knowledge_retrieval/entities.py`: Remove duplicate `WeightedScoreConfig`, import from `core.rag.entities`
- `services/entities/knowledge_entities/rag_pipeline_entities.py`: Remove duplicates
- `services/rag_pipeline/rag_pipeline.py`: Use package-level import for event classes
- `tests/unit_tests/services/enterprise/test_plugin_manager_service.py`: Import `PluginCredentialType` from `core.entities`

## Test plan
- [x] `ruff check` passes on all changed files
