### PR TITLE
refactor: strengthen extension and segment dict typing

### DIFF
--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, TypedDict, cast
 
 from flask import request
 from flask_restx import marshal
@@ -33,15 +33,19 @@ from services.errors.chunk import ChildChunkIndexingError as ChildChunkIndexingS
 from services.summary_index_service import SummaryIndexService
 
 
-def _marshal_segment_with_summary(segment, dataset_id: str) -> dict[str, Any]:
+class SegmentWithSummaryDict(TypedDict, total=False):
+    summary: str | None
+
+
+def _marshal_segment_with_summary(segment, dataset_id: str) -> SegmentWithSummaryDict:
     """Marshal a single segment and enrich it with summary content."""
-    segment_dict: dict[str, Any] = dict(marshal(segment, segment_fields))  # type: ignore[arg-type]
+    segment_dict = cast(SegmentWithSummaryDict, dict(marshal(segment, segment_fields)))  # type: ignore[arg-type]
     summary = SummaryIndexService.get_segment_summary(segment_id=segment.id, dataset_id=dataset_id)
     segment_dict["summary"] = summary.summary_content if summary else None
     return segment_dict
 
 
-def _marshal_segments_with_summary(segments, dataset_id: str) -> list[dict[str, Any]]:
+def _marshal_segments_with_summary(segments, dataset_id: str) -> list[SegmentWithSummaryDict]:
     """Marshal multiple segments and enrich them with summary content (batch query)."""
     segment_ids = [segment.id for segment in segments]
     summaries: dict[str, str | None] = {}
