### PR TITLE
fix(#34636): replace SimpleNamespace with typed mocks in 4 controllers tests 🤖🤖🤖

### DIFF
--- a/api/tests/unit_tests/controllers/files/test_image_preview.py
+++ b/api/tests/unit_tests/controllers/files/test_image_preview.py
@@ -14,13 +14,14 @@ def unwrap(func):
 
 
 @pytest.fixture(autouse=True)
-def mock_db():
+def mock_db(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    Replace Flask-SQLAlchemy db with a plain object
-    to avoid touching Flask app context entirely.
+    Replace Flask-SQLAlchemy db with a plain object to avoid touching Flask app context
+    entirely. monkeypatch.setattr is used so pytest restores the original attribute after
+    the test, and so the type of ``module.db`` is not statically constrained by the fake.
     """
     fake_db = types.SimpleNamespace(engine=object())
-    module.db = fake_db
+    monkeypatch.setattr(module, "db", fake_db)
 
 
 class DummyUploadFile:
@@ -38,13 +39,17 @@ def fake_request(args: dict):
 
 class TestImagePreviewApi:
     @patch.object(module, "FileService")
-    def test_success(self, mock_file_service):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-            }
+    def test_success(self, mock_file_service, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                }
+            ),
         )
 
         generator = iter([b"img"])
@@ -61,13 +66,17 @@ class TestImagePreviewApi:
         assert response.mimetype == "image/png"
 
     @patch.object(module, "FileService")
-    def test_unsupported_file_type(self, mock_file_service):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-            }
+    def test_unsupported_file_type(self, mock_file_service, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                }
+            ),
         )
 
         mock_file_service.return_value.get_image_preview.side_effect = (
@@ -84,14 +93,18 @@ class TestImagePreviewApi:
 class TestFilePreviewApi:
     @patch.object(module, "enforce_download_for_html")
     @patch.object(module, "FileService")
-    def test_basic_stream(self, mock_file_service, mock_enforce):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": False,
-            }
+    def test_basic_stream(self, mock_file_service, mock_enforce, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": False,
+                }
+            ),
         )
 
         generator = iter([b"data"])
@@ -114,14 +127,18 @@ class TestFilePreviewApi:
 
     @patch.object(module, "enforce_download_for_html")
     @patch.object(module, "FileService")
-    def test_as_attachment(self, mock_file_service, mock_enforce):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": True,
-            }
+    def test_as_attachment(self, mock_file_service, mock_enforce, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": True,
+                }
+            ),
         )
 
         generator = iter([b"data"])
@@ -146,14 +163,18 @@ class TestFilePreviewApi:
         mock_enforce.assert_called_once()
 
     @patch.object(module, "FileService")
-    def test_unsupported_file_type(self, mock_file_service):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": False,
-            }
+    def test_unsupported_file_type(self, mock_file_service, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": False,
+                }
+            ),
         )
 
         mock_file_service.return_value.get_file_generator_by_file_id.side_effect = (

--- a/api/tests/unit_tests/controllers/files/test_tool_files.py
+++ b/api/tests/unit_tests/controllers/files/test_tool_files.py
@@ -24,12 +24,6 @@ class DummyToolFile:
         self.filename = filename
 
 
-@pytest.fixture(autouse=True)
-def mock_global_db():
-    fake_db = types.SimpleNamespace(engine=object())
-    module.global_db = fake_db
-
-
 class TestToolFileApi:
     @patch.object(module, "verify_tool_file_signature", return_value=True)
     @patch.object(module, "ToolFileManager")
@@ -37,14 +31,19 @@ class TestToolFileApi:
         self,
         mock_tool_file_manager,
         mock_verify,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": False,
-            }
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": False,
+                }
+            ),
         )
 
         stream = iter([b"data"])
@@ -75,14 +74,19 @@ class TestToolFileApi:
         self,
         mock_tool_file_manager,
         mock_verify,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": True,
-            }
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": True,
+                }
+            ),
         )
 
         stream = iter([b"data"])
@@ -105,14 +109,18 @@ class TestToolFileApi:
         mock_verify.assert_called_once()
 
     @patch.object(module, "verify_tool_file_signature", return_value=False)
-    def test_invalid_signature(self, mock_verify):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "bad-sig",
-                "as_attachment": False,
-            }
+    def test_invalid_signature(self, mock_verify, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "bad-sig",
+                    "as_attachment": False,
+                }
+            ),
         )
 
         api = module.ToolFileApi()
@@ -127,14 +135,19 @@ class TestToolFileApi:
         self,
         mock_tool_file_manager,
         mock_verify,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": False,
-            }
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": False,
+                }
+            ),
         )
 
         mock_tool_file_manager.return_value.get_file_generator_by_tool_file_id.return_value = (
@@ -154,14 +167,19 @@ class TestToolFileApi:
         self,
         mock_tool_file_manager,
         mock_verify,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "as_attachment": False,
-            }
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "as_attachment": False,
+                }
+            ),
         )
 
         mock_tool_file_manager.return_value.get_file_generator_by_tool_file_id.side_effect = Exception("boom")

--- a/api/tests/unit_tests/controllers/files/test_upload.py
+++ b/api/tests/unit_tests/controllers/files/test_upload.py
@@ -57,18 +57,23 @@ class TestPluginUploadFileApi:
         mock_tool_file_manager,
         mock_get_user,
         mock_verify_signature,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         dummy_file = DummyFile()
 
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "tenant_id": "tenant-1",
-                "user_id": "user-1",
-            },
-            file=dummy_file,
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "tenant_id": "tenant-1",
+                    "user_id": "user-1",
+                },
+                file=dummy_file,
+            ),
         )
 
         tool_file_manager_instance = mock_tool_file_manager.return_value
@@ -85,15 +90,19 @@ class TestPluginUploadFileApi:
         assert result["id"] == "file-id"
         assert result["preview_url"] == "signed-url"
 
-    def test_missing_file(self):
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "tenant_id": "tenant-1",
-                "user_id": "user-1",
-            }
+    def test_missing_file(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "tenant_id": "tenant-1",
+                    "user_id": "user-1",
+                }
+            ),
         )
 
         api = module.PluginUploadFileApi()
@@ -104,18 +113,22 @@ class TestPluginUploadFileApi:
 
     @patch.object(module, "get_user", return_value=DummyUser())
     @patch.object(module, "verify_plugin_file_signature", return_value=False)
-    def test_invalid_signature(self, mock_verify, mock_get_user):
+    def test_invalid_signature(self, mock_verify, mock_get_user, monkeypatch: pytest.MonkeyPatch):
         dummy_file = DummyFile()
 
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "bad",
-                "tenant_id": "tenant-1",
-                "user_id": "user-1",
-            },
-            file=dummy_file,
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "bad",
+                    "tenant_id": "tenant-1",
+                    "user_id": "user-1",
+                },
+                file=dummy_file,
+            ),
         )
 
         api = module.PluginUploadFileApi()
@@ -132,18 +145,23 @@ class TestPluginUploadFileApi:
         mock_tool_file_manager,
         mock_verify,
         mock_get_user,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         dummy_file = DummyFile()
 
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "tenant_id": "tenant-1",
-                "user_id": "user-1",
-            },
-            file=dummy_file,
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "tenant_id": "tenant-1",
+                    "user_id": "user-1",
+                },
+                file=dummy_file,
+            ),
         )
 
         mock_tool_file_manager.return_value.create_file_by_raw.side_effect = (
@@ -164,18 +182,23 @@ class TestPluginUploadFileApi:
         mock_tool_file_manager,
         mock_verify,
         mock_get_user,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         dummy_file = DummyFile()
 
-        module.request = fake_request(
-            {
-                "timestamp": "123",
-                "nonce": "abc",
-                "sign": "sig",
-                "tenant_id": "tenant-1",
-                "user_id": "user-1",
-            },
-            file=dummy_file,
+        monkeypatch.setattr(
+            module,
+            "request",
+            fake_request(
+                {
+                    "timestamp": "123",
+                    "nonce": "abc",
+                    "sign": "sig",
+                    "tenant_id": "tenant-1",
+                    "user_id": "user-1",
+                },
+                file=dummy_file,
+            ),
         )
 
         mock_tool_file_manager.return_value.create_file_by_raw.side_effect = (

--- a/api/tests/unit_tests/controllers/web/test_workflow_events.py
+++ b/api/tests/unit_tests/controllers/web/test_workflow_events.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,14 +10,34 @@ from flask import Flask
 from controllers.web.error import NotFoundError
 from controllers.web.workflow_events import WorkflowEventsApi
 from models.enums import CreatorUserRole
+from models.model import App, EndUser
+from models.workflow import WorkflowRun
 
 
-def _workflow_app() -> SimpleNamespace:
-    return SimpleNamespace(id="app-1", tenant_id="tenant-1", mode="workflow")
+def _workflow_app() -> App:
+    app = MagicMock(spec=App)
+    app.id = "app-1"
+    app.tenant_id = "tenant-1"
+    app.mode = "workflow"
+    return app
 
 
-def _end_user() -> SimpleNamespace:
-    return SimpleNamespace(id="eu-1")
+def _end_user() -> EndUser:
+    end_user = MagicMock(spec=EndUser)
+    end_user.id = "eu-1"
+    return end_user
+
+
+def _workflow_run(**overrides: object) -> WorkflowRun:
+    run = MagicMock(spec=WorkflowRun)
+    run.id = "run-1"
+    run.app_id = "app-1"
+    run.created_by_role = CreatorUserRole.END_USER
+    run.created_by = "eu-1"
+    run.finished_at = None
+    for key, value in overrides.items():
+        setattr(run, key, value)
+    return run
 
 
 # ---------------------------------------------------------------------------
@@ -41,13 +60,7 @@ class TestWorkflowEventsApi:
     @patch("controllers.web.workflow_events.db")
     def test_workflow_run_wrong_app(self, mock_db: MagicMock, mock_factory: MagicMock, app: Flask) -> None:
         mock_db.engine = "engine"
-        run = SimpleNamespace(
-            id="run-1",
-            app_id="other-app",
-            created_by_role=CreatorUserRole.END_USER,
-            created_by="eu-1",
-            finished_at=None,
-        )
+        run = _workflow_run(app_id="other-app")
         mock_repo = MagicMock()
         mock_repo.get_workflow_run_by_id_and_tenant_id.return_value = run
         mock_factory.create_api_workflow_run_repository.return_value = mock_repo
@@ -62,13 +75,7 @@ class TestWorkflowEventsApi:
         self, mock_db: MagicMock, mock_factory: MagicMock, app: Flask
     ) -> None:
         mock_db.engine = "engine"
-        run = SimpleNamespace(
-            id="run-1",
-            app_id="app-1",
-            created_by_role=CreatorUserRole.ACCOUNT,
-            created_by="eu-1",
-            finished_at=None,
-        )
+        run = _workflow_run(created_by_role=CreatorUserRole.ACCOUNT)
         mock_repo = MagicMock()
         mock_repo.get_workflow_run_by_id_and_tenant_id.return_value = run
         mock_factory.create_api_workflow_run_repository.return_value = mock_repo
@@ -81,13 +88,7 @@ class TestWorkflowEventsApi:
     @patch("controllers.web.workflow_events.db")
     def test_workflow_run_wrong_end_user(self, mock_db: MagicMock, mock_factory: MagicMock, app: Flask) -> None:
         mock_db.engine = "engine"
-        run = SimpleNamespace(
-            id="run-1",
-            app_id="app-1",
-            created_by_role=CreatorUserRole.END_USER,
-            created_by="other-user",
-            finished_at=None,
-        )
+        run = _workflow_run(created_by="other-user")
         mock_repo = MagicMock()
         mock_repo.get_workflow_run_by_id_and_tenant_id.return_value = run
         mock_factory.create_api_workflow_run_repository.return_value = mock_repo
@@ -105,13 +106,7 @@ class TestWorkflowEventsApi:
         from datetime import datetime
 
         mock_db.engine = "engine"
-        run = SimpleNamespace(
-            id="run-1",
-            app_id="app-1",
-            created_by_role=CreatorUserRole.END_USER,
-            created_by="eu-1",
-            finished_at=datetime(2024, 1, 1),
-        )
+        run = _workflow_run(finished_at=datetime(2024, 1, 1))
         mock_repo = MagicMock()
         mock_repo.get_workflow_run_by_id_and_tenant_id.return_value = run
         mock_factory.create_api_workflow_run_repository.return_value = mock_repo


### PR DESCRIPTION
Fixes part of #34636.

## Summary

Replaces `SimpleNamespace` test doubles with typed alternatives in four controllers test files, clearing **26** of the ~616 remaining `pyrefly` `SimpleNamespace is not assignable` errors.

| File | Errors (was → is) | Approach |
|---|---|---|
| `api/tests/unit_tests/controllers/files/test_image_preview.py` | 6 → 0 | `monkeypatch.setattr` for module-level `db` / `request` |
| `api/tests/unit_tests/controllers/files/test_tool_files.py` | 5 → 0 | `monkeypatch.setattr` for `request`; dead `global_db` fixture removed |
| `api/tests/unit_tests/controllers/files/test_upload.py` | 5 → 0 | `monkeypatch.setattr` for `request` |
| `api/tests/unit_tests/controllers/web/test_workflow_events.py` | 10 → 0 | `MagicMock(spec=App \| EndUser \| WorkflowRun)` test doubles |
| **Total** | **26 → 0** | |

Context: see the [shared-workload recap](https://github.com/langgenius/dify/issues/34636#issuecomment-4225877845) on the issue. This batch is coordinated with #34659 (merged), #34779, #34864, #34866, and my open #34872 — no file overlap.

## Approach per file

### `test_image_preview.py`, `test_tool_files.py`, `test_upload.py`

These tests monkey-patch Flask's module-level `request` (a `LocalProxy[Request]`) and `db` (a `SQLAlchemy`) with a `SimpleNamespace`, which triggers `bad-assignment` errors because direct attribute assignment is statically checked against the target's declared type.

Switching to `monkeypatch.setattr(module, "request", fake_request(...))` fixes this in the simplest way: `MonkeyPatch.setattr` is typed as `value: Any` at the call site, so pyrefly no longer widens the error into the assignment. As a side benefit:

- **Test isolation improves** — pytest now restores the original attribute after each test, which the previous direct-assignment pattern did not do.
- **Fixture leakage is gone** — the old `module.request = fake_request(...)` inside test bodies would have leaked into subsequent tests run in the same process if any assertion raised between the assignment and the test's end.
- **No production code changes** — only test plumbing.

The `fake_request(...)` / `DummyUploadFile` / `DummyFile` helpers are kept as-is — they're perfectly valid test doubles; only the *way they get attached to the module* changes.

In `test_tool_files.py`, I also removed the `mock_global_db` autouse fixture. It patched `module.global_db = types.SimpleNamespace(engine=object())`, but `controllers.files.tool_files` imports neither `db` nor `global_db`, and nothing in the controller references `global_db`. The fixture was a silent no-op — it never guarded any test behaviour. Grep confirms:

```
$ grep -rn 'global_db' api/controllers/
(no matches)
```

Removing it eliminates one SimpleNamespace occurrence with zero behavioural impact.

### `test_workflow_events.py`

Here the `SimpleNamespace` fakes are passed as method arguments to `WorkflowEventsApi().get(app_model: App, end_user: EndUser, task_id: str)`, and as the return value of the repository which the controller later treats as a `WorkflowRun`. This is exactly the pattern that @iamPulakesh fixed in #34659, so I used the same approach: `MagicMock(spec=App)`, `MagicMock(spec=EndUser)`, and `MagicMock(spec=WorkflowRun)` with attributes set via `.attr = value`.

I also extracted a small `_workflow_run(**overrides)` helper to centralise the default run-fake setup — the previous code duplicated the same 6-line `SimpleNamespace(id="run-1", app_id="app-1", ...)` block across four test methods and each one only tweaked a single field.

## Verification (local)

Commit: `385c520290` off `upstream/main@b3aebb71ff`.

**1. `pyrefly` on the four files — before vs after**

```
$ uv run --dev pyrefly check \
    tests/unit_tests/controllers/files/test_image_preview.py \
    tests/unit_tests/controllers/files/test_tool_files.py \
    tests/unit_tests/controllers/files/test_upload.py \
    tests/unit_tests/controllers/web/test_workflow_events.py
 INFO 0 errors
```

Before: 26 `SimpleNamespace` errors across the four files (counted from `uv run --dev pyrefly check` against `main@b3aebb71ff`).

**2. `pytest` on the four files**

```
$ uv run --dev pytest tests/unit_tests/controllers/files/test_image_preview.py \
    tests/unit_tests/controllers/files/test_tool_files.py \
    tests/unit_tests/controllers/files/test_upload.py \
    tests/unit_tests/controllers/web/test_workflow_events.py
...
23 passed, 2 warnings in 4.54s
```

**3. Broader sanity check — full `unit_tests/controllers` suite**

```
$ uv run --dev pytest tests/unit_tests/controllers/ -q
...
2024 passed, 23 warnings in 61.43s
```

**4. `ruff format --check` and `ruff check`**

```
$ uv run --project api --dev ruff format --check <files>
4 files already formatted

$ uv run --project api --dev ruff check <files>
All checks passed!
```

## Non-goals

- Not touching the ~82 other files still affected by #34636 — those are listed in the [recap comment](https://github.com/langgenius/dify/issues/34636#issuecomment-4225877845) and are up for grabs.
- No production code changes — test plumbing only.

🤖🤖🤖
