### PR TITLE
refactor: replace bare dict with dict[str, Any] in rag_pipeline and datasource_provider services

### DIFF
--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -26,13 +26,13 @@ def _to_timestamp(value: datetime | int | None) -> int | None:
 
 class MCPServerCreatePayload(BaseModel):
     description: str | None = Field(default=None, description="Server description")
-    parameters: dict = Field(..., description="Server parameters configuration")
+    parameters: dict[str, Any] = Field(..., description="Server parameters configuration")
 
 
 class MCPServerUpdatePayload(BaseModel):
     id: str = Field(..., description="Server ID")
     description: str | None = Field(default=None, description="Server description")
-    parameters: dict = Field(..., description="Server parameters configuration")
+    parameters: dict[str, Any] = Field(..., description="Server parameters configuration")
     status: str | None = Field(default=None, description="Server status")
 
 

--- a/api/models/types.py
+++ b/api/models/types.py
@@ -103,10 +103,14 @@ class AdjustedJSON(TypeDecorator[dict | list | None]):
         else:
             return dialect.type_descriptor(sa.JSON())
 
-    def process_bind_param(self, value: dict | list | None, dialect: Dialect) -> dict | list | None:
+    def process_bind_param(
+        self, value: dict[str, Any] | list[Any] | None, dialect: Dialect
+    ) -> dict[str, Any] | list[Any] | None:
         return value
 
-    def process_result_value(self, value: dict | list | None, dialect: Dialect) -> dict | list | None:
+    def process_result_value(
+        self, value: dict[str, Any] | list[Any] | None, dialect: Dialect
+    ) -> dict[str, Any] | list[Any] | None:
         return value
 
 

--- a/api/services/datasource_provider_service.py
+++ b/api/services/datasource_provider_service.py
@@ -318,7 +318,7 @@ class DatasourceProviderService:
         self,
         tenant_id: str,
         datasource_provider_id: DatasourceProviderID,
-        client_params: dict | None,
+        client_params: dict[str, Any] | None,
         enabled: bool | None,
     ):
         """
@@ -352,7 +352,7 @@ class DatasourceProviderService:
                 original_params = (
                     encrypter.decrypt(tenant_oauth_client_params.client_params) if tenant_oauth_client_params else {}
                 )
-                new_params: dict = {
+                new_params: dict[str, Any] = {
                     key: value if value != HIDDEN_VALUE else original_params.get(key, UNKNOWN_VALUE)
                     for key, value in client_params.items()
                 }
@@ -500,7 +500,7 @@ class DatasourceProviderService:
         provider_id: DatasourceProviderID,
         avatar_url: str | None,
         expire_at: int,
-        credentials: dict,
+        credentials: dict[str, Any],
         credential_id: str,
     ) -> None:
         """
@@ -566,7 +566,7 @@ class DatasourceProviderService:
         provider_id: DatasourceProviderID,
         avatar_url: str | None,
         expire_at: int,
-        credentials: dict,
+        credentials: dict[str, Any],
     ) -> None:
         """
         add datasource oauth provider
@@ -634,7 +634,7 @@ class DatasourceProviderService:
         name: str | None,
         tenant_id: str,
         provider_id: DatasourceProviderID,
-        credentials: dict,
+        credentials: dict[str, Any],
     ) -> None:
         """
         validate datasource provider credentials.
@@ -947,7 +947,13 @@ class DatasourceProviderService:
         return copy_credentials_list
 
     def update_datasource_credentials(
-        self, tenant_id: str, auth_id: str, provider: str, plugin_id: str, credentials: dict | None, name: str | None
+        self,
+        tenant_id: str,
+        auth_id: str,
+        provider: str,
+        plugin_id: str,
+        credentials: dict[str, Any] | None,
+        name: str | None,
     ) -> None:
         """
         update datasource credentials.

--- a/api/services/plugin/oauth_service.py
+++ b/api/services/plugin/oauth_service.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from typing import Any
 
 from core.plugin.impl.base import BasePluginClient
 from extensions.ext_redis import redis_client
@@ -16,7 +17,7 @@ class OAuthProxyService(BasePluginClient):
         tenant_id: str,
         plugin_id: str,
         provider: str,
-        extra_data: dict = {},
+        extra_data: dict[str, Any] = {},
         credential_id: str | None = None,
     ):
         """

