### PR TITLE
fix(devcontainer): pin Node.js version to 22 instead of floating LTS tag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,
-			"version": "lts"
+			"version": "22"
 		},
 		"ghcr.io/devcontainers-extra/features/npm-package:1": {
 			"package": "typescript",


### PR DESCRIPTION
## Summary

- Pin the Node.js version in `.devcontainer/devcontainer.json` from `"lts"` to `"22"`, ensuring the devcontainer environment is reproducible and consistent with the project's `engines.node: "^22.22.1"` constraint.

## Why

`"lts"` is a floating reference — when Node 24 enters its LTS phase, the devcontainer would automatically upgrade, potentially breaking compatibility with the project's `package.json` engine constraints.

## Test plan

- [ ] Rebuild the devcontainer and verify `node --version` returns `v22.x.x`
- [ ] Run `pnpm install` inside the container and confirm no engines check errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)