### PR TITLE
refactor(auth): standardize failed login audit logging

### DIFF
--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -1,3 +1,5 @@
+import logging
+
 import flask_login
 from flask import make_response, request
 from flask_restx import Resource
@@ -42,12 +44,13 @@ from libs.token import (
 )
 from services.account_service import AccountService, InvitationDetailDict, RegisterService, TenantService
 from services.billing_service import BillingService
-from services.entities.auth_entities import LoginPayloadBase
+from services.entities.auth_entities import LoginFailureReason, LoginPayloadBase
 from services.errors.account import AccountRegisterError
 from services.errors.workspace import WorkSpaceNotAllowedCreateError, WorkspacesLimitExceededError
 from services.feature_service import FeatureService
 
 DEFAULT_REF_TEMPLATE_SWAGGER_2_0 = "#/definitions/{model}"
+logger = logging.getLogger(__name__)
 
 
 class LoginPayload(LoginPayloadBase):
@@ -91,10 +94,12 @@ class LoginApi(Resource):
         normalized_email = request_email.lower()
 
         if dify_config.BILLING_ENABLED and BillingService.is_email_in_freeze(normalized_email):
+            _log_console_login_failure(email=normalized_email, reason=LoginFailureReason.ACCOUNT_IN_FREEZE)
             raise AccountInFreezeError()
 
         is_login_error_rate_limit = AccountService.is_login_error_rate_limit(normalized_email)
         if is_login_error_rate_limit:
+            _log_console_login_failure(email=normalized_email, reason=LoginFailureReason.LOGIN_RATE_LIMITED)
             raise EmailPasswordLoginLimitError()
 
         invite_token = args.invite_token
@@ -110,14 +115,20 @@ class LoginApi(Resource):
                 invitee_email = data.get("email") if data else None
                 invitee_email_normalized = invitee_email.lower() if isinstance(invitee_email, str) else invitee_email
                 if invitee_email_normalized != normalized_email:
+                    _log_console_login_failure(
+                        email=normalized_email,
+                        reason=LoginFailureReason.INVALID_INVITATION_EMAIL,
+                    )
                     raise InvalidEmailError()
             account = _authenticate_account_with_case_fallback(
                 request_email, normalized_email, args.password, invite_token
             )
         except services.errors.account.AccountLoginError:
+            _log_console_login_failure(email=normalized_email, reason=LoginFailureReason.ACCOUNT_BANNED)
             raise AccountBannedError()
         except services.errors.account.AccountPasswordError as exc:
             AccountService.add_login_error_rate_limit(normalized_email)
+            _log_console_login_failure(email=normalized_email, reason=LoginFailureReason.INVALID_CREDENTIALS)
             raise AuthenticationFailedError() from exc
         # SELF_HOSTED only have one workspace
         tenants = TenantService.get_join_tenants(account)
@@ -240,20 +251,24 @@ class EmailCodeLoginApi(Resource):
 
         token_data = AccountService.get_email_code_login_data(args.token)
         if token_data is None:
+            _log_console_login_failure(email=user_email, reason=LoginFailureReason.INVALID_EMAIL_CODE_TOKEN)
             raise InvalidTokenError()
 
         token_email = token_data.get("email")
         normalized_token_email = token_email.lower() if isinstance(token_email, str) else token_email
         if normalized_token_email != user_email:
+            _log_console_login_failure(email=user_email, reason=LoginFailureReason.EMAIL_CODE_EMAIL_MISMATCH)
             raise InvalidEmailError()
 
         if token_data["code"] != args.code:
+            _log_console_login_failure(email=user_email, reason=LoginFailureReason.INVALID_EMAIL_CODE)
             raise EmailCodeError()
 
         AccountService.revoke_email_code_login_token(args.token)
         try:
             account = _get_account_with_case_fallback(original_email)
         except AccountRegisterError:
+            _log_console_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_IN_FREEZE)
             raise AccountInFreezeError()
         if account:
             tenants = TenantService.get_join_tenants(account)
