### PR TITLE
refactor: avoid passing dict in HitTestingService.retrieve

### DIFF
--- a/api/controllers/console/datasets/hit_testing.py
+++ b/api/controllers/console/datasets/hit_testing.py
@@ -128,7 +128,6 @@ class HitTestingApi(Resource, DatasetsHitTestingBase):
 
         dataset = self.get_and_validate_dataset(dataset_id_str)
         payload = HitTestingPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
-        self.hit_testing_args_check(args)
+        self.hit_testing_args_check(payload)
 
-        return HitTestingResponse.model_validate(self.perform_hit_testing(dataset, args)).model_dump(mode="json")
+        return HitTestingResponse.model_validate(self.perform_hit_testing(dataset, payload)).model_dump(mode="json")

--- a/api/controllers/console/datasets/hit_testing_base.py
+++ b/api/controllers/console/datasets/hit_testing_base.py
@@ -53,26 +53,27 @@ class DatasetsHitTestingBase:
         return dataset
 
     @staticmethod
-    def hit_testing_args_check(args: dict[str, Any]):
+    def hit_testing_args_check(args: dict[str, Any] | HitTestingPayload):
+        if isinstance(args, HitTestingPayload):
+            args = args.model_dump(exclude_none=True)
         HitTestingService.hit_testing_args_check(args)
 
     @staticmethod
-    def parse_args(payload: dict[str, Any]) -> dict[str, Any]:
+    def parse_args(payload: dict[str, Any]) -> HitTestingPayload:
         """Validate and return hit-testing arguments from an incoming payload."""
-        hit_testing_payload = HitTestingPayload.model_validate(payload or {})
-        return hit_testing_payload.model_dump(exclude_none=True)
+        return HitTestingPayload.model_validate(payload or {})
 
     @staticmethod
-    def perform_hit_testing(dataset, args):
+    def perform_hit_testing(dataset, args: HitTestingPayload):
         assert isinstance(current_user, Account)
         try:
             response = HitTestingService.retrieve(
                 dataset=dataset,
-                query=args.get("query"),
+                query=args.query,
                 account=current_user,
-                retrieval_model=args.get("retrieval_model"),
-                external_retrieval_model=args.get("external_retrieval_model"),
-                attachment_ids=args.get("attachment_ids"),
+                retrieval_model=args.retrieval_model,
+                external_retrieval_model=args.external_retrieval_model or {},
+                attachment_ids=args.attachment_ids,
                 limit=10,
             )
             return {"query": response["query"], "records": marshal(response["records"], hit_testing_record_fields)}

--- a/api/services/entities/knowledge_entities/knowledge_entities.py
+++ b/api/services/entities/knowledge_entities/knowledge_entities.py
@@ -83,6 +83,7 @@ class RetrievalModel(BaseModel):
     score_threshold_enabled: bool
     score_threshold: float | None = None
     weights: WeightModel | None = None
+    metadata_filtering_conditions: dict[str, Any] | None = None
 
 
 class MetaDataConfig(BaseModel):

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -144,7 +144,9 @@ class HitTestingService:
             query=query,
             attachment_ids=attachment_ids,
             top_k=retrieval_model.top_k,
-            score_threshold=(retrieval_model.score_threshold or 0.0) if retrieval_model.score_threshold_enabled else 0.0,
+            score_threshold=(retrieval_model.score_threshold or 0.0)
+            if retrieval_model.score_threshold_enabled
+            else 0.0,
             reranking_model=cls._serialize_reranking_model(retrieval_model),
             reranking_mode=retrieval_model.reranking_mode or "reranking_model",
             weights=cls._serialize_weights(retrieval_model),

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -93,7 +93,9 @@ class HitTestingService:
             attachment_ids=attachment_ids,
             top_k=retrieval_model.top_k,
             score_threshold=retrieval_model.score_threshold if retrieval_model.score_threshold_enabled else 0.0,
