### PR TITLE
refactor: replace bare dict with dict[str, Any] in models, providers, extensions, libs, and test utilities

### DIFF
--- a/api/extensions/storage/opendal_storage.py
+++ b/api/extensions/storage/opendal_storage.py
@@ -2,6 +2,7 @@ import logging
 import os
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import opendal
 from dotenv import dotenv_values
@@ -19,7 +20,7 @@ def _get_opendal_kwargs(*, scheme: str, env_file_path: str = ".env", prefix: str
         if key.startswith(config_prefix):
             kwargs[key[len(config_prefix) :].lower()] = value
 
-    file_env_vars: dict = dotenv_values(env_file_path) or {}
+    file_env_vars: dict[str, Any] = dotenv_values(env_file_path) or {}
     for key, value in file_env_vars.items():
         if key.startswith(config_prefix) and key[len(config_prefix) :].lower() not in kwargs and value:
             kwargs[key[len(config_prefix) :].lower()] = value

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -1551,7 +1551,7 @@ class PipelineBuiltInTemplate(TypeBase):
     name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     description: Mapped[str] = mapped_column(LongText, nullable=False)
     chunk_structure: Mapped[str] = mapped_column(sa.String(255), nullable=False)
-    icon: Mapped[dict] = mapped_column(sa.JSON, nullable=False)
+    icon: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
     yaml_content: Mapped[str] = mapped_column(LongText, nullable=False)
     copyright: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     privacy_policy: Mapped[str] = mapped_column(sa.String(255), nullable=False)
@@ -1584,7 +1584,7 @@ class PipelineCustomizedTemplate(TypeBase):
     name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     description: Mapped[str] = mapped_column(LongText, nullable=False)
     chunk_structure: Mapped[str] = mapped_column(sa.String(255), nullable=False)
-    icon: Mapped[dict] = mapped_column(sa.JSON, nullable=False)
+    icon: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
     position: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     yaml_content: Mapped[str] = mapped_column(LongText, nullable=False)
     install_count: Mapped[int] = mapped_column(sa.Integer, nullable=False)
@@ -1657,7 +1657,7 @@ class DocumentPipelineExecutionLog(TypeBase):
     datasource_type: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     datasource_info: Mapped[str] = mapped_column(LongText, nullable=False)
     datasource_node_id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
-    input_data: Mapped[dict] = mapped_column(sa.JSON, nullable=False)
+    input_data: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
     created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), init=False

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1007,7 +1007,7 @@ class OAuthProviderApp(TypeBase):
     app_icon: Mapped[str] = mapped_column(String(255), nullable=False)
     client_id: Mapped[str] = mapped_column(String(255), nullable=False)
     client_secret: Mapped[str] = mapped_column(String(255), nullable=False)
-    app_label: Mapped[dict] = mapped_column(sa.JSON, nullable=False, default_factory=dict)
+    app_label: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False, default_factory=dict)
     redirect_uris: Mapped[list] = mapped_column(sa.JSON, nullable=False, default_factory=list)
     scope: Mapped[str] = mapped_column(
         String(255),
@@ -2495,7 +2495,7 @@ class TraceAppConfig(TypeBase):
     )
     app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     tracing_provider: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    tracing_config: Mapped[dict | None] = mapped_column(sa.JSON, nullable=True)
+    tracing_config: Mapped[dict[str, Any] | None] = mapped_column(sa.JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )

--- a/api/models/oauth.py
+++ b/api/models/oauth.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy import func
@@ -22,7 +23,7 @@ class DatasourceOauthParamConfig(TypeBase):
     )
     plugin_id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     provider: Mapped[str] = mapped_column(sa.String(255), nullable=False)
-    system_credentials: Mapped[dict] = mapped_column(AdjustedJSON, nullable=False)
+    system_credentials: Mapped[dict[str, Any]] = mapped_column(AdjustedJSON, nullable=False)
 
 
 class DatasourceProvider(TypeBase):
@@ -40,7 +41,7 @@ class DatasourceProvider(TypeBase):
     provider: Mapped[str] = mapped_column(sa.String(128), nullable=False)
     plugin_id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     auth_type: Mapped[str] = mapped_column(sa.String(255), nullable=False)
