### PR TITLE
refactor(api): deduplicate Pydantic models across fields and controllers

### DIFF
--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import exists, func, select
 from werkzeug.exceptions import InternalServerError, NotFound
 
+from controllers.common.controller_schemas import MessageFeedbackPayload as _MessageFeedbackPayloadBase
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
 from controllers.console.app.error import (
@@ -59,10 +60,8 @@ class ChatMessagesQuery(BaseModel):
         return uuid_value(value)
 
 
-class MessageFeedbackPayload(BaseModel):
+class MessageFeedbackPayload(_MessageFeedbackPayloadBase):
     message_id: str = Field(..., description="Message ID")
-    rating: Literal["like", "dislike"] | None = Field(default=None, description="Feedback rating")
-    content: str | None = Field(default=None, description="Feedback content")
 
     @field_validator("message_id")
     @classmethod

--- a/api/fields/conversation_fields.py
+++ b/api/fields/conversation_fields.py
@@ -80,7 +80,7 @@ class Feedback(ResponseModel):
     from_account: SimpleAccount | None = None
 
 
-class Annotation(ResponseModel):
+class ConversationAnnotation(ResponseModel):
     id: str
     question: str | None = None
     content: str
@@ -95,7 +95,7 @@ class Annotation(ResponseModel):
         return value
 
 
-class AnnotationHitHistory(ResponseModel):
+class ConversationAnnotationHitHistory(ResponseModel):
     annotation_id: str
     annotation_create_account: SimpleAccount | None = None
     created_at: int | None = None
@@ -151,8 +151,8 @@ class MessageDetail(ResponseModel):
     from_account_id: str | None = None
     feedbacks: list[Feedback]
     workflow_run_id: str | None = None
-    annotation: Annotation | None = None
-    annotation_hit_history: AnnotationHitHistory | None = None
+    annotation: ConversationAnnotation | None = None
+    annotation_hit_history: ConversationAnnotationHitHistory | None = None
     created_at: int | None = None
     agent_thoughts: list[AgentThought]
     message_files: list[MessageFile]
@@ -223,7 +223,7 @@ class Conversation(ResponseModel):
     read_at: int | None = None
     created_at: int | None = None
     updated_at: int | None = None
-    annotation: Annotation | None = None
+    annotation: ConversationAnnotation | None = None
     model_config_: SimpleModelConfig | None = Field(default=None, alias="model_config")
     user_feedback_stats: FeedbackStat | None = None
     admin_feedback_stats: FeedbackStat | None = None

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -4,16 +4,13 @@ from datetime import datetime
 from uuid import uuid4
 
 from graphon.file import File
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
 from core.entities.execution_extra_content import ExecutionExtraContentDomainModel
+from fields.base import ResponseModel
 from fields.conversation_fields import AgentThought, JSONValue, MessageFile
 
 type JSONValueType = JSONValue
-
-
-class ResponseModel(BaseModel):
-    model_config = ConfigDict(from_attributes=True, extra="ignore")
 
 
 class SimpleFeedback(ResponseModel):


### PR DESCRIPTION
Part of https://github.com/langgenius/dify/issues/32385 (Pydantic model deduplication).

## Summary
- Remove duplicate `ResponseModel` definition in `fields/message_fields.py`, import from canonical `fields/base.py` instead
- Rename `Annotation`/`AnnotationHitHistory` in `fields/conversation_fields.py` to `ConversationAnnotation`/`ConversationAnnotationHitHistory` to eliminate name collision with differently-shaped models in `fields/annotation_fields.py`
- Make `MessageFeedbackPayload` in `controllers/console/app/message.py` inherit from the shared base in `controller_schemas.py` instead of redefining `rating` and `content` fields

## Why this change
`ResponseModel` was defined in both `fields/base.py` and `fields/message_fields.py` with different `ConfigDict` options (`message_fields` was missing `populate_by_name`, `serialize_by_alias`, `protected_namespaces`). Subclasses could silently inherit different behavior depending on which they imported.

`Annotation` and `AnnotationHitHistory` existed in both `annotation_fields.py` and `conversation_fields.py` with different field shapes (e.g. `answer` vs `content`, presence of `account`), creating risk of importing the wrong one at the same name.

`MessageFeedbackPayload` in `console/app/message.py` was the last remaining standalone copy after the other three controllers were consolidated into `controller_schemas.py` — it duplicated `rating` and `content` instead of inheriting.

## Changes
- `fields/message_fields.py`: Remove local `ResponseModel`, import from `fields.base`
- `fields/conversation_fields.py`: Rename `Annotation` → `ConversationAnnotation`, `AnnotationHitHistory` → `ConversationAnnotationHitHistory`; update all in-file type references
- `controllers/console/app/message.py`: Inherit `MessageFeedbackPayload` from `controller_schemas.MessageFeedbackPayload`, keeping only the `message_id` extension

## Test plan
- [x] `ruff check` passes