-            reranking_model=retrieval_model.reranking_model.model_dump() if retrieval_model.reranking_enable and retrieval_model.reranking_model else None,
+            reranking_model=retrieval_model.reranking_model.model_dump()
+            if retrieval_model.reranking_enable and retrieval_model.reranking_model
+            else None,
             reranking_mode=retrieval_model.reranking_mode or "reranking_model",
             weights=retrieval_model.weights.model_dump() if retrieval_model.weights else None,
             document_ids_filter=document_ids_filter,

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -53,11 +53,15 @@ class HitTestingService:
         start = time.perf_counter()
 
         # get retrieval model , if the model is not setting , using default
+        base_model_dict = default_retrieval_model.copy()
+        if dataset.retrieval_model:
+            base_model_dict.update(dataset.retrieval_model)
+
         if not retrieval_model:
-            retrieval_model_dict = dataset.retrieval_model or default_retrieval_model
-            retrieval_model = RetrievalModel.model_validate(retrieval_model_dict)
+            retrieval_model = RetrievalModel.model_validate(base_model_dict)
         elif isinstance(retrieval_model, dict):
-            retrieval_model = RetrievalModel.model_validate(retrieval_model)
+            base_model_dict.update(retrieval_model)
+            retrieval_model = RetrievalModel.model_validate(base_model_dict)
 
         document_ids_filter = None
         metadata_filtering_conditions = retrieval_model.metadata_filtering_conditions or {}

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -1,12 +1,14 @@
 import json
 import logging
 import time
+from copy import deepcopy
 from typing import Any, TypedDict
 
 from graphon.model_runtime.entities import LLMMode
 
 from core.app.app_config.entities import ModelConfig
-from core.rag.datasource.retrieval_service import RetrievalService
+from core.rag.data_post_processor.data_post_processor import RerankingModelDict, WeightsDict
+from core.rag.datasource.retrieval_service import DefaultRetrievalModelDict, RetrievalService
 from core.rag.index_processor.constant.query_type import QueryType
 from core.rag.models.document import Document
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
@@ -29,7 +31,7 @@ class RetrieveResponseDict(TypedDict):
     records: list[dict[str, Any]]
 
 
