### PR TITLE
refactor(api): type DatasourceInvokeMeta.to_dict with TypedDict

### DIFF
--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from yarl import URL
@@ -179,6 +179,12 @@ class DatasourceProviderEntityWithPlugin(DatasourceProviderEntity):
     datasources: list[DatasourceEntity] = Field(default_factory=list)
 
 
+class DatasourceInvokeMetaDict(TypedDict):
+    time_cost: float
+    error: str | None
+    tool_config: dict[str, Any] | None
+
+
 class DatasourceInvokeMeta(BaseModel):
     """
     Datasource invoke meta
@@ -202,12 +208,13 @@ class DatasourceInvokeMeta(BaseModel):
         """
         return cls(time_cost=0.0, error=error, tool_config={})
 
-    def to_dict(self) -> dict:
-        return {
+    def to_dict(self) -> DatasourceInvokeMetaDict:
+        result: DatasourceInvokeMetaDict = {
             "time_cost": self.time_cost,
             "error": self.error,
             "tool_config": self.tool_config,
         }
+        return result
 
 
 class DatasourceLabel(BaseModel):


### PR DESCRIPTION
Part of #32863 (`api/core/datasource/entities/`)

## Summary
- Define `DatasourceInvokeMetaDict` TypedDict for `DatasourceInvokeMeta.to_dict()` return type
- Replace bare `dict` return annotation with the new TypedDict

## Why this change
`DatasourceInvokeMeta.to_dict()` returned an untyped bare `dict`, losing the structure of its three fixed keys (`time_cost`, `error`, `tool_config`). A TypedDict makes the return shape explicit and enables downstream type checking.

## Changes
- `api/core/datasource/entities/datasource_entities.py`: Define `DatasourceInvokeMetaDict`, annotate `DatasourceInvokeMeta.to_dict`