### PR TITLE
refactor(api): type DatasourceProviderApiEntity.to_dict with TypedDict

### DIFF
--- a/api/core/datasource/entities/api_entities.py
+++ b/api/core/datasource/entities/api_entities.py
@@ -1,10 +1,10 @@
-from typing import Literal, Optional
+from typing import Any, Literal, Optional, TypedDict
 
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, field_validator
 
 from core.datasource.entities.datasource_entities import DatasourceParameter
-from core.tools.entities.common_entities import I18nObject
+from core.tools.entities.common_entities import I18nObject, I18nObjectDict
 
 
 class DatasourceApiEntity(BaseModel):
@@ -18,6 +18,23 @@ class DatasourceApiEntity(BaseModel):
 
 
 ToolProviderTypeApiLiteral = Optional[Literal["builtin", "api", "workflow"]]
+
+
+class DatasourceProviderApiEntityDict(TypedDict):
+    id: str
+    author: str
+    name: str
+    plugin_id: str | None
+    plugin_unique_identifier: str | None
+    description: I18nObjectDict
+    icon: str | dict
+    label: I18nObjectDict
+    type: str
+    team_credentials: dict | None
+    is_team_authorization: bool
+    allow_delete: bool
+    datasources: list[Any]
+    labels: list[str]
 
 
 class DatasourceProviderApiEntity(BaseModel):
@@ -42,7 +59,7 @@ class DatasourceProviderApiEntity(BaseModel):
     def convert_none_to_empty_list(cls, v):
         return v if v is not None else []
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> DatasourceProviderApiEntityDict:
         # -------------
         # overwrite datasource parameter types for temp fix
         datasources = jsonable_encoder(self.datasources)
@@ -53,7 +70,7 @@ class DatasourceProviderApiEntity(BaseModel):
                         parameter["type"] = "files"
         # -------------
 
-        return {
+        result: DatasourceProviderApiEntityDict = {
             "id": self.id,
             "author": self.author,
             "name": self.name,
@@ -69,3 +86,4 @@ class DatasourceProviderApiEntity(BaseModel):
             "datasources": datasources,
             "labels": self.labels,
         }
+        return result


### PR DESCRIPTION
Part of #32863 (`api/core/datasource/entities/`)

## Summary
- Define `DatasourceProviderApiEntityDict` TypedDict for the return value of `DatasourceProviderApiEntity.to_dict()`
- Use explicit variable annotation pattern for basedpyright compatibility

## Why this change
`DatasourceProviderApiEntity.to_dict()` returned a bare `dict` with 14 fixed keys. Adding a TypedDict makes the return shape explicit, improving editor autocomplete and catching key-name typos at type-check time.

## Changes
- `api/core/datasource/entities/api_entities.py`: Define `DatasourceProviderApiEntityDict`, annotate `to_dict()` return type