### PR TITLE
refactor(api): migrate consumers to shared RAG domain entities from core/rag/entities/

### DIFF
--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from enum import StrEnum, auto
 from typing import Any, Literal
 
@@ -9,6 +8,7 @@ from graphon.variables.input_entities import VariableEntity as WorkflowVariableE
 from pydantic import BaseModel, Field
 
 from core.rag.data_post_processor.data_post_processor import RerankingModelDict, WeightsDict
+from core.rag.entities import MetadataFilteringCondition
 from models.model import AppMode
 
 
@@ -111,55 +111,11 @@ class ExternalDataVariableEntity(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
 
 
-SupportedComparisonOperator = Literal[
-    # for string or array
-    "contains",
-    "not contains",
-    "start with",
-    "end with",
-    "is",
-    "is not",
-    "empty",
-    "not empty",
-    "in",
-    "not in",
-    # for number
-    "=",
-    "≠",
-    ">",
-    "<",
-    "≥",
-    "≤",
-    # for time
-    "before",
-    "after",
-]
-
-
 class ModelConfig(BaseModel):
     provider: str
     name: str
     mode: LLMMode
     completion_params: dict[str, Any] = Field(default_factory=dict)
-
-
-class Condition(BaseModel):
-    """
-    Condition detail
-    """
-
-    name: str
-    comparison_operator: SupportedComparisonOperator
-    value: str | Sequence[str] | None | int | float = None
-
-
-class MetadataFilteringCondition(BaseModel):
-    """
-    Metadata Filtering Condition.
-    """
-
-    logical_operator: Literal["and", "or"] | None = "and"
-    conditions: list[Condition] | None = Field(default=None, deprecated=True)
 
 
 class DatasetRetrieveConfigEntity(BaseModel):

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -15,7 +15,7 @@ from core.rag.data_post_processor.data_post_processor import DataPostProcessor, 
 from core.rag.datasource.keyword.keyword_factory import Keyword
 from core.rag.datasource.vdb.vector_factory import Vector
 from core.rag.embedding.retrieval import AttachmentInfoDict, RetrievalChildChunk, RetrievalSegments
-from core.rag.entities.metadata_entities import MetadataCondition
+from core.rag.entities import MetadataFilteringCondition
 from core.rag.index_processor.constant.doc_type import DocType
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from core.rag.index_processor.constant.query_type import QueryType
@@ -182,7 +182,9 @@ class RetrievalService:
         if not dataset:
             return []
         metadata_condition = (
-            MetadataCondition.model_validate(metadata_filtering_conditions) if metadata_filtering_conditions else None
+            MetadataFilteringCondition.model_validate(metadata_filtering_conditions)
+            if metadata_filtering_conditions
+            else None
         )
         all_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
             dataset.tenant_id,

--- a/api/core/rag/entities/__init__.py
+++ b/api/core/rag/entities/__init__.py
@@ -1,15 +1,19 @@
 from core.rag.entities.citation_metadata import RetrievalSourceMetadata
 from core.rag.entities.context_entities import DocumentContext
+from core.rag.entities.metadata_entities import Condition, MetadataFilteringCondition, SupportedComparisonOperator
 from core.rag.entities.processing_entities import ParentMode, PreProcessingRule, Rule, Segmentation
 from core.rag.entities.retrieval_settings import KeywordSetting, VectorSetting
 
 __all__ = [
+    "Condition",
     "DocumentContext",
     "KeywordSetting",
+    "MetadataFilteringCondition",
     "ParentMode",
     "PreProcessingRule",
     "RetrievalSourceMetadata",
     "Rule",
     "Segmentation",
+    "SupportedComparisonOperator",
     "VectorSetting",
 ]

--- a/api/core/rag/entities/metadata_entities.py
+++ b/api/core/rag/entities/metadata_entities.py
@@ -38,9 +38,9 @@ class Condition(BaseModel):
     value: str | Sequence[str] | None | int | float = None
 
 
-class MetadataCondition(BaseModel):
+class MetadataFilteringCondition(BaseModel):
     """
-    Metadata Condition.
+    Metadata Filtering Condition.
     """
 
     logical_operator: Literal["and", "or"] | None = "and"

--- a/api/core/rag/rerank/entity/weight.py
+++ b/api/core/rag/rerank/entity/weight.py
@@ -1,16 +1,6 @@
 from pydantic import BaseModel
 
-
-class VectorSetting(BaseModel):
-    vector_weight: float
-
-    embedding_provider_name: str
-
-    embedding_model_name: str
-
-
-class KeywordSetting(BaseModel):
-    keyword_weight: float
+from core.rag.entities import KeywordSetting, VectorSetting
 
 
 class Weights(BaseModel):

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -39,9 +39,9 @@ from core.prompt.simple_prompt_transform import ModelMode
 from core.rag.data_post_processor.data_post_processor import DataPostProcessor, RerankingModelDict, WeightsDict
 from core.rag.datasource.keyword.jieba.jieba_keyword_table_handler import JiebaKeywordTableHandler
 from core.rag.datasource.retrieval_service import DefaultRetrievalModelDict, RetrievalService
+from core.rag.entities import Condition
 from core.rag.entities.citation_metadata import RetrievalSourceMetadata
 from core.rag.entities.context_entities import DocumentContext
-from core.rag.entities.metadata_entities import Condition, MetadataCondition
 from core.rag.index_processor.constant.doc_type import DocType
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from core.rag.index_processor.constant.query_type import QueryType
@@ -604,7 +604,7 @@ class DatasetRetrieval:
         planning_strategy: PlanningStrategy,
         message_id: str | None = None,
         metadata_filter_document_ids: dict[str, list[str]] | None = None,
-        metadata_condition: MetadataCondition | None = None,
+        metadata_condition: MetadataFilteringCondition | None = None,
     ):
         tools = []
         for dataset in available_datasets:
