### PR TITLE
refactor: replace bare dict with dict[str, Any] in enterprise telemetry, external data tool, and moderation tests

### DIFF
--- a/api/tests/unit_tests/core/external_data_tool/test_base.py
+++ b/api/tests/unit_tests/core/external_data_tool/test_base.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 import pytest
 
 from core.extension.extensible import ExtensionModule

--- a/api/tests/unit_tests/core/external_data_tool/test_base.py
+++ b/api/tests/unit_tests/core/external_data_tool/test_base.py
@@ -1,3 +1,4 @@
+from typing import Any
 import pytest
 
 from core.extension.extensible import ExtensionModule
@@ -12,10 +13,10 @@ class TestExternalDataTool:
         # Create a concrete subclass to test init
         class ConcreteTool(ExternalDataTool):
             @classmethod
-            def validate_config(cls, tenant_id: str, config: dict):
+            def validate_config(cls, tenant_id: str, config: dict[str, Any]):
                 return super().validate_config(tenant_id, config)
 
-            def query(self, inputs: dict, query: str | None = None) -> str:
+            def query(self, inputs: dict[str, Any], query: str | None = None) -> str:
                 return super().query(inputs, query)
 
         tool = ConcreteTool(tenant_id="tenant_1", app_id="app_1", variable="var_1", config={"key": "value"})
@@ -28,10 +29,10 @@ class TestExternalDataTool:
         # Create a concrete subclass to test init
         class ConcreteTool(ExternalDataTool):
             @classmethod
-            def validate_config(cls, tenant_id: str, config: dict):
+            def validate_config(cls, tenant_id: str, config: dict[str, Any]):
                 pass
 
-            def query(self, inputs: dict, query: str | None = None) -> str:
+            def query(self, inputs: dict[str, Any], query: str | None = None) -> str:
                 return ""
 
         tool = ConcreteTool(tenant_id="tenant_1", app_id="app_1", variable="var_1")
@@ -43,10 +44,10 @@ class TestExternalDataTool:
     def test_validate_config_raises_not_implemented(self):
         class ConcreteTool(ExternalDataTool):
             @classmethod
-            def validate_config(cls, tenant_id: str, config: dict):
+            def validate_config(cls, tenant_id: str, config: dict[str, Any]):
                 return super().validate_config(tenant_id, config)
 
-            def query(self, inputs: dict, query: str | None = None) -> str:
+            def query(self, inputs: dict[str, Any], query: str | None = None) -> str:
                 return ""
 
         with pytest.raises(NotImplementedError):
@@ -55,10 +56,10 @@ class TestExternalDataTool:
     def test_query_raises_not_implemented(self):
         class ConcreteTool(ExternalDataTool):
             @classmethod
-            def validate_config(cls, tenant_id: str, config: dict):
+            def validate_config(cls, tenant_id: str, config: dict[str, Any]):
                 pass
 
-            def query(self, inputs: dict, query: str | None = None) -> str:
+            def query(self, inputs: dict[str, Any], query: str | None = None) -> str:
                 return super().query(inputs, query)
 
         tool = ConcreteTool(tenant_id="tenant_1", app_id="app_1", variable="var_1")

--- a/api/tests/unit_tests/core/moderation/test_content_moderation.py
+++ b/api/tests/unit_tests/core/moderation/test_content_moderation.py
@@ -10,6 +10,7 @@ This module tests all aspects of the content moderation system including:
 - Configuration validation
 """
 
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -28,7 +29,7 @@ class TestKeywordsModeration:
     """Test suite for custom keyword-based content moderation."""
 
     @pytest.fixture
-    def keywords_config(self) -> dict:
+    def keywords_config(self) -> dict[str, Any]:
         """
         Fixture providing a standard keywords moderation configuration.
 
@@ -48,7 +49,7 @@ class TestKeywordsModeration:
         }
 
     @pytest.fixture
-    def keywords_moderation(self, keywords_config: dict) -> KeywordsModeration:
+    def keywords_moderation(self, keywords_config: dict[str, Any]) -> KeywordsModeration:
         """
         Fixture providing a KeywordsModeration instance.
 
@@ -64,7 +65,7 @@ class TestKeywordsModeration:
             config=keywords_config,
         )
 
-    def test_validate_config_success(self, keywords_config: dict):
+    def test_validate_config_success(self, keywords_config: dict[str, Any]):
         """Test successful validation of keywords moderation configuration."""
         # Should not raise any exception
         KeywordsModeration.validate_config("test-tenant", keywords_config)
@@ -274,7 +275,7 @@ class TestOpenAIModeration:
     """Test suite for OpenAI-based content moderation."""
 
     @pytest.fixture
-    def openai_config(self) -> dict:
+    def openai_config(self) -> dict[str, Any]:
         """
         Fixture providing OpenAI moderation configuration.
 
