### PR TITLE
fix(web): clear stale conversation_id from localStorage on 404

### DIFF
--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -144,6 +144,13 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   const [conversationIdInfo, setConversationIdInfo] = useLocalStorageState<Record<string, Record<string, string>>>(CONVERSATION_ID_INFO, {
     defaultValue: {},
   })
+  const removeConversationIdInfo = useCallback((targetAppId: string) => {
+    setConversationIdInfo((prev) => {
+      const newInfo = { ...prev }
+      delete newInfo[targetAppId]
+      return newInfo
+    })
+  }, [setConversationIdInfo])
   const currentConversationId = useMemo(() => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '', [appId, conversationIdInfo, userId])
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
     if (appId) {
@@ -185,7 +192,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   })
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
+  const { data: appChatListData, isLoading: appChatListDataLoading, error: appChatListDataError } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
     appId,
@@ -194,6 +201,14 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   })
+  // When the backend reports the conversation no longer exists (404), clear
+  // the stale conversation_id from localStorage so the chatbot falls back to
+  // starting a new conversation. Without this, the user would be stuck in an
+  // infinite retry loop (GitHub issue #34731).
+  useEffect(() => {
+    if (appChatListDataError instanceof Response && appChatListDataError.status === 404 && appId)
+      removeConversationIdInfo(appId)
+  }, [appChatListDataError, appId, removeConversationIdInfo])
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -146,11 +146,19 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     pinned: false,
     limit: 100,
   })
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
+  const { data: appChatListData, isLoading: appChatListDataLoading, error: appChatListDataError } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
     appId,
   })
+  // When the backend reports the conversation no longer exists (404), clear
+  // the stale conversation_id from localStorage so the chatbot falls back to
+  // starting a new conversation. Without this, the user would be stuck in an
+  // infinite retry loop (GitHub issue #34731).
+  useEffect(() => {
+    if (appChatListDataError instanceof Response && appChatListDataError.status === 404 && appId)
+      removeConversationIdInfo(appId)
+  }, [appChatListDataError, appId, removeConversationIdInfo])
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -135,7 +135,10 @@ export const generationConversationName = async (appSourceType: AppSourceType, i
 }
 
 export const fetchChatList = async (conversationId: string, appSourceType: AppSourceType, installedAppId = '') => {
-  return getAction('get', appSourceType)(getUrl('messages', appSourceType, installedAppId), { params: { conversation_id: conversationId, limit: 20, last_id: '' } }) as any
+  // Pass silent: true so a stale conversation_id returning 404 does not spam
+  // toast errors to the user. The caller (useShareChatList) is responsible
+  // for detecting the 404 and clearing the stale id from localStorage.
+  return getAction('get', appSourceType)(getUrl('messages', appSourceType, installedAppId), { params: { conversation_id: conversationId, limit: 20, last_id: '' } }, { silent: true }) as any
 }
 
 // Abandoned API interface

--- a/web/service/use-share.ts
+++ b/web/service/use-share.ts
@@ -131,6 +131,14 @@ export const useShareChatList = (params: ShareChatListParams, options: ShareQuer
     // back to a conversation. This fixes issue where recent messages don't appear
     // until switching away and back again (GitHub issue #30378).
     staleTime: 0,
+    // Do not retry when the conversation no longer exists on the server.
+    // Without this, a stale conversation_id in localStorage causes an infinite
+    // retry loop of 404s on every window focus (GitHub issue #34731).
+    retry: (failureCount, error: unknown) => {
+      if (error instanceof Response && error.status === 404)
+        return false
+      return failureCount < 3
+    },
   })
 }
 


### PR DESCRIPTION
Fixes #34731.

When a conversation has been deleted on the server but the Web App chatbot still has its `conversation_id` in localStorage, the page enters an infinite loop: it refetches `GET /api/messages?conversation_id=...`, gets `404`, shows a toast, and retries again every couple of seconds. The "Reset conversation" button only clears the visual state, not the localStorage entry, so the only real workaround is for the user to manually clear site data.

The reporter and @dosu already traced the root cause pretty well. Summarizing:

1. `useShareChatList` in `web/service/use-share.ts` doesn't configure `retry`, so TanStack Query uses its default (3 retries) and also refetches on window focus.
2. `fetchChatList` doesn't pass `silent: true`, so every failed attempt fires a toast via `afterResponseErrorCode` in `web/service/fetch.ts`.
3. Both `embedded-chatbot/hooks.tsx` and `chat-with-history/hooks.tsx` destructure only `data` and `isLoading` from `useShareChatList` — the `error` state is ignored, so nothing clears the stale `conversation_id` from localStorage when the 404 comes back.

## The fix

Three small changes, all frontend:

**`web/service/share.ts`** — `fetchChatList` now passes `silent: true` so a 404 response doesn't spam toasts. The 404 is a legitimate "conversation no longer exists" signal that the hook layer handles; it shouldn't look like a server error to the user.

**`web/service/use-share.ts`** — `useShareChatList` now disables retries for 404s:

```ts
retry: (failureCount, error: unknown) => {
  if (error instanceof Response && error.status === 404)
    return false
  return failureCount < 3
}
```

Other HTTP failures still get the default 3 retries.

**`web/app/components/base/chat/embedded-chatbot/hooks.tsx`** and **`web/app/components/base/chat/chat-with-history/hooks.tsx`** — both now read `error` from `useShareChatList` and run a `useEffect` that calls `removeConversationIdInfo(appId)` when the error is a 404 `Response`. Clearing the stale entry causes `currentConversationId` to fall back to `''`, which in turn disables the query (since `isEnabled` checks `!!params.conversationId`), and the chatbot starts a fresh conversation.

`chat-with-history/hooks.tsx` didn't previously have a `removeConversationIdInfo` helper, so I added one matching the shape of the existing `embedded-chatbot` implementation.

## Why this shape instead of alternatives

- **Backend fix (return 200 with an empty array on deleted conversations)** — would mask real 404s and lose the useful "this id is gone" signal. The frontend already has everything it needs to handle this cleanly.
- **Reset conversation button also clears localStorage** — the reporter mentioned that the button only resets the visual state. I looked at #33362 which tracks that separately. Fixing the infinite-loop symptom doesn't require touching the button, and wiring both into one PR would widen scope.
- **Suppressing the toast only, without retry/clear logic** — would stop the visible spam but leave the underlying retry storm running in the network tab. The retry stop + localStorage clear is what actually makes the page recover.

## Testing

Manually reproduced on a self-hosted stack (`docker compose -p dify up -d`) with a Chatflow app exposed as a Web App:

1. Opened the chatbot URL, sent a message, confirmed `conversationIdInfo` is populated in `Application → Local Storage → conversationIdInfo`.
2. Deleted the conversation from the console as admin.
3. Reloaded the chatbot page.

**Before the fix:** Network tab shows `GET /api/messages?...` returning 404 every 2–3 seconds, toast error pops up repeatedly, page never recovers. Clicking "Reset conversation" does nothing useful.

**After the fix:** Exactly one `GET /api/messages?...` 404 in the network tab, no toast, `conversationIdInfo` is cleared from localStorage on the same tick, the chatbot falls back to the new-conversation state automatically.

Also re-tested the happy path (send messages in a valid conversation, switch conversations, refresh) to confirm I didn't break the normal chat-list loading flow.
