### PR TITLE
fix: preserve citation feature when converting workflows

### DIFF
--- a/api/services/workflow/workflow_converter.py
+++ b/api/services/workflow/workflow_converter.py
@@ -180,6 +180,7 @@ class WorkflowConverter:
                     "text_to_speech": app_model_config_dict.get("text_to_speech"),
                     "file_upload": app_model_config_dict.get("file_upload"),
                     "sensitive_word_avoidance": app_model_config_dict.get("sensitive_word_avoidance"),
+                    "retriever_resource": app_model_config_dict.get("retriever_resource"),
                 }
             case AppMode.ADVANCED_CHAT:
                 answer_node = self._convert_to_answer_node()

--- a/api/tests/unit_tests/services/workflow/test_workflow_converter_additional.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_converter_additional.py
@@ -536,6 +536,7 @@ def test_convert_app_model_config_to_workflow_should_build_workflow_mode_with_en
             "text_to_speech": {"enabled": False},
             "file_upload": {"enabled": False},
             "sensitive_word_avoidance": {"enabled": False},
+            "retriever_resource": {"enabled": True},
         },
     )
 
@@ -581,7 +582,8 @@ def test_convert_app_model_config_to_workflow_should_build_workflow_mode_with_en
     assert node_ids == ["start", "llm", "end"]
 
     features = json.loads(workflow.features)
-    assert set(features.keys()) == {"text_to_speech", "file_upload", "sensitive_word_avoidance"}
+    assert features["retriever_resource"] == {"enabled": True}
+    assert set(features.keys()) == {"text_to_speech", "file_upload", "sensitive_word_avoidance", "retriever_resource"}
 
 
 def test_convert_to_app_config_should_route_to_correct_manager(


### PR DESCRIPTION
## Summary
This PR preserves the retriever citation feature when converting workflow/chatflow apps so citation metadata continues to appear after publish.

## Issues
- fixes #27603

## Verification
- python3 -m py_compile passed
- targeted workflow converter tests passed locally