### PR TITLE
test: migrate AudioService TTS message-ID lookup tests to Testcontainers integration tests

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
+++ b/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
@@ -1,0 +1,246 @@
+"""
+Integration tests for AudioService.transcript_tts message-ID path.
+
+Migrated from unit_tests/services/test_audio_service.py, replacing
+db.session.get mock patches with real Message rows persisted in PostgreSQL.
+
+Covers:
+- transcript_tts with valid message_id that resolves to a real Message
+- transcript_tts returns None for invalid (non-UUID) message_id
+- transcript_tts returns None when message_id is a valid UUID but no row exists
+- transcript_tts returns None when message exists but has an empty answer
+"""
+
+from collections.abc import Generator
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from core.app.entities.app_invoke_entities import InvokeFrom
+from models.account import Account, Tenant, TenantAccountJoin
+from models.enums import ConversationFromSource, MessageStatus
+from models.model import App, AppMode, Conversation, Message
+from services.audio_service import AudioService
+
+
+class AudioServiceDBIntegrationTestDataFactory:
+    """Helpers for creating real DB rows used by audio-service integration tests."""
+
+    @staticmethod
+    def create_app_and_account(db_session: Session):
+        tenant = Tenant(name=f"Tenant {uuid4()}")
+        db_session.add(tenant)
+        db_session.flush()
+
+        account = Account(
+            name=f"Account {uuid4()}",
+            email=f"audio_{uuid4()}@example.com",
+            password="hashed-password",
+            password_salt="salt",
+            interface_language="en-US",
+            timezone="UTC",
+        )
+        db_session.add(account)
+        db_session.flush()
+
+        tenant_join = TenantAccountJoin(
+            tenant_id=tenant.id,
+            account_id=account.id,
+            role="owner",
+            current=True,
+        )
+        db_session.add(tenant_join)
+        db_session.flush()
+
+        app = App(
+            tenant_id=tenant.id,
+            name=f"App {uuid4()}",
+            description="",
+            mode=AppMode.CHAT.value,
+            icon_type="emoji",
+            icon="bot",
+            icon_background="#FFFFFF",
+            enable_site=False,
+            enable_api=True,
+            api_rpm=100,
+            api_rph=100,
+            is_demo=False,
+            is_public=False,
+            is_universal=False,
+            created_by=account.id,
+            updated_by=account.id,
+        )
+        db_session.add(app)
+        db_session.commit()
+        return app, account
+
+    @staticmethod
+    def create_conversation(db_session: Session, app: App, account: Account) -> Conversation:
+        conversation = Conversation(
+            app_id=app.id,
+            app_model_config_id=None,
+            model_provider=None,
+            model_id="",
+            override_model_configs=None,
+            mode=app.mode,
+            name=f"Conversation {uuid4()}",
+            summary="",
+            inputs={},
+            introduction="",
+            system_instruction="",
+            system_instruction_tokens=0,
+            status="normal",
+            invoke_from=InvokeFrom.WEB_APP.value,
+            from_source=ConversationFromSource.CONSOLE,
+            from_end_user_id=None,
+            from_account_id=account.id,
+            dialogue_count=0,
+            is_deleted=False,
+        )
+        conversation.inputs = {}
+        db_session.add(conversation)
+        db_session.commit()
+        return conversation
+
+    @staticmethod
+    def create_message(
+        db_session: Session,
+        app: App,
+        conversation: Conversation,
+        account: Account,
+        *,
+        answer: str = "Message answer text",
+        status: str = MessageStatus.NORMAL,
+    ) -> Message:
+        message = Message(
+            app_id=app.id,
+            model_provider=None,
+            model_id="",
+            override_model_configs=None,
+            conversation_id=conversation.id,
+            inputs={},
+            query="Test query",
+            message={"messages": [{"role": "user", "content": "Test query"}]},
+            message_tokens=0,
+            message_unit_price=Decimal(0),
+            message_price_unit=Decimal("0.001"),
+            answer=answer,
+            answer_tokens=0,
+            answer_unit_price=Decimal(0),
+            answer_price_unit=Decimal("0.001"),
+            parent_message_id=None,
+            provider_response_latency=0,
+            total_price=Decimal(0),
+            currency="USD",
+            status=status,
+            invoke_from=InvokeFrom.WEB_APP.value,
+            from_source=ConversationFromSource.CONSOLE,
+            from_end_user_id=None,
+            from_account_id=account.id,
+        )
+        db_session.add(message)
+        db_session.commit()
+        return message
+
+
+class TestAudioServiceTranscriptTTSMessageLookup:
+    """Integration tests for AudioService.transcript_tts message-ID lookup via real DB."""
+
+    @pytest.fixture(autouse=True)
+    def _auto_rollback(self, db_session_with_containers: Session) -> Generator[None, None, None]:
+        yield
+        db_session_with_containers.rollback()
+
+    def test_transcript_tts_with_message_id_success(
+        self, db_session_with_containers: Session, flask_app_with_containers
+    ) -> None:
+        """transcript_tts invokes TTS with the message answer when message_id resolves to a real row."""
+        app, account = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
+        conversation = AudioServiceDBIntegrationTestDataFactory.create_conversation(
+            db_session_with_containers, app, account
+        )
+        message = AudioServiceDBIntegrationTestDataFactory.create_message(
+            db_session_with_containers,
+            app,
+            conversation,
+            account,
+            answer="Hello from message",
+        )
+
+        mock_model_instance = MagicMock()
+        mock_model_instance.invoke_tts.return_value = b"audio from message"
+
+        mock_model_manager = MagicMock()
+        mock_model_manager.get_default_model_instance.return_value = mock_model_instance
+
+        with (
+            flask_app_with_containers.app_context(),
+            patch("services.audio_service.ModelManager.for_tenant", return_value=mock_model_manager),
+        ):
+            result = AudioService.transcript_tts(
+                app_model=app,
+                message_id=message.id,
+                voice="en-US-Neural",
+            )
+
+        assert result == b"audio from message"
+        mock_model_instance.invoke_tts.assert_called_once_with(
+            content_text="Hello from message",
+            voice="en-US-Neural",
+        )
+
+    def test_transcript_tts_returns_none_for_invalid_message_id(
+        self, db_session_with_containers: Session, flask_app_with_containers
+    ) -> None:
+        """transcript_tts returns None immediately when message_id is not a valid UUID."""
+        app, _ = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
+
+        with flask_app_with_containers.app_context():
+            result = AudioService.transcript_tts(
+                app_model=app,
+                message_id="invalid-uuid",
+            )
+
+        assert result is None
+
+    def test_transcript_tts_returns_none_for_nonexistent_message(
+        self, db_session_with_containers: Session, flask_app_with_containers
+    ) -> None:
+        """transcript_tts returns None when message_id is a valid UUID but no Message row exists."""
+        app, _ = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
+
+        with flask_app_with_containers.app_context():
+            result = AudioService.transcript_tts(
+                app_model=app,
+                message_id=str(uuid4()),
+            )
+
+        assert result is None
+
+    def test_transcript_tts_returns_none_for_empty_message_answer(
+        self, db_session_with_containers: Session, flask_app_with_containers
+    ) -> None:
+        """transcript_tts returns None when the resolved message has an empty answer."""
+        app, account = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
+        conversation = AudioServiceDBIntegrationTestDataFactory.create_conversation(
+            db_session_with_containers, app, account
+        )
+        message = AudioServiceDBIntegrationTestDataFactory.create_message(
+            db_session_with_containers,
+            app,
+            conversation,
+            account,
+            answer="",
+            status=MessageStatus.NORMAL,
+        )
+
+        with flask_app_with_containers.app_context():
+            result = AudioService.transcript_tts(
+                app_model=app,
+                message_id=message.id,
+            )
+
+        assert result is None

