### PR TITLE
fix: guard chat file preview rendering when mime type is missing

### DIFF
--- a/web/app/components/base/file-uploader/file-uploader-in-chat-input/__tests__/file-item.spec.tsx
+++ b/web/app/components/base/file-uploader/file-uploader-in-chat-input/__tests__/file-item.spec.tsx
@@ -222,6 +222,21 @@ describe('FileItem (chat-input)', () => {
     expect(document.querySelector('audio')).not.toBeInTheDocument()
   })
 
+  it('should not throw when file type is missing', () => {
+    expect(() => {
+      render(
+        <FileItem
+          file={createFile({
+            name: 'generated.png',
+            type: undefined as unknown as string,
+            supportFileType: 'document',
+          })}
+          canPreview
+        />,
+      )
+    }).not.toThrow()
+  })
+
   it('should close video preview', () => {
     render(
       <FileItem

--- a/web/app/components/base/file-uploader/file-uploader-in-chat-input/file-item.tsx
+++ b/web/app/components/base/file-uploader/file-uploader-in-chat-input/file-item.tsx
@@ -36,6 +36,7 @@ const FileItem = ({
   const [previewUrl, setPreviewUrl] = useState('')
   const ext = getFileExtension(name, type, isRemote)
   const uploadError = progress === -1
+  const [typeCategory = '', typeSubtype = ''] = type?.split('/') ?? []
 
   let tmp_preview_url = url || base64Url
   if (!tmp_preview_url && file?.originalFile)
@@ -121,7 +122,7 @@ const FileItem = ({
         </div>
       </div>
       {
-        type.split('/')[0] === 'audio' && canPreview && previewUrl && (
+        typeCategory === 'audio' && canPreview && previewUrl && (
           <AudioPreview
             title={name}
             url={previewUrl}
@@ -130,7 +131,7 @@ const FileItem = ({
         )
       }
       {
-        type.split('/')[0] === 'video' && canPreview && previewUrl && (
+        typeCategory === 'video' && canPreview && previewUrl && (
           <VideoPreview
             title={name}
             url={previewUrl}
@@ -139,7 +140,7 @@ const FileItem = ({
         )
       }
       {
-        type.split('/')[1] === 'pdf' && canPreview && previewUrl && (
+        typeSubtype === 'pdf' && canPreview && previewUrl && (
           <PdfPreview url={previewUrl} onCancel={() => { setPreviewUrl('') }} />
         )
       }


### PR DESCRIPTION
## Summary
This PR prevents chat file preview rendering from crashing when attachment payloads arrive without a MIME type.

## Issues
- fixes #33122

## Verification
- added a regression test for missing type handling

## Notes
I attempted to run the relevant frontend tests locally, but the current environment is missing the vite-plus native binding required by the test runner.