### PR TITLE
test: migrate conftest and plugin lifecycle tests to SQLAlchemy 2.0 select() API

### DIFF
--- a/api/tests/integration_tests/conftest.py
+++ b/api/tests/integration_tests/conftest.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 import pytest
 from flask import Flask
 from flask.testing import FlaskClient
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from app_factory import create_app
@@ -83,15 +84,15 @@ def setup_account(request) -> Generator[Account, None, None]:
 
     with _CACHED_APP.test_request_context():
         with Session(bind=db.engine, expire_on_commit=False) as session:
-            account = session.query(Account).filter_by(email=email).one()
+            account = session.scalars(select(Account).filter_by(email=email)).one()
 
     yield account
 
     with _CACHED_APP.test_request_context():
-        db.session.query(DifySetup).delete()
-        db.session.query(TenantAccountJoin).delete()
-        db.session.query(Account).delete()
-        db.session.query(Tenant).delete()
+        db.session.execute(delete(DifySetup))
+        db.session.execute(delete(TenantAccountJoin))
+        db.session.execute(delete(Account))
+        db.session.execute(delete(Tenant))
         db.session.commit()
 
 

--- a/api/tests/integration_tests/services/plugin/test_plugin_lifecycle.py
+++ b/api/tests/integration_tests/services/plugin/test_plugin_lifecycle.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select
 
 from core.db.session_factory import session_factory
 from models import Tenant
@@ -61,7 +61,11 @@ class TestPluginPermissionLifecycle:
         assert perm.debug_permission == TenantPluginPermission.DebugPermission.ADMINS
 
         with session_factory.create_session() as session:
-            count = session.query(TenantPluginPermission).where(TenantPluginPermission.tenant_id == tenant).count()
+            count = session.scalar(
+                select(func.count())
+                .select_from(TenantPluginPermission)
+                .where(TenantPluginPermission.tenant_id == tenant)
+            )
         assert count == 1
 
 


### PR DESCRIPTION
Part of #22668

## Summary

- `tests/integration_tests/conftest.py`: replace `session.query(Account).filter_by().one()` with `session.scalars(select(...).filter_by()).one()`; replace 4× `db.session.query(Model).delete()` teardown calls with `db.session.execute(delete(Model))`
- `tests/integration_tests/services/plugin/test_plugin_lifecycle.py`: replace 1× `.query().where().count()` with `session.scalar(select(func.count()).select_from(...).where(...))`
