### PR TITLE
fix: handle numpy scalar types in safe_json_value

### DIFF
--- a/api/core/tools/utils/message_transformer.py
+++ b/api/core/tools/utils/message_transformer.py
@@ -41,6 +41,10 @@ def safe_json_value(v):
             return v.hex()
     elif isinstance(v, memoryview):
         return v.tobytes().hex()
+    elif isinstance(v, np.integer):
+        return int(v)
+    elif isinstance(v, np.floating):
+        return float(v)
     elif isinstance(v, np.ndarray):
         return v.tolist()
     elif isinstance(v, dict):


### PR DESCRIPTION
## Summary
Add explicit handling for `np.integer` and `np.floating` scalar types in `safe_json_value()`.

## Problem
`safe_json_value()` handles `np.ndarray` (via `.tolist()`) but misses numpy scalar types like `np.int64`, `np.float64`, etc. These fall through to the `else` clause and are returned as-is. Since `json.dumps()` cannot serialize numpy scalar types, this causes a `TypeError` at runtime when tool results contain numpy scalars.

In numpy >= 2.0, scalar types no longer inherit from Python builtins, making this even more likely to fail.

## Change
Added two checks before the existing `np.ndarray` handling:
- `np.integer` → `int(v)`
- `np.floating` → `float(v)`

Related to #34405 (parameter precision loss with numeric types).