### PR TITLE
fix(api): replace `assert isinstance` with proper runtime type checks in message transformers

### DIFF
--- a/api/core/datasource/utils/message_transformer.py
+++ b/api/core/datasource/utils/message_transformer.py
@@ -71,8 +71,8 @@ class DatasourceFileMessageTransformer:
                 if not isinstance(message.message, DatasourceMessage.BlobMessage):
                     raise ValueError("unexpected message type")
 
-                # FIXME: should do a type check here.
-                assert isinstance(message.message.blob, bytes)
+                if not isinstance(message.message.blob, bytes):
+                    raise TypeError(f"Expected blob to be bytes, got {type(message.message.blob).__name__}")
                 tool_file_manager = ToolFileManager()
                 blob_tool_file: ToolFile | None = tool_file_manager.create_file_by_raw(
                     user_id=user_id,

--- a/api/core/tools/utils/message_transformer.py
+++ b/api/core/tools/utils/message_transformer.py
@@ -118,7 +118,8 @@ class ToolFileMessageTransformer:
                 if not isinstance(message.message, ToolInvokeMessage.BlobMessage):
                     raise ValueError("unexpected message type")
 
-                assert isinstance(message.message.blob, bytes)
+                if not isinstance(message.message.blob, bytes):
+                    raise TypeError(f"Expected blob to be bytes, got {type(message.message.blob).__name__}")
                 tool_file_manager = ToolFileManager()
                 tool_file = tool_file_manager.create_file_by_raw(
                     user_id=user_id,


### PR DESCRIPTION
## Summary
Replaces unsafe `assert isinstance(...)` calls with proper runtime type checks in `ToolFileMessageTransformer` and `DatasourceFileMessageTransformer`.

## Why this change
`assert` is stripped in optimized mode (`python -O`), making it unreliable as a runtime guard. I  replaced it with an explicit `raise TypeError` ensures the blob type invariant is always enforced in prod.

## Changes
**`api/core/datasource/utils/message_transformer.py`:** and **`api/core/tools/utils/message_transformer.py`:**
- Replaced `assert isinstance(message.message.blob, bytes)` with an explicit `raise TypeError` 

##Checks
ruffchecks- passed