### PR TITLE
chore: url in tool description support clicking jump directly

### DIFF
--- a/web/app/components/workflow/nodes/tool/components/tool-form/__tests__/item.spec.tsx
+++ b/web/app/components/workflow/nodes/tool/components/tool-form/__tests__/item.spec.tsx
@@ -78,6 +78,7 @@ describe('tool/tool-form/item', () => {
     mockUseLanguage.mockReturnValue('en_US')
   })
 
+  // Text input fields render their descriptions inline above the input.
   it('should render text input labels and forward props to form input item', () => {
     const handleChange = vi.fn()
     const handleManageInputField = vi.fn()
@@ -121,6 +122,31 @@ describe('tool/tool-form/item', () => {
     })
   })
 
+  // URL fragments inside descriptions should be rendered as external links.
+  it('should render URLs in descriptions as external links', () => {
+    render(
+      <ToolFormItem
+        readOnly={false}
+        nodeId="tool-node"
+        schema={createSchema({
+          tooltip: {
+            en_US: 'Visit https://docs.dify.ai/tools for docs',
+            zh_Hans: 'Visit https://docs.dify.ai/tools for docs',
+          },
+        })}
+        value={{}}
+        onChange={vi.fn()}
+      />,
+    )
+
+    const link = screen.getByRole('link', { name: 'https://docs.dify.ai/tools' })
+    expect(link).toHaveAttribute('href', 'https://docs.dify.ai/tools')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(link.parentElement).toHaveTextContent('Visit https://docs.dify.ai/tools for docs')
+  })
+
+  // Non-text fields keep their descriptions inside the tooltip and support JSON schema preview.
   it('should show tooltip for non-description fields and open the schema modal', () => {
     const objectSchema = createSchema({
       name: 'tool_config',

--- a/web/app/components/workflow/nodes/tool/components/tool-form/item.tsx
+++ b/web/app/components/workflow/nodes/tool/components/tool-form/item.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { FC } from 'react'
+import type { FC, ReactNode } from 'react'
 import type { ToolVarInputs } from '../../types'
 import type { CredentialFormSchema } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import type { Tool } from '@/app/components/tools/types'
@@ -14,6 +14,52 @@ import { FormTypeEnum } from '@/app/components/header/account-setting/model-prov
 import { useLanguage } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import { SchemaModal } from '@/app/components/plugins/plugin-detail-panel/tool-selector/components'
 import FormInputItem from '@/app/components/workflow/nodes/_base/components/form-input-item'
+
+const URL_REGEX = /((?:https?:\/\/|www\.)\S+)/g
+
+const normalizeUrl = (url: string) => {
+  if (url.startsWith('http://') || url.startsWith('https://'))
+    return url
+
+  return `https://${url}`
+}
+
+const renderDescriptionWithLinks = (description: string): ReactNode => {
+  const matches = [...description.matchAll(URL_REGEX)]
+
+  if (!matches.length)
+    return description
+
+  const parts: ReactNode[] = []
+  let currentIndex = 0
+
+  matches.forEach((match, index) => {
+    const [url] = match
+    const start = match.index ?? 0
+
+    if (start > currentIndex)
+      parts.push(description.slice(currentIndex, start))
+
+    parts.push(
+      <a
+        key={`${url}-${index}`}
+        href={normalizeUrl(url)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-text-accent hover:underline"
+      >
+        {url}
+      </a>,
+    )
+
+    currentIndex = start + url.length
+  })
+
+  if (currentIndex < description.length)
+    parts.push(description.slice(currentIndex))
+
+  return parts
+}
 
 type Props = {
   readOnly: boolean
@@ -87,7 +133,9 @@ const ToolFormItem: FC<Props> = ({
           )}
         </div>
         {showDescription && tooltip && (
-          <div className="body-xs-regular pb-0.5 text-text-tertiary">{tooltip[language] || tooltip.en_US}</div>
+          <div className="body-xs-regular break-words pb-0.5 text-text-tertiary">
+            {renderDescriptionWithLinks(tooltip[language] || tooltip.en_US)}
+          </div>
         )}
       </div>
       <FormInputItem

--- a/web/app/components/workflow/nodes/tool/components/tool-form/item.tsx
+++ b/web/app/components/workflow/nodes/tool/components/tool-form/item.tsx
@@ -15,14 +15,7 @@ import { useLanguage } from '@/app/components/header/account-setting/model-provi
 import { SchemaModal } from '@/app/components/plugins/plugin-detail-panel/tool-selector/components'
 import FormInputItem from '@/app/components/workflow/nodes/_base/components/form-input-item'
 
-const URL_REGEX = /((?:https?:\/\/|www\.)\S+)/g
-
-const normalizeUrl = (url: string) => {
-  if (url.startsWith('http://') || url.startsWith('https://'))
-    return url
-
-  return `https://${url}`
-}
+const URL_REGEX = /(https?:\/\/\S+)/g
 
 const renderDescriptionWithLinks = (description: string): ReactNode => {
   const matches = [...description.matchAll(URL_REGEX)]
@@ -43,7 +36,7 @@ const renderDescriptionWithLinks = (description: string): ReactNode => {
     parts.push(
       <a
         key={`${url}-${index}`}
-        href={normalizeUrl(url)}
+        href={url}
         target="_blank"
         rel="noopener noreferrer"
         className="text-text-accent hover:underline"


### PR DESCRIPTION

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
