### PR TITLE
refactor(api): deduplicate shared auth request payloads into auth_entities.py

### DIFF
--- a/api/controllers/console/auth/forgot_password.py
+++ b/api/controllers/console/auth/forgot_password.py
@@ -3,7 +3,7 @@ import secrets
 
 from flask import request
 from flask_restx import Resource
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import sessionmaker
 
 from controllers.common.schema import register_schema_models
@@ -20,33 +20,16 @@ from controllers.console.wraps import email_password_login_enabled, setup_requir
 from events.tenant_event import tenant_was_created
 from extensions.ext_database import db
 from libs.helper import EmailStr, extract_remote_ip
-from libs.password import hash_password, valid_password
+from libs.password import hash_password
 from services.account_service import AccountService, TenantService
+from services.entities.auth_entities import (
+    ForgotPasswordCheckPayload,
+    ForgotPasswordResetPayload,
+    ForgotPasswordSendPayload,
+)
 from services.feature_service import FeatureService
 
 DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
-
-
-class ForgotPasswordSendPayload(BaseModel):
-    email: EmailStr = Field(...)
-    language: str | None = Field(default=None)
-
-
-class ForgotPasswordCheckPayload(BaseModel):
-    email: EmailStr = Field(...)
-    code: str = Field(...)
-    token: str = Field(...)
-
-
-class ForgotPasswordResetPayload(BaseModel):
-    token: str = Field(...)
-    new_password: str = Field(...)
-    password_confirm: str = Field(...)
-
-    @field_validator("new_password", "password_confirm")
-    @classmethod
-    def validate_password(cls, value: str) -> str:
-        return valid_password(value)
 
 
 class ForgotPasswordEmailResponse(BaseModel):

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -42,6 +42,7 @@ from libs.token import (
 )
 from services.account_service import AccountService, InvitationDetailDict, RegisterService, TenantService
 from services.billing_service import BillingService
+from services.entities.auth_entities import LoginPayloadBase
 from services.errors.account import AccountRegisterError
 from services.errors.workspace import WorkSpaceNotAllowedCreateError, WorkspacesLimitExceededError
 from services.feature_service import FeatureService
@@ -49,9 +50,7 @@ from services.feature_service import FeatureService
 DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
 
 
-class LoginPayload(BaseModel):
-    email: EmailStr = Field(..., description="Email address")
-    password: str = Field(..., description="Password")
+class LoginPayload(LoginPayloadBase):
     remember_me: bool = Field(default=False, description="Remember me flag")
     invite_token: str | None = Field(default=None, description="Invitation token")
 

--- a/api/controllers/web/forgot_password.py
+++ b/api/controllers/web/forgot_password.py
@@ -3,7 +3,6 @@ import secrets
 
 from flask import request
 from flask_restx import Resource
-from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import sessionmaker
 
 from controllers.common.schema import register_schema_models
@@ -19,33 +18,15 @@ from controllers.console.error import EmailSendIpLimitError
 from controllers.console.wraps import email_password_login_enabled, only_edition_enterprise, setup_required
 from controllers.web import web_ns
 from extensions.ext_database import db
-from libs.helper import EmailStr, extract_remote_ip
-from libs.password import hash_password, valid_password
+from libs.helper import extract_remote_ip
+from libs.password import hash_password
 from models.account import Account
 from services.account_service import AccountService
-
-
-class ForgotPasswordSendPayload(BaseModel):
-    email: EmailStr
-    language: str | None = None
-
-
-class ForgotPasswordCheckPayload(BaseModel):
-    email: EmailStr
-    code: str
-    token: str = Field(min_length=1)
-
-
-class ForgotPasswordResetPayload(BaseModel):
-    token: str = Field(min_length=1)
-    new_password: str
-    password_confirm: str
-
-    @field_validator("new_password", "password_confirm")
-    @classmethod
-    def validate_password(cls, value: str) -> str:
-        return valid_password(value)
-
+from services.entities.auth_entities import (
+    ForgotPasswordCheckPayload,
+    ForgotPasswordResetPayload,
+    ForgotPasswordSendPayload,
+)
 
 register_schema_models(web_ns, ForgotPasswordSendPayload, ForgotPasswordCheckPayload, ForgotPasswordResetPayload)
 

--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -29,13 +29,11 @@ from libs.token import (
 )
 from services.account_service import AccountService
 from services.app_service import AppService
+from services.entities.auth_entities import LoginPayloadBase
 from services.webapp_auth_service import WebAppAuthService
 
 
-class LoginPayload(BaseModel):
-    email: EmailStr
-    password: str
-
+class LoginPayload(LoginPayloadBase):
     @field_validator("password")
     @classmethod
     def validate_password(cls, value: str) -> str:

--- a/api/services/entities/auth_entities.py
+++ b/api/services/entities/auth_entities.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel, Field, field_validator
+
+from libs.helper import EmailStr
+from libs.password import valid_password
+
+
+class LoginPayloadBase(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class ForgotPasswordSendPayload(BaseModel):
+    email: EmailStr
+    language: str | None = None
+
+
+class ForgotPasswordCheckPayload(BaseModel):
+    email: EmailStr
+    code: str
+    token: str = Field(min_length=1)
+
+
+class ForgotPasswordResetPayload(BaseModel):
+    token: str = Field(min_length=1)
+    new_password: str
+    password_confirm: str
+
+    @field_validator("new_password", "password_confirm")
+    @classmethod
+    def validate_password(cls, value: str) -> str:
+        return valid_password(value)


### PR DESCRIPTION
Part of #32385.

## Summary
- Extract `LoginPayloadBase` (email + password fields) into `services/entities/auth_entities.py` as a shared base class
- Extract `ForgotPasswordSendPayload`, `ForgotPasswordCheckPayload`, `ForgotPasswordResetPayload` into the same shared module
- Web `LoginPayload` inherits base and adds password format validator; console `LoginPayload` inherits base and adds `remember_me`/`invite_token` fields
- Remove identical class definitions from `controllers/web/login.py`, `controllers/console/auth/login.py`, `controllers/web/forgot_password.py`, `controllers/console/auth/forgot_password.py`

## Why this change
`ForgotPasswordSendPayload`, `ForgotPasswordCheckPayload`, and `ForgotPasswordResetPayload` were defined identically in both `web/forgot_password.py` and `console/auth/forgot_password.py`. `LoginPayload` shared the same `email`/`password` core across `web/login.py` and `console/auth/login.py` with minor field additions per controller.

Consolidating into `services/entities/` follows Dify's existing pattern (`services/entities/knowledge_entities/`, `services/entities/model_provider_entities.py`) and ensures a single source of truth for auth request schemas.


## Changes
- `services/entities/auth_entities.py`: New file — `LoginPayloadBase`, `ForgotPasswordSendPayload`, `ForgotPasswordCheckPayload`, `ForgotPasswordResetPayload`
- `controllers/web/forgot_password.py`: Remove 3 class definitions, import from shared module
- `controllers/console/auth/forgot_password.py`: Remove 3 class definitions, import from shared module
- `controllers/web/login.py`: `LoginPayload` extends `LoginPayloadBase`, adds password validator
- `controllers/console/auth/login.py`: `LoginPayload` extends `LoginPayloadBase`, adds `remember_me`/`invite_token`

## Test plan
- [x] `ruff check` passes

