### PR TITLE
fix: open restore version panel raise 500

### DIFF
--- a/api/controllers/console/app/workflow.py
+++ b/api/controllers/console/app/workflow.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from flask import abort, request
-from flask_restx import Resource, fields, marshal_with
+from flask_restx import Resource, fields, marshal, marshal_with
 from graphon.enums import NodeType
 from graphon.file import File
 from graphon.graph_engine.manager import GraphEngineManager
@@ -942,7 +942,6 @@ class PublishedAllWorkflowApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
-    @marshal_with(workflow_pagination_model)
     @edit_permission_required
     def get(self, app_model: App):
         """
@@ -970,9 +969,10 @@ class PublishedAllWorkflowApi(Resource):
                 user_id=user_id,
                 named_only=named_only,
             )
+            serialized_workflows = marshal(workflows, workflow_fields_copy)
 
             return {
-                "items": workflows,
+                "items": serialized_workflows,
                 "page": page,
                 "limit": limit,
                 "has_more": has_more,

--- a/api/tests/unit_tests/controllers/console/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow.py
@@ -258,6 +258,63 @@ def test_restore_published_workflow_to_draft_returns_400_for_invalid_structure(
     assert exc.value.description == "invalid workflow graph"
 
 
+def test_get_published_workflows_marshals_items_before_session_closes(app, monkeypatch: pytest.MonkeyPatch) -> None:
+    api = workflow_module.PublishedAllWorkflowApi()
+    handler = _unwrap(api.get)
+
+    session_state = {"open": False}
+
+    class _SessionContext:
+        def __enter__(self):
+            session_state["open"] = True
+            return object()
+
+        def __exit__(self, exc_type, exc, tb):
+            session_state["open"] = False
+            return False
+
+    class _SessionMaker:
+        def begin(self):
+            return _SessionContext()
+
+    class _Workflow:
+        @property
+        def id(self):
+            assert session_state["open"] is True
+            return "w1"
+
+    monkeypatch.setattr(workflow_module, "db", SimpleNamespace(engine=object()))
+    monkeypatch.setattr(workflow_module, "sessionmaker", lambda *_args, **_kwargs: _SessionMaker())
+    monkeypatch.setattr(workflow_module, "current_account_with_tenant", lambda: (SimpleNamespace(id="u1"), "t1"))
+    monkeypatch.setattr(
+        workflow_module,
+        "WorkflowService",
+        lambda: SimpleNamespace(
+            get_all_published_workflow=lambda **_kwargs: ([_Workflow()], False),
+        ),
+    )
+
+    def _fake_marshal(items, fields):
+        assert session_state["open"] is True
+        return [{"id": item.id} for item in items]
+
+    monkeypatch.setattr(workflow_module, "marshal", _fake_marshal)
+
+    with app.test_request_context(
+        "/apps/app/workflows",
+        method="GET",
+        query_string={"page": 1, "limit": 10, "user_id": "", "named_only": "false"},
+    ):
+        response = handler(api, app_model=SimpleNamespace(id="app", workflow_id="wf-1"))
+
+    assert response == {
+        "items": [{"id": "w1"}],
+        "page": 1,
+        "limit": 10,
+        "has_more": False,
+    }
+
+
 def test_draft_workflow_get_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         workflow_module, "WorkflowService", lambda: SimpleNamespace(get_draft_workflow=lambda **_k: None)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

error stack:
```
2026-04-15 03:19:23,313 ERROR [app.py:875] f350d7d217 Exception on /console/api/apps/8aebf41c-7a93-4365-bf4a-8c0a06c432e7/workflows [GET]
Traceback (most recent call last):
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/api.py", line 404, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/resource.py", line 41, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/controllers/console/wraps.py", line 225, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/libs/login.py", line 100, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/controllers/console/wraps.py", line 44, in decorated
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/controllers/console/app/wraps.py", line 77, in decorated_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 266, in wrapper
    return marshal(
           ^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 54, in marshal
    out, has_wildcards = _marshal(data, fields, envelope, skip_none, mask, ordered)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 187, in _marshal
    out = OrderedDict(items) if ordered else dict(items)
                                             ^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 177, in <genexpr>
    else __format_field(k, v)
         ^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 170, in __format_field
    value = field.output(key, data, ordered=ordered)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 367, in output
    return self.format(value)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 352, in format
    self.container.output(
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 276, in output
    return marshal(value, self.nested, skip_none=self.skip_none, ordered=ordered)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 54, in marshal
    out, has_wildcards = _marshal(data, fields, envelope, skip_none, mask, ordered)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 187, in _marshal
    out = OrderedDict(items) if ordered else dict(items)
                                             ^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 177, in <genexpr>
    else __format_field(k, v)
         ^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/marshalling.py", line 170, in __format_field
    value = field.output(key, data, ordered=ordered)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 200, in output
    value = get_value(key if self.attribute is None else self.attribute, obj)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 76, in get_value
    return _get_value_for_keys(key.split("."), obj, default)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 81, in _get_value_for_keys
    return _get_value_for_key(keys[0], obj, default)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/flask_restx/fields.py", line 99, in _get_value_for_key
    return getattr(obj, key, default)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 569, in __get__
    return self.impl.get(state, dict_)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1096, in get
    value = self._fire_loader_callables(state, key, passive)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1126, in _fire_loader_callables
    return state._load_expired(state, passive)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/state.py", line 828, in _load_expired
    self.manager.expired_attribute_loader(self, toload, passive)
  File "/Users/hejl/projects/dify/api/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 1607, in load_scalar_attributes
    raise orm_exc.DetachedInstanceError(
sqlalchemy.orm.exc.DetachedInstanceError: Instance <Workflow at 0x121532ab0> is not bound to a Session; attribute refresh operation cannot proceed (Background on this error at: https://sqlalche.me/e/20/bhk3)
2026-04-15 03:19:23,322 INFO [_internal.py:97] f350d7d217 127.0.0.1 - - [15/Apr/2026 03:19:23] "GET /console/api/apps/8aebf41c-7a93-4365-bf4a-8c0a06c432e7/workflows?page=1&limit=10&user_id=&named_only=false HTTP/1.1" 500 -
```

caused by https://github.com/langgenius/dify/pull/34282

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
