### PR TITLE
fix(web): keep workflow panel operator anchor mounted during menu close animation

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/node-control.tsx
+++ b/web/app/components/workflow/nodes/_base/components/node-control.tsx
@@ -1,15 +1,12 @@
 import type { FC } from 'react'
 import type { Node } from '../../../types'
+import { cn } from '@langgenius/dify-ui/cn'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@langgenius/dify-ui/tooltip'
-import {
-  memo,
-  useCallback,
-  useState,
-} from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Stop,
@@ -31,23 +28,19 @@ const NodeControl: FC<NodeControlProps> = ({
   pluginInstallLocked,
 }) => {
   const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
   const { handleNodeSelect } = useNodesInteractions()
   const workflowStore = useWorkflowStore()
   const isSingleRunning = data._singleRunningStatus === NodeRunningStatus.Running
-  const handleOpenChange = useCallback((newOpen: boolean) => {
-    setOpen(newOpen)
-  }, [])
 
   const isChildNode = !!(data.isInIteration || data.isInLoop)
   return (
     <div
-      className={`
-      absolute -top-7 right-0 hidden h-7 pb-1
-      ${!pluginInstallLocked && 'group-hover:flex'}
-      ${data.selected && 'flex!'}
-      ${open && 'flex!'}
-      `}
+      className={cn(
+        'invisible absolute -top-7 right-0 flex h-7 pb-1',
+        !pluginInstallLocked && 'group-hover:visible',
+        data.selected && 'visible',
+        'has-[[data-popup-open]]:visible',
+      )}
     >
       <div
         className="nodrag nopan nowheel flex h-6 items-center rounded-lg border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg px-0.5 text-text-tertiary shadow-md backdrop-blur-[5px]"
@@ -93,7 +86,6 @@ const NodeControl: FC<NodeControlProps> = ({
           id={id}
           data={data}
           offset={0}
-          onOpenChange={handleOpenChange}
           triggerClassName="w-5! h-5!"
         />
       </div>

--- a/web/app/components/workflow/nodes/_base/components/panel-operator/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/panel-operator/index.tsx
@@ -20,7 +20,6 @@ type PanelOperatorProps = {
   triggerClassName?: string
   offset?: OffsetOptions | number
   onOpenChange?: (open: boolean) => void
-  inNode?: boolean
   showHelpLink?: boolean
 }
 const PanelOperator = ({
@@ -45,15 +44,14 @@ const PanelOperator = ({
     ? offset.crossAxis
     : 0
 
-  const handleOpenChange = useCallback((newOpen: boolean) => {
-    setOpen(newOpen)
-
-    if (onOpenChange)
-      onOpenChange(newOpen)
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    onOpenChange?.(nextOpen)
   }, [onOpenChange])
 
   return (
     <DropdownMenu
+      modal={false}
       open={open}
       onOpenChange={handleOpenChange}
     >
@@ -62,7 +60,7 @@ const PanelOperator = ({
         aria-label={t('operation.more', { ns: 'common' })}
         className={cn(
           'nodrag nopan nowheel flex h-6 w-6 cursor-pointer items-center justify-center rounded-md hover:bg-state-base-hover',
-          open && 'bg-state-base-hover',
+          'data-[popup-open]:bg-state-base-hover',
           triggerClassName,
         )}
       >
@@ -77,7 +75,7 @@ const PanelOperator = ({
         <PanelOperatorPopup
           id={id}
           data={data}
-          onClosePopup={() => handleOpenChange(false)}
+          onClosePopup={() => setOpen(false)}
           showHelpLink={showHelpLink}
         />
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary

Closing the node \`...\` menu made the popup visibly fly to the top-left during the exit animation. The cause was architectural, not stylistic.

\`NodeControl\` wrapped the menu trigger in a container that toggled \`display: none\` based on an \`open\` state mirrored from the menu via \`onOpenChange\`. Base UI fires \`onOpenChange(false)\` synchronously at the **start** of its close transition, so the anchor's DOM got \`display: none\`-d while the popup was still animating out. The positioner then read a \`(0, 0, 0, 0)\` bounding rect and repositioned the popup to the top-left.

## Fix

Collapse the two duplicated \`open\` states into one owner (\`PanelOperator\`), and keep the anchor geometrically alive for the menu's entire lifecycle.

- Drop the redundant \`open\` \`useState\` + \`handleOpenChange\` in \`NodeControl\`.
- Container switches from \`hidden\` (\`display: none\`) to \`invisible\` (\`visibility: hidden\`). It's \`absolute\` so no layout impact, and \`getBoundingClientRect()\` stays valid throughout opening → idle → closing.
- Container visibility is now derived from Base UI's own \`data-popup-open\` attribute on the trigger via \`has-[[data-popup-open]]:visible\` — no JS mirror, no callback plumbing.
- Trigger highlight uses \`data-[popup-open]:bg-state-base-hover\` from the same attribute, replacing \`open && 'bg-state-base-hover'\`.
- \`modal={false}\` on the dropdown so the workflow canvas keeps pan/zoom/hover while the menu is open.
- Remove dead \`inNode\` prop from \`PanelOperator\`.

Net diff: \`+14 / -24\`.

## Why this, not a callback patch

A naive fix would add \`onOpenChangeComplete\` and postpone the \`display: none\` until the animation ends. That doubles down on the real smell — two state owners synchronized by callbacks — and is still fragile (relies on animation-complete timing). Removing the duplicate state is the smaller change and fixes the invariant the positioner actually requires: the anchor must outlive the popup.

## Test plan

- [x] \`pnpm vitest run app/components/workflow/nodes/_base/components/panel-operator/__tests__/\` — 8/8 pass
- [x] \`pnpm vitest run app/components/workflow/__tests__/node-contextmenu.spec.tsx\` — 3/3 pass (shared \`PanelOperatorPopup\` usage in right-click context menu unaffected)
- [ ] Manual: open a node's \`...\` menu on the canvas, click outside — popup exit animation stays pinned to the button, does not fly to top-left
- [ ] Manual: with the menu open, pan/scroll/hover other canvas nodes — canvas remains interactive (\`modal={false}\`)
- [ ] Manual: trigger highlight still appears while menu is open
- [ ] Manual: workflow side-panel header \`...\` (the other \`PanelOperator\` call site) still works


Made with [Cursor](https://cursor.com)