### PR TITLE
refactor(api): deduplicate I18nObject in datasource entities

### DIFF
--- a/api/core/datasource/entities/common_entities.py
+++ b/api/core/datasource/entities/common_entities.py
@@ -1,37 +1,3 @@
-from typing import TypedDict
+from core.tools.entities.common_entities import I18nObject, I18nObjectDict
 
-from pydantic import BaseModel, Field, model_validator
-
-
-class I18nObjectDict(TypedDict):
-    zh_Hans: str | None
-    en_US: str
-    pt_BR: str | None
-    ja_JP: str | None
-
-
-class I18nObject(BaseModel):
-    """
-    Model class for i18n object.
-    """
-
-    en_US: str
-    zh_Hans: str | None = Field(default=None)
-    pt_BR: str | None = Field(default=None)
-    ja_JP: str | None = Field(default=None)
-
-    @model_validator(mode="after")
-    def _(self):
-        self.zh_Hans = self.zh_Hans or self.en_US
-        self.pt_BR = self.pt_BR or self.en_US
-        self.ja_JP = self.ja_JP or self.en_US
-        return self
-
-    def to_dict(self) -> I18nObjectDict:
-        result: I18nObjectDict = {
-            "zh_Hans": self.zh_Hans,
-            "en_US": self.en_US,
-            "pt_BR": self.pt_BR,
-            "ja_JP": self.ja_JP,
-        }
-        return result
+__all__ = ["I18nObject", "I18nObjectDict"]


### PR DESCRIPTION
## Summary
- Replace the duplicated `I18nObject` and `I18nObjectDict` classes in `core/datasource/entities/common_entities.py` with re-exports from the canonical definition in `core/tools/entities/common_entities.py`
- Zero behavioral change — all existing import paths continue to work

Part of #32385 (Pydantic model deduplication).

## Test plan
- [x] `from core.datasource.entities.common_entities import I18nObject, I18nObjectDict` resolves to the canonical classes
- [x] `ruff check` passes
- [x] Existing tests pass in CI