### PR TITLE
refactor: replace bare dict with dict[str, Any] in tools manage services

### DIFF
--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -92,7 +92,7 @@ class ApiToolManageService:
 
     @staticmethod
     def convert_schema_to_tool_bundles(
-        schema: str, extra_info: dict | None = None
+        schema: str, extra_info: dict[str, Any] | None = None
     ) -> tuple[list[ApiToolBundle], ApiProviderSchemaType]:
         """
         convert schema to tool bundles
@@ -109,8 +109,8 @@ class ApiToolManageService:
         user_id: str,
         tenant_id: str,
         provider_name: str,
-        icon: dict,
-        credentials: dict,
+        icon: dict[str, Any],
+        credentials: dict[str, Any],
         schema_type: ApiProviderSchemaType,
         schema: str,
         privacy_policy: str,
@@ -244,8 +244,8 @@ class ApiToolManageService:
         tenant_id: str,
         provider_name: str,
         original_provider: str,
-        icon: dict,
-        credentials: dict,
+        icon: dict[str, Any],
+        credentials: dict[str, Any],
         _schema_type: ApiProviderSchemaType,
         schema: str,
         privacy_policy: str | None,
@@ -356,8 +356,8 @@ class ApiToolManageService:
         tenant_id: str,
         provider_name: str,
         tool_name: str,
-        credentials: dict,
-        parameters: dict,
+        credentials: dict[str, Any],
+        parameters: dict[str, Any],
         schema_type: ApiProviderSchemaType,
         schema: str,
     ):

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -147,7 +147,7 @@ class BuiltinToolManageService:
         tenant_id: str,
         provider: str,
         credential_id: str,
-        credentials: dict | None = None,
+        credentials: dict[str, Any] | None = None,
         name: str | None = None,
     ):
         """
@@ -177,7 +177,7 @@ class BuiltinToolManageService:
                     )
 
                     original_credentials = encrypter.decrypt(db_provider.credentials)
-                    new_credentials: dict = {
+                    new_credentials: dict[str, Any] = {
                         key: value if value != HIDDEN_VALUE else original_credentials.get(key, UNKNOWN_VALUE)
                         for key, value in credentials.items()
                     }
@@ -216,7 +216,7 @@ class BuiltinToolManageService:
         api_type: CredentialType,
         tenant_id: str,
         provider: str,
-        credentials: dict,
+        credentials: dict[str, Any],
         expires_at: int = -1,
         name: str | None = None,
     ):
@@ -657,7 +657,7 @@ class BuiltinToolManageService:
     def save_custom_oauth_client_params(
         tenant_id: str,
         provider: str,
-        client_params: dict | None = None,
+        client_params: dict[str, Any] | None = None,
         enable_oauth_custom_client: bool | None = None,
     ):
         """

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -69,7 +69,9 @@ class ToolTransformService:
                 return ""
 
     @staticmethod
-    def repack_provider(tenant_id: str, provider: dict | ToolProviderApiEntity | PluginDatasourceProviderEntity):
+    def repack_provider(
+        tenant_id: str, provider: dict[str, Any] | ToolProviderApiEntity | PluginDatasourceProviderEntity
+    ):
         """
         repack provider
 

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import datetime
+from typing import Any
 
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from sqlalchemy import delete, or_, select
@@ -35,7 +36,7 @@ class WorkflowToolManageService:
         workflow_app_id: str,
         name: str,
         label: str,
-        icon: dict,
+        icon: dict[str, Any],
         description: str,
         parameters: list[WorkflowToolParameterConfiguration],
         privacy_policy: str = "",
@@ -117,7 +118,7 @@ class WorkflowToolManageService:
         workflow_tool_id: str,
         name: str,
         label: str,
-        icon: dict,
+        icon: dict[str, Any],
         description: str,
         parameters: list[WorkflowToolParameterConfiguration],
         privacy_policy: str = "",


### PR DESCRIPTION
## Summary
Tighten bare `dict` annotations in the tool provider services:
- `services/tools/api_tools_manage_service.py` — 7 method parameters  (`credentials`, `icon`, `parameters`, `extra_info`)
- `services/tools/builtin_tools_manage_service.py` — 4 occurrences  (`credentials`, `client_params`, `new_credentials` local var)
- `services/tools/workflow_tools_manage_service.py` — 2 `icon` parameters
- `services/tools/tools_transform_service.py` — `repack_provider.provider`  union type

All values are provider-defined / icon dicts with dynamic keys, so `dict[str, Any]` is the correct shape.

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes
