### PR TITLE
refactor: replace bare dict with typed annotations in core plugin module

### DIFF
--- a/api/core/plugin/entities/endpoint.py
+++ b/api/core/plugin/entities/endpoint.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -31,7 +32,7 @@ class EndpointEntity(BasePluginEntity):
     entity of an endpoint
     """
 
-    settings: dict
+    settings: dict[str, Any]
     tenant_id: str
     plugin_id: str
     expired_at: datetime

--- a/api/core/plugin/entities/marketplace.py
+++ b/api/core/plugin/entities/marketplace.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from graphon.model_runtime.entities.provider_entities import ProviderEntity
 from pydantic import BaseModel, Field, computed_field, model_validator
 
@@ -40,7 +42,7 @@ class MarketplacePluginDeclaration(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def transform_declaration(cls, data: dict):
+    def transform_declaration(cls, data: dict[str, Any]) -> dict[str, Any]:
         if "endpoint" in data and not data["endpoint"]:
             del data["endpoint"]
         if "model" in data and not data["model"]:

--- a/api/core/plugin/entities/plugin.py
+++ b/api/core/plugin/entities/plugin.py
@@ -123,7 +123,7 @@ class PluginDeclaration(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_category(cls, values: dict):
+    def validate_category(cls, values: dict[str, Any]) -> dict[str, Any]:
         # auto detect category
         if values.get("tool"):
             values["category"] = PluginCategory.Tool

--- a/api/core/plugin/entities/plugin_daemon.py
+++ b/api/core/plugin/entities/plugin_daemon.py
@@ -73,7 +73,7 @@ class PluginBasicBooleanResponse(BaseModel):
     """
 
     result: bool
-    credentials: dict | None = None
+    credentials: dict[str, Any] | None = None
 
 
 class PluginModelSchemaEntity(BaseModel):

--- a/api/core/plugin/entities/request.py
+++ b/api/core/plugin/entities/request.py
@@ -49,7 +49,7 @@ class RequestInvokeTool(BaseModel):
     tool_type: Literal["builtin", "workflow", "api", "mcp"]
     provider: str
     tool: str
-    tool_parameters: dict
+    tool_parameters: dict[str, Any]
     credential_id: str | None = None
 
 
@@ -209,7 +209,7 @@ class RequestInvokeEncrypt(BaseModel):
     opt: Literal["encrypt", "decrypt", "clear"]
     namespace: Literal["endpoint"]
     identity: str
-    data: dict = Field(default_factory=dict)
+    data: dict[str, Any] = Field(default_factory=dict)
     config: list[BasicProviderConfig] = Field(default_factory=list)
 
 

--- a/api/core/plugin/impl/datasource.py
+++ b/api/core/plugin/impl/datasource.py
@@ -26,7 +26,7 @@ class PluginDatasourceManager(BasePluginClient):
         Fetch datasource providers for the given tenant.
         """
 
-        def transformer(json_response: dict[str, Any]) -> dict:
+        def transformer(json_response: dict[str, Any]) -> dict[str, Any]:
             if json_response.get("data"):
                 for provider in json_response.get("data", []):
                     declaration = provider.get("declaration", {}) or {}
@@ -68,7 +68,7 @@ class PluginDatasourceManager(BasePluginClient):
         Fetch datasource providers for the given tenant.
         """
 
-        def transformer(json_response: dict[str, Any]) -> dict:
+        def transformer(json_response: dict[str, Any]) -> dict[str, Any]:
             if json_response.get("data"):
                 for provider in json_response.get("data", []):
                     declaration = provider.get("declaration", {}) or {}
@@ -110,7 +110,7 @@ class PluginDatasourceManager(BasePluginClient):
 
         tool_provider_id = DatasourceProviderID(provider_id)
 
-        def transformer(json_response: dict[str, Any]) -> dict:
+        def transformer(json_response: dict[str, Any]) -> dict[str, Any]:
             data = json_response.get("data")
             if data:
                 for datasource in data.get("declaration", {}).get("datasources", []):

--- a/api/core/plugin/impl/endpoint.py
+++ b/api/core/plugin/impl/endpoint.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from core.plugin.entities.endpoint import EndpointEntityWithInstance
 from core.plugin.impl.base import BasePluginClient
 from core.plugin.impl.exc import PluginDaemonInternalServerError
@@ -5,7 +7,12 @@ from core.plugin.impl.exc import PluginDaemonInternalServerError
 
 class PluginEndpointClient(BasePluginClient):
     def create_endpoint(
-        self, tenant_id: str, user_id: str, plugin_unique_identifier: str, name: str, settings: dict
+        self,
+        tenant_id: str,
+        user_id: str,
+        plugin_unique_identifier: str,
+        name: str,
+        settings: dict[str, Any],
     ) -> bool:
         """
         Create an endpoint for the given plugin.
@@ -49,7 +56,9 @@ class PluginEndpointClient(BasePluginClient):
             params={"plugin_id": plugin_id, "page": page, "page_size": page_size},
         )
 
-    def update_endpoint(self, tenant_id: str, user_id: str, endpoint_id: str, name: str, settings: dict):
+    def update_endpoint(
+        self, tenant_id: str, user_id: str, endpoint_id: str, name: str, settings: dict[str, Any]
+    ) -> bool:
         """
         Update the settings of the given endpoint.
         """

--- a/api/core/plugin/impl/model.py
+++ b/api/core/plugin/impl/model.py
@@ -80,7 +80,7 @@ class PluginModelClient(BasePluginClient):
         return None
 
     def validate_provider_credentials(
-        self, tenant_id: str, user_id: str | None, plugin_id: str, provider: str, credentials: dict
+        self, tenant_id: str, user_id: str | None, plugin_id: str, provider: str, credentials: dict[str, Any]
     ) -> bool:
         """
         validate the credentials of the provider

--- a/api/core/plugin/impl/plugin.py
+++ b/api/core/plugin/impl/plugin.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import Any
 
 from requests import HTTPError
 
@@ -263,7 +264,7 @@ class PluginInstaller(BasePluginClient):
         original_plugin_unique_identifier: str,
         new_plugin_unique_identifier: str,
         source: PluginInstallationSource,
-        meta: dict,
+        meta: dict[str, Any],
     ) -> PluginInstallTaskStartResponse:
         """
         Upgrade a plugin.


### PR DESCRIPTION
## Summary

Replaces bare `dict` type hints with `dict[str, Any]` across the core plugin module:

- `core/plugin/entities/marketplace.py` — `transform_declaration` validator signature and return type.
- `core/plugin/entities/plugin.py` — `validate_category` validator signature and return type.
- `core/plugin/entities/endpoint.py` — `EndpointEntity.settings` model field.
- `core/plugin/entities/plugin_daemon.py` — `PluginBasicBooleanResponse.credentials` model field.
- `core/plugin/entities/request.py` — `tool_parameters` and `data` model fields.
- `core/plugin/impl/datasource.py` — three `transformer` return types.
- `core/plugin/impl/endpoint.py` — `create_endpoint` / `update_endpoint` settings parameter (and adds explicit `-> bool` on update).
- `core/plugin/impl/model.py` — `validate_provider_credentials` credentials parameter.
- `core/plugin/impl/plugin.py` — `upgrade_plugin` meta parameter.

Contributes to #22651.

## Test plan

- [x] `make lint` passes
- [x] `make type-check-core` passes (1391 files)