### PR TITLE
refactor: replace bare dict with dict[str, Any] in services unit test helpers

### DIFF
--- a/api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
@@ -30,8 +31,8 @@ def jina_module() -> ModuleType:
     return module
 
 
-def _credentials(api_key: str | None = "test_api_key_123", auth_type: str = "bearer") -> dict:
-    config: dict = {} if api_key is None else {"api_key": api_key}
+def _credentials(api_key: str | None = "test_api_key_123", auth_type: str = "bearer") -> dict[str, Any]:
+    config: dict[str, Any] = {} if api_key is None else {"api_key": api_key}
     return {"auth_type": auth_type, "config": config}
 
 
@@ -47,7 +48,7 @@ def test_init_rejects_invalid_auth_type(jina_module: ModuleType) -> None:
 
 
 @pytest.mark.parametrize("credentials", [{"auth_type": "bearer", "config": {}}, {"auth_type": "bearer"}])
-def test_init_requires_api_key(jina_module: ModuleType, credentials: dict) -> None:
+def test_init_requires_api_key(jina_module: ModuleType, credentials: dict[str, Any]) -> None:
     with pytest.raises(ValueError, match="No API key provided"):
         jina_module.JinaAuth(credentials)
 

--- a/api/tests/unit_tests/services/dataset_service_test_helpers.py
+++ b/api/tests/unit_tests/services/dataset_service_test_helpers.py
@@ -7,6 +7,7 @@ document, and segment service test modules that exercise
 
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import pytest
@@ -166,7 +167,7 @@ class DatasetServiceUnitDataFactory:
         built_in_field_enabled: bool = False,
         doc_form: str | None = "text_model",
         enable_api: bool = False,
-        summary_index_setting: dict | None = None,
+        summary_index_setting: dict[str, Any] | None = None,
         **kwargs,
     ) -> Mock:
         dataset = Mock(spec=Dataset)
@@ -214,12 +215,12 @@ class DatasetServiceUnitDataFactory:
         archived: bool = False,
         enabled: bool = True,
         data_source_type: str = "upload_file",
-        data_source_info_dict: dict | None = None,
+        data_source_info_dict: dict[str, Any] | None = None,
         data_source_info: str | None = None,
         doc_form: str = "text_model",
         need_summary: bool = True,
         position: int = 0,
-        doc_metadata: dict | None = None,
+        doc_metadata: dict[str, Any] | None = None,
         name: str = "Document",
         **kwargs,
     ) -> Mock:

--- a/api/tests/unit_tests/services/external_dataset_service.py
+++ b/api/tests/unit_tests/services/external_dataset_service.py
@@ -51,7 +51,7 @@ class ExternalDatasetTestDataFactory:
         tenant_id: str = "tenant-1",
         name: str = "Test API",
         description: str = "Description",
-        settings: dict | None = None,
+        settings: dict[str, Any] | None = None,
     ) -> ExternalKnowledgeApis:
         """
         Create a concrete ``ExternalKnowledgeApis`` instance with minimal fields.
@@ -220,7 +220,7 @@ class TestExternalDatasetServiceValidateApiList:
             ({"endpoint": "https://example.com"}, "api_key is required"),
         ],
     )
-    def test_validate_api_list_failures(self, config: dict, expected_message: str):
+    def test_validate_api_list_failures(self, config: dict[str, Any], expected_message: str):
         """
         Invalid configs should raise ``ValueError`` with a clear message.
         """

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -6,6 +6,7 @@ which handles retrieval testing operations for datasets, including internal
 dataset retrieval and external knowledge base retrieval.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -30,7 +31,7 @@ class HitTestingTestDataFactory:
         dataset_id: str = "dataset-123",
         tenant_id: str = "tenant-123",
         provider: str = "vendor",
-        retrieval_model: dict | None = None,
+        retrieval_model: dict[str, Any] | None = None,
         **kwargs,
     ) -> Mock:
         """
