### PR TITLE
refactor(api): type workflow generator args dict with TypedDict

### DIFF
--- a/api/services/webapp_auth_service.py
+++ b/api/services/webapp_auth_service.py
@@ -1,13 +1,14 @@
 import enum
 import secrets
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from sqlalchemy import select
 from werkzeug.exceptions import NotFound, Unauthorized
 
 from configs import dify_config
 from extensions.ext_database import db
-from libs.helper import TokenManager, _TokenData
+from libs.helper import TokenManager
 from libs.passport import PassportService
 from libs.password import compare_password
 from models import Account, AccountStatus
@@ -83,7 +84,7 @@ class WebAppAuthService:
         return token
 
     @classmethod
-    def get_email_code_login_data(cls, token: str) -> _TokenData | None:
+    def get_email_code_login_data(cls, token: str) -> dict[str, Any] | None:
         return TokenManager.get_token_data(token, "email_code_login")
 
     @classmethod

--- a/api/services/webapp_auth_service.py
+++ b/api/services/webapp_auth_service.py
@@ -1,14 +1,13 @@
 import enum
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
 from sqlalchemy import select
 from werkzeug.exceptions import NotFound, Unauthorized
 
 from configs import dify_config
 from extensions.ext_database import db
-from libs.helper import TokenManager
+from libs.helper import TokenManager, _TokenData
 from libs.passport import PassportService
 from libs.password import compare_password
 from models import Account, AccountStatus
@@ -84,7 +83,7 @@ class WebAppAuthService:
         return token
 
     @classmethod
-    def get_email_code_login_data(cls, token: str) -> dict[str, Any] | None:
+    def get_email_code_login_data(cls, token: str) -> _TokenData | None:
         return TokenManager.get_token_data(token, "email_code_login")
 
     @classmethod

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -13,6 +13,7 @@ from celery import shared_task
 from graphon.runtime import GraphRuntimeState
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
+from typing_extensions import TypedDict
 
 from configs import dify_config
 from core.app.apps.workflow.app_generator import SKIP_PREPARE_USER_INPUTS_KEY, WorkflowAppGenerator
@@ -40,6 +41,17 @@ from tasks.workflow_cfs_scheduler.cfs_scheduler import AsyncWorkflowCFSPlanEntit
 from tasks.workflow_cfs_scheduler.entities import AsyncWorkflowQueue, AsyncWorkflowSystemStrategy
 
 logger = logging.getLogger(__name__)
+
+
+# Functional form is required because the key starts with an underscore.
+WorkflowGeneratorArgsDict = TypedDict(  # noqa: UP013
+    "WorkflowGeneratorArgsDict",
+    {
+        "inputs": dict[str, Any],
+        "files": list[Any],
+        "_skip_prepare_user_inputs": bool,
+    },
+)
 
 
 @shared_task(queue=AsyncWorkflowQueue.PROFESSIONAL_QUEUE)
@@ -90,15 +102,13 @@ def execute_workflow_sandbox(task_data_dict: dict[str, Any]):
     )
 
 
-def _build_generator_args(trigger_data: TriggerData) -> dict[str, Any]:
+def _build_generator_args(trigger_data: TriggerData) -> WorkflowGeneratorArgsDict:
     """Build args passed into WorkflowAppGenerator.generate for Celery executions."""
-
-    args: dict[str, Any] = {
-        "inputs": dict(trigger_data.inputs),
-        "files": list(trigger_data.files),
-        SKIP_PREPARE_USER_INPUTS_KEY: True,
-    }
-    return args
+    return WorkflowGeneratorArgsDict(
+        inputs=dict(trigger_data.inputs),
+        files=list(trigger_data.files),
+        **{SKIP_PREPARE_USER_INPUTS_KEY: True},
+    )
 
 
 def _execute_workflow_common(

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -13,7 +13,7 @@ from celery import shared_task
 from graphon.runtime import GraphRuntimeState
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from configs import dify_config
 from core.app.apps.workflow.app_generator import SKIP_PREPARE_USER_INPUTS_KEY, WorkflowAppGenerator
@@ -50,6 +50,7 @@ WorkflowGeneratorArgsDict = TypedDict(  # noqa: UP013
         "inputs": dict[str, Any],
         "files": list[Any],
         "_skip_prepare_user_inputs": bool,
+        "workflow_id": NotRequired[str],
     },
 )
 

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -13,7 +13,7 @@ from celery import shared_task
 from graphon.runtime import GraphRuntimeState
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import TypedDict
 
 from configs import dify_config
 from core.app.apps.workflow.app_generator import WorkflowAppGenerator

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from typing_extensions import TypedDict
 
 from configs import dify_config