@@ -293,7 +294,7 @@ class TestOpenAIModeration:
         }
 
     @pytest.fixture
-    def openai_moderation(self, openai_config: dict) -> OpenAIModeration:
+    def openai_moderation(self, openai_config: dict[str, Any]) -> OpenAIModeration:
         """
         Fixture providing an OpenAIModeration instance.
 
@@ -309,7 +310,7 @@ class TestOpenAIModeration:
             config=openai_config,
         )
 
-    def test_validate_config_success(self, openai_config: dict):
+    def test_validate_config_success(self, openai_config: dict[str, Any]):
         """Test successful validation of OpenAI moderation configuration."""
         # Should not raise any exception
         OpenAIModeration.validate_config("test-tenant", openai_config)

--- a/api/tests/unit_tests/enterprise/telemetry/test_enterprise_trace.py
+++ b/api/tests/unit_tests/enterprise/telemetry/test_enterprise_trace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -57,7 +58,7 @@ _T1 = datetime(2024, 1, 10, 12, 0, 5, tzinfo=UTC)
 
 
 def make_workflow_info(**overrides) -> WorkflowTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "workflow_id": "wf-001",
         "tenant_id": "tenant-abc",
         "workflow_run_id": "run-001",
@@ -86,7 +87,7 @@ def make_workflow_info(**overrides) -> WorkflowTraceInfo:
 
 
 def make_node_info(**overrides) -> WorkflowNodeTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "workflow_id": "wf-001",
         "workflow_run_id": "run-001",
         "tenant_id": "tenant-abc",
@@ -115,7 +116,7 @@ def make_node_info(**overrides) -> WorkflowNodeTraceInfo:
 
 
 def make_draft_node_info(**overrides) -> DraftNodeExecutionTrace:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "workflow_id": "wf-001",
         "workflow_run_id": "run-draft-001",
         "tenant_id": "tenant-abc",
@@ -136,7 +137,7 @@ def make_draft_node_info(**overrides) -> DraftNodeExecutionTrace:
 
 
 def make_message_info(**overrides) -> MessageTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "message_id": "msg-001",
         "conversation_model": "gpt-4",
         "message_tokens": 40,
@@ -161,7 +162,7 @@ def make_message_info(**overrides) -> MessageTraceInfo:
 
 
 def make_tool_info(**overrides) -> ToolTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "message_id": "msg-001",
         "tool_name": "web_search",
         "tool_inputs": {"query": "test"},
@@ -176,7 +177,7 @@ def make_tool_info(**overrides) -> ToolTraceInfo:
 
 
 def make_moderation_info(**overrides) -> ModerationTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "message_id": "msg-001",
         "flagged": False,
         "action": "pass",
@@ -189,7 +190,7 @@ def make_moderation_info(**overrides) -> ModerationTraceInfo:
 
 
 def make_suggested_question_info(**overrides) -> SuggestedQuestionTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "message_id": "msg-001",
         "total_tokens": 30,
         "suggested_question": ["Question A?", "Question B?"],
@@ -206,7 +207,7 @@ def make_suggested_question_info(**overrides) -> SuggestedQuestionTraceInfo:
 
 
 def make_dataset_retrieval_info(**overrides) -> DatasetRetrievalTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "message_id": "msg-001",
         "documents": [
             {
@@ -236,7 +237,7 @@ def make_dataset_retrieval_info(**overrides) -> DatasetRetrievalTraceInfo:
 
 
 def make_generate_name_info(**overrides) -> GenerateNameTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "message_id": "msg-001",
         "tenant_id": "tenant-abc",
         "conversation_id": "conv-001",
@@ -251,7 +252,7 @@ def make_generate_name_info(**overrides) -> GenerateNameTraceInfo:
 
 
 def make_prompt_generation_info(**overrides) -> PromptGenerationTraceInfo:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "tenant_id": "tenant-abc",
         "user_id": "user-001",
         "app_id": "app-001",


### PR DESCRIPTION
## Summary

Part of langgenius/dify#22651 — replacing bare `dict` annotations with `dict[str, Any]`.

- `tests/unit_tests/enterprise/telemetry/test_enterprise_trace.py`: 10× `defaults: dict = {` → `dict[str, Any]`
- `tests/unit_tests/core/external_data_tool/test_base.py`: 8× `config: dict` / `inputs: dict` → `dict[str, Any]`
- `tests/unit_tests/core/moderation/test_content_moderation.py`: 6× bare `dict` parameter annotations → `dict[str, Any]`

Added `from typing import Any` where missing.

## Test plan

- [ ] No logic changes — type annotation improvements only
- [ ] All existing tests continue to pass unchanged
