### PR TITLE
refactor: replace bare dict with dict[str, Any] in helper cache modules

### DIFF
--- a/api/core/helper/model_provider_cache.py
+++ b/api/core/helper/model_provider_cache.py
@@ -1,6 +1,7 @@
 import json
 from enum import StrEnum
 from json import JSONDecodeError
+from typing import Any
 
 from extensions.ext_redis import redis_client
 
@@ -15,7 +16,7 @@ class ProviderCredentialsCache:
     def __init__(self, tenant_id: str, identity_id: str, cache_type: ProviderCredentialsCacheType):
         self.cache_key = f"{cache_type}_credentials:tenant_id:{tenant_id}:id:{identity_id}"
 
-    def get(self) -> dict | None:
+    def get(self) -> dict[str, Any] | None:
         """
         Get cached model provider credentials.
 
@@ -33,7 +34,7 @@ class ProviderCredentialsCache:
         else:
             return None
 
-    def set(self, credentials: dict):
+    def set(self, credentials: dict[str, Any]):
         """
         Cache model provider credentials.
 

--- a/api/core/helper/provider_cache.py
+++ b/api/core/helper/provider_cache.py
@@ -17,7 +17,7 @@ class ProviderCredentialsCache(ABC):
         """Generate cache key based on subclass implementation"""
         pass
 
-    def get(self) -> dict | None:
+    def get(self) -> dict[str, Any] | None:
         """Get cached provider credentials"""
         cached_credentials = redis_client.get(self.cache_key)
         if cached_credentials:
@@ -71,7 +71,7 @@ class ToolProviderCredentialsCache(ProviderCredentialsCache):
 class NoOpProviderCredentialCache:
     """No-op provider credential cache"""
 
-    def get(self) -> dict | None:
+    def get(self) -> dict[str, Any] | None:
         """Get cached provider credentials"""
         return None
 

--- a/api/core/helper/tool_parameter_cache.py
+++ b/api/core/helper/tool_parameter_cache.py
@@ -1,6 +1,7 @@
 import json
 from enum import StrEnum
 from json import JSONDecodeError
+from typing import Any
 
 from extensions.ext_redis import redis_client
 
@@ -18,7 +19,7 @@ class ToolParameterCache:
             f":identity_id:{identity_id}"
         )
 
-    def get(self) -> dict | None:
+    def get(self) -> dict[str, Any] | None:
         """
         Get cached model provider credentials.
 
@@ -36,7 +37,7 @@ class ToolParameterCache:
         else:
             return None
 
-    def set(self, parameters: dict):
+    def set(self, parameters: dict[str, Any]):
         """Cache model provider credentials."""
         redis_client.setex(self.cache_key, 86400, json.dumps(parameters))
 


### PR DESCRIPTION
## Summary
Replace bare `dict` in three sibling Redis-backed credential cache helpers:
- `core/helper/provider_cache.py` — `get` on `ProviderCredentialsCache` and  `NoOpProviderCredentialCache` (`Any` already imported)
- `core/helper/model_provider_cache.py` — `get` and `set(credentials)`
- `core/helper/tool_parameter_cache.py` — `get` and `set(parameters)`

All caches store JSON-serialized credentials / tool parameters with provider-defined keys, so `dict[str, Any]` is the correct shape.

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes