### PR TITLE
fix: keep Add API Key modal outside popover lifecycle in authorized flow

### DIFF
--- a/web/app/components/plugins/plugin-auth/authorize/add-api-key-button.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/add-api-key-button.tsx
@@ -15,6 +15,7 @@ export type AddApiKeyButtonProps = {
   disabled?: boolean
   onUpdate?: () => void
   formSchemas?: FormSchema[]
+  onOpenModal?: () => void
 }
 const AddApiKeyButton = ({
   pluginPayload,
@@ -23,6 +24,7 @@ const AddApiKeyButton = ({
   disabled,
   onUpdate,
   formSchemas = [],
+  onOpenModal,
 }: AddApiKeyButtonProps) => {
   const [isApiKeyModalOpen, setIsApiKeyModalOpen] = useState(false)
 
@@ -31,13 +33,20 @@ const AddApiKeyButton = ({
       <Button
         className="w-full"
         variant={buttonVariant}
-        onClick={() => setIsApiKeyModalOpen(true)}
+        onClick={() => {
+          if (onOpenModal) {
+            onOpenModal()
+            return
+          }
+
+          setIsApiKeyModalOpen(true)
+        }}
         disabled={disabled}
       >
         {buttonText}
       </Button>
       {
-        isApiKeyModalOpen && (
+        !onOpenModal && isApiKeyModalOpen && (
           <ApiKeyModal
             pluginPayload={pluginPayload}
             onClose={() => setIsApiKeyModalOpen(false)}

--- a/web/app/components/plugins/plugin-auth/authorize/index.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/index.tsx
@@ -20,6 +20,7 @@ type AuthorizeProps = {
   disabled?: boolean
   onUpdate?: () => void
   notAllowCustomCredential?: boolean
+  onOpenApiKeyModal?: () => void
 }
 const Authorize = ({
   pluginPayload,
@@ -30,6 +31,7 @@ const Authorize = ({
   disabled,
   onUpdate,
   notAllowCustomCredential,
+  onOpenApiKeyModal,
 }: AuthorizeProps) => {
   const { t } = useTranslation()
   const oAuthButtonProps: AddOAuthButtonProps = useMemo(() => {
@@ -94,6 +96,7 @@ const Authorize = ({
           {...apiKeyButtonProps}
           disabled={disabled || notAllowCustomCredential}
           onUpdate={onUpdate}
+          onOpenModal={onOpenApiKeyModal}
         />
       </div>
     )
@@ -106,7 +109,7 @@ const Authorize = ({
       )
     }
     return Item
-  }, [notAllowCustomCredential, apiKeyButtonProps, disabled, onUpdate, t])
+  }, [notAllowCustomCredential, apiKeyButtonProps, disabled, onUpdate, onOpenApiKeyModal, t])
 
   return (
     <>

--- a/web/app/components/plugins/plugin-auth/authorized/index.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/index.tsx
@@ -133,10 +133,15 @@ const Authorized = ({
     }
   }, [deletePluginCredential, onUpdate, t, handleSetDoingAction])
   const [editValues, setEditValues] = useState<Record<string, unknown> | null>(null)
+  const [isAddApiKeyModalOpen, setIsAddApiKeyModalOpen] = useState(false)
   const handleEdit = useCallback((id: string, values: Record<string, unknown>) => {
     setMergedIsOpen(false)
     pendingOperationCredentialId.current = id
     setEditValues(values)
+  }, [setMergedIsOpen])
+  const handleOpenAddApiKeyModal = useCallback(() => {
+    setMergedIsOpen(false)
+    setIsAddApiKeyModalOpen(true)
   }, [setMergedIsOpen])
   const handleRemove = useCallback(() => {
     setDeleteCredentialId(pendingOperationCredentialId.current)
@@ -330,6 +335,7 @@ const Authorized = ({
                       canApiKey={canApiKey}
                       disabled={disabled}
                       onUpdate={onUpdate}
+                      onOpenApiKeyModal={handleOpenAddApiKeyModal}
                     />
                   </div>
                 </>
@@ -353,6 +359,16 @@ const Authorized = ({
           </AlertDialogActions>
         </AlertDialogContent>
       </AlertDialog>
+      {
+        isAddApiKeyModalOpen && (
+          <ApiKeyModal
+            pluginPayload={pluginPayload}
+            onClose={() => setIsAddApiKeyModalOpen(false)}
+            disabled={disabled || doingAction}
+            onUpdate={onUpdate}
+          />
+        )
+      }
       {
         !!editValues && (
           <ApiKeyModal


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

fix https://github.com/langgenius/dify/issues/35456

#### Root Cause and Context

During the #35431 , Authorized was migrated from PortalToFollowElem to @langgenius/dify-ui/popover.
That migration itself is correct, but it exposed a lifecycle issue in existing modal ownership.

In the authorized flow, the “Add API Key” button is rendered inside the Popover content (Authorized -> Authorize -> AddApiKeyButton).
AddApiKeyButton previously owned its own isApiKeyModalOpen state and conditionally rendered ApiKeyModal in its own subtree.

When users clicked inside the modal input, the parent Popover treated that interaction as outside and closed.
Once Popover closed, the Popover content subtree unmounted, including AddApiKeyButton, so its local modal state was lost and the modal closed immediately.

#### Why this happened

The issue is not in AuthForm or modal form logic.
It is a UI state ownership problem: a modal with independent lifecycle was mounted under a transient Popover subtree.

#### Fix

We moved “Add API Key modal” ownership to Authorized (outside Popover content) and changed AddApiKeyButton to support an external open handler.
Now, in authorized mode, clicking “Add API” triggers an outer state update, and the modal remains mounted independently of Popover open/close state.

#### Result

- Clicking/focusing the API key input no longer closes the modal unexpectedly.
- Existing edit modal behavior remains unchanged.
- Related plugin-auth tests pass after the change.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
