### PR TITLE
refactor: replace bare dict with dict[str, Any] in ops_service tracin…

### DIFF
--- a/api/services/ops_service.py
+++ b/api/services/ops_service.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sqlalchemy import select
 
 from core.ops.entities.config_entity import BaseTracingConfig
@@ -135,7 +137,7 @@ class OpsService:
         return trace_config_data.to_dict()
 
     @classmethod
-    def create_tracing_app_config(cls, app_id: str, tracing_provider: str, tracing_config: dict):
+    def create_tracing_app_config(cls, app_id: str, tracing_provider: str, tracing_config: dict[str, Any]):
         """
         Create tracing app config
         :param app_id: app id
@@ -210,7 +212,7 @@ class OpsService:
         return {"result": "success"}
 
     @classmethod
-    def update_tracing_app_config(cls, app_id: str, tracing_provider: str, tracing_config: dict):
+    def update_tracing_app_config(cls, app_id: str, tracing_provider: str, tracing_config: dict[str, Any]):
         """
         Update tracing app config
         :param app_id: app id


### PR DESCRIPTION
## Summary
- Replace bare `dict` annotation on the `tracing_config` parameter of  `OpsService.create_tracing_app_config` and `update_tracing_app_config`  with `dict[str, Any]`.
- Tracing config is provider-specific (arize, langfuse, langsmith, opik,  phoenix, etc.); `dict[str, Any]` matches the truly dynamic key space.

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes
