### PR TITLE
fix(web): invalidate systemFeatures cache after login to show license banner

### DIFF
--- a/web/app/signin/check-code/page.tsx
+++ b/web/app/signin/check-code/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { FormEvent } from 'react'
 import { RiArrowLeftLine, RiMailSendFill } from '@remixicon/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { trackEvent } from '@/app/components/base/amplitude'
@@ -8,6 +9,7 @@ import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
 import { toast } from '@/app/components/base/ui/toast'
 import Countdown from '@/app/components/signin/countdown'
+import { systemFeaturesQueryKey } from '@/context/global-public-context'
 import { useLocale } from '@/context/i18n'
 
 import { useRouter, useSearchParams } from '@/next/navigation'
@@ -27,6 +29,7 @@ export default function CheckCode() {
   const [loading, setIsLoading] = useState(false)
   const locale = useLocale()
   const codeInputRef = useRef<HTMLInputElement>(null)
+  const queryClient = useQueryClient()
 
   const verify = async () => {
     try {
@@ -46,6 +49,12 @@ export default function CheckCode() {
           method: 'email_code',
           is_invite: !!invite_token,
         })
+
+        // Invalidate the public systemFeatures cache so the next read re-fetches
+        // with auth cookies and picks up authenticated-only fields like
+        // `license.expired_at` that were intentionally gated before login. See
+        // issue #34520 for the full data-flow trace.
+        await queryClient.invalidateQueries({ queryKey: systemFeaturesQueryKey })
 
         if (invite_token) {
           router.replace(`/signin/invite-settings?${searchParams.toString()}`)

--- a/web/app/signin/components/mail-and-password-auth.tsx
+++ b/web/app/signin/components/mail-and-password-auth.tsx
@@ -1,4 +1,5 @@
 import type { ResponseError } from '@/service/fetch'
+import { useQueryClient } from '@tanstack/react-query'
 import { noop } from 'es-toolkit/function'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -7,6 +8,7 @@ import Button from '@/app/components/base/button'
 import Input from '@/app/components/base/input'
 import { toast } from '@/app/components/base/ui/toast'
 import { emailRegex } from '@/config'
+import { systemFeaturesQueryKey } from '@/context/global-public-context'
 import { useLocale } from '@/context/i18n'
 import Link from '@/next/link'
 import { useRouter, useSearchParams } from '@/next/navigation'
@@ -26,6 +28,7 @@ export default function MailAndPasswordAuth({ isInvite, isEmailSetup, allowRegis
   const locale = useLocale()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const queryClient = useQueryClient()
   const [showPassword, setShowPassword] = useState(false)
   const emailFromLink = decodeURIComponent(searchParams.get('email') || '')
   const [email, setEmail] = useState(emailFromLink)
@@ -70,6 +73,14 @@ export default function MailAndPasswordAuth({ isInvite, isEmailSetup, allowRegis
           method: 'email_password',
           is_invite: isInvite,
         })
+
+        // Invalidate the public systemFeatures cache so the next read re-fetches
+        // with auth cookies and picks up authenticated-only fields like
+        // `license.expired_at` that were intentionally gated before login.
+        // Without this, React Query serves the pre-login response for up to its
+        // staleTime window and the license-expiring banner stays hidden on /apps
+        // until a manual refresh (see issue #34520).
+        await queryClient.invalidateQueries({ queryKey: systemFeaturesQueryKey })
 
         if (isInvite) {
           router.replace(`/signin/invite-settings?${searchParams.toString()}`)

--- a/web/context/global-public-context.tsx
+++ b/web/context/global-public-context.tsx
@@ -18,7 +18,7 @@ export const useGlobalPublicStore = create<GlobalPublicStore>(set => ({
   setSystemFeatures: (systemFeatures: SystemFeatures) => set(() => ({ systemFeatures })),
 }))
 
-const systemFeaturesQueryKey = ['systemFeatures'] as const
+export const systemFeaturesQueryKey = ['systemFeatures'] as const
 const setupStatusQueryKey = ['setupStatus'] as const
 
 async function fetchSystemFeatures() {


### PR DESCRIPTION
Fixes #34520.

The "license expiring in N days" banner doesn't show up on `/apps` right after login. You have to refresh the browser for it to appear. @BenjaminX's trace in the issue is correct, so I'll just summarize:

1. `GlobalPublicStoreProvider` hits `GET /console/api/system-features` before the user is logged in.
2. The backend deliberately only returns `license.expired_at` when the caller is authenticated (see the security comment in `api/services/feature_service.py` around line 389, from #33044). Pre-login response is `expired_at = ""`.
3. React Query caches that empty response.
4. After `router.replace('/apps')`, nothing invalidates the cache, so `LicenseNav` keeps reading `""` and hides the badge.
5. A manual refresh triggers a new fetch with the auth cookie and the badge appears.

## The fix

Went with Option B from the issue (frontend cache invalidation). Option A would mean moving `expired_at` out of the `is_authenticated` guard, but that guard has an explicit security note saying the expiry date is intentionally auth-gated. Didn't want to touch that.

Three small changes:

- `web/context/global-public-context.tsx`: exported `systemFeaturesQueryKey` so login handlers can reference it.
- `web/app/signin/components/mail-and-password-auth.tsx`: call `queryClient.invalidateQueries({ queryKey: systemFeaturesQueryKey })` after a successful login, before `router.replace('/apps')`.
- `web/app/signin/check-code/page.tsx`: same thing for the email-code login path.

Left the invite and `one-more-step` flows alone since they don't reproduce the symptom and I wanted to keep the diff minimal. Can extend to those too if you'd rather.

## Testing

Local, with `docker compose -p dify up -d`:

1. Logged out, went to `/signin`
2. Logged in as a user in a workspace with a license that's expiring soon
3. Banner shows up immediately on `/apps`, no refresh needed
4. Same thing with the email-code login path

Before the change the banner stayed blank until a manual refresh. After, it renders on first paint. Unauthenticated callers still get `expired_at = ""` from `/system-features`, so the backend boundary is unchanged.
