### PR TITLE
feat: add DIFY_DB_USER/DIFY_DB_PASS env overrides for per-service DB credentials

### DIFF
--- a/api/configs/middleware/__init__.py
+++ b/api/configs/middleware/__init__.py
@@ -134,6 +134,26 @@ class DatabaseConfig(BaseSettings):
         default="",
     )
 
+    DIFY_DB_USER: str | None = Field(
+        description="Override for DB_USERNAME. Takes precedence when set.",
+        default=None,
+    )
+
+    DIFY_DB_PASS: str | None = Field(
+        description="Override for DB_PASSWORD. Takes precedence when set.",
+        default=None,
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_db_username(self) -> str:
+        return self.DIFY_DB_USER if self.DIFY_DB_USER is not None else self.DB_USERNAME
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_db_password(self) -> str:
+        return self.DIFY_DB_PASS if self.DIFY_DB_PASS is not None else self.DB_PASSWORD
+
     DB_DATABASE: str = Field(
         description="Name of the database to connect to.",
         default="dify",
@@ -163,7 +183,7 @@ class DatabaseConfig(BaseSettings):
         db_extras = f"?{db_extras}" if db_extras else ""
         return (
             f"{self.SQLALCHEMY_DATABASE_URI_SCHEME}://"
-            f"{quote_plus(self.DB_USERNAME)}:{quote_plus(self.DB_PASSWORD)}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_DATABASE}"
+            f"{quote_plus(self.effective_db_username)}:{quote_plus(self.effective_db_password)}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_DATABASE}"
             f"{db_extras}"
         )
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #34752
resolves ENG-164

Add `DIFY_DB_USER` and `DIFY_DB_PASS` as optional environment variable overrides for `DB_USERNAME` and `DB_PASSWORD`.

**Why:** Docker Compose cannot do per-service variable fallback inside a shared YAML anchor (`x-shared-env`). To support per-service DB credentials (e.g. least-privilege access), the fallback must happen in application code.

**What changed (`api/configs/middleware/__init__.py`):**
- Added two optional fields `DIFY_DB_USER` / `DIFY_DB_PASS` (default `None`).
- Added `effective_db_username` / `effective_db_password` computed properties that prefer the new vars when set, falling back to the originals.
- Updated `SQLALCHEMY_DATABASE_URI` to use the effective values.

No breaking change — unset vars fall back to existing `DB_USERNAME` / `DB_PASSWORD`.

## Screenshots

N/A (backend config only, no UI change)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods