### PR TITLE
fix(web): set app card dropdown menu to non-modal

### DIFF
--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -208,14 +208,16 @@ vi.mock('@/app/components/base/ui/dropdown-menu', () => {
     DropdownMenu: ({
       children,
       open = false,
+      modal,
       onOpenChange,
     }: {
       children: React.ReactNode
       open?: boolean
+      modal?: boolean
       onOpenChange?: (open: boolean) => void
     }) => (
       <DropdownMenuContext value={{ isOpen: open, setOpen: onOpenChange ?? vi.fn() }}>
-        <div data-testid="dropdown-menu" data-open={open}>
+        <div data-testid="dropdown-menu" data-open={open} data-modal={modal}>
           {children}
         </div>
       </DropdownMenuContext>
@@ -459,6 +461,11 @@ describe('AppCard', () => {
     it('should render operations dropdown menu', () => {
       render(<AppCard app={mockApp} />)
       expect(screen.getByTestId('dropdown-menu')).toBeInTheDocument()
+    })
+
+    it('should render dropdown menu as non-modal', () => {
+      render(<AppCard app={mockApp} />)
+      expect(screen.getByTestId('dropdown-menu')).toHaveAttribute('data-modal', 'false')
     })
 
     it('should show edit option when dropdown menu is opened', async () => {

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -514,7 +514,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh }: AppCardProps) => {
                 )}
               >
                 <div className="mx-1 h-[14px] w-px shrink-0 bg-divider-regular" />
-                <DropdownMenu open={isOperationsMenuOpen} onOpenChange={setIsOperationsMenuOpen}>
+                <DropdownMenu modal={false} open={isOperationsMenuOpen} onOpenChange={setIsOperationsMenuOpen}>
                   <DropdownMenuTrigger
                     aria-label={t('operation.more', { ns: 'common' })}
                     className={cn(


### PR DESCRIPTION
## Summary

- Set `modal={false}` on the app card operations `DropdownMenu` so it no longer traps focus or blocks interaction with elements outside the menu. This is the expected behavior for a lightweight context menu on card lists.
- Updated the dropdown-menu mock in tests to forward the `modal` prop and added a test asserting `modal={false}`.

From Cursor

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Made with [Cursor](https://cursor.com)