### PR TITLE
fix(web): anchor legacy Modal overlay to viewport regardless of ancestor context

### DIFF
--- a/web/app/components/base/modal/modal.tsx
+++ b/web/app/components/base/modal/modal.tsx
@@ -62,6 +62,17 @@ const Modal = ({
     <PortalToFollowElem open>
       <PortalToFollowElemContent
         className={cn('z-9998 flex h-full w-full items-center justify-center bg-background-overlay', wrapperClassName)}
+        // PortalToFollowElem is a tooltip/dropdown primitive built on floating-ui.
+        // This Modal uses it without a `PortalToFollowElemTrigger`, so floating-ui
+        // has no reference element to anchor against and its computed
+        // `position: absolute` + `transform` inline styles become unreliable.
+        // In most contexts the overlay still ends up covering the viewport, but
+        // when the Modal renders inside another overlay (e.g. a base-ui Dialog
+        // whose Popup has its own `transform`), the computed position collapses
+        // the overlay into a narrow strip instead of a full-viewport backdrop.
+        // See #34803. Override the computed position with plain viewport-fixed
+        // values so the modal overlay is always anchored to the viewport.
+        style={{ position: 'fixed', inset: 0, transform: 'none' }}
         onClick={clickOutsideNotClose ? noop : onClose}
       >
         <div


### PR DESCRIPTION
Fixes #34803.

Clicking "+ Configure → Add API Key" on a data source in Settings collapses the modal into a narrow strip in the left gutter instead of opening centered.

`base/modal/modal.tsx` is built on `PortalToFollowElem` (a floating-ui dropdown primitive) without a trigger. With no reference element, floating-ui's computed `position: absolute` + `transform: translate(...)` inline styles usually happen to cover the viewport anyway, but the Settings page is wrapped in `MenuDialog`, a base-ui Dialog whose Popup has `-translate-x-1/2 -translate-y-1/2`, and that ancestor transform throws the positioning chain off.

One-line fix: pass `style={{ position: 'fixed', inset: 0, transform: 'none' }}` to `PortalToFollowElemContent`. The style prop is spread after floatingStyles inside that component so the override wins, and `fixed` + `inset: 0` is what the modal backdrop should have been doing all along. Left a comment on the line so the hack doesn't get cleaned up later.

The real fix is migrating this component to `base/ui/dialog` (tracked in #32767), but that's a bigger job and this helps all 8 Modal consumers at once without needing to unwind anything later.

11 modal tests + 156 plugin-auth authorize tests pass, lint and types clean. I don't have a self-hosted Dify with Firecrawl installed to reproduce the exact screenshot in the issue, so if someone's already in a repro env I'd appreciate a quick eyeball check.
