### PR TITLE
refactor(api): extract Conversation/Message TypedDict definitions into model_dict_types module

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -242,98 +242,14 @@ class AppModelConfigDict(TypedDict):
     provider: NotRequired[str | None]
 
 
-class ConversationDict(TypedDict):
-    id: str
-    app_id: str
-    app_model_config_id: str | None
-    model_provider: str | None
-    override_model_configs: str | None
-    model_id: str | None
-    mode: str
-    name: str
-    summary: str | None
-    inputs: dict[str, Any]
-    introduction: str | None
-    system_instruction: str | None
-    system_instruction_tokens: int
-    status: str
-    invoke_from: str | None
-    from_source: str
-    from_end_user_id: str | None
-    from_account_id: str | None
-    read_at: datetime | None
-    read_account_id: str | None
-    dialogue_count: int
-    created_at: datetime
-    updated_at: datetime
-
-
-class MessageDict(TypedDict):
-    id: str
-    app_id: str
-    conversation_id: str
-    model_id: str | None
-    inputs: dict[str, Any]
-    query: str
-    total_price: Decimal | None
-    message: dict[str, Any]
-    answer: str
-    status: str
-    error: str | None
-    message_metadata: dict[str, Any]
-    from_source: str
-    from_end_user_id: str | None
-    from_account_id: str | None
-    created_at: str
-    updated_at: str
-    agent_based: bool
-    workflow_run_id: str | None
-
-
-class MessageFeedbackDict(TypedDict):
-    id: str
-    app_id: str
-    conversation_id: str
-    message_id: str
-    rating: str
-    content: str | None
-    from_source: str
-    from_end_user_id: str | None
-    from_account_id: str | None
-    created_at: str
-    updated_at: str
-
-
-class MessageFileInfo(TypedDict, total=False):
-    belongs_to: str | None
-    upload_file_id: str | None
-    id: str
-    tenant_id: str
-    type: str
-    transfer_method: str
-    remote_url: str | None
-    related_id: str | None
-    filename: str | None
-    extension: str | None
-    mime_type: str | None
-    size: int
-    dify_model_identity: str
-    url: str | None
-
-
-class ExtraContentDict(TypedDict, total=False):
-    type: str
-    workflow_run_id: str
-
-
-class TraceAppConfigDict(TypedDict):
-    id: str
-    app_id: str
-    tracing_provider: str | None
-    tracing_config: dict[str, Any]
-    is_active: bool
-    created_at: str | None
-    updated_at: str | None
+from .model_dict_types import (
+    ConversationDict,
+    ExtraContentDict,
+    MessageDict,
+    MessageFeedbackDict,
+    MessageFileInfo,
+    TraceAppConfigDict,
+)
 
 
 class DifySetup(TypeBase):

--- a/api/models/model_dict_types.py
+++ b/api/models/model_dict_types.py
@@ -1,0 +1,99 @@
+"""TypedDict definitions for Conversation, Message, and related model dict return types."""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, TypedDict
+
+
+class ConversationDict(TypedDict):
+    id: str
+    app_id: str
+    app_model_config_id: str | None
+    model_provider: str | None
+    override_model_configs: str | None
+    model_id: str | None
+    mode: str
+    name: str
+    summary: str | None
+    inputs: dict[str, Any]
+    introduction: str | None
+    system_instruction: str | None
+    system_instruction_tokens: int
+    status: str
+    invoke_from: str | None
+    from_source: str
+    from_end_user_id: str | None
+    from_account_id: str | None
+    read_at: datetime | None
+    read_account_id: str | None
+    dialogue_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class MessageDict(TypedDict):
+    id: str
+    app_id: str
+    conversation_id: str
+    model_id: str | None
+    inputs: dict[str, Any]
+    query: str
+    total_price: Decimal | None
+    message: dict[str, Any]
+    answer: str
+    status: str
+    error: str | None
+    message_metadata: dict[str, Any]
+    from_source: str
+    from_end_user_id: str | None
+    from_account_id: str | None
+    created_at: str
+    updated_at: str
+    agent_based: bool
+    workflow_run_id: str | None
+
+
+class MessageFeedbackDict(TypedDict):
+    id: str
+    app_id: str
+    conversation_id: str
+    message_id: str
+    rating: str
+    content: str | None
+    from_source: str
+    from_end_user_id: str | None
+    from_account_id: str | None
+    created_at: str
+    updated_at: str
+
+
+class MessageFileInfo(TypedDict, total=False):
+    belongs_to: str | None
+    upload_file_id: str | None
+    id: str
+    tenant_id: str
+    type: str
+    transfer_method: str
+    remote_url: str | None
+    related_id: str | None
+    filename: str | None
+    extension: str | None
+    mime_type: str | None
+    size: int
+    dify_model_identity: str
+    url: str | None
+
+
+class ExtraContentDict(TypedDict, total=False):
+    type: str
+    workflow_run_id: str
+
+
+class TraceAppConfigDict(TypedDict):
+    id: str
+    app_id: str
+    tracing_provider: str | None
+    tracing_config: dict[str, Any]
+    is_active: bool
+    created_at: str | None
+    updated_at: str | None


### PR DESCRIPTION
## Summary
- Extract 6 TypedDict definitions (`ConversationDict`, `MessageDict`, `MessageFeedbackDict`, `MessageFileInfo`, `ExtraContentDict`, `TraceAppConfigDict`) from `api/models/model.py` into `api/models/model_dict_types.py`
- Re-export all types from `model.py` to maintain backward compatibility

Part of #31096

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
