### PR TITLE
refactor(web): add Zustand context store utilities and migrate stores

### DIFF
--- a/web/app/components/base/features/__tests__/hooks.spec.ts
+++ b/web/app/components/base/features/__tests__/hooks.spec.ts
@@ -25,7 +25,7 @@ describe('useFeatures', () => {
     // Act & Assert
     expect(() => {
       renderHook(() => useFeatures(s => s.features))
-    }).toThrow('Missing FeaturesContext.Provider in the tree')
+    }).toThrow('Missing Features provider in the tree')
   })
 
   it('should return undefined when feature does not exist', () => {
@@ -55,9 +55,9 @@ describe('useFeaturesStore', () => {
     expect(result.current).toBe(store)
   })
 
-  it('should return null when used outside provider', () => {
-    const { result } = renderHook(() => useFeaturesStore())
-
-    expect(result.current).toBeNull()
+  it('should throw error when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useFeaturesStore())
+    }).toThrow('Missing Features provider in the tree')
   })
 })

--- a/web/app/components/base/features/context.tsx
+++ b/web/app/components/base/features/context.tsx
@@ -1,26 +1,20 @@
 import type {
   FeaturesState,
-  FeaturesStore,
+  FeatureStoreState,
 } from './store'
-import {
-  createContext,
-  useRef,
-} from 'react'
+import { createStoreContext, useStoreRef } from '@/stores/create-context-store'
 import { createFeaturesStore } from './store'
 
-export const FeaturesContext = createContext<FeaturesStore | null>(null)
+export const FeaturesContext = createStoreContext<FeatureStoreState>('Features')
 
 type FeaturesProviderProps = {
   children: React.ReactNode
 } & Partial<FeaturesState>
