### PR TITLE
refactor(mcp): remove unused AnyFunction alias, tighten callback type

### DIFF
--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -55,7 +55,7 @@ class RequestResponder[ReceiveRequestT: ClientRequest | ServerRequest, SendResul
 
     request: ReceiveRequestT
     _session: "BaseSession[Any, Any, SendResultT, ReceiveRequestT, Any]"
-    _on_complete: Callable[["RequestResponder[ReceiveRequestT, SendResultT]"], Any]
+    _on_complete: Callable[["RequestResponder[ReceiveRequestT, SendResultT]"], object]
 
     def __init__(
         self,
@@ -63,7 +63,7 @@ class RequestResponder[ReceiveRequestT: ClientRequest | ServerRequest, SendResul
         request_meta: RequestParams.Meta | None,
         request: ReceiveRequestT,
         session: "BaseSession[Any, Any, SendResultT, ReceiveRequestT, Any]",
-        on_complete: Callable[["RequestResponder[ReceiveRequestT, SendResultT]"], Any],
+        on_complete: Callable[["RequestResponder[ReceiveRequestT, SendResultT]"], object],
     ):
         self.request_id = request_id
         self.request_meta = request_meta

--- a/api/core/mcp/types.py
+++ b/api/core/mcp/types.py
@@ -31,7 +31,6 @@ ProgressToken = str | int
 Cursor = str
 Role = Literal["user", "assistant"]
 RequestId = Annotated[int | str, Field(union_mode="left_to_right")]
-type AnyFunction = Callable[..., Any]
 
 
 class RequestParams(BaseModel):


### PR DESCRIPTION
Part of: https://github.com/langgenius/dify/issues/34878Part of: https://github.com/langgenius/dify/issues/34878

## Summary
- Remove unused `type AnyFunction = Callable[..., Any]` alias from `types.py`
- Narrow `_on_complete` callback return type from `Any` to `object` in `RequestResponder`

## Why this change
`AnyFunction` was defined but never imported anywhere in the codebase — dead code.

`_on_complete` callback's return value is always discarded (called as a statement on line 90, never captured). `Any` disables type checking on the return; `object` correctly says "returns something we don't use."

## Changes
- `core/mcp/types.py`: Remove dead `AnyFunction` type alias
- `core/mcp/session/base_session.py`: `Callable[..., Any]` → `Callable[..., object]` on `_on_complete`

## Test plan
- [x] `basedpyright` passes
- [x] `ruff check` passes
- [x] 383 MCP unit tests pass