-default_retrieval_model = {
+default_retrieval_model: DefaultRetrievalModelDict = {
     "search_method": RetrievalMethod.SEMANTIC_SEARCH,
     "reranking_enable": False,
     "reranking_model": {"reranking_provider_name": "", "reranking_model_name": ""},
@@ -39,6 +41,65 @@ default_retrieval_model = {
 
 
 class HitTestingService:
+    @staticmethod
+    def _deep_merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+        merged = deepcopy(base)
+        for key, value in override.items():
+            current_value = merged.get(key)
+            if isinstance(current_value, dict) and isinstance(value, dict):
+                merged[key] = HitTestingService._deep_merge_dicts(current_value, value)
+            else:
+                merged[key] = value
+        return merged
+
+    @classmethod
+    def _normalize_retrieval_model(
+        cls, dataset: Dataset, retrieval_model: RetrievalModel | dict[str, Any] | None
+    ) -> RetrievalModel:
+        merged_model_dict: dict[str, Any] = deepcopy(dict(default_retrieval_model))
+        if dataset.retrieval_model:
+            merged_model_dict = cls._deep_merge_dicts(merged_model_dict, dataset.retrieval_model)
+
+        if isinstance(retrieval_model, RetrievalModel):
+            incoming_model_dict = retrieval_model.model_dump(exclude_unset=True)
+        else:
+            incoming_model_dict = retrieval_model or {}
+
+        if incoming_model_dict:
+            merged_model_dict = cls._deep_merge_dicts(merged_model_dict, incoming_model_dict)
+
+        return RetrievalModel.model_validate(merged_model_dict)
+
+    @staticmethod
+    def _serialize_reranking_model(retrieval_model: RetrievalModel) -> RerankingModelDict | None:
+        if not retrieval_model.reranking_enable or not retrieval_model.reranking_model:
+            return None
+
+        return {
+            "reranking_provider_name": retrieval_model.reranking_model.reranking_provider_name or "",
+            "reranking_model_name": retrieval_model.reranking_model.reranking_model_name or "",
+        }
+
+    @staticmethod
+    def _serialize_weights(retrieval_model: RetrievalModel) -> WeightsDict | None:
+        if (
+            not retrieval_model.weights
+            or not retrieval_model.weights.vector_setting
+            or not retrieval_model.weights.keyword_setting
+        ):
+            return None
+
+        return {
+            "vector_setting": {
+                "vector_weight": retrieval_model.weights.vector_setting.vector_weight,
+                "embedding_provider_name": retrieval_model.weights.vector_setting.embedding_provider_name,
+                "embedding_model_name": retrieval_model.weights.vector_setting.embedding_model_name,
+            },
+            "keyword_setting": {
+                "keyword_weight": retrieval_model.weights.keyword_setting.keyword_weight,
+            },
+        }
+
     @classmethod
     def retrieve(
         cls,
@@ -52,16 +113,7 @@ class HitTestingService:
     ):
         start = time.perf_counter()
 
-        # get retrieval model , if the model is not setting , using default
-        base_model_dict = default_retrieval_model.copy()
-        if dataset.retrieval_model:
-            base_model_dict.update(dataset.retrieval_model)
-
-        if not retrieval_model:
-            retrieval_model = RetrievalModel.model_validate(base_model_dict)
-        elif isinstance(retrieval_model, dict):
-            base_model_dict.update(retrieval_model)
-            retrieval_model = RetrievalModel.model_validate(base_model_dict)
+        retrieval_model = cls._normalize_retrieval_model(dataset, retrieval_model)
 
         document_ids_filter = None
         metadata_filtering_conditions = retrieval_model.metadata_filtering_conditions or {}
@@ -92,12 +144,10 @@ class HitTestingService:
             query=query,
             attachment_ids=attachment_ids,
             top_k=retrieval_model.top_k,
-            score_threshold=retrieval_model.score_threshold if retrieval_model.score_threshold_enabled else 0.0,
-            reranking_model=retrieval_model.reranking_model.model_dump()
-            if retrieval_model.reranking_enable and retrieval_model.reranking_model
-            else None,
+            score_threshold=(retrieval_model.score_threshold or 0.0) if retrieval_model.score_threshold_enabled else 0.0,
+            reranking_model=cls._serialize_reranking_model(retrieval_model),
             reranking_mode=retrieval_model.reranking_mode or "reranking_model",
-            weights=retrieval_model.weights.model_dump() if retrieval_model.weights else None,
+            weights=cls._serialize_weights(retrieval_model),
             document_ids_filter=document_ids_filter,
         )
 
@@ -133,7 +183,7 @@ class HitTestingService:
         account: Account,
         external_retrieval_model: dict[str, Any] | None = None,
         metadata_filtering_conditions: dict[str, Any] | None = None,
-    ):
+    ) -> RetrieveResponseDict:
         if dataset.provider != "external":
             return {
                 "query": {"content": query},
@@ -164,7 +214,7 @@ class HitTestingService:
         db.session.add(dataset_query)
         db.session.commit()
 
-        return dict(cls.compact_external_retrieve_response(dataset, query, all_documents))
+        return cls.compact_external_retrieve_response(dataset, query, all_documents)
 
     @classmethod
     def compact_retrieve_response(cls, query: str, documents: list[Document]) -> RetrieveResponseDict:

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -15,6 +15,7 @@ from extensions.ext_database import db
 from models import Account
 from models.dataset import Dataset, DatasetQuery
 from models.enums import CreatorUserRole, DatasetQuerySource
+from services.entities.knowledge_entities.knowledge_entities import RetrievalModel
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class HitTestingService:
         dataset: Dataset,
         query: str,
         account: Account,
-        retrieval_model: dict[str, Any] | None,
+        retrieval_model: RetrievalModel | dict[str, Any] | None,
         external_retrieval_model: dict[str, Any],
         attachment_ids: list | None = None,
         limit: int = 10,
@@ -53,22 +54,25 @@ class HitTestingService:
 
         # get retrieval model , if the model is not setting , using default
         if not retrieval_model:
-            retrieval_model = dataset.retrieval_model or default_retrieval_model
-        assert isinstance(retrieval_model, dict)
+            retrieval_model_dict = dataset.retrieval_model or default_retrieval_model
+            retrieval_model = RetrievalModel.model_validate(retrieval_model_dict)
+        elif isinstance(retrieval_model, dict):
+            retrieval_model = RetrievalModel.model_validate(retrieval_model)
+
         document_ids_filter = None
-        metadata_filtering_conditions = retrieval_model.get("metadata_filtering_conditions", {})
+        metadata_filtering_conditions = retrieval_model.metadata_filtering_conditions or {}
         if metadata_filtering_conditions and query:
             dataset_retrieval = DatasetRetrieval()
 
             from core.rag.entities import MetadataFilteringCondition
 
-            metadata_filtering_conditions = MetadataFilteringCondition.model_validate(metadata_filtering_conditions)
+            metadata_filtering_conditions_obj = MetadataFilteringCondition.model_validate(metadata_filtering_conditions)
 
             metadata_filter_document_ids, metadata_condition = dataset_retrieval.get_metadata_filter_condition(
                 dataset_ids=[dataset.id],
                 query=query,
                 metadata_filtering_mode="manual",
-                metadata_filtering_conditions=metadata_filtering_conditions,
+                metadata_filtering_conditions=metadata_filtering_conditions_obj,
                 inputs={},
                 tenant_id="",
                 user_id="",
@@ -79,19 +83,15 @@ class HitTestingService:
             if metadata_condition and not document_ids_filter:
                 return cls.compact_retrieve_response(query, [])
         all_documents = RetrievalService.retrieve(
-            retrieval_method=RetrievalMethod(retrieval_model.get("search_method", RetrievalMethod.SEMANTIC_SEARCH)),
+            retrieval_method=RetrievalMethod(retrieval_model.search_method or RetrievalMethod.SEMANTIC_SEARCH),
             dataset_id=dataset.id,
             query=query,
             attachment_ids=attachment_ids,
-            top_k=retrieval_model.get("top_k", 4),
-            score_threshold=retrieval_model.get("score_threshold", 0.0)
-            if retrieval_model["score_threshold_enabled"]
-            else 0.0,
-            reranking_model=retrieval_model.get("reranking_model", None)
-            if retrieval_model["reranking_enable"]
-            else None,
-            reranking_mode=retrieval_model.get("reranking_mode") or "reranking_model",
-            weights=retrieval_model.get("weights", None),
+            top_k=retrieval_model.top_k,
+            score_threshold=retrieval_model.score_threshold if retrieval_model.score_threshold_enabled else 0.0,
+            reranking_model=retrieval_model.reranking_model.model_dump() if retrieval_model.reranking_enable and retrieval_model.reranking_model else None,
+            reranking_mode=retrieval_model.reranking_mode or "reranking_model",
+            weights=retrieval_model.weights.model_dump() if retrieval_model.weights else None,
             document_ids_filter=document_ids_filter,
         )
 

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -57,7 +57,7 @@ class HitTestingService:
         cls, dataset: Dataset, retrieval_model: RetrievalModel | dict[str, Any] | None
     ) -> RetrievalModel:
         merged_model_dict: dict[str, Any] = deepcopy(dict(default_retrieval_model))
-        if dataset.retrieval_model:
+        if isinstance(dataset.retrieval_model, dict):
             merged_model_dict = cls._deep_merge_dicts(merged_model_dict, dataset.retrieval_model)
 
         if isinstance(retrieval_model, RetrievalModel):

--- a/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
@@ -304,11 +304,23 @@ class TestHitTestingService:
             "search_method": "hybrid_search",
             "top_k": 10,
             "reranking_enable": True,
-            "reranking_model": {"provider": "test"},
+            "reranking_model": {
+                "reranking_provider_name": "test-provider",
+                "reranking_model_name": "test-reranker",
+            },
             "reranking_mode": "weighted_sum",
             "score_threshold_enabled": True,
             "score_threshold": 0.5,
-            "weights": {"vector": 0.5, "keyword": 0.5},
+            "weights": {
+                "vector_setting": {
+                    "vector_weight": 0.5,
+                    "embedding_provider_name": "openai",
+                    "embedding_model_name": "text-embedding-3-small",
+                },
+                "keyword_setting": {
+                    "keyword_weight": 0.5,
+                },
+            },
         }
         mock_retrieve.return_value = []
 
@@ -323,6 +335,18 @@ class TestHitTestingService:
         mock_retrieve.assert_called_once()
         kwargs = mock_retrieve.call_args.kwargs
         assert kwargs["score_threshold"] == 0.5
-        assert kwargs["reranking_model"] == {"provider": "test"}
+        assert kwargs["reranking_model"] == {
+            "reranking_provider_name": "test-provider",
+            "reranking_model_name": "test-reranker",
+        }
         assert kwargs["reranking_mode"] == "weighted_sum"
-        assert kwargs["weights"] == {"vector": 0.5, "keyword": 0.5}
+        assert kwargs["weights"] == {
+            "vector_setting": {
+                "vector_weight": 0.5,
+                "embedding_provider_name": "openai",
+                "embedding_model_name": "text-embedding-3-small",
+            },
+            "keyword_setting": {
+                "keyword_weight": 0.5,
+            },
+        }

--- a/api/tests/unit_tests/controllers/console/datasets/test_hit_testing_base.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_hit_testing_base.py
@@ -14,6 +14,7 @@ from controllers.console.app.error import (
 from controllers.console.datasets.error import DatasetNotInitializedError
 from controllers.console.datasets.hit_testing_base import (
     DatasetsHitTestingBase,
+    HitTestingPayload,
 )
 from core.errors.error import (
     LLMBadRequestError,
@@ -108,7 +109,8 @@ class TestParseArgs:
 
         result = DatasetsHitTestingBase.parse_args(payload)
 
-        assert result["query"] == "hello"
+        assert isinstance(result, HitTestingPayload)
+        assert result.query == "hello"
 
     def test_parse_args_invalid(self):
         payload = {"query": "x" * 300}
@@ -123,85 +125,94 @@ class TestPerformHitTesting:
             "query": "hello",
             "records": [],
         }
+        payload = HitTestingPayload(query="hello")
 
         with patch.object(
             HitTestingService,
             "retrieve",
             return_value=response,
         ):
-            result = DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+            result = DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
         assert result["query"] == "hello"
         assert result["records"] == []
 
     def test_index_not_initialized(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=services.errors.index.IndexNotInitializedError(),
         ):
             with pytest.raises(DatasetNotInitializedError):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_provider_token_not_init(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=ProviderTokenNotInitError("token missing"),
         ):
             with pytest.raises(ProviderNotInitializeError):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_quota_exceeded(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=QuotaExceededError(),
         ):
             with pytest.raises(ProviderQuotaExceededError):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_model_not_supported(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=ModelCurrentlyNotSupportError(),
         ):
             with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_llm_bad_request(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=LLMBadRequestError("bad request"),
         ):
             with pytest.raises(ProviderNotInitializeError):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_invoke_error(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=InvokeError("invoke failed"),
         ):
             with pytest.raises(CompletionRequestError):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_value_error(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=ValueError("bad args"),
         ):
             with pytest.raises(ValueError, match="bad args"):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)
 
     def test_unexpected_error(self, dataset):
+        payload = HitTestingPayload(query="hello")
         with patch.object(
             HitTestingService,
             "retrieve",
             side_effect=Exception("boom"),
         ):
             with pytest.raises(InternalServerError, match="boom"):
-                DatasetsHitTestingBase.perform_hit_testing(dataset, {"query": "hello"})
+                DatasetsHitTestingBase.perform_hit_testing(dataset, payload)

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py
@@ -165,11 +165,11 @@ class TestHitTestingApiPost:
 
         assert response["query"] == "complex query"
         call_kwargs = mock_hit_svc.retrieve.call_args
-        # retrieval_model is serialized via model_dump, verify key fields
+        # retrieval_model now stays as a validated RetrievalModel through the controller/base path.
         passed_retrieval_model = call_kwargs.kwargs.get("retrieval_model")
         assert passed_retrieval_model is not None
-        assert passed_retrieval_model["search_method"] == "semantic_search"
-        assert passed_retrieval_model["top_k"] == 10
+        assert passed_retrieval_model.search_method == "semantic_search"
+        assert passed_retrieval_model.top_k == 10
 
     @patch("controllers.service_api.dataset.hit_testing.service_api_ns")
     @patch("controllers.console.datasets.hit_testing_base.DatasetService")

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -15,6 +15,7 @@ from core.rag.models.document import Document
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from models import Account
 from models.dataset import Dataset
+from services.entities.knowledge_entities.knowledge_entities import RetrievalModel
 from services.hit_testing_service import HitTestingService
 
 
@@ -380,6 +381,138 @@ class TestHitTestingServiceRetrieve:
             call_kwargs = mock_retrieve.call_args[1]
             assert call_kwargs["retrieval_method"] == RetrievalMethod.HYBRID_SEARCH
             assert call_kwargs["top_k"] == 3
+
+    def test_retrieve_deep_merges_nested_retrieval_model_dicts(self, mock_db_session):
+        dataset = HitTestingTestDataFactory.create_dataset_mock(
+            retrieval_model={
+                "reranking_mode": "weighted_score",
+                "weights": {
+                    "vector_setting": {
+                        "vector_weight": 0.6,
+                        "embedding_provider_name": "openai",
+                        "embedding_model_name": "text-embedding-3-small",
+                    }
+                },
+            }
+        )
+        account = HitTestingTestDataFactory.create_user_mock()
+        query = "test query"
+        retrieval_model = {
+            "weights": {
+                "keyword_setting": {
+                    "keyword_weight": 0.4,
+                }
+            }
+        }
+        external_retrieval_model = {}
+
+        documents = [HitTestingTestDataFactory.create_document_mock()]
+        mock_records = [HitTestingTestDataFactory.create_retrieval_record_mock()]
+
+        with (
+            patch("services.hit_testing_service.RetrievalService.retrieve", autospec=True) as mock_retrieve,
+            patch(
+                "services.hit_testing_service.RetrievalService.format_retrieval_documents", autospec=True
+            ) as mock_format,
+            patch("services.hit_testing_service.time.perf_counter", autospec=True) as mock_perf_counter,
+        ):
+            mock_perf_counter.side_effect = [0.0, 0.1]
+            mock_retrieve.return_value = documents
+            mock_format.return_value = mock_records
+
+            HitTestingService.retrieve(dataset, query, account, retrieval_model, external_retrieval_model)
+
+            call_kwargs = mock_retrieve.call_args[1]
+            assert call_kwargs["reranking_mode"] == "weighted_score"
+            assert call_kwargs["weights"] == {
+                "vector_setting": {
+                    "vector_weight": 0.6,
+                    "embedding_provider_name": "openai",
+                    "embedding_model_name": "text-embedding-3-small",
+                },
+                "keyword_setting": {
+                    "keyword_weight": 0.4,
+                },
+            }
+
+    def test_retrieve_with_retrieval_model_instance_merges_dataset_optional_fields(self, mock_db_session):
+        dataset = HitTestingTestDataFactory.create_dataset_mock(
+            retrieval_model={
+                "reranking_mode": "weighted_score",
+                "weights": {
+                    "vector_setting": {
+                        "vector_weight": 0.7,
+                        "embedding_provider_name": "openai",
+                        "embedding_model_name": "text-embedding-3-small",
+                    },
+                    "keyword_setting": {
+                        "keyword_weight": 0.3,
+                    },
+                },
+            }
+        )
+        account = HitTestingTestDataFactory.create_user_mock()
+        query = "test query"
+        retrieval_model = RetrievalModel(
+            search_method=RetrievalMethod.KEYWORD_SEARCH,
+            reranking_enable=False,
+            top_k=2,
+            score_threshold_enabled=False,
+        )
+        external_retrieval_model = {}
+
+        documents = [HitTestingTestDataFactory.create_document_mock()]
+        mock_records = [HitTestingTestDataFactory.create_retrieval_record_mock()]
+
+        with (
+            patch("services.hit_testing_service.RetrievalService.retrieve", autospec=True) as mock_retrieve,
+            patch(
+                "services.hit_testing_service.RetrievalService.format_retrieval_documents", autospec=True
+            ) as mock_format,
+            patch("services.hit_testing_service.time.perf_counter", autospec=True) as mock_perf_counter,
+        ):
+            mock_perf_counter.side_effect = [0.0, 0.1]
+            mock_retrieve.return_value = documents
+            mock_format.return_value = mock_records
+
+            HitTestingService.retrieve(dataset, query, account, retrieval_model, external_retrieval_model)
+
+            call_kwargs = mock_retrieve.call_args[1]
+            assert call_kwargs["retrieval_method"] == RetrievalMethod.KEYWORD_SEARCH
+            assert call_kwargs["reranking_mode"] == "weighted_score"
+            assert call_kwargs["weights"] == dataset.retrieval_model["weights"]
+
+    def test_retrieve_falls_back_to_zero_score_threshold_when_enabled_but_unset(self, mock_db_session):
+        dataset = HitTestingTestDataFactory.create_dataset_mock()
+        account = HitTestingTestDataFactory.create_user_mock()
+        query = "test query"
+        retrieval_model = {
+            "search_method": RetrievalMethod.SEMANTIC_SEARCH,
+            "reranking_enable": False,
+            "top_k": 4,
+            "score_threshold_enabled": True,
+            "score_threshold": None,
+        }
+        external_retrieval_model = {}
+
+        documents = [HitTestingTestDataFactory.create_document_mock()]
+        mock_records = [HitTestingTestDataFactory.create_retrieval_record_mock()]
+
+        with (
+            patch("services.hit_testing_service.RetrievalService.retrieve", autospec=True) as mock_retrieve,
+            patch(
+                "services.hit_testing_service.RetrievalService.format_retrieval_documents", autospec=True
+            ) as mock_format,
+            patch("services.hit_testing_service.time.perf_counter", autospec=True) as mock_perf_counter,
+        ):
+            mock_perf_counter.side_effect = [0.0, 0.1]
+            mock_retrieve.return_value = documents
+            mock_format.return_value = mock_records
+
+            HitTestingService.retrieve(dataset, query, account, retrieval_model, external_retrieval_model)
+
+            call_kwargs = mock_retrieve.call_args[1]
+            assert call_kwargs["score_threshold"] == 0.0
 
 
 class TestHitTestingServiceExternalRetrieve:

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -213,7 +213,10 @@ class TestHitTestingServiceRetrieve:
             "top_k": 5,
             "score_threshold_enabled": True,
             "score_threshold": 0.7,
