### PR TITLE
fix(storage): restore S3-compatible checksum settings for boto3 >=1.36

### DIFF
--- a/api/extensions/storage/aws_s3_storage.py
+++ b/api/extensions/storage/aws_s3_storage.py
@@ -32,7 +32,16 @@ class AwsS3Storage(BaseStorage):
                 aws_access_key_id=dify_config.S3_ACCESS_KEY,
                 endpoint_url=dify_config.S3_ENDPOINT,
                 region_name=dify_config.S3_REGION,
-                config=Config(s3={"addressing_style": dify_config.S3_ADDRESS_STYLE}),
+                config=Config(
+                    s3={"addressing_style": dify_config.S3_ADDRESS_STYLE},
+                    # boto3 >=1.36.1 enables checksum calculation by default, which
+                    # sends AWS-proprietary checksum headers (x-amz-checksum-*)
+                    # that S3-compatible services like MinIO don't support and
+                    # reject outright. Disable automatic checksums so uploads work
+                    # on any S3-compatible backend. See #34384.
+                    request_checksum_calculation="when_required",
+                    response_checksum_validation="when_required",
+                ),
             )
         # create bucket
         try:


### PR DESCRIPTION
Fixes #34384.

boto3 >=1.36.1 enables checksum calculation by default, sending AWS-proprietary `x-amz-checksum-*` headers that S3-compatible services like MinIO don't support. File uploads broke after upgrading from Dify 1.13.0 to 1.13.3 because the accompanying boto3 bump crossed the 1.36 threshold.

These checksum settings (`request_checksum_calculation` / `response_checksum_validation`) were previously present in the Config but were removed as "redundant" in an earlier refactor. They're not redundant for non-AWS S3 backends.

Restored `request_checksum_calculation="when_required"` and `response_checksum_validation="when_required"` in the boto3 Config so checksums are only computed when the server explicitly requests them. This makes uploads work on MinIO and other S3-compatible services while keeping full AWS S3 behavior unchanged.

Ruff clean. One file, one config change.