### PR TITLE
fix(web): stop Splash after useUserProfile errors

### DIFF
--- a/web/app/components/__tests__/splash.spec.tsx
+++ b/web/app/components/__tests__/splash.spec.tsx
@@ -1,0 +1,59 @@
+import type { MockedFunction } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useUserProfile } from '@/service/use-common'
+import Splash from '../splash'
+
+vi.mock('@/service/use-common', () => ({
+  useUserProfile: vi.fn(),
+}))
+
+const mockUseUserProfile = useUserProfile as MockedFunction<typeof useUserProfile>
+
+describe('Splash', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render the loading indicator while the profile query is pending', () => {
+    mockUseUserProfile.mockReturnValue({
+      isPending: true,
+      isError: false,
+      data: undefined,
+    } as ReturnType<typeof useUserProfile>)
+
+    render(<Splash />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('should not render the loading indicator when the profile query succeeds', () => {
+    mockUseUserProfile.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        profile: { id: 'user-1' },
+        meta: {
+          currentVersion: '1.13.3',
+          currentEnv: 'DEVELOPMENT',
+        },
+      },
+    } as ReturnType<typeof useUserProfile>)
+
+    render(<Splash />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('should stop rendering the loading indicator when the profile query errors', () => {
+    mockUseUserProfile.mockReturnValue({
+      isPending: false,
+      isError: true,
+      data: undefined,
+      error: new Error('profile request failed'),
+    } as ReturnType<typeof useUserProfile>)
+
+    render(<Splash />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+})

--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -5,7 +5,7 @@ import { useUserProfile } from '@/service/use-common'
 import Loading from './base/loading'
 
 const Splash: FC<PropsWithChildren> = () => {
-  const { isPending, isError, data } = useUserProfile()
+  const { isPending } = useUserProfile()
 
   if (isPending) {
     return (
@@ -14,9 +14,6 @@ const Splash: FC<PropsWithChildren> = () => {
       </div>
     )
   }
-
-  if (isError || !data?.profile)
-    return null
 
   return null
 }

--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -5,15 +5,19 @@ import { useUserProfile } from '@/service/use-common'
 import Loading from './base/loading'
 
 const Splash: FC<PropsWithChildren> = () => {
-  const { isPending, data } = useUserProfile()
+  const { isPending, isError, data } = useUserProfile()
 
-  if (isPending || !data?.profile) {
+  if (isPending) {
     return (
       <div className="fixed inset-0 z-9999999 flex h-full items-center justify-center bg-background-body">
         <Loading />
       </div>
     )
   }
+
+  if (isError || !data?.profile)
+    return null
+
   return null
 }
 export default React.memo(Splash)


### PR DESCRIPTION
## Summary

Keep the first-screen optimization from #35313, but stop `Splash` from blocking the page after the shared profile query has already failed.

After the migration to `useUserProfile()`, the component still renders the loader whenever `!data?.profile`. In the error case, that means the overlay can remain visible even though the request is no longer pending.

This PR narrows the blocking condition to the actual pending state:
- render the loader while the profile query is pending
- fall through when the query errors or returns no profile payload

That preserves the deduplicated `/account/profile` request while avoiding an indefinite loading state.

## Test plan

- Added `web/app/components/__tests__/splash.spec.tsx`
- Verified the splash renders during the pending state
- Verified the splash disappears when the query succeeds
- Verified the splash also disappears when the query errors
- Ran: `PATH=/tmp/node-v22.22.1-darwin-arm64/bin:$PATH corepack pnpm test app/components/__tests__/splash.spec.tsx`

Fixes #35324
