### PR TITLE
refactor: migrate session.query to select API in delete conversation task

### DIFF
--- a/api/tasks/delete_conversation_task.py
+++ b/api/tasks/delete_conversation_task.py
@@ -3,6 +3,7 @@ import time
 
 import click
 from celery import shared_task
+from sqlalchemy import delete
 
 from core.db.session_factory import session_factory
 from models import ConversationVariable
@@ -29,28 +30,30 @@ def delete_conversation_related_data(conversation_id: str):
 
     with session_factory.create_session() as session:
         try:
-            session.query(MessageAnnotation).where(MessageAnnotation.conversation_id == conversation_id).delete(
-                synchronize_session=False
+            session.execute(
+                delete(MessageAnnotation).where(MessageAnnotation.conversation_id == conversation_id)
             )
 
-            session.query(MessageFeedback).where(MessageFeedback.conversation_id == conversation_id).delete(
-                synchronize_session=False
+            session.execute(
+                delete(MessageFeedback).where(MessageFeedback.conversation_id == conversation_id)
             )
 
-            session.query(ToolConversationVariables).where(
-                ToolConversationVariables.conversation_id == conversation_id
-            ).delete(synchronize_session=False)
-
-            session.query(ToolFile).where(ToolFile.conversation_id == conversation_id).delete(synchronize_session=False)
-
-            session.query(ConversationVariable).where(ConversationVariable.conversation_id == conversation_id).delete(
-                synchronize_session=False
+            session.execute(
+                delete(ToolConversationVariables).where(
+                    ToolConversationVariables.conversation_id == conversation_id
+                )
             )
 
-            session.query(Message).where(Message.conversation_id == conversation_id).delete(synchronize_session=False)
+            session.execute(delete(ToolFile).where(ToolFile.conversation_id == conversation_id))
 
-            session.query(PinnedConversation).where(PinnedConversation.conversation_id == conversation_id).delete(
-                synchronize_session=False
+            session.execute(
+                delete(ConversationVariable).where(ConversationVariable.conversation_id == conversation_id)
+            )
+
+            session.execute(delete(Message).where(Message.conversation_id == conversation_id))
+
+            session.execute(
+                delete(PinnedConversation).where(PinnedConversation.conversation_id == conversation_id)
             )
 
             session.commit()

--- a/api/tasks/delete_conversation_task.py
+++ b/api/tasks/delete_conversation_task.py
@@ -30,31 +30,21 @@ def delete_conversation_related_data(conversation_id: str):
 
     with session_factory.create_session() as session:
         try:
-            session.execute(
-                delete(MessageAnnotation).where(MessageAnnotation.conversation_id == conversation_id)
-            )
+            session.execute(delete(MessageAnnotation).where(MessageAnnotation.conversation_id == conversation_id))
+
+            session.execute(delete(MessageFeedback).where(MessageFeedback.conversation_id == conversation_id))
 
             session.execute(
-                delete(MessageFeedback).where(MessageFeedback.conversation_id == conversation_id)
-            )
-
-            session.execute(
-                delete(ToolConversationVariables).where(
-                    ToolConversationVariables.conversation_id == conversation_id
-                )
+                delete(ToolConversationVariables).where(ToolConversationVariables.conversation_id == conversation_id)
             )
 
             session.execute(delete(ToolFile).where(ToolFile.conversation_id == conversation_id))
 
-            session.execute(
-                delete(ConversationVariable).where(ConversationVariable.conversation_id == conversation_id)
-            )
+            session.execute(delete(ConversationVariable).where(ConversationVariable.conversation_id == conversation_id))
 
             session.execute(delete(Message).where(Message.conversation_id == conversation_id))
 
-            session.execute(
-                delete(PinnedConversation).where(PinnedConversation.conversation_id == conversation_id)
-            )
+            session.execute(delete(PinnedConversation).where(PinnedConversation.conversation_id == conversation_id))
 
             session.commit()
 


### PR DESCRIPTION
## Summary
- Migrate `session.query()` to SQLAlchemy 2.0 `select()` API in `tasks/delete_conversation_task.py`
- 7× `.query(Model).where(...).delete(synchronize_session=False)` → `session.execute(delete(Model).where(...))`
- Models migrated: MessageAnnotation, MessageFeedback, ToolConversationVariables, ToolFile, ConversationVariable, Message, PinnedConversation

## Test plan
- [x] All 158 task unit tests pass
- [x] basedpyright: 0 errors, 0 warnings
- [x] mypy: 0 errors

Part of #22668