### PR TITLE
fix: import DSL and copy app not work

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -8,7 +8,7 @@ from flask_restx import Resource
 from graphon.enums import WorkflowExecutionStatus
 from pydantic import AliasChoices, BaseModel, Field, computed_field, field_validator
 from sqlalchemy import select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest
 
 from controllers.common.helpers import FileInfo
@@ -37,7 +37,7 @@ from models.model import IconType
 from services.app_dsl_service import AppDslService
 from services.app_service import AppService
 from services.enterprise.enterprise_service import EnterpriseService
-from services.entities.dsl_entities import ImportMode
+from services.entities.dsl_entities import ImportMode, ImportStatus
 from services.entities.knowledge_entities.knowledge_entities import (
     DataSource,
     InfoList,
@@ -623,7 +623,7 @@ class AppCopyApi(Resource):
 
         args = CopyAppPayload.model_validate(console_ns.payload or {})
 
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = AppDslService(session)
             yaml_content = import_service.export_dsl(app_model=app_model, include_secret=True)
             result = import_service.import_app(
@@ -636,6 +636,13 @@ class AppCopyApi(Resource):
                 icon=args.icon,
                 icon_background=args.icon_background,
             )
+            if result.status == ImportStatus.FAILED:
+                session.rollback()
+                return result.model_dump(mode="json"), 400
+            if result.status == ImportStatus.PENDING:
+                session.rollback()
+                return result.model_dump(mode="json"), 202
+            session.commit()
 
             # Inherit web app permission from original app
             if result.app_id and FeatureService.get_system_features().webapp_auth.enabled:

--- a/api/controllers/console/app/app_import.py
+++ b/api/controllers/console/app/app_import.py
@@ -1,6 +1,6 @@
 from flask_restx import Resource
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
 from controllers.common.schema import register_schema_models
 from controllers.console.app.wraps import get_app_model
@@ -52,8 +52,9 @@ class AppImportApi(Resource):
         current_user, _ = current_account_with_tenant()
         args = AppImportPayload.model_validate(console_ns.payload)
 
-        # Create service with session
-        with sessionmaker(db.engine).begin() as session:
+        # AppDslService performs internal commits for some creation paths, so use a plain
+        # Session here instead of nesting it inside sessionmaker(...).begin().
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = AppDslService(session)
             # Import app
             account = current_user
@@ -69,6 +70,10 @@ class AppImportApi(Resource):
                 icon_background=args.icon_background,
                 app_id=args.app_id,
             )
+            if result.status == ImportStatus.FAILED:
+                session.rollback()
+            else:
+                session.commit()
         if result.app_id and FeatureService.get_system_features().webapp_auth.enabled:
             # update web app setting as private
             EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, "private")
@@ -95,12 +100,15 @@ class AppImportConfirmApi(Resource):
         # Check user role first
         current_user, _ = current_account_with_tenant()
 
-        # Create service with session
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = AppDslService(session)
             # Confirm import
             account = current_user
             result = import_service.confirm_import(import_id=import_id, account=account)
+            if result.status == ImportStatus.FAILED:
+                session.rollback()
+            else:
+                session.commit()
 
         # Return appropriate status code based on result
         if result.status == ImportStatus.FAILED:
@@ -117,7 +125,7 @@ class AppImportCheckDependenciesApi(Resource):
     @account_initialization_required
     @edit_permission_required
     def get(self, app_model: App):
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = AppDslService(session)
             result = import_service.check_dependencies(app_model=app_model)
 

--- a/api/controllers/inner_api/app/dsl.py
+++ b/api/controllers/inner_api/app/dsl.py
@@ -9,7 +9,7 @@ from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
 from sqlalchemy import select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
 from controllers.common.schema import register_schema_model
 from controllers.console.wraps import setup_required
@@ -56,7 +56,7 @@ class EnterpriseAppDSLImport(Resource):
 
         account.set_tenant_id(workspace_id)
 
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             dsl_service = AppDslService(session)
             result = dsl_service.import_app(
                 account=account,
@@ -65,6 +65,10 @@ class EnterpriseAppDSLImport(Resource):
                 name=args.name,
                 description=args.description,
             )
+            if result.status == ImportStatus.FAILED:
+                session.rollback()
+            else:
+                session.commit()
 
         if result.status == ImportStatus.FAILED:
             return result.model_dump(mode="json"), 400

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_app_import_api.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_app_import_api.py
@@ -96,6 +96,56 @@ class TestAppImportApi:
         assert status == 200
         assert response["status"] == ImportStatus.COMPLETED
 