@@ -83,7 +84,7 @@ class HitTestingTestDataFactory:
     @staticmethod
     def create_document_mock(
         content: str = "Test document content",
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
         **kwargs,
     ) -> Mock:
         """

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -8,6 +8,7 @@ Target: 1500+ lines of comprehensive test coverage.
 import json
 import re
 from datetime import datetime
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -31,7 +32,7 @@ class ExternalDatasetServiceTestDataFactory:
         api_id: str = "api-123",
         tenant_id: str = "tenant-123",
         name: str = "Test API",
-        settings: dict | None = None,
+        settings: dict[str, Any] | None = None,
         **kwargs,
     ) -> Mock:
         """Create a mock ExternalKnowledgeApis object."""
@@ -120,8 +121,8 @@ class ExternalDatasetServiceTestDataFactory:
     def create_api_setting_mock(
         url: str = "https://api.example.com/retrieval",
         request_method: str = "post",
-        headers: dict | None = None,
-        params: dict | None = None,
+        headers: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> ExternalKnowledgeApiSetting:
         """Create an ExternalKnowledgeApiSetting object."""
         if headers is None:

--- a/api/tests/unit_tests/services/test_operation_service.py
+++ b/api/tests/unit_tests/services/test_operation_service.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -105,7 +106,7 @@ class TestOperationService:
     )
     @patch.object(OperationService, "_send_request")
     def test_should_map_parameters_correctly_when_record_utm_called(
-        self, mock_send: MagicMock, utm_info: dict, expected_params: dict
+        self, mock_send: MagicMock, utm_info: dict[str, Any], expected_params: dict[str, Any]
     ):
         """Test that record_utm correctly maps utm_info to parameters and calls _send_request"""
         # Arrange

--- a/api/tests/unit_tests/services/test_trigger_provider_service.py
+++ b/api/tests/unit_tests/services/test_trigger_provider_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,9 +29,9 @@ def _mock_get_trigger_provider(mocker: MockerFixture, provider: object | None) -
 
 def _encrypter_mock(
     *,
-    decrypted: dict | None = None,
-    encrypted: dict | None = None,
-    masked: dict | None = None,
+    decrypted: dict[str, Any] | None = None,
+    encrypted: dict[str, Any] | None = None,
+    masked: dict[str, Any] | None = None,
 ) -> MagicMock:
     enc = MagicMock()
     enc.decrypt.return_value = decrypted or {}

--- a/api/tests/unit_tests/services/test_website_service.py
+++ b/api/tests/unit_tests/services/test_website_service.py
@@ -89,7 +89,7 @@ def test_website_crawl_api_request_from_args_valid_and_to_crawl_request() -> Non
         ({"provider": "firecrawl", "url": "https://example.com"}, "Options are required"),
     ],
 )
-def test_website_crawl_api_request_from_args_requires_fields(args: dict, missing_msg: str) -> None:
+def test_website_crawl_api_request_from_args_requires_fields(args: dict[str, Any], missing_msg: str) -> None:
     with pytest.raises(ValueError, match=missing_msg):
         WebsiteCrawlApiRequest.from_args(args)
 

--- a/api/tests/unit_tests/services/vector_service.py
+++ b/api/tests/unit_tests/services/vector_service.py
@@ -114,6 +114,7 @@ This test suite follows a comprehensive testing strategy that covers:
 ================================================================================
 """
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -156,7 +157,7 @@ class VectorServiceTestDataFactory:
         indexing_technique: str = IndexTechniqueType.HIGH_QUALITY,
         embedding_model_provider: str = "openai",
         embedding_model: str = "text-embedding-ada-002",
-        index_struct_dict: dict | None = None,
+        index_struct_dict: dict[str, Any] | None = None,
         **kwargs,
     ) -> Mock:
         """


### PR DESCRIPTION
## Summary

Part of langgenius/dify#22651 — replacing bare `dict` annotations with `dict[str, Any]`.

- `dataset_service_test_helpers.py`: `summary_index_setting`, `data_source_info_dict`, `doc_metadata` → `dict[str, Any] | None`
- `test_operation_service.py`: `utm_info: dict`, `expected_params: dict` → `dict[str, Any]`
- `test_external_dataset_service.py`: `settings`, `headers`, `params` → `dict[str, Any] | None`
- `test_jina_auth_standalone_module.py`: `_credentials()` return type + `config` variable → `dict[str, Any]`
- `hit_service.py`: `retrieval_model`, `metadata` → `dict[str, Any] | None`
- `vector_service.py`: `index_struct_dict` → `dict[str, Any] | None`
- `test_trigger_provider_service.py`: `decrypted`, `encrypted`, `masked` → `dict[str, Any] | None`
- `test_website_service.py`: `args: dict` → `dict[str, Any]`
- `external_dataset_service.py`: `settings`, `config` → `dict[str, Any]`

Added `from typing import Any` where missing.

## Test plan

- [ ] No logic changes — type annotation improvements only
- [ ] All existing tests continue to pass unchanged
