### PR TITLE
refactor: migrate verify_subscription_credentials return type to TypedDict

### DIFF
--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -3,7 +3,7 @@ import logging
 import time as _time
 import uuid
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypedDict
 
 from sqlalchemy import desc, func
 from sqlalchemy.orm import Session, sessionmaker
@@ -40,6 +40,10 @@ from models.trigger import (
 from services.plugin.plugin_service import PluginService
 
 logger = logging.getLogger(__name__)
+
+
+class VerifyCredentialsResult(TypedDict):
+    verified: bool
 
 
 class TriggerProviderService:
@@ -792,7 +796,7 @@ class TriggerProviderService:
         provider_id: TriggerProviderID,
         subscription_id: str,
         credentials: dict[str, Any],
-    ) -> dict[str, Any]:
+    ) -> VerifyCredentialsResult:
         """
         Verify credentials for an existing subscription without updating it.
 


### PR DESCRIPTION
## Summary

Migrates the `-> dict[str, Any]` return type hint on `TriggerProviderService.verify_subscription_credentials()` in `api/services/trigger/trigger_provider_service.py` to a proper `TypedDict` definition as part of the broader type safety refactor.

## Changes

- Added `VerifyCredentialsResult` TypedDict with a single `verified: bool` field, modeling the stable JSON response shape returned by `verify_subscription_credentials()` (both return sites yield `{"verified": True}`)
- Changed the method return type from `dict[str, Any]` to `VerifyCredentialsResult`
- No logic, no call-site changes — the controller at `controllers/console/workspace/trigger_providers.py` passes the result straight to Flask-RESTx for JSON serialization, and the dict is never mutated or unpacked

## Related Issue

Closes part of #32863

## Checklist

- [x] Only type hints changed, no logic modified
- [x] Existing tests pass (`tests/unit_tests/services/test_trigger_provider_service.py` — 49/49, including all 5 `verify_subscription_credentials` tests)
- [x] Ruff linting passes (no new errors introduced)
- [x] basedpyright reports no new errors across the service, its controller, and the test file (0 errors, 0 warnings, 0 notes)