### PR TITLE
refactor(api): type _build_log_dict return with LogDict TypedDict

### DIFF
--- a/api/core/logging/structured_formatter.py
+++ b/api/core/logging/structured_formatter.py
@@ -28,7 +28,7 @@ class LogDict(_LogDictRequired, total=False):
     trace_id: str
     span_id: str
     identity: IdentityDict
-    attributes: Any
+    attributes: dict[str, Any]
     stack_trace: str
 
 

--- a/api/core/logging/structured_formatter.py
+++ b/api/core/logging/structured_formatter.py
@@ -16,6 +16,22 @@ class IdentityDict(TypedDict, total=False):
     user_type: str
 
 
+class _LogDictRequired(TypedDict):
+    ts: str
+    severity: str
+    service: str
+    caller: str
+    message: str
+
+
+class LogDict(_LogDictRequired, total=False):
+    trace_id: str
+    span_id: str
+    identity: IdentityDict
+    attributes: Any
+    stack_trace: str
+
+
 class StructuredJSONFormatter(logging.Formatter):
     """
     JSON log formatter following the specified schema:
@@ -55,9 +71,9 @@ class StructuredJSONFormatter(logging.Formatter):
 
             return json.dumps(log_dict, default=str, ensure_ascii=False)
 
-    def _build_log_dict(self, record: logging.LogRecord) -> dict[str, Any]:
+    def _build_log_dict(self, record: logging.LogRecord) -> LogDict:
         # Core fields
-        log_dict: dict[str, Any] = {
+        log_dict: LogDict = {
             "ts": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             "severity": self.SEVERITY_MAP.get(record.levelno, "INFO"),
             "service": self._service_name,

--- a/api/core/logging/structured_formatter.py
+++ b/api/core/logging/structured_formatter.py
@@ -3,7 +3,7 @@
 import logging
 import traceback
 from datetime import UTC, datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import orjson
 
@@ -16,20 +16,17 @@ class IdentityDict(TypedDict, total=False):
     user_type: str
 
 
-class _LogDictRequired(TypedDict):
+class LogDict(TypedDict):
     ts: str
     severity: str
     service: str
     caller: str
     message: str
-
-
-class LogDict(_LogDictRequired, total=False):
-    trace_id: str
-    span_id: str
-    identity: IdentityDict
-    attributes: dict[str, Any]
-    stack_trace: str
+    trace_id: NotRequired[str]
+    span_id: NotRequired[str]
+    identity: NotRequired[IdentityDict]
+    attributes: NotRequired[dict[str, Any]]
+    stack_trace: NotRequired[str]
 
 
 class StructuredJSONFormatter(logging.Formatter):


### PR DESCRIPTION
Part of #32863 (`api/core/logging/structured_formatter.py`)

## Summary
- Define `LogDict` TypedDict (required + optional split) for the `_build_log_dict` return type
- Replace `dict[str, Any]` return annotation and local variable annotation with `LogDict`

## Why this change
`_build_log_dict` builds a structured JSON log entry with 5 required fields (`ts`, `severity`, `service`, `caller`, `message`) and 5 optional fields (`trace_id`, `span_id`, `identity`, `attributes`, `stack_trace`). The file already defines `IdentityDict` as a TypedDict, so extending it with `LogDict` is a natural fit.

## Changes
- `api/core/logging/structured_formatter.py`: Define `_LogDictRequired` and `LogDict`, annotate `_build_log_dict` return type and `log_dict` variable