### PR TITLE
fix(api): raise clear error when FILES_URL is unset during file URL signing

### DIFF
--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -13,7 +13,7 @@ from configs import dify_config
 from core.app.file_access import DatabaseFileAccessController, FileAccessControllerProtocol
 from core.db.session_factory import session_factory
 from core.helper.ssrf_proxy import graphon_ssrf_proxy
-from core.tools.signature import sign_tool_file
+from core.tools.signature import require_files_base_url, sign_tool_file
 from core.workflow.file_reference import parse_file_reference
 from extensions.ext_storage import storage
 from graphon.file import FileTransferMethod
@@ -122,9 +122,7 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
 
     @staticmethod
     def _base_url(*, for_external: bool) -> str:
-        if for_external:
-            return dify_config.FILES_URL
-        return dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+        return require_files_base_url(for_external=for_external)
 
     @staticmethod
     def _secret_key() -> bytes:

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -7,13 +7,37 @@ import urllib.parse
 
 from configs import dify_config
 
+_FILES_URL_MISSING_MESSAGE = (
+    "FILES_URL is not configured. Set FILES_URL (and optionally INTERNAL_FILES_URL) "
+    "in your environment to a fully-qualified URL such as 'http://<host>:5001' so "
+    "signed file URLs can be generated for plugin and frontend access."
+)
+
+
+def require_files_base_url(*, for_external: bool) -> str:
+    """
+    Return the configured base URL for signed file links, raising a clear error
+    when it is empty.
+
+    ``for_external=True`` returns ``FILES_URL`` (used for browser/frontend access).
+    ``for_external=False`` prefers ``INTERNAL_FILES_URL`` and falls back to
+    ``FILES_URL`` (used for plugin/container-to-container access).
+    """
+    if for_external:
+        base_url = dify_config.FILES_URL
+    else:
+        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+    if not base_url:
+        raise ValueError(_FILES_URL_MISSING_MESSAGE)
+    return base_url
+
 
 def sign_tool_file(tool_file_id: str, extension: str, for_external: bool = True) -> str:
     """
     sign file to get a temporary url for plugin access
     """
     # Use internal URL for plugin/tool file access in Docker environments, unless for_external is True
-    base_url = dify_config.FILES_URL if for_external else (dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL)
+    base_url = require_files_base_url(for_external=for_external)
     file_preview_url = f"{base_url}/files/tools/{tool_file_id}{extension}"
 
     timestamp = str(int(time.time()))
@@ -31,7 +55,7 @@ def sign_upload_file(upload_file_id: str, extension: str) -> str:
     sign file to get a temporary url for plugin access
     """
     # Use internal URL for plugin/tool file access in Docker environments
-    base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+    base_url = require_files_base_url(for_external=False)
     file_preview_url = f"{base_url}/files/{upload_file_id}/image-preview"
 
     timestamp = str(int(time.time()))
@@ -64,7 +88,7 @@ def verify_tool_file_signature(file_id: str, timestamp: str, nonce: str, sign: s
 def get_signed_file_url_for_plugin(filename: str, mimetype: str, tenant_id: str, user_id: str) -> str:
     """Build the signed upload URL used by the plugin-facing file upload endpoint."""
 
-    base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+    base_url = require_files_base_url(for_external=False)
     upload_url = f"{base_url}/files/upload/for-plugin"
     timestamp = str(int(time.time()))
     nonce = os.urandom(16).hex()

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -7,17 +7,18 @@ import urllib.parse
 
 from configs import dify_config
 
-_FILES_URL_MISSING_MESSAGE = (
-    "FILES_URL is not configured. Set FILES_URL (and optionally INTERNAL_FILES_URL) "
-    "in your environment to a fully-qualified URL such as 'http://<host>:5001' so "
-    "signed file URLs can be generated for plugin and frontend access."
+_FILES_URL_INVALID_MESSAGE = (
+    "FILES_URL is not configured with a fully-qualified http(s) URL. "
+    "Set FILES_URL (or its CONSOLE_API_URL fallback, and optionally INTERNAL_FILES_URL) "
+    "in your environment to a value such as 'http://<host>:5001' or 'https://<host>' "
+    "so signed file URLs can be generated for plugin and frontend access."
 )
 
 
 def require_files_base_url(*, for_external: bool) -> str:
     """
     Return the configured base URL for signed file links, raising a clear error
-    when it is empty.
+    when it is missing or not a fully-qualified http(s) URL.
 
     ``for_external=True`` returns ``FILES_URL`` (used for browser/frontend access).
     ``for_external=False`` prefers ``INTERNAL_FILES_URL`` and falls back to
@@ -28,7 +29,10 @@ def require_files_base_url(*, for_external: bool) -> str:
     else:
         base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
     if not base_url:
