### PR TITLE
refactor(api): type _jsonify_form_definition payload with FormDefinitionPayload TypedDict

### DIFF
--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from flask import Response, request
 from flask_restx import Resource
 from pydantic import BaseModel
+from typing import Any, NotRequired, TypedDict
 from sqlalchemy import select
 from werkzeug.exceptions import Forbidden
 
@@ -58,10 +59,19 @@ def _to_timestamp(value: datetime) -> int:
     return int(value.timestamp())
 
 
+class FormDefinitionPayload(TypedDict):
+    form_content: Any
+    inputs: Any
+    resolved_default_values: dict[str, str]
+    user_actions: Any
+    expiration_time: int
+    site: NotRequired[dict]
+
+
 def _jsonify_form_definition(form: Form, site_payload: dict | None = None) -> Response:
     """Return the form payload (optionally with site) as a JSON response."""
     definition_payload = form.get_definition().model_dump()
-    payload = {
+    payload: FormDefinitionPayload = {
         "form_content": definition_payload["rendered_content"],
         "inputs": definition_payload["inputs"],
         "resolved_default_values": _stringify_default_values(definition_payload["default_values"]),

--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -5,11 +5,11 @@ Web App Human Input Form APIs.
 import json
 import logging
 from datetime import datetime
+from typing import Any, NotRequired, TypedDict
 
 from flask import Response, request
 from flask_restx import Resource
 from pydantic import BaseModel
-from typing import Any, NotRequired, TypedDict
 from sqlalchemy import select
 from werkzeug.exceptions import Forbidden
 


### PR DESCRIPTION
Part of #32863 (`api/controllers/web/human_input_form.py`)

## Summary
- Define `FormDefinitionPayload` TypedDict for the payload dict built in `_jsonify_form_definition`
- Annotate the `payload` local variable with the new TypedDict

## Why this change
`_jsonify_form_definition` builds a fixed-structure payload dict with 5 required keys (`form_content`, `inputs`, `resolved_default_values`, `user_actions`, `expiration_time`) and one optional key (`site`). The intermediate dict was untyped, hiding the contract from the JSON serialization and the REST layer.

## Changes
- `api/controllers/web/human_input_form.py`: Define `FormDefinitionPayload` with `NotRequired[dict]` for the optional `site` field, annotate the `payload` variable