### PR TITLE
refactor: replace inline api.model response schemas with register_schema_models in activate

### DIFF
--- a/api/controllers/console/auth/activate.py
+++ b/api/controllers/console/auth/activate.py
@@ -47,9 +47,7 @@ class ActivationResponse(BaseModel):
     result: str = Field(description="Operation result")
 
 
-register_schema_models(
-    console_ns, ActivateCheckQuery, ActivatePayload, ActivationCheckResponse, ActivationResponse
-)
+register_schema_models(console_ns, ActivateCheckQuery, ActivatePayload, ActivationCheckResponse, ActivationResponse)
 
 
 @console_ns.route("/activate/check")

--- a/api/controllers/console/auth/activate.py
+++ b/api/controllers/console/auth/activate.py
@@ -38,7 +38,18 @@ class ActivatePayload(BaseModel):
         return timezone(value)
 
 
-register_schema_models(console_ns, ActivateCheckQuery, ActivatePayload)
+class ActivationCheckResponse(BaseModel):
+    is_valid: bool = Field(description="Whether token is valid")
+    data: dict | None = Field(default=None, description="Activation data if valid")
+
+
+class ActivationResponse(BaseModel):
+    result: str = Field(description="Operation result")
+
+
+register_schema_models(
+    console_ns, ActivateCheckQuery, ActivatePayload, ActivationCheckResponse, ActivationResponse
+)
 
 
 @console_ns.route("/activate/check")
@@ -46,6 +57,11 @@ class ActivateCheckApi(Resource):
     @console_ns.doc("check_activation_token")
     @console_ns.doc(description="Check if activation token is valid")
     @console_ns.expect(console_ns.models[ActivateCheckQuery.__name__])
+    @console_ns.response(
+        200,
+        "Success",
+        console_ns.models[ActivationCheckResponse.__name__],
+    )
     def get(self):
         args = ActivateCheckQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
 
@@ -79,6 +95,11 @@ class ActivateApi(Resource):
     @console_ns.doc("activate_account")
     @console_ns.doc(description="Activate account with invitation token")
     @console_ns.expect(console_ns.models[ActivatePayload.__name__])
+    @console_ns.response(
+        200,
+        "Account activated successfully",
+        console_ns.models[ActivationResponse.__name__],
+    )
     @console_ns.response(400, "Already activated or invalid token")
     def post(self):
         args = ActivatePayload.model_validate(console_ns.payload)

--- a/api/controllers/console/auth/activate.py
+++ b/api/controllers/console/auth/activate.py
@@ -1,8 +1,9 @@
 from flask import request
-from flask_restx import Resource, fields
+from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
 
 from constants.languages import supported_language
+from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
 from controllers.console.error import AlreadyActivateError
 from extensions.ext_database import db
@@ -10,8 +11,6 @@ from libs.datetime_utils import naive_utc_now
 from libs.helper import EmailStr, timezone
 from models import AccountStatus
 from services.account_service import RegisterService
-
-DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
 
 
 class ActivateCheckQuery(BaseModel):
@@ -39,8 +38,7 @@ class ActivatePayload(BaseModel):
         return timezone(value)
 
 
-for model in (ActivateCheckQuery, ActivatePayload):
-    console_ns.schema_model(model.__name__, model.model_json_schema(ref_template=DEFAULT_REF_TEMPLATE_SWAGGER_2_0))
+register_schema_models(console_ns, ActivateCheckQuery, ActivatePayload)
 
 
 @console_ns.route("/activate/check")
@@ -48,17 +46,6 @@ class ActivateCheckApi(Resource):
     @console_ns.doc("check_activation_token")
     @console_ns.doc(description="Check if activation token is valid")
     @console_ns.expect(console_ns.models[ActivateCheckQuery.__name__])
-    @console_ns.response(
-        200,
-        "Success",
-        console_ns.model(
-            "ActivationCheckResponse",
-            {
-                "is_valid": fields.Boolean(description="Whether token is valid"),
-                "data": fields.Raw(description="Activation data if valid"),
-            },
-        ),
-    )
     def get(self):
         args = ActivateCheckQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
 
@@ -92,16 +79,6 @@ class ActivateApi(Resource):
     @console_ns.doc("activate_account")
     @console_ns.doc(description="Activate account with invitation token")
     @console_ns.expect(console_ns.models[ActivatePayload.__name__])
-    @console_ns.response(
-        200,
-        "Account activated successfully",
-        console_ns.model(
-            "ActivationResponse",
-            {
-                "result": fields.String(description="Operation result"),
-            },
-        ),
-    )
     @console_ns.response(400, "Already activated or invalid token")
     def post(self):
         args = ActivatePayload.model_validate(console_ns.payload)


### PR DESCRIPTION
Part of #28015

## Summary

Remove inline `console_ns.model()` response schema definitions from `@console_ns.response()` decorators. Use `register_schema_models()` instead of manual `schema_model()` calls. Remove unused `fields` import and `DEFAULT_REF_TEMPLATE_SWAGGER_2_0` constant.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
