### PR TITLE
refactor(api): type _sign_query return with SignedQueryDict TypedDict

### DIFF
--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -102,7 +102,12 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         self._assert_upload_file_access(upload_file_id=upload_file_id)
         base_url = self._base_url(for_external=for_external)
         url = f"{base_url}/files/{upload_file_id}/file-preview"
-        query: dict[str, str] = dict(self._sign_query(payload=f"file-preview|{upload_file_id}"))
+        signed = self._sign_query(payload=f"file-preview|{upload_file_id}")
+        query: dict[str, str] = {
+            "timestamp": signed["timestamp"],
+            "nonce": signed["nonce"],
+            "sign": signed["sign"],
+        }
         if as_attachment:
             query["as_attachment"] = "true"
         return f"{url}?{urllib.parse.urlencode(query)}"

--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -102,7 +102,7 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         self._assert_upload_file_access(upload_file_id=upload_file_id)
         base_url = self._base_url(for_external=for_external)
         url = f"{base_url}/files/{upload_file_id}/file-preview"
-        query = self._sign_query(payload=f"file-preview|{upload_file_id}")
+        query: dict[str, str] = dict(self._sign_query(payload=f"file-preview|{upload_file_id}"))
         if as_attachment:
             query["as_attachment"] = "true"
         return f"{url}?{urllib.parse.urlencode(query)}"

--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -7,7 +7,7 @@ import os
 import time
 import urllib.parse
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 from graphon.file import FileTransferMethod
 from graphon.file.protocols import HttpResponseProtocol, WorkflowFileRuntimeProtocol
@@ -23,6 +23,12 @@ from extensions.ext_storage import storage
 
 if TYPE_CHECKING:
     from graphon.file import File
+
+
+class SignedQueryDict(TypedDict):
+    timestamp: str
+    nonce: str
+    sign: str
 
 
 class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
@@ -130,7 +136,7 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
     def _secret_key() -> bytes:
         return dify_config.SECRET_KEY.encode() if dify_config.SECRET_KEY else b""
 
-    def _sign_query(self, *, payload: str) -> dict[str, str]:
+    def _sign_query(self, *, payload: str) -> SignedQueryDict:
         timestamp = str(int(time.time()))
         nonce = os.urandom(16).hex()
         sign = hmac.new(self._secret_key(), f"{payload}|{timestamp}|{nonce}".encode(), hashlib.sha256).digest()


### PR DESCRIPTION
Part of #32863 (`api/core/app/workflow/file_runtime.py`)

## Summary
- Define `SignedQueryDict` TypedDict for the `_sign_query` return type
- Replace `dict[str, str]` return annotation with the new TypedDict

## Why this change
`_sign_query` returns a fixed 3-key dict (`timestamp`, `nonce`, `sign`) used as URL query params for signed file access. The bare `dict[str, str]` hides this structure from callers and downstream urllib.parse.urlencode usage.

## Changes
- `api/core/app/workflow/file_runtime.py`: Define `SignedQueryDict`, annotate `_sign_query` return type