### PR TITLE
test: migrate trigger integration tests to SQLAlchemy 2.0 select API

### DIFF
--- a/api/tests/test_containers_integration_tests/trigger/conftest.py
+++ b/api/tests/test_containers_integration_tests/trigger/conftest.py
@@ -11,6 +11,7 @@ from collections.abc import Generator
 from typing import Any
 
 import pytest
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
 from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
@@ -40,9 +41,9 @@ def tenant_and_account(db_session_with_containers: Session) -> Generator[tuple[T
     yield tenant, account
 
     # Cleanup
-    db_session_with_containers.query(TenantAccountJoin).filter_by(tenant_id=tenant.id).delete()
-    db_session_with_containers.query(Account).filter_by(id=account.id).delete()
-    db_session_with_containers.query(Tenant).filter_by(id=tenant.id).delete()
+    db_session_with_containers.execute(delete(TenantAccountJoin).where(TenantAccountJoin.tenant_id == tenant.id))
+    db_session_with_containers.execute(delete(Account).where(Account.id == account.id))
+    db_session_with_containers.execute(delete(Tenant).where(Tenant.id == tenant.id))
     db_session_with_containers.commit()
 
 
@@ -93,14 +94,14 @@ def app_model(
     )
     from models.workflow import Workflow
 
-    db_session_with_containers.query(WorkflowTriggerLog).filter_by(app_id=app.id).delete()
-    db_session_with_containers.query(WorkflowSchedulePlan).filter_by(app_id=app.id).delete()
-    db_session_with_containers.query(WorkflowWebhookTrigger).filter_by(app_id=app.id).delete()
-    db_session_with_containers.query(WorkflowPluginTrigger).filter_by(app_id=app.id).delete()
-    db_session_with_containers.query(AppTrigger).filter_by(app_id=app.id).delete()
-    db_session_with_containers.query(TriggerSubscription).filter_by(tenant_id=tenant.id).delete()
-    db_session_with_containers.query(Workflow).filter_by(app_id=app.id).delete()
-    db_session_with_containers.query(App).filter_by(id=app.id).delete()
+    db_session_with_containers.execute(delete(WorkflowTriggerLog).where(WorkflowTriggerLog.app_id == app.id))
+    db_session_with_containers.execute(delete(WorkflowSchedulePlan).where(WorkflowSchedulePlan.app_id == app.id))
+    db_session_with_containers.execute(delete(WorkflowWebhookTrigger).where(WorkflowWebhookTrigger.app_id == app.id))
+    db_session_with_containers.execute(delete(WorkflowPluginTrigger).where(WorkflowPluginTrigger.app_id == app.id))
+    db_session_with_containers.execute(delete(AppTrigger).where(AppTrigger.app_id == app.id))
+    db_session_with_containers.execute(delete(TriggerSubscription).where(TriggerSubscription.tenant_id == tenant.id))
+    db_session_with_containers.execute(delete(Workflow).where(Workflow.app_id == app.id))
+    db_session_with_containers.execute(delete(App).where(App.id == app.id))
     db_session_with_containers.commit()
 
 

--- a/api/tests/test_containers_integration_tests/trigger/test_trigger_e2e.py
+++ b/api/tests/test_containers_integration_tests/trigger/test_trigger_e2e.py
@@ -11,6 +11,7 @@ import pytest
 from flask import Flask, Response
 from flask.testing import FlaskClient
 from graphon.enums import BuiltinNodeTypes
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from configs import dify_config
@@ -227,7 +228,9 @@ def test_webhook_trigger_creates_trigger_log(
     assert response.status_code == 200
 
     db_session_with_containers.expire_all()
-    logs = db_session_with_containers.query(WorkflowTriggerLog).filter_by(app_id=app_model.id).all()
+    logs = db_session_with_containers.scalars(
+        select(WorkflowTriggerLog).where(WorkflowTriggerLog.app_id == app_model.id)
+    ).all()
     assert logs, "Webhook trigger should create trigger log"
 
 
@@ -611,7 +614,9 @@ def test_schedule_trigger_creates_trigger_log(
 
     # Verify WorkflowTriggerLog was created
     db_session_with_containers.expire_all()
-    logs = db_session_with_containers.query(WorkflowTriggerLog).filter_by(app_id=app_model.id).all()
+    logs = db_session_with_containers.scalars(
+        select(WorkflowTriggerLog).where(WorkflowTriggerLog.app_id == app_model.id)
+    ).all()
     assert logs, "Schedule trigger should create WorkflowTriggerLog"
     assert logs[0].trigger_type == AppTriggerType.TRIGGER_SCHEDULE
     assert logs[0].root_node_id == schedule_node_id
@@ -786,11 +791,12 @@ def test_plugin_trigger_full_chain_with_db_verification(
 
     # Verify database records exist
     db_session_with_containers.expire_all()
-    plugin_triggers = (
-        db_session_with_containers.query(WorkflowPluginTrigger)
-        .filter_by(app_id=app_model.id, node_id=plugin_node_id)
-        .all()
-    )
+    plugin_triggers = db_session_with_containers.scalars(
+        select(WorkflowPluginTrigger).where(
+            WorkflowPluginTrigger.app_id == app_model.id,
+            WorkflowPluginTrigger.node_id == plugin_node_id,
+        )
+    ).all()
     assert plugin_triggers, "WorkflowPluginTrigger record should exist"
     assert plugin_triggers[0].provider_id == provider_id
     assert plugin_triggers[0].event_name == "test_event"


### PR DESCRIPTION
Part of https://github.com/langgenius/dify/issues/22668

## Summary
- Migrate trigger integration tests from legacy `Session.query(...)` style to SQLAlchemy 2.0 query APIs.
- Replace read paths with `select(...)` + `session.scalars(...)`.
- Replace cleanup delete paths with `delete(...)` + `session.execute(...)`.

## Changes
- Updated `api/tests/test_containers_integration_tests/trigger/conftest.py`
  - Migrated fixture cleanup calls from `query(...).filter_by(...).delete()` to `execute(delete(...).where(...))`.
- Updated `api/tests/test_containers_integration_tests/trigger/test_trigger_e2e.py`
  - Migrated record lookups from `query(...).filter_by(...).all()` to `scalars(select(...).where(...)).all()`.