### PR TITLE
refactor: replace bare dict with typed annotations in core rag module

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -735,7 +735,9 @@ class IndexingRunner:
 
     @staticmethod
     def _update_document_index_status(
-        document_id: str, after_indexing_status: IndexingStatus, extra_update_params: dict | None = None
+        document_id: str,
+        after_indexing_status: IndexingStatus,
+        extra_update_params: Mapping[Any, Any] | None = None,
     ):
         """
         Update the document indexing status.
@@ -762,7 +764,7 @@ class IndexingRunner:
         db.session.commit()
 
     @staticmethod
-    def _update_segments_by_document(dataset_document_id: str, update_params: dict):
+    def _update_segments_by_document(dataset_document_id: str, update_params: Mapping[Any, Any]):
         """
         Update the document segment by document id.
         """

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -174,8 +174,8 @@ class RetrievalService:
         cls,
         dataset_id: str,
         query: str,
-        external_retrieval_model: dict | None = None,
-        metadata_filtering_conditions: dict | None = None,
+        external_retrieval_model: dict[str, Any] | None = None,
+        metadata_filtering_conditions: dict[str, Any] | None = None,
     ):
         stmt = select(Dataset).where(Dataset.id == dataset_id)
         dataset = db.session.scalar(stmt)

--- a/api/core/rag/embedding/cached_embedding.py
+++ b/api/core/rag/embedding/cached_embedding.py
@@ -106,7 +106,7 @@ class CacheEmbedding(Embeddings):
 
         return text_embeddings
 
-    def embed_multimodal_documents(self, multimodel_documents: list[dict]) -> list[list[float]]:
+    def embed_multimodal_documents(self, multimodel_documents: list[dict[str, Any]]) -> list[list[float]]:
         """Embed file documents."""
         # use doc embedding cache or store if not exists
         multimodel_embeddings: list[Any] = [None for _ in range(len(multimodel_documents))]
@@ -232,7 +232,7 @@ class CacheEmbedding(Embeddings):
 
         return embedding_results  # type: ignore
 
-    def embed_multimodal_query(self, multimodel_document: dict) -> list[float]:
+    def embed_multimodal_query(self, multimodel_document: dict[str, Any]) -> list[float]:
         """Embed multimodal documents."""
         # use doc embedding cache or store if not exists
         file_id = multimodel_document["file_id"]

--- a/api/core/rag/embedding/embedding_base.py
+++ b/api/core/rag/embedding/embedding_base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class Embeddings(ABC):
@@ -10,7 +11,7 @@ class Embeddings(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def embed_multimodal_documents(self, multimodel_documents: list[dict]) -> list[list[float]]:
+    def embed_multimodal_documents(self, multimodel_documents: list[dict[str, Any]]) -> list[list[float]]:
         """Embed file documents."""
         raise NotImplementedError
 
@@ -20,7 +21,7 @@ class Embeddings(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def embed_multimodal_query(self, multimodel_document: dict) -> list[float]:
+    def embed_multimodal_query(self, multimodel_document: dict[str, Any]) -> list[float]:
         """Embed multimodal query."""
         raise NotImplementedError
 

--- a/api/core/rag/retrieval/output_parser/react_output.py
+++ b/api/core/rag/retrieval/output_parser/react_output.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import NamedTuple, Union
+from typing import Any, NamedTuple, Union
 
 
 @dataclass
@@ -10,7 +10,7 @@ class ReactAction:
 
     tool: str
     """The name of the Tool to execute."""
-    tool_input: Union[str, dict]
+    tool_input: Union[str, dict[str, Any]]
     """The input to pass in to the Tool."""
     log: str
     """Additional information to log about the action."""
@@ -19,7 +19,7 @@ class ReactAction:
 class ReactFinish(NamedTuple):
     """The final return value of an ReactFinish."""
 
-    return_values: dict
+    return_values: dict[str, Any]
     """Dictionary of return values."""
     log: str
     """Additional information to log about the return value"""

--- a/api/core/rag/retrieval/router/multi_dataset_react_route.py
+++ b/api/core/rag/retrieval/router/multi_dataset_react_route.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator, Sequence
-from typing import Union
+from typing import Any, Union
 
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import PromptMessage, PromptMessageRole, PromptMessageTool
@@ -139,7 +139,7 @@ class ReactMultiDatasetRouter:
 
     def _invoke_llm(
         self,
-        completion_param: dict,
+        completion_param: dict[str, Any],
         model_instance: ModelInstance,
         prompt_messages: list[PromptMessage],
         stop: list[str],

--- a/api/core/rag/splitter/text_splitter.py
+++ b/api/core/rag/splitter/text_splitter.py
@@ -63,7 +63,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
     def split_text(self, text: str) -> list[str]:
         """Split text into multiple components."""
 
-    def create_documents(self, texts: list[str], metadatas: list[dict] | None = None) -> list[Document]:
+    def create_documents(self, texts: list[str], metadatas: list[dict[str, Any]] | None = None) -> list[Document]:
         """Create documents from a list of texts."""
         _metadatas = metadatas or [{}] * len(texts)
         documents = []


### PR DESCRIPTION
## Summary

Replaces bare `dict` type hints with `dict[str, Any]`, `list[dict[str, Any]]`, or `Mapping[Any, Any]` across the core RAG and indexing modules:

- `core/rag/embedding/embedding_base.py` / `cached_embedding.py` — `embed_multimodal_documents` / `embed_multimodal_query` parameter types.
- `core/rag/retrieval/output_parser/react_output.py` — `ReactAction.tool_input` and `ReactFinish.return_values`.
- `core/rag/retrieval/router/multi_dataset_react_route.py` — `_invoke_llm.completion_param`.
- `core/rag/datasource/retrieval_service.py` — `external_retrieve` parameters.
- `core/rag/splitter/text_splitter.py` — `create_documents.metadatas`.
- `core/indexing_runner.py` — `_update_document_index_status.extra_update_params` and `_update_segments_by_document.update_params` use `Mapping[Any, Any]` because SQLAlchemy `InstrumentedAttribute` instances are used as keys (not strings).

Contributes to #22651.

## Test plan

- [x] `make lint` passes
- [x] `make type-check-core` passes (1391 files)