### PR TITLE
refactor: replace bare dict with typed annotations in external_data_tool

### DIFF
--- a/api/core/extension/extensible.py
+++ b/api/core/extension/extensible.py
@@ -32,9 +32,9 @@ class Extensible:
 
     name: str
     tenant_id: str
-    config: dict | None = None
+    config: dict[str, Any] | None = None
 
-    def __init__(self, tenant_id: str, config: dict | None = None):
+    def __init__(self, tenant_id: str, config: dict[str, Any] | None = None):
         self.tenant_id = tenant_id
         self.config = config
 

--- a/api/core/external_data_tool/api/api.py
+++ b/api/core/external_data_tool/api/api.py
@@ -11,7 +11,11 @@ from models.api_based_extension import APIBasedExtension, APIBasedExtensionPoint
 
 
 class ApiToolConfig(TypedDict, total=False):
-    """Config shape for ApiExternalDataTool, passed via validate_config and stored in self.config."""
+    """Expected config shape for ApiExternalDataTool.
+
+    Not used directly in method signatures (base class accepts dict[str, Any]);
+    kept here to document the keys this tool reads from config.
+    """
 
     api_based_extension_id: str
 
@@ -25,7 +29,7 @@ class ApiExternalDataTool(ExternalDataTool):
     """the unique name of external data tool"""
 
     @classmethod
-    def validate_config(cls, tenant_id: str, config: ApiToolConfig):
+    def validate_config(cls, tenant_id: str, config: dict[str, Any]):
         """
         Validate the incoming form config data.
 

--- a/api/core/external_data_tool/api/api.py
+++ b/api/core/external_data_tool/api/api.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Any, TypedDict
+
 from sqlalchemy import select
 
 from core.extension.api_based_extension_requestor import APIBasedExtensionRequestor
@@ -5,6 +8,12 @@ from core.external_data_tool.base import ExternalDataTool
 from core.helper import encrypter
 from extensions.ext_database import db
 from models.api_based_extension import APIBasedExtension, APIBasedExtensionPoint
+
+
+class ApiToolConfig(TypedDict, total=False):
+    """Config shape for ApiExternalDataTool, passed via validate_config and stored in self.config."""
+
+    api_based_extension_id: str
 
 
 class ApiExternalDataTool(ExternalDataTool):
@@ -16,7 +25,7 @@ class ApiExternalDataTool(ExternalDataTool):
     """the unique name of external data tool"""
 
     @classmethod
-    def validate_config(cls, tenant_id: str, config: dict):
+    def validate_config(cls, tenant_id: str, config: ApiToolConfig):
         """
         Validate the incoming form config data.
 
@@ -37,7 +46,7 @@ class ApiExternalDataTool(ExternalDataTool):
         if not api_based_extension:
             raise ValueError("api_based_extension_id is invalid")
 
-    def query(self, inputs: dict, query: str | None = None) -> str:
+    def query(self, inputs: Mapping[str, Any], query: str | None = None) -> str:
         """
         Query the external data tool.
 

--- a/api/core/external_data_tool/base.py
+++ b/api/core/external_data_tool/base.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any
 
 from core.extension.extensible import Extensible, ExtensionModule
 
@@ -15,14 +17,14 @@ class ExternalDataTool(Extensible, ABC):
     variable: str
     """the tool variable name of app tool"""
 
-    def __init__(self, tenant_id: str, app_id: str, variable: str, config: dict | None = None):
+    def __init__(self, tenant_id: str, app_id: str, variable: str, config: dict[str, Any] | None = None):
         super().__init__(tenant_id, config)
         self.app_id = app_id
         self.variable = variable
 
     @classmethod
     @abstractmethod
-    def validate_config(cls, tenant_id: str, config: dict):
+    def validate_config(cls, tenant_id: str, config: dict[str, Any]):
         """
         Validate the incoming form config data.
 
@@ -33,7 +35,7 @@ class ExternalDataTool(Extensible, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def query(self, inputs: dict, query: str | None = None) -> str:
+    def query(self, inputs: Mapping[str, Any], query: str | None = None) -> str:
         """
         Query the external data tool.
 


### PR DESCRIPTION
## Summary
- `extensible.py`: `config: dict | None` → `dict[str, Any] | None`
- `external_data_tool/base.py`: `config: dict` → `dict[str, Any]`,
  `inputs: dict` → `Mapping[str, Any]`
- `external_data_tool/api/api.py`: introduce `ApiToolConfig` TypedDict for
  the known `api_based_extension_id` key; `inputs: dict` → `Mapping[str, Any]`
- No behavior change — types only

Part of #22651