@@ -49,9 +53,9 @@ def _marshal_segments_with_summary(segments, dataset_id: str) -> list[dict[str, 
         summary_records = SummaryIndexService.get_segments_summaries(segment_ids=segment_ids, dataset_id=dataset_id)
         summaries = {chunk_id: record.summary_content for chunk_id, record in summary_records.items()}
 
-    result: list[dict[str, Any]] = []
+    result: list[SegmentWithSummaryDict] = []
     for segment in segments:
-        segment_dict: dict[str, Any] = dict(marshal(segment, segment_fields))  # type: ignore[arg-type]
+        segment_dict = cast(SegmentWithSummaryDict, dict(marshal(segment, segment_fields)))  # type: ignore[arg-type]
         segment_dict["summary"] = summaries.get(segment.id)
         result.append(segment_dict)
     return result

--- a/api/core/external_data_tool/factory.py
+++ b/api/core/external_data_tool/factory.py
@@ -1,8 +1,8 @@
 from collections.abc import Mapping
 from typing import Any, cast
 
-from core.external_data_tool.base import ExternalDataTool
 from core.extension.extensible import ExtensionModule
+from core.external_data_tool.base import ExternalDataTool
 from extensions.ext_code_based_extension import code_based_extension
 
 

--- a/api/core/external_data_tool/factory.py
+++ b/api/core/external_data_tool/factory.py
@@ -1,13 +1,16 @@
 from collections.abc import Mapping
 from typing import Any, cast
 
+from core.external_data_tool.base import ExternalDataTool
 from core.extension.extensible import ExtensionModule
 from extensions.ext_code_based_extension import code_based_extension
 
 
 class ExternalDataToolFactory:
     def __init__(self, name: str, tenant_id: str, app_id: str, variable: str, config: dict[str, Any]):
-        extension_class = code_based_extension.extension_class(ExtensionModule.EXTERNAL_DATA_TOOL, name)
+        extension_class = cast(
+            type[ExternalDataTool], code_based_extension.extension_class(ExtensionModule.EXTERNAL_DATA_TOOL, name)
+        )
         self.__extension_instance = extension_class(
             tenant_id=tenant_id, app_id=app_id, variable=variable, config=config
         )
@@ -22,9 +25,10 @@ class ExternalDataToolFactory:
         :param config: the form config data
         :return:
         """
-        extension_class = code_based_extension.extension_class(ExtensionModule.EXTERNAL_DATA_TOOL, name)
-        # FIXME mypy issue here, figure out how to fix it
-        extension_class.validate_config(tenant_id, config)  # type: ignore
+        extension_class = cast(
+            type[ExternalDataTool], code_based_extension.extension_class(ExtensionModule.EXTERNAL_DATA_TOOL, name)
+        )
+        extension_class.validate_config(tenant_id, config)
 
     def query(self, inputs: Mapping[str, Any], query: str | None = None) -> str:
         """

--- a/api/core/external_data_tool/factory.py
+++ b/api/core/external_data_tool/factory.py
@@ -38,4 +38,4 @@ class ExternalDataToolFactory:
         :param query: the query of chat app
         :return: the tool query result
         """
-        return cast(str, self.__extension_instance.query(inputs, query))
+        return self.__extension_instance.query(inputs, query)

--- a/api/core/moderation/factory.py
+++ b/api/core/moderation/factory.py
@@ -9,9 +9,7 @@ class ModerationFactory:
     __extension_instance: Moderation
 
     def __init__(self, name: str, app_id: str, tenant_id: str, config: dict[str, Any]):
-        extension_class = cast(
-            type[Moderation], code_based_extension.extension_class(ExtensionModule.MODERATION, name)
-        )
+        extension_class = cast(type[Moderation], code_based_extension.extension_class(ExtensionModule.MODERATION, name))
         self.__extension_instance = extension_class(app_id, tenant_id, config)
 
     @classmethod
@@ -24,9 +22,7 @@ class ModerationFactory:
         :param config: the form config data
         :return:
         """
-        extension_class = cast(
-            type[Moderation], code_based_extension.extension_class(ExtensionModule.MODERATION, name)
-        )
+        extension_class = cast(type[Moderation], code_based_extension.extension_class(ExtensionModule.MODERATION, name))
         extension_class.validate_config(tenant_id, config)
 
     def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:

--- a/api/core/moderation/factory.py
+++ b/api/core/moderation/factory.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from core.extension.extensible import ExtensionModule
 from core.moderation.base import Moderation, ModerationInputsResult, ModerationOutputsResult
@@ -9,7 +9,9 @@ class ModerationFactory:
     __extension_instance: Moderation
 
     def __init__(self, name: str, app_id: str, tenant_id: str, config: dict[str, Any]):
-        extension_class = code_based_extension.extension_class(ExtensionModule.MODERATION, name)
+        extension_class = cast(
+            type[Moderation], code_based_extension.extension_class(ExtensionModule.MODERATION, name)
+        )
         self.__extension_instance = extension_class(app_id, tenant_id, config)
 
     @classmethod
@@ -22,9 +24,10 @@ class ModerationFactory:
         :param config: the form config data
         :return:
         """
-        extension_class = code_based_extension.extension_class(ExtensionModule.MODERATION, name)
-        # FIXME: mypy error, try to fix it instead of using type: ignore
-        extension_class.validate_config(tenant_id, config)  # type: ignore
+        extension_class = cast(
+            type[Moderation], code_based_extension.extension_class(ExtensionModule.MODERATION, name)
+        )
+        extension_class.validate_config(tenant_id, config)
 
     def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:
         """


### PR DESCRIPTION
## Summary

- Replace broad dict annotations in segment marshal helpers with a dedicated `SegmentWithSummaryDict` `TypedDict`.
- Remove `# type: ignore` in extension factories by casting extension classes to concrete types (`Moderation` and `ExternalDataTool`).
- Keep runtime behavior unchanged while improving static type safety and maintainability.

## Changes

- `api/controllers/service_api/dataset/segment.py`
  - Added `SegmentWithSummaryDict` (`TypedDict`) for marshaled segment payloads with optional `summary`.
  - Updated `_marshal_segment_with_summary` and `_marshal_segments_with_summary` return types to use the new typed structure.
  - Replaced generic local dict typing with `cast(...)` to align with the marshaled output shape.

- `api/core/moderation/factory.py`
  - Typed `extension_class` via `cast(type[Moderation], ...)`.
  - Removed `type: ignore` from `validate_config` call.

- `api/core/external_data_tool/factory.py`
  - Typed `extension_class` via `cast(type[ExternalDataTool], ...)`.
  - Removed `type: ignore` from `validate_config` call.

##Related Issues
- Part of: https://github.com/langgenius/dify/issues/32863