### PR TITLE
chore: allow disabling app-level PostgreSQL timezone injection

### DIFF
--- a/api/configs/middleware/__init__.py
+++ b/api/configs/middleware/__init__.py
@@ -160,6 +160,16 @@ class DatabaseConfig(BaseSettings):
         default="",
     )
 
+    DB_TIMEZONE: str = Field(
+        description=(
+            "PostgreSQL session timezone injected via startup options."
+            " Default is 'UTC' for out-of-the-box consistency."
+            " Set to empty string to disable app-level timezone injection, for example when using RDS Proxy"
+            " together with a database-side default timezone."
+        ),
+        default="UTC",
+    )
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def SQLALCHEMY_DATABASE_URI_SCHEME(self) -> str:
@@ -227,12 +237,13 @@ class DatabaseConfig(BaseSettings):
         connect_args: dict[str, str] = {}
         # Use the dynamic SQLALCHEMY_DATABASE_URI_SCHEME property
         if self.SQLALCHEMY_DATABASE_URI_SCHEME.startswith("postgresql"):
-            timezone_opt = "-c timezone=UTC"
-            if options:
-                merged_options = f"{options} {timezone_opt}"
-            else:
-                merged_options = timezone_opt
-            connect_args = {"options": merged_options}
+            merged_options = options.strip()
+            db_timezone = self.DB_TIMEZONE.strip()
+            if db_timezone:
+                timezone_opt = f"-c timezone={db_timezone}"
+                merged_options = f"{merged_options} {timezone_opt}".strip() if merged_options else timezone_opt
+            if merged_options:
+                connect_args = {"options": merged_options}
 
         result: SQLAlchemyEngineOptionsDict = {
             "pool_size": self.SQLALCHEMY_POOL_SIZE,

--- a/api/configs/middleware/__init__.py
+++ b/api/configs/middleware/__init__.py
@@ -160,9 +160,9 @@ class DatabaseConfig(BaseSettings):
         default="",
     )
 
-    DB_TIMEZONE: str = Field(
+    DB_SESSION_TIMEZONE_OVERRIDE: str = Field(
         description=(
-            "PostgreSQL session timezone injected via startup options."
+            "PostgreSQL session timezone override injected via startup options."
             " Default is 'UTC' for out-of-the-box consistency."
             " Set to empty string to disable app-level timezone injection, for example when using RDS Proxy"
             " together with a database-side default timezone."
@@ -238,9 +238,9 @@ class DatabaseConfig(BaseSettings):
         # Use the dynamic SQLALCHEMY_DATABASE_URI_SCHEME property
         if self.SQLALCHEMY_DATABASE_URI_SCHEME.startswith("postgresql"):
             merged_options = options.strip()
-            db_timezone = self.DB_TIMEZONE.strip()
-            if db_timezone:
-                timezone_opt = f"-c timezone={db_timezone}"
+            session_timezone_override = self.DB_SESSION_TIMEZONE_OVERRIDE.strip()
+            if session_timezone_override:
+                timezone_opt = f"-c timezone={session_timezone_override}"
                 merged_options = f"{merged_options} {timezone_opt}".strip() if merged_options else timezone_opt
             if merged_options:
                 connect_args = {"options": merged_options}

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -145,7 +145,7 @@ def test_inner_api_config_exist(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_db_extras_options_merging(monkeypatch: pytest.MonkeyPatch):
-    """Test that DB_EXTRAS options are properly merged with default timezone setting"""
+    """Test that DB_EXTRAS options are merged with the default timezone startup option."""
     # Set environment variables
     monkeypatch.setenv("DB_TYPE", "postgresql")
     monkeypatch.setenv("DB_USERNAME", "postgres")
@@ -158,13 +158,26 @@ def test_db_extras_options_merging(monkeypatch: pytest.MonkeyPatch):
     # Create config
     config = DifyConfig()
 
-    # Get engine options
-    engine_options = config.SQLALCHEMY_ENGINE_OPTIONS
-
-    # Verify options contains both search_path and timezone
-    options = engine_options["connect_args"]["options"]
+    options = config.SQLALCHEMY_ENGINE_OPTIONS["connect_args"]["options"]
     assert "search_path=myschema" in options
     assert "timezone=UTC" in options
+
+
+def test_db_timezone_can_disable_app_level_timezone_injection(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DB_TYPE", "postgresql")
+    monkeypatch.setenv("DB_USERNAME", "postgres")
+    monkeypatch.setenv("DB_PASSWORD", "postgres")
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_PORT", "5432")
+    monkeypatch.setenv("DB_DATABASE", "dify")
+    monkeypatch.setenv("DB_EXTRAS", "options=-c search_path=myschema")
+    monkeypatch.setenv("DB_TIMEZONE", "")
+
+    config = DifyConfig()
+
+    assert config.SQLALCHEMY_ENGINE_OPTIONS["connect_args"] == {
+        "options": "-c search_path=myschema",
+    }
 
 
 def test_pubsub_redis_url_default(monkeypatch: pytest.MonkeyPatch):

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -163,7 +163,7 @@ def test_db_extras_options_merging(monkeypatch: pytest.MonkeyPatch):
     assert "timezone=UTC" in options
 
 
-def test_db_timezone_can_disable_app_level_timezone_injection(monkeypatch: pytest.MonkeyPatch):
+def test_db_session_timezone_override_can_disable_app_level_timezone_injection(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DB_TYPE", "postgresql")
     monkeypatch.setenv("DB_USERNAME", "postgres")
     monkeypatch.setenv("DB_PASSWORD", "postgres")
@@ -171,7 +171,7 @@ def test_db_timezone_can_disable_app_level_timezone_injection(monkeypatch: pytes
     monkeypatch.setenv("DB_PORT", "5432")
     monkeypatch.setenv("DB_DATABASE", "dify")
     monkeypatch.setenv("DB_EXTRAS", "options=-c search_path=myschema")
-    monkeypatch.setenv("DB_TIMEZONE", "")
+    monkeypatch.setenv("DB_SESSION_TIMEZONE_OVERRIDE", "")
 
     config = DifyConfig()
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->
```
(192.168.68.12), port 5432 failed: FATAL:  Feature not supported: RDS Proxy currently doesn’t support command-line options.\n\n(Background on this error at: https://sqlalche.me/e/20/e3q8)\n"}
```

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
