### PR TITLE
refactor(api): type _serialize_full_content with FullContentDict TypedDict

### DIFF
--- a/api/controllers/console/app/workflow_draft_variable.py
+++ b/api/controllers/console/app/workflow_draft_variable.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 from functools import wraps
-from typing import Any
+from typing import Any, TypedDict
 
 from flask import Response, request
 from flask_restx import Resource, fields, marshal, marshal_with
@@ -86,7 +86,14 @@ def _serialize_variable_type(workflow_draft_var: WorkflowDraftVariable) -> str:
     return value_type.exposed_type().value
 
 
-def _serialize_full_content(variable: WorkflowDraftVariable) -> dict | None:
+class FullContentDict(TypedDict):
+    size_bytes: int | None
+    value_type: str
+    length: int | None
+    download_url: str
+
+
+def _serialize_full_content(variable: WorkflowDraftVariable) -> FullContentDict | None:
     """Serialize full_content information for large variables."""
     if not variable.is_truncated():
         return None
@@ -94,12 +101,13 @@ def _serialize_full_content(variable: WorkflowDraftVariable) -> dict | None:
     variable_file = variable.variable_file
     assert variable_file is not None
 
-    return {
+    result: FullContentDict = {
         "size_bytes": variable_file.size,
         "value_type": variable_file.value_type.exposed_type().value,
         "length": variable_file.length,
         "download_url": file_helpers.get_signed_file_url(variable_file.upload_file_id, as_attachment=True),
     }
+    return result
 
 
 def _ensure_variable_access(


### PR DESCRIPTION
Part of #32863 (`api/controllers/console/app/`)

## Summary
- Define `FullContentDict` TypedDict for `_serialize_full_content()` return type
- Replace bare `dict` return annotation with `FullContentDict | None`

## Why this change
`_serialize_full_content()` returned bare `dict | None`, hiding its fixed 4-key structure (`size_bytes`, `value_type`, `length`, `download_url`). A TypedDict makes the shape and value types explicit.

## Changes
- `api/controllers/console/app/workflow_draft_variable.py`: Define `FullContentDict`, annotate `_serialize_full_content`