### PR TITLE
refactor(api): replace SimpleNamespace with typed mocks in 5 test files 🤖🤖🤖

### DIFF
--- a/api/tests/unit_tests/core/app/features/test_annotation_reply.py
+++ b/api/tests/unit_tests/core/app/features/test_annotation_reply.py
@@ -1,9 +1,17 @@
 import logging
-from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.features.annotation_reply.annotation_reply import AnnotationReplyFeature
+from models.model import App, Message
+
+
+def _make_app() -> Mock:
+    return Mock(spec=App, id="app-1", tenant_id="tenant-1")
+
+
+def _make_message() -> Mock:
+    return Mock(spec=Message, id="msg-1")
 
 
 class TestAnnotationReplyFeature:
@@ -14,8 +22,8 @@ class TestAnnotationReplyFeature:
             mock_db.session.scalar.return_value = None
 
             result = feature.query(
-                app_record=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
-                message=SimpleNamespace(id="msg-1"),
+                app_record=_make_app(),
+                message=_make_message(),
                 query="hi",
                 user_id="user-1",
                 invoke_from=InvokeFrom.SERVICE_API,
@@ -25,14 +33,14 @@ class TestAnnotationReplyFeature:
 
     def test_query_returns_none_when_binding_missing(self):
         feature = AnnotationReplyFeature()
-        annotation_setting = SimpleNamespace(collection_binding_detail=None)
+        annotation_setting = Mock(collection_binding_detail=None)
 
         with patch("core.app.features.annotation_reply.annotation_reply.db") as mock_db:
             mock_db.session.scalar.return_value = annotation_setting
 
             result = feature.query(
-                app_record=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
-                message=SimpleNamespace(id="msg-1"),
+                app_record=_make_app(),
+                message=_make_message(),
                 query="hi",
                 user_id="user-1",
                 invoke_from=InvokeFrom.SERVICE_API,
@@ -42,19 +50,19 @@ class TestAnnotationReplyFeature:
 
     def test_query_returns_annotation_and_records_history_for_api(self):
         feature = AnnotationReplyFeature()
-        annotation_setting = SimpleNamespace(
+        annotation_setting = Mock(
             score_threshold=None,
-            collection_binding_detail=SimpleNamespace(provider_name="prov", model_name="model"),
+            collection_binding_detail=Mock(provider_name="prov", model_name="model"),
         )
-        dataset_binding = SimpleNamespace(id="binding-1")
-        annotation = SimpleNamespace(
+        dataset_binding = Mock(id="binding-1")
+        annotation = Mock(
             id="ann-1",
             question_text="question",
             content="content",
             account_id="acct-1",
-            account=SimpleNamespace(name="Alice"),
+            account=Mock(name="Alice"),
         )
-        document = SimpleNamespace(metadata={"annotation_id": "ann-1", "score": 0.8})
+        document = Mock(metadata={"annotation_id": "ann-1", "score": 0.8})
         vector_instance = Mock()
         vector_instance.search_by_vector.return_value = [document]
 
@@ -74,8 +82,8 @@ class TestAnnotationReplyFeature:
             mock_annotation_service.get_annotation_by_id.return_value = annotation
 
             result = feature.query(
-                app_record=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
-                message=SimpleNamespace(id="msg-1"),
+                app_record=_make_app(),
+                message=_make_message(),
                 query="hi",
                 user_id="user-1",
                 invoke_from=InvokeFrom.SERVICE_API,
@@ -89,19 +97,19 @@ class TestAnnotationReplyFeature:
 
     def test_query_returns_annotation_and_records_history_for_console(self):
         feature = AnnotationReplyFeature()
-        annotation_setting = SimpleNamespace(
+        annotation_setting = Mock(
             score_threshold=0.5,
-            collection_binding_detail=SimpleNamespace(provider_name="prov", model_name="model"),
+            collection_binding_detail=Mock(provider_name="prov", model_name="model"),
         )
-        dataset_binding = SimpleNamespace(id="binding-1")
-        annotation = SimpleNamespace(
+        dataset_binding = Mock(id="binding-1")
+        annotation = Mock(
             id="ann-1",
             question_text="question",
             content="content",
             account_id="acct-1",
             account=None,
         )
-        document = SimpleNamespace(metadata={"annotation_id": "ann-1", "score": 0.6})
+        document = Mock(metadata={"annotation_id": "ann-1", "score": 0.6})
         vector_instance = Mock()
         vector_instance.search_by_vector.return_value = [document]
 
@@ -121,8 +129,8 @@ class TestAnnotationReplyFeature:
             mock_annotation_service.get_annotation_by_id.return_value = annotation
 
             result = feature.query(
-                app_record=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
-                message=SimpleNamespace(id="msg-1"),
+                app_record=_make_app(),
+                message=_make_message(),
                 query="hi",
                 user_id="user-1",
                 invoke_from=InvokeFrom.EXPLORE,
@@ -134,9 +142,9 @@ class TestAnnotationReplyFeature:
 
     def test_query_logs_and_returns_none_on_exception(self, caplog):
         feature = AnnotationReplyFeature()
-        annotation_setting = SimpleNamespace(
+        annotation_setting = Mock(
             score_threshold=None,
-            collection_binding_detail=SimpleNamespace(provider_name="prov", model_name="model"),
+            collection_binding_detail=Mock(provider_name="prov", model_name="model"),
         )
 
         with (
@@ -147,13 +155,13 @@ class TestAnnotationReplyFeature:
             patch("core.app.features.annotation_reply.annotation_reply.Vector") as mock_vector,
         ):
             mock_db.session.scalar.return_value = annotation_setting
-            mock_binding_service.get_dataset_collection_binding.return_value = SimpleNamespace(id="binding-1")
+            mock_binding_service.get_dataset_collection_binding.return_value = Mock(id="binding-1")
             mock_vector.return_value.search_by_vector.side_effect = RuntimeError("boom")
 
             with caplog.at_level(logging.WARNING):
                 result = feature.query(
-                    app_record=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
-                    message=SimpleNamespace(id="msg-1"),
+                    app_record=_make_app(),
+                    message=_make_message(),
                     query="hi",
                     user_id="user-1",
                     invoke_from=InvokeFrom.SERVICE_API,

--- a/api/tests/unit_tests/core/app/features/test_hosting_moderation.py
+++ b/api/tests/unit_tests/core/app/features/test_hosting_moderation.py
@@ -1,5 +1,6 @@
-from types import SimpleNamespace
 from unittest.mock import Mock, patch
+
+from graphon.model_runtime.entities.message_entities import PromptMessage
 
 from core.app.features.hosting_moderation.hosting_moderation import HostingModerationFeature
 
@@ -8,12 +9,12 @@ class TestHostingModerationFeature:
     def test_check_aggregates_text_and_calls_moderation(self):
         application_generate_entity = Mock()
         application_generate_entity.model_conf = {"model": "mock"}
-        application_generate_entity.app_config = SimpleNamespace(tenant_id="tenant-1")
+        application_generate_entity.app_config = Mock(tenant_id="tenant-1")
 
         prompt_messages = [
-            SimpleNamespace(content="hello"),
-            SimpleNamespace(content=123),
-            SimpleNamespace(content="world"),
+            Mock(spec=PromptMessage, content="hello"),
+            Mock(spec=PromptMessage, content=123),
+            Mock(spec=PromptMessage, content="world"),
         ]
 
         with patch("core.app.features.hosting_moderation.hosting_moderation.moderation.check_moderation") as mock_check:

--- a/api/tests/unit_tests/core/app/features/test_hosting_moderation.py
+++ b/api/tests/unit_tests/core/app/features/test_hosting_moderation.py
@@ -1,8 +1,7 @@
 from unittest.mock import Mock, patch
 
-from graphon.model_runtime.entities.message_entities import PromptMessage
-
 from core.app.features.hosting_moderation.hosting_moderation import HostingModerationFeature
+from graphon.model_runtime.entities.message_entities import PromptMessage
 
 
 class TestHostingModerationFeature:

--- a/api/tests/unit_tests/services/test_code_based_extension_service.py
+++ b/api/tests/unit_tests/services/test_code_based_extension_service.py
@@ -1,15 +1,15 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
+from core.extension.extensible import ModuleExtension
 from services.code_based_extension_service import CodeBasedExtensionService
 
 
 class TestCodeBasedExtensionService:
     def test_should_return_only_non_builtin_extensions_with_public_fields(self, monkeypatch: pytest.MonkeyPatch):
         """Test service returns only non-builtin extensions with name/label/form_schema fields."""
-        moderation_extension = SimpleNamespace(
+        moderation_extension = ModuleExtension(
             name="custom-moderation",
             label={"en-US": "Custom Moderation"},
             form_schema=[{"variable": "api_key"}],
@@ -17,7 +17,7 @@ class TestCodeBasedExtensionService:
             extension_class=object,
             position=20,
         )
-        builtin_extension = SimpleNamespace(
+        builtin_extension = ModuleExtension(
             name="builtin-moderation",
             label={"en-US": "Builtin Moderation"},
             form_schema=[{"variable": "token"}],
@@ -25,7 +25,7 @@ class TestCodeBasedExtensionService:
             extension_class=object,
             position=1,
         )
-        retrieval_extension = SimpleNamespace(
+        retrieval_extension = ModuleExtension(
             name="custom-retrieval",
             label={"en-US": "Custom Retrieval"},
             form_schema=None,
@@ -58,7 +58,7 @@ class TestCodeBasedExtensionService:
 
     def test_should_return_empty_list_when_all_extensions_are_builtin(self, monkeypatch: pytest.MonkeyPatch):
         """Test builtin extensions are filtered out completely."""
-        builtin_extension = SimpleNamespace(
+        builtin_extension = ModuleExtension(
             name="builtin-moderation",
             label={"en-US": "Builtin Moderation"},
             form_schema=[{"variable": "token"}],

--- a/api/tests/unit_tests/services/workflow/test_workflow_human_input_delivery.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_human_input_delivery.py
@@ -1,6 +1,5 @@
 import uuid
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -14,6 +13,8 @@ from core.workflow.human_input_adapter import (
 )
 from graphon.enums import BuiltinNodeTypes
 from graphon.nodes.human_input.entities import HumanInputNodeData
+from models import Account
+from models.model import App
 from services import workflow_service as workflow_service_module
 from services.workflow_service import WorkflowService
 
@@ -52,16 +53,22 @@ def _make_email_method(enabled: bool = True, debug_mode: bool = False) -> EmailD
     )
 
 
+def _make_app() -> Mock:
+    return Mock(spec=App, tenant_id="tenant-1", id="app-1")
+
+
+def _make_account() -> Mock:
+    return Mock(spec=Account, id="account-1")
+
+
 def test_human_input_delivery_requires_draft_workflow():
     service = _make_service()
     service.get_draft_workflow = MagicMock(return_value=None)  # type: ignore[method-assign]
-    app_model = SimpleNamespace(tenant_id="tenant-1", id="app-1")
-    account = SimpleNamespace(id="account-1")
 
     with pytest.raises(ValueError, match="Workflow not initialized"):
         service.test_human_input_delivery(
-            app_model=app_model,
-            account=account,
+            app_model=_make_app(),
+            account=_make_account(),
             node_id="node-1",
             delivery_method_id="delivery-1",
         )
@@ -90,12 +97,9 @@ def test_human_input_delivery_allows_disabled_method(monkeypatch: pytest.MonkeyP
         MagicMock(return_value=test_service_instance),
     )
 
-    app_model = SimpleNamespace(tenant_id="tenant-1", id="app-1")
-    account = SimpleNamespace(id="account-1")
-
     service.test_human_input_delivery(
-        app_model=app_model,
-        account=account,
+        app_model=_make_app(),
+        account=_make_account(),
         node_id="node-1",
         delivery_method_id=str(delivery_method.id),
     )
@@ -126,12 +130,9 @@ def test_human_input_delivery_dispatches_to_test_service(monkeypatch: pytest.Mon
         MagicMock(return_value=test_service_instance),
     )
 
-    app_model = SimpleNamespace(tenant_id="tenant-1", id="app-1")
-    account = SimpleNamespace(id="account-1")
-
     service.test_human_input_delivery(
-        app_model=app_model,
-        account=account,
+        app_model=_make_app(),
+        account=_make_account(),
         node_id="node-1",
         delivery_method_id=str(delivery_method.id),
         inputs={"#node-1.output#": "value"},
@@ -165,11 +166,9 @@ def test_human_input_delivery_debug_mode_overrides_recipients(monkeypatch: pytes
         MagicMock(return_value=test_service_instance),
     )
 
-    app_model = SimpleNamespace(tenant_id="tenant-1", id="app-1")
-    account = SimpleNamespace(id="account-1")
-
+    account = _make_account()
     service.test_human_input_delivery(
-        app_model=app_model,
+        app_model=_make_app(),
         account=account,
         node_id="node-1",
         delivery_method_id=str(delivery_method.id),

--- a/api/tests/unit_tests/services/workflow/test_workflow_restore.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_restore.py
@@ -1,10 +1,11 @@
 import json
-from types import SimpleNamespace
+from unittest.mock import Mock
 
+from models import Account
 from models.workflow import Workflow
 from services.workflow_restore import apply_published_workflow_snapshot_to_draft
 
-LEGACY_FEATURES = {
+LEGACY_FEATURES: dict[str, object] = {
     "file_upload": {
         "image": {
             "enabled": True,
@@ -21,7 +22,7 @@ LEGACY_FEATURES = {
     "text_to_speech": {"enabled": False, "language": "", "voice": ""},
 }
 
-NORMALIZED_FEATURES = {
+NORMALIZED_FEATURES: dict[str, object] = {
     "file_upload": {
         "enabled": True,
         "allowed_file_types": ["image"],
@@ -67,7 +68,7 @@ def test_apply_published_workflow_snapshot_to_draft_copies_serialized_features_w
         app_id="app-id",
         source_workflow=source_workflow,
         draft_workflow=None,
-        account=SimpleNamespace(id="account-id"),
+        account=Mock(spec=Account, id="account-id"),
         updated_at_factory=lambda: source_workflow.updated_at,
     )
 


### PR DESCRIPTION
## Summary
- Replace `SimpleNamespace` with `Mock(spec=App)`, `Mock(spec=Message)`, `Mock(spec=Account)`, `Mock(spec=PromptMessage)`, and real `ModuleExtension` instances across 5 test files to fix pyrefly `bad-argument-type` errors
- Add `_make_app()` / `_make_message()` / `_make_account()` helpers to reduce repetition
- Annotate dict constants in `test_workflow_restore.py` to fix a pre-existing pyrefly `bad-argument-type` error

Part of #34636

### Files changed
| File | SimpleNamespace removed | Replacement |
|------|------------------------|-------------|
| `test_annotation_reply.py` | 26 | `Mock(spec=App)`, `Mock(spec=Message)`, `Mock()` |
| `test_hosting_moderation.py` | 5 | `Mock(spec=PromptMessage)`, `Mock()` |
| `test_workflow_human_input_delivery.py` | 9 | `Mock(spec=App)`, `Mock(spec=Account)` |
| `test_workflow_restore.py` | 2 | `Mock(spec=Account)` |
| `test_code_based_extension_service.py` | 5 | `ModuleExtension(...)` (real instances) |

## Test plan
- [x] `pyrefly check` reports 0 errors on all 5 files
- [x] All 14 unit tests pass (`pytest -v`)
- [x] `ruff check` and `ruff format` pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>