+    def test_import_post_commits_session_on_success(self, app, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = app_import_module.AppImportApi()
+        method = _unwrap(api.post)
+
+        _install_features(monkeypatch, enabled=False)
+        monkeypatch.setattr(
+            app_import_module.AppDslService,
+            "import_app",
+            lambda *_args, **_kwargs: _Result(ImportStatus.COMPLETED, app_id="app-123"),
+        )
+        monkeypatch.setattr(app_import_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+
+        fake_session = MagicMock()
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = None
+        monkeypatch.setattr(app_import_module, "Session", lambda *_args, **_kwargs: fake_session)
+
+        with app.test_request_context("/console/api/apps/imports", method="POST", json={"mode": "yaml-content"}):
+            response, status = method()
+
+        fake_session.commit.assert_called_once_with()
+        fake_session.rollback.assert_not_called()
+        assert status == 200
+        assert response["status"] == ImportStatus.COMPLETED
+
+    def test_import_post_rolls_back_session_on_failure(self, app, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = app_import_module.AppImportApi()
+        method = _unwrap(api.post)
+
+        _install_features(monkeypatch, enabled=False)
+        monkeypatch.setattr(
+            app_import_module.AppDslService,
+            "import_app",
+            lambda *_args, **_kwargs: _Result(ImportStatus.FAILED, app_id=None),
+        )
+        monkeypatch.setattr(app_import_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+
+        fake_session = MagicMock()
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = None
+        monkeypatch.setattr(app_import_module, "Session", lambda *_args, **_kwargs: fake_session)
+
+        with app.test_request_context("/console/api/apps/imports", method="POST", json={"mode": "yaml-content"}):
+            response, status = method()
+
+        fake_session.rollback.assert_called_once_with()
+        fake_session.commit.assert_not_called()
+        assert status == 400
+        assert response["status"] == ImportStatus.FAILED
+
 
 class TestAppImportConfirmApi:
     @pytest.fixture

--- a/api/tests/unit_tests/controllers/console/app/test_app_import_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_import_api.py
@@ -48,9 +48,7 @@ class TestAppImportApi:
     def api(self):
         return app_import_module.AppImportApi()
 
-    def test_import_post_returns_failed_status_and_rolls_back(
-        self, api, app, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_import_post_returns_failed_status_and_rolls_back(self, api, app, monkeypatch: pytest.MonkeyPatch) -> None:
         method = _unwrap(api.post)
 
         _install_features(monkeypatch, enabled=False)

--- a/api/tests/unit_tests/controllers/console/app/test_app_import_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_import_api.py
@@ -1,0 +1,141 @@
+"""Unit tests for console app import endpoints."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from controllers.console.app import app_import as app_import_module
+from services.app_dsl_service import ImportStatus
+
+
+def _unwrap(func):
+    bound_self = getattr(func, "__self__", None)
+    while hasattr(func, "__wrapped__"):
+        func = func.__wrapped__
+    if bound_self is not None:
+        return func.__get__(bound_self, bound_self.__class__)
+    return func
+
+
+class _Result:
+    def __init__(self, status: ImportStatus, app_id: str | None = "app-1"):
+        self.status = status
+        self.app_id = app_id
+
+    def model_dump(self, mode: str = "json"):
+        return {"status": self.status, "app_id": self.app_id}
+
+
+def _install_features(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
+    features = SimpleNamespace(webapp_auth=SimpleNamespace(enabled=enabled))
+    monkeypatch.setattr(app_import_module.FeatureService, "get_system_features", lambda: features)
+
+
+def _mock_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    fake_session = MagicMock()
+    fake_session.__enter__.return_value = fake_session
+    fake_session.__exit__.return_value = None
+    monkeypatch.setattr(app_import_module, "db", SimpleNamespace(engine=object()))
+    monkeypatch.setattr(app_import_module, "Session", lambda *_args, **_kwargs: fake_session)
+    return fake_session
+
+
+class TestAppImportApi:
+    @pytest.fixture
+    def api(self):
+        return app_import_module.AppImportApi()
+
+    def test_import_post_returns_failed_status_and_rolls_back(
+        self, api, app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        method = _unwrap(api.post)
+
+        _install_features(monkeypatch, enabled=False)
+        session = _mock_session(monkeypatch)
+        monkeypatch.setattr(
+            app_import_module.AppDslService,
+            "import_app",
+            lambda *_args, **_kwargs: _Result(ImportStatus.FAILED, app_id=None),
+        )
+        monkeypatch.setattr(app_import_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+
+        with app.test_request_context("/console/api/apps/imports", method="POST", json={"mode": "yaml-content"}):
+            response, status = method()
+
+        session.rollback.assert_called_once_with()
+        session.commit.assert_not_called()
+        assert status == 400
+        assert response["status"] == ImportStatus.FAILED
+
+    def test_import_post_returns_pending_status_and_commits(self, api, app, monkeypatch: pytest.MonkeyPatch) -> None:
+        method = _unwrap(api.post)
+
+        _install_features(monkeypatch, enabled=False)
+        session = _mock_session(monkeypatch)
+        monkeypatch.setattr(
+            app_import_module.AppDslService,
+            "import_app",
+            lambda *_args, **_kwargs: _Result(ImportStatus.PENDING),
+        )
+        monkeypatch.setattr(app_import_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+
+        with app.test_request_context("/console/api/apps/imports", method="POST", json={"mode": "yaml-content"}):
+            response, status = method()
+
+        session.commit.assert_called_once_with()
+        session.rollback.assert_not_called()
+        assert status == 202
+        assert response["status"] == ImportStatus.PENDING
+
+    def test_import_post_updates_webapp_auth_when_enabled(self, api, app, monkeypatch: pytest.MonkeyPatch) -> None:
+        method = _unwrap(api.post)
+
+        _install_features(monkeypatch, enabled=True)
+        session = _mock_session(monkeypatch)
+        monkeypatch.setattr(
+            app_import_module.AppDslService,
+            "import_app",
+            lambda *_args, **_kwargs: _Result(ImportStatus.COMPLETED, app_id="app-123"),
+        )
+        update_access = MagicMock()
+        monkeypatch.setattr(app_import_module.EnterpriseService.WebAppAuth, "update_app_access_mode", update_access)
+        monkeypatch.setattr(app_import_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+
+        with app.test_request_context("/console/api/apps/imports", method="POST", json={"mode": "yaml-content"}):
+            response, status = method()
+
+        session.commit.assert_called_once_with()
+        session.rollback.assert_not_called()
+        update_access.assert_called_once_with("app-123", "private")
+        assert status == 200
+        assert response["status"] == ImportStatus.COMPLETED
+
+
+class TestAppImportConfirmApi:
+    @pytest.fixture
+    def api(self):
+        return app_import_module.AppImportConfirmApi()
+
+    def test_import_confirm_returns_failed_status_and_rolls_back(
+        self, api, app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        method = _unwrap(api.post)
+
+        session = _mock_session(monkeypatch)
+        monkeypatch.setattr(
+            app_import_module.AppDslService,
+            "confirm_import",
+            lambda *_args, **_kwargs: _Result(ImportStatus.FAILED),
+        )
+        monkeypatch.setattr(app_import_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+
+        with app.test_request_context("/console/api/apps/imports/import-1/confirm", method="POST"):
+            response, status = method(import_id="import-1")
+
+        session.rollback.assert_called_once_with()
+        session.commit.assert_not_called()
+        assert status == 400
+        assert response["status"] == ImportStatus.FAILED

--- a/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
+++ b/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
@@ -102,16 +102,16 @@ class TestEnterpriseAppDSLImport:
 
     @pytest.fixture
     def _mock_import_deps(self):
-        """Patch db, sessionmaker, and AppDslService for import handler tests."""
-        mock_session_ctx = MagicMock()
-        mock_session_ctx.__enter__ = MagicMock(return_value=MagicMock())
-        mock_session_ctx.__exit__ = MagicMock(return_value=False)
-        mock_sessionmaker = MagicMock(return_value=MagicMock(begin=MagicMock(return_value=mock_session_ctx)))
+        """Patch db, Session, and AppDslService for import handler tests."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
         with (
             patch("controllers.inner_api.app.dsl.db"),
-            patch("controllers.inner_api.app.dsl.sessionmaker", mock_sessionmaker),
+            patch("controllers.inner_api.app.dsl.Session", return_value=mock_session),
             patch("controllers.inner_api.app.dsl.AppDslService") as mock_dsl_cls,
         ):
+            self._mock_session = mock_session
             self._mock_dsl = MagicMock()
             mock_dsl_cls.return_value = self._mock_dsl
             yield
@@ -147,6 +147,8 @@ class TestEnterpriseAppDSLImport:
         assert status_code == 200
         assert body["status"] == "completed"
         mock_account.set_tenant_id.assert_called_once_with("ws-123")
+        self._mock_session.commit.assert_called_once_with()
+        self._mock_session.rollback.assert_not_called()
 
     @pytest.mark.usefixtures("_mock_import_deps")
     @patch("controllers.inner_api.app.dsl._get_active_account")
@@ -162,6 +164,8 @@ class TestEnterpriseAppDSLImport:
 
         assert status_code == 202
         assert body["status"] == "pending"
+        self._mock_session.commit.assert_called_once_with()
+        self._mock_session.rollback.assert_not_called()
 
     @pytest.mark.usefixtures("_mock_import_deps")
     @patch("controllers.inner_api.app.dsl._get_active_account")
@@ -177,6 +181,8 @@ class TestEnterpriseAppDSLImport:
 
         assert status_code == 400
         assert body["status"] == "failed"
+        self._mock_session.rollback.assert_called_once_with()
+        self._mock_session.commit.assert_not_called()
 
     @patch("controllers.inner_api.app.dsl._get_active_account")
     def test_import_account_not_found_returns_404(self, mock_get_account, api_instance, app: Flask):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

Import DSL error:
```
2026-04-15 03:03:15,390 INFO [_internal.py:97] 5633a3747d 127.0.0.1 - - [15/Apr/2026 03:03:15] "OPTIONS /console/api/apps/imports HTTP/1.1" 200 -
2026-04-15 03:03:15,921 ERROR [app_dsl_service.py:308] af899746da Failed to import app
Traceback (most recent call last):
  File "/Users/hejl/projects/dify/api/services/app_dsl_service.py", line 278, in import_app
    app = self._create_or_update_app(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/services/app_dsl_service.py", line 459, in _create_or_update_app
    app_was_created.send(app, account=account)
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/blinker/base.py", line 249, in send
    result = receiver(sender, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/events/event_handlers/create_installed_app_when_app_created.py", line 11, in handle
    tenant_id=app.tenant_id,
              ^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 569, in __get__
    return self.impl.get(state, dict_)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1096, in get
    value = self._fire_loader_callables(state, key, passive)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1126, in _fire_loader_callables
    return state._load_expired(state, passive)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/state.py", line 828, in _load_expired
    self.manager.expired_attribute_loader(self, toload, passive)
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 1674, in load_scalar_attributes
    result = load_on_ident(
             ^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 510, in load_on_ident
    return load_on_pk_identity(
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 695, in load_on_pk_identity
    session.execute(
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2351, in execute
    return self._execute_internal(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2239, in _execute_internal
    conn = self._connection_for_bind(bind)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2103, in _connection_for_bind
    TransactionalContext._trans_ctx_check(self)
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/engine/util.py", line 111, in _trans_ctx_check
    raise exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Can't operate on closed transaction inside context manager.  Please complete the context manager before emitting further commands.
```

Copy app error:
```
 File "/app/api/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/.venv/lib/python3.12/site-packages/flask_restx/api.py", line 404, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/.venv/lib/python3.12/site-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/.venv/lib/python3.12/site-packages/flask_restx/resource.py", line 41, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
File "/app/api/controllers/console/wraps.py", line 225, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
File "/app/api/libs/login.py", line 100, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/controllers/console/wraps.py", line 44, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
File "/app/api/controllers/console/app/wraps.py", line 77, in decorated_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/controllers/console/wraps.py", line 319, in decorated_function
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
File "/app/api/controllers/console/app/app.py", line 663, in post
    app = session.scalar(stmt)
          ^^^^^^^^^^^^^^^^^^^^
File "/app/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2399, in scalar
    return self._execute_internal(
           ^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2239, in _execute_internal
    conn = self._connection_for_bind(bind)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2103, in _connection_for_bind
    TransactionalContext._trans_ctx_check(self)
File "/app/api/.venv/lib/python3.12/site-packages/sqlalchemy/engine/util.py", line 111, in _trans_ctx_check
    raise exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Can't operate on closed transaction inside context manager. Please complete the context manager before emitting further commands.
```

caused by https://github.com/langgenius/dify/pull/34693


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
