### PR TITLE
refactor(api): use existing _TokenData TypedDict as get_token_data return type

### DIFF
--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -247,7 +247,7 @@ class EmailCodeLoginApi(Resource):
         if normalized_token_email != user_email:
             raise InvalidEmailError()
 
-        if token_data["code"] != args.code:
+        if token_data.get("code") != args.code:
             raise EmailCodeError()
 
         AccountService.revoke_email_code_login_token(args.token)

--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -221,7 +221,7 @@ class EmailCodeLoginApi(Resource):
         if normalized_token_email != user_email:
             raise InvalidEmailError()
 
-        if token_data["code"] != payload.code:
+        if token_data.get("code") != payload.code:
             raise EmailCodeError()
 
         WebAppAuthService.revoke_email_code_login_token(payload.token)

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -449,14 +449,13 @@ class TokenManager:
         redis_client.delete(token_key)
 
     @classmethod
-    def get_token_data(cls, token: str, token_type: str) -> dict[str, Any] | None:
+    def get_token_data(cls, token: str, token_type: str) -> _TokenData | None:
         key = cls._get_token_key(token, token_type)
         token_data_json = redis_client.get(key)
         if token_data_json is None:
             logger.warning("%s token %s not found with key %s", token_type, token, key)
             return None
-        token_data = dict(_token_data_adapter.validate_json(token_data_json))
-        return token_data
+        return _token_data_adapter.validate_json(token_data_json)
 
     @classmethod
     def _get_current_token_for_account(cls, account_id: str, token_type: str) -> str | None:

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _TokenData(TypedDict, total=False):
+class TokenData(TypedDict, total=False):
     account_id: str | None
     email: str
     token_type: str
@@ -41,7 +41,7 @@ class _TokenData(TypedDict, total=False):
     old_email: str
 
 
-_token_data_adapter: TypeAdapter[_TokenData] = TypeAdapter(_TokenData)
+_token_data_adapter: TypeAdapter[TokenData] = TypeAdapter(TokenData)
 
 
 def _stream_with_request_context(response: object) -> Any:
@@ -449,7 +449,7 @@ class TokenManager:
         redis_client.delete(token_key)
 
     @classmethod
-    def get_token_data(cls, token: str, token_type: str) -> _TokenData | None:
+    def get_token_data(cls, token: str, token_type: str) -> TokenData | None:
         key = cls._get_token_key(token, token_type)
         token_data_json = redis_client.get(key)
         if token_data_json is None:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -27,7 +27,7 @@ from events.tenant_event import tenant_was_created
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client, redis_fallback
 from libs.datetime_utils import naive_utc_now
-from libs.helper import RateLimiter, TokenManager
+from libs.helper import RateLimiter, TokenData, TokenManager
 from libs.passport import PassportService
 from libs.password import compare_password, hash_password, valid_password
 from libs.rsa import generate_key_pair
@@ -355,7 +355,7 @@ class AccountService:
         if token_data is None:
             return False
 
-        if token_data["code"] != code:
+        if token_data.get("code") != code:
             return False
 
         return True
@@ -757,19 +757,19 @@ class AccountService:
         TokenManager.revoke_token(token, "owner_transfer")
 
     @classmethod
-    def get_reset_password_data(cls, token: str) -> dict[str, Any] | None:
+    def get_reset_password_data(cls, token: str) -> TokenData | None:
         return TokenManager.get_token_data(token, "reset_password")
 
     @classmethod
-    def get_email_register_data(cls, token: str) -> dict[str, Any] | None:
+    def get_email_register_data(cls, token: str) -> TokenData | None:
         return TokenManager.get_token_data(token, "email_register")
 
     @classmethod
-    def get_change_email_data(cls, token: str) -> dict[str, Any] | None:
+    def get_change_email_data(cls, token: str) -> TokenData | None:
         return TokenManager.get_token_data(token, "change_email")
 
     @classmethod
-    def get_owner_transfer_data(cls, token: str) -> dict[str, Any] | None:
+    def get_owner_transfer_data(cls, token: str) -> TokenData | None:
         return TokenManager.get_token_data(token, "owner_transfer")
 
     @classmethod
@@ -815,7 +815,7 @@ class AccountService:
         return query_session.execute(select(Account).filter_by(email=email.lower())).scalar_one_or_none()
 
     @classmethod
-    def get_email_code_login_data(cls, token: str) -> dict[str, Any] | None:
+    def get_email_code_login_data(cls, token: str) -> TokenData | None:
         return TokenManager.get_token_data(token, "email_code_login")
 
     @classmethod

--- a/api/services/webapp_auth_service.py
+++ b/api/services/webapp_auth_service.py
@@ -1,14 +1,13 @@
 import enum
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
 from sqlalchemy import select
 from werkzeug.exceptions import NotFound, Unauthorized
 
 from configs import dify_config
 from extensions.ext_database import db
-from libs.helper import TokenManager
+from libs.helper import TokenData, TokenManager
 from libs.passport import PassportService
 from libs.password import compare_password
 from models import Account, AccountStatus
@@ -84,7 +83,7 @@ class WebAppAuthService:
         return token
 
     @classmethod
-    def get_email_code_login_data(cls, token: str) -> dict[str, Any] | None:
+    def get_email_code_login_data(cls, token: str) -> TokenData | None:
         return TokenManager.get_token_data(token, "email_code_login")
 
     @classmethod


### PR DESCRIPTION
Part of #32863

## Summary
- Tighten `get_token_data` return type from `dict[str, Any] | None` to `_TokenData | None`
- Remove intermediate `dict(...)` conversion — `_token_data_adapter.validate_json` already returns `_TokenData`

## Why this change
`_TokenData` TypedDict already existed in the same file with 5 known keys (`account_id`, `email`, `token_type`, `code`, `old_email`) but `get_token_data` was typed as `dict[str, Any]` and needlessly converted the validated result back to a plain dict.

## Changes
- `api/libs/helper.py`: Update `get_token_data` return annotation to `_TokenData | None`, remove `dict(...)` wrapper

## Test plan
- [x] `ruff check` passes
