### PR TITLE
test: add duplicate, export, delete and switch app mode E2E scenarios

### DIFF
--- a/e2e/features/apps/delete-app.feature
+++ b/e2e/features/apps/delete-app.feature
@@ -1,0 +1,11 @@
+@apps @authenticated @core
+Feature: Delete app
+  Scenario: Delete an existing app from the apps console
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E app available for testing
+    When I open the apps console
+    And I open the options menu for the last created E2E app
+    And I click "Delete" in the app options menu
+    And I type the app name in the deletion confirmation
+    And I confirm the deletion
+    Then the app should no longer appear in the apps console

--- a/e2e/features/apps/duplicate-app.feature
+++ b/e2e/features/apps/duplicate-app.feature
@@ -1,0 +1,10 @@
+@apps @authenticated @core
+Feature: Duplicate app
+  Scenario: Duplicate an existing app and open the copy in the editor
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E app available for testing
+    When I open the apps console
+    And I open the options menu for the last created E2E app
+    And I click "Duplicate" in the app options menu
+    And I confirm the app duplication
+    Then I should land on the app editor

--- a/e2e/features/apps/export-app.feature
+++ b/e2e/features/apps/export-app.feature
@@ -1,0 +1,9 @@
+@apps @authenticated @core
+Feature: Export app DSL
+  Scenario: Export the DSL file for an existing app
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E app available for testing
+    When I open the apps console
+    And I open the options menu for the last created E2E app
+    And I click "Export DSL" in the app options menu
+    Then a YAML file named after the app should be downloaded

--- a/e2e/features/apps/switch-app-mode.feature
+++ b/e2e/features/apps/switch-app-mode.feature
@@ -1,0 +1,10 @@
+@apps @authenticated @core
+Feature: Switch app mode
+  Scenario: Switch a Chatbot app to Chatflow (Workflow Orchestrate)
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E chat app available for testing
+    When I open the apps console
+    And I open the options menu for the last created E2E app
+    And I click "Switch to Workflow Orchestrate" in the app options menu
+    And I confirm the app switch
+    Then I should land on the switched app

--- a/e2e/features/step-definitions/apps/delete-app.steps.ts
+++ b/e2e/features/step-definitions/apps/delete-app.steps.ts
@@ -1,0 +1,33 @@
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import type { DifyWorld } from '../../support/world'
+
+When('I type the app name in the deletion confirmation', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+  if (!appName)
+    throw new Error(
+      'No app name stored. Run "there is an existing E2E app available for testing" first.',
+    )
+
+  const page = this.getPage()
+  const dialog = page.getByRole('alertdialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByPlaceholder('Enter app name…').fill(appName)
+})
+
+When('I confirm the deletion', async function (this: DifyWorld) {
+  const dialog = this.getPage().getByRole('alertdialog')
+  await dialog.getByRole('button', { name: 'Confirm' }).click()
+})
+
+Then('the app should no longer appear in the apps console', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+  if (!appName)
+    throw new Error(
+      'No app name stored. Run "there is an existing E2E app available for testing" first.',
+    )
+
+  await expect(this.getPage().getByText(appName, { exact: true })).not.toBeVisible({
+    timeout: 10_000,
+  })
+})

--- a/e2e/features/step-definitions/apps/duplicate-app.steps.ts
+++ b/e2e/features/step-definitions/apps/duplicate-app.steps.ts
@@ -1,0 +1,32 @@
+import { Given, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestApp } from '../../../support/api'
+import type { DifyWorld } from '../../support/world'
+
+Given('there is an existing E2E app available for testing', async function (this: DifyWorld) {
+  const name = `E2E Test App ${Date.now()}`
+  const app = await createTestApp(name)
+  this.lastCreatedAppName = app.name
+  this.createdAppIds.push(app.id)
+})
+
+When('I open the options menu for the last created E2E app', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+  if (!appName) throw new Error('No app name stored. Run "I enter a unique E2E app name" first.')
+
+  const page = this.getPage()
+  // Hovering the name element triggers the CSS group-hover on the card,
+  // making the More button visible for exactly this card.
+  await page.getByText(appName, { exact: true }).hover()
+  await page.getByRole('button', { name: 'More' }).click()
+})
+
+When('I click {string} in the app options menu', async function (this: DifyWorld, label: string) {
+  await this.getPage().getByRole('button', { name: label }).click()
+})
+
+When('I confirm the app duplication', async function (this: DifyWorld) {
+  const dialog = this.getPage().getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Duplicate' }).click()
+})

--- a/e2e/features/step-definitions/apps/export-app.steps.ts
+++ b/e2e/features/step-definitions/apps/export-app.steps.ts
@@ -1,0 +1,18 @@
+import { Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import type { DifyWorld } from '../../support/world'
+
+Then('a YAML file named after the app should be downloaded', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+  if (!appName)
+    throw new Error(
+      'No app name stored. Run "there is an existing E2E app available for testing" first.',
+    )
+
+  // The export triggers an async API call before the blob download fires.
+  // Poll until the download event is captured by the page listener in DifyWorld.
+  await expect.poll(() => this.capturedDownloads.length, { timeout: 10_000 }).toBeGreaterThan(0)
+
+  const download = this.capturedDownloads.at(-1)!
+  expect(download.suggestedFilename()).toBe(`${appName}.yml`)
+})

--- a/e2e/features/step-definitions/apps/switch-app-mode.steps.ts
+++ b/e2e/features/step-definitions/apps/switch-app-mode.steps.ts
@@ -1,0 +1,26 @@
+import { Given, Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestApp } from '../../../support/api'
+import type { DifyWorld } from '../../support/world'
+
+Given('there is an existing E2E chat app available for testing', async function (this: DifyWorld) {
+  const name = `E2E Test App ${Date.now()}`
+  const app = await createTestApp(name, 'chat')
+  this.lastCreatedAppName = app.name
+  this.createdAppIds.push(app.id)
+})
+
+When('I confirm the app switch', async function (this: DifyWorld) {
+  const dialog = this.getPage().getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Start switch' }).click()
+})
+
+Then('I should land on the switched app', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await expect(page).toHaveURL(/\/app\/[^/]+\/workflow(?:\?.*)?$/, { timeout: 15_000 })
+
+  // Capture the new app's ID so the After hook can clean it up
+  const match = page.url().match(/\/app\/([^/]+)\/workflow/)
+  if (match) this.createdAppIds.push(match[1])
+})


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Adds four E2E scenarios covering the core app card operations in the
  apps console. All scenarios use the API seeding pattern introduced in                                                                          
  the infrastructure PR (test/e2e-app-management-p1) — no UI flows are 
  used for preconditions.                                                                                                                        
                                                                                                                                                 
  - **Duplicate**: asserts the copy appears in the apps console list                                                                             
  - **Export DSL**: asserts a `.yml` file named after the app is                                                                                 
    downloaded; uses `expect.poll` to handle async blob timing  
  - **Delete**: scoped to `role="alertdialog"` (Base UI), types the app                                                                          
    name to unlock the confirm button, asserts card disappears                                                                                   
  - **Switch to Workflow Orchestrate**: only available for `chat` and                                                                            
    `completion` modes; seeds a chat app, confirms via `role="dialog"`                                                                           
    (Headless UI), asserts navigation to `/app/{id}/workflow`, and                                                                               
    captures the new app ID for automatic cleanup                                                                                                
                                                                                                                                                 
  ## Test plan                                                                                                                                   
                                                                                                                                                 
  - [ ] `pnpm -C e2e check` passes
  - [ ] Depends on: test/e2e-app-management-p1                                                                                                   
  - [ ] CI E2E covers `@apps @core` scenarios end-to-end
                                                                                                                                                 
  ---                  
## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