--- a/api/services/rag_pipeline/rag_pipeline_dsl_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_dsl_service.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -526,7 +526,7 @@ class RagPipelineDslService:
         self,
         *,
         pipeline: Pipeline | None,
-        data: dict,
+        data: dict[str, Any],
         account: Account,
         dependencies: list[PluginDependency] | None = None,
     ) -> Pipeline:
@@ -660,7 +660,9 @@ class RagPipelineDslService:
 
         return yaml.dump(export_data, allow_unicode=True)  # type: ignore
 
-    def _append_workflow_export_data(self, *, export_data: dict, pipeline: Pipeline, include_secret: bool) -> None:
+    def _append_workflow_export_data(
+        self, *, export_data: dict[str, Any], pipeline: Pipeline, include_secret: bool
+    ) -> None:
         """
         Append workflow export data
         :param export_data: export data

--- a/api/services/rag_pipeline/rag_pipeline_transform_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_transform_service.py
@@ -2,6 +2,7 @@ import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import yaml
@@ -154,7 +155,7 @@ class RagPipelineTransformService:
             raise ValueError("Unsupported doc form")
         return pipeline_yaml
 
-    def _deal_file_extensions(self, node: dict):
+    def _deal_file_extensions(self, node: dict[str, Any]):
         file_extensions = node.get("data", {}).get("fileExtensions", [])
         if not file_extensions:
             return node
@@ -167,7 +168,7 @@ class RagPipelineTransformService:
         dataset: Dataset,
         indexing_technique: str | None,
         retrieval_model: RetrievalSetting | None,
-        node: dict,
+        node: dict[str, Any],
     ):
         knowledge_configuration_dict = node.get("data", {})
 
@@ -191,7 +192,7 @@ class RagPipelineTransformService:
 
     def _create_pipeline(
         self,
-        data: dict,
+        data: dict[str, Any],
     ) -> Pipeline:
         """Create a new app or update an existing one."""
         pipeline_data = data.get("rag_pipeline", {})
@@ -258,7 +259,7 @@ class RagPipelineTransformService:
         db.session.add(pipeline)
         return pipeline
 
-    def _deal_dependencies(self, pipeline_yaml: dict, tenant_id: str):
+    def _deal_dependencies(self, pipeline_yaml: dict[str, Any], tenant_id: str):
         installer_manager = PluginInstaller()
         installed_plugins = installer_manager.list_plugins(tenant_id)
 


### PR DESCRIPTION
## Summary
Tighten bare `dict` annotations in rag_pipeline services, datasource
provider service, and a few adjacent files:
- `services/rag_pipeline/rag_pipeline_transform_service.py` —  `_deal_file_extensions.node`, `_create_pipeline.data`, node/yaml params
- `services/rag_pipeline/rag_pipeline_dsl_service.py` —  `_create_or_update_pipeline.data`, `_append_workflow_export_data.export_data`
- `services/datasource_provider_service.py` — 6 params  (`client_params`, `credentials`, `new_params` local)
- `services/plugin/oauth_service.py` — `create_proxy_context.extra_data`
- `controllers/console/app/mcp_server.py` — 2× `MCPServerCreatePayload.parameters` /  `MCPServerUpdatePayload.parameters` Pydantic fields
- `models/types.py` — SQLAlchemy `TypeDecorator.process_bind_param` /  `process_result_value` value parameters (now `dict[str, Any] | list[Any] | None`)

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes (1391 files)
