### PR TITLE
refactor: replace bare dict with dict[str, Any] in VDB providers and libs

### DIFF
--- a/api/libs/broadcast_channel/redis/_subscription.py
+++ b/api/libs/broadcast_channel/redis/_subscription.py
@@ -3,7 +3,7 @@ import queue
 import threading
 import types
 from collections.abc import Generator, Iterator
-from typing import Self
+from typing import Any, Self
 
 from libs.broadcast_channel.channel import Subscription
 from libs.broadcast_channel.exc import SubscriptionClosedError
@@ -221,7 +221,7 @@ class RedisSubscriptionBase(Subscription):
         """Unsubscribe from the Redis topic using the appropriate command."""
         raise NotImplementedError
 
-    def _get_message(self) -> dict | None:
+    def _get_message(self) -> dict[str, Any] | None:
         """Get a message from Redis using the appropriate method."""
         raise NotImplementedError
 

--- a/api/libs/broadcast_channel/redis/channel.py
+++ b/api/libs/broadcast_channel/redis/channel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from libs.broadcast_channel.channel import Producer, Subscriber, Subscription
 from redis import Redis, RedisCluster
 
@@ -62,7 +64,7 @@ class _RedisSubscription(RedisSubscriptionBase):
         assert self._pubsub is not None
         self._pubsub.unsubscribe(self._topic)
 
-    def _get_message(self) -> dict | None:
+    def _get_message(self) -> dict[str, Any] | None:
         assert self._pubsub is not None
         return self._pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
 

--- a/api/libs/broadcast_channel/redis/sharded_channel.py
+++ b/api/libs/broadcast_channel/redis/sharded_channel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from libs.broadcast_channel.channel import Producer, Subscriber, Subscription
 from redis import Redis, RedisCluster
 
@@ -60,7 +62,7 @@ class _RedisShardedSubscription(RedisSubscriptionBase):
         assert self._pubsub is not None
         self._pubsub.sunsubscribe(self._topic)  # type: ignore[attr-defined]
 
-    def _get_message(self) -> dict | None:
+    def _get_message(self) -> dict[str, Any] | None:
         assert self._pubsub is not None
         # NOTE(QuantumGhost): this is an issue in
         # upstream code. If Sharded PubSub is used with Cluster, the

--- a/api/libs/exception.py
+++ b/api/libs/exception.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 from werkzeug.exceptions import HTTPException
 
 
 class BaseHTTPException(HTTPException):
     error_code: str = "unknown"
-    data: dict | None = None
+    data: dict[str, Any] | None = None
 
     def __init__(self, description=None, response=None):
         super().__init__(description, response)

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -410,7 +410,7 @@ class TokenManager:
         token_type: str,
         account: "Account | None" = None,
         email: str | None = None,
-        additional_data: dict | None = None,
+        additional_data: dict[str, Any] | None = None,
     ) -> str:
         if account is None and email is None:
             raise ValueError("Account or email must be provided")

--- a/api/libs/sendgrid.py
+++ b/api/libs/sendgrid.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import sendgrid
 from python_http_client.exceptions import ForbiddenError, UnauthorizedError
@@ -12,7 +13,7 @@ class SendGridClient:
         self.sendgrid_api_key = sendgrid_api_key
         self._from = _from
 
-    def send(self, mail: dict):
+    def send(self, mail: dict[str, Any]):
         logger.debug("Sending email with SendGrid")
         _to = ""
         try:

--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -1,5 +1,6 @@
 import logging
 import smtplib
+from typing import Any
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -20,7 +21,7 @@ class SMTPClient:
         self.use_tls = use_tls
         self.opportunistic_tls = opportunistic_tls
 
-    def send(self, mail: dict):
+    def send(self, mail: dict[str, Any]):
         smtp: smtplib.SMTP | None = None
         local_host = dify_config.SMTP_LOCAL_HOSTNAME
         try:

--- a/api/libs/smtp.py
+++ b/api/libs/smtp.py
@@ -1,8 +1,8 @@
 import logging
 import smtplib
-from typing import Any
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from typing import Any
 
 from configs import dify_config
 

--- a/api/providers/vdb/vdb-alibabacloud-mysql/src/dify_vdb_alibabacloud_mysql/alibabacloud_mysql_vector.py
+++ b/api/providers/vdb/vdb-alibabacloud-mysql/src/dify_vdb_alibabacloud_mysql/alibabacloud_mysql_vector.py
@@ -35,7 +35,7 @@ class AlibabaCloudMySQLVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values.get("host"):
             raise ValueError("config ALIBABACLOUD_MYSQL_HOST is required")
         if not values.get("port"):

