### PR TITLE
fix: handle plugin local upload on 2xx responses

### DIFF
--- a/web/app/components/plugins/install-plugin/install-from-local-package/steps/__tests__/uploading.spec.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/steps/__tests__/uploading.spec.tsx
@@ -128,7 +128,10 @@ describe('Uploading', () => {
   // ================================
   describe('Upload Behavior', () => {
     it('should call uploadFile on mount', async () => {
-      mockUploadFile.mockResolvedValue({})
+      mockUploadFile.mockResolvedValue({
+        unique_identifier: 'uid',
+        manifest: createMockManifest(),
+      })
 
       render(<Uploading {...defaultProps} />)
 
@@ -138,7 +141,7 @@ describe('Uploading', () => {
     })
 
     it('should call uploadFile with isBundle=true for bundle files', async () => {
-      mockUploadFile.mockResolvedValue({})
+      mockUploadFile.mockResolvedValue(createMockDependencies())
 
       render(<Uploading {...defaultProps} isBundle />)
 
@@ -161,13 +164,52 @@ describe('Uploading', () => {
       })
     })
 
-    // NOTE: The uploadFile API has an unconventional contract where it always rejects.
-    // Success vs failure is determined by whether response.message exists:
-    // - If response.message exists → treated as failure (calls onFailed)
-    // - If response.message is absent → treated as success (calls onPackageUploaded/onBundleUploaded)
-    // This explains why we use mockRejectedValue for "success" scenarios below.
+    // Success payloads arrive on resolve when HTTP status is 2xx (e.g. 200 or 201).
+    // Non-2xx responses reject the XHR; the parsed body is still passed through finishUpload via e.response.
 
-    it('should call onPackageUploaded when upload rejects without error message (success case)', async () => {
+    it('should call onPackageUploaded when upload resolves with package payload (2xx)', async () => {
+      const mockResult = {
+        unique_identifier: 'test-uid',
+        manifest: createMockManifest(),
+      }
+      mockUploadFile.mockResolvedValue(mockResult)
+
+      const onPackageUploaded = vi.fn()
+      render(
+        <Uploading
+          {...defaultProps}
+          isBundle={false}
+          onPackageUploaded={onPackageUploaded}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(onPackageUploaded).toHaveBeenCalledWith({
+          uniqueIdentifier: mockResult.unique_identifier,
+          manifest: mockResult.manifest,
+        })
+      })
+    })
+
+    it('should call onBundleUploaded when upload resolves with bundle payload (2xx)', async () => {
+      const mockDependencies = createMockDependencies()
+      mockUploadFile.mockResolvedValue(mockDependencies)
+
+      const onBundleUploaded = vi.fn()
+      render(
+        <Uploading
+          {...defaultProps}
+          isBundle
+          onBundleUploaded={onBundleUploaded}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(onBundleUploaded).toHaveBeenCalledWith(mockDependencies)
+      })
+    })
+
+    it('should call onPackageUploaded when upload rejects without error message (non-2xx body)', async () => {
       const mockResult = {
         unique_identifier: 'test-uid',
         manifest: createMockManifest(),
@@ -190,26 +232,6 @@ describe('Uploading', () => {
           uniqueIdentifier: mockResult.unique_identifier,
           manifest: mockResult.manifest,
         })
-      })
-    })
-
-    it('should call onBundleUploaded when upload rejects without error message (success case)', async () => {
-      const mockDependencies = createMockDependencies()
-      mockUploadFile.mockRejectedValue({
-        response: mockDependencies,
-      })
-
-      const onBundleUploaded = vi.fn()
-      render(
-        <Uploading
-          {...defaultProps}
-          isBundle
-          onBundleUploaded={onBundleUploaded}
-        />,
-      )
-
-      await waitFor(() => {
-        expect(onBundleUploaded).toHaveBeenCalledWith(mockDependencies)
       })
     })
   })
@@ -260,36 +282,34 @@ describe('Uploading', () => {
   // Edge Cases Tests
   // ================================
   describe('Edge Cases', () => {
-    it('should handle empty response gracefully', async () => {
+    it('should call onFailed when package payload is empty', async () => {
       mockUploadFile.mockRejectedValue({
         response: {},
       })
 
+      const onFailed = vi.fn()
       const onPackageUploaded = vi.fn()
-      render(<Uploading {...defaultProps} onPackageUploaded={onPackageUploaded} />)
+      render(<Uploading {...defaultProps} onFailed={onFailed} onPackageUploaded={onPackageUploaded} />)
 
       await waitFor(() => {
-        expect(onPackageUploaded).toHaveBeenCalledWith({
-          uniqueIdentifier: undefined,
-          manifest: undefined,
-        })
+        expect(onFailed).toHaveBeenCalledWith('plugin.installModal.pluginLoadErrorDesc')
       })
+      expect(onPackageUploaded).not.toHaveBeenCalled()
     })
 
-    it('should handle response with only unique_identifier', async () => {
+    it('should call onFailed when package response omits manifest', async () => {
       mockUploadFile.mockRejectedValue({
         response: { unique_identifier: 'only-uid' },
       })
 
+      const onFailed = vi.fn()
       const onPackageUploaded = vi.fn()
-      render(<Uploading {...defaultProps} onPackageUploaded={onPackageUploaded} />)
+      render(<Uploading {...defaultProps} onFailed={onFailed} onPackageUploaded={onPackageUploaded} />)
 
       await waitFor(() => {
-        expect(onPackageUploaded).toHaveBeenCalledWith({
-          uniqueIdentifier: 'only-uid',
-          manifest: undefined,
-        })
+        expect(onFailed).toHaveBeenCalledWith('plugin.installModal.pluginLoadErrorDesc')
       })
+      expect(onPackageUploaded).not.toHaveBeenCalled()
     })
 
     it('should handle file with special characters in name', () => {
@@ -319,7 +339,10 @@ describe('Uploading', () => {
     })
 
     it('should pass isBundle=false to uploadFile for package files', async () => {
-      mockUploadFile.mockResolvedValue({})
+      mockUploadFile.mockResolvedValue({
+        unique_identifier: 'u',
+        manifest: createMockManifest(),
+      })
 
       render(<Uploading {...defaultProps} isBundle={false} />)
 
@@ -329,7 +352,7 @@ describe('Uploading', () => {
     })
 
     it('should pass isBundle=true to uploadFile for bundle files', async () => {
-      mockUploadFile.mockResolvedValue({})
+      mockUploadFile.mockResolvedValue(createMockDependencies())
 
       render(<Uploading {...defaultProps} isBundle />)
 

--- a/web/app/components/plugins/install-plugin/install-from-local-package/steps/uploading.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/steps/uploading.tsx
@@ -33,24 +33,34 @@ const Uploading: FC<Props> = ({
   const { t } = useTranslation()
   const fileName = file.name
   const handleUpload = async () => {
+    const finishUpload = (res: unknown) => {
+      const body = res !== null && res !== undefined && typeof res === 'object' && !Array.isArray(res)
+        ? (res as { message?: string, unique_identifier?: string, manifest?: PluginDeclaration })
+        : null
+
+      if (body?.message) {
+        onFailed(body.message)
+        return
+      }
+      if (isBundle) {
+        onBundleUploaded(res as Dependency[])
+        return
+      }
+      const uniqueIdentifier = body?.unique_identifier
+      const manifest = body?.manifest
+      if (!uniqueIdentifier || !manifest) {
+        onFailed(t(`${i18nPrefix}.pluginLoadErrorDesc`, { ns: 'plugin' }))
+        return
+      }
+      onPackageUploaded({ uniqueIdentifier, manifest })
+    }
+
     try {
-      await uploadFile(file, isBundle)
+      const res = await uploadFile(file, isBundle)
+      finishUpload(res)
     }
     catch (e: any) {
-      if (e.response?.message) {
-        onFailed(e.response?.message)
-      }
-      else { // Why it would into this branch?
-        const res = e.response
-        if (isBundle) {
-          onBundleUploaded(res)
-          return
-        }
-        onPackageUploaded({
-          uniqueIdentifier: res.unique_identifier,
-          manifest: res.manifest,
-        })
-      }
+      finishUpload(e?.response)
     }
   }
 

--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -423,7 +423,7 @@ export const upload = async (options: UploadOptions, isPublicAPI?: boolean, url?
     xhr.responseType = 'json'
     xhr.onreadystatechange = function () {
       if (xhr.readyState === 4) {
-        if (xhr.status === 201)
+        if (xhr.status >= 200 && xhr.status < 300)
           resolve(xhr.response)
         else
           reject(xhr)


### PR DESCRIPTION
## Summary
Fixes #33382
Plugin upload can return HTTP 200 with a JSON body. After treating 2xx as success in upload(), the promise resolves instead of rejecting. uploading.tsx only handled the payload in catch, so the UI stayed on the uploading step.

## How to verify

- Install a plugin from a local package/bundle against an API that returns 200 on upload; the flow should move past uploading.
- Run: pnpm test -- app/components/plugins/install-plugin/install-from-local-package/steps/__tests__/uploading.spec.tsx (from web/).


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
