### PR TITLE
fix(web): copy multi-output workflow results

### DIFF
--- a/web/app/components/app/text-generate/item/__tests__/action-groups.spec.tsx
+++ b/web/app/components/app/text-generate/item/__tests__/action-groups.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { WorkflowRunningStatus } from '@/app/components/workflow/types'
 import { AppSourceType } from '@/service/share'
 import GenerationActionGroups from '../action-groups'
 
@@ -125,6 +126,34 @@ describe('GenerationActionGroups', () => {
     fireEvent.click(screen.getByRole('button', { name: 'operation.copy' }))
 
     expect(mockCopy).toHaveBeenCalledWith(JSON.stringify({ result: 'hello world' }))
+  })
+
+  it('should copy serialized workflow detail output when result text is unavailable', () => {
+    render(
+      <GenerationActionGroups
+        appSourceType={AppSourceType.webApp}
+        content='{"confirmed_rules":["rule-1"],"master_json":{"ok":true}}'
+        currentTab="DETAIL"
+        depth={1}
+        isError={false}
+        isInWebApp
+        isWorkflow
+        messageId="msg-5"
+        onMoreLikeThis={mockOnMoreLikeThis}
+        onOpenLogModal={mockOnOpenLogModal}
+        onRetry={mockOnRetry}
+        workflowProcessData={{
+          expand: false,
+          resultText: '',
+          status: WorkflowRunningStatus.Succeeded,
+          tracing: [],
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'operation.copy' }))
+
+    expect(mockCopy).toHaveBeenCalledWith('{"confirmed_rules":["rule-1"],"master_json":{"ok":true}}')
   })
 
   it('should expose retry and disagree actions in the appropriate states', () => {

--- a/web/app/components/app/text-generate/item/__tests__/utils.spec.ts
+++ b/web/app/components/app/text-generate/item/__tests__/utils.spec.ts
@@ -67,5 +67,10 @@ describe('text generation utils', () => {
       isWorkflow: true,
       workflowProcessData: { resultText: 'workflow-result' } as any,
     })).toBe('workflow-result')
+    expect(getCopyContent({
+      content: '{"answer":"fallback"}',
+      isWorkflow: true,
+      workflowProcessData: { resultText: '' } as any,
+    })).toBe('{"answer":"fallback"}')
   })
 })

--- a/web/app/components/app/text-generate/item/action-groups.tsx
+++ b/web/app/components/app/text-generate/item/action-groups.tsx
@@ -67,7 +67,10 @@ const GenerationActionGroups: FC<GenerationActionGroupsProps> = ({
 }) => {
   const { t } = useTranslation()
   const isTryApp = appSourceType === AppSourceTypeEnum.tryApp
-  const showCopyAction = (currentTab === 'RESULT' && workflowProcessData?.resultText) || !isWorkflow
+  const hasWorkflowCopyContent = currentTab === 'RESULT'
+    ? !!workflowProcessData?.resultText
+    : currentTab === 'DETAIL' && content !== undefined && content !== null && content !== ''
+  const showCopyAction = isWorkflow ? hasWorkflowCopyContent : true
 
   return (
     <>

--- a/web/app/components/app/text-generate/item/utils.ts
+++ b/web/app/components/app/text-generate/item/utils.ts
@@ -83,4 +83,4 @@ export const getCopyContent = ({
   content: unknown
   isWorkflow?: boolean
   workflowProcessData?: WorkflowProcess
-}) => isWorkflow ? workflowProcessData?.resultText : content
+}) => isWorkflow ? (workflowProcessData?.resultText || content) : content


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #34632.

Published Workflow WebApp runs with multiple output fields serialize the full result into the Detail content while `workflowProcessData.resultText` remains empty. The action bar only showed copy for workflow Result-tab text, so multi-output workflow results had no usable main copy action.

This change exposes the workflow copy action on the Detail tab when serialized output exists, and makes workflow copy content fall back to that serialized output when `resultText` is empty. It keeps the existing single-string Result-tab behavior unchanged.

## Screenshots

| Before | After |
|--------|-------|
| Multi-output workflow Detail output had no main copy action. | Detail output exposes the copy action and copies the serialized JSON result. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Validation

- `PATH=/home/sarthak/.npm/_npx/54df5c7b67c3fbcf/node_modules/node/bin:$PATH ../node_modules/.bin/vp test app/components/app/text-generate/item/__tests__/action-groups.spec.tsx app/components/app/text-generate/item/__tests__/utils.spec.ts`
- `PATH=/home/sarthak/.npm/_npx/54df5c7b67c3fbcf/node_modules/node/bin:$PATH ../node_modules/.bin/vp run lint:ci app/components/app/text-generate/item/action-groups.tsx app/components/app/text-generate/item/utils.ts app/components/app/text-generate/item/__tests__/action-groups.spec.tsx app/components/app/text-generate/item/__tests__/utils.spec.ts`
- `PATH=/home/sarthak/.npm/_npx/54df5c7b67c3fbcf/node_modules/node/bin:$PATH NODE_OPTIONS=--max-old-space-size=8192 ../node_modules/.bin/vp run type-check`
- pre-commit hook completed: ESLint autofix, `type-check:tsgo`, and `knip`