--- a/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_openapi.py
+++ b/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_openapi.py
@@ -34,7 +34,7 @@ class AnalyticdbVectorOpenAPIConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["access_key_id"]:
             raise ValueError("config ANALYTICDB_KEY_ID is required")
         if not values["access_key_secret"]:

--- a/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
+++ b/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
@@ -24,7 +24,7 @@ class AnalyticdbVectorBySqlConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config ANALYTICDB_HOST is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-baidu/src/dify_vdb_baidu/baidu_vector.py
+++ b/api/providers/vdb/vdb-baidu/src/dify_vdb_baidu/baidu_vector.py
@@ -59,7 +59,7 @@ class BaiduConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["endpoint"]:
             raise ValueError("config BAIDU_VECTOR_DB_ENDPOINT is required")
         if not values["account"]:

--- a/api/providers/vdb/vdb-clickzetta/src/dify_vdb_clickzetta/clickzetta_vector.py
+++ b/api/providers/vdb/vdb-clickzetta/src/dify_vdb_clickzetta/clickzetta_vector.py
@@ -51,7 +51,7 @@ class ClickzettaConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         """
         Validate the configuration values.
         """

--- a/api/providers/vdb/vdb-couchbase/src/dify_vdb_couchbase/couchbase_vector.py
+++ b/api/providers/vdb/vdb-couchbase/src/dify_vdb_couchbase/couchbase_vector.py
@@ -36,7 +36,7 @@ class CouchbaseConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values.get("connection_string"):
             raise ValueError("config COUCHBASE_CONNECTION_STRING is required")
         if not values.get("user"):

--- a/api/providers/vdb/vdb-hologres/src/dify_vdb_hologres/hologres_vector.py
+++ b/api/providers/vdb/vdb-hologres/src/dify_vdb_hologres/hologres_vector.py
@@ -43,7 +43,7 @@ class HologresVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values.get("host"):
             raise ValueError("config HOLOGRES_HOST is required")
         if not values.get("database"):

--- a/api/providers/vdb/vdb-matrixone/src/dify_vdb_matrixone/matrixone_vector.py
+++ b/api/providers/vdb/vdb-matrixone/src/dify_vdb_matrixone/matrixone_vector.py
@@ -43,7 +43,7 @@ class MatrixoneConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config host is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-oceanbase/src/dify_vdb_oceanbase/oceanbase_vector.py
+++ b/api/providers/vdb/vdb-oceanbase/src/dify_vdb_oceanbase/oceanbase_vector.py
@@ -49,7 +49,7 @@ class OceanBaseVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config OCEANBASE_VECTOR_HOST is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-opengauss/src/dify_vdb_opengauss/opengauss.py
+++ b/api/providers/vdb/vdb-opengauss/src/dify_vdb_opengauss/opengauss.py
@@ -29,7 +29,7 @@ class OpenGaussConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config OPENGAUSS_HOST is required")
         if not values["port"]:

--- a/api/providers/vdb/vdb-oracle/src/dify_vdb_oracle/oraclevector.py
+++ b/api/providers/vdb/vdb-oracle/src/dify_vdb_oracle/oraclevector.py
@@ -36,7 +36,7 @@ class OracleVectorConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["user"]:
             raise ValueError("config ORACLE_USER is required")
         if not values["password"]:

--- a/api/providers/vdb/vdb-pgvecto-rs/src/dify_vdb_pgvecto_rs/pgvecto_rs.py
+++ b/api/providers/vdb/vdb-pgvecto-rs/src/dify_vdb_pgvecto_rs/pgvecto_rs.py
@@ -33,7 +33,7 @@ class PgvectoRSConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_config(cls, values: dict):
+    def validate_config(cls, values: dict[str, Any]):
         if not values["host"]:
             raise ValueError("config PGVECTO_RS_HOST is required")
         if not values["port"]:


### PR DESCRIPTION
Replace bare `dict` with `dict[str, Any]` in `validate_config(cls, values:)` for 12 VDB providers: baidu, oracle, opengauss, oceanbase, alibabacloud-mysql, analyticdb (sql + openapi), couchbase, pgvecto-rs, clickzetta, matrixone, hologres. 
Also update `libs/sendgrid.py`, `libs/smtp.py`, `libs/exception.py`, `libs/helper.py`, and redis broadcast channel files. 

Add `from typing import Any` where missing.

Part of langgenius/dify#22651.