### PR TITLE
chore: fix grammar in comments and test descriptions

### DIFF
--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -331,7 +331,7 @@ class TriggerSubscriptionUpdateApi(Resource):
             # For rename only, just update the name
             rename = request.name is not None and not any((request.credentials, request.parameters, request.properties))
             # When credential type is UNAUTHORIZED, it indicates the subscription was manually created
-            # For Manually created subscription, they dont have credentials, parameters
+            # For Manually created subscription, they don't have credentials, parameters
             # They only have name and properties(which is input by user)
             manually_created = subscription.credential_type == CredentialType.UNAUTHORIZED
             if rename or manually_created:

--- a/web/app/components/rag-pipeline/components/panel/input-field/field-list/__tests__/index.spec.tsx
+++ b/web/app/components/rag-pipeline/components/panel/input-field/field-list/__tests__/index.spec.tsx
@@ -357,7 +357,7 @@ describe('FieldItem', () => {
   })
 
   describe('Callback Stability', () => {
-    it('should maintain stable handleOnClickEdit when props dont change', () => {
+    it('should maintain stable handleOnClickEdit when props don't change', () => {
       const onClickEdit = vi.fn()
       const payload = createInputVar()
 

--- a/web/app/components/rag-pipeline/components/panel/test-run/preparation/data-source-options/__tests__/index.spec.tsx
+++ b/web/app/components/rag-pipeline/components/panel/test-run/preparation/data-source-options/__tests__/index.spec.tsx
@@ -321,7 +321,7 @@ describe('OptionCard', () => {
   })
 
   describe('Callback Stability', () => {
-    it('should maintain stable handleClickCard callback when props dont change', () => {
+    it('should maintain stable handleClickCard callback when props don't change', () => {
       const onClick = vi.fn()
       const nodeData = createNodeData()
 


### PR DESCRIPTION
Fixes three grammatical errors:\n- 'dont' → 'don't' in test descriptions (2 files)\n- 'dont' → 'don't' in Python comment