### PR TITLE
fix(api): handle reasoning model output in suggested questions generation

### DIFF
--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -155,6 +155,13 @@ class LLMGenerator:
             )
 
             text_content = response.message.get_text_content()
+            # Reasoning models (DeepSeek-R1, o1, etc.) prepend a
+            # <think>...</think> block to their output. Strip it before
+            # parsing so the output parser sees only the question list.
+            # Without this, the parser fails on the XML prefix and the
+            # function silently returns []. See #34475.
+            if text_content:
+                text_content = re.sub(r"<think>[\s\S]*?</think>\s*", "", text_content)
             questions = output_parser.parse(text_content) if text_content else []
         except InvokeError:
             questions = []

--- a/api/core/llm_generator/prompts.py
+++ b/api/core/llm_generator/prompts.py
@@ -110,8 +110,10 @@ SUGGESTED_QUESTIONS_AFTER_ANSWER_INSTRUCTION_PROMPT = os.getenv(
     "SUGGESTED_QUESTIONS_PROMPT", _DEFAULT_SUGGESTED_QUESTIONS_AFTER_ANSWER_PROMPT
 )
 
-# Configurable LLM parameters for suggested questions (can be overridden by environment variables)
-SUGGESTED_QUESTIONS_MAX_TOKENS = int(os.getenv("SUGGESTED_QUESTIONS_MAX_TOKENS", "256"))
+# Configurable LLM parameters for suggested questions (can be overridden by environment variables).
+# Default raised from 256 to 512 for reasoning models (DeepSeek-R1, o1, etc.)
+# whose <think> prefix consumes part of the token budget. See #34475.
+SUGGESTED_QUESTIONS_MAX_TOKENS = int(os.getenv("SUGGESTED_QUESTIONS_MAX_TOKENS", "512"))
 SUGGESTED_QUESTIONS_TEMPERATURE = float(os.getenv("SUGGESTED_QUESTIONS_TEMPERATURE", "0"))
 
 GENERATOR_QA_PROMPT = (


### PR DESCRIPTION
Fixes #34475.

Reasoning models (DeepSeek-R1, o1, etc.) prepend a `<think>...</think>` block to their output. In `generate_suggested_questions_after_answer()`, this caused two problems:

1. The `<think>` prefix broke the output parser which expects a clean question list, so the function silently returned `[]`.
2. The thinking tokens consumed most of the `max_tokens=256` budget, leaving too few tokens for the actual JSON output.

Two changes:

- Strip `<think>` blocks from the response text before passing to the output parser (regex, same pattern used elsewhere in the codebase for reasoning model handling, e.g. `structured_output.py:292`).
- Raise the default `max_tokens` from 256 to 512 to give reasoning models room for both the thinking prefix and the question list. Still overridable via `SUGGESTED_QUESTIONS_MAX_TOKENS` env var.

Ruff clean. Tested the stripping regex against reasoning model output with think blocks, empty think blocks, and normal model output — all pass.