@@ -743,7 +743,7 @@ class DatasetRetrieval:
         reranking_enable: bool = True,
         message_id: str | None = None,
         metadata_filter_document_ids: dict[str, list[str]] | None = None,
-        metadata_condition: MetadataCondition | None = None,
+        metadata_condition: MetadataFilteringCondition | None = None,
         attachment_ids: list[str] | None = None,
     ):
         if not available_datasets:
@@ -1063,7 +1063,7 @@ class DatasetRetrieval:
         top_k: int,
         all_documents: list[Document],
         document_ids_filter: list[str] | None = None,
-        metadata_condition: MetadataCondition | None = None,
+        metadata_condition: MetadataFilteringCondition | None = None,
         attachment_ids: list[str] | None = None,
     ):
         with flask_app.app_context():
@@ -1339,7 +1339,7 @@ class DatasetRetrieval:
         metadata_model_config: ModelConfig,
         metadata_filtering_conditions: MetadataFilteringCondition | None,
         inputs: dict,
-    ) -> tuple[dict[str, list[str]] | None, MetadataCondition | None]:
+    ) -> tuple[dict[str, list[str]] | None, MetadataFilteringCondition | None]:
         document_query = select(DatasetDocument).where(
             DatasetDocument.dataset_id.in_(dataset_ids),
             DatasetDocument.indexing_status == "completed",
@@ -1371,7 +1371,7 @@ class DatasetRetrieval:
                             value=filter.get("value"),
                         )
                     )
