### PR TITLE
refactor: replace bare dict with WorkflowRunListArgs TypedDict

### DIFF
--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -36,7 +36,7 @@ from models import Account, App, AppMode, EndUser, WorkflowArchiveLog, WorkflowR
 from models.workflow import WorkflowRun
 from repositories.factory import DifyAPIRepositoryFactory
 from services.retention.workflow_run.constants import ARCHIVE_BUNDLE_NAME
-from services.workflow_run_service import WorkflowRunService
+from services.workflow_run_service import WorkflowRunListArgs, WorkflowRunService
 
 
 def _build_backstage_input_url(form_token: str | None) -> str | None:
@@ -214,7 +214,11 @@ class AdvancedChatAppWorkflowRunListApi(Resource):
         Get advanced chat app workflow run list
         """
         args_model = WorkflowRunListQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
-        args = args_model.model_dump(exclude_none=True)
+        args: WorkflowRunListArgs = {"limit": args_model.limit}
+        if args_model.last_id is not None:
+            args["last_id"] = args_model.last_id
+        if args_model.status is not None:
+            args["status"] = args_model.status
 
         # Default to DEBUGGING if not specified
         triggered_from = (
@@ -356,7 +360,11 @@ class WorkflowRunListApi(Resource):
         Get workflow run list
         """
         args_model = WorkflowRunListQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
-        args = args_model.model_dump(exclude_none=True)
+        args: WorkflowRunListArgs = {"limit": args_model.limit}
+        if args_model.last_id is not None:
+            args["last_id"] = args_model.last_id
+        if args_model.status is not None:
+            args["status"] = args_model.status
 
         # Default to DEBUGGING for workflow if not specified (backward compatibility)
         triggered_from = (

--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -1,5 +1,6 @@
 import threading
 from collections.abc import Sequence
+from typing import TypedDict
 
 from sqlalchemy import Engine
 from sqlalchemy.orm import sessionmaker
@@ -17,6 +18,14 @@ from models import (
 )
 from repositories.api_workflow_run_repository import APIWorkflowRunRepository
 from repositories.factory import DifyAPIRepositoryFactory
+
+
+class WorkflowRunListArgs(TypedDict, total=False):
+    """Expected shape of the args dict passed to workflow run pagination methods."""
+
+    limit: int
+    last_id: str
+    status: str
 
 
 class WorkflowRunService:
@@ -37,7 +46,10 @@ class WorkflowRunService:
         self._workflow_run_repo = DifyAPIRepositoryFactory.create_api_workflow_run_repository(self._session_factory)
 
     def get_paginate_advanced_chat_workflow_runs(
-        self, app_model: App, args: dict, triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING
+        self,
+        app_model: App,
+        args: WorkflowRunListArgs,
+        triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING,
     ) -> InfiniteScrollPagination:
         """
         Get advanced chat app workflow run list
@@ -73,7 +85,10 @@ class WorkflowRunService:
         return pagination
 
     def get_paginate_workflow_runs(
-        self, app_model: App, args: dict, triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING
+        self,
+        app_model: App,
+        args: WorkflowRunListArgs,
+        triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING,
     ) -> InfiniteScrollPagination:
         """
         Get workflow run list


### PR DESCRIPTION
## Summary
- Introduce `WorkflowRunListArgs` TypedDict (`total=False`, fields: `limit`,  `last_id`, `status`) for the args dict passed to both
  `WorkflowRunService.get_paginate_workflow_runs` and  `get_paginate_advanced_chat_workflow_runs`.
- `total=False` matches the runtime contract — the service reads the keys  via `.get(...)` and the controllers use `model_dump(exclude_none=True)`.
- Update both call sites in `controllers/console/app/workflow_run.py` to  construct `WorkflowRunListArgs` selectively from the validated  `WorkflowRunListQuery` Pydantic model instead of `model_dump(exclude_none=True)`.

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes (basedpyright + mypy, 1388 files)
- [x] `make test TARGET_TESTS=./api/tests/unit_tests/services/test_workflow_run_service_pause.py` — 14 tests pass
