### PR TITLE
refactor(api): remove type: ignore and FIXME comments in factories

### DIFF
--- a/api/core/external_data_tool/factory.py
+++ b/api/core/external_data_tool/factory.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from core.extension.extensible import ExtensionModule
+from core.external_data_tool.base import ExternalDataTool
 from extensions.ext_code_based_extension import code_based_extension
 
 
@@ -23,8 +24,7 @@ class ExternalDataToolFactory:
         :return:
         """
         extension_class = code_based_extension.extension_class(ExtensionModule.EXTERNAL_DATA_TOOL, name)
-        # FIXME mypy issue here, figure out how to fix it
-        extension_class.validate_config(tenant_id, config)  # type: ignore
+        cast(type[ExternalDataTool], extension_class).validate_config(tenant_id, config)
 
     def query(self, inputs: Mapping[str, Any], query: str | None = None) -> str:
         """

--- a/api/core/moderation/factory.py
+++ b/api/core/moderation/factory.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from core.extension.extensible import ExtensionModule
 from core.moderation.base import Moderation, ModerationInputsResult, ModerationOutputsResult
 from extensions.ext_code_based_extension import code_based_extension
@@ -21,8 +23,7 @@ class ModerationFactory:
         :return:
         """
         extension_class = code_based_extension.extension_class(ExtensionModule.MODERATION, name)
-        # FIXME: mypy error, try to fix it instead of using type: ignore
-        extension_class.validate_config(tenant_id, config)  # type: ignore
+        cast(type[Moderation], extension_class).validate_config(tenant_id, config)
 
     def moderation_for_inputs(self, inputs: dict, query: str = "") -> ModerationInputsResult:
         """


### PR DESCRIPTION
Remove FIXME and `type: ignore` in `ModerationFactory` and `ExternalDataToolFactory`.

`extension_class()` returns a bare `type`, so mypy doesn't know `validate_config` exists on the returned class. Using `cast(type[Moderation], ...)` and `cast(type[ExternalDataTool], ...)` fixes it without silencing th
e checker.

No runtime changes.

Fixes #34977
- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues
- [ ] I've added a test for each change that was introduced
- [ ] I've updated the documentation accordingly