### PR TITLE
fix(rag): include is_summary and original_chunk_id in default vector projection

### DIFF
--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -41,7 +41,23 @@ class AbstractVectorFactory(ABC):
 class Vector:
     def __init__(self, dataset: Dataset, attributes: list | None = None):
         if attributes is None:
-            attributes = ["doc_id", "dataset_id", "document_id", "doc_hash", "doc_type"]
+            # `is_summary` and `original_chunk_id` are stored on summary vectors
+            # by `SummaryIndexService` and read back by `RetrievalService` to
+            # route summary hits through their original parent chunks. They
+            # must be listed here so vector backends that use this list as an
+            # explicit return-properties projection (notably Weaviate) actually
+            # return those fields; without them, summary hits silently
+            # collapse into `is_summary = False` branches and the summary
+            # retrieval path is a no-op. See #34884.
+            attributes = [
+                "doc_id",
+                "dataset_id",
+                "document_id",
+                "doc_hash",
+                "doc_type",
+                "is_summary",
+                "original_chunk_id",
+            ]
         self._dataset = dataset
         self._embeddings = self._get_embeddings()
         self._attributes = attributes

--- a/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
@@ -121,7 +121,18 @@ def test_vector_init_uses_default_and_custom_attributes(vector_factory_module):
         default_vector = vector_factory_module.Vector(dataset)
         custom_vector = vector_factory_module.Vector(dataset, attributes=["doc_id"])
 
-    assert default_vector._attributes == ["doc_id", "dataset_id", "document_id", "doc_hash", "doc_type"]
+    # `is_summary` and `original_chunk_id` must be in the default return-properties
+    # projection so summary index retrieval works on backends that honor the list
+    # as an explicit projection (e.g. Weaviate). See #34884.
+    assert default_vector._attributes == [
+        "doc_id",
+        "dataset_id",
+        "document_id",
+        "doc_hash",
+        "doc_type",
+        "is_summary",
+        "original_chunk_id",
+    ]
     assert custom_vector._attributes == ["doc_id"]
     assert default_vector._embeddings == "embeddings"
     assert default_vector._vector_processor == "processor"


### PR DESCRIPTION
Partial fix for #34884. The reporter described two bugs; I'm fixing Bug 1, which is real, and explaining below why Bug 2 doesn't actually trigger in the current codebase.

**Bug 1.** The default `attributes` list on `Vector.__init__` in `vector_factory.py` gets passed down to Weaviate as an explicit `return_properties` projection. `SummaryIndexService` writes `is_summary=True` and `original_chunk_id=<segment.id>` on every summary vector it stores, but neither field was in that list, so Weaviate never returned them. `RetrievalService` then evaluated `is_summary = document.metadata.get("is_summary", False)` which came back `False` on every summary hit, skipped the summary routing branch, and treated the summary vector as a regular chunk whose `doc_id` didn't match any `DocumentSegment.index_node_id`. The hit silently vanished after consuming a `top_k` slot.

Added both fields to the default list. Other backends (Qdrant, pgvector, etc.) aren't affected since they return all metadata regardless of the projection, but the shared `Vector` class is the right place to fix it so the contract is consistent across backends. Pinned the new shape in `test_vector_init_uses_default_and_custom_attributes` so a future refactor can't quietly drop the two fields again.

**Bug 2, not fixed.** The reporter's theory is that `summary_score_map.get(segment.id)` always misses because the map is keyed by `str` (from `original_chunk_id` in metadata) while `segment.id` is a `uuid.UUID`. That would be a real bug, but `DocumentSegment.id` is declared with the `StringUUID` column type, whose `process_result_value` literally does `return str(value)`. So `segment.id` comes off the ORM as a `str`, not a `uuid.UUID`, and the lookups work. @dosu reached the same conclusion on the issue.

Once Bug 1 lands and Weaviate actually returns the summary metadata, the reporter can verify end-to-end. If they still see score-inheritance issues on a non-Weaviate backend after that, it's probably a metadata-serialization quirk specific to one backend and worth tracking as its own issue with a concrete repro, rather than pre-emptively wrapping `str()` around the lookups here.

45 `test_vector_factory` + 37 `test_weaviate_vector` tests pass, ruff clean. I don't have a Weaviate-backed instance with Summary Index enabled to run the reporter's flow end-to-end.
