### PR TITLE
chore(web): drop delay={0} from tooltip triggers and retype DocName

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3081,11 +3081,6 @@
       "count": 1
     }
   },
-  "web/app/components/header/account-dropdown/compliance.tsx": {
-    "erasable-syntax-only/enums": {
-      "count": 1
-    }
-  },
   "web/app/components/header/account-setting/api-based-extension-page/modal.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/web/app/components/header/account-dropdown/compliance.tsx
+++ b/web/app/components/header/account-dropdown/compliance.tsx
@@ -19,12 +19,13 @@ import SparklesSoft from '../../base/icons/src/public/common/SparklesSoft'
 import PremiumBadge from '../../base/premium-badge'
 import { MenuItemContent } from './menu-item-content'
 
-enum DocName {
-  SOC2_Type_I = 'SOC2_Type_I',
-  SOC2_Type_II = 'SOC2_Type_II',
-  ISO_27001 = 'ISO_27001',
-  GDPR = 'GDPR',
-}
+const DocName = {
+  SOC2_Type_I: 'SOC2_Type_I',
+  SOC2_Type_II: 'SOC2_Type_II',
+  ISO_27001: 'ISO_27001',
+  GDPR: 'GDPR',
+} as const
+type DocName = typeof DocName[keyof typeof DocName]
 
 type ComplianceDocActionVisualProps = {
   isCurrentPlanCanDownload: boolean
@@ -61,7 +62,6 @@ function ComplianceDocActionVisual({
   return (
     <Tooltip>
       <TooltipTrigger
-        delay={0}
         disabled={!canShowUpgradeTooltip}
         render={(
           <PremiumBadge color="blue" allowHover={true}>

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/usage-priority-section.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/usage-priority-section.tsx
@@ -34,7 +34,6 @@ export default function UsagePrioritySection({ value, disabled, onSelect }: Usag
           <Tooltip>
             <TooltipTrigger
               aria-label={t('modelProvider.card.usagePriorityTip', { ns: 'common' })}
-              delay={0}
               render={(
                 <span className="flex h-4 w-4 shrink-0 items-center justify-center">
                   <span aria-hidden className="i-ri-question-line h-3.5 w-3.5 text-text-quaternary hover:text-text-tertiary" />

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/quota-panel.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/quota-panel.tsx
@@ -102,7 +102,6 @@ const QuotaPanel: FC<QuotaPanelProps> = ({
           <Tooltip>
             <TooltipTrigger
               aria-label={tipText}
-              delay={0}
               render={(
                 <span className="ml-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
                   <span aria-hidden className="i-ri-question-line h-3.5 w-3.5 text-text-quaternary hover:text-text-tertiary" />
@@ -150,7 +149,6 @@ const QuotaPanel: FC<QuotaPanelProps> = ({
                 <Tooltip key={key}>
                   <TooltipTrigger
                     aria-label={tooltipText}
-                    delay={0}
                     render={(
                       <div
                         className={cn('relative h-6 w-6', !providerType && 'cursor-pointer hover:opacity-80')}

--- a/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
@@ -141,7 +141,6 @@ const SystemModel: FC<SystemModelSelectorProps> = ({
         <Tooltip>
           <TooltipTrigger
             aria-label={tipText}
-            delay={0}
             render={(
               <span className="ml-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
                 <span aria-hidden className="i-ri-question-line h-3.5 w-3.5 text-text-quaternary hover:text-text-tertiary" />

--- a/web/app/components/plugins/plugin-detail-panel/detail-header/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/detail-header/index.tsx
@@ -189,7 +189,6 @@ const DetailHeader = ({
             {isAutoUpgradeEnabled && !isReadmeView && (
               <Tooltip>
                 <TooltipTrigger
-                  delay={0}
                   render={(
                     <div>
                       <Badge className="mr-1 cursor-pointer px-1">

--- a/web/app/components/workflow/nodes/_base/components/layout/field-title.tsx
+++ b/web/app/components/workflow/nodes/_base/components/layout/field-title.tsx
@@ -64,7 +64,6 @@ export const FieldTitle = memo(({
             tooltip && (
               <Tooltip>
                 <TooltipTrigger
-                  delay={0}
                   render={(
                     <span className="ml-1 flex h-4 w-4 shrink-0 items-center justify-center">
                       <span aria-hidden className="i-ri-question-line h-3.5 w-3.5 text-text-quaternary hover:text-text-tertiary" />

--- a/web/app/components/workflow/nodes/llm/components/panel-memory-section.tsx
+++ b/web/app/components/workflow/nodes/llm/components/panel-memory-section.tsx
@@ -52,7 +52,6 @@ const PanelMemorySection: FC<Props> = ({
               <div className="text-xs font-semibold text-text-secondary uppercase">{t('nodes.common.memories.title', { ns: 'workflow' })}</div>
               <Tooltip>
                 <TooltipTrigger
-                  delay={0}
                   render={(
                     <span className="ml-1 flex h-4 w-4 shrink-0 items-center justify-center">
                       <span aria-hidden className="i-ri-question-line h-3.5 w-3.5 text-text-quaternary hover:text-text-tertiary" />
@@ -75,7 +74,6 @@ const PanelMemorySection: FC<Props> = ({
                   <div className="text-xs font-semibold text-text-secondary uppercase">user</div>
                   <Tooltip>
                     <TooltipTrigger
-                      delay={0}
                       render={(
                         <span className="ml-1 flex h-4 w-4 shrink-0 items-center justify-center">
                           <span aria-hidden className="i-ri-question-line h-3.5 w-3.5 text-text-quaternary hover:text-text-tertiary" />

--- a/web/app/components/workflow/nodes/llm/components/panel-output-section.tsx
+++ b/web/app/components/workflow/nodes/llm/components/panel-output-section.tsx
@@ -43,7 +43,6 @@ const PanelOutputSection: FC<Props> = ({
             {(!isModelSupportStructuredOutput && !!inputs.structured_output_enabled) && (
               <Tooltip>
                 <TooltipTrigger
-                  delay={0}
                   render={(
                     <div>
                       <RiAlertFill className="mr-1 size-4 text-text-warning-secondary" />
@@ -61,7 +60,6 @@ const PanelOutputSection: FC<Props> = ({
             <div className="mr-0.5 system-xs-medium-uppercase text-text-tertiary">{t('structOutput.structured', { ns: 'app' })}</div>
             <Tooltip>
               <TooltipTrigger
-                delay={0}
                 render={(
                   <div>
                     <RiQuestionLine className="size-3.5 text-text-quaternary" />


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Two small, related frontend cleanups under `web/`:

1. **Drop per-call \`delay={0}\` on TooltipTrigger (11 usages, 8 files).**
   The whole app already wraps itself in `<TooltipProvider delay={300} closeDelay={200}>` (`web/app/layout.tsx:74`). The `delay={0}` overrides forced immediate opening at individual call sites, which:
   - bypassed Base UI's rest-hover model (W3C tooltip convention),
   - opted these triggers out of the delay-group "instant handoff" that makes adjacent tooltips feel snappy,
   - produced an inconsistent hover cadence across the product.

   After this change, all these tooltips inherit the provider cadence. The affected surfaces are all info/description tooltips hanging off `?` / `i` icons or small badges:
   - LLM node panels (`panel-output-section`, `panel-memory-section`)
   - Workflow node `FieldTitle` (shared across many node panels — see `knowledge-base`, `iteration`, `loop`, `http`, `agent-strategy`, etc.)
   - Model provider settings (`quota-panel`, `usage-priority-section`, `system-model-selector`)
   - Account dropdown compliance submenu upgrade badge
   - Plugin detail header auto-update badge

2. **Retype \`DocName\` in \`compliance.tsx\` to a TS-friendly shape.**
   Replace the string-valued \`enum DocName\` with an \`as const\` object plus a companion type of the same name:

   \`\`\`ts
   const DocName = {
     SOC2_Type_I: 'SOC2_Type_I',
     SOC2_Type_II: 'SOC2_Type_II',
     ISO_27001: 'ISO_27001',
     GDPR: 'GDPR',
   } as const
   type DocName = typeof DocName[keyof typeof DocName]
   \`\`\`

   This removes the runtime enum emit, is friendlier to strict TS modes (`erasableSyntaxOnly` / `verbatimModuleSyntax`), allows tree-shaking, and keeps every existing `DocName.X` call site unchanged because the identifier lives in both the value and type namespaces.

How to reach each tooltip change (for reviewer QA):
- `workflow?action=showSettings&tab=provider` → Settings dialog → any `?` icon (\`system-model-selector\`)
- Model Provider page → per-provider card → quota tooltip and model-badge tooltips (\`quota-panel\`)
- Model Provider page → provider card → credential dropdown → "Usage priority" row `?` (\`usage-priority-section\`)
- Any workflow canvas → LLM node panel → "Structured output" row `?` / warning icon (\`panel-output-section\`) and "Memory" section `?` (\`panel-memory-section\`)
- Any workflow canvas → node panels that use \`FieldTitle\` with a \`tooltip\` prop → `?` icon (\`field-title\`)
- Top-right avatar → Compliance submenu → upgrade badge on a restricted doc row (\`compliance\`)
- Plugin detail panel → header auto-update badge (\`detail-header\`)

No behavior change beyond timing; nothing new rendered; no visual tweaks.

From Cursor

## Screenshots

| Before | After |
|--------|-------|
| tooltip opens instantly on hover, ignores provider delay | tooltip respects global 300ms open / 200ms close cadence |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Made with [Cursor](https://cursor.com)