### PR TITLE
feat(redis): Event Bus follows main Redis mode; guard Celery broker against Cluster URLs

### DIFF
--- a/api/configs/middleware/cache/redis_pubsub_config.py
+++ b/api/configs/middleware/cache/redis_pubsub_config.py
@@ -148,14 +148,21 @@ class RedisPubSubConfig(BaseSettings):
     def _first_cluster_node(clusters: str | None) -> tuple[str, int]:
         if not clusters:
             raise ValueError("REDIS_USE_CLUSTERS is true but REDIS_CLUSTERS is unset")
-        for raw in clusters.split(","):
+        # IPv6 addresses must use bracketed form (e.g. "[fe80::1]:7001"); the
+        # rpartition(":") below is ambiguous for bare-colon IPv6 literals.
+        for index, raw in enumerate(clusters.split(","), start=1):
             node = raw.strip()
             if not node:
                 continue
             host, sep, port_str = node.rpartition(":")
             if not sep or not host or not port_str.isdigit():
+                # Deliberately do not echo the raw entry — an operator who
+                # misused REDIS_CLUSTERS by pasting a full DSN like
+                # "pw@host" would leak the password into startup logs. The
+                # 1-based position is enough to locate the offending entry.
                 raise ValueError(
-                    f"REDIS_CLUSTERS entry {node!r} is malformed; expected host:port"
+                    f"REDIS_CLUSTERS entry at position {index} is malformed; "
+                    "expected 'host:port' format"
                 )
             return host, int(port_str)
         # REDIS_CLUSTERS was set but contained only whitespace / empty segments

--- a/api/configs/middleware/cache/redis_pubsub_config.py
+++ b/api/configs/middleware/cache/redis_pubsub_config.py
@@ -12,6 +12,15 @@ class RedisConfigDefaults(Protocol):
     REDIS_PASSWORD: str | None
     REDIS_DB: int
     REDIS_USE_SSL: bool
+    # Sentinel mode — the main Redis client uses Sentinel topology. The pubsub
+    # URL builder can't encode Sentinel into a single seed URL, so Sentinel
+    # combined with Cluster is rejected unless PUBSUB_REDIS_URL is explicit.
+    REDIS_USE_SENTINEL: bool | None
+    # Cluster mode — when REDIS_USE_CLUSTERS is True the default pubsub URL
+    # is built from the first entry in REDIS_CLUSTERS instead of REDIS_HOST.
+    REDIS_USE_CLUSTERS: bool
+    REDIS_CLUSTERS: str | None
+    REDIS_CLUSTERS_PASSWORD: str | None
 
 
 def _redis_defaults(config: object) -> RedisConfigDefaults:
@@ -40,7 +49,11 @@ class RedisPubSubConfig(BaseSettings):
     PUBSUB_REDIS_USE_CLUSTERS: bool = Field(
         validation_alias=AliasChoices("EVENT_BUS_REDIS_USE_CLUSTERS", "PUBSUB_REDIS_USE_CLUSTERS"),
         description=(
-            "Enable Redis Cluster mode for pub/sub or streams transport. Recommended for large deployments. "
+            "Enable Redis Cluster mode for the Event Bus (pub/sub / streams) transport. "
+            "Advanced option: only turn this on when the Event Bus traffic is the bottleneck "
+            "and you want horizontal fan-out across multiple Redis nodes. Most deployments "
+            "should leave this False and let the Event Bus reuse the main Sentinel / standalone "
+            "Redis client. "
             "Also accepts ENV: EVENT_BUS_REDIS_USE_CLUSTERS."
         ),
         default=False,
@@ -70,15 +83,88 @@ class RedisPubSubConfig(BaseSettings):
         default=600,
     )
 
