### PR TITLE
fix: doc modal hidden by config modal

### DIFF
--- a/web/app/components/plugins/readme-panel/index.tsx
+++ b/web/app/components/plugins/readme-panel/index.tsx
@@ -87,7 +87,7 @@ const ReadmePanel: FC = () => {
 
   const portalContent = showType === ReadmeShowType.drawer
     ? (
-        <div className="fixed inset-0 z-999 flex justify-start" onClick={onClose}>
+        <div className="fixed inset-0 z-1002 flex justify-start" onClick={onClose}>
           <div
             className={cn(
               'pointer-events-auto mb-2 ml-2 mr-2 mt-16 w-[600px] max-w-[600px] justify-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0 shadow-xl',
@@ -101,7 +101,7 @@ const ReadmePanel: FC = () => {
         </div>
       )
     : (
-        <div className="fixed inset-0 z-999 flex items-center justify-center p-2" onClick={onClose}>
+        <div className="fixed inset-0 z-1002 flex items-center justify-center p-2" onClick={onClose}>
           <div
             className={cn(
               'pointer-events-auto relative h-[calc(100vh-16px)] w-full max-w-[800px] rounded-2xl bg-components-panel-bg p-0 shadow-xl',


### PR DESCRIPTION

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