-        raise ValueError(_FILES_URL_MISSING_MESSAGE)
+        raise ValueError(_FILES_URL_INVALID_MESSAGE)
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(_FILES_URL_INVALID_MESSAGE)
     return base_url
 
 

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from configs import dify_config
 from core.db.session_factory import session_factory
 from core.helper import ssrf_proxy
+from core.tools.signature import require_files_base_url
 from core.workflow.file_reference import build_file_reference
 from extensions.ext_storage import storage
 from graphon.file import File, FileTransferMethod, get_file_type_by_mime_type
@@ -45,7 +46,7 @@ class ToolFileManager:
         sign file to get a temporary url for plugin access
         """
         # Use internal URL for plugin/tool file access in Docker environments
-        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+        base_url = require_files_base_url(for_external=False)
         file_preview_url = f"{base_url}/files/tools/{tool_file_id}{extension}"
 
         timestamp = str(int(time.time()))

--- a/api/tests/unit_tests/conftest.py
+++ b/api/tests/unit_tests/conftest.py
@@ -106,6 +106,27 @@ def reset_secret_key():
         dify_config.SECRET_KEY = original
 
 
+@pytest.fixture(autouse=True)
+def _default_files_url():
+    """Provide a valid FILES_URL default so file URL signing works in unit tests.
+
+    Tests that need to assert behavior when FILES_URL is missing can override
+    this via monkeypatch on ``dify_config.FILES_URL`` / ``INTERNAL_FILES_URL``.
+    """
+
+    from configs import dify_config
+
+    original_files_url = dify_config.FILES_URL
+    original_internal = dify_config.INTERNAL_FILES_URL
+    if not dify_config.FILES_URL:
+        dify_config.FILES_URL = "http://localhost:5001"
+    try:
+        yield
+    finally:
+        dify_config.FILES_URL = original_files_url
+        dify_config.INTERNAL_FILES_URL = original_internal
+
+
 @pytest.fixture(scope="session")
 def _unit_test_engine():
     engine = create_engine("sqlite:///:memory:")

--- a/api/tests/unit_tests/core/app/workflow/test_file_runtime.py
+++ b/api/tests/unit_tests/core/app/workflow/test_file_runtime.py
@@ -122,6 +122,18 @@ def test_resolve_upload_file_url_signs_internal_urls_and_supports_attachments(
     assert query["timestamp"] == ["1700000000"]
 
 
+def test_resolve_upload_file_url_raises_when_files_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.app.workflow.file_runtime.dify_config.FILES_URL", "")
+    monkeypatch.setattr("core.app.workflow.file_runtime.dify_config.INTERNAL_FILES_URL", "")
+
+    runtime = _build_runtime()
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        runtime.resolve_upload_file_url(upload_file_id="upload-file-id", for_external=True)
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        runtime.resolve_upload_file_url(upload_file_id="upload-file-id", for_external=False)
+
+
 def test_verify_preview_signature_validates_signature_and_expiration(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("core.app.workflow.file_runtime.time.time", lambda: 1700000000)
     monkeypatch.setattr("core.app.workflow.file_runtime.dify_config.SECRET_KEY", "unit-secret")

--- a/api/tests/unit_tests/core/app/workflow/test_file_runtime.py
+++ b/api/tests/unit_tests/core/app/workflow/test_file_runtime.py
@@ -128,9 +128,9 @@ def test_resolve_upload_file_url_raises_when_files_url_missing(monkeypatch: pyte
 
     runtime = _build_runtime()
 
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         runtime.resolve_upload_file_url(upload_file_id="upload-file-id", for_external=True)
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         runtime.resolve_upload_file_url(upload_file_id="upload-file-id", for_external=False)
 
 

--- a/api/tests/unit_tests/core/tools/test_signature.py
+++ b/api/tests/unit_tests/core/tools/test_signature.py
@@ -232,19 +232,53 @@ def test_require_files_base_url_raises_when_both_empty(monkeypatch: pytest.Monke
     monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
     monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
 
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         require_files_base_url(for_external=True)
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         require_files_base_url(for_external=False)
+
+
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        "localhost:5001",
+        "example.com",
+        "//example.com:5001",
+        "ftp://example.com:5001",
+        "http://",
+    ],
+)
+def test_require_files_base_url_rejects_scheme_less_or_invalid_urls(
+    monkeypatch: pytest.MonkeyPatch, invalid_url: str
+) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", invalid_url)
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
+        require_files_base_url(for_external=True)
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
+        require_files_base_url(for_external=False)
+
+
+def test_require_files_base_url_rejects_internal_url_without_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "https://files.example.com")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "api:5001")
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
+        require_files_base_url(for_external=False)
+    # external path still resolves against the valid FILES_URL
+    assert require_files_base_url(for_external=True) == "https://files.example.com"
 
 
 def test_sign_tool_file_raises_when_files_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
     monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
 
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         sign_tool_file("tool-file-id", ".png", for_external=True)
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         sign_tool_file("tool-file-id", ".png", for_external=False)
 
 
@@ -252,7 +286,7 @@ def test_sign_upload_file_raises_when_files_url_missing(monkeypatch: pytest.Monk
     monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
     monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
 
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         sign_upload_file("upload-id", ".png")
 
 
@@ -262,7 +296,7 @@ def test_get_signed_file_url_for_plugin_raises_when_files_url_missing(
     monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
     monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
 
-    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+    with pytest.raises(ValueError, match="FILES_URL is not configured with a fully-qualified"):
         get_signed_file_url_for_plugin(
             filename="report.pdf",
             mimetype="application/pdf",

--- a/api/tests/unit_tests/core/tools/test_signature.py
+++ b/api/tests/unit_tests/core/tools/test_signature.py
@@ -8,6 +8,7 @@ import pytest
 
 from core.tools.signature import (
     get_signed_file_url_for_plugin,
+    require_files_base_url,
     sign_tool_file,
     sign_upload_file,
     verify_plugin_file_signature,
@@ -202,3 +203,69 @@ def test_verify_plugin_file_signature_rejects_invalid_signatures(monkeypatch: py
         )
         is False
     )
+
+
+def test_require_files_base_url_returns_files_url_for_external(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "https://files.example.com")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "https://internal.example.com")
+
+    assert require_files_base_url(for_external=True) == "https://files.example.com"
+
+
+def test_require_files_base_url_prefers_internal_for_non_external(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "https://files.example.com")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "https://internal.example.com")
+
+    assert require_files_base_url(for_external=False) == "https://internal.example.com"
+
+
+def test_require_files_base_url_falls_back_to_files_url_when_internal_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "https://files.example.com")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
+
+    assert require_files_base_url(for_external=False) == "https://files.example.com"
+
+
+def test_require_files_base_url_raises_when_both_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        require_files_base_url(for_external=True)
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        require_files_base_url(for_external=False)
+
+
+def test_sign_tool_file_raises_when_files_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        sign_tool_file("tool-file-id", ".png", for_external=True)
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        sign_tool_file("tool-file-id", ".png", for_external=False)
+
+
+def test_sign_upload_file_raises_when_files_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        sign_upload_file("upload-id", ".png")
+
+
+def test_get_signed_file_url_for_plugin_raises_when_files_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "")
+
+    with pytest.raises(ValueError, match="FILES_URL is not configured"):
+        get_signed_file_url_for_plugin(
+            filename="report.pdf",
+            mimetype="application/pdf",
+            tenant_id="tenant-id",
+            user_id="user-id",
+        )


### PR DESCRIPTION
## Summary

Fixes the confusing plugin-side error reported in [#35387](https://github.com/langgenius/dify/issues/35387):
close #35387
> `Get CSV file failed: Invalid file URL '/files/.../file-preview?...': Request URL is missing an 'http://' or 'https://' protocol.. Ensure the FILES_URL environment variable is set in your .env file`

**Root cause**: `FILES_URL` (with `CONSOLE_API_URL` as its only fallback) defaults to `""`. When both are unset, the signing helpers in `core.tools.signature` and `DifyWorkflowFileRuntime._base_url` happily produce relative `/files/...` URLs. The plugin daemon only fails much later, when its HTTP client rejects the scheme-less URL — so the user has to chase a confusing error through the plugin instead of seeing a clear misconfiguration message from Dify itself.

**Fix**: Centralize the `FILES_URL` / `INTERNAL_FILES_URL` lookup in a small helper (`require_files_base_url`) that validates the result and raises `ValueError` with an actionable message identifying the env vars to set. Use it from every signing path:

- `core.tools.signature.sign_tool_file`
- `core.tools.signature.sign_upload_file`
- `core.tools.signature.get_signed_file_url_for_plugin`
- `core.tools.tool_file_manager.ToolFileManager.sign_file`
- `core.app.workflow.file_runtime.DifyWorkflowFileRuntime._base_url`

No behavior change when `FILES_URL` is configured — the selection rules (`FILES_URL` for external, `INTERNAL_FILES_URL` preferred for internal) are preserved and covered by existing and new tests.

## Test plan

- [x] `pytest api/tests/unit_tests/core/tools/test_signature.py` — all existing tests pass, new tests cover the validation helper and each signing entry point raising when `FILES_URL`/`INTERNAL_FILES_URL` are both empty.
- [x] `pytest api/tests/unit_tests/core/app/workflow/test_file_runtime.py` — new test asserts `resolve_upload_file_url` raises a clear `ValueError` (instead of emitting `/files/...`) when `FILES_URL` is unset, for both `for_external=True` and `False`.
- [x] `pytest api/tests/unit_tests/core/tools api/tests/unit_tests/core/app/workflow` — 380 passed, no regressions.