### PR TITLE
fix: splash keeps rendering when useUserProfile fails

### DIFF
--- a/web/app/components/splash.tsx
+++ b/web/app/components/splash.tsx
@@ -5,9 +5,9 @@ import { useUserProfile } from '@/service/use-common'
 import Loading from './base/loading'
 
 const Splash: FC<PropsWithChildren> = () => {
-  const { isPending, data } = useUserProfile()
+  const { isPending, data, isError } = useUserProfile()
 
-  if (isPending || !data?.profile) {
+  if ((isPending || !data?.profile) && !isError) {
     return (
       <div className="fixed inset-0 z-9999999 flex h-full items-center justify-center bg-background-body">
         <Loading />


### PR DESCRIPTION
Fixes #35324.

The `Splash` component was previously rendering the loading state whenever `isPending || !data?.profile` was true. However, if the `useUserProfile` query failed, `data` would remain undefined, causing the splash screen to stay visible indefinitely.

This PR adds a check for `isError` to ensure the splash screen is dismissed if the profile query fails, allowing the normal error or redirect flow to proceed.