### PR TITLE
refactor(api): type _error_to_stream_response with ErrorStreamResponseDict TypedDict

### DIFF
--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping
-from typing import Any, Union
+from typing import Any, TypedDict, Union
 
 from graphon.model_runtime.errors.invoke import InvokeError
 
@@ -10,6 +10,12 @@ from core.app.entities.task_entities import AppBlockingResponse, AppStreamRespon
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 
 logger = logging.getLogger(__name__)
+
+
+class ErrorStreamResponseDict(TypedDict):
+    code: str
+    message: str
+    status: int
 
 
 class AppGenerateResponseConverter(ABC):
@@ -107,7 +113,7 @@ class AppGenerateResponseConverter(ABC):
         return metadata
 
     @classmethod
-    def _error_to_stream_response(cls, e: Exception) -> dict[str, Any]:
+    def _error_to_stream_response(cls, e: Exception) -> ErrorStreamResponseDict:
         """
         Error to stream response.
         :param e: exception
@@ -127,7 +133,7 @@ class AppGenerateResponseConverter(ABC):
         }
 
         # Determine the response based on the type of exception
-        data: dict[str, Any] | None = None
+        data: ErrorStreamResponseDict | None = None
         for k, v in error_responses.items():
             if isinstance(e, k):
                 data = v


### PR DESCRIPTION
Part of #32863 (`api/core/app/apps/base_app_generate_response_converter.py`)

## Summary
- Define `ErrorStreamResponseDict` TypedDict for the `_error_to_stream_response` return type
- Replace `dict[str, Any]` return annotation and `data` variable annotation with the new TypedDict

## Why this change
`_error_to_stream_response` returns a fixed 3-key dict (`code`, `message`, `status`) for every code path. The bare `dict[str, Any]` hides this contract from the stream response serializer and callers in the chat/completion pipelines.

## Changes
- `api/core/app/apps/base_app_generate_response_converter.py`: Define `ErrorStreamResponseDict`, annotate `_error_to_stream_response` return type and `data` local variable