### PR TITLE
fix: disable unused kb rerank settings for single dataset

### DIFF
--- a/web/app/components/app/configuration/dataset-config/params-config/__tests__/config-content.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/__tests__/config-content.spec.tsx
@@ -18,11 +18,13 @@ vi.mock('@/app/components/header/account-setting/model-provider-page/model-selec
   type Props = {
     defaultModel?: { provider: string, model: string }
     onSelect?: (model: { provider: string, model: string }) => void
+    readonly?: boolean
   }
 
-  const MockModelSelector = ({ defaultModel, onSelect }: Props) => (
+  const MockModelSelector = ({ defaultModel, onSelect, readonly }: Props) => (
     <button
       type="button"
+      disabled={readonly}
       onClick={() => onSelect?.(defaultModel ?? { provider: 'mock-provider', model: 'mock-model' })}
     >
       Mock ModelSelector
@@ -227,6 +229,17 @@ describe('ConfigContent', () => {
             search_method: RETRIEVE_METHOD.semantic,
           },
         }),
+        createDataset({
+          id: 'dataset-id-2',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
       ]
 
       // Act
@@ -269,6 +282,18 @@ describe('ConfigContent', () => {
       })
       const selectedDatasets: DataSet[] = [
         createDataset({
+          id: 'dataset-id-2',
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+        createDataset({
+          id: 'dataset-id-2',
           indexing_technique: 'high_quality' as IndexingType,
           provider: 'dify',
           embedding_model: 'text-embedding',
@@ -319,6 +344,16 @@ describe('ConfigContent', () => {
             search_method: RETRIEVE_METHOD.semantic,
           },
         }),
+        createDataset({
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
       ]
 
       // Act
@@ -358,6 +393,17 @@ describe('ConfigContent', () => {
             search_method: RETRIEVE_METHOD.semantic,
           },
         }),
+        createDataset({
+          id: 'dataset-id-2',
+          indexing_technique: 'economy' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
       ]
 
       // Act
@@ -377,6 +423,70 @@ describe('ConfigContent', () => {
           reranking_enable: true,
         }),
       )
+    })
+
+    it('should disable weighted score interactions when only one dataset is selected', () => {
+      const onChange = vi.fn<(configs: DatasetConfigs, isRetrievalModeChange?: boolean) => void>()
+      const datasetConfigs = createDatasetConfigs({
+        reranking_mode: RerankingModeEnum.WeightedScore,
+      })
+      const selectedDatasets: DataSet[] = [
+        createDataset({
+          indexing_technique: 'high_quality' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+      ]
+
+      render(
+        <ConfigContent
+          datasetConfigs={datasetConfigs}
+          onChange={onChange}
+          selectedDatasets={selectedDatasets}
+        />,
+      )
+
+      expect(screen.getByLabelText('dataset.weightedScore.semantic')).toBeDisabled()
+    })
+
+    it('should disable rerank toggle and model selector when only one dataset is selected', () => {
+      const onChange = vi.fn<(configs: DatasetConfigs, isRetrievalModeChange?: boolean) => void>()
+      const datasetConfigs = createDatasetConfigs({
+        reranking_enable: true,
+        reranking_mode: RerankingModeEnum.RerankingModel,
+        reranking_model: {
+          reranking_provider_name: 'provider',
+          reranking_model_name: 'rerank-model',
+        },
+      })
+      const selectedDatasets: DataSet[] = [
+        createDataset({
+          indexing_technique: 'economy' as IndexingType,
+          provider: 'dify',
+          embedding_model: 'text-embedding',
+          embedding_model_provider: 'openai',
+          retrieval_model_dict: {
+            ...baseRetrievalConfig,
+            search_method: RETRIEVE_METHOD.semantic,
+          },
+        }),
+      ]
+
+      render(
+        <ConfigContent
+          datasetConfigs={datasetConfigs}
+          onChange={onChange}
+          selectedDatasets={selectedDatasets}
+        />,
+      )
+
+      expect(screen.getAllByRole('switch')[0]).toHaveAttribute('aria-disabled', 'true')
+      expect(screen.getByRole('button', { name: 'Mock ModelSelector' })).toBeDisabled()
     })
   })
 })

--- a/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/config-content.tsx
@@ -88,6 +88,7 @@ const ConfigContent: FC<Props> = ({
       model_name: datasetConfigs.reranking_model?.reranking_model_name ?? '',
     }
   }, [datasetConfigs.reranking_model])
+  const rerankSettingsDisabled = type === RETRIEVE_TYPE.multiWay && selectedDatasets.length <= 1
 
   const handleParamChange = (key: string, value: number) => {
     if (key === 'top_k') {
@@ -132,6 +133,9 @@ const ConfigContent: FC<Props> = ({
   }
 
   const handleRerankModeChange = (mode: RerankingModeEnum) => {
+    if (rerankSettingsDisabled)
+      return
+
     if (mode === datasetConfigs.reranking_mode)
       return
 
@@ -178,13 +182,16 @@ const ConfigContent: FC<Props> = ({
   }, [datasetConfigs.reranking_enable, canManuallyToggleRerank])
 
   const handleManuallyToggleRerank = useCallback((enable: boolean) => {
+    if (rerankSettingsDisabled)
+      return
+
     if (!currentRerankModel && enable)
       toast.error(t('errorMsg.rerankModelRequired', { ns: 'workflow' }))
     onChange({
       ...datasetConfigs,
       reranking_enable: enable,
     })
-  }, [currentRerankModel, datasetConfigs, onChange])
+  }, [currentRerankModel, datasetConfigs, onChange, rerankSettingsDisabled, t])
 
   return (
     <div>
@@ -238,7 +245,8 @@ const ConfigContent: FC<Props> = ({
                     <div
                       key={option.value}
                       className={cn(
-                        'flex h-8 w-[calc((100%-8px)/2)] cursor-pointer items-center justify-center rounded-lg border border-components-option-card-option-border bg-components-option-card-option-bg system-sm-medium text-text-secondary',
+                        'flex h-8 w-[calc((100%-8px)/2)] items-center justify-center rounded-lg border border-components-option-card-option-border bg-components-option-card-option-bg system-sm-medium text-text-secondary',
+                        rerankSettingsDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                         selectedRerankMode === option.value && 'border-[1.5px] border-components-option-card-option-selected-border bg-components-option-card-option-selected-bg text-text-primary',
                       )}
                       onClick={() => handleRerankModeChange(option.value)}
@@ -269,6 +277,7 @@ const ConfigContent: FC<Props> = ({
                         size="md"
                         checked={showRerankModel ?? false}
                         onCheckedChange={handleManuallyToggleRerank}
+                        disabled={rerankSettingsDisabled}
                       />
                     )
                   }
@@ -298,6 +307,7 @@ const ConfigContent: FC<Props> = ({
                           })
                         }}
                         modelList={rerankModelList}
+                        readonly={rerankSettingsDisabled}
                       />
                     </div>
                   )
@@ -317,6 +327,7 @@ const ConfigContent: FC<Props> = ({
                     ],
                   }}
                   onChange={handleWeightedScoreChange}
+                  readonly={rerankSettingsDisabled}
                 />
                 <TopKItem
                   value={datasetConfigs.top_k}


### PR DESCRIPTION
## Summary
This PR disables rerank settings that do not apply when only a single dataset is selected, while keeping the effective retrieval controls enabled.

## Issues
- fixes #30916

## Verification
- targeted frontend test passed locally
- eslint, tsgo --noEmit, and knip commit checks passed