-                metadata_condition = MetadataCondition(
+                metadata_condition = MetadataFilteringCondition(
                     logical_operator=metadata_filtering_conditions.logical_operator
                     if metadata_filtering_conditions
                     else "or",  # type: ignore
@@ -1400,7 +1400,7 @@ class DatasetRetrieval:
                         expected_value,
                         filters,
                     )
-                metadata_condition = MetadataCondition(
+                metadata_condition = MetadataFilteringCondition(
                     logical_operator=metadata_filtering_conditions.logical_operator,
                     conditions=conditions,
                 )
@@ -1723,7 +1723,7 @@ class DatasetRetrieval:
         self,
         flask_app: Flask,
         available_datasets: list[Dataset],
-        metadata_condition: MetadataCondition | None,
+        metadata_condition: MetadataFilteringCondition | None,
         metadata_filter_document_ids: dict[str, list[str]] | None,
         all_documents: list[Document],
         tenant_id: str,

--- a/api/core/workflow/nodes/knowledge_index/entities.py
+++ b/api/core/workflow/nodes/knowledge_index/entities.py
@@ -4,6 +4,7 @@ from graphon.entities.base_node_data import BaseNodeData
 from graphon.enums import NodeType
 from pydantic import BaseModel
 
+from core.rag.entities import KeywordSetting, VectorSetting
 from core.rag.index_processor.index_processor_base import SummaryIndexSettingDict
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from core.workflow.nodes.knowledge_index import KNOWLEDGE_INDEX_NODE_TYPE
@@ -16,24 +17,6 @@ class RerankingModelConfig(BaseModel):
 
     reranking_provider_name: str
     reranking_model_name: str
-
-
-class VectorSetting(BaseModel):
-    """
-    Vector Setting.
-    """
-
-    vector_weight: float
-    embedding_provider_name: str
-    embedding_model_name: str
-
-
-class KeywordSetting(BaseModel):
-    """
-    Keyword Setting.
-    """
-
-    keyword_weight: float
 
 
 class WeightedScoreConfig(BaseModel):

--- a/api/core/workflow/nodes/knowledge_retrieval/entities.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/entities.py
@@ -1,10 +1,13 @@
-from collections.abc import Sequence
 from typing import Literal
 
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.enums import BuiltinNodeTypes, NodeType
 from graphon.nodes.llm.entities import ModelConfig, VisionConfig
 from pydantic import BaseModel, Field
+
+from core.rag.entities import Condition, KeywordSetting, MetadataFilteringCondition, VectorSetting
+
+__all__ = ["Condition"]
 
 
 class RerankingModelConfig(BaseModel):
@@ -14,24 +17,6 @@ class RerankingModelConfig(BaseModel):
 
     provider: str
     model: str
-
-
-class VectorSetting(BaseModel):
-    """
-    Vector Setting.
-    """
-
-    vector_weight: float
-    embedding_provider_name: str
-    embedding_model_name: str
-
-
-class KeywordSetting(BaseModel):
-    """
-    Keyword Setting.
-    """
-
-    keyword_weight: float
 
 
 class WeightedScoreConfig(BaseModel):
@@ -62,50 +47,6 @@ class SingleRetrievalConfig(BaseModel):
     """
 
     model: ModelConfig
-
-
-SupportedComparisonOperator = Literal[
-    # for string or array
-    "contains",
-    "not contains",
-    "start with",
-    "end with",
-    "is",
-    "is not",
-    "empty",
-    "not empty",
-    "in",
-    "not in",
-    # for number
-    "=",
-    "≠",
-    ">",
-    "<",
-    "≥",
-    "≤",
-    # for time
-    "before",
-    "after",
-]
-
-
-class Condition(BaseModel):
-    """
-    Condition detail
-    """
-
-    name: str
-    comparison_operator: SupportedComparisonOperator
-    value: str | Sequence[str] | None | int | float = None
-
-
-class MetadataFilteringCondition(BaseModel):
-    """
-    Metadata Filtering Condition.
-    """
-
-    logical_operator: Literal["and", "or"] | None = "and"
-    conditions: list[Condition] | None = Field(default=None, deprecated=True)
 
 
 class KnowledgeRetrievalNodeData(BaseNodeData):

--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import func, select
 
 from constants import HIDDEN_VALUE
 from core.helper import ssrf_proxy
-from core.rag.entities.metadata_entities import MetadataCondition
+from core.rag.entities import MetadataFilteringCondition
 from extensions.ext_database import db
 from libs.datetime_utils import naive_utc_now
 from models.dataset import (
@@ -302,7 +302,7 @@ class ExternalDatasetService:
         dataset_id: str,
         query: str,
         external_retrieval_parameters: dict,
-        metadata_condition: MetadataCondition | None = None,
+        metadata_condition: MetadataFilteringCondition | None = None,
     ):
         external_knowledge_binding = db.session.scalar(
             select(ExternalKnowledgeBindings)

--- a/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
@@ -236,7 +236,7 @@ class TestRetrievalServiceInternals:
         assert mock_retrieve.call_count == 2
 
     @patch("core.rag.datasource.retrieval_service.ExternalDatasetService.fetch_external_knowledge_retrieval")
-    @patch("core.rag.datasource.retrieval_service.MetadataCondition.model_validate")
+    @patch("core.rag.datasource.retrieval_service.MetadataFilteringCondition.model_validate")
     @patch("core.rag.datasource.retrieval_service.db.session.scalar")
     def test_external_retrieve_with_metadata_conditions(self, mock_scalar, mock_validate, mock_fetch):
         mock_scalar.return_value = SimpleNamespace(tenant_id="tenant-1")

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -11,9 +11,6 @@ from graphon.model_runtime.entities.model_entities import ModelFeature
 from sqlalchemy import column
 
 from core.app.app_config.entities import (
-    Condition as AppCondition,
-)
-from core.app.app_config.entities import (
     DatasetEntity,
     DatasetRetrieveConfigEntity,
 )
@@ -29,6 +26,7 @@ from core.entities.agent_entities import PlanningStrategy
 from core.entities.model_entities import ModelStatus
 from core.rag.data_post_processor.data_post_processor import WeightsDict
 from core.rag.datasource.retrieval_service import RetrievalService
+from core.rag.entities import Condition as AppCondition
 from core.rag.index_processor.constant.doc_type import DocType
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from core.rag.models.document import Document


### PR DESCRIPTION
Part of https://github.com/langgenius/dify/issues/32385, Follow up PRs are coming.

**Following PR should be merged before current PR: https://github.com/langgenius/dify/pull/34685**

## Summary
- Remove duplicated `VectorSetting` and `KeywordSetting` definitions from `rerank/entity/weight.py`, `knowledge_index/entities.py`, and `knowledge_retrieval/entities.py`
- Remove duplicated `SupportedComparisonOperator`, `Condition`, and `MetadataFilteringCondition` definitions from `app_config/entities.py` and `knowledge_retrieval/entities.py`
- Rename `MetadataCondition` → `MetadataFilteringCondition` in `metadata_entities.py` and update all usages
- Update all consumer imports to use the shared `core.rag.entities` module

## Why this change
These types were independently defined in 4 separate modules with identical structure. After extracting the canonical definitions into `core/rag/entities/` (see #34680), this PR removes the duplicates and migrates all consumers to the shared import path.

`MetadataCondition` was renamed to `MetadataFilteringCondition` to align with the name already used in `app_config/entities.py` and `knowledge_retrieval/entities.py`, making the naming consistent across the codebase.

## Changes
- `core/rag/entities/__init__.py`: Add `Condition`, `MetadataFilteringCondition`, `SupportedComparisonOperator` exports
- `core/rag/entities/metadata_entities.py`: Rename `MetadataCondition` → `MetadataFilteringCondition`
- `core/app/app_config/entities.py`: Remove 3 duplicated types, import `MetadataFilteringCondition` from `core.rag.entities`
- `core/workflow/nodes/knowledge_retrieval/entities.py`: Remove 5 duplicated types, import from `core.rag.entities`
- `core/workflow/nodes/knowledge_index/entities.py`: Remove `VectorSetting`/`KeywordSetting`, import from `core.rag.entities`
- `core/rag/rerank/entity/weight.py`: Remove `VectorSetting`/`KeywordSetting`, import from `core.rag.entities`
- `core/rag/datasource/retrieval_service.py`: Update import
- `core/rag/retrieval/dataset_retrieval.py`: Update imports and all `MetadataCondition` usages
- `services/external_knowledge_service.py`: Update import and type hint
- `tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py`: Update `@patch` path
- `tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py`: Update `Condition` import source

## Test plan
- [x] `ruff check` passes
