### PR TITLE
refactor(web): convert TracingProvider enum to as-const in tracing/type.ts

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type.ts
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type.ts
@@ -1,15 +1,16 @@
-export enum TracingProvider {
-  arize = 'arize',
-  phoenix = 'phoenix',
-  langSmith = 'langsmith',
-  langfuse = 'langfuse',
-  opik = 'opik',
-  weave = 'weave',
-  aliyun = 'aliyun',
-  mlflow = 'mlflow',
-  databricks = 'databricks',
-  tencent = 'tencent',
-}
+export const TracingProvider = {
+  arize: 'arize',
+  phoenix: 'phoenix',
+  langSmith: 'langsmith',
+  langfuse: 'langfuse',
+  opik: 'opik',
+  weave: 'weave',
+  aliyun: 'aliyun',
+  mlflow: 'mlflow',
+  databricks: 'databricks',
+  tencent: 'tencent',
+} as const
+export type TracingProvider = typeof TracingProvider[keyof typeof TracingProvider]
 
 export type ArizeConfig = {
   api_key: string

--- a/web/eslint-suppressions.json
+++ b/web/eslint-suppressions.json
@@ -146,11 +146,6 @@
       "count": 1
     }
   },
-  "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type.ts": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    }
-  },
   "app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx": {
     "ts/no-explicit-any": {
       "count": 1


### PR DESCRIPTION
Convert `TracingProvider` enum to `as const` object with companion type alias in `web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type.ts`.

Part of #27998