### PR TITLE
refactor: replace bare dict with dict[str, Any] in openai_moderation

### DIFF
--- a/api/core/moderation/openai_moderation/openai_moderation.py
+++ b/api/core/moderation/openai_moderation/openai_moderation.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from graphon.model_runtime.entities.model_entities import ModelType
 
 from core.model_manager import ModelManager
@@ -8,7 +10,7 @@ class OpenAIModeration(Moderation):
     name: str = "openai_moderation"
 
     @classmethod
-    def validate_config(cls, tenant_id: str, config: dict):
+    def validate_config(cls, tenant_id: str, config: dict[str, Any]):
         """
         Validate the incoming form config data.
 
@@ -18,7 +20,7 @@ class OpenAIModeration(Moderation):
         """
         cls._validate_inputs_and_outputs_config(config, True)
 
-    def moderation_for_inputs(self, inputs: dict, query: str = "") -> ModerationInputsResult:
+    def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:
         flagged = False
         preset_response = ""
         if self.config is None:
@@ -49,7 +51,7 @@ class OpenAIModeration(Moderation):
             flagged=flagged, action=ModerationAction.DIRECT_OUTPUT, preset_response=preset_response
         )
 
-    def _is_violated(self, inputs: dict):
+    def _is_violated(self, inputs: dict[str, Any]):
         text = "\n".join(str(inputs.values()))
         model_manager = ModelManager.for_tenant(tenant_id=self.tenant_id)
         model_instance = model_manager.get_model_instance(


### PR DESCRIPTION
## Summary
- Replace bare `dict` annotations with `dict[str, Any]` in `api/core/moderation/openai_moderation/openai_moderation.py`
- Update `validate_config`, `moderation_for_inputs`, and `_is_violated` type annotations for clearer payload typing
- Keep behavior unchanged; this is a typing-only refactor as part of #22651

## Test plan
- [x] Lint diagnostics check on modified file reports no issues