-from core.app.apps.workflow.app_generator import SKIP_PREPARE_USER_INPUTS_KEY, WorkflowAppGenerator
+from core.app.apps.workflow.app_generator import WorkflowAppGenerator
 from core.app.entities.app_invoke_entities import InvokeFrom, WorkflowAppGenerateEntity
 from core.app.layers.pause_state_persist_layer import PauseStateLayerConfig, WorkflowResumptionContext
 from core.app.layers.timeslice_layer import TimeSliceLayer
@@ -105,11 +105,11 @@ def execute_workflow_sandbox(task_data_dict: dict[str, Any]):
 
 def _build_generator_args(trigger_data: TriggerData) -> WorkflowGeneratorArgsDict:
     """Build args passed into WorkflowAppGenerator.generate for Celery executions."""
-    return WorkflowGeneratorArgsDict(
-        inputs=dict(trigger_data.inputs),
-        files=list(trigger_data.files),
-        **{SKIP_PREPARE_USER_INPUTS_KEY: True},
-    )
+    return {
+        "inputs": dict(trigger_data.inputs),
+        "files": list(trigger_data.files),
+        "_skip_prepare_user_inputs": True,
+    }
 
 
 def _execute_workflow_common(

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -13,7 +13,7 @@ from celery import shared_task
 from graphon.runtime import GraphRuntimeState
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from configs import dify_config
 from core.app.apps.workflow.app_generator import WorkflowAppGenerator
@@ -43,16 +43,11 @@ from tasks.workflow_cfs_scheduler.entities import AsyncWorkflowQueue, AsyncWorkf
 logger = logging.getLogger(__name__)
 
 
-# Functional form is required because the key starts with an underscore.
-WorkflowGeneratorArgsDict = TypedDict(  # noqa: UP013
-    "WorkflowGeneratorArgsDict",
-    {
-        "inputs": dict[str, Any],
-        "files": list[Any],
-        "_skip_prepare_user_inputs": bool,
-        "workflow_id": NotRequired[str],
-    },
-)
+class WorkflowGeneratorArgsDict(TypedDict):
+    inputs: dict[str, Any]
+    files: list[Any]
+    _skip_prepare_user_inputs: bool
+    workflow_id: NotRequired[str]
 
 
 @shared_task(queue=AsyncWorkflowQueue.PROFESSIONAL_QUEUE)

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -7,13 +7,13 @@ with appropriate retry policies and error handling.
 
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NotRequired
 
 from celery import shared_task
 from graphon.runtime import GraphRuntimeState
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import TypedDict
 
 from configs import dify_config
 from core.app.apps.workflow.app_generator import SKIP_PREPARE_USER_INPUTS_KEY, WorkflowAppGenerator


### PR DESCRIPTION
Part of #32863

## Summary
- Add `WorkflowGeneratorArgsDict` TypedDict (functional form), annotate `_build_generator_args` return type

## Why this change
`_build_generator_args` builds a fixed 3-key dict (`inputs`, `files`, `_skip_prepare_user_inputs`) typed as `dict[str, Any]`. The TypedDict makes this contract explicit. Functional TypedDict syntax is required because `_skip_prepare_user_inputs` starts with an underscore, which is not valid as a class attribute name.

## Changes
- `api/tasks/async_workflow_tasks.py`: Define `WorkflowGeneratorArgsDict`, annotate `_build_generator_args`

## Test plan
- [x] `ruff check` passes
