### PR TITLE
chore(deps): bump base ui to 1.4.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: 8.2.0
       version: 8.2.0
     '@base-ui/react':
-      specifier: 1.4.0
-      version: 1.4.0
+      specifier: 1.4.1
+      version: 1.4.1
     '@chromatic-com/storybook':
       specifier: 5.1.2
       version: 5.1.2
@@ -643,7 +643,7 @@ importers:
     devDependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@chromatic-com/storybook':
         specifier: 'catalog:'
         version: 5.1.2(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -790,7 +790,7 @@ importers:
         version: 1.27.7(@amplitude/rrweb@2.0.0-alpha.37)
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@emoji-mart/data':
         specifier: 'catalog:'
         version: 1.2.1
@@ -1539,8 +1539,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.4.0':
-    resolution: {integrity: sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==}
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -1549,11 +1549,15 @@ packages:
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
     peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
       '@types/react':
         optional: true
+      date-fns:
+        optional: true
 
-  '@base-ui/utils@0.2.7':
-    resolution: {integrity: sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==}
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -8622,10 +8626,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/utils': 0.2.11
       react: 19.2.5
@@ -8634,7 +8638,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@base-ui/utils@0.2.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalog:
   '@amplitude/analytics-browser': 2.39.0
   '@amplitude/plugin-session-replay-browser': 1.27.7
   '@antfu/eslint-config': 8.2.0
-  '@base-ui/react': 1.4.0
+  '@base-ui/react': 1.4.1
   '@chromatic-com/storybook': 5.1.2
   '@cucumber/cucumber': 12.8.0
   '@egoist/tailwindcss-icons': 1.9.2

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -13,9 +13,9 @@ import storybook from 'eslint-plugin-storybook'
 import {
   HYOBAN_PREFER_TAILWIND_ICONS_OPTIONS,
   NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS,
-  NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS,
   OVERLAY_MIGRATION_LEGACY_BASE_FILES,
   OVERLAY_RESTRICTED_IMPORT_PATTERNS,
+  WEB_RESTRICTED_IMPORT_PATTERNS,
 } from './eslint.constants.mjs'
 import dify from './plugins/eslint/index.js'
 
@@ -161,13 +161,13 @@ export default antfu(
     },
   },
   {
-    name: 'dify/no-direct-next-imports',
+    name: 'dify/restricted-imports',
     files: [GLOB_TS, GLOB_TSX],
     ignores: ['next/**'],
     rules: {
       'no-restricted-imports': ['error', {
         paths: NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS,
-        patterns: NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS,
+        patterns: WEB_RESTRICTED_IMPORT_PATTERNS,
       }],
     },
   },
@@ -183,7 +183,7 @@ export default antfu(
       'no-restricted-imports': ['error', {
         paths: NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS,
         patterns: [
-          ...NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS,
+          ...WEB_RESTRICTED_IMPORT_PATTERNS,
           ...OVERLAY_RESTRICTED_IMPORT_PATTERNS,
         ],
       }],

--- a/web/eslint.constants.mjs
+++ b/web/eslint.constants.mjs
@@ -5,7 +5,7 @@ export const NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS = [
   },
 ]
 
-export const NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS = [
+const NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS = [
   {
     group: ['next/image'],
     message: 'Do not import next/image. Use native img tags instead.',
@@ -18,6 +18,21 @@ export const NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS = [
     group: ['next/*', '!next/font', '!next/font/*', '!next/image', '!next/image/*'],
     message: 'Import Next APIs from the corresponding @/next/* module instead of next/*.',
   },
+]
+
+const BASE_UI_RESTRICTED_IMPORT_PATTERNS = [
+  {
+    group: [
+      '@base-ui/react',
+      '@base-ui/react/*',
+    ],
+    message: 'Do not import Base UI directly in web. Use @langgenius/dify-ui/* primitives instead.',
+  },
+]
+
+export const WEB_RESTRICTED_IMPORT_PATTERNS = [
+  ...NEXT_PLATFORM_RESTRICTED_IMPORT_PATTERNS,
+  ...BASE_UI_RESTRICTED_IMPORT_PATTERNS,
 ]
 
 export const OVERLAY_RESTRICTED_IMPORT_PATTERNS = [


### PR DESCRIPTION
## Summary
- bump `@base-ui/react` from 1.4.0 to 1.4.1 in the workspace catalog
- refresh `pnpm-lock.yaml`, including the `@base-ui/utils` 0.2.8 transitive update
- pick up Base UI optional `date-fns` / `@date-fns/tz` peer metadata and patch bug fixes

## Why
Base UI 1.4.1 fixes several overlay interaction edge cases, including hover highlight cleanup for items clipped by scroll containers. Dify Select and Dropdown wrappers use scrollable list/popover containers, so this patch is relevant while remaining low risk.

## Validation
- `pnpm --filter @langgenius/dify-ui type-check`
- `pnpm --filter dify-web type-check:tsgo`