### PR TITLE
test(types): replace Account/Tenant status string literals with enum values

### DIFF
--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
@@ -12,7 +12,7 @@ from constants import HEADER_NAME_CSRF_TOKEN
 from libs.datetime_utils import naive_utc_now
 from libs.token import _real_cookie_name, generate_csrf_token
 from models import Account, DifySetup, Tenant, TenantAccountJoin
-from models.account import AccountStatus, TenantAccountRole
+from models.account import AccountStatus, TenantAccountRole, TenantStatus
 from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import App, AppMode, Conversation, Message
 from models.workflow import WorkflowRun
@@ -30,7 +30,7 @@ def _create_account_and_tenant(db_session: Session) -> tuple[Account, Tenant]:
     db_session.add(account)
     db_session.commit()
 
-    tenant = Tenant(name="Test Tenant", status="normal")
+    tenant = Tenant(name="Test Tenant", status=TenantStatus.NORMAL)
     db_session.add(tenant)
     db_session.commit()
 

--- a/api/tests/test_containers_integration_tests/controllers/console/helpers.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/helpers.py
@@ -11,7 +11,7 @@ from constants import HEADER_NAME_CSRF_TOKEN
 from libs.datetime_utils import naive_utc_now
 from libs.token import _real_cookie_name, generate_csrf_token
 from models import Account, DifySetup, Tenant, TenantAccountJoin
-from models.account import AccountStatus, TenantAccountRole
+from models.account import AccountStatus, TenantAccountRole, TenantStatus
 from models.model import App, AppMode
 from services.account_service import AccountService
 
@@ -37,7 +37,7 @@ def create_console_account_and_tenant(db_session: Session) -> tuple[Account, Ten
     db_session.add(account)
     db_session.commit()
 
-    tenant = Tenant(name="Test Tenant", status="normal")
+    tenant = Tenant(name="Test Tenant", status=TenantStatus.NORMAL)
     db_session.add(tenant)
     db_session.commit()
 

--- a/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
+++ b/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
@@ -88,11 +88,11 @@ class TestPauseStatePersistenceLayerTestContainers:
     def setup_test_data(self, db_session_with_containers, file_service, workflow_run_service):
         """Set up test data for each test method using TestContainers."""
         # Create test tenant and account
-        from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+        from models.account import AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 
         tenant = Tenant(
             name="Test Tenant",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -101,7 +101,7 @@ class TestPauseStatePersistenceLayerTestContainers:
             email="test@example.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/core/repositories/test_human_input_form_repository_impl.py
+++ b/api/tests/test_containers_integration_tests/core/repositories/test_human_input_form_repository_impl.py
@@ -18,7 +18,14 @@ from core.workflow.human_input_compat import (
     MemberRecipient,
     WebAppDeliveryMethod,
 )
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import (
+    Account,
+    AccountStatus,
+    Tenant,
+    TenantAccountJoin,
+    TenantAccountRole,
+    TenantStatus,
+)
 from models.human_input import (
     EmailExternalRecipientPayload,
     EmailMemberRecipientPayload,
@@ -29,7 +36,7 @@ from models.human_input import (
 
 
 def _create_tenant_with_members(session: Session, member_emails: list[str]) -> tuple[Tenant, list[Account]]:
-    tenant = Tenant(name="Test Tenant", status="normal")
+    tenant = Tenant(name="Test Tenant", status=TenantStatus.NORMAL)
     session.add(tenant)
     session.flush()
 
@@ -39,7 +46,7 @@ def _create_tenant_with_members(session: Session, member_emails: list[str]) -> t
             email=email,
             name=f"Member {index}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         session.add(account)
         session.flush()

--- a/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
+++ b/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
@@ -29,7 +29,7 @@ from core.workflow.node_runtime import DifyHumanInputNodeRuntime
 from core.workflow.system_variables import build_system_variables
 from libs.datetime_utils import naive_utc_now
 from models import Account
-from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.model import App, AppMode, IconType
 from models.workflow import Workflow, WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom, WorkflowRun
@@ -175,7 +175,7 @@ class TestHumanInputResumeNodeExecutionIntegration:
     def setup_test_data(self, db_session_with_containers: Session):
         tenant = Tenant(
             name="Test Tenant",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -184,7 +184,7 @@ class TestHumanInputResumeNodeExecutionIntegration:
             email="test@example.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/services/test_account_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_account_service.py
@@ -9,7 +9,7 @@ from werkzeug.exceptions import Unauthorized
 
 from configs import dify_config
 from controllers.console.error import AccountNotFound, NotAllowedCreateWorkspace
-from models import AccountStatus, TenantAccountJoin
+from models import AccountStatus, TenantAccountJoin, TenantStatus
 from services.account_service import AccountService, RegisterService, TenantService, TokenPair
 from services.errors.account import (
     AccountAlreadyInTenantError,
@@ -2851,7 +2851,7 @@ class TestRegisterService:
             interface_language="en-US",
             password=existing_pending_member_password,
         )
-        existing_account.status = "pending"
+        existing_account.status = AccountStatus.PENDING
 
         db_session_with_containers.commit()
 
@@ -2941,7 +2941,7 @@ class TestRegisterService:
             interface_language="en-US",
             password=already_in_tenant_password,
         )
-        existing_account.status = "active"
+        existing_account.status = AccountStatus.ACTIVE
 
         db_session_with_containers.commit()
 
@@ -3331,7 +3331,7 @@ class TestRegisterService:
         TenantService.create_tenant_member(tenant, account, role="normal")
 
         # Change tenant status to non-normal
-        tenant.status = "archive"
+        tenant.status = TenantStatus.ARCHIVE
 
         db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
@@ -7,7 +7,14 @@ from graphon.model_runtime.entities.model_entities import ModelType
 from sqlalchemy.orm import Session
 
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import (
+    Account,
+    AccountStatus,
+    Tenant,
+    TenantAccountJoin,
+    TenantAccountRole,
+    TenantStatus,
+)
 from models.dataset import Dataset, ExternalKnowledgeApis, ExternalKnowledgeBindings
 from models.enums import DataSourceType
 from services.dataset_service import DatasetService
@@ -26,12 +33,12 @@ class DatasetUpdateTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
 
-        tenant = Tenant(name=f"tenant-{account.id}", status="normal")
+        tenant = Tenant(name=f"tenant-{account.id}", status=TenantStatus.NORMAL)
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/tasks/test_document_indexing_sync_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_document_indexing_sync_task.py
@@ -16,7 +16,7 @@ from sqlalchemy import delete, func, select, update
 
 from core.indexing_runner import DocumentIsPausedError, IndexingRunner
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
-from models import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models import Account, AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 from models.dataset import Dataset, Document, DocumentSegment
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.document_indexing_sync_task import document_indexing_sync_task
@@ -31,12 +31,12 @@ class DocumentIndexingSyncTaskTestDataFactory:
             email=f"{uuid4()}@example.com",
             name=f"user-{uuid4()}",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.flush()
 
-        tenant = Tenant(name=f"tenant-{account.id}", status="normal")
+        tenant = Tenant(name=f"tenant-{account.id}", status=TenantStatus.NORMAL)
         db_session_with_containers.add(tenant)
         db_session_with_containers.flush()
 

--- a/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
+++ b/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
@@ -33,7 +33,7 @@ from extensions.ext_storage import storage
 from libs.datetime_utils import naive_utc_now
 from models import Account
 from models import WorkflowPause as WorkflowPauseModel
-from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import AccountStatus, Tenant, TenantAccountJoin, TenantAccountRole, TenantStatus
 from models.model import UploadFile
 from models.workflow import Workflow, WorkflowRun
 from repositories.sqlalchemy_api_workflow_run_repository import (
@@ -181,7 +181,7 @@ class TestWorkflowPauseIntegration:
 
         tenant = Tenant(
             name="Test Tenant",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -190,7 +190,7 @@ class TestWorkflowPauseIntegration:
             email="test@example.com",
             name="Test User",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         db_session_with_containers.add(account)
         db_session_with_containers.commit()
@@ -696,7 +696,7 @@ class TestWorkflowPauseIntegration:
 
         tenant2 = Tenant(
             name="Test Tenant 2",
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         self.session.add(tenant2)
         self.session.commit()
@@ -705,7 +705,7 @@ class TestWorkflowPauseIntegration:
             email="test2@example.com",
             name="Test User 2",
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
         self.session.add(account2)
         self.session.commit()

--- a/api/tests/unit_tests/controllers/console/test_workspace_account.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_account.py
@@ -11,7 +11,7 @@ from controllers.console.workspace.account import (
     ChangeEmailSendEmailApi,
     CheckEmailUnique,
 )
-from models import Account
+from models import Account, AccountStatus
 from services.account_service import AccountService
 
 
@@ -33,7 +33,7 @@ def _build_account(email: str, account_id: str = "acc", tenant: object | None = 
     account = Account(name=account_id, email=email)
     account.email = email
     account.id = account_id
-    account.status = "active"
+    account.status = AccountStatus.ACTIVE
     account._current_tenant = tenant_obj
     return account
 

--- a/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
+++ b/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
@@ -18,6 +18,7 @@ from controllers.inner_api.app.dsl import (
     InnerAppDSLImportPayload,
     _get_active_account,
 )
+from models.account import AccountStatus
 from services.app_dsl_service import ImportStatus
 
 
@@ -63,7 +64,7 @@ class TestGetActiveAccount:
     @patch("controllers.inner_api.app.dsl.db")
     def test_returns_active_account(self, mock_db):
         mock_account = MagicMock()
-        mock_account.status = "active"
+        mock_account.status = AccountStatus.ACTIVE
         mock_db.session.scalar.return_value = mock_account
 
         result = _get_active_account("user@example.com")
@@ -74,7 +75,7 @@ class TestGetActiveAccount:
     @patch("controllers.inner_api.app.dsl.db")
     def test_returns_none_for_inactive_account(self, mock_db):
         mock_account = MagicMock()
-        mock_account.status = "banned"
+        mock_account.status = AccountStatus.BANNED
         mock_db.session.scalar.return_value = mock_account
 
         result = _get_active_account("banned@example.com")

--- a/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
@@ -20,6 +20,7 @@ from controllers.inner_api.workspace.workspace import (
     WorkspaceCreatePayload,
     WorkspaceOwnerlessPayload,
 )
+from models.account import TenantStatus
 
 
 class TestWorkspaceCreatePayload:
@@ -98,7 +99,7 @@ class TestEnterpriseWorkspace:
         mock_tenant.id = "tenant-id"
         mock_tenant.name = "My Workspace"
         mock_tenant.plan = "sandbox"
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
         mock_tenant.created_at = now
         mock_tenant.updated_at = now
         mock_tenant_svc.create_tenant.return_value = mock_tenant
@@ -162,7 +163,7 @@ class TestEnterpriseWorkspaceNoOwnerEmail:
         mock_tenant.name = "My Workspace"
         mock_tenant.encrypt_public_key = "pub-key"
         mock_tenant.plan = "sandbox"
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
         mock_tenant.custom_config = None
         mock_tenant.created_at = now
         mock_tenant.updated_at = now

--- a/api/tests/unit_tests/controllers/service_api/app/test_app.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_app.py
@@ -10,6 +10,7 @@ from flask import Flask
 
 from controllers.service_api.app.app import AppInfoApi, AppMetaApi, AppParameterApi
 from controllers.service_api.app.error import AppUnavailableError
+from models.account import TenantStatus
 from models.model import App, AppMode
 from tests.unit_tests.conftest import setup_mock_tenant_account_query
 
@@ -62,7 +63,7 @@ class TestAppParameterApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         # Mock DB queries for app and tenant
         mock_db.session.get.side_effect = [
@@ -110,7 +111,7 @@ class TestAppParameterApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app_model,
@@ -151,7 +152,7 @@ class TestAppParameterApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app_model,
@@ -190,7 +191,7 @@ class TestAppParameterApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app_model,
@@ -253,7 +254,7 @@ class TestAppMetaApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app_model,
@@ -321,7 +322,7 @@ class TestAppInfoApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app_model,
@@ -378,7 +379,7 @@ class TestAppInfoApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app,
@@ -424,7 +425,7 @@ class TestAppInfoApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app,
@@ -476,7 +477,7 @@ class TestAppInfoApi:
         mock_validate_token.return_value = mock_api_token
 
         mock_tenant = Mock()
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         mock_db.session.get.side_effect = [
             mock_app,

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from configs import dify_config
-from models.account import Account, AccountStatus
+from models.account import Account, AccountStatus, TenantStatus
 from services.account_service import AccountService, RegisterService, TenantService
 from services.errors.account import (
     AccountAlreadyInTenantError,
@@ -1697,7 +1697,7 @@ class TestRegisterService:
         # Setup test data
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
         mock_account = TestAccountAssociatedDataFactory.create_account_mock(
             account_id="user-123", email="test@example.com"
         )
@@ -1759,7 +1759,7 @@ class TestRegisterService:
         # Setup test data
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
 
         # Mock Redis data
         invitation_data = {
@@ -1784,7 +1784,7 @@ class TestRegisterService:
         # Setup test data
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
-        mock_tenant.status = "normal"
+        mock_tenant.status = TenantStatus.NORMAL
         mock_account = TestAccountAssociatedDataFactory.create_account_mock(
             account_id="different-user-456", email="test@example.com"
         )


### PR DESCRIPTION
## Summary

Fixes pyrefly `[bad-argument-type]` errors across 14 test files where
`Account.status` and `Tenant.status` are passed as raw string literals
(`"active"`, `"normal"`, `"pending"`, `"banned"`, `"archive"`) instead of
their declared enum types.

The model columns are typed as `AccountStatus` / `TenantStatus`, both of
which are `enum.StrEnum` subclasses. Runtime behavior is **unchanged** —
`AccountStatus.ACTIVE == "active"` is `True` — but pyrefly correctly
flags the literal strings because the declared parameter type is the
enum, not `str`.

This is a behavior-preserving, type-safe cleanup. Replace each literal
with the matching enum constant:

| Before | After |
|---|---|
| `status="active"` | `status=AccountStatus.ACTIVE` |
| `status="banned"` | `status=AccountStatus.BANNED` |
| `status="pending"` | `status=AccountStatus.PENDING` |
| `status="normal"` | `status=TenantStatus.NORMAL` |
| `status="archive"` | `status=TenantStatus.ARCHIVE` |

Fixes #33439.

## Scope

- 14 test files touched
- Strictly `Account.status` and `Tenant.status` sites — other status
  fields (`App.status`, `Conversation.status`, `Message.status`, etc.)
  are **out of scope** for this PR
- Both constructor-kwarg sites and attribute-assignment sites
- Missing `AccountStatus` / `TenantStatus` imports added where needed

## Testing

- `ruff check api/tests/` → all checks passed
- No runtime behavior change — the `StrEnum` equality means existing
  tests see the same string value they did before
- All touched files parse cleanly

## Out of scope (follow-ups)

Other string-literal status usages I noticed but deliberately left
untouched, since the issue only called out Account/Tenant:

- `app.status = "normal"` → `App.status: AppStatus`
- `conversation.status = "normal"` → `Conversation.status: ConversationStatus`
- `message.status = "normal"` → `Message.status: MessageStatus`

Happy to do a follow-up PR for these if desired.