-    def _build_default_pubsub_url(self) -> str:
+    def _build_default_pubsub_url(self) -> str | None:
+        """Build the default Event Bus Redis URL from REDIS_* config.
+
+        Returns None to signal that the Event Bus client should reuse the main
+        Redis client (the caller in ``ext_redis.init_app`` already initialises
+        ``_pubsub_redis_client = client`` before consulting this URL, and only
+        overrides it when a non-empty URL is returned).
+
+        - Sentinel mode (without Cluster): returns None. The main Redis client
+          is a Sentinel ``master_for`` handle that already does master discovery
+          and automatic failover, so the Event Bus gets HA for free by reusing
+          it. Encoding Sentinel topology into a single seed URL would lose that
+          failover.
+        - Cluster mode (without Sentinel): builds a seed URL from the first
+          ``REDIS_CLUSTERS`` node; ``RedisCluster.from_url`` uses it only for
+          bootstrap discovery and then talks to every shard directly.
+        - Sentinel + Cluster both enabled: ambiguous — raises so the operator
+          must set PUBSUB_REDIS_URL explicitly.
+        - Standalone fallback: builds a URL from REDIS_HOST / REDIS_PORT.
+        """
         defaults = _redis_defaults(self)
+        scheme = "rediss" if defaults.REDIS_USE_SSL else "redis"
+        username = defaults.REDIS_USERNAME or None
+
+        # Sentinel-only: let the caller reuse the main Sentinel client.
+        # Important: Helm renders REDIS_HOST unconditionally (to the Sentinel
+        # service host or a placeholder), so without this early return the
+        # standalone fallback below would silently build a URL pointing at a
+        # Sentinel-address-treated-as-Redis — which either fails or talks to
+        # the wrong backend. Returning None is the deliberate "no default URL
+        # needed; the main client already handles Sentinel" signal.
+        if defaults.REDIS_USE_SENTINEL and not defaults.REDIS_USE_CLUSTERS:
+            return None
+
+        # Cluster mode: the address list lives in REDIS_CLUSTERS, not REDIS_HOST.
+        # We pick the first node as a seed; RedisCluster.from_url uses it only
+        # for bootstrap discovery and then talks to every shard directly.
+        if defaults.REDIS_USE_CLUSTERS:
+            # The main Redis client routes Sentinel before Cluster in
+            # ext_redis.init_app, so if both flags are on the pubsub client
+            # would silently talk to a different backend than the main client.
+            # Force the operator to set PUBSUB_REDIS_URL explicitly instead.
+            if defaults.REDIS_USE_SENTINEL:
+                raise ValueError(
+                    "REDIS_USE_SENTINEL and REDIS_USE_CLUSTERS are both enabled; "
+                    "PUBSUB_REDIS_URL must be set explicitly because the default "
+                    "builder cannot pick a single backend for pubsub."
+                )
+            host, port = self._first_cluster_node(defaults.REDIS_CLUSTERS)
+            password = defaults.REDIS_CLUSTERS_PASSWORD or defaults.REDIS_PASSWORD or None
+            netloc = self._format_netloc(username, password, host, port)
+            # Redis Cluster disables SELECT DB, so no "/<db>" path component.
+            return urlunparse((scheme, netloc, "", "", "", ""))
+
         if not defaults.REDIS_HOST or not defaults.REDIS_PORT:
             raise ValueError("PUBSUB_REDIS_URL must be set when default Redis URL cannot be constructed")
 
-        scheme = "rediss" if defaults.REDIS_USE_SSL else "redis"
-        username = defaults.REDIS_USERNAME or None
         password = defaults.REDIS_PASSWORD or None
+        netloc = self._format_netloc(username, password, defaults.REDIS_HOST, defaults.REDIS_PORT)
+        return urlunparse((scheme, netloc, f"/{defaults.REDIS_DB}", "", "", ""))
 
+    @staticmethod
+    def _first_cluster_node(clusters: str | None) -> tuple[str, int]:
+        if not clusters:
+            raise ValueError("REDIS_USE_CLUSTERS is true but REDIS_CLUSTERS is unset")
+        for raw in clusters.split(","):
+            node = raw.strip()
+            if not node:
+                continue
+            host, sep, port_str = node.rpartition(":")
+            if not sep or not host or not port_str.isdigit():
+                raise ValueError(
+                    f"REDIS_CLUSTERS entry {node!r} is malformed; expected host:port"
+                )
+            return host, int(port_str)
+        # REDIS_CLUSTERS was set but contained only whitespace / empty segments
+        # (e.g. "   ,   "). Distinct from the unset case so operators can tell
+        # which env var they need to fix.
+        raise ValueError("REDIS_CLUSTERS contains no valid host:port entries")
+
+    @staticmethod
+    def _format_netloc(username: str | None, password: str | None, host: str, port: int) -> str:
         userinfo = ""
         if username:
             userinfo = quote_plus(username)