-            "weights": {"vector_setting": 0.5, "keyword_setting": 0.5},
+            "weights": {
+                "vector_setting": {"vector_weight": 0.5, "embedding_provider_name": "openai", "embedding_model_name": "text-embedding-3-small"},
+                "keyword_setting": {"keyword_weight": 0.5}
+            },
         }
         external_retrieval_model = {}
 
@@ -257,7 +260,7 @@ class TestHitTestingServiceRetrieve:
         retrieval_model = {
             "metadata_filtering_conditions": {
                 "conditions": [
-                    {"field": "category", "operator": "is", "value": "test"},
+                    {"name": "category", "comparison_operator": "is", "value": "test"},
                 ],
             },
         }
@@ -308,7 +311,7 @@ class TestHitTestingServiceRetrieve:
         retrieval_model = {
             "metadata_filtering_conditions": {
                 "conditions": [
-                    {"field": "category", "operator": "is", "value": "test"},
+                    {"name": "category", "comparison_operator": "is", "value": "test"},
                 ],
             },
         }
@@ -708,7 +711,7 @@ class TestHitTestingServiceHitTestingArgsCheck:
         args = {"query": ""}
 
         # Act & Assert
-        with pytest.raises(ValueError, match="Query is required and cannot exceed 250 characters"):
+        with pytest.raises(ValueError, match="Query or attachment_ids is required"):
             HitTestingService.hit_testing_args_check(args)
 
     def test_hit_testing_args_check_none_query(self):
@@ -721,7 +724,7 @@ class TestHitTestingServiceHitTestingArgsCheck:
         args = {"query": None}
 
         # Act & Assert
-        with pytest.raises(ValueError, match="Query is required and cannot exceed 250 characters"):
+        with pytest.raises(ValueError, match="Query or attachment_ids is required"):
             HitTestingService.hit_testing_args_check(args)
 
     def test_hit_testing_args_check_too_long_query(self):
@@ -734,7 +737,7 @@ class TestHitTestingServiceHitTestingArgsCheck:
         args = {"query": "a" * 251}
 
         # Act & Assert
