### PR TITLE
refactor: replace bare dict with dict[str, Any] in rag extractors

### DIFF
--- a/api/core/rag/extractor/csv_extractor.py
+++ b/api/core/rag/extractor/csv_extractor.py
@@ -1,6 +1,7 @@
 """Abstract interface for document loader implementations."""
 
 import csv
+from typing import Any
 
 import pandas as pd
 
@@ -23,7 +24,7 @@ class CSVExtractor(BaseExtractor):
         encoding: str | None = None,
         autodetect_encoding: bool = False,
         source_column: str | None = None,
-        csv_args: dict | None = None,
+        csv_args: dict[str, Any] | None = None,
     ):
         """Initialize with file path."""
         self._file_path = file_path

--- a/api/core/rag/extractor/watercrawl/provider.py
+++ b/api/core/rag/extractor/watercrawl/provider.py
@@ -120,7 +120,7 @@ class WaterCrawlProvider:
         }
 
     def _get_results(
-        self, crawl_request_id: str, query_params: dict | None = None
+        self, crawl_request_id: str, query_params: dict[str, Any] | None = None
     ) -> Generator[WatercrawlDocumentData, None, None]:
         page = 0
         page_size = 100


### PR DESCRIPTION
## Summary
Tighten two small bare `dict` annotations in the RAG extractor module:
- `core/rag/extractor/watercrawl/provider.py`: `_get_results.query_params`  → `dict[str, Any] | None` (`Any` already imported)
- `core/rag/extractor/csv_extractor.py`: `CSVExtractor.__init__.csv_args`  → `dict[str, Any] | None` (passes through to pandas/csv reader; truly dynamic)

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes
