### PR TITLE
perf(web): optimize first-screen rendering performance

### DIFF
--- a/web/app/(commonLayout)/layout.tsx
+++ b/web/app/(commonLayout)/layout.tsx
@@ -5,7 +5,6 @@ import InSiteMessageNotification from '@/app/components/app/in-site-message/noti
 import AmplitudeProvider from '@/app/components/base/amplitude'
 import GA, { GaType } from '@/app/components/base/ga'
 import Zendesk from '@/app/components/base/zendesk'
-import GotoAnything from '@/app/components/goto-anything'
 import Header from '@/app/components/header'
 import HeaderWrapper from '@/app/components/header/header-wrapper'
 import ReadmePanel from '@/app/components/plugins/readme-panel'
@@ -13,9 +12,14 @@ import { AppContextProvider } from '@/context/app-context-provider'
 import { EventEmitterContextProvider } from '@/context/event-emitter-provider'
 import { ModalContextProvider } from '@/context/modal-context-provider'
 import { ProviderContextProvider } from '@/context/provider-context-provider'
+import dynamic from '@/next/dynamic'
 import PartnerStack from '../components/billing/partner-stack'
 import Splash from '../components/splash'
 import RoleRouteGuard from './role-route-guard'
+
+const GotoAnything = dynamic(() => import('@/app/components/goto-anything'), {
+  ssr: false,
+})
 
 const Layout = ({ children }: { children: ReactNode }) => {
   return (

--- a/web/app/components/devtools/react-scan/loader.tsx
+++ b/web/app/components/devtools/react-scan/loader.tsx
@@ -9,7 +9,7 @@ export function ReactScanLoader() {
     <Script
       src="//unpkg.com/react-scan/dist/auto.global.js"
       crossOrigin="anonymous"
-      strategy="beforeInteractive"
+      strategy="afterInteractive"
     />
   )
 }

--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -1,15 +1,13 @@
 'use client'
 import type { FC, PropsWithChildren } from 'react'
 import * as React from 'react'
-import { useIsLogin } from '@/service/use-common'
+import { useUserProfile } from '@/service/use-common'
 import Loading from './base/loading'
 
 const Splash: FC<PropsWithChildren> = () => {
-  // would auto redirect to signin page if not logged in
-  const { isLoading, data: loginData } = useIsLogin()
-  const isLoggedIn = loginData?.logged_in
+  const { isPending, data } = useUserProfile()
 
-  if (isLoading || !isLoggedIn) {
+  if (isPending || !data?.profile) {
     return (
       <div className="fixed inset-0 z-9999999 flex h-full items-center justify-center bg-background-body">
         <Loading />


### PR DESCRIPTION
## Summary

Optimize initial page load by reducing redundant main-thread work:

- **Lazy-load GotoAnything**: Convert to `next/dynamic` with `ssr: false` to reduce initial JS bundle size.
- **Deduplicate login-check API call**: Replace `useIsLogin()` in `Splash` with `useUserProfile()` to leverage TanStack Query deduplication, avoiding a redundant `/account/profile` request.
- **Defer react-scan**: Change from `beforeInteractive` to `afterInteractive` to prevent render-blocking in dev mode.