### PR TITLE
fix(web): release responding lock on annotation-reply message_end

### DIFF
--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -357,14 +357,24 @@ export const useChat = (
         })
       },
       onMessageEnd: (messageEnd) => {
-        updateChatTreeNode(messageId, (responseItem) => {
-          if (messageEnd.metadata?.annotation_reply) {
+        const annotationReply = messageEnd.metadata?.annotation_reply
+        if (annotationReply) {
+          updateChatTreeNode(messageId, (responseItem) => {
             responseItem.annotation = ({
-              id: messageEnd.metadata.annotation_reply.id,
-              authorName: messageEnd.metadata.annotation_reply.account.name,
+              id: annotationReply.id,
+              authorName: annotationReply.account.name,
             })
-            return
-          }
+          })
+          // When the backend short-circuits with an annotation reply, the
+          // regular onCompleted terminal event is not emitted, so the chat UI
+          // would otherwise stay locked in the "generating" state until the
+          // SSE connection closes. Release the responding lock here to match
+          // the regenerate-flow onMessageEnd handler in this same file and to
+          // fix #34885.
+          handleResponding(false)
+          return
+        }
+        updateChatTreeNode(messageId, (responseItem) => {
           responseItem.citation = messageEnd.metadata?.retriever_resources || []
           const processedFilesFromResponse = getProcessedFilesFromResponse(messageEnd.files || [])
           responseItem.allFiles = uniqBy([...(responseItem.allFiles || []), ...(processedFilesFromResponse || [])], 'id')


### PR DESCRIPTION
Fixes #34885. Same root cause as the prematurely-closed #33103.

When a Chatflow message matches an annotation reply, the backend fires a single `message_end` event with `metadata.annotation_reply` and closes the stream without going through the normal terminal event that triggers `onCompleted`. So `handleResponding(false)`, which normally runs inside `onCompleted`, never fires, and the chat UI stays stuck in "generating" until the SSE connection physically closes.

The file already has a working version of this path. The regenerate-flow `onMessageEnd` handler around line 881 correctly does `handleResponding(false); return` in its annotation branch. The initial-send handler around line 359 just wasn't doing the same thing. I restructured it to match: check for `annotation_reply` at the callback level, apply the annotation via `updateChatTreeNode`, release the responding lock, return. Non-annotation branch is untouched.

686 tests in `app/components/base/chat/chat/` pass, lint and types clean. I don't have an annotation configured on a live Dify to reproduce visually, but since I'm mirroring a sibling function in the same file I'm pretty confident in the shape of the fix.
