### PR TITLE
refactor(api): enable reportUntypedFunctionDecorator in pyright config (#26412)

### DIFF
--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -94,10 +94,9 @@ def get_user_tenant[**P, R](view_func: Callable[P, R]) -> Callable[P, R]:
 
 
 def plugin_data[**P, R](
-    view: Callable[P, R] | None = None,
     *,
     payload_type: type[BaseModel],
-) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(view_func: Callable[P, R]) -> Callable[P, R]:
         @wraps(view_func)
         def decorated_view(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -116,7 +115,4 @@ def plugin_data[**P, R](
 
         return decorated_view
 
-    if view is None:
-        return decorator
-    else:
-        return decorator(view)
+    return decorator

--- a/api/libs/external_api.py
+++ b/api/libs/external_api.py
@@ -17,7 +17,6 @@ def http_status_message(code):
 
 
 def register_external_error_handlers(api: Api):
-    @api.errorhandler(HTTPException)
     def handle_http_exception(e: HTTPException):
         got_request_exception.send(current_app, exception=e)
 
@@ -74,27 +73,18 @@ def register_external_error_handlers(api: Api):
                     headers["Set-Cookie"] = build_force_logout_cookie_headers()
             return data, status_code, headers
 
-    _ = handle_http_exception
-
-    @api.errorhandler(ValueError)
     def handle_value_error(e: ValueError):
         got_request_exception.send(current_app, exception=e)
         status_code = 400
         data = {"code": "invalid_param", "message": str(e), "status": status_code}
         return data, status_code
 
-    _ = handle_value_error
-
-    @api.errorhandler(AppInvokeQuotaExceededError)
     def handle_quota_exceeded(e: AppInvokeQuotaExceededError):
         got_request_exception.send(current_app, exception=e)
         status_code = 429
         data = {"code": "too_many_requests", "message": str(e), "status": status_code}
         return data, status_code
 
-    _ = handle_quota_exceeded
-
-    @api.errorhandler(Exception)
     def handle_general_exception(e: Exception):
         got_request_exception.send(current_app, exception=e)
 
@@ -113,7 +103,10 @@ def register_external_error_handlers(api: Api):
 
         return data, status_code
 
-    _ = handle_general_exception
+    api.errorhandler(HTTPException)(handle_http_exception)
+    api.errorhandler(ValueError)(handle_value_error)
+    api.errorhandler(AppInvokeQuotaExceededError)(handle_quota_exceeded)
+    api.errorhandler(Exception)(handle_general_exception)
 
 
 class ExternalApi(Api):

--- a/api/pyrightconfig.json
+++ b/api/pyrightconfig.json
@@ -47,7 +47,6 @@
   "reportMissingTypeArgument": "hint",
   "reportUnnecessaryComparison": "hint",
   "reportUnnecessaryIsInstance": "hint",
-  "reportUntypedFunctionDecorator": "hint",
   "reportUnnecessaryTypeIgnoreComment": "hint",
   "reportAttributeAccessIssue": "hint",
   "pythonVersion": "3.12",


### PR DESCRIPTION
## Summary

Incremental step for #26412 — removes the `reportUntypedFunctionDecorator: "hint"` override from `api/pyrightconfig.json` so the rule runs at strict-mode default severity, and fixes the 19 errors that surfaced.

- **`controllers/inner_api/plugin/wraps.py`**: `plugin_data` was declared with an optional `view` parameter and a union return type (`Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]`), which pyright could not resolve at the call sites — every `@plugin_data(payload_type=...)` usage was flagged as an untyped decorator (15 errors in `controllers/inner_api/plugin/plugin.py`). The `view` parameter was never used in practice (all call sites go through the `payload_type` keyword), so the signature is simplified to a plain decorator factory returning `Callable[[Callable[P, R]], Callable[P, R]]`.
- **`libs/external_api.py`**: the 4 `@api.errorhandler(...)` registrations come from `flask_restx`, which is listed in `allowedUntypedLibraries`. Even so, `reportUntypedFunctionDecorator` still fires on these lines. Converted to explicit `api.errorhandler(X)(handler)` calls, which is equivalent at runtime and avoids the untyped-decorator form entirely (also drops the `_ = handle_*` unused-variable placeholders that existed only to silence linters).
- **`pyrightconfig.json`**: removes the `reportUntypedFunctionDecorator: "hint"` line.

## Verification

- `uv run --group dev basedpyright` → 0 `reportUntypedFunctionDecorator` errors (before: 19).
- `uv run --group dev pytest tests/unit_tests/controllers/inner_api/plugin/` → 35 passed.
- `uv run --group dev ruff check` / `ruff format --check` → clean.

## Test plan

- [x] Type check passes with the rule at strict default
- [x] Existing unit tests for `plugin_data` and inner_api plugin routes pass
- [x] No behavioral change: decorator/handler registration is semantically equivalent