-    encrypted_credentials: Mapped[dict] = mapped_column(AdjustedJSON, nullable=False)
+    encrypted_credentials: Mapped[dict[str, Any]] = mapped_column(AdjustedJSON, nullable=False)
     avatar_url: Mapped[str] = mapped_column(LongText, nullable=True, default="default")
     is_default: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"), default=False)
     expires_at: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default="-1", default=-1)
@@ -70,7 +71,7 @@ class DatasourceOauthTenantParamConfig(TypeBase):
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     provider: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     plugin_id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
-    client_params: Mapped[dict] = mapped_column(AdjustedJSON, nullable=False, default_factory=dict)
+    client_params: Mapped[dict[str, Any]] = mapped_column(AdjustedJSON, nullable=False, default_factory=dict)
     enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/api/models/source.py
+++ b/api/models/source.py
@@ -25,7 +25,7 @@ class DataSourceOauthBinding(TypeBase):
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     access_token: Mapped[str] = mapped_column(String(255), nullable=False)
     provider: Mapped[str] = mapped_column(String(255), nullable=False)
-    source_info: Mapped[dict] = mapped_column(AdjustedJSON, nullable=False)
+    source_info: Mapped[dict[str, Any]] = mapped_column(AdjustedJSON, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )

--- a/api/providers/vdb/vdb-elasticsearch/src/dify_vdb_elasticsearch/elasticsearch_ja_vector.py
+++ b/api/providers/vdb/vdb-elasticsearch/src/dify_vdb_elasticsearch/elasticsearch_ja_vector.py
@@ -23,7 +23,7 @@ class ElasticSearchJaVector(ElasticSearchVector):
         self,
         embeddings: list[list[float]],
         metadatas: list[dict[Any, Any]] | None = None,
-        index_params: dict | None = None,
+        index_params: dict[str, Any] | None = None,
     ):
         lock_name = f"vector_indexing_lock_{self._collection_name}"
         with redis_client.lock(lock_name, timeout=20):

--- a/api/providers/vdb/vdb-pgvecto-rs/src/dify_vdb_pgvecto_rs/collection.py
+++ b/api/providers/vdb/vdb-pgvecto-rs/src/dify_vdb_pgvecto_rs/collection.py
@@ -1,3 +1,4 @@
+from typing import Any
 from uuid import UUID
 
 from numpy import ndarray
@@ -8,5 +9,5 @@ class CollectionORM(DeclarativeBase):
     __tablename__: str
     id: Mapped[UUID]
     text: Mapped[str]
-    meta: Mapped[dict]
+    meta: Mapped[dict[str, Any]]
     vector: Mapped[ndarray]

--- a/api/providers/vdb/vdb-pgvecto-rs/src/dify_vdb_pgvecto_rs/pgvecto_rs.py
+++ b/api/providers/vdb/vdb-pgvecto-rs/src/dify_vdb_pgvecto_rs/pgvecto_rs.py
@@ -67,7 +67,7 @@ class PGVectoRS(BaseVector):
                 primary_key=True,
             )
             text: Mapped[str]
-            meta: Mapped[dict] = mapped_column(postgresql.JSONB)
+            meta: Mapped[dict[str, Any]] = mapped_column(postgresql.JSONB)
             vector: Mapped[ndarray] = mapped_column(VECTOR(dim))
 
         self._table = _Table

--- a/api/services/entities/knowledge_entities/knowledge_entities.py
+++ b/api/services/entities/knowledge_entities/knowledge_entities.py
@@ -87,7 +87,7 @@ class RetrievalModel(BaseModel):
 
 class MetaDataConfig(BaseModel):
     doc_type: str
-    doc_metadata: dict
+    doc_metadata: dict[str, Any]
 
 
 class KnowledgeConfig(BaseModel):

--- a/api/tests/unit_tests/core/tools/test_custom_tool.py
+++ b/api/tests/unit_tests/core/tools/test_custom_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import httpx
 import pytest
@@ -14,7 +15,7 @@ from core.tools.entities.tool_entities import ToolEntity, ToolIdentity, ToolInvo
 from core.tools.errors import ToolInvokeError, ToolParameterValidationError, ToolProviderCredentialValidationError
 
 