-        with pytest.raises(ValueError, match="Query is required and cannot exceed 250 characters"):
+        with pytest.raises(ValueError, match="Query cannot exceed 250 characters"):
             HitTestingService.hit_testing_args_check(args)
 
     def test_hit_testing_args_check_exactly_250_characters(self):

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -214,8 +214,12 @@ class TestHitTestingServiceRetrieve:
             "score_threshold_enabled": True,
             "score_threshold": 0.7,
             "weights": {
-                "vector_setting": {"vector_weight": 0.5, "embedding_provider_name": "openai", "embedding_model_name": "text-embedding-3-small"},
-                "keyword_setting": {"keyword_weight": 0.5}
+                "vector_setting": {
+                    "vector_weight": 0.5,
+                    "embedding_provider_name": "openai",
+                    "embedding_model_name": "text-embedding-3-small",
+                },
+                "keyword_setting": {"keyword_weight": 0.5},
             },
         }
         external_retrieval_model = {}

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -32,7 +32,7 @@ class HitTestingTestDataFactory:
         dataset_id: str = "dataset-123",
         tenant_id: str = "tenant-123",
         provider: str = "vendor",
-        retrieval_model: dict[str, Any] | None = None,
+        retrieval_model: dict[str, Any] | str | None = None,
         **kwargs,
     ) -> Mock:
         """
@@ -513,6 +513,38 @@ class TestHitTestingServiceRetrieve:
 
             call_kwargs = mock_retrieve.call_args[1]
             assert call_kwargs["score_threshold"] == 0.0
+
+    def test_retrieve_ignores_non_dict_dataset_retrieval_model_when_request_model_is_provided(self, mock_db_session):
+        dataset = HitTestingTestDataFactory.create_dataset_mock(provider="external", retrieval_model="external-config")
+        account = HitTestingTestDataFactory.create_user_mock()
+        query = "test query"
+        retrieval_model = {
+            "search_method": RetrievalMethod.KEYWORD_SEARCH,
+            "reranking_enable": False,
+            "top_k": 6,
+            "score_threshold_enabled": False,
+        }
+        external_retrieval_model = {}
+
+        documents = [HitTestingTestDataFactory.create_document_mock()]
+        mock_records = [HitTestingTestDataFactory.create_retrieval_record_mock()]
+
+        with (
+            patch("services.hit_testing_service.RetrievalService.retrieve", autospec=True) as mock_retrieve,
+            patch(
+                "services.hit_testing_service.RetrievalService.format_retrieval_documents", autospec=True
+            ) as mock_format,
+            patch("services.hit_testing_service.time.perf_counter", autospec=True) as mock_perf_counter,
+        ):
+            mock_perf_counter.side_effect = [0.0, 0.1]
+            mock_retrieve.return_value = documents
+            mock_format.return_value = mock_records
+
+            HitTestingService.retrieve(dataset, query, account, retrieval_model, external_retrieval_model)
+
+            call_kwargs = mock_retrieve.call_args[1]
+            assert call_kwargs["retrieval_method"] == RetrievalMethod.KEYWORD_SEARCH
+            assert call_kwargs["top_k"] == 6
 
 
 class TestHitTestingServiceExternalRetrieve:


### PR DESCRIPTION
Related to #31497.

This PR refactors the HitTesting flow to pass the Pydantic `RetrievalModel` instead of dictionaries, cleaning up multiple `.get()` calls and improving type safety in the controller and service layers.

### Key Changes
1. **Controller Layer**: Updated `HitTestingBase.parse_args` to return a validated `HitTestingPayload` object instead of immediately dumping it back to a dictionary.
2. **Service Layer**: Modified `HitTestingService.retrieve` to properly type-hint and handle `RetrievalModel` directly. It now performs a smart merge of default dataset retrieval settings with the provided input before Pydantic validation, ensuring robustness against partial dictionaries.
3. **Tests**: Fixed several legacy unit tests in `tests/unit_tests/services/hit_service.py` that were providing invalid mock data structures (e.g., using `field` instead of `name` in metadata conditions, and providing incorrect weight schemas) which were previously silently ignored by the loose `.get()` dict lookups.