### PR TITLE
refactor: migrate _model_to_insertion_dict return type to TypedDict

### DIFF
--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -3,8 +3,8 @@ import json
 import logging
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from enum import StrEnum
 from datetime import datetime
+from enum import StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict
 
 from graphon.enums import NodeType

--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict
 
 from graphon.enums import NodeType
 from graphon.file import File
@@ -725,8 +725,27 @@ def _batch_upsert_draft_variable(
     session.execute(stmt)
 
 
-def _model_to_insertion_dict(model: WorkflowDraftVariable) -> dict[str, Any]:
-    d: dict[str, Any] = {
+class _InsertionDict(TypedDict, total=False):
+    id: str
+    app_id: str
+    user_id: str | None
+    last_edited_at: None
+    node_id: str
+    name: str
+    selector: Any
+    value_type: str
+    value: Any
+    node_execution_id: str | None
+    file_id: str | None
+    visible: bool
+    editable: bool
+    created_at: Any
+    updated_at: Any
+    description: str
+
+
+def _model_to_insertion_dict(model: WorkflowDraftVariable) -> _InsertionDict:
+    d: _InsertionDict = {
         "id": model.id,
         "app_id": model.app_id,
         "user_id": model.user_id,

--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -4,7 +4,8 @@ import logging
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from enum import StrEnum
-from typing import Any, ClassVar, TypedDict
+from datetime import datetime
+from typing import Any, ClassVar, NotRequired, TypedDict
 
 from graphon.enums import NodeType
 from graphon.file import File
@@ -725,23 +726,23 @@ def _batch_upsert_draft_variable(
     session.execute(stmt)
 
 
-class _InsertionDict(TypedDict, total=False):
+class _InsertionDict(TypedDict):
     id: str
     app_id: str
     user_id: str | None
-    last_edited_at: None
+    last_edited_at: datetime | None
     node_id: str
     name: str
-    selector: Any
-    value_type: str
-    value: Any
+    selector: str
+    value_type: SegmentType
+    value: str
     node_execution_id: str | None
     file_id: str | None
-    visible: bool
-    editable: bool
-    created_at: Any
-    updated_at: Any
-    description: str
+    visible: NotRequired[bool]
+    editable: NotRequired[bool]
+    created_at: NotRequired[datetime]
+    updated_at: NotRequired[datetime]
+    description: NotRequired[str]
 
 
 def _model_to_insertion_dict(model: WorkflowDraftVariable) -> _InsertionDict:


### PR DESCRIPTION
## Summary

Migrates the `-> dict[str, Any]` return type on `_model_to_insertion_dict()` in `api/services/workflow_draft_variable_service.py` to a proper `_InsertionDict` TypedDict, as part of the broader type safety refactor tracked in #32863.

## Changes

- Added `_InsertionDict` TypedDict with fields matching the `WorkflowDraftVariable` model columns used in bulk insert statements (`id`, `app_id`, `user_id`, `node_id`, `name`, `selector`, `value_type`, `value`, etc.)
- Required fields use `total=True` (default); conditional fields (`visible`, `editable`, `created_at`, `updated_at`, `description`) use `NotRequired` since they are only included when non-None
- Field types match the ORM model precisely (`selector: str`, `value_type: SegmentType`, `created_at/updated_at: datetime`)
- Changed `_model_to_insertion_dict` return annotation from `dict[str, Any]` to `_InsertionDict`
- No logic changes, only type annotations

fixes #32863