### PR TITLE
refactor: migrate SegmentAttachmentBinding to TypeBase

### DIFF
--- a/api/core/rag/docstore/dataset_docstore.py
+++ b/api/core/rag/docstore/dataset_docstore.py
@@ -244,7 +244,7 @@ class DatasetDocumentStore:
         return document_segment
 
     def add_multimodel_documents_binding(self, segment_id: str, multimodel_documents: list[AttachmentDocument] | None):
-        if multimodel_documents:
+        if multimodel_documents and self._document_id is not None:
             for multimodel_document in multimodel_documents:
                 binding = SegmentAttachmentBinding(
                     tenant_id=self._dataset.tenant_id,

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -1655,11 +1655,7 @@ class SegmentAttachmentBinding(TypeBase):
     segment_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     attachment_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        sa.DateTime,
-        nullable=False,
-        insert_default=func.current_timestamp(),
-        server_default=func.current_timestamp(),
-        init=False,
+        sa.DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )
 
 

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -1633,7 +1633,7 @@ class PipelineRecommendedPlugin(TypeBase):
     )
 
 
-class SegmentAttachmentBinding(Base):
+class SegmentAttachmentBinding(TypeBase):
     __tablename__ = "segment_attachment_bindings"
     __table_args__ = (
         sa.PrimaryKeyConstraint("id", name="segment_attachment_binding_pkey"),
@@ -1646,13 +1646,21 @@ class SegmentAttachmentBinding(Base):
         ),
         sa.Index("segment_attachment_binding_attachment_idx", "attachment_id"),
     )
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuidv7()))
+    id: Mapped[str] = mapped_column(
+        StringUUID, insert_default=lambda: str(uuidv7()), default_factory=lambda: str(uuidv7()), init=False
+    )
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     dataset_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     document_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     segment_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     attachment_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime,
+        nullable=False,
+        insert_default=func.current_timestamp(),
+        server_default=func.current_timestamp(),
+        init=False,
+    )
 
 
 class DocumentSegmentSummary(Base):

--- a/api/tests/unit_tests/core/rag/docstore/test_dataset_docstore.py
+++ b/api/tests/unit_tests/core/rag/docstore/test_dataset_docstore.py
@@ -721,6 +721,30 @@ class TestDatasetDocumentStoreMultimodelBinding:
 
             mock_db.session.add.assert_not_called()
 
+    def test_add_multimodel_documents_binding_with_none_document_id(self):
+        """Test that no bindings are added when document_id is None."""
+
+        mock_dataset = MagicMock(spec=Dataset)
+        mock_dataset.id = "test-dataset-id"
+        mock_dataset.tenant_id = "tenant-1"
+
+        mock_attachment = MagicMock(spec=AttachmentDocument)
+        mock_attachment.metadata = {"doc_id": "attachment-1"}
+
+        with patch("core.rag.docstore.dataset_docstore.db") as mock_db:
+            mock_session = MagicMock()
+            mock_db.session = mock_session
+
+            store = DatasetDocumentStore(
+                dataset=mock_dataset,
+                user_id="test-user-id",
+                document_id=None,
+            )
+
+            store.add_multimodel_documents_binding("seg-1", [mock_attachment])
+
+            mock_db.session.add.assert_not_called()
+
 
 class TestDatasetDocumentStoreAddDocumentsUpdateChild:
     """Tests for add_documents when updating existing documents with children."""


### PR DESCRIPTION
## Summary
- Migrate `SegmentAttachmentBinding` from `Base` to `TypeBase` (MappedAsDataclass)
- Auto-generated fields (`id`, `created_at`) use `init=False` with `insert_default`/`default_factory`


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods


Part of #23579