### PR TITLE
fix(web): resolve Dify compact array types in tool output schema

### DIFF
--- a/web/app/components/workflow/nodes/tool/__tests__/output-schema-utils.spec.ts
+++ b/web/app/components/workflow/nodes/tool/__tests__/output-schema-utils.spec.ts
@@ -229,6 +229,23 @@ describe('output-schema-utils', () => {
       })
     })
 
+    describe('Dify compact types (workflow-as-tool output_schema)', () => {
+      it('should resolve array[string] to arrayString (issue #34428)', () => {
+        const result = resolveVarType({ type: 'array[string]' })
+        expect(result.type).toBe(VarType.arrayString)
+      })
+
+      it('should resolve Array[string] case-insensitively', () => {
+        const result = resolveVarType({ type: 'Array[string]' })
+        expect(result.type).toBe(VarType.arrayString)
+      })
+
+      it('should resolve array[object] to arrayObject', () => {
+        const result = resolveVarType({ type: 'array[object]' })
+        expect(result.type).toBe(VarType.arrayObject)
+      })
+    })
+
     describe('unknown types', () => {
       it('should resolve unknown type to any', () => {
         const result = resolveVarType({ type: 'unknown_type' })

--- a/web/app/components/workflow/nodes/tool/output-schema-utils.ts
+++ b/web/app/components/workflow/nodes/tool/output-schema-utils.ts
@@ -3,6 +3,30 @@ import { VarType } from '@/app/components/workflow/types'
 import { getMatchedSchemaType } from '../_base/components/variable/use-match-schema-type'
 
 /**
+ * Workflow-as-tool and some internal APIs store Dify VarType strings (e.g. `array[string]`)
+ * in JSON Schema `type` instead of standard `{ type: 'array', items: { type: 'string' } }`.
+ * Map those compact strings to VarType so downstream (e.g. Code node var picker) does not
+ * fall back to `any` and get filtered out.
+ */
+const resolveDifyCompactTypeString = (typeStr: string): VarType | undefined => {
+  const trimmed = typeStr.trim()
+  const m = /^array\[(string|number|integer|boolean|object|file|any)\]$/i.exec(trimmed)
+  if (!m)
+    return undefined
+  const inner = m[1].toLowerCase()
+  const map: Record<string, VarType> = {
+    string: VarType.arrayString,
+    number: VarType.arrayNumber,
+    integer: VarType.arrayNumber,
+    boolean: VarType.arrayBoolean,
+    object: VarType.arrayObject,
+    file: VarType.arrayFile,
+    any: VarType.arrayAny,
+  }
+  return map[inner]
+}
+
+/**
  * Normalizes a JSON Schema type to a simple string type.
  * Handles complex schemas with oneOf, anyOf, allOf.
  */
@@ -54,6 +78,12 @@ export const resolveVarType = (
   schemaTypeDefinitions?: SchemaTypeDefinition[],
 ): { type: VarType, schemaType?: string } => {
   const schemaType = getMatchedSchemaType(schema, schemaTypeDefinitions)
+  if (schema && typeof schema.type === 'string') {
+    const compact = resolveDifyCompactTypeString(schema.type)
+    if (compact !== undefined)
+      return { type: compact, schemaType }
+  }
+
   const normalizedType = normalizeJsonSchemaType(schema)
 
   switch (normalizedType) {


### PR DESCRIPTION
## Summary
  Fixes workflow-as-tool outputs whose JSON Schema encodes Dify compact types (e.g. `array[string]`) 
  in the `type` field instead of standard JSON Schema (`type: "array"` + `items`). `resolveVarType` 
  did not recognize those strings, fell back to `VarType.any`, and the Code node’s variable picker 
  filters out `any`, so array/object-like fields (e.g. `body`) were hidden while scalar fields (e.g. 
  `message`) still appeared.
  This change maps compact `array[...]` type strings to the correct `VarType` values before the 
  existing normalization/switch logic.
  **Fixes #34428**
  ## Test plan
  - [X] Unit tests added/updated in 
  `web/app/components/workflow/nodes/tool/__tests__/output-schema-utils.spec.ts` for `array[string]`, 
  `Array[string]`, and `array[object]`.
  - [X] (Optional) Manual: Chatflow with a workflow tool whose outputs include an array field + a 
  string field → Code node input variable selector lists both.
  ## Screenshots
  N/A (behavioral fix in variable picker / type resolution; no UI copy or layout change).
  ---
  Related issue: **Tool node output variables with JSON object format not showing in Code node input 
  selector** — https://github.com/langgenius/dify/issues/34428