@@ -87,14 +173,17 @@ class RedisPubSubConfig(BaseSettings):
             userinfo = f"{userinfo}:{password_part}" if userinfo else f":{password_part}"
         if userinfo:
             userinfo = f"{userinfo}@"
-
-        db = defaults.REDIS_DB
-
-        netloc = f"{userinfo}{defaults.REDIS_HOST}:{defaults.REDIS_PORT}"
-        return urlunparse((scheme, netloc, f"/{db}", "", "", ""))
+        return f"{userinfo}{host}:{port}"
 
     @property
-    def normalized_pubsub_redis_url(self) -> str:
+    def normalized_pubsub_redis_url(self) -> str | None:
+        """Resolve the Event Bus Redis URL.
+
+        Returns None when the Event Bus should reuse the main Redis client
+        (no explicit ``PUBSUB_REDIS_URL`` override AND the main client mode is
+        Sentinel). Callers are expected to treat ``None`` / empty as "no
+        standalone pubsub client needed" and fall back to the main client.
+        """
         pubsub_redis_url = self.PUBSUB_REDIS_URL
         if pubsub_redis_url:
             cleaned = pubsub_redis_url.strip()

--- a/api/configs/middleware/cache/redis_pubsub_config.py
+++ b/api/configs/middleware/cache/redis_pubsub_config.py
@@ -160,10 +160,7 @@ class RedisPubSubConfig(BaseSettings):
                 # misused REDIS_CLUSTERS by pasting a full DSN like
                 # "pw@host" would leak the password into startup logs. The
                 # 1-based position is enough to locate the offending entry.
-                raise ValueError(
-                    f"REDIS_CLUSTERS entry at position {index} is malformed; "
-                    "expected 'host:port' format"
-                )
+                raise ValueError(f"REDIS_CLUSTERS entry at position {index} is malformed; expected 'host:port' format")
             return host, int(port_str)
         # REDIS_CLUSTERS was set but contained only whitespace / empty segments
         # (e.g. "   ,   "). Distinct from the unset case so operators can tell

--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -1,6 +1,6 @@
 import ssl
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 import pytz  # type: ignore[import-untyped]
 from celery import Celery, Task
@@ -90,7 +90,36 @@ def get_celery_redis_global_keyprefix() -> str | None:
     return f"{normalized_prefix}:"
 
 
+_CLUSTER_SCHEMES = ("redis+cluster://", "rediss+cluster://")
+
+
+def _reject_cluster_broker_url(broker_url: str | None, backend_url: str | None) -> None:
+    """Celery / Kombu's redis transport does not support Redis Cluster.
+
+    Fail fast at startup if CELERY_BROKER_URL or CELERY_RESULT_BACKEND is a
+    redis+cluster:// URL, rather than crashing later on the first task enqueue
+    or result store. Catches the common mis-config where operators assume the
+    cluster story is symmetric with the main Redis client.
+    """
+    for label, url in (("CELERY_BROKER_URL", broker_url), ("CELERY_RESULT_BACKEND", backend_url)):
+        if not url:
+            continue
+        lowered = url.lower()
+        for scheme in _CLUSTER_SCHEMES:
+            if lowered.startswith(scheme):
+                raise ValueError(
+                    f"{label} is set to a Redis Cluster URL ({scheme}); Celery/Kombu's redis "
+                    "transport does not support Redis Cluster. Use a standalone or Sentinel "
+                    "Redis instance for Celery broker/backend."
+                )
+
+
 def init_app(app: DifyApp) -> Celery:
+    _reject_cluster_broker_url(
+        dify_config.CELERY_BROKER_URL,
+        cast("str | None", dify_config.CELERY_RESULT_BACKEND),
+    )
+
     class FlaskTask(Task):
         def __call__(self, *args: object, **kwargs: object) -> object:
             from core.logging.context import init_request_context

--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -104,7 +104,11 @@ def _reject_cluster_broker_url(broker_url: str | None, backend_url: str | None) 
     for label, url in (("CELERY_BROKER_URL", broker_url), ("CELERY_RESULT_BACKEND", backend_url)):
         if not url:
             continue