@@ -279,6 +294,7 @@ class EmailCodeLoginApi(Resource):
             except WorkSpaceNotAllowedCreateError:
                 raise NotAllowedCreateWorkspace()
             except AccountRegisterError:
+                _log_console_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_IN_FREEZE)
                 raise AccountInFreezeError()
             except WorkspacesLimitExceededError:
                 raise WorkspacesLimitExceeded()
@@ -336,3 +352,12 @@ def _authenticate_account_with_case_fallback(
         if original_email == normalized_email:
             raise
         return AccountService.authenticate(normalized_email, password, invite_token)
+
+
+def _log_console_login_failure(*, email: str, reason: LoginFailureReason) -> None:
+    logger.warning(
+        "Console login failed: email=%s reason=%s ip_address=%s",
+        email,
+        reason,
+        extract_remote_ip(request),
+    )

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -4,6 +4,7 @@ import flask_login
 from flask import make_response, request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
+from werkzeug.exceptions import Unauthorized
 
 import services
 from configs import dify_config
@@ -267,6 +268,9 @@ class EmailCodeLoginApi(Resource):
         AccountService.revoke_email_code_login_token(args.token)
         try:
             account = _get_account_with_case_fallback(original_email)
+        except Unauthorized as exc:
+            _log_console_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_BANNED)
+            raise AccountBannedError() from exc
         except AccountRegisterError:
             _log_console_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_IN_FREEZE)
             raise AccountInFreezeError()

--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -4,6 +4,7 @@ from flask import make_response, request
 from flask_restx import Resource
 from jwt import InvalidTokenError
 from pydantic import BaseModel, Field, field_validator
+from werkzeug.exceptions import Unauthorized
 
 import services
 from configs import dify_config
@@ -237,7 +238,11 @@ class EmailCodeLoginApi(Resource):
             raise EmailCodeError()
 
         WebAppAuthService.revoke_email_code_login_token(payload.token)
-        account = WebAppAuthService.get_user_through_email(token_email)
+        try:
+            account = WebAppAuthService.get_user_through_email(token_email)
+        except Unauthorized as exc:
+            _log_web_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_BANNED)
+            raise AccountBannedError() from exc
         if not account:
             _log_web_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_NOT_FOUND)
             raise AuthenticationFailedError()

--- a/api/controllers/web/login.py
+++ b/api/controllers/web/login.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import make_response, request
 from flask_restx import Resource
 from jwt import InvalidTokenError
@@ -20,7 +22,7 @@ from controllers.console.wraps import (
 )
 from controllers.web import web_ns
 from controllers.web.wraps import decode_jwt_token
-from libs.helper import EmailStr
+from libs.helper import EmailStr, extract_remote_ip
 from libs.passport import PassportService
 from libs.password import valid_password
 from libs.token import (
@@ -29,8 +31,10 @@ from libs.token import (
 )
 from services.account_service import AccountService
 from services.app_service import AppService
-from services.entities.auth_entities import LoginPayloadBase
+from services.entities.auth_entities import LoginFailureReason, LoginPayloadBase
 from services.webapp_auth_service import WebAppAuthService
+
+logger = logging.getLogger(__name__)
 
 
 class LoginPayload(LoginPayloadBase):
@@ -76,14 +80,18 @@ class LoginApi(Resource):
     def post(self):
         """Authenticate user and login."""
         payload = LoginPayload.model_validate(web_ns.payload or {})
+        normalized_email = payload.email.lower()
 
         try:
             account = WebAppAuthService.authenticate(payload.email, payload.password)
         except services.errors.account.AccountLoginError:
+            _log_web_login_failure(email=normalized_email, reason=LoginFailureReason.ACCOUNT_BANNED)
             raise AccountBannedError()
         except services.errors.account.AccountPasswordError:
+            _log_web_login_failure(email=normalized_email, reason=LoginFailureReason.INVALID_CREDENTIALS)
             raise AuthenticationFailedError()
         except services.errors.account.AccountNotFoundError:
+            _log_web_login_failure(email=normalized_email, reason=LoginFailureReason.ACCOUNT_NOT_FOUND)
             raise AuthenticationFailedError()
 
         token = WebAppAuthService.login(account=account)
@@ -212,21 +220,26 @@ class EmailCodeLoginApi(Resource):
 
         token_data = WebAppAuthService.get_email_code_login_data(payload.token)
         if token_data is None:
+            _log_web_login_failure(email=user_email, reason=LoginFailureReason.INVALID_EMAIL_CODE_TOKEN)
             raise InvalidTokenError()
 
         token_email = token_data.get("email")
         if not isinstance(token_email, str):
+            _log_web_login_failure(email=user_email, reason=LoginFailureReason.EMAIL_CODE_EMAIL_MISMATCH)
             raise InvalidEmailError()
         normalized_token_email = token_email.lower()
         if normalized_token_email != user_email:
+            _log_web_login_failure(email=user_email, reason=LoginFailureReason.EMAIL_CODE_EMAIL_MISMATCH)
             raise InvalidEmailError()
 
         if token_data["code"] != payload.code:
+            _log_web_login_failure(email=user_email, reason=LoginFailureReason.INVALID_EMAIL_CODE)
             raise EmailCodeError()
 
         WebAppAuthService.revoke_email_code_login_token(payload.token)
         account = WebAppAuthService.get_user_through_email(token_email)
         if not account:
+            _log_web_login_failure(email=user_email, reason=LoginFailureReason.ACCOUNT_NOT_FOUND)
             raise AuthenticationFailedError()
 
         token = WebAppAuthService.login(account=account)
@@ -234,3 +247,12 @@ class EmailCodeLoginApi(Resource):
         response = make_response({"result": "success", "data": {"access_token": token}})
         # set_access_token_to_cookie(request, response, token, samesite="None", httponly=False)
         return response
+
+
+def _log_web_login_failure(*, email: str, reason: LoginFailureReason) -> None:
+    logger.warning(
+        "Web login failed: email=%s reason=%s ip_address=%s",
+        email,
+        reason,
+        extract_remote_ip(request),
+    )

--- a/api/services/entities/auth_entities.py
+++ b/api/services/entities/auth_entities.py
@@ -1,7 +1,23 @@
+from enum import StrEnum, auto
+
 from pydantic import BaseModel, Field, field_validator
 
 from libs.helper import EmailStr
 from libs.password import valid_password
+
+
+class LoginFailureReason(StrEnum):
+    """Bounded reason codes for failed login audit logs."""
+
+    ACCOUNT_BANNED = auto()
+    ACCOUNT_IN_FREEZE = auto()
+    ACCOUNT_NOT_FOUND = auto()
+    EMAIL_CODE_EMAIL_MISMATCH = auto()
+    INVALID_CREDENTIALS = auto()
+    INVALID_EMAIL_CODE = auto()
+    INVALID_EMAIL_CODE_TOKEN = auto()
+    INVALID_INVITATION_EMAIL = auto()
+    LOGIN_RATE_LIMITED = auto()
 
 
 class LoginPayloadBase(BaseModel):

--- a/api/tests/unit_tests/controllers/console/auth/test_login_logout.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_login_logout.py
@@ -26,6 +26,7 @@ from controllers.console.error import (
     AccountInFreezeError,
     WorkspacesLimitExceeded,
 )
+from services.entities.auth_entities import LoginFailureReason
 from services.errors.account import AccountLoginError, AccountPasswordError
 
 
@@ -197,12 +198,17 @@ class TestLoginApi:
         mock_get_invitation.return_value = None
 
         # Act & Assert
-        with app.test_request_context(
-            "/login", method="POST", json={"email": "test@example.com", "password": encode_password("password")}
-        ):
-            login_api = LoginApi()
-            with pytest.raises(EmailPasswordLoginLimitError):
-                login_api.post()
+        with patch("controllers.console.auth.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/login", method="POST", json={"email": "test@example.com", "password": encode_password("password")}
+            ):
+                login_api = LoginApi()
+                with pytest.raises(EmailPasswordLoginLimitError):
+                    login_api.post()
+
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "test@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.LOGIN_RATE_LIMITED
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", True)
@@ -220,12 +226,17 @@ class TestLoginApi:
         mock_is_frozen.return_value = True
 
         # Act & Assert
-        with app.test_request_context(
-            "/login", method="POST", json={"email": "frozen@example.com", "password": encode_password("password")}
-        ):
-            login_api = LoginApi()
-            with pytest.raises(AccountInFreezeError):
-                login_api.post()
+        with patch("controllers.console.auth.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/login", method="POST", json={"email": "frozen@example.com", "password": encode_password("password")}
+            ):
+                login_api = LoginApi()
+                with pytest.raises(AccountInFreezeError):
+                    login_api.post()
+
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "frozen@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.ACCOUNT_IN_FREEZE
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
@@ -257,14 +268,20 @@ class TestLoginApi:
         mock_authenticate.side_effect = AccountPasswordError("Invalid password")
 
         # Act & Assert
-        with app.test_request_context(
-            "/login", method="POST", json={"email": "test@example.com", "password": encode_password("WrongPass123!")}
-        ):
-            login_api = LoginApi()
-            with pytest.raises(AuthenticationFailedError):
-                login_api.post()
+        with patch("controllers.console.auth.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/login",
+                method="POST",
+                json={"email": "test@example.com", "password": encode_password("WrongPass123!")},
+            ):
+                login_api = LoginApi()
+                with pytest.raises(AuthenticationFailedError):
+                    login_api.post()
 
         mock_add_rate_limit.assert_called_once_with("test@example.com")
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "test@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.INVALID_CREDENTIALS
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)
@@ -288,12 +305,19 @@ class TestLoginApi:
         mock_authenticate.side_effect = AccountLoginError("Account is banned")
 
         # Act & Assert
-        with app.test_request_context(
-            "/login", method="POST", json={"email": "banned@example.com", "password": encode_password("ValidPass123!")}
-        ):
-            login_api = LoginApi()
-            with pytest.raises(AccountBannedError):
-                login_api.post()
+        with patch("controllers.console.auth.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/login",
+                method="POST",
+                json={"email": "banned@example.com", "password": encode_password("ValidPass123!")},
+            ):
+                login_api = LoginApi()
+                with pytest.raises(AccountBannedError):
+                    login_api.post()
+
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "banned@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.ACCOUNT_BANNED
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.dify_config.BILLING_ENABLED", False)

--- a/api/tests/unit_tests/controllers/console/auth/test_login_logout.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_login_logout.py
@@ -14,13 +14,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from flask_restx import Api
+from werkzeug.exceptions import Unauthorized
 
 from controllers.console.auth.error import (
     AuthenticationFailedError,
     EmailPasswordLoginLimitError,
     InvalidEmailError,
 )
-from controllers.console.auth.login import LoginApi, LogoutApi
+from controllers.console.auth.login import EmailCodeLoginApi, LoginApi, LogoutApi
 from controllers.console.error import (
     AccountBannedError,
     AccountInFreezeError,
@@ -33,6 +34,11 @@ from services.errors.account import AccountLoginError, AccountPasswordError
 def encode_password(password: str) -> str:
     """Helper to encode password as Base64 for testing."""
     return base64.b64encode(password.encode("utf-8")).decode()
+
+
+def encode_code(code: str) -> str:
+    """Helper to encode verification code as Base64 for testing."""
+    return base64.b64encode(code.encode("utf-8")).decode()
 
 
 class TestLoginApi:
@@ -440,6 +446,33 @@ class TestLoginApi:
         ]
         mock_add_rate_limit.assert_not_called()
         mock_reset_rate_limit.assert_called_once_with("upper@example.com")
+
+    @patch("controllers.console.auth.login.AccountService.get_email_code_login_data")
+    @patch("controllers.console.auth.login.AccountService.revoke_email_code_login_token")
+    @patch("controllers.console.auth.login._get_account_with_case_fallback")
+    def test_email_code_login_logs_banned_account(
+        self,
+        mock_get_account,
+        mock_revoke_token,
+        mock_get_token_data,
+        app,
+    ):
+        mock_get_token_data.return_value = {"email": "User@Example.com", "code": "123456"}
+        mock_get_account.side_effect = Unauthorized("Account is banned.")
+
+        with patch("controllers.console.auth.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/email-code-login/validity",
+                method="POST",
+                json={"email": "User@Example.com", "code": encode_code("123456"), "token": "token-123"},
+            ):
+                with pytest.raises(AccountBannedError):
+                    EmailCodeLoginApi().post()
+
+        mock_revoke_token.assert_called_once_with("token-123")
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "user@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.ACCOUNT_BANNED
 
 
 class TestLogoutApi:

--- a/api/tests/unit_tests/controllers/console/auth/test_login_logout.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_login_logout.py
@@ -447,6 +447,7 @@ class TestLoginApi:
         mock_add_rate_limit.assert_not_called()
         mock_reset_rate_limit.assert_called_once_with("upper@example.com")
 
+    @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.AccountService.get_email_code_login_data")
     @patch("controllers.console.auth.login.AccountService.revoke_email_code_login_token")
     @patch("controllers.console.auth.login._get_account_with_case_fallback")
@@ -455,8 +456,10 @@ class TestLoginApi:
         mock_get_account,
         mock_revoke_token,
         mock_get_token_data,
+        mock_db,
         app,
     ):
+        mock_db.session.query.return_value.first.return_value = MagicMock()
         mock_get_token_data.return_value = {"email": "User@Example.com", "code": "123456"}
         mock_get_account.side_effect = Unauthorized("Account is banned.")
 

--- a/api/tests/unit_tests/controllers/web/test_web_login.py
+++ b/api/tests/unit_tests/controllers/web/test_web_login.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from jwt import InvalidTokenError
+from werkzeug.exceptions import Unauthorized
 
 import services.errors.account
 from controllers.web.login import EmailCodeLoginApi, EmailCodeLoginSendEmailApi, LoginApi, LoginStatusApi, LogoutApi
@@ -185,6 +186,39 @@ class TestLoginApi:
         assert mock_log_warning.call_count == 1
         assert mock_log_warning.call_args.args[1] == "user@example.com"
         assert mock_log_warning.call_args.args[2] == LoginFailureReason.INVALID_EMAIL_CODE_TOKEN
+
+    @patch("controllers.web.login.WebAppAuthService.revoke_email_code_login_token")
+    @patch(
+        "controllers.web.login.WebAppAuthService.get_user_through_email",
+        side_effect=Unauthorized("Account is banned."),
+    )
+    @patch(
+        "controllers.web.login.WebAppAuthService.get_email_code_login_data",
+        return_value={"email": "User@Example.com", "code": "123456"},
+    )
+    def test_email_code_login_logs_banned_account(
+        self,
+        mock_get_token_data: MagicMock,
+        mock_get_user: MagicMock,
+        mock_revoke_token: MagicMock,
+        app: Flask,
+    ) -> None:
+        from controllers.console.error import AccountBannedError
+
+        with patch("controllers.web.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/web/email-code-login/validity",
+                method="POST",
+                json={"email": "User@Example.com", "code": encode_code("123456"), "token": "token-123"},
+            ):
+                with pytest.raises(AccountBannedError):
+                    EmailCodeLoginApi().post()
+
+        mock_get_token_data.assert_called_once_with("token-123")
+        mock_revoke_token.assert_called_once_with("token-123")
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "user@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.ACCOUNT_BANNED
 
 
 class TestLoginStatusApi:

--- a/api/tests/unit_tests/controllers/web/test_web_login.py
+++ b/api/tests/unit_tests/controllers/web/test_web_login.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from jwt import InvalidTokenError
 
 import services.errors.account
 from controllers.web.login import EmailCodeLoginApi, EmailCodeLoginSendEmailApi, LoginApi, LoginStatusApi, LogoutApi
+from services.entities.auth_entities import LoginFailureReason
 
 
 def encode_code(code: str) -> str:
@@ -115,13 +117,18 @@ class TestLoginApi:
     def test_login_banned_account(self, mock_auth: MagicMock, app: Flask) -> None:
         from controllers.console.error import AccountBannedError
 
-        with app.test_request_context(
-            "/web/login",
-            method="POST",
-            json={"email": "user@example.com", "password": base64.b64encode(b"Valid1234").decode()},
-        ):
-            with pytest.raises(AccountBannedError):
-                LoginApi().post()
+        with patch("controllers.web.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/web/login",
+                method="POST",
+                json={"email": "user@example.com", "password": base64.b64encode(b"Valid1234").decode()},
+            ):
+                with pytest.raises(AccountBannedError):
+                    LoginApi().post()
+
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "user@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.ACCOUNT_BANNED
 
     @patch(
         "controllers.web.login.WebAppAuthService.authenticate",
@@ -130,13 +137,54 @@ class TestLoginApi:
     def test_login_wrong_password(self, mock_auth: MagicMock, app: Flask) -> None:
         from controllers.console.auth.error import AuthenticationFailedError
 
-        with app.test_request_context(
-            "/web/login",
-            method="POST",
-            json={"email": "user@example.com", "password": base64.b64encode(b"Valid1234").decode()},
-        ):
-            with pytest.raises(AuthenticationFailedError):
-                LoginApi().post()
+        with patch("controllers.web.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/web/login",
+                method="POST",
+                json={"email": "user@example.com", "password": base64.b64encode(b"Valid1234").decode()},
+            ):
+                with pytest.raises(AuthenticationFailedError):
+                    LoginApi().post()
+
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "user@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.INVALID_CREDENTIALS
+
+    @patch(
+        "controllers.web.login.WebAppAuthService.authenticate",
+        side_effect=services.errors.account.AccountNotFoundError(),
+    )
+    def test_login_account_not_found(self, mock_auth: MagicMock, app: Flask) -> None:
+        from controllers.console.auth.error import AuthenticationFailedError
+
+        with patch("controllers.web.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/web/login",
+                method="POST",
+                json={"email": "missing@example.com", "password": base64.b64encode(b"Valid1234").decode()},
+            ):
+                with pytest.raises(AuthenticationFailedError):
+                    LoginApi().post()
+
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "missing@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.ACCOUNT_NOT_FOUND
+
+    @patch("controllers.web.login.WebAppAuthService.get_email_code_login_data", return_value=None)
+    def test_email_code_login_logs_invalid_token(self, mock_get_token_data: MagicMock, app: Flask) -> None:
+        with patch("controllers.web.login.logger.warning") as mock_log_warning:
+            with app.test_request_context(
+                "/web/email-code-login/validity",
+                method="POST",
+                json={"email": "user@example.com", "code": encode_code("123456"), "token": "token-123"},
+            ):
+                with pytest.raises(InvalidTokenError):
+                    EmailCodeLoginApi().post()
+
+        mock_get_token_data.assert_called_once_with("token-123")
+        assert mock_log_warning.call_count == 1
+        assert mock_log_warning.call_args.args[1] == "user@example.com"
+        assert mock_log_warning.call_args.args[2] == LoginFailureReason.INVALID_EMAIL_CODE_TOKEN
 
 
 class TestLoginStatusApi:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #35053.

- add warning-level audit logs for failed console and web login paths
- standardize failed-login reason codes with the shared `LoginFailureReason` enum
- keep the log payload limited to normalized email, reason code, and remote IP

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [ ] Ive updated the documentation accordingly.
