### PR TITLE
refactor: replace bare dict with dict[str, Any] in OpenAPI tools parser

### DIFF
--- a/api/core/tools/utils/parser.py
+++ b/api/core/tools/utils/parser.py
@@ -32,7 +32,7 @@ class OpenAPISpecDict(TypedDict):
 class ApiBasedToolSchemaParser:
     @staticmethod
     def parse_openapi_to_tool_bundle(
-        openapi: Mapping[str, Any], extra_info: dict | None = None, warning: dict | None = None
+        openapi: Mapping[str, Any], extra_info: dict[str, Any] | None = None, warning: dict[str, Any] | None = None
     ) -> list[ApiToolBundle]:
         warning = warning if warning is not None else {}
         extra_info = extra_info if extra_info is not None else {}
@@ -236,7 +236,7 @@ class ApiBasedToolSchemaParser:
         return value
 
     @staticmethod
-    def _get_tool_parameter_type(parameter: dict) -> ToolParameter.ToolParameterType | None:
+    def _get_tool_parameter_type(parameter: dict[str, Any]) -> ToolParameter.ToolParameterType | None:
         parameter = parameter or {}
         typ: str | None = None
         if parameter.get("format") == "binary":
@@ -265,7 +265,7 @@ class ApiBasedToolSchemaParser:
 
     @staticmethod
     def parse_openapi_yaml_to_tool_bundle(
-        yaml: str, extra_info: dict | None = None, warning: dict | None = None
+        yaml: str, extra_info: dict[str, Any] | None = None, warning: dict[str, Any] | None = None
     ) -> list[ApiToolBundle]:
         """
         parse openapi yaml to tool bundle
@@ -278,14 +278,14 @@ class ApiBasedToolSchemaParser:
         warning = warning if warning is not None else {}
         extra_info = extra_info if extra_info is not None else {}
 
-        openapi: dict = safe_load(yaml)
+        openapi: dict[str, Any] = safe_load(yaml)
         if openapi is None:
             raise ToolApiSchemaError("Invalid openapi yaml.")
         return ApiBasedToolSchemaParser.parse_openapi_to_tool_bundle(openapi, extra_info=extra_info, warning=warning)
 
     @staticmethod
     def parse_swagger_to_openapi(
-        swagger: dict, extra_info: dict | None = None, warning: dict | None = None
+        swagger: dict[str, Any], extra_info: dict[str, Any] | None = None, warning: dict[str, Any] | None = None
     ) -> OpenAPISpecDict:
         warning = warning or {}
         """
@@ -351,7 +351,7 @@ class ApiBasedToolSchemaParser:
 
     @staticmethod
     def parse_openai_plugin_json_to_tool_bundle(
-        json: str, extra_info: dict | None = None, warning: dict | None = None
+        json: str, extra_info: dict[str, Any] | None = None, warning: dict[str, Any] | None = None
     ) -> list[ApiToolBundle]:
         """
         parse openapi plugin yaml to tool bundle
@@ -392,7 +392,7 @@ class ApiBasedToolSchemaParser:
 
     @staticmethod
     def auto_parse_to_tool_bundle(
-        content: str, extra_info: dict | None = None, warning: dict | None = None
+        content: str, extra_info: dict[str, Any] | None = None, warning: dict[str, Any] | None = None
     ) -> tuple[list[ApiToolBundle], ApiProviderSchemaType]:
         """
         auto parse to tool bundle


### PR DESCRIPTION
## Summary
- Replace seven bare `dict` / `dict | None` annotations in  `ApiBasedToolSchemaParser` with `dict[str, Any]` / `dict[str, Any] | None`:
  - `parse_openapi_to_tool_bundle`: `extra_info`, `warning`
  - `_get_tool_parameter_type`: `parameter`
  - `parse_openapi_yaml_to_tool_bundle`: `extra_info`, `warning`, local `openapi` variable
  - `parse_swagger_to_openapi`: `swagger`, `extra_info`, `warning`
  - `parse_json_to_tool_bundle`: `extra_info`, `warning`
  - `auto_parse_to_tool_bundle`: `extra_info`, `warning`
- All are parsed JSON/YAML payloads with dynamic keys — `dict[str, Any]`  is the correct shape. `Any` is already imported.

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes
- [x] `make test TARGET_TESTS=./api/tests/unit_tests/core/tools/utils/test_parser.py` — 14 tests pass
