### PR TITLE
fix(inner_api): ensure EndUser lookup is tenant-scoped for non-anonymous users

### DIFF
--- a/api/controllers/inner_api/plugin/wraps.py
+++ b/api/controllers/inner_api/plugin/wraps.py
@@ -42,7 +42,14 @@ def get_user(tenant_id: str, user_id: str | None) -> EndUser:
                     .limit(1)
                 )
             else:
-                user_model = session.get(EndUser, user_id)
+                user_model = session.scalar(
+                    select(EndUser)
+                    .where(
+                        EndUser.id == user_id,
+                        EndUser.tenant_id == tenant_id,
+                    )
+                    .limit(1)
+                )
 
             if not user_model:
                 user_model = EndUser(


### PR DESCRIPTION
Fixes #35323

This PR ensures that when a `user_id` is provided to the plugin inner API, the lookup for the `EndUser` is scoped to the provided `tenant_id`. 

Previously, non-anonymous users were looked up using `session.get(EndUser, user_id)`, which ignores tenant boundaries. This could allow resolving an `EndUser` from a different tenant if their ID was known. 

The fix changes the lookup to use a filtered query:
```python
user_model = session.scalar(
    select(EndUser)
    .where(
        EndUser.id == user_id,
        EndUser.tenant_id == tenant_id,
    )
    .limit(1)
)
```

This aligns the non-anonymous path with the existing anonymous path and maintains strict tenant isolation.