### PR TITLE
test: migrate mail and segment indexing integration tests to SQLAlchemy 2.0 APIs

### DIFF
--- a/api/tests/test_containers_integration_tests/tasks/test_create_segment_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_create_segment_to_index_task.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 import pytest
 from faker import Faker
+from sqlalchemy import delete
 
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from extensions.ext_redis import redis_client
@@ -28,12 +29,12 @@ class TestCreateSegmentToIndexTask:
         """Clean up database and Redis before each test to ensure isolation."""
 
         # Clear all test data using fixture session
-        db_session_with_containers.query(DocumentSegment).delete()
-        db_session_with_containers.query(Document).delete()
-        db_session_with_containers.query(Dataset).delete()
-        db_session_with_containers.query(TenantAccountJoin).delete()
-        db_session_with_containers.query(Tenant).delete()
-        db_session_with_containers.query(Account).delete()
+        db_session_with_containers.execute(delete(DocumentSegment))
+        db_session_with_containers.execute(delete(Document))
+        db_session_with_containers.execute(delete(Dataset))
+        db_session_with_containers.execute(delete(TenantAccountJoin))
+        db_session_with_containers.execute(delete(Tenant))
+        db_session_with_containers.execute(delete(Account))
         db_session_with_containers.commit()
 
         # Clear Redis cache

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_email_code_login_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_email_code_login_task.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from faker import Faker
+from sqlalchemy import delete
 
 from libs.email_i18n import EmailType
 from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
@@ -41,9 +42,9 @@ class TestSendEmailCodeLoginMailTask:
         from extensions.ext_redis import redis_client
 
         # Clear all test data
-        db_session_with_containers.query(TenantAccountJoin).delete()
-        db_session_with_containers.query(Tenant).delete()
-        db_session_with_containers.query(Account).delete()
+        db_session_with_containers.execute(delete(TenantAccountJoin))
+        db_session_with_containers.execute(delete(Tenant))
+        db_session_with_containers.execute(delete(Account))
         db_session_with_containers.commit()
 
         # Clear Redis cache

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_invite_member_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_invite_member_task.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from faker import Faker
+from sqlalchemy import delete, select
 
 from extensions.ext_redis import redis_client
 from libs.email_i18n import EmailType
@@ -44,9 +45,9 @@ class TestMailInviteMemberTask:
     def cleanup_database(self, db_session_with_containers):
         """Clean up database before each test to ensure isolation."""
         # Clear all test data
-        db_session_with_containers.query(TenantAccountJoin).delete()
-        db_session_with_containers.query(Tenant).delete()
-        db_session_with_containers.query(Account).delete()
+        db_session_with_containers.execute(delete(TenantAccountJoin))
+        db_session_with_containers.execute(delete(Tenant))
+        db_session_with_containers.execute(delete(Account))
         db_session_with_containers.commit()
 
         # Clear Redis cache
@@ -491,10 +492,10 @@ class TestMailInviteMemberTask:
         assert tenant.name is not None
 
         # Verify tenant relationship exists
-        tenant_join = (
-            db_session_with_containers.query(TenantAccountJoin)
-            .filter_by(tenant_id=tenant.id, account_id=pending_account.id)
-            .first()
+        tenant_join = db_session_with_containers.scalar(
+            select(TenantAccountJoin)
+            .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == pending_account.id)
+            .limit(1)
         )
         assert tenant_join is not None
         assert tenant_join.role == TenantAccountRole.NORMAL


### PR DESCRIPTION
## Summary
- Migrate legacy ORM query usage in three TestContainers integration test modules to SQLAlchemy 2.0 style APIs.
- Replace `Session.query(...).delete()` cleanup patterns with `Session.execute(delete(...))`.
- Replace one `query(...).filter_by(...).first()` lookup with `Session.scalar(select(...).where(...).limit(1))`.

## Changes
### Updated files
- `api/tests/test_containers_integration_tests/tasks/test_mail_email_code_login_task.py`
  - Added `delete` import.
  - Migrated cleanup fixture delete calls to `Session.execute(delete(...))`.
- `api/tests/test_containers_integration_tests/tasks/test_mail_invite_member_task.py`
  - Added `delete` and `select` imports.
  - Migrated cleanup fixture delete calls to `Session.execute(delete(...))`.
  - Migrated tenant-account existence lookup to `Session.scalar(select(...).where(...).limit(1))`.
- `api/tests/test_containers_integration_tests/tasks/test_create_segment_to_index_task.py`
  - Added `delete` import.
  - Migrated cleanup fixture delete calls to `Session.execute(delete(...))`.

## Related Issue
- Part of https://github.com/langgenius/dify/issues/22668