### PR TITLE
refactor: replace bare dict with dict[str, Any] in entities, workflow nodes, and tasks

### DIFF
--- a/api/core/datasource/entities/api_entities.py
+++ b/api/core/datasource/entities/api_entities.py
@@ -14,7 +14,7 @@ class DatasourceApiEntity(BaseModel):
     description: I18nObject
     parameters: list[DatasourceParameter] | None = None
     labels: list[str] = Field(default_factory=list)
-    output_schema: dict | None = None
+    output_schema: dict[str, Any] | None = None
 
 
 ToolProviderTypeApiLiteral = Literal["builtin", "api", "workflow"] | None
@@ -30,7 +30,7 @@ class DatasourceProviderApiEntityDict(TypedDict):
     icon: str | dict
     label: I18nObjectDict
     type: str
-    team_credentials: dict | None
+    team_credentials: dict[str, Any] | None
     is_team_authorization: bool
     allow_delete: bool
     datasources: list[Any]
@@ -45,8 +45,8 @@ class DatasourceProviderApiEntity(BaseModel):
     icon: str | dict
     label: I18nObject  # label
     type: str
-    masked_credentials: dict | None = None
-    original_credentials: dict | None = None
+    masked_credentials: dict[str, Any] | None = None
+    original_credentials: dict[str, Any] | None = None
     is_team_authorization: bool = False
     allow_delete: bool = True
     plugin_id: str | None = Field(default="", description="The plugin id of the datasource")

--- a/api/core/workflow/nodes/knowledge_index/protocols.py
+++ b/api/core/workflow/nodes/knowledge_index/protocols.py
@@ -43,15 +43,20 @@ class IndexProcessorProtocol(Protocol):
         original_document_id: str,
         chunks: Mapping[str, Any],
         batch: Any,
-        summary_index_setting: dict | None = None,
+        summary_index_setting: dict[str, Any] | None = None,
     ) -> IndexingResultDict: ...
 
     def get_preview_output(
-        self, chunks: Any, dataset_id: str, document_id: str, chunk_structure: str, summary_index_setting: dict | None
+        self,
+        chunks: Any,
+        dataset_id: str,
+        document_id: str,
+        chunk_structure: str,
+        summary_index_setting: dict[str, Any] | None,
     ) -> Preview: ...
 
 
 class SummaryIndexServiceProtocol(Protocol):
     def generate_and_vectorize_summary(
-        self, dataset_id: str, document_id: str, is_preview: bool, summary_index_setting: dict | None = None
+        self, dataset_id: str, document_id: str, is_preview: bool, summary_index_setting: dict[str, Any] | None = None
     ) -> None: ...

--- a/api/core/workflow/nodes/trigger_schedule/entities.py
+++ b/api/core/workflow/nodes/trigger_schedule/entities.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.enums import NodeType
@@ -16,7 +16,7 @@ class TriggerScheduleNodeData(BaseNodeData):
     mode: str = Field(default="visual", description="Schedule mode: visual or cron")
     frequency: str | None = Field(default=None, description="Frequency for visual mode: hourly, daily, weekly, monthly")
     cron_expression: str | None = Field(default=None, description="Cron expression for cron mode")
-    visual_config: dict | None = Field(default=None, description="Visual configuration details")
+    visual_config: dict[str, Any] | None = Field(default=None, description="Visual configuration details")
     timezone: str = Field(default="UTC", description="Timezone for schedule execution")
 
 

--- a/api/core/workflow/nodes/trigger_webhook/node.py
+++ b/api/core/workflow/nodes/trigger_webhook/node.py
@@ -75,7 +75,7 @@ class TriggerWebhookNode(Node[WebhookData]):
             outputs=outputs,
         )
 
-    def generate_file_var(self, param_name: str, file: dict):
+    def generate_file_var(self, param_name: str, file: dict[str, Any]):
         file_id = resolve_file_record_id(file.get("reference") or file.get("related_id"))
         transfer_method_value = file.get("transfer_method")
         if transfer_method_value:
@@ -147,7 +147,7 @@ class TriggerWebhookNode(Node[WebhookData]):
                 outputs[param_name] = str(webhook_data.get("body", {}).get("raw", ""))
                 continue
             elif self.node_data.content_type == ContentType.BINARY:
-                raw_data: dict = webhook_data.get("body", {}).get("raw", {})
+                raw_data: dict[str, Any] = webhook_data.get("body", {}).get("raw", {})
                 file_var = self.generate_file_var(param_name, raw_data)
                 if file_var:
                     outputs[param_name] = file_var

--- a/api/extensions/storage/clickzetta_volume/file_lifecycle.py
+++ b/api/extensions/storage/clickzetta_volume/file_lifecycle.py
@@ -65,7 +65,7 @@ class FileMetadata:
         return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> FileMetadata:
+    def from_dict(cls, data: dict[str, Any]) -> FileMetadata:
         """Create instance from dictionary"""
         data = data.copy()
         data["created_at"] = datetime.fromisoformat(data["created_at"])
@@ -459,7 +459,7 @@ class FileLifecycleManager:
                 newest_file=None,
             )
 
-    def _create_version_backup(self, filename: str, metadata: dict):
+    def _create_version_backup(self, filename: str, metadata: dict[str, Any]):
         """Create version backup"""
         try:
             # Read current file content
@@ -487,7 +487,7 @@ class FileLifecycleManager:
             logger.warning("Failed to load metadata: %s", e)
             return {}
 
-    def _save_metadata(self, metadata_dict: dict):
+    def _save_metadata(self, metadata_dict: dict[str, Any]):
         """Save metadata file"""
         try:
             metadata_content = json.dumps(metadata_dict, indent=2, ensure_ascii=False)

--- a/api/services/entities/external_knowledge_entities/external_knowledge_entities.py
+++ b/api/services/entities/external_knowledge_entities/external_knowledge_entities.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 from pydantic import BaseModel
 
@@ -22,5 +22,5 @@ class ProcessStatusSetting(BaseModel):
 class ExternalKnowledgeApiSetting(BaseModel):
     url: str
     request_method: str
-    headers: dict | None = None
-    params: dict | None = None
+    headers: dict[str, Any] | None = None
+    params: dict[str, Any] | None = None

--- a/api/services/entities/knowledge_entities/knowledge_entities.py
+++ b/api/services/entities/knowledge_entities/knowledge_entities.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, field_validator
 
@@ -97,7 +97,7 @@ class KnowledgeConfig(BaseModel):
     data_source: DataSource | None = None
     process_rule: ProcessRule | None = None
     retrieval_model: RetrievalModel | None = None
-    summary_index_setting: dict | None = None
+    summary_index_setting: dict[str, Any] | None = None
     doc_form: str = "text_model"
     doc_language: str = "English"
     embedding_model: str | None = None

--- a/api/services/entities/knowledge_entities/rag_pipeline_entities.py
+++ b/api/services/entities/knowledge_entities/rag_pipeline_entities.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, field_validator
 
@@ -73,7 +73,7 @@ class KnowledgeConfiguration(BaseModel):
     keyword_number: int | None = 10
     retrieval_model: RetrievalSetting
     # add summary index setting
-    summary_index_setting: dict | None = None
+    summary_index_setting: dict[str, Any] | None = None
 
     @field_validator("embedding_model_provider", mode="before")
     @classmethod

--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -3,6 +3,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
+from typing import Any
 
 import click
 import pandas as pd
@@ -51,8 +52,8 @@ def batch_create_segment_to_index_task(
 
     # Initialize variables with default values
     upload_file_key: str | None = None
-    dataset_config: dict | None = None
-    document_config: dict | None = None
+    dataset_config: dict[str, Any] | None = None
+    document_config: dict[str, Any] | None = None
 
     with session_factory.create_session() as session:
         try:

--- a/api/tasks/remove_app_and_related_data_task.py
+++ b/api/tasks/remove_app_and_related_data_task.py
@@ -679,7 +679,7 @@ def _delete_workflow_trigger_logs(tenant_id: str, app_id: str):
     )
 
 
-def _delete_records(query_sql: str, params: dict, delete_func: Callable, name: str) -> None:
+def _delete_records(query_sql: str, params: dict[str, Any], delete_func: Callable, name: str) -> None:
     while True:
         with session_factory.create_session() as session:
             rs = session.execute(sa.text(query_sql), params)

--- a/api/tasks/workflow_execution_tasks.py
+++ b/api/tasks/workflow_execution_tasks.py
@@ -7,6 +7,7 @@ improving performance by offloading storage operations to background workers.
 
 import json
 import logging
+from typing import Any
 
 from celery import shared_task
 from graphon.entities import WorkflowExecution
@@ -23,7 +24,7 @@ logger = logging.getLogger(__name__)
 @shared_task(queue="workflow_storage", bind=True, max_retries=3, default_retry_delay=60)
 def save_workflow_execution_task(
     self,
-    execution_data: dict,
+    execution_data: dict[str, Any],
     tenant_id: str,
     app_id: str,
     triggered_from: str,

--- a/api/tasks/workflow_node_execution_tasks.py
+++ b/api/tasks/workflow_node_execution_tasks.py
@@ -7,6 +7,7 @@ improving performance by offloading storage operations to background workers.
 
 import json
 import logging
+from typing import Any
 
 from celery import shared_task
 from graphon.entities.workflow_node_execution import (
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 @shared_task(queue="workflow_storage", bind=True, max_retries=3, default_retry_delay=60)
 def save_workflow_node_execution_task(
     self,
-    execution_data: dict,
+    execution_data: dict[str, Any],
     tenant_id: str,
     app_id: str,
     triggered_from: str,


### PR DESCRIPTION
## Summary
Tighten bare `dict` annotations across entity classes, workflow node implementations, celery tasks, and extension storage:

### Entities & protocols
- `core/datasource/entities/api_entities.py` — `DatasourceApiEntity.output_schema`,
  `DatasourceProviderApiEntityDict.team_credentials`,  `DatasourceProviderApiEntity.masked_credentials`/`original_credentials`
- `services/entities/external_knowledge_entities.py` — `headers`, `params`
- `services/entities/knowledge_entities/*.py` — 2× `summary_index_setting`
- `core/workflow/nodes/knowledge_index/protocols.py` — 3× `summary_index_setting`

### Workflow nodes
- `core/workflow/nodes/trigger_webhook/node.py` — `generate_file_var.file`,  `raw_data` local
- `core/workflow/nodes/trigger_schedule/entities.py` —  `TriggerScheduleNodeData.visual_config`

### Tasks
- `tasks/batch_create_segment_to_index_task.py` —  `dataset_config`, `document_config` locals
- `tasks/workflow_node_execution_tasks.py` —  `save_workflow_node_execution_task.execution_data`
- `tasks/workflow_execution_tasks.py` —  `save_workflow_execution_task.execution_data`
- `tasks/remove_app_and_related_data_task.py` — `_delete_records.params`

### Storage
- `extensions/storage/clickzetta_volume/file_lifecycle.py` —  `FileMetadata.from_dict.data`, `_create_version_backup.metadata`,
  `_save_metadata.metadata_dict`

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes (1391 files)
