### PR TITLE
refactor(api): type Celery SSL options and Sentinel transport dicts with TypedDicts

### DIFF
--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -5,12 +5,30 @@ from typing import Any
 import pytz  # type: ignore[import-untyped]
 from celery import Celery, Task
 from celery.schedules import crontab
+from typing_extensions import TypedDict
 
 from configs import dify_config
 from dify_app import DifyApp
 
 
-def get_celery_ssl_options() -> dict[str, Any] | None:
+class _CelerySentinelKwargsDict(TypedDict):
+    socket_timeout: float | None
+    password: str | None
+
+
+class CelerySentinelTransportDict(TypedDict):
+    master_name: str | None
+    sentinel_kwargs: _CelerySentinelKwargsDict
+
+
+class CelerySSLOptionsDict(TypedDict):
+    ssl_cert_reqs: int
+    ssl_ca_certs: str | None
+    ssl_certfile: str | None
+    ssl_keyfile: str | None
+
+
+def get_celery_ssl_options() -> CelerySSLOptionsDict | None:
     """Get SSL configuration for Celery broker/backend connections."""
     # Only apply SSL if we're using Redis as broker/backend
     if not dify_config.BROKER_USE_SSL:
@@ -33,26 +51,24 @@ def get_celery_ssl_options() -> dict[str, Any] | None:
 
     ssl_cert_reqs = cert_reqs_map.get(dify_config.REDIS_SSL_CERT_REQS, ssl.CERT_NONE)
 
-    ssl_options = {
-        "ssl_cert_reqs": ssl_cert_reqs,
-        "ssl_ca_certs": dify_config.REDIS_SSL_CA_CERTS,
-        "ssl_certfile": dify_config.REDIS_SSL_CERTFILE,
-        "ssl_keyfile": dify_config.REDIS_SSL_KEYFILE,
-    }
-
-    return ssl_options
+    return CelerySSLOptionsDict(
+        ssl_cert_reqs=ssl_cert_reqs,
+        ssl_ca_certs=dify_config.REDIS_SSL_CA_CERTS,
+        ssl_certfile=dify_config.REDIS_SSL_CERTFILE,
+        ssl_keyfile=dify_config.REDIS_SSL_KEYFILE,
+    )
 
 
-def get_celery_broker_transport_options() -> dict[str, Any]:
+def get_celery_broker_transport_options() -> CelerySentinelTransportDict | dict[str, Any]:
     """Get broker transport options (e.g. Redis Sentinel) for Celery connections."""
     if dify_config.CELERY_USE_SENTINEL:
-        return {
-            "master_name": dify_config.CELERY_SENTINEL_MASTER_NAME,
-            "sentinel_kwargs": {
-                "socket_timeout": dify_config.CELERY_SENTINEL_SOCKET_TIMEOUT,
-                "password": dify_config.CELERY_SENTINEL_PASSWORD,
-            },
-        }
+        return CelerySentinelTransportDict(
+            master_name=dify_config.CELERY_SENTINEL_MASTER_NAME,
+            sentinel_kwargs=_CelerySentinelKwargsDict(
+                socket_timeout=dify_config.CELERY_SENTINEL_SOCKET_TIMEOUT,
+                password=dify_config.CELERY_SENTINEL_PASSWORD,
+            ),
+        )
     return {}
 
 


### PR DESCRIPTION
Part of #32863

## Summary
- Add `CelerySSLOptionsDict` TypedDict, annotate `get_celery_ssl_options` return type
- Add `_CelerySentinelKwargsDict` and `CelerySentinelTransportDict` TypedDicts, annotate `get_celery_broker_transport_options` return type

## Why this change
Both functions return fixed-key dicts typed as `dict[str, Any]`. The TypedDicts make the SSL cert fields and Sentinel master/kwargs structure explicit and checkable.

## Changes
- `api/extensions/ext_celery.py`: Define `CelerySSLOptionsDict`, `_CelerySentinelKwargsDict`, `CelerySentinelTransportDict`; update both function return types

## Test plan
- [x] `ruff check` passes
