### PR TITLE
refactor(billing): use Infotip for UsageInfo help icon, migrate storage tooltip to dify-ui

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2218,11 +2218,6 @@
       "count": 3
     }
   },
-  "web/app/components/billing/usage-info/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/common/image-previewer/index.tsx": {
     "no-irregular-whitespace": {
       "count": 1

--- a/web/app/components/billing/usage-info/__tests__/index.spec.tsx
+++ b/web/app/components/billing/usage-info/__tests__/index.spec.tsx
@@ -309,7 +309,7 @@ describe('UsageInfo', () => {
           />,
         )
 
-        expect(container.querySelector('[data-state]')).toBeInTheDocument()
+        expect(container.querySelectorAll('.cursor-default').length).toBeGreaterThan(0)
       })
     })
   })

--- a/web/app/components/billing/usage-info/__tests__/vector-space-info.spec.tsx
+++ b/web/app/components/billing/usage-info/__tests__/vector-space-info.spec.tsx
@@ -3,7 +3,8 @@ import { defaultPlan } from '../../config'
 import { Plan } from '../../type'
 import VectorSpaceInfo from '../vector-space-info'
 
-const queryPlaceholder = () => document.body.querySelector('[aria-hidden="true"]')
+const queryPlaceholder = () =>
+  document.body.querySelector('[aria-hidden="true"].bg-components-progress-bar-bg')
 
 // Mock provider context with configurable plan
 let mockPlanType = Plan.sandbox

--- a/web/app/components/billing/usage-info/index.tsx
+++ b/web/app/components/billing/usage-info/index.tsx
@@ -3,9 +3,10 @@ import type { MeterTone } from '@langgenius/dify-ui/meter'
 import type { ComponentType, FC, ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import { MeterIndicator, MeterRoot, MeterTrack } from '@langgenius/dify-ui/meter'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import Tooltip from '@/app/components/base/tooltip'
+import { Infotip } from '@/app/components/base/infotip'
 import { NUM_INFINITE } from '../config'
 
 type Props = {
@@ -159,11 +160,11 @@ const UsageInfo: FC<Props> = ({
   const wrapWithStorageTooltip = (children: ReactNode) => {
     if (storageMode && storageTooltip) {
       return (
-        <Tooltip
-          popupContent={<div className="w-[200px]">{storageTooltip}</div>}
-          asChild={false}
-        >
-          <div className="cursor-default">{children}</div>
+        <Tooltip>
+          <TooltipTrigger render={<div className="cursor-default">{children}</div>} />
+          <TooltipContent className="w-[200px] max-w-[200px]">
+            {storageTooltip}
+          </TooltipContent>
         </Tooltip>
       )
     }
@@ -178,13 +179,9 @@ const UsageInfo: FC<Props> = ({
       <div className="flex items-center gap-1">
         <div className="system-xs-medium text-text-tertiary">{name}</div>
         {tooltip && (
-          <Tooltip
-            popupContent={(
-              <div className="w-[180px]">
-                {tooltip}
-              </div>
-            )}
-          />
+          <Infotip aria-label={tooltip} popupClassName="w-[180px] max-w-[180px]">
+            {tooltip}
+          </Infotip>
         )}
       </div>
       <div className="flex items-center gap-1 system-md-semibold text-text-primary">


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: \`Fixes #<issue number>\`.

## Summary

Cleans up the tooltip usage in `UsageInfo` (the metric cards rendered in **Settings → Billing**, plus the workspace banner). Two related changes, both contained to `web/app/components/billing/usage-info`:

1. **Help-icon tooltip → `Infotip`.** The icon-only `<Tooltip popupContent={...} />` next to the metric name was relying on the deprecated `Tooltip`'s default `?` glyph trigger. Per the project's own `Infotip` docstring (citing Base UI):
   > Popups that open when hovering an info icon should use Popover with the \`openOnHover\` prop on the trigger instead of a tooltip. This way, touch users and screen reader users can access the content.

   Replaced with `<Infotip aria-label={tooltip}>{tooltip}</Infotip>`, which uses the existing accessibility-friendly Popover primitive in the codebase.

2. **Storage hover tooltip → `@langgenius/dify-ui/tooltip`.** `wrapWithStorageTooltip` wraps the storage value/meter (the trigger has its own meaning — showing data — so it's a legitimate tooltip pattern, not an infotip). Migrated off the deprecated `@/app/components/base/tooltip` to the modern `Tooltip` / `TooltipTrigger` / `TooltipContent` from `@langgenius/dify-ui/tooltip`. This also clears the existing `no-restricted-imports` lint error in this file.

Other tooltip sites in the billing area were intentionally left alone:
- `priority-label/index.tsx`: trigger is a meaningful badge, not an info glyph — true tooltip use case (and not actually rendered in the Billing tab; only used in dataset embedding flows).
- `pricing/plans/cloud-plan-item/list/item/tooltip.tsx`: bespoke pricing-card UI, out of scope.

### Test adjustments
- `vector-space-info.spec.tsx`: tightened `queryPlaceholder` from `[aria-hidden=\"true\"]` to `[aria-hidden=\"true\"].bg-components-progress-bar-bg`, since the new `Infotip`'s `?` icon is also `aria-hidden`.
- `index.spec.tsx`: replaced the storage-tooltip `[data-state]` assertion (Base UI renders this on the portalized popup, outside `container`) with a check on the trigger's stable `cursor-default` marker.

All 392 tests under `app/components/billing` pass; ESLint clean on the modified files.

## Screenshots

| Before | After |
|--------|-------|
| Help \`?\` icon used a hover-only Tooltip — unreachable on touch / screen readers | Help \`?\` icon uses \`Infotip\` (Popover with \`openOnHover\`), accessible to touch and screen-reader users |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran \`make lint && make type-check\` (backend) and \`cd web && pnpm exec vp staged\` (frontend) to appease the lint gods

From Cursor Agent

Made with [Cursor](https://cursor.com)