### PR TITLE
refactor: migrate web human_input_form from reqparse to Pydantic BaseModel

### DIFF
--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -7,7 +7,8 @@ import logging
 from datetime import datetime
 
 from flask import Response, request
-from flask_restx import Resource, reqparse
+from flask_restx import Resource
+from pydantic import BaseModel
 from sqlalchemy import select
 from werkzeug.exceptions import Forbidden
 
@@ -22,6 +23,12 @@ from models.model import App, Site
 from services.human_input_service import Form, FormNotFoundError, HumanInputService
 
 logger = logging.getLogger(__name__)
+
+
+class HumanInputFormSubmitPayload(BaseModel):
+    inputs: dict
+    action: str
+
 
 _FORM_SUBMIT_RATE_LIMITER = RateLimiter(
     prefix="web_form_submit_rate_limit",
@@ -112,10 +119,7 @@ class HumanInputFormApi(Resource):
             "action": "Approve"
         }
         """
-        parser = reqparse.RequestParser()
-        parser.add_argument("inputs", type=dict, required=True, location="json")
-        parser.add_argument("action", type=str, required=True, location="json")
-        args = parser.parse_args()
+        payload = HumanInputFormSubmitPayload.model_validate(request.get_json())
 
         ip_address = extract_remote_ip(request)
         if _FORM_SUBMIT_RATE_LIMITER.is_rate_limited(ip_address):
@@ -135,8 +139,8 @@ class HumanInputFormApi(Resource):
             service.submit_form_by_token(
                 recipient_type=recipient_type,
                 form_token=form_token,
-                selected_action_id=args["action"],
-                form_data=args["inputs"],
+                selected_action_id=payload.action,
+                form_data=payload.inputs,
                 submission_end_user_id=None,
                 # submission_end_user_id=_end_user.id,
             )


### PR DESCRIPTION
Fixes #28015

## Summary

Replace `reqparse.RequestParser` with Pydantic `BaseModel` in the web human input form submission endpoint. Adds `HumanInputFormSubmitPayload` model with `inputs` and `action` fields, aligning with the codebase's ongoing migration to Pydantic for request validation.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
