### PR TITLE
fix: handle None from Redis get() in annotation status endpoints

### DIFF
--- a/api/controllers/console/app/annotation.py
+++ b/api/controllers/console/app/annotation.py
@@ -188,7 +188,8 @@ class AnnotationReplyActionStatusApi(Resource):
         error_msg = ""
         if job_status == "error":
             app_annotation_error_key = f"{action}_app_annotation_error_{str(job_id)}"
-            error_msg = redis_client.get(app_annotation_error_key).decode()
+            error_result = redis_client.get(app_annotation_error_key)
+            error_msg = error_result.decode() if error_result else "Unknown error"
 
         return {"job_id": job_id, "job_status": job_status, "error_msg": error_msg}, 200
 
@@ -408,7 +409,8 @@ class AnnotationBatchImportStatusApi(Resource):
         error_msg = ""
         if job_status == "error":
             indexing_error_msg_key = f"app_annotation_batch_import_error_msg_{str(job_id)}"
-            error_msg = redis_client.get(indexing_error_msg_key).decode()
+            error_result = redis_client.get(indexing_error_msg_key)
+            error_msg = error_result.decode() if error_result else "Unknown error"
 
         return {"job_id": job_id, "job_status": job_status, "error_msg": error_msg}, 200
 

--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -80,7 +80,8 @@ class AnnotationReplyActionStatusApi(Resource):
         error_msg = ""
         if job_status == "error":
             app_annotation_error_key = f"{action}_app_annotation_error_{str(job_id)}"
-            error_msg = redis_client.get(app_annotation_error_key).decode()
+            error_result = redis_client.get(app_annotation_error_key)
+            error_msg = error_result.decode() if error_result else "Unknown error"
 
         return {"job_id": job_id, "job_status": job_status, "error_msg": error_msg}, 200
 


### PR DESCRIPTION
## Summary

Fix `AttributeError` crash when calling `.decode()` on `None` in annotation status endpoints.

## Problem

When an annotation job (enable/disable annotation reply, or batch import) has status `"error"`, the endpoint fetches the error message from Redis and immediately calls `.decode()`:

```python
error_msg = redis_client.get(app_annotation_error_key).decode()
```

If the Redis key has expired or was never written (worker crashed before setting it), `redis_client.get()` returns `None`, and `.decode()` raises `AttributeError`, returning a 500 to the client.

This is a race condition between the job status key (which shows `"error"`) and the error message key, which may have a different TTL or may not have been set at all.

## Fix

Add a None check before calling `.decode()`:

```python
error_result = redis_client.get(app_annotation_error_key)
error_msg = error_result.decode() if error_result else "Unknown error"
```

Applied in three locations:
- `api/controllers/console/app/annotation.py` — `AnnotationReplyActionStatusApi.get()`
- `api/controllers/console/app/annotation.py` — `AnnotationBatchImportStatusApi.get()`
- `api/controllers/service_api/app/annotation.py` — `AnnotationReplyActionStatusApi.get()`

## Test Plan

- [ ] Trigger an annotation job, let it fail
- [ ] Call status endpoint — should return `{"job_status": "error", "error_msg": "Unknown error"}` instead of 500
- [ ] When the error key exists, the real error message is still returned correctly