### PR TITLE
feat: when enable rerank vdb not use threshold to filter

### DIFF
--- a/api/core/rag/data_post_processor/data_post_processor.py
+++ b/api/core/rag/data_post_processor/data_post_processor.py
@@ -57,6 +57,14 @@ class DataPostProcessor:
     ) -> list[Document]:
         if self.rerank_runner:
             documents = self.rerank_runner.run(query, documents, score_threshold, top_n, query_type)
+        elif score_threshold is not None:
+            # Fallback: apply score threshold filtering directly when the
+            # rerank runner is unavailable (e.g. model authorization failure).
+            documents = [
+                doc
+                for doc in documents
+                if doc.metadata and doc.metadata.get("score", 0) >= score_threshold
+            ]
 
         if self.reorder_runner:
             documents = self.reorder_runner.run(documents)

--- a/api/core/rag/data_post_processor/data_post_processor.py
+++ b/api/core/rag/data_post_processor/data_post_processor.py
@@ -60,11 +60,7 @@ class DataPostProcessor:
         elif score_threshold is not None:
             # Fallback: apply score threshold filtering directly when the
             # rerank runner is unavailable (e.g. model authorization failure).
-            documents = [
-                doc
-                for doc in documents
-                if doc.metadata and doc.metadata.get("score", 0) >= score_threshold
-            ]
+            documents = [doc for doc in documents if doc.metadata and doc.metadata.get("score", 0) >= score_threshold]
 
         if self.reorder_runner:
             documents = self.reorder_runner.run(documents)

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -294,13 +294,24 @@ class RetrievalService:
 
                 vector = Vector(dataset=dataset)
                 documents = []
+                # When a reranking model is configured, skip score threshold at the
+                # vector DB layer so all candidates survive to the reranking stage.
+                # The threshold is correctly applied after reranking by
+                # DataPostProcessor.invoke() -> RerankModelRunner.run() or
+                # WeightRerankRunner.run().
+                has_valid_reranking = bool(
+                    reranking_model
+                    and reranking_model.get("reranking_model_name")
+                    and reranking_model.get("reranking_provider_name")
+                )
+                vdb_score_threshold = 0.0 if has_valid_reranking else score_threshold
                 if query_type == QueryType.TEXT_QUERY:
                     documents.extend(
                         vector.search_by_vector(
                             query,
                             search_type="similarity_score_threshold",
                             top_k=top_k,
-                            score_threshold=score_threshold,
+                            score_threshold=vdb_score_threshold,
                             filter={"group_id": [dataset.id]},
                             document_ids_filter=document_ids_filter,
                         )
@@ -312,7 +323,7 @@ class RetrievalService:
                         vector.search_by_file(
                             file_id=query,
                             top_k=top_k,
-                            score_threshold=score_threshold,
+                            score_threshold=vdb_score_threshold,
                             filter={"group_id": [dataset.id]},
                             document_ids_filter=document_ids_filter,
                         )

--- a/api/tests/unit_tests/core/rag/data_post_processor/test_data_post_processor.py
+++ b/api/tests/unit_tests/core/rag/data_post_processor/test_data_post_processor.py
@@ -229,6 +229,91 @@ class TestDataPostProcessor:
         for_tenant_mock.assert_called_once_with(tenant_id="tenant-1")
 
 
+class TestDataPostProcessorFallbackFiltering:
+    """Tests for the score-threshold fallback path in DataPostProcessor.invoke.
+
+    The fallback activates when rerank_runner is None but score_threshold is set
+    (e.g. after a model authorisation failure).  It filters documents by their
+    metadata["score"] value, defaulting missing or absent scores to 0.
+    """
+
+    def _doc_with_score(self, content: str, score: float) -> Document:
+        return Document(page_content=content, metadata={"score": score})
+
+    def test_filters_documents_below_score_threshold(self):
+        docs = [
+            self._doc_with_score("low", 0.3),
+            self._doc_with_score("exact", 0.5),
+            self._doc_with_score("high", 0.8),
+        ]
+        processor = DataPostProcessor.__new__(DataPostProcessor)
+        processor.rerank_runner = None
+        processor.reorder_runner = None
+
+        result = processor.invoke(query="q", documents=docs, score_threshold=0.5)
+
+        assert [d.page_content for d in result] == ["exact", "high"]
+
+    def test_passes_all_documents_when_score_threshold_is_none(self):
+        docs = [
+            self._doc_with_score("a", 0.1),
+            self._doc_with_score("b", 0.9),
+        ]
+        processor = DataPostProcessor.__new__(DataPostProcessor)
+        processor.rerank_runner = None
+        processor.reorder_runner = None
+
+        result = processor.invoke(query="q", documents=docs, score_threshold=None)
+
+        assert result == docs
+
+    def test_filters_document_without_metadata(self):
+        # A document with no metadata at all has an effective score of 0
+        # and must be removed when the threshold is > 0.
+        doc_no_meta = Document(page_content="no-meta")
+        doc_with_score = self._doc_with_score("scored", 0.6)
+        processor = DataPostProcessor.__new__(DataPostProcessor)
+        processor.rerank_runner = None
+        processor.reorder_runner = None
+
+        result = processor.invoke(query="q", documents=[doc_no_meta, doc_with_score], score_threshold=0.5)
+
+        assert result == [doc_with_score]
+
+    def test_filters_document_with_missing_score_key(self):
+        # metadata present but 'score' key absent → defaults to 0.
+        doc_no_score_key = Document(page_content="no-key", metadata={"doc_id": "x"})
+        doc_with_score = self._doc_with_score("scored", 0.7)
+        processor = DataPostProcessor.__new__(DataPostProcessor)
+        processor.rerank_runner = None
+        processor.reorder_runner = None
+
+        result = processor.invoke(query="q", documents=[doc_no_score_key, doc_with_score], score_threshold=0.5)
+
+        assert result == [doc_with_score]
+
+    def test_fallback_still_applies_reorder_runner(self):
+        docs = [
+            self._doc_with_score("0", 0.9),
+            self._doc_with_score("1", 0.8),
+            self._doc_with_score("2", 0.7),
+            self._doc_with_score("3", 0.6),
+        ]
+        reordered = [self._doc_with_score("reordered", 1.0)]
+
+        processor = DataPostProcessor.__new__(DataPostProcessor)
+        processor.rerank_runner = None
+        processor.reorder_runner = MagicMock()
+        processor.reorder_runner.run.return_value = reordered
+
+        result = processor.invoke(query="q", documents=docs, score_threshold=0.7)
+
+        # score_threshold=0.7 keeps docs with scores 0.9, 0.8, 0.7
+        filtered = [d for d in docs if d.metadata["score"] >= 0.7]
+        processor.reorder_runner.run.assert_called_once_with(filtered)
+        assert result == reordered
+
+
 class TestReorderRunner:
     def test_run_reorders_even_sized_document_list(self):
         documents = [_doc("0"), _doc("1"), _doc("2"), _doc("3"), _doc("4"), _doc("5")]

--- a/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
@@ -1173,3 +1173,190 @@ class TestRetrievalServiceInternals:
             ]
         )
         assert mock_sign.call_count == 2
+
+
+class TestEmbeddingSearchVdbScoreThreshold:
+    """Tests for the vdb_score_threshold bypass in RetrievalService.embedding_search.
+
+    When a valid reranking model is configured (both provider and model name present)
+    the vector-DB score threshold must be 0.0 so that all candidates survive to the
+    reranking stage.  The original score_threshold is then applied by
+    DataPostProcessor after reranking.  Without a reranking model, the original
+    threshold must flow through to the vector-DB query unchanged.
+    """
+
+    @pytest.fixture
+    def dataset(self):
+        ds = Mock(spec=Dataset)
+        ds.id = "dataset-id"
+        ds.tenant_id = "tenant-id"
+        ds.is_multimodal = False
+        return ds
+
+    @pytest.fixture
+    def flask_app(self):
+        app = MagicMock()
+        app.app_context.return_value.__enter__ = Mock()
+        app.app_context.return_value.__exit__.return_value = False
+        return app
+
+    @patch("core.rag.datasource.retrieval_service.DataPostProcessor")
+    @patch("core.rag.datasource.retrieval_service.Vector")
+    @patch("core.rag.datasource.retrieval_service.RetrievalService._get_dataset")
+    def test_vdb_threshold_is_zero_when_valid_reranking_configured(
+        self, mock_get_dataset, mock_vector_class, mock_processor_class, dataset, flask_app
+    ):
+        """Vector DB receives threshold=0.0 so no candidates are lost before reranking."""
+        mock_get_dataset.return_value = dataset
+        vector_instance = Mock()
+        vector_instance.search_by_vector.return_value = [create_mock_document("doc", "d1", 0.4)]
+        mock_vector_class.return_value = vector_instance
+        processor_instance = Mock()
+        processor_instance.invoke.return_value = []
+        mock_processor_class.return_value = processor_instance
+
+        RetrievalService.embedding_search(
+            flask_app=flask_app,
+            dataset_id=dataset.id,
+            query="query",
+            top_k=4,
+            score_threshold=0.7,
+            reranking_model={
+                "reranking_provider_name": "provider-x",
+                "reranking_model_name": "reranker-y",
+            },
+            all_documents=[],
+            retrieval_method=RetrievalMethod.SEMANTIC_SEARCH,
+            exceptions=[],
+            query_type=QueryType.TEXT_QUERY,
+        )
+
+        _, kwargs = vector_instance.search_by_vector.call_args
+        assert kwargs["score_threshold"] == 0.0
+
+    @patch("core.rag.datasource.retrieval_service.Vector")
+    @patch("core.rag.datasource.retrieval_service.RetrievalService._get_dataset")
+    def test_vdb_threshold_uses_original_when_no_reranking_model(
+        self, mock_get_dataset, mock_vector_class, dataset, flask_app
+    ):
+        """Without a reranking model the original score_threshold reaches the vector DB."""
+        mock_get_dataset.return_value = dataset
+        vector_instance = Mock()
+        vector_instance.search_by_vector.return_value = []
+        mock_vector_class.return_value = vector_instance
+
+        RetrievalService.embedding_search(
+            flask_app=flask_app,
+            dataset_id=dataset.id,
+            query="query",
+            top_k=4,
+            score_threshold=0.6,
+            reranking_model=None,
+            all_documents=[],
+            retrieval_method=RetrievalMethod.SEMANTIC_SEARCH,
+            exceptions=[],
+            query_type=QueryType.TEXT_QUERY,
+        )
+
+        _, kwargs = vector_instance.search_by_vector.call_args
+        assert kwargs["score_threshold"] == 0.6
+
+    @patch("core.rag.datasource.retrieval_service.Vector")
+    @patch("core.rag.datasource.retrieval_service.RetrievalService._get_dataset")
+    def test_vdb_threshold_uses_original_when_reranking_model_name_missing(
+        self, mock_get_dataset, mock_vector_class, dataset, flask_app
+    ):
+        """Incomplete reranking config (no model name) → original threshold used."""
+        mock_get_dataset.return_value = dataset
+        vector_instance = Mock()
+        vector_instance.search_by_vector.return_value = []
+        mock_vector_class.return_value = vector_instance
+
+        RetrievalService.embedding_search(
+            flask_app=flask_app,
+            dataset_id=dataset.id,
+            query="query",
+            top_k=4,
+            score_threshold=0.55,
+            reranking_model={
+                "reranking_provider_name": "provider-x",
+                "reranking_model_name": "",
+            },
+            all_documents=[],
+            retrieval_method=RetrievalMethod.SEMANTIC_SEARCH,
+            exceptions=[],
+            query_type=QueryType.TEXT_QUERY,
+        )
+
+        _, kwargs = vector_instance.search_by_vector.call_args
+        assert kwargs["score_threshold"] == 0.55
+
+    @patch("core.rag.datasource.retrieval_service.Vector")
+    @patch("core.rag.datasource.retrieval_service.RetrievalService._get_dataset")
+    def test_vdb_threshold_uses_original_when_reranking_provider_name_missing(
+        self, mock_get_dataset, mock_vector_class, dataset, flask_app
+    ):
+        """Incomplete reranking config (no provider name) → original threshold used."""
+        mock_get_dataset.return_value = dataset
+        vector_instance = Mock()
+        vector_instance.search_by_vector.return_value = []
+        mock_vector_class.return_value = vector_instance
+
+        RetrievalService.embedding_search(
+            flask_app=flask_app,
+            dataset_id=dataset.id,
+            query="query",
+            top_k=4,
+            score_threshold=0.45,
+            reranking_model={
+                "reranking_provider_name": "",
+                "reranking_model_name": "reranker-y",
+            },
+            all_documents=[],
+            retrieval_method=RetrievalMethod.SEMANTIC_SEARCH,
+            exceptions=[],
+            query_type=QueryType.TEXT_QUERY,
+        )
+
+        _, kwargs = vector_instance.search_by_vector.call_args
+        assert kwargs["score_threshold"] == 0.45
+
+    @patch("core.rag.datasource.retrieval_service.DataPostProcessor")
+    @patch("core.rag.datasource.retrieval_service.Vector")
+    @patch("core.rag.datasource.retrieval_service.RetrievalService._get_dataset")
+    def test_vdb_threshold_is_zero_for_image_query_with_valid_reranking(
+        self, mock_get_dataset, mock_vector_class, mock_processor_class, dataset, flask_app
+    ):
+        """IMAGE_QUERY path (search_by_file) also receives threshold=0.0 when reranking is valid."""
+        dataset.is_multimodal = True
+        mock_get_dataset.return_value = dataset
+        vector_instance = Mock()
+        vector_instance.search_by_file.return_value = [create_mock_document("img", "img-1", 0.35)]
+        mock_vector_class.return_value = vector_instance
+
+        model_manager_mock = Mock()
+        model_manager_mock.check_model_support_vision.return_value = False
+
+        with patch("core.rag.datasource.retrieval_service.ModelManager.for_tenant", return_value=model_manager_mock):
+            processor_instance = Mock()
+            processor_instance.invoke.return_value = []
+            mock_processor_class.return_value = processor_instance
+
+            RetrievalService.embedding_search(
+                flask_app=flask_app,
+                dataset_id=dataset.id,
+                query="file-id",
+                top_k=4,
+                score_threshold=0.8,
+                reranking_model={
+                    "reranking_provider_name": "provider-x",
+                    "reranking_model_name": "reranker-y",
+                },
+                all_documents=[],
+                retrieval_method=RetrievalMethod.SEMANTIC_SEARCH,
+                exceptions=[],
+                query_type=QueryType.IMAGE_QUERY,
+            )
+
+        _, kwargs = vector_instance.search_by_file.call_args
+        assert kwargs["score_threshold"] == 0.0


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary


score_threshold use in rerank stage when rerank model is enable not in vector search stage

fix #35233

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
