### PR TITLE
fix(api): preserve precision for large integers in safe_int

### DIFF
--- a/api/extensions/logstore/repositories/__init__.py
+++ b/api/extensions/logstore/repositories/__init__.py
@@ -23,7 +23,15 @@ def safe_int(value: Any, default: int = 0) -> int:
     """
     if value is None or value in {"null", ""}:
         return default
+    # Try int() first to preserve precision for large integers.
+    # int(float("25227143063332189585438")) silently truncates because
+    # float64 only carries ~15-17 significant digits. int() on a
+    # string handles arbitrary precision. Fall back to int(float())
+    # only for float-like strings such as "3.14". See #34405.
     try:
-        return int(float(value))
+        return int(value)
     except (ValueError, TypeError):
-        return default
+        try:
+            return int(float(value))
+        except (ValueError, TypeError):
+            return default


### PR DESCRIPTION
Fixes #34405.

`safe_int()` was converting through `float` first via `int(float(value))`, which silently truncates integers with more than ~15 significant digits because float64 can't represent them exactly. For example: `int(float('25227143063332189585438'))` yields `25227143063332188061696`, losing the last 8 digits. The reporter saw this when passing large integers through code nodes and MCP tool nodes.

Fix: try `int(value)` first for arbitrary-precision integer conversion. Fall back to `int(float(value))` only when `int()` fails, which still handles float-like strings like `"3.14"` or `"1e10"`.

Verified: large int `25227143063332189585438` round-trips correctly, normal ints, float strings, None, "null", empty string, and garbage inputs all behave as before. Ruff clean.