--- a/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
+++ b/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
@@ -100,7 +100,6 @@ class AudioServiceDBIntegrationTestDataFactory:
             dialogue_count=0,
             is_deleted=False,
         )
-        conversation.inputs = {}
         db_session.add(conversation)
         db_session.commit()
         return conversation

--- a/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
+++ b/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
@@ -17,168 +17,145 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from core.app.entities.app_invoke_entities import InvokeFrom
-from models.account import Account, Tenant, TenantAccountJoin
+from models.account import TenantAccountJoin
 from models.enums import ConversationFromSource, MessageStatus
 from models.model import App, AppMode, Conversation, Message
 from services.audio_service import AudioService
+from tests.test_containers_integration_tests.controllers.console.helpers import (
+    create_console_account_and_tenant,
+    create_console_app,
+)
 
 
-class AudioServiceDBIntegrationTestDataFactory:
-    """Helpers for creating real DB rows used by audio-service integration tests."""
+def _create_conversation(db_session: Session, app: App, account_id: str) -> Conversation:
+    """Create a Conversation row via flush() so the rollback-based teardown can remove it."""
+    conversation = Conversation(
+        app_id=app.id,
+        app_model_config_id=None,
+        model_provider=None,
+        model_id="",
+        override_model_configs=None,
+        mode=app.mode,
+        name=f"Conversation {uuid4()}",
+        summary="",
+        inputs={},
+        introduction="",
+        system_instruction="",
+        system_instruction_tokens=0,
+        status="normal",
+        invoke_from=InvokeFrom.WEB_APP.value,
+        from_source=ConversationFromSource.CONSOLE,
+        from_end_user_id=None,
+        from_account_id=account_id,
+        dialogue_count=0,
+        is_deleted=False,
+    )
+    db_session.add(conversation)
+    db_session.flush()
+    return conversation
 
