### PR TITLE
fix(#34636): replace SimpleNamespace with model instances in feedback…

### DIFF
--- a/api/tests/integration_tests/controllers/console/app/test_feedback_export_api.py
+++ b/api/tests/integration_tests/controllers/console/app/test_feedback_export_api.py
@@ -3,7 +3,6 @@
 import json
 import uuid
 from datetime import datetime
-from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -15,7 +14,7 @@ from libs.datetime_utils import naive_utc_now
 from models import App, Tenant
 from models.account import Account, TenantAccountJoin, TenantAccountRole
 from models.enums import FeedbackFromSource, FeedbackRating
-from models.model import AppMode, MessageFeedback
+from models.model import AppMode, Conversation, Message, MessageFeedback
 from services.feedback_service import FeedbackService
 
 
@@ -99,19 +98,20 @@ class TestFeedbackExportApi:
             created_at=naive_utc_now(),
         )
 
-        # Mock message and conversation
-        mock_message = SimpleNamespace(
+        mock_message = Message(
             id=message_id,
+            app_id=app_id,
             conversation_id=conversation_id,
             query="What is the weather today?",
+            message={"text": "What is the weather today?"},
             answer="It's sunny and 25 degrees outside.",
             inputs={"query": "What is the weather today?"},
             created_at=naive_utc_now(),
         )
 
-        mock_conversation = SimpleNamespace(id=conversation_id, name="Weather Conversation", app_id=app_id)
+        mock_conversation = Conversation(id=conversation_id, name="Weather Conversation", app_id=app_id)
 
-        mock_app = SimpleNamespace(id=app_id, name="Weather App")
+        mock_app = App(id=app_id, name="Weather App")
 
         return {
             "user_feedback": user_feedback,


### PR DESCRIPTION
Fixes #34636

## Summary

This PR updates the feedback export integration test to use real model instances instead of `SimpleNamespace` test doubles.

- Replace `SimpleNamespace` objects with `Message`, `Conversation`, and `App` instances in the feedback export test
- Add the required `Message` fields used by the export flow, including `app_id` and `message`
- Keep the test setup aligned with production models so the export path is exercised with realistic objects

No additional dependencies are required.

## Screenshots

| Before | After |
|--------|-------|
| N/A (test-only change) | N/A (test-only change) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
