### PR TITLE
refactor: replace bare dict with dict[str, Any] in plugin endpoint_service

### DIFF
--- a/api/services/plugin/endpoint_service.py
+++ b/api/services/plugin/endpoint_service.py
@@ -1,9 +1,13 @@
+from typing import Any
+
 from core.plugin.impl.endpoint import PluginEndpointClient
 
 
 class EndpointService:
     @classmethod
-    def create_endpoint(cls, tenant_id: str, user_id: str, plugin_unique_identifier: str, name: str, settings: dict):
+    def create_endpoint(
+        cls, tenant_id: str, user_id: str, plugin_unique_identifier: str, name: str, settings: dict[str, Any]
+    ):
         return PluginEndpointClient().create_endpoint(
             tenant_id=tenant_id,
             user_id=user_id,
@@ -32,7 +36,7 @@ class EndpointService:
         )
 
     @classmethod
-    def update_endpoint(cls, tenant_id: str, user_id: str, endpoint_id: str, name: str, settings: dict):
+    def update_endpoint(cls, tenant_id: str, user_id: str, endpoint_id: str, name: str, settings: dict[str, Any]):
         return PluginEndpointClient().update_endpoint(
             tenant_id=tenant_id,
             user_id=user_id,


### PR DESCRIPTION
## Summary
- Replace bare `dict` annotation on the `settings` parameter of both  `EndpointService.create_endpoint` and `EndpointService.update_endpoint`  with `dict[str, Any]`.
- `settings` is a free-form plugin config dict; `dict[str, Any]` is the correct shape (genuinely dynamic keys per plugin).

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes
