### PR TITLE
refactor: replace bare dict with dict[str, Any] in VDB providers

### DIFF
--- a/api/providers/vdb/vdb-elasticsearch/src/dify_vdb_elasticsearch/elasticsearch_vector.py
+++ b/api/providers/vdb/vdb-elasticsearch/src/dify_vdb_elasticsearch/elasticsearch_vector.py
@@ -43,7 +43,7 @@ class ElasticSearchConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         use_cloud = values.get("use_cloud", False)
         cloud_url = values.get("cloud_url")
 
@@ -258,7 +258,7 @@ class ElasticSearchVector(BaseVector):
         self,
         embeddings: list[list[float]],
         metadatas: list[dict[Any, Any]] | None = None,
-        index_params: dict | None = None,
+        index_params: dict[str, Any] | None = None,
     ):
         lock_name = f"vector_indexing_lock_{self._collection_name}"
         with redis_client.lock(lock_name, timeout=20):

--- a/api/providers/vdb/vdb-huawei-cloud/src/dify_vdb_huawei_cloud/huawei_cloud_vector.py
+++ b/api/providers/vdb/vdb-huawei-cloud/src/dify_vdb_huawei_cloud/huawei_cloud_vector.py
@@ -44,7 +44,7 @@ class HuaweiCloudVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["hosts"]:
             raise ValueError("config HOSTS is required")
         return values
@@ -169,7 +169,7 @@ class HuaweiCloudVector(BaseVector):
         self,
         embeddings: list[list[float]],
         metadatas: list[dict[Any, Any]] | None = None,
-        index_params: dict | None = None,
+        index_params: dict[str, Any] | None = None,
     ):
         lock_name = f"vector_indexing_lock_{self._collection_name}"
         with redis_client.lock(lock_name, timeout=20):

--- a/api/providers/vdb/vdb-lindorm/src/dify_vdb_lindorm/lindorm_vector.py
+++ b/api/providers/vdb/vdb-lindorm/src/dify_vdb_lindorm/lindorm_vector.py
@@ -44,7 +44,7 @@ class LindormVectorStoreConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["hosts"]:
             raise ValueError("config URL is required")
         if not values["username"]:
@@ -336,7 +336,10 @@ class LindormVectorStore(BaseVector):
         return docs
 
     def create_collection(
-        self, embeddings: list, metadatas: list[dict] | None = None, index_params: dict | None = None
+        self,
+        embeddings: list[list[float]],
+        metadatas: list[dict[str, Any]] | None = None,
+        index_params: dict[str, Any] | None = None,
     ):
         if not embeddings:
             raise ValueError(f"Embeddings list cannot be empty for collection create '{self._collection_name}'")

--- a/api/providers/vdb/vdb-milvus/src/dify_vdb_milvus/milvus_vector.py
+++ b/api/providers/vdb/vdb-milvus/src/dify_vdb_milvus/milvus_vector.py
@@ -45,7 +45,7 @@ class MilvusConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         """
         Validate the configuration values.
         Raises ValueError if required fields are missing.
@@ -302,7 +302,10 @@ class MilvusVector(BaseVector):
         )
 
     def create_collection(
-        self, embeddings: list, metadatas: list[dict] | None = None, index_params: dict | None = None
+        self,
+        embeddings: list[list[float]],
+        metadatas: list[dict[str, Any]] | None = None,
+        index_params: dict[str, Any] | None = None,
     ):
         """
         Create a new collection in Milvus with the specified schema and index parameters.

--- a/api/providers/vdb/vdb-opensearch/src/dify_vdb_opensearch/opensearch_vector.py
+++ b/api/providers/vdb/vdb-opensearch/src/dify_vdb_opensearch/opensearch_vector.py
@@ -49,7 +49,7 @@ class OpenSearchConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values.get("host"):
             raise ValueError("config OPENSEARCH_HOST is required")
         if not values.get("port"):
@@ -252,7 +252,10 @@ class OpenSearchVector(BaseVector):
         return docs
 
     def create_collection(
-        self, embeddings: list, metadatas: list[dict] | None = None, index_params: dict | None = None
+        self,
+        embeddings: list[list[float]],
+        metadatas: list[dict[str, Any]] | None = None,
+        index_params: dict[str, Any] | None = None,
     ):
         lock_name = f"vector_indexing_lock_{self._collection_name.lower()}"
         with redis_client.lock(lock_name, timeout=20):

--- a/api/providers/vdb/vdb-pgvector/src/dify_vdb_pgvector/pgvector.py
+++ b/api/providers/vdb/vdb-pgvector/src/dify_vdb_pgvector/pgvector.py
@@ -34,7 +34,7 @@ class PGVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config PGVECTOR_HOST is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py
+++ b/api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py
@@ -38,7 +38,7 @@ class RelytConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config RELYT_HOST is required")
         if not values["port"]:
@@ -239,7 +239,7 @@ class RelytVector(BaseVector):
         self,
         embedding: list[float],
         k: int = 4,
-        filter: dict | None = None,
+        filter: dict[str, Any] | None = None,
     ) -> list[tuple[Document, float]]:
         # Add the filter if provided
 

--- a/api/providers/vdb/vdb-tablestore/src/dify_vdb_tablestore/tablestore_vector.py
+++ b/api/providers/vdb/vdb-tablestore/src/dify_vdb_tablestore/tablestore_vector.py
@@ -30,7 +30,7 @@ class TableStoreConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["access_key_id"]:
             raise ValueError("config ACCESS_KEY_ID is required")
         if not values["access_key_secret"]:

--- a/api/providers/vdb/vdb-tidb-vector/src/dify_vdb_tidb_vector/tidb_vector.py
+++ b/api/providers/vdb/vdb-tidb-vector/src/dify_vdb_tidb_vector/tidb_vector.py
@@ -31,7 +31,7 @@ class TiDBVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config TIDB_VECTOR_HOST is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-upstash/src/dify_vdb_upstash/upstash_vector.py
+++ b/api/providers/vdb/vdb-upstash/src/dify_vdb_upstash/upstash_vector.py
@@ -20,7 +20,7 @@ class UpstashVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["url"]:
             raise ValueError("Upstash URL is required")
         if not values["token"]:

--- a/api/providers/vdb/vdb-vastbase/src/dify_vdb_vastbase/vastbase_vector.py
+++ b/api/providers/vdb/vdb-vastbase/src/dify_vdb_vastbase/vastbase_vector.py
@@ -28,7 +28,7 @@ class VastbaseVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config VASTBASE_HOST is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -82,7 +82,7 @@ class WeaviateConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict) -> dict:
+    def validate_config(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validates that required configuration values are present."""
         if not values["endpoint"]:
             raise ValueError("config WEAVIATE_ENDPOINT is required")


### PR DESCRIPTION
## Summary
Tighten bare `dict` / `dict | None` annotations across 12 vector database provider packages under `api/providers/vdb/`:
- Relyt, OpenSearch, Milvus, Lindorm, Huawei Cloud, Elasticsearch —  `validate_config.values`, `create_collection.metadatas`/`index_params`,  `similarity_search_with_score_by_vector.filter`
- PgVector, TiDB, Tablestore, Upstash, Vastbase, Weaviate —  `validate_config.values`

All VDB config values are provider-specific, so `dict[str, Any]` is the correct shape. `Any` is already imported in each file.

No behavior change — types only.

Part of #22651.

## Test plan
- [x] `make lint` passes
- [x] `make type-check-core` passes (1391 files)
