### PR TITLE
refactor(services): replace Union with | syntax in service layer

### DIFF
--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import uuid
 from collections.abc import Callable, Generator, Mapping
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from configs import dify_config
 from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
@@ -88,7 +88,7 @@ class AppGenerateService:
     def generate(
         cls,
         app_model: App,
-        user: Union[Account, EndUser],
+        user: Account | EndUser,
         args: Mapping[str, Any],
         invoke_from: InvokeFrom,
         streaming: bool = True,
@@ -356,11 +356,11 @@ class AppGenerateService:
     def generate_more_like_this(
         cls,
         app_model: App,
-        user: Union[Account, EndUser],
+        user: Account | EndUser,
         message_id: str,
         invoke_from: InvokeFrom,
         streaming: bool = True,
-    ) -> Union[Mapping, Generator]:
+    ) -> Mapping | Generator:
         """
         Generate more like this
         :param app_model: app model

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -5,7 +5,7 @@ import uuid
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager, suppress
 from tempfile import NamedTemporaryFile
-from typing import Literal, Union
+from typing import Literal
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from graphon.file import helpers as file_helpers
@@ -52,7 +52,7 @@ class FileService:
         filename: str,
         content: bytes,
         mimetype: str,
-        user: Union[Account, EndUser],
+        user: Account | EndUser,
         source: Literal["datasets"] | None = None,
         source_url: str = "",
     ) -> UploadFile:

--- a/api/services/rag_pipeline/pipeline_generate_service.py
+++ b/api/services/rag_pipeline/pipeline_generate_service.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, Union
+from typing import Any
 
 from configs import dify_config
 from core.app.apps.pipeline.pipeline_generator import PipelineGenerator
@@ -17,7 +17,7 @@ class PipelineGenerateService:
     def generate(
         cls,
         pipeline: Pipeline,
-        user: Union[Account, EndUser],
+        user: Account | EndUser,
         args: Mapping[str, Any],
         invoke_from: InvokeFrom,
         streaming: bool = True,


### PR DESCRIPTION
## Summary
- Replace `Union[Account, EndUser]` with `Account | EndUser` in `app_generate_service.py` (2 occurrences)
- Replace `Union[Mapping, Generator]` with `Mapping | Generator` in `app_generate_service.py`
- Replace `Union[Account, EndUser]` with `Account | EndUser` in `file_service.py`
- Replace `Union[Account, EndUser]` with `Account | EndUser` in `pipeline_generate_service.py`
- Remove unused `Union` imports from all three files

## Why this change
Python 3.10+ `X | Y` syntax supersedes `Union[X, Y]`. The rest of the codebase already uses `|` — these were leftovers in the service layer.

## Changes
- `services/app_generate_service.py`: Replace `Union` with `|`, remove unused import
- `services/file_service.py`: Replace `Union` with `|`, remove unused import
- `services/rag_pipeline/pipeline_generate_service.py`: Replace `Union` with `|`, remove unused import

## Test plan
- [x] `basedpyright` passes
- [x] `mypy` passes (1387 source files)
- [x] `ruff check` passes
