### PR TITLE
refactor(api): modernize type annotations — replace Optional/Union with | syntax

### DIFF
--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from graphon.file import File, FileUploadConfig
 from graphon.model_runtime.entities.model_entities import AIModelEntity
@@ -131,7 +131,7 @@ class AppGenerateEntity(BaseModel):
     extras: dict[str, Any] = Field(default_factory=dict)
 
     # tracing instance
-    trace_manager: Optional["TraceQueueManager"] = Field(default=None, exclude=True, repr=False)
+    trace_manager: "TraceQueueManager | None" = Field(default=None, exclude=True, repr=False)
 
 
 class EasyUIBasedAppGenerateEntity(AppGenerateEntity):

--- a/api/core/datasource/entities/api_entities.py
+++ b/api/core/datasource/entities/api_entities.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, TypedDict
+from typing import Any, Literal, TypedDict
 
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, field_validator
@@ -17,7 +17,7 @@ class DatasourceApiEntity(BaseModel):
     output_schema: dict | None = None
 
 
-ToolProviderTypeApiLiteral = Optional[Literal["builtin", "api", "workflow"]]
+ToolProviderTypeApiLiteral = Literal["builtin", "api", "workflow"] | None
 
 
 class DatasourceProviderApiEntityDict(TypedDict):

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -468,9 +468,7 @@ class TokenManager:
         return current_token
 
     @classmethod
-    def _set_current_token_for_account(
-        cls, account_id: str, token: str, token_type: str, expiry_minutes: int | float
-    ):
+    def _set_current_token_for_account(cls, account_id: str, token: str, token_type: str, expiry_minutes: int | float):
         key = cls._get_account_token_key(account_id, token_type)
         expiry_seconds = int(expiry_minutes * 60)
         redis_client.setex(key, expiry_seconds, token)

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -10,7 +10,7 @@ import uuid
 from collections.abc import Callable, Generator, Mapping
 from datetime import datetime
 from hashlib import sha256
-from typing import TYPE_CHECKING, Annotated, Any, Optional, Protocol, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Protocol, cast
 from uuid import UUID
 from zoneinfo import available_timezones
 
@@ -81,7 +81,7 @@ def escape_like_pattern(pattern: str) -> str:
     return pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-def extract_tenant_id(user: Union["Account", "EndUser"]) -> str | None:
+def extract_tenant_id(user: "Account | EndUser") -> str | None:
     """
     Extract tenant_id from Account or EndUser object.
 
@@ -164,7 +164,10 @@ def email(email):
 EmailStr = Annotated[str, AfterValidator(email)]
 
 
-def uuid_value(value: Any) -> str:
+def uuid_value(value: str | UUID) -> str:
+    if isinstance(value, UUID):
+        return str(value)
+
     if value == "":
         return str(value)
 
@@ -405,7 +408,7 @@ class TokenManager:
     def generate_token(
         cls,
         token_type: str,
-        account: Optional["Account"] = None,
+        account: "Account | None" = None,
         email: str | None = None,
         additional_data: dict | None = None,
     ) -> str:
@@ -466,7 +469,7 @@ class TokenManager:
 
     @classmethod
     def _set_current_token_for_account(
-        cls, account_id: str, token: str, token_type: str, expiry_minutes: Union[int, float]
+        cls, account_id: str, token: str, token_type: str, expiry_minutes: int | float
     ):
         key = cls._get_account_token_key(account_id, token_type)
         expiry_seconds = int(expiry_minutes * 60)


### PR DESCRIPTION
Part of: https://github.com/langgenius/dify/issues/34878Part of: https://github.com/langgenius/dify/issues/34878

## Summary
- Replace `Optional["TenantAccountRole"]` with `TenantAccountRole | None` across `TokenManager.generate_token`
- Replace `Union["Account", "EndUser"]` with `Account | EndUser` in `extract_tenant_id`
- Replace `Union[int, float]` with `int | float` in `TokenManager._set_current_token_for_account`
- Tighten `uuid_value(value: Any)` to `uuid_value(value: str | UUID)` with early return for `UUID` input
- Replace `Optional[Literal[...]]` with `Literal[...] | None` in `ToolProviderTypeApiLiteral`
- Replace `Optional["TraceQueueManager"]` with `TraceQueueManager | None` in `AppGenerateEntity`
- Remove unused `Optional` and `Union` imports from all three files

## Why this change
Python 3.10+ `X | None` syntax supersedes `Optional[X]` and `Union[X, Y]`. The rest of the codebase already uses `| None` — these were leftovers.

`uuid_value` accepted `Any` but only `str` and `UUID` are valid inputs (`uuid.UUID()` accepts `str | bytes | int`, and callers pass `str | UUID` via `normalize_uuid`). The `Any` hid a type mismatch where `UUID` was passed directly to `uuid.UUID()` which doesn't accept `UUID` objects.

## Changes
- `libs/helper.py`: Tighten `uuid_value` param type, replace `Optional`/`Union` with `|`, remove imports
- `core/datasource/entities/api_entities.py`: Replace `Optional[Literal[...]]`, remove `Optional` import
- `core/app/entities/app_invoke_entities.py`: Replace `Optional["TraceQueueManager"]`, remove `Optional` import

## Test plan
- [x] `basedpyright` passes
- [x] `ruff check` passes