-        lowered = url.lower()
+        # Strip before lowering so a leading-whitespace misconfiguration
+        # (e.g. a YAML quoting slip that leaves " redis+cluster://...") still
+        # gets caught here with a precise error, rather than falling through
+        # to Kombu's URL parser for a less actionable failure.
+        lowered = url.strip().lower()
         for scheme in _CLUSTER_SCHEMES:
             if lowered.startswith(scheme):
                 raise ValueError(

--- a/api/extensions/ext_redis.py
+++ b/api/extensions/ext_redis.py
@@ -447,6 +447,18 @@ def init_app(app: DifyApp):
     redis_client.initialize(client)
     app.extensions["redis"] = redis_client
 
+    # Event Bus (pub/sub / streams) client.
+    #
+    # Default: reuse the main Redis client. This gives the Event Bus the same
+    # HA semantics as the main client — Sentinel failover works for free
+    # without encoding Sentinel topology into a single pubsub URL.
+    #
+    # Override path: if PUBSUB_REDIS_URL is set (or the main client is in
+    # Cluster mode, in which case _build_default_pubsub_url produces a seed
+    # URL from REDIS_CLUSTERS), build a dedicated pubsub client. This is the
+    # "advanced fan-out" path — e.g. pointing the Event Bus at an independent
+    # Redis Cluster so streaming events can scale horizontally without
+    # touching the main Redis.
     global _pubsub_redis_client
     _pubsub_redis_client = client
     if dify_config.normalized_pubsub_redis_url:

--- a/api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py
+++ b/api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py
@@ -1,0 +1,247 @@
+"""Unit tests for the default pubsub URL builder in RedisPubSubConfig.
+
+The tests drive ``RedisPubSubConfig._build_default_pubsub_url`` through a
+duck-typed stand-in for the full pydantic-settings config so each branch
+(standalone, cluster, error cases) can be exercised in isolation.
+"""
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from configs.middleware.cache.redis_pubsub_config import RedisPubSubConfig
+
+
+def _make_config(**overrides: object) -> RedisPubSubConfig:
+    """Return a RedisPubSubConfig wired to a stub that carries the Redis envs."""
+    defaults: dict[str, object] = {
+        "REDIS_HOST": "",
+        "REDIS_PORT": 0,
+        "REDIS_USERNAME": None,
+        "REDIS_PASSWORD": None,
+        "REDIS_DB": 0,
+        "REDIS_USE_SSL": False,
+        "REDIS_USE_SENTINEL": False,
+        "REDIS_USE_CLUSTERS": False,
+        "REDIS_CLUSTERS": None,
+        "REDIS_CLUSTERS_PASSWORD": None,
+    }
+    defaults.update(overrides)
+    # RedisPubSubConfig reads the Redis fields by casting ``self`` to
+    # RedisConfigDefaults; attaching them to the instance via SimpleNamespace
+    # plumbing would shadow the pydantic fields, so we build a bare instance
+    # and bolt the attributes on directly.
+    cfg = RedisPubSubConfig()
+    for key, value in defaults.items():
+        object.__setattr__(cfg, key, value)
+    return cfg
+
+
+class TestStandaloneURL:
+    def test_builds_default_url_from_host_and_port(self) -> None:
+        cfg = _make_config(
+            REDIS_HOST="redis.example.com",
+            REDIS_PORT=6379,
+            REDIS_DB=2,
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url == "redis://redis.example.com:6379/2"
+
+    def test_encodes_userinfo(self) -> None:
+        cfg = _make_config(
+            REDIS_HOST="r.example",
+            REDIS_PORT=6379,
+            REDIS_USERNAME="user name",
+            REDIS_PASSWORD="p@ss:word/",
+            REDIS_DB=0,
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url == "redis://user+name:p%40ss%3Aword%2F@r.example:6379/0"
+
+    def test_ssl_switches_scheme_to_rediss(self) -> None:
+        cfg = _make_config(
+            REDIS_HOST="r.example",
+            REDIS_PORT=6379,
+            REDIS_USE_SSL=True,
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url.startswith("rediss://")
+
+    def test_raises_when_host_and_cluster_both_empty(self) -> None:
+        cfg = _make_config()
+
+        with pytest.raises(ValueError, match="PUBSUB_REDIS_URL must be set"):
+            cfg._build_default_pubsub_url()
+
+
+class TestClusterURL:
+    def test_builds_seed_url_from_first_cluster_node(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001,node2:7002,node3:7003",
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        # No /db path component, matching Redis Cluster's single-DB semantics.
+        assert url == "redis://node1:7001"
+
+    def test_cluster_respects_dedicated_password(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001",
+            REDIS_PASSWORD="main-pw",
+            REDIS_CLUSTERS_PASSWORD="cluster-pw",
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url == "redis://:cluster-pw@node1:7001"
+
+    def test_cluster_falls_back_to_redis_password_when_cluster_password_missing(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001",
+            REDIS_PASSWORD="main-pw",
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url == "redis://:main-pw@node1:7001"
+
+    def test_cluster_tolerates_whitespace_and_skips_blank_entries(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS=" , node1:7001 , node2:7002",
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url == "redis://node1:7001"
+
+    def test_cluster_with_ssl(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001",
+            REDIS_USE_SSL=True,
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url.startswith("rediss://")
+
+    def test_cluster_unset_nodes_raises(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS=None,
+        )
+
+        with pytest.raises(ValueError, match="REDIS_CLUSTERS is unset"):
+            cfg._build_default_pubsub_url()
+
+    def test_cluster_blank_string_raises(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="   ,   ",
+        )
+
+        with pytest.raises(ValueError, match="no valid host:port entries"):
+            cfg._build_default_pubsub_url()
+
+    def test_cluster_malformed_entry_raises(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="host-without-port",
+        )
+
+        with pytest.raises(ValueError, match="malformed"):
+            cfg._build_default_pubsub_url()
+
+    def test_cluster_ignores_legacy_redis_host(self) -> None:
+        # Operator migrating from standalone to cluster forgot to clear
+        # REDIS_HOST. Cluster branch takes precedence; REDIS_HOST is ignored.
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001",
+            REDIS_HOST="legacy.example",
+            REDIS_PORT=6379,
+        )
+
+        assert cfg._build_default_pubsub_url() == "redis://node1:7001"
+
+    def test_cluster_with_sentinel_requires_explicit_pubsub_url(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_USE_SENTINEL=True,
+            REDIS_CLUSTERS="node1:7001",
+        )
+
+        with pytest.raises(ValueError, match="PUBSUB_REDIS_URL must be set explicitly"):
+            cfg._build_default_pubsub_url()
+
+
+class TestSentinelURL:
+    """Sentinel mode returns None so the Event Bus reuses the main Sentinel
+    client — which already handles master discovery and failover. Encoding
+    Sentinel topology into a single seed URL would lose failover."""
+
+    def test_sentinel_mode_returns_none_so_main_client_is_reused(self) -> None:
+        cfg = _make_config(REDIS_USE_SENTINEL=True)
+
+        assert cfg._build_default_pubsub_url() is None
+
+    def test_sentinel_mode_ignores_incidental_redis_host(self) -> None:
+        # Helm Chart renders REDIS_HOST unconditionally even in Sentinel mode
+        # (it may point at the Sentinel service or a placeholder). The Sentinel
+        # early-return must NOT fall through to the standalone URL builder,
+        # which would silently construct a URL pointing at the Sentinel
+        # address as if it were a plain Redis.
+        cfg = _make_config(
+            REDIS_USE_SENTINEL=True,
+            REDIS_HOST="sentinel-master-placeholder",
+            REDIS_PORT=26379,
+        )
+
+        assert cfg._build_default_pubsub_url() is None
+
+    def test_sentinel_mode_ignores_ssl_flag(self) -> None:
+        # SSL is a property of the real connection, which is resolved via the
+        # main Sentinel client — not via a pubsub URL. Sentinel branch still
+        # returns None regardless of useSSL.
+        cfg = _make_config(REDIS_USE_SENTINEL=True, REDIS_USE_SSL=True)
+
+        assert cfg._build_default_pubsub_url() is None
+
+    def test_normalized_returns_none_in_sentinel_mode(self) -> None:
+        cfg = _make_config(REDIS_USE_SENTINEL=True)
+
+        assert cfg.normalized_pubsub_redis_url is None
+
+
+class TestNormalizedPubSubURL:
+    def test_explicit_pubsub_url_wins_over_mode_flags(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001",
+        )
+        # PUBSUB_REDIS_URL is a real pydantic field on RedisPubSubConfig, so
+        # cast through the attribute setter.
+        object.__setattr__(cfg, "PUBSUB_REDIS_URL", "redis://override.example:6379/0")
+
+        assert cfg.normalized_pubsub_redis_url == "redis://override.example:6379/0"
+
+    def test_empty_explicit_pubsub_url_falls_back_to_default_builder(self) -> None:
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="node1:7001",
+        )
+        object.__setattr__(cfg, "PUBSUB_REDIS_URL", "   ")
+
+        assert cast(str, cfg.normalized_pubsub_redis_url) == "redis://node1:7001"

--- a/api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py
+++ b/api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py
@@ -5,7 +5,6 @@ duck-typed stand-in for the full pydantic-settings config so each branch
 (standalone, cluster, error cases) can be exercised in isolation.
 """
 
-from types import SimpleNamespace
 from typing import cast
 
 import pytest

--- a/api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py
+++ b/api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py
@@ -80,6 +80,20 @@ class TestStandaloneURL:
         with pytest.raises(ValueError, match="PUBSUB_REDIS_URL must be set"):
             cfg._build_default_pubsub_url()
 
+    def test_db_zero_still_included_in_path_component(self) -> None:
+        # REDIS_DB=0 is the common default; verify the URL path is "/0" and
+        # not an empty path or bare host:port. urlunparse has path-vs-empty
+        # quirks; this guards against an accidental regression there.
+        cfg = _make_config(
+            REDIS_HOST="r.example",
+            REDIS_PORT=6379,
+            REDIS_DB=0,
+        )
+
+        url = cfg._build_default_pubsub_url()
+
+        assert url == "redis://r.example:6379/0"
+
 
 class TestClusterURL:
     def test_builds_seed_url_from_first_cluster_node(self) -> None:
@@ -161,8 +175,43 @@ class TestClusterURL:
             REDIS_CLUSTERS="host-without-port",
         )
 
-        with pytest.raises(ValueError, match="malformed"):
+        with pytest.raises(ValueError, match="position 1.*malformed"):
             cfg._build_default_pubsub_url()
+
+    def test_cluster_malformed_entry_reports_position_not_raw_value(self) -> None:
+        # A misuser pasting a DSN with credentials into REDIS_CLUSTERS would
+        # leak the password if the error echoed the raw entry. The error must
+        # reference the position instead so startup logs stay clean. The
+        # malformed entry must be the first non-empty one — the parser
+        # returns on the first valid host:port, so only leading malformed
+        # entries reach the error path.
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="super-secret-password@lonely-host,good-node:7001",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            cfg._build_default_pubsub_url()
+
+        message = str(exc_info.value)
+        assert "position 1" in message
+        assert "super-secret-password" not in message
+
+    def test_cluster_malformed_entry_skips_blank_leading_segments(self) -> None:
+        # The 1-based position counts every comma-separated segment, including
+        # blank ones. "  ,bad@entry,good:7001" reports position 2 because the
+        # blank leading segment is position 1 (skipped, not errored on).
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="  ,password-leak@host,good:7001",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            cfg._build_default_pubsub_url()
+
+        message = str(exc_info.value)
+        assert "position 2" in message
+        assert "password-leak" not in message
 
     def test_cluster_ignores_legacy_redis_host(self) -> None:
         # Operator migrating from standalone to cluster forgot to clear
@@ -245,3 +294,15 @@ class TestNormalizedPubSubURL:
         object.__setattr__(cfg, "PUBSUB_REDIS_URL", "   ")
 
         assert cast(str, cfg.normalized_pubsub_redis_url) == "redis://node1:7001"
+
+    def test_whitespace_wrapped_explicit_pubsub_url_is_stripped(self) -> None:
+        # A valid URL that happens to carry incidental leading / trailing
+        # whitespace (YAML quoting slip, etc.) must be returned as the
+        # cleaned URL, not cause a fallback to the default builder.
+        cfg = _make_config(
+            REDIS_USE_CLUSTERS=True,
+            REDIS_CLUSTERS="cluster-seed:7001",  # would "win" if stripping failed
+        )
+        object.__setattr__(cfg, "PUBSUB_REDIS_URL", "  redis://override.example:6379/0  ")
+
+        assert cfg.normalized_pubsub_redis_url == "redis://override.example:6379/0"

--- a/api/tests/unit_tests/extensions/test_celery_broker_validation.py
+++ b/api/tests/unit_tests/extensions/test_celery_broker_validation.py
@@ -1,0 +1,69 @@
+"""Unit tests for the Celery broker URL cluster guard in ext_celery."""
+
+import pytest
+
+from extensions.ext_celery import _reject_cluster_broker_url
+
+
+class TestRejectClusterBrokerURL:
+    def test_plain_redis_broker_is_allowed(self) -> None:
+        _reject_cluster_broker_url(
+            broker_url="redis://:pw@redis:6379/0",
+            backend_url="redis://:pw@redis:6379/1",
+        )
+
+    def test_sentinel_broker_is_allowed(self) -> None:
+        _reject_cluster_broker_url(
+            broker_url="sentinel://sentinel-a:26379;sentinel-b:26379",
+            backend_url=None,
+        )
+
+    def test_none_urls_are_allowed(self) -> None:
+        _reject_cluster_broker_url(broker_url=None, backend_url=None)
+
+    def test_redis_cluster_broker_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="CELERY_BROKER_URL"):
+            _reject_cluster_broker_url(
+                broker_url="redis+cluster://:pw@n1:7001,n2:7002",
+                backend_url=None,
+            )
+
+    def test_rediss_cluster_broker_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="CELERY_BROKER_URL"):
+            _reject_cluster_broker_url(
+                broker_url="rediss+cluster://:pw@n1:7001",
+                backend_url=None,
+            )
+
+    def test_cluster_broker_is_rejected_case_insensitive(self) -> None:
+        with pytest.raises(ValueError, match="CELERY_BROKER_URL"):
+            _reject_cluster_broker_url(
+                broker_url="REDIS+CLUSTER://:pw@n1:7001",
+                backend_url=None,
+            )
+
+    def test_cluster_result_backend_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="CELERY_RESULT_BACKEND"):
+            _reject_cluster_broker_url(
+                broker_url="redis://:pw@redis:6379/0",
+                backend_url="redis+cluster://:pw@n1:7001",
+            )
+
+    def test_sentinel_broker_with_cluster_backend_is_rejected(self) -> None:
+        # Mixed config: broker is Sentinel (allowed) but backend is Cluster
+        # (not). The validator must still flag the backend.
+        with pytest.raises(ValueError, match="CELERY_RESULT_BACKEND"):
+            _reject_cluster_broker_url(
+                broker_url="sentinel://s1:26379;s2:26379",
+                backend_url="redis+cluster://:pw@n1:7001",
+            )
+
+    def test_rejection_message_names_kombu_and_recommends_standalone_or_sentinel(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            _reject_cluster_broker_url(
+                broker_url="redis+cluster://n1:7001",
+                backend_url=None,
+            )
+        message = str(exc_info.value)
+        assert "Kombu" in message
+        assert "standalone or Sentinel" in message

--- a/api/tests/unit_tests/extensions/test_celery_broker_validation.py
+++ b/api/tests/unit_tests/extensions/test_celery_broker_validation.py
@@ -58,6 +58,17 @@ class TestRejectClusterBrokerURL:
                 backend_url="redis+cluster://:pw@n1:7001",
             )
 
+    def test_whitespace_wrapped_cluster_broker_is_rejected(self) -> None:
+        # A YAML quoting slip may leave leading / trailing whitespace on the
+        # URL. The validator must strip before scheme-matching so the
+        # operator still gets the precise Kombu-limitation error instead of
+        # a later opaque failure from Kombu's own URL parser.
+        with pytest.raises(ValueError, match="CELERY_BROKER_URL"):
+            _reject_cluster_broker_url(
+                broker_url="  redis+cluster://:pw@n1:7001  ",
+                backend_url=None,
+            )
+
     def test_rejection_message_names_kombu_and_recommends_standalone_or_sentinel(self) -> None:
         with pytest.raises(ValueError) as exc_info:
             _reject_cluster_broker_url(


### PR DESCRIPTION
Fixes #35480
                                                                                                                                                                                                                                                                                
  ## Summary
                                                                                                                                                                                                                                                                                
  Add two config-layer guardrails so Redis-adjacent subsystems stay
  aligned with the declared deployment mode.

  1. **Event Bus follows the main Redis mode.**                                                                                                                                                                                                                                 
     `_build_default_pubsub_url` now branches on `REDIS_USE_SENTINEL`
     and `REDIS_USE_CLUSTERS`:                                                                                                                                                                                                                                                  
     - **Sentinel** mode returns `None`. `ext_redis.init_app` keeps its                                                                                                                                                                                                         
       default `_pubsub_redis_client = client` assignment, so the Event                                                                                                                                                                                                         
       Bus reuses the main `Sentinel.master_for(...)` handle and                                                                                                                                                                                                                
       inherits failover for free. Previously the builder fell through                                                                                                                                                                                                          
       to the standalone branch and silently produced a URL from                                                                                                                                                                                                                
       `REDIS_HOST:REDIS_PORT` — either unreachable (when Helm renders                                                                                                                                                                                                          
       `REDIS_HOST` to the Sentinel service address) or pinned to the                                                                                                                                                                                                           
       master IP at startup with no failover thereafter.                                                                                                                                                                                                                        
     - **Cluster** mode builds a seed URL from the first                                                                                                                                                                                                                        
       `REDIS_CLUSTERS` entry. `RedisCluster.from_url` uses it only                                                                                                                                                                                                             
       for bootstrap discovery and then talks to every shard directly.                                                                                                                                                                                                          
       Before this change, Cluster-only deployments without an explicit                                                                                                                                                                                                         
       `PUBSUB_REDIS_URL` raised `ValueError` on boot.                                                                                                                                                                                                                          
     - **Sentinel + Cluster both enabled** is ambiguous — raise                                                                                                                                                                                                                 
       `ValueError` telling the operator to set `PUBSUB_REDIS_URL`                                                                                                                                                                                                              
       explicitly.                                                                                                                                                                                                                                                              
     - `_format_netloc` is extracted so the Cluster and standalone                                                                                                                                                                                                              
       branches cannot drift on userinfo encoding.                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                
  2. **Celery broker rejects Cluster URLs at startup.**                                                                                                                                                                                                                         
     `ext_celery._reject_cluster_broker_url` scans `CELERY_BROKER_URL`                                                                                                                                                                                                          
     and `CELERY_RESULT_BACKEND` (lowercased, whitespace-stripped) for                                                                                                                                                                                                          
     the `redis+cluster://` / `rediss+cluster://` prefixes and raises                                                                                                                                                                                                           
     with a clear message naming the offending env var and pointing at                                                                                                                                                                                                          
     standalone / Sentinel as the supported options. Kombu's Redis                                                                                                                                                                                                              
     transport does not support Redis Cluster (BRPOP, ETA ZSets, and                                                                                                                                                                                                            
     the unacked Hash all assume a single slot), so catching this at                                                                                                                                                                                                            
     startup avoids an opaque failure on the first task enqueue.                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
  ## Hardening                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                
  - `_first_cluster_node`'s malformed-entry error reports the 1-based                                                                                                                                                                                                           
    position instead of echoing the raw entry, so a mistakenly-pasted
    DSN (with password) never reaches startup logs.                                                                                                                                                                                                                             
  - IPv6 note: `REDIS_CLUSTERS` entries must use bracketed form for                                                                                                                                                                                                             
    IPv6 literals; added an inline reminder near the `rpartition(":")`.                                                                                                                                                                                                         
  - 34 unit tests across                                                                                                                                                                                                                                                        
    `api/tests/unit_tests/configs/middleware/cache/test_redis_pubsub_config.py`                                                                                                                                                                                                 
    and                                                                                                                                                                                                                                                                         
    `api/tests/unit_tests/extensions/test_celery_broker_validation.py`
    cover the three Event Bus branches, Sentinel + Cluster rejection,                                                                                                                                                                                                           
    `REDIS_DB=0` URL shape, whitespace handling in both the                                                                                                                                                                                                                     
    `PUBSUB_REDIS_URL` override path and the Celery scheme check,                                                                                                                                                                                                               
    and the sanitised `REDIS_CLUSTERS` malformed-entry error.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
  ## Screenshots                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
  N/A (backend / config-layer change).                                                                                                                                                                                                                                          
  
  ## Checklist                                                                                                                                                                                                                                                                  
                                                            
  - [ ] This change requires a documentation update                                                                                                                                                                                                                             
  - [x] I understand that this PR may be closed in case there was no previous discussion
  - [x] I've added a test for each change that was introduced                                                                                                                                                                                                                   
  - [ ] I've updated the documentation accordingly                                                                                                                                                                                                                              
  - [ ] I ran `make lint && make type-check` — pending                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                