-export const FeaturesProvider = ({ children, ...props }: FeaturesProviderProps) => {
-  const storeRef = useRef<FeaturesStore | undefined>(undefined)
-
-  if (!storeRef.current)
-    storeRef.current = createFeaturesStore(props)
+export function FeaturesProvider({ children, ...props }: FeaturesProviderProps) {
+  const store = useStoreRef(() => createFeaturesStore(props))
 
   return (
-    <FeaturesContext.Provider value={storeRef.current}>
+    <FeaturesContext.Provider value={store}>
       {children}
     </FeaturesContext.Provider>
   )

--- a/web/app/components/base/features/hooks.ts
+++ b/web/app/components/base/features/hooks.ts
@@ -1,16 +1,12 @@
+import type { StoreApi } from 'zustand'
 import type { FeatureStoreState } from './store'
-import { useContext } from 'react'
-import { useStore } from 'zustand'
+import { useContextStore, useContextStoreApi } from '@/stores/create-context-store'
 import { FeaturesContext } from './context'
 
 export function useFeatures<T>(selector: (state: FeatureStoreState) => T): T {
-  const store = useContext(FeaturesContext)
-  if (!store)
-    throw new Error('Missing FeaturesContext.Provider in the tree')
-
-  return useStore(store, selector)
+  return useContextStore(FeaturesContext, selector)
 }
 
-export function useFeaturesStore() {
-  return useContext(FeaturesContext)
+export function useFeaturesStore(): StoreApi<FeatureStoreState> {
+  return useContextStoreApi(FeaturesContext)
 }

--- a/web/app/components/base/features/store.ts
+++ b/web/app/components/base/features/store.ts
@@ -17,8 +17,6 @@ export type FeaturesAction = {
 
 export type FeatureStoreState = FeaturesState & FeaturesAction & FeaturesModal
 
-export type FeaturesStore = ReturnType<typeof createFeaturesStore>
-
 export const createFeaturesStore = (initProps?: Partial<FeaturesState>) => {
   const DEFAULT_PROPS: FeaturesState = {
     features: {

--- a/web/app/components/base/file-uploader/__tests__/store.spec.tsx
+++ b/web/app/components/base/file-uploader/__tests__/store.spec.tsx
@@ -83,7 +83,7 @@ describe('useStore', () => {
 
     expect(() => {
       renderHook(() => useStore(s => s.files))
-    }).toThrow('Missing FileContext.Provider in the tree')
+    }).toThrow('Missing File provider in the tree')
 
     consoleError.mockRestore()
   })
@@ -102,9 +102,10 @@ describe('useFileStore', () => {
     expect(result.current).toBe(store)
   })
 
-  it('should return null when no provider exists', () => {
-    const { result } = renderHook(() => useFileStore())
-    expect(result.current).toBeNull()
+  it('should throw error when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useFileStore())
+    }).toThrow('Missing File provider in the tree')
   })
 })
 

--- a/web/app/components/base/file-uploader/store.tsx
+++ b/web/app/components/base/file-uploader/store.tsx
@@ -1,26 +1,21 @@
 import type {
   FileEntity,
 } from './types'
-import {
-  createContext,
-  useContext,
-  useRef,
-} from 'react'
-import {
-  create,
-  useStore as useZustandStore,
-} from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import { createStoreContext, useContextStore, useContextStoreApi, useStoreRef } from '@/stores/create-context-store'
 
 type Shape = {
   files: FileEntity[]
   setFiles: (files: FileEntity[]) => void
 }
 
+export const FileContext = createStoreContext<Shape>('File')
+
 export const createFileStore = (
   value: FileEntity[] = [],
   onChange?: (files: FileEntity[]) => void,
 ) => {
-  return create<Shape>(set => ({
+  return createStore<Shape>(set => ({
     files: value ? [...value] : [],
     setFiles: (files) => {
       set({ files })
@@ -29,19 +24,12 @@ export const createFileStore = (
   }))
 }
 
-type FileStore = ReturnType<typeof createFileStore>
-export const FileContext = createContext<FileStore | null>(null)
-
 export function useStore<T>(selector: (state: Shape) => T): T {
-  const store = useContext(FileContext)
-  if (!store)
-    throw new Error('Missing FileContext.Provider in the tree')
-
-  return useZustandStore(store, selector)
+  return useContextStore(FileContext, selector)
 }
 
-export const useFileStore = () => {
-  return useContext(FileContext)!
+export function useFileStore() {
+  return useContextStoreApi(FileContext)
 }
 
 type FileProviderProps = {
@@ -49,18 +37,15 @@ type FileProviderProps = {
   value?: FileEntity[]
   onChange?: (files: FileEntity[]) => void
 }
-export const FileContextProvider = ({
+export function FileContextProvider({
   children,
-  value,
+  value = [],
   onChange,
-}: FileProviderProps) => {
-  const storeRef = useRef<FileStore | undefined>(undefined)
-
-  if (!storeRef.current)
-    storeRef.current = createFileStore(value, onChange)
+}: FileProviderProps) {
+  const store = useStoreRef(() => createFileStore(value, onChange))
 
   return (
-    <FileContext.Provider value={storeRef.current}>
+    <FileContext.Provider value={store}>
       {children}
     </FileContext.Provider>
   )

--- a/web/app/components/datasets/common/image-uploader/store.tsx
+++ b/web/app/components/datasets/common/image-uploader/store.tsx
@@ -1,26 +1,21 @@
 import type {
   FileEntity,
 } from './types'
-import {
-  createContext,
-  useContext,
-  useRef,
-} from 'react'
-import {
-  create,
-  useStore,
-} from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import { createStoreContext, useContextStore, useContextStoreApi, useStoreRef } from '@/stores/create-context-store'
 
 type Shape = {
   files: FileEntity[]
   setFiles: (files: FileEntity[]) => void
 }
 
+const FileContext = createStoreContext<Shape>('File')
+
 export const createFileStore = (
   value: FileEntity[] = [],
   onChange?: (files: FileEntity[]) => void,
 ) => {
-  return create<Shape>(set => ({
+  return createStore<Shape>(set => ({
     files: value ? [...value] : [],
     setFiles: (files) => {
       set({ files })
@@ -29,19 +24,12 @@ export const createFileStore = (
   }))
 }
 
-type FileStore = ReturnType<typeof createFileStore>
-const FileContext = createContext<FileStore | null>(null)
-
 export function useFileStoreWithSelector<T>(selector: (state: Shape) => T): T {
-  const store = useContext(FileContext)
-  if (!store)
-    throw new Error('Missing FileContext.Provider in the tree')
-
-  return useStore(store, selector)
+  return useContextStore(FileContext, selector)
 }
 
-export const useFileStore = () => {
-  return useContext(FileContext)!
+export function useFileStore() {
+  return useContextStoreApi(FileContext)
 }
 
 type FileProviderProps = {
@@ -49,18 +37,15 @@ type FileProviderProps = {
   value?: FileEntity[]
   onChange?: (files: FileEntity[]) => void
 }
-export const FileContextProvider = ({
+export function FileContextProvider({
   children,
-  value,
+  value = [],
   onChange,
-}: FileProviderProps) => {
-  const storeRef = useRef<FileStore | undefined>(undefined)
-
-  if (!storeRef.current)
-    storeRef.current = createFileStore(value, onChange)
+}: FileProviderProps) {
+  const store = useStoreRef(() => createFileStore(value, onChange))
 
   return (
-    <FileContext.Provider value={storeRef.current}>
+    <FileContext.Provider value={store}>
       {children}
     </FileContext.Provider>
   )

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/index.spec.ts
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/index.spec.ts
@@ -54,7 +54,7 @@ describe('useDataSourceStoreWithSelector', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useDataSourceStoreWithSelector(s => s.currentCredentialId))
-    }).toThrow('Missing DataSourceContext.Provider in the tree')
+    }).toThrow('Missing DataSource provider in the tree')
   })
 
   it('should return selected state when used inside provider', () => {
@@ -72,7 +72,7 @@ describe('useDataSourceStore', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useDataSourceStore())
-    }).toThrow('Missing DataSourceContext.Provider in the tree')
+    }).toThrow('Missing DataSource provider in the tree')
   })
 
   it('should return store when used inside provider', () => {

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/store/__tests__/provider.spec.tsx
@@ -1,13 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { use } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import DataSourceProvider, { DataSourceContext } from '../provider'
-
-const mockStore = { getState: vi.fn(), setState: vi.fn(), subscribe: vi.fn() }
-
-vi.mock('../', () => ({
-  createDataSourceStore: () => mockStore,
-}))
 
 // Test consumer component that reads from context
 function ContextConsumer() {
@@ -20,10 +14,6 @@ function ContextConsumer() {
 }
 
 describe('DataSourceProvider', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   // Rendering: verifies children are passed through
   describe('Rendering', () => {
     it('should render children', () => {
@@ -62,11 +52,11 @@ describe('DataSourceProvider', () => {
   // Stability: verifies the store reference is stable across re-renders
   describe('Store Stability', () => {
     it('should reuse same store on re-render (stable reference)', () => {
-      const storeValues: Array<typeof mockStore | null> = []
+      const storeValues: unknown[] = []
 
       function StoreCapture() {
         const store = use(DataSourceContext)
-        storeValues.push(store as typeof mockStore | null)
+        storeValues.push(store)
         return null
       }
 

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/store/index.ts
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/store/index.ts
@@ -3,8 +3,8 @@ import type { LocalFileSliceShape } from './slices/local-file'
 import type { OnlineDocumentSliceShape } from './slices/online-document'
 import type { OnlineDriveSliceShape } from './slices/online-drive'
 import type { WebsiteCrawlSliceShape } from './slices/website-crawl'
-import { use } from 'react'
-import { createStore, useStore } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import { useContextStore, useContextStoreApi } from '@/stores/create-context-store'
 import { DataSourceContext } from './provider'
 import { createCommonSlice } from './slices/common'
 import { createLocalFileSlice } from './slices/local-file'
@@ -28,18 +28,10 @@ export const createDataSourceStore = () => {
   }))
 }
 
-export const useDataSourceStoreWithSelector = <T>(selector: (state: DataSourceShape) => T): T => {
-  const store = use(DataSourceContext)
-  if (!store)
-    throw new Error('Missing DataSourceContext.Provider in the tree')
-
-  return useStore(store, selector)
+export function useDataSourceStoreWithSelector<T>(selector: (state: DataSourceShape) => T): T {
+  return useContextStore(DataSourceContext, selector)
 }
 
-export const useDataSourceStore = () => {
-  const store = use(DataSourceContext)
-  if (!store)
-    throw new Error('Missing DataSourceContext.Provider in the tree')
-
-  return store
+export function useDataSourceStore() {
+  return useContextStoreApi(DataSourceContext)
 }

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/store/provider.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/store/provider.tsx
@@ -1,11 +1,8 @@
-import { createContext, useRef } from 'react'
+import type { DataSourceShape } from './'
+import { createStoreContext, useStoreRef } from '@/stores/create-context-store'
 import { createDataSourceStore } from './'
 
-type DataSourceStoreApi = ReturnType<typeof createDataSourceStore>
-
-type DataSourceContextType = DataSourceStoreApi | null
-
-export const DataSourceContext = createContext<DataSourceContextType>(null)
+export const DataSourceContext = createStoreContext<DataSourceShape>('DataSource')
 
 type DataSourceProviderProps = {
   children: React.ReactNode
@@ -14,13 +11,10 @@ type DataSourceProviderProps = {
 const DataSourceProvider = ({
   children,
 }: DataSourceProviderProps) => {
-  const storeRef = useRef<DataSourceStoreApi>(null)
-
-  if (!storeRef.current)
-    storeRef.current = createDataSourceStore()
+  const store = useStoreRef(() => createDataSourceStore())
 
   return (
-    <DataSourceContext.Provider value={storeRef.current!}>
+    <DataSourceContext.Provider value={store}>
       {children}
     </DataSourceContext.Provider>
   )

--- a/web/stores/__tests__/create-context-store.spec.tsx
+++ b/web/stores/__tests__/create-context-store.spec.tsx
@@ -1,0 +1,144 @@
+import type { StoreApi } from 'zustand'
+import { act, render, renderHook, screen } from '@testing-library/react'
+import { use } from 'react'
+import { describe, expect, it } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { createStoreContext, useContextStore, useContextStoreApi, useStoreRef } from '../create-context-store'
+
+type TestShape = {
+  count: number
+  increment: () => void
+}
+
+const createTestStore = (initial = 0) =>
+  createStore<TestShape>(set => ({
+    count: initial,
+    increment: () => set(s => ({ count: s.count + 1 })),
+  }))
+
+describe('createStoreContext', () => {
+  it('should create a context with null default value', () => {
+    const context = createStoreContext<TestShape>('Test')
+
+    function Consumer() {
+      const value = use(context)
+      return <div data-testid="value">{value === null ? 'null' : 'has-store'}</div>
+    }
+
+    render(<Consumer />)
+    expect(screen.getByTestId('value')).toHaveTextContent('null')
+  })
+
+  it('should set displayName on the context', () => {
+    const context = createStoreContext<TestShape>('MyStore')
+    expect(context.displayName).toBe('MyStore')
+  })
+})
+
+describe('useStoreRef', () => {
+  it('should create the store once and return the same reference on re-renders', () => {
+    const stores: StoreApi<TestShape>[] = []
+    const context = createStoreContext<TestShape>('Test')
+
+    function TestProvider({ children }: { children: React.ReactNode }) {
+      const store = useStoreRef(() => createTestStore())
+      stores.push(store)
+      return <context.Provider value={store}>{children}</context.Provider>
+    }
+
+    const { rerender } = render(
+      <TestProvider>
+        <div>child</div>
+      </TestProvider>,
+    )
+
+    rerender(
+      <TestProvider>
+        <div>child</div>
+      </TestProvider>,
+    )
+
+    expect(stores).toHaveLength(2)
+    expect(stores[0]).toBe(stores[1])
+  })
+})
+
+describe('useContextStore', () => {
+  it('should return selected state from context store', () => {
+    const context = createStoreContext<TestShape>('Test')
+    const store = createTestStore(42)
+
+    const { result } = renderHook(() => useContextStore(context, s => s.count), {
+      wrapper: ({ children }) => (
+        <context.Provider value={store}>{children}</context.Provider>
+      ),
+    })
+
+    expect(result.current).toBe(42)
+  })
+
+  it('should throw with displayName in error message when used outside provider', () => {
+    const context = createStoreContext<TestShape>('MyFeature')
+
+    expect(() => {
+      renderHook(() => useContextStore(context, s => s.count))
+    }).toThrow('Missing MyFeature provider in the tree')
+  })
+
+  it('should throw with default name when displayName is not set', () => {
+    const context = createStoreContext<TestShape>('')
+    context.displayName = ''
+
+    expect(() => {
+      renderHook(() => useContextStore(context, s => s.count))
+    }).toThrow('Missing Store provider in the tree')
+  })
+
+  it('should re-render when selected state changes', () => {
+    const context = createStoreContext<TestShape>('Test')
+    const store = createTestStore(0)
+
+    function Counter() {
+      const count = useContextStore(context, s => s.count)
+      return <div data-testid="count">{count}</div>
+    }
+
+    render(
+      <context.Provider value={store}>
+        <Counter />
+      </context.Provider>,
+    )
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0')
+
+    act(() => {
+      store.getState().increment()
+    })
+
+    expect(screen.getByTestId('count')).toHaveTextContent('1')
+  })
+})
+
+describe('useContextStoreApi', () => {
+  it('should return the store API from context', () => {
+    const context = createStoreContext<TestShape>('Test')
+    const store = createTestStore(7)
+
+    const { result } = renderHook(() => useContextStoreApi(context), {
+      wrapper: ({ children }) => (
+        <context.Provider value={store}>{children}</context.Provider>
+      ),
+    })
+
+    expect(result.current).toBe(store)
+    expect(result.current.getState().count).toBe(7)
+  })
+
+  it('should throw when used outside provider', () => {
+    const context = createStoreContext<TestShape>('Test')
+
+    expect(() => {
+      renderHook(() => useContextStoreApi(context))
+    }).toThrow('Missing Test provider in the tree')
+  })
+})

--- a/web/stores/create-context-store.tsx
+++ b/web/stores/create-context-store.tsx
@@ -1,0 +1,80 @@
+import type { StoreApi } from 'zustand'
+import { createContext, useContext, useRef } from 'react'
+import { useStore } from 'zustand'
+
+/**
+ * Creates a typed React context for a Zustand store with null default.
+ * Sets displayName for better DevTools labels and error messages.
+ */
+export function createStoreContext<TState>(name: string) {
+  const context = createContext<StoreApi<TState> | null>(null)
+  context.displayName = name
+  return context
+}
+
+/**
+ * Hook to lazily initialize a store once via useRef.
+ * Use inside a Provider component to create the store on first render.
+ *
+ * @example
+ * ```tsx
+ * function MyProvider({ children }: PropsWithChildren) {
+ *   const store = useStoreRef(() => createStore<Shape>(set => ({ ... })))
+ *   return <MyContext.Provider value={store}>{children}</MyContext.Provider>
+ * }
+ * ```
+ */
+export function useStoreRef<T>(factory: () => StoreApi<T>): StoreApi<T> {
+  const storeRef = useRef<StoreApi<T>>(null)
+  if (!storeRef.current)
+    storeRef.current = factory()
+
+  return storeRef.current
+}
+
+/**
+ * Hook to select state from a Zustand store provided via React context.
+ * Throws if the provider is missing.
+ *
+ * @example
+ * ```tsx
+ * export function useMyFeature<T>(selector: (state: Shape) => T): T {
+ *   return useContextStore(MyContext, selector)
+ * }
+ * ```
+ */
+export function useContextStore<TState, T>(
+  context: React.Context<StoreApi<TState> | null>,
+  selector: (state: TState) => T,
+): T {
+  const store = useContext(context)
+  if (!store) {
+    const name = context.displayName || 'Store'
+    throw new Error(`Missing ${name} provider in the tree`)
+  }
+
+  return useStore(store, selector)
+}
+
+/**
+ * Hook to access the raw Zustand store API from React context.
+ * Throws if the provider is missing.
+ *
+ * @example
+ * ```tsx
+ * export function useMyStore() {
+ *   return useContextStoreApi(MyContext)
+ * }
+ * ```
+ */
+export function useContextStoreApi<TState>(
+  context: React.Context<StoreApi<TState> | null>,
+): StoreApi<TState> {
+  const store = useContext(context)
+  if (!store) {
+    const name = context.displayName || 'Store'
+    throw new Error(`Missing ${name} provider in the tree`)
+  }
+
+  return store
+}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Closes #31172

Add composable helpers that eliminate repeated Context + Provider + Hook boilerplate for Zustand stores, and migrate four stores to use them.

### New utility: `web/stores/create-context-store.tsx`

Four lint-compliant helpers defined at module level:

- **`createStoreContext<T>(name)`** — typed `Context<StoreApi<T> | null>` with displayName
- **`useStoreRef(factory)`** — lazy store init via `useRef` for Providers
- **`useContextStore(context, selector)`** — selector hook with clear error on missing provider
- **`useContextStoreApi(context)`** — store API hook with clear error on missing provider

### Migrated stores

| Store | What changed |
|-------|-------------|
| `file-uploader/store.tsx` | Uses helpers, removed manual Context/Provider/Hook boilerplate |
| `image-uploader/store.tsx` | Same |
| `features/context.tsx` + `hooks.ts` | Provider uses `useStoreRef`, hooks use `useContextStore` |
| `data-source/store/` | Provider uses `useStoreRef`, hooks use `useContextStore` |

### Behavioral improvement

`useFeaturesStore()` and `useFileStore()` now **throw** with a clear error when used outside their provider, instead of silently returning `null` (which would crash on `.getState()` anyway).

## Changes

- `web/stores/create-context-store.tsx` — new utility (80 lines)
- `web/stores/__tests__/create-context-store.spec.tsx` — 9 tests for the utility
- `web/app/components/base/file-uploader/store.tsx` — migrated
- `web/app/components/datasets/common/image-uploader/store.tsx` — migrated
- `web/app/components/base/features/context.tsx` — migrated
- `web/app/components/base/features/hooks.ts` — migrated
- `web/app/components/base/features/store.ts` — removed unused `FeaturesStore` type
- `web/app/components/datasets/.../data-source/store/index.ts` — migrated
- `web/app/components/datasets/.../data-source/store/provider.tsx` — migrated
- Updated test files for new error messages and throw-on-missing behavior

Net: **-63 lines** in existing files, +224 lines in new utility + tests.

## Test plan

- [x] `pnpm lint:fix --quiet` passes (with `--pass-on-unpruned-suppressions`)
- [x] `pnpm type-check:tsgo` passes
- [x] `pnpm knip` passes
- [x] 1007 affected tests pass across 74 test files
- [x] New utility has 9 dedicated tests

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.