### PR TITLE
fix(mcp): omit None fields from OAuth Dynamic Client Registration payload

### DIFF
--- a/api/core/mcp/auth/auth_flow.py
+++ b/api/core/mcp/auth/auth_flow.py
@@ -525,9 +525,16 @@ def register_client(
     else:
         registration_url = urljoin(server_url, "/register")
 
+    # Per RFC 7591 §2, optional client metadata fields that are not provided
+    # should be omitted from the registration request rather than sent as
+    # explicit JSON `null`. `OAuthClientMetadata` has several optional fields
+    # (`scope`, `client_uri`, `grant_types`, etc.) that default to `None`;
+    # without `exclude_none=True`, Pydantic serializes them as `null` and
+    # registration servers that strictly validate field types (e.g. GitLab
+    # MCP) respond with HTTP 400 `invalid_client_metadata`. See #34857.
     response = ssrf_proxy.post(
         registration_url,
-        json=client_metadata.model_dump(),
+        json=client_metadata.model_dump(exclude_none=True),
         headers={"Content-Type": "application/json"},
     )
     if not response.is_success:

--- a/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
+++ b/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
@@ -496,9 +496,44 @@ class TestAuthorizationFlow:
         # Verify request
         mock_post.assert_called_once_with(
             "https://auth.example.com/register",
-            json=client_metadata.model_dump(),
+            json=client_metadata.model_dump(exclude_none=True),
             headers={"Content-Type": "application/json"},
         )
+
+    @patch("core.helper.ssrf_proxy.post")
+    def test_register_client_omits_none_fields(self, mock_post):
+        """Unset optional metadata fields must not be sent as JSON null.
+
+        Regression test for #34857: registration servers that strictly
+        validate the request body (e.g. GitLab MCP) reject `null` values
+        where a string is expected. Per RFC 7591 §2, optional fields that
+        are not provided should be absent from the request body.
+        """
+        mock_response = Mock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "client_id": "new-client-id",
+            "client_name": "Dify",
+            "redirect_uris": ["https://redirect.example.com"],
+        }
+        mock_post.return_value = mock_response
+
+        # Only populate the two required fields; everything else defaults to None.
+        client_metadata = OAuthClientMetadata(
+            client_name="Dify",
+            redirect_uris=["https://redirect.example.com"],
+        )
+
+        register_client("https://api.example.com", None, client_metadata)
+
+        sent_json = mock_post.call_args.kwargs["json"]
+        assert sent_json == {
+            "client_name": "Dify",
+            "redirect_uris": ["https://redirect.example.com"],
+        }
+        # Explicitly guard against null leakage in any optional field.
+        for key in ("scope", "client_uri", "grant_types", "response_types", "token_endpoint_auth_method"):
+            assert key not in sent_json
 
     def test_register_client_no_endpoint(self):
         """Test client registration when no endpoint available."""


### PR DESCRIPTION
Fixes #34857. @uskaidev filed this with the full root-cause analysis and the exact one-line fix already identified, so I just applied it and added a regression test.

Short version: `OAuthClientMetadata` has a bunch of optional fields defaulting to `None` (`scope`, `client_uri`, `grant_types`, etc.). `register_client()` was serializing with plain `model_dump()`, so unset fields went out as JSON `null`. Per RFC 7591 §2 they're supposed to just be absent from the payload, and strict MCP registration servers (the reporter hit this against GitLab's `gitlab-mcp`) respond with `invalid_client_metadata` when they see the nulls.

Fix is `model_dump(exclude_none=True)`. I left a comment above the call referencing the issue and the RFC so the next refactor of this file doesn't quietly undo it.

The existing `test_register_client_success` was asserting the serialized payload shape, so I updated that to match. I also added `test_register_client_omits_none_fields`: it constructs an `OAuthClientMetadata` with only the two required fields, calls `register_client`, and checks that `mock_post` received exactly `{"client_name", "redirect_uris"}` with none of the optional fields leaking through as null.

49 tests in `test_auth_flow.py` pass, ruff and format clean. I don't have a GitLab MCP instance to verify the end-to-end OAuth flow against the real server, but the regression test pins the exact payload shape that was being rejected.
