### PR TITLE
fix(mcp): catch JSONDecodeError in OAuth discovery functions 🤖🤖🤖

### DIFF
--- a/api/core/mcp/auth/auth_flow.py
+++ b/api/core/mcp/auth/auth_flow.py
@@ -146,7 +146,7 @@ def discover_protected_resource_metadata(
                 return ProtectedResourceMetadata.model_validate(response.json())
             elif response.status_code == 404:
                 continue  # Try next URL
-        except (RequestError, ValidationError):
+        except (RequestError, ValidationError, json.JSONDecodeError):
             continue  # Try next URL
 
     return None
@@ -166,7 +166,7 @@ def discover_oauth_authorization_server_metadata(
                 return OAuthMetadata.model_validate(response.json())
             elif response.status_code == 404:
                 continue  # Try next URL
-        except (RequestError, ValidationError):
+        except (RequestError, ValidationError, json.JSONDecodeError):
             continue  # Try next URL
 
     return None
@@ -276,7 +276,7 @@ def check_support_resource_discovery(server_url: str) -> tuple[bool, str]:
             else:
                 return False, ""
         return False, ""
-    except RequestError:
+    except (RequestError, json.JSONDecodeError, IndexError):
         # Not support resource discovery, fall back to well-known OAuth metadata
         return False, ""
 

--- a/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
+++ b/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
@@ -862,6 +862,15 @@ class TestAuthOrchestration:
         result = discover_protected_resource_metadata(None, "https://api.example.com")
         assert result is None
 
+        # JSONDecodeError (non-JSON 200 response)
+        mock_get.side_effect = None
+        bad_json_response = Mock()
+        bad_json_response.status_code = 200
+        bad_json_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        mock_get.return_value = bad_json_response
+        result = discover_protected_resource_metadata(None, "https://api.example.com")
+        assert result is None
+
     @patch("core.helper.ssrf_proxy.get")
     def test_discover_oauth_authorization_server_metadata(self, mock_get):
         # Success
@@ -889,6 +898,14 @@ class TestAuthOrchestration:
         mock_response.json.return_value = {"invalid": "data"}
         mock_get.side_effect = None
         mock_get.return_value = mock_response
+        result = discover_oauth_authorization_server_metadata(None, "https://api.example.com")
+        assert result is None
+
+        # JSONDecodeError (non-JSON 200 response)
+        bad_json_response = Mock()
+        bad_json_response.status_code = 200
+        bad_json_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        mock_get.return_value = bad_json_response
         result = discover_oauth_authorization_server_metadata(None, "https://api.example.com")
         assert result is None
 
@@ -994,6 +1011,24 @@ class TestAuthOrchestration:
 
         # Case 5: RequestError
         mock_get.side_effect = httpx.RequestError("Error")
+        supported, url = check_support_resource_discovery("https://api")
+        assert supported is False
+
+        # Case 6: JSONDecodeError (non-JSON 200 response)
+        mock_get.side_effect = None
+        bad_json_res = Mock()
+        bad_json_res.status_code = 200
+        bad_json_res.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        mock_get.return_value = bad_json_res
+        supported, url = check_support_resource_discovery("https://api")
+        assert supported is False
+        assert url == ""
+
+        # Case 7: Empty authorization_servers array (IndexError)
+        empty_res = Mock()
+        empty_res.status_code = 200
+        empty_res.json.return_value = {"authorization_servers": []}
+        mock_get.return_value = empty_res
         supported, url = check_support_resource_discovery("https://api")
         assert supported is False
 


### PR DESCRIPTION
## Summary

Three OAuth discovery functions in `auth_flow.py` crash with unhandled `json.JSONDecodeError` when an MCP server returns an HTTP 200 response with a non-JSON body (e.g. an HTML page from a reverse proxy, an empty body, or malformed JSON).

**Affected functions:**
- `discover_protected_resource_metadata()` — except clause catches `RequestError` and `ValidationError` but not `json.JSONDecodeError`
- `discover_oauth_authorization_server_metadata()` — same
- `check_support_resource_discovery()` — except clause only catches `RequestError`, missing both `json.JSONDecodeError` and `IndexError`

**Fix:** Add the missing exception types to each except clause so non-JSON responses are treated the same as network errors — skip and try the next URL, or return a safe fallback.

## Changes

- `api/core/mcp/auth/auth_flow.py`: Add `json.JSONDecodeError` to the two discovery functions' except clauses; add `json.JSONDecodeError` and `IndexError` to `check_support_resource_discovery()`
- `api/tests/unit_tests/core/mcp/auth/test_auth_flow.py`: Add tests for non-JSON 200 responses and empty array edge cases in all three functions

## Verification

Before fix — a non-JSON 200 response causes:
```
json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
propagating up to the caller and crashing the MCP OAuth flow.

After fix — all three functions gracefully handle the error:
- `discover_*` functions skip to the next URL and return `None` if all fail
- `check_support_resource_discovery` returns `(False, "")` and falls back to well-known metadata

All 48 unit tests pass, including the 4 new error-path tests.

## Test plan

- [x] All 48 existing + new unit tests pass (`pytest api/tests/unit_tests/core/mcp/auth/test_auth_flow.py`)
- [x] Ruff format clean
- [x] Ruff lint clean
- [x] No new type-check errors in changed files

Fixes #34867