-    @staticmethod
-    def create_app_and_account(db_session: Session):
-        tenant = Tenant(name=f"Tenant {uuid4()}")
-        db_session.add(tenant)
-        db_session.flush()
 
-        account = Account(
-            name=f"Account {uuid4()}",
-            email=f"audio_{uuid4()}@example.com",
-            password="hashed-password",
-            password_salt="salt",
-            interface_language="en-US",
-            timezone="UTC",
-        )
-        db_session.add(account)
-        db_session.flush()
-
-        tenant_join = TenantAccountJoin(
-            tenant_id=tenant.id,
-            account_id=account.id,
-            role="owner",
-            current=True,
-        )
-        db_session.add(tenant_join)
-        db_session.flush()
-
-        app = App(
-            tenant_id=tenant.id,
-            name=f"App {uuid4()}",
-            description="",
-            mode=AppMode.CHAT.value,
-            icon_type="emoji",
-            icon="bot",
-            icon_background="#FFFFFF",
-            enable_site=False,
-            enable_api=True,
-            api_rpm=100,
-            api_rph=100,
-            is_demo=False,
-            is_public=False,
-            is_universal=False,
-            created_by=account.id,
-            updated_by=account.id,
-        )
-        db_session.add(app)
-        db_session.commit()
-        return app, account
-
-    @staticmethod
-    def create_conversation(db_session: Session, app: App, account: Account) -> Conversation:
-        conversation = Conversation(
-            app_id=app.id,
-            app_model_config_id=None,
-            model_provider=None,
-            model_id="",
-            override_model_configs=None,
-            mode=app.mode,
-            name=f"Conversation {uuid4()}",
-            summary="",
-            inputs={},
-            introduction="",
-            system_instruction="",
-            system_instruction_tokens=0,
-            status="normal",
-            invoke_from=InvokeFrom.WEB_APP.value,
-            from_source=ConversationFromSource.CONSOLE,
-            from_end_user_id=None,
-            from_account_id=account.id,
-            dialogue_count=0,
-            is_deleted=False,
-        )
-        db_session.add(conversation)
-        db_session.commit()
-        return conversation
-
-    @staticmethod
-    def create_message(
-        db_session: Session,
-        app: App,
-        conversation: Conversation,
-        account: Account,
-        *,
-        answer: str = "Message answer text",
-        status: str = MessageStatus.NORMAL,
-    ) -> Message:
-        message = Message(
-            app_id=app.id,
-            model_provider=None,
-            model_id="",
-            override_model_configs=None,
-            conversation_id=conversation.id,
-            inputs={},
-            query="Test query",
-            message={"messages": [{"role": "user", "content": "Test query"}]},
-            message_tokens=0,
-            message_unit_price=Decimal(0),
-            message_price_unit=Decimal("0.001"),
-            answer=answer,
-            answer_tokens=0,
-            answer_unit_price=Decimal(0),
-            answer_price_unit=Decimal("0.001"),
-            parent_message_id=None,
-            provider_response_latency=0,
-            total_price=Decimal(0),
-            currency="USD",
-            status=status,
-            invoke_from=InvokeFrom.WEB_APP.value,
-            from_source=ConversationFromSource.CONSOLE,
-            from_end_user_id=None,
-            from_account_id=account.id,
-        )
-        db_session.add(message)
-        db_session.commit()
-        return message
+def _create_message(
+    db_session: Session,
+    app: App,
+    conversation: Conversation,
+    account_id: str,
+    *,
+    answer: str = "Message answer text",
+    status: MessageStatus | str = MessageStatus.NORMAL,
+) -> Message:
+    """Create a Message row via flush() so the rollback-based teardown can remove it."""
+    message = Message(
+        app_id=app.id,
+        model_provider=None,
+        model_id="",
+        override_model_configs=None,
+        conversation_id=conversation.id,
+        inputs={},
+        query="Test query",
+        message={"messages": [{"role": "user", "content": "Test query"}]},
+        message_tokens=0,
+        message_unit_price=Decimal(0),
+        message_price_unit=Decimal("0.001"),
+        answer=answer,
+        answer_tokens=0,
+        answer_unit_price=Decimal(0),
+        answer_price_unit=Decimal("0.001"),
+        parent_message_id=None,
+        provider_response_latency=0,
+        total_price=Decimal(0),
+        currency="USD",
+        status=status,
+        invoke_from=InvokeFrom.WEB_APP.value,
+        from_source=ConversationFromSource.CONSOLE,
+        from_end_user_id=None,
+        from_account_id=account_id,
+    )
+    db_session.add(message)
+    db_session.flush()
+    return message
 
 
 class TestAudioServiceTranscriptTTSMessageLookup:
     """Integration tests for AudioService.transcript_tts message-ID lookup via real DB."""
 
     @pytest.fixture(autouse=True)
