### PR TITLE
fix(docker): create /home/dify so Gunicorn 25 control socket can start

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -55,6 +55,14 @@ ARG NODE_PACKAGE_VERSION=22.21.0-1nodesource1
 ARG NODESOURCE_KEY_FPR=6F71F525282841EEDAF851B42F59B5F99B1BE0B4
 RUN groupadd -r -g ${dify_uid} dify && \
     useradd -r -u ${dify_uid} -g ${dify_uid} -s /bin/bash dify && \
+    # Create /home/dify explicitly: `useradd -r` skips home-directory creation
+    # even though the passwd entry still points at /home/dify, which breaks
+    # tools that expect the user's HOME to exist on disk. Notably, Gunicorn
+    # 25's control socket writes into HOME and fails with
+    # `[Errno 13] Permission denied: '/home/dify'` if this directory is
+    # missing. See #34463.
+    mkdir -p /home/dify && \
+    chown dify:dify /home/dify && \
     chown -R dify:dify /app
 
 RUN \


### PR DESCRIPTION
Fixes #34463.

When the api container starts as the non-root `dify` user, Gunicorn 25 crashes immediately with `[Errno 13] Permission denied: '/home/dify'`. The passwd entry correctly points at `/home/dify` as the user's home, but the directory doesn't exist on disk — `api/Dockerfile` creates the user with `useradd -r` (system user), and the `-r` flag suppresses home-directory creation.

This used to work. #26419 originally did an explicit `mkdir -p /home/dify`, #28756 removed that line while parameterizing the UID, and then #33298 updated Gunicorn to 25.x which introduced a control socket that writes into the user's HOME. The missing home directory that was previously a latent wart is now a startup crash.

Fix is the minimal recreation of the #26419 lines, right after `useradd`:

```dockerfile
mkdir -p /home/dify && \
chown dify:dify /home/dify && \
```

I went with explicit `mkdir` + `chown` rather than `useradd -m` because that's the shape that was working before, and because a standalone block with a comment explaining the *why* is harder to silently drop in a future refactor than a single flag buried in a long useradd invocation — which is exactly how the regression got reintroduced last time. Left a comment referencing #34463 and the Gunicorn reason above the new lines.

Sanity-checked the shell comment syntax I used in the RUN block (`cmd && \` → `# comment` → `cmd2 && \`) against both `bash` and `/bin/sh` — both handle comment lines inside a line-continued block correctly, the logical command stays `cmd && cmd2`. Also grep'd the other Dockerfiles in the repo; only `api/Dockerfile` has this `useradd -r` pattern, so the fix is scoped.

I don't have the api image rebuilt and running locally to visually confirm gunicorn comes up clean, so if a reviewer is already in a build env a quick sanity check that `/home/dify` exists as `dify:dify` in the final image would be appreciated.
