### PR TITLE
refactor(api): type ToolInvokeMeta.to_dict with TypedDict

### DIFF
--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -450,6 +450,12 @@ class WorkflowToolParameterConfiguration(BaseModel):
     form: ToolParameter.ToolParameterForm = Field(..., description="The form of the parameter")
 
 
+class ToolInvokeMetaDict(TypedDict):
+    time_cost: float
+    error: str | None
+    tool_config: dict[str, Any] | None
+
+
 class ToolInvokeMeta(BaseModel):
     """
     Tool invoke meta
@@ -473,12 +479,13 @@ class ToolInvokeMeta(BaseModel):
         """
         return cls(time_cost=0.0, error=error, tool_config={})
 
-    def to_dict(self):
-        return {
+    def to_dict(self) -> ToolInvokeMetaDict:
+        result: ToolInvokeMetaDict = {
             "time_cost": self.time_cost,
             "error": self.error,
             "tool_config": self.tool_config,
         }
+        return result
 
 
 class ToolLabel(BaseModel):


### PR DESCRIPTION
Part of #32863 (`api/core/tools/entities/`)

## Summary
- Define `ToolInvokeMetaDict` TypedDict for `ToolInvokeMeta.to_dict()` return type
- Add missing return type annotation to `to_dict`

## Why this change
`ToolInvokeMeta.to_dict()` had no return type annotation, losing the fixed 3-key structure (`time_cost`, `error`, `tool_config`). A TypedDict makes the return shape explicit and enables downstream type checking.

## Changes
- `api/core/tools/entities/tool_entities.py`: Define `ToolInvokeMetaDict`, annotate `ToolInvokeMeta.to_dict`