### PR TITLE
refactor(api): replace Optional/Union with | syntax, remove dead AnyFunction

### DIFF
--- a/api/core/mcp/types.py
+++ b/api/core/mcp/types.py
@@ -31,7 +31,6 @@ ProgressToken = str | int
 Cursor = str
 Role = Literal["user", "assistant"]
 RequestId = Annotated[int | str, Field(union_mode="left_to_right")]
-type AnyFunction = Callable[..., Any]
 
 
 class RequestParams(BaseModel):

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Generator, Mapping
 from os import listdir, path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Literal, Optional, Protocol, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 import sqlalchemy as sa
 from graphon.runtime import VariablePool
@@ -100,7 +100,7 @@ class ToolManager:
     _builtin_provider_lock = Lock()
     _hardcoded_providers: dict[str, BuiltinToolProviderController] = {}
     _builtin_providers_loaded = False
-    _builtin_tools_labels: dict[str, Union[I18nObject, None]] = {}
+    _builtin_tools_labels: dict[str, I18nObject | None] = {}
 
     @classmethod
     def get_hardcoded_provider(cls, provider: str) -> BuiltinToolProviderController:
@@ -190,7 +190,7 @@ class ToolManager:
         invoke_from: InvokeFrom = InvokeFrom.DEBUGGER,
         tool_invoke_from: ToolInvokeFrom = ToolInvokeFrom.AGENT,
         credential_id: str | None = None,
-    ) -> Union[BuiltinTool, PluginTool, ApiTool, WorkflowTool, MCPTool]:
+    ) -> BuiltinTool | PluginTool | ApiTool | WorkflowTool | MCPTool:
         """
         get the tool runtime
 
@@ -398,7 +398,7 @@ class ToolManager:
         agent_tool: AgentToolEntity,
         user_id: str | None = None,
         invoke_from: InvokeFrom = InvokeFrom.DEBUGGER,
-        variable_pool: Optional["VariablePool"] = None,
+        variable_pool: "VariablePool | None" = None,
     ) -> Tool:
         """
         get the agent tool runtime
@@ -442,7 +442,7 @@ class ToolManager:
         workflow_tool: WorkflowToolRuntimeSpec,
         user_id: str | None = None,
         invoke_from: InvokeFrom = InvokeFrom.DEBUGGER,
-        variable_pool: Optional["VariablePool"] = None,
+        variable_pool: "VariablePool | None" = None,
     ) -> Tool:
         """
         get the workflow tool runtime
@@ -634,7 +634,7 @@ class ToolManager:
         cls._builtin_providers_loaded = False
 
     @classmethod
-    def get_tool_label(cls, tool_name: str) -> Union[I18nObject, None]:
+    def get_tool_label(cls, tool_name: str) -> I18nObject | None:
         """
         get the tool label
 
@@ -1052,7 +1052,7 @@ class ToolManager:
     def _convert_tool_parameters_type(
         cls,
         parameters: list[ToolParameter],
-        variable_pool: Optional["VariablePool"],
+        variable_pool: "VariablePool | None",
         tool_configurations: Mapping[str, Any],
         typ: Literal["agent", "workflow", "tool"] = "workflow",
     ) -> dict[str, Any]:

--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Generator, Mapping, Sequence
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, cast
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -121,7 +121,7 @@ class WorkflowType(StrEnum):
         raise ValueError(f"invalid workflow type value {value}")
 
     @classmethod
-    def from_app_mode(cls, app_mode: Union[str, "AppMode"]) -> "WorkflowType":
+    def from_app_mode(cls, app_mode: "str | AppMode") -> "WorkflowType":
         """
         Get workflow type from app mode.
 
@@ -1051,7 +1051,7 @@ class WorkflowNodeExecutionModel(Base):  # This model is expected to have `offlo
                     )
         return extras
 
-    def _get_offload_by_type(self, type_: ExecutionOffLoadType) -> Optional["WorkflowNodeExecutionOffload"]:
+    def _get_offload_by_type(self, type_: ExecutionOffLoadType) -> "WorkflowNodeExecutionOffload | None":
         return next(iter([i for i in self.offload_data if i.type_ == type_]), None)
 
     @property


### PR DESCRIPTION
Part of: https://github.com/langgenius/dify/issues/34878

## Summary
- Replace `Optional["VariablePool"]` with `VariablePool | None` in `tool_manager.py` (4 occurrences)
- Replace `Union[I18nObject, None]` with `I18nObject | None` and `Union[BuiltinTool, ...]` with `|` syntax in `tool_manager.py`
- Replace `Union[str, "AppMode"]` with `str | AppMode` in `workflow.py`
- Replace `Optional["WorkflowNodeExecutionOffload"]` with `WorkflowNodeExecutionOffload | None` in `workflow.py`
- Remove unused `Optional`, `Union` imports
- Remove dead `type AnyFunction = Callable[..., Any]` from `mcp/types.py` (defined but never imported)

## Why this change
Python 3.10+ `X | Y` syntax supersedes `Optional[X]` and `Union[X, Y]`. The rest of the codebase already uses `|` — these were leftovers.

`AnyFunction` in `mcp/types.py` was defined but never imported anywhere — dead code.

## Changes
- `core/tools/tool_manager.py`: Replace `Optional`/`Union` with `|`, remove unused imports
- `models/workflow.py`: Replace `Union`/`Optional` with `|`, remove unused `Union` import
- `core/mcp/types.py`: Remove dead `AnyFunction` alias

## Test plan
- [x] `basedpyright` passes
- [x] `ruff check` passes
