### PR TITLE
fix: fix tool output duplicate

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -262,6 +262,8 @@ class ToolEngine:
                         ensure_ascii=False,
                     )
                 )
+            elif response.type == ToolInvokeMessage.MessageType.VARIABLE:
+                continue
             else:
                 parts.append(str(response.message))
 

--- a/api/core/tools/utils/workflow_configuration_sync.py
+++ b/api/core/tools/utils/workflow_configuration_sync.py
@@ -17,10 +17,8 @@ class WorkflowToolConfigurationUtils:
         """
         nodes = graph.get("nodes", [])
         start_node = next(filter(lambda x: x.get("data", {}).get("type") == "start", nodes), None)
-
         if not start_node:
             return []
-
         return [VariableEntity.model_validate(variable) for variable in start_node.get("data", {}).get("variables", [])]
 
     @classmethod

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -84,6 +84,7 @@ class WorkflowToolManageService:
         try:
             WorkflowToolProviderController.from_db(workflow_tool_provider)
         except Exception as e:
+            logger.warning(e, exc_info=True)
             raise ValueError(str(e))
 
         with Session(db.engine, expire_on_commit=False) as session, session.begin():

--- a/api/tests/unit_tests/core/tools/test_tool_engine.py
+++ b/api/tests/unit_tests/core/tools/test_tool_engine.py
@@ -260,6 +260,28 @@ def test_agent_invoke_engine_meta_error():
     assert error_meta.error == "meta failure"
 
 
+def test_convert_tool_response_excludes_variable_messages():
+    """Regression test for issue #34723.
+
+    WorkflowTool._invoke yields VARIABLE, TEXT, and suppressed-JSON messages.
+    _convert_tool_response_to_str must skip VARIABLE messages so that the
+    returned string contains only the TEXT representation and not a
+    duplicated, garbled Pydantic repr of the same data.
+    """
+    tool = _build_tool()
+    outputs = {"reports": "hello"}
+    messages = [
+        tool.create_variable_message(variable_name="reports", variable_value="hello"),
+        tool.create_text_message('{"reports": "hello"}'),
+        tool.create_json_message(outputs, suppress_output=True),
+    ]
+
+    result = ToolEngine._convert_tool_response_to_str(messages)
+
+    assert result == '{"reports": "hello"}'
+    assert "variable_name" not in result
+
+
 def test_agent_invoke_tool_invoke_error():
     tool = _build_tool(with_llm_parameter=True)
     callback = Mock()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

when tool message type is variable skip it, str(response.message) is no use for llm fix #34723

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