-def _build_tool(*, openapi: dict | None = None) -> ApiTool:
+def _build_tool(*, openapi: dict[str, Any] | None = None) -> ApiTool:
     entity = ToolEntity(
         identity=ToolIdentity(
             author="author",

--- a/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
+++ b/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 import core.tools.utils.message_transformer as mt
@@ -13,7 +15,7 @@ class _FakeToolFile:
 class _FakeToolFileManager:
     """Fake ToolFileManager to capture the mimetype passed in."""
 
-    last_call: dict | None = None
+    last_call: dict[str, Any] | None = None
 
     def __init__(self, *args, **kwargs):
         pass

--- a/api/tests/unit_tests/core/tools/utils/test_model_invocation_utils.py
+++ b/api/tests/unit_tests/core/tools/utils/test_model_invocation_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,7 +26,7 @@ from graphon.model_runtime.errors.invoke import (
 from core.tools.utils.model_invocation_utils import InvokeModelError, ModelInvocationUtils
 
 
-def _mock_model_instance(*, schema: dict | None = None) -> SimpleNamespace:
+def _mock_model_instance(*, schema: dict[str, Any] | None = None) -> SimpleNamespace:
     model_type_instance = Mock()
     model_type_instance.get_model_schema.return_value = (
         SimpleNamespace(model_properties=schema or {}) if schema is not None else None

--- a/api/tests/unit_tests/libs/test_pyrefly_type_coverage.py
+++ b/api/tests/unit_tests/libs/test_pyrefly_type_coverage.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from libs.pyrefly_type_coverage import (
     CoverageSummary,
@@ -8,11 +9,11 @@ from libs.pyrefly_type_coverage import (
 )
 
 
-def _make_report(summary: dict) -> str:
+def _make_report(summary: dict[str, Any]) -> str:
     return json.dumps({"module_reports": [], "summary": summary})
 
 
-_SAMPLE_SUMMARY: dict = {
+_SAMPLE_SUMMARY: dict[str, Any] = {
     "n_modules": 100,
     "n_typable": 1000,
     "n_typed": 400,

--- a/api/tests/unit_tests/libs/test_sendgrid_client.py
+++ b/api/tests/unit_tests/libs/test_sendgrid_client.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,7 +7,7 @@ from python_http_client.exceptions import UnauthorizedError
 from libs.sendgrid import SendGridClient
 
 
-def _mail(to: str = "user@example.com") -> dict:
+def _mail(to: str = "user@example.com") -> dict[str, Any]:
     return {"to": to, "subject": "Hi", "html": "<b>Hi</b>"}
 
 

--- a/api/tests/unit_tests/libs/test_smtp_client.py
+++ b/api/tests/unit_tests/libs/test_smtp_client.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -5,7 +6,7 @@ import pytest
 from libs.smtp import SMTPClient
 
 
-def _mail() -> dict:
+def _mail() -> dict[str, Any]:
     return {"to": "user@example.com", "subject": "Hi", "html": "<b>Hi</b>"}
 
 

--- a/api/tests/unit_tests/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/tools/test_mcp_tool.py
@@ -1,5 +1,6 @@
 import base64
 from decimal import Decimal
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -20,7 +21,7 @@ from core.tools.entities.tool_entities import ToolEntity, ToolIdentity, ToolInvo
 from core.tools.mcp_tool.tool import MCPTool
 
 
-def _make_mcp_tool(output_schema: dict | None = None) -> MCPTool:
+def _make_mcp_tool(output_schema: dict[str, Any] | None = None) -> MCPTool:
     identity = ToolIdentity(
         author="test",
         name="test_mcp_tool",


### PR DESCRIPTION
## Summary

Part of langgenius/dify#22651 — replacing bare `dict` annotations with `dict[str, Any]`.

- `models/dataset.py`, `models/model.py`, `models/oauth.py`, `models/source.py`: `Mapped[dict]` → `Mapped[dict[str, Any]]` on JSON ORM columns
- `providers/vdb/vdb-pgvecto-rs/`: `meta: Mapped[dict]` → `Mapped[dict[str, Any]]`
- `providers/vdb/vdb-elasticsearch/`: `index_params: dict | None` → `dict[str, Any] | None`
- `services/entities/knowledge_entities/`: `doc_metadata: dict` → `dict[str, Any]`
- `extensions/storage/opendal_storage.py`: `file_env_vars: dict` → `dict[str, Any]`
- `libs/json_in_md_parser.py`: `parsed: dict` → `dict[str, Any]`
- 7 test files (libs/tools): added `from typing import Any` + fixed annotations

## Test plan

- [ ] No logic changes — type annotation improvements only
- [ ] All existing tests continue to pass unchanged
