### PR TITLE
refactor: migrate session.query to select API in webhook service

### DIFF
--- a/api/services/trigger/webhook_service.py
+++ b/api/services/trigger/webhook_service.py
@@ -104,32 +104,32 @@ class WebhookService:
         """
         with Session(db.engine) as session:
             # Get webhook trigger
-            webhook_trigger = (
-                session.query(WorkflowWebhookTrigger).where(WorkflowWebhookTrigger.webhook_id == webhook_id).first()
+            webhook_trigger = session.scalar(
+                select(WorkflowWebhookTrigger).where(WorkflowWebhookTrigger.webhook_id == webhook_id).limit(1)
             )
             if not webhook_trigger:
                 raise ValueError(f"Webhook not found: {webhook_id}")
 
             if is_debug:
-                workflow = (
-                    session.query(Workflow)
-                    .filter(
+                workflow = session.scalar(
+                    select(Workflow)
+                    .where(
                         Workflow.app_id == webhook_trigger.app_id,
                         Workflow.version == Workflow.VERSION_DRAFT,
                     )
                     .order_by(Workflow.created_at.desc())
-                    .first()
+                    .limit(1)
                 )
             else:
                 # Check if the corresponding AppTrigger exists
-                app_trigger = (
-                    session.query(AppTrigger)
-                    .filter(
+                app_trigger = session.scalar(
+                    select(AppTrigger)
+                    .where(
                         AppTrigger.app_id == webhook_trigger.app_id,
                         AppTrigger.node_id == webhook_trigger.node_id,
                         AppTrigger.trigger_type == AppTriggerType.TRIGGER_WEBHOOK,
                     )
-                    .first()
+                    .limit(1)
                 )
 
                 if not app_trigger:
@@ -146,14 +146,14 @@ class WebhookService:
                     raise ValueError(f"Webhook trigger is disabled for webhook {webhook_id}")
 
                 # Get workflow
-                workflow = (
-                    session.query(Workflow)
-                    .filter(
+                workflow = session.scalar(
+                    select(Workflow)
+                    .where(
                         Workflow.app_id == webhook_trigger.app_id,
                         Workflow.version != Workflow.VERSION_DRAFT,
                     )
                     .order_by(Workflow.created_at.desc())
-                    .first()
+                    .limit(1)
                 )
             if not workflow:
                 raise ValueError(f"Workflow not found for app {webhook_trigger.app_id}")

--- a/api/tests/unit_tests/services/test_webhook_service.py
+++ b/api/tests/unit_tests/services/test_webhook_service.py
@@ -657,7 +657,7 @@ def _app(**kwargs: Any) -> App:
 def test_get_webhook_trigger_and_workflow_should_raise_when_webhook_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange
     fake_session = MagicMock()
-    fake_session.query.return_value = _FakeQuery(None)
+    fake_session.scalar.return_value = None
     _patch_session(monkeypatch, fake_session)
 
     # Act / Assert
@@ -671,7 +671,7 @@ def test_get_webhook_trigger_and_workflow_should_raise_when_app_trigger_not_foun
     # Arrange
     webhook_trigger = SimpleNamespace(app_id="app-1", node_id="node-1")
     fake_session = MagicMock()
-    fake_session.query.side_effect = [_FakeQuery(webhook_trigger), _FakeQuery(None)]
+    fake_session.scalar.side_effect = [webhook_trigger, None]
     _patch_session(monkeypatch, fake_session)
 
     # Act / Assert
@@ -686,7 +686,7 @@ def test_get_webhook_trigger_and_workflow_should_raise_when_app_trigger_rate_lim
     webhook_trigger = SimpleNamespace(app_id="app-1", node_id="node-1")
     app_trigger = SimpleNamespace(status=AppTriggerStatus.RATE_LIMITED)
     fake_session = MagicMock()
-    fake_session.query.side_effect = [_FakeQuery(webhook_trigger), _FakeQuery(app_trigger)]
+    fake_session.scalar.side_effect = [webhook_trigger, app_trigger]
     _patch_session(monkeypatch, fake_session)
 
     # Act / Assert
@@ -701,7 +701,7 @@ def test_get_webhook_trigger_and_workflow_should_raise_when_app_trigger_disabled
     webhook_trigger = SimpleNamespace(app_id="app-1", node_id="node-1")
     app_trigger = SimpleNamespace(status=AppTriggerStatus.DISABLED)
     fake_session = MagicMock()
-    fake_session.query.side_effect = [_FakeQuery(webhook_trigger), _FakeQuery(app_trigger)]
+    fake_session.scalar.side_effect = [webhook_trigger, app_trigger]
     _patch_session(monkeypatch, fake_session)
 
     # Act / Assert
@@ -714,7 +714,7 @@ def test_get_webhook_trigger_and_workflow_should_raise_when_workflow_not_found(m
     webhook_trigger = SimpleNamespace(app_id="app-1", node_id="node-1")
     app_trigger = SimpleNamespace(status=AppTriggerStatus.ENABLED)
     fake_session = MagicMock()
-    fake_session.query.side_effect = [_FakeQuery(webhook_trigger), _FakeQuery(app_trigger), _FakeQuery(None)]
+    fake_session.scalar.side_effect = [webhook_trigger, app_trigger, None]
     _patch_session(monkeypatch, fake_session)
 
     # Act / Assert
@@ -732,7 +732,7 @@ def test_get_webhook_trigger_and_workflow_should_return_values_for_non_debug_mod
     workflow.get_node_config_by_id.return_value = {"data": {"key": "value"}}
 
     fake_session = MagicMock()
-    fake_session.query.side_effect = [_FakeQuery(webhook_trigger), _FakeQuery(app_trigger), _FakeQuery(workflow)]
+    fake_session.scalar.side_effect = [webhook_trigger, app_trigger, workflow]
     _patch_session(monkeypatch, fake_session)
 
     # Act
@@ -751,7 +751,7 @@ def test_get_webhook_trigger_and_workflow_should_return_values_for_debug_mode(mo
     workflow.get_node_config_by_id.return_value = {"data": {"mode": "debug"}}
 
     fake_session = MagicMock()
-    fake_session.query.side_effect = [_FakeQuery(webhook_trigger), _FakeQuery(workflow)]
+    fake_session.scalar.side_effect = [webhook_trigger, workflow]
     _patch_session(monkeypatch, fake_session)
 
     # Act


### PR DESCRIPTION
## Summary
- Migrate legacy `session.query(Model).where(...).first()` to modern
  `session.scalar(select(Model).where(...).limit(1))` in webhook service

Part of #22668

## Changes
- `services/trigger/webhook_service.py` — WorkflowWebhookTrigger, AppTrigger, and Workflow lookups (4 queries)
- Test mock updates (necessary): `test_webhook_service.py` — `_FakeQuery` chain → `session.scalar.side_effect`

## Test plan
- [x] `ruff check` passes
- [x] `make type-check` — no new errors
- [x] 75 affected tests pass