-    def _auto_rollback(self, db_session_with_containers: Session) -> Generator[None, None, None]:
+    def _setup_cleanup(self, db_session_with_containers: Session) -> Generator[None, None, None]:
+        """Track rows created by shared helpers that commit, then clean up after the test.
+
+        The shared console helpers (create_console_account_and_tenant, create_console_app)
+        commit their inserts so the rows survive a simple rollback. This fixture records
+        the app/account/tenant created per test and explicitly deletes them after the test
+        so the DB does not accumulate state across tests. Conversation/Message rows are
+        created via flush() only, so the trailing rollback removes them.
+        """
+        self._committed_rows: list = []
         yield
         db_session_with_containers.rollback()
+        for entity in reversed(self._committed_rows):
+            db_session_with_containers.execute(delete(type(entity)).where(type(entity).id == entity.id))
+        db_session_with_containers.commit()
 
-    def test_transcript_tts_with_message_id_success(
-        self, db_session_with_containers: Session, flask_app_with_containers
-    ) -> None:
-        """transcript_tts invokes TTS with the message answer when message_id resolves to a real row."""
-        app, account = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
-        conversation = AudioServiceDBIntegrationTestDataFactory.create_conversation(
-            db_session_with_containers, app, account
+    def _setup_app_and_account(self, db_session: Session) -> tuple[App, str, str]:
+        """Create committed app/account/tenant using shared helpers and track them for cleanup."""
+        account, tenant = create_console_account_and_tenant(db_session)
+        app = create_console_app(db_session, tenant_id=tenant.id, account_id=account.id, mode=AppMode.CHAT)
+
+        # Track rows in the order they must be deleted (FK-safe: app and join before account/tenant)
+        self._committed_rows.append(app)
+        join = db_session.scalar(
+            select(TenantAccountJoin).where(
+                TenantAccountJoin.account_id == account.id,
+                TenantAccountJoin.tenant_id == tenant.id,
+            )
         )
-        message = AudioServiceDBIntegrationTestDataFactory.create_message(
+        if join is not None:
+            self._committed_rows.append(join)
+        self._committed_rows.extend([account, tenant])
+        return app, account.id, tenant.id
+
+    def test_transcript_tts_with_message_id_success(self, db_session_with_containers: Session) -> None:
+        """transcript_tts invokes TTS with the message answer when message_id resolves to a real row."""
+        app, account_id, _ = self._setup_app_and_account(db_session_with_containers)
+        conversation = _create_conversation(db_session_with_containers, app, account_id)
+        message = _create_message(
             db_session_with_containers,
             app,
             conversation,
-            account,
+            account_id,
             answer="Hello from message",
         )
 
         mock_model_instance = MagicMock()
         mock_model_instance.invoke_tts.return_value = b"audio from message"
-
         mock_model_manager = MagicMock()
         mock_model_manager.get_default_model_instance.return_value = mock_model_instance
 
-        with (
-            flask_app_with_containers.app_context(),
-            patch("services.audio_service.ModelManager.for_tenant", return_value=mock_model_manager),
-        ):
+        with patch("services.audio_service.ModelManager.for_tenant", return_value=mock_model_manager):
             result = AudioService.transcript_tts(
                 app_model=app,
                 message_id=message.id,
@@ -191,55 +168,44 @@ class TestAudioServiceTranscriptTTSMessageLookup:
             voice="en-US-Neural",
         )
 
-    def test_transcript_tts_returns_none_for_invalid_message_id(
-        self, db_session_with_containers: Session, flask_app_with_containers
-    ) -> None:
+    def test_transcript_tts_returns_none_for_invalid_message_id(self, db_session_with_containers: Session) -> None:
         """transcript_tts returns None immediately when message_id is not a valid UUID."""
-        app, _ = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
+        app, _, _ = self._setup_app_and_account(db_session_with_containers)
 
-        with flask_app_with_containers.app_context():
-            result = AudioService.transcript_tts(
-                app_model=app,
-                message_id="invalid-uuid",
-            )
-
-        assert result is None
-
-    def test_transcript_tts_returns_none_for_nonexistent_message(
-        self, db_session_with_containers: Session, flask_app_with_containers
-    ) -> None:
-        """transcript_tts returns None when message_id is a valid UUID but no Message row exists."""
-        app, _ = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
-
-        with flask_app_with_containers.app_context():
-            result = AudioService.transcript_tts(
-                app_model=app,
-                message_id=str(uuid4()),
-            )
-
-        assert result is None
-
-    def test_transcript_tts_returns_none_for_empty_message_answer(
-        self, db_session_with_containers: Session, flask_app_with_containers
-    ) -> None:
-        """transcript_tts returns None when the resolved message has an empty answer."""
-        app, account = AudioServiceDBIntegrationTestDataFactory.create_app_and_account(db_session_with_containers)
-        conversation = AudioServiceDBIntegrationTestDataFactory.create_conversation(
-            db_session_with_containers, app, account
+        result = AudioService.transcript_tts(
+            app_model=app,
+            message_id="invalid-uuid",
         )
-        message = AudioServiceDBIntegrationTestDataFactory.create_message(
+
+        assert result is None
+
+    def test_transcript_tts_returns_none_for_nonexistent_message(self, db_session_with_containers: Session) -> None:
+        """transcript_tts returns None when message_id is a valid UUID but no Message row exists."""
+        app, _, _ = self._setup_app_and_account(db_session_with_containers)
+
+        result = AudioService.transcript_tts(
+            app_model=app,
+            message_id=str(uuid4()),
+        )
+
+        assert result is None
+
+    def test_transcript_tts_returns_none_for_empty_message_answer(self, db_session_with_containers: Session) -> None:
+        """transcript_tts returns None when the resolved message has an empty answer."""
+        app, account_id, _ = self._setup_app_and_account(db_session_with_containers)
+        conversation = _create_conversation(db_session_with_containers, app, account_id)
+        message = _create_message(
             db_session_with_containers,
             app,
             conversation,
-            account,
+            account_id,
             answer="",
             status=MessageStatus.NORMAL,
         )
 
-        with flask_app_with_containers.app_context():
-            result = AudioService.transcript_tts(
-                app_model=app,
-                message_id=message.id,
-            )
+        result = AudioService.transcript_tts(
+            app_model=app,
+            message_id=message.id,
+        )
 
         assert result is None

--- a/api/tests/unit_tests/services/test_audio_service.py
+++ b/api/tests/unit_tests/services/test_audio_service.py
@@ -403,43 +403,6 @@ class TestAudioServiceTTS:
             voice="en-US-Neural",
         )
 
-    @patch("services.audio_service.db.session", autospec=True)
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
-    def test_transcript_tts_with_message_id_success(self, mock_model_manager_class, mock_db_session, factory):
-        """Test successful TTS with message ID."""
-        # Arrange
-        app_model_config = factory.create_app_model_config_mock(
-            text_to_speech_dict={"enabled": True, "voice": "en-US-Neural"}
-        )
-        app = factory.create_app_mock(
-            mode=AppMode.CHAT,
-            app_model_config=app_model_config,
-        )
-
-        message = factory.create_message_mock(
-            message_id="550e8400-e29b-41d4-a716-446655440000",
-            answer="Message answer text",
-        )
-
-        # Mock database lookup
-        mock_db_session.get.return_value = message
-
-        # Mock ModelManager
-        mock_model_manager = mock_model_manager_class.return_value
-        mock_model_instance = MagicMock()
-        mock_model_instance.invoke_tts.return_value = b"audio from message"
-        mock_model_manager.get_default_model_instance.return_value = mock_model_instance
-
-        # Act
-        result = AudioService.transcript_tts(
-            app_model=app,
-            message_id="550e8400-e29b-41d4-a716-446655440000",
-        )
-
-        # Assert
-        assert result == b"audio from message"
-        mock_model_instance.invoke_tts.assert_called_once()
-
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_with_default_voice(self, mock_model_manager_class, factory):
         """Test TTS uses default voice when none specified."""
@@ -543,62 +506,6 @@ class TestAudioServiceTTS:
         # Act & Assert
         with pytest.raises(ValueError, match="Text is required"):
             AudioService.transcript_tts(app_model=app, text=None)
-
-    @patch("services.audio_service.db.session")
-    def test_transcript_tts_returns_none_for_invalid_message_id(self, mock_db_session, factory):
-        """Test that TTS returns None for invalid message ID format."""
-        # Arrange
-        app = factory.create_app_mock()
-
-        # Act
-        result = AudioService.transcript_tts(
-            app_model=app,
-            message_id="invalid-uuid",
-        )
-
-        # Assert
-        assert result is None
-
-    @patch("services.audio_service.db.session")
-    def test_transcript_tts_returns_none_for_nonexistent_message(self, mock_db_session, factory):
-        """Test that TTS returns None when message doesn't exist."""
-        # Arrange
-        app = factory.create_app_mock()
-
-        # Mock database lookup returning None
-        mock_db_session.get.return_value = None
-
-        # Act
-        result = AudioService.transcript_tts(
-            app_model=app,
-            message_id="550e8400-e29b-41d4-a716-446655440000",
-        )
-
-        # Assert
-        assert result is None
-
-    @patch("services.audio_service.db.session")
-    def test_transcript_tts_returns_none_for_empty_message_answer(self, mock_db_session, factory):
-        """Test that TTS returns None when message answer is empty."""
-        # Arrange
-        app = factory.create_app_mock()
-
-        message = factory.create_message_mock(
-            answer="",
-            status=MessageStatus.NORMAL,
-        )
-
-        # Mock database lookup
-        mock_db_session.get.return_value = message
-
-        # Act
-        result = AudioService.transcript_tts(
-            app_model=app,
-            message_id="550e8400-e29b-41d4-a716-446655440000",
-        )
-
-        # Assert
-        assert result is None
 
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_raises_error_when_no_voices_available(self, mock_model_manager_class, factory):


### PR DESCRIPTION
Closes part of #32454.

Migrates four `db.session`-mocked unit tests from `unit_tests/services/test_audio_service.py` to a new real PostgreSQL-backed
integration test file. No integration test file existed for this service before this PR.

### Changes
- **Created** `tests/test_containers_integration_tests/services/test_audio_service_db.py` (4 tests in `TestAudioServiceTranscriptTTSMessageLookup`)
  - `test_transcript_tts_with_message_id_success` — creates a real `Message` row, patches `ModelManager`, and asserts the TTS audio is returned
  - `test_transcript_tts_returns_none_for_invalid_message_id` — asserts `None` is returned immediately for a non-UUID `message_id` (no DB row needed)
  - `test_transcript_tts_returns_none_for_nonexistent_message` — asserts `None` when `message_id` is a valid UUID but no `Message` row exists
  - `test_transcript_tts_returns_none_for_empty_message_answer` — creates a real `Message` with `answer=""` and asserts `None` is returned
- **Removed** the same four tests from `tests/unit_tests/services/test_audio_service.py`

### Why
The removed tests patched `services.audio_service.db.session` to stub `db.session.get(Message, id)`. The new tests exercise that real lookup against a live PostgreSQL container, ensuring the correct short-circuit behaviour for invalid, missing, and empty-answer messages.

### Tests

All tests passed.