### PR TITLE
refactor(web): convert enums to as-const in billing and agent types

### DIFF
--- a/web/app/components/billing/type.ts
+++ b/web/app/components/billing/type.ts
@@ -1,16 +1,19 @@
-export enum Plan {
-  sandbox = 'sandbox',
-  professional = 'professional',
-  team = 'team',
-  enterprise = 'enterprise',
-}
-export enum Priority {
-  standard = 'standard',
-  priority = 'priority',
-  topPriority = 'top-priority',
-}
+export const Plan = {
+  sandbox: 'sandbox',
+  professional: 'professional',
+  team: 'team',
+  enterprise: 'enterprise',
+} as const
+export type Plan = typeof Plan[keyof typeof Plan]
 
-export type BasicPlan = Plan.sandbox | Plan.professional | Plan.team
+export const Priority = {
+  standard: 'standard',
+  priority: 'priority',
+  topPriority: 'top-priority',
+} as const
+export type Priority = typeof Priority[keyof typeof Priority]
+
+export type BasicPlan = typeof Plan['sandbox'] | typeof Plan['professional'] | typeof Plan['team']
 
 export type PlanInfo = {
   level: number
@@ -31,11 +34,12 @@ export type PlanInfo = {
   annotatedResponse: number
 }
 
-export enum SelfHostedPlan {
-  community = 'community',
-  premium = 'premium',
-  enterprise = 'enterprise',
-}
+export const SelfHostedPlan = {
+  community: 'community',
+  premium: 'premium',
+  enterprise: 'enterprise',
+} as const
+export type SelfHostedPlan = typeof SelfHostedPlan[keyof typeof SelfHostedPlan]
 
 export type UsagePlanInfo = Pick<PlanInfo, 'buildApps' | 'teamMembers' | 'annotatedResponse' | 'documentsUploadQuota' | 'apiRateLimit' | 'triggerEvents'> & { vectorSpace: number }
 
@@ -50,11 +54,12 @@ export type BillingQuota = {
   reset_date?: number | null
 }
 
-export enum DocumentProcessingPriority {
-  standard = 'standard',
-  priority = 'priority',
-  topPriority = 'top-priority',
-}
+export const DocumentProcessingPriority = {
+  standard: 'standard',
+  priority: 'priority',
+  topPriority: 'top-priority',
+} as const
+export type DocumentProcessingPriority = typeof DocumentProcessingPriority[keyof typeof DocumentProcessingPriority]
 
 export type CurrentPlanInfoBackend = {
   billing: {

--- a/web/app/components/workflow/nodes/agent/types.ts
+++ b/web/app/components/workflow/nodes/agent/types.ts
@@ -15,6 +15,7 @@ export type AgentNodeType = CommonNodeType & {
   tool_node_version?: string
 }
 
-export enum AgentFeature {
-  HISTORY_MESSAGES = 'history-messages',
-}
+export const AgentFeature = {
+  HISTORY_MESSAGES: 'history-messages',
+} as const
+export type AgentFeature = typeof AgentFeature[keyof typeof AgentFeature]

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -3453,11 +3453,6 @@
       "count": 1
     }
   },
-  "app/components/billing/type.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 4
-    }
-  },
   "app/components/billing/upgrade-btn/index.tsx": {
     "ts/no-explicit-any": {
       "count": 3
@@ -7884,9 +7879,6 @@
     }
   },
   "app/components/workflow/nodes/agent/types.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }


### PR DESCRIPTION
Convert `export enum` declarations to `as const` objects with companion type aliases.

- `web/app/components/billing/type.ts` — `Plan`, `Priority`, `SelfHostedPlan`, `DocumentProcessingPriority`
- `web/app/components/workflow/nodes/agent/types.ts` — `AgentFeature`

`BasicPlan` is updated to derive from `Plan` const values directly.

Fixes #27998