### PR TITLE
fix(web): keep Add model dialog footer visible when form overflows

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -295,15 +295,15 @@ const ModelModal: FC<ModelModalProps> = ({
     <Dialog open onOpenChange={handleOpenChange}>
       <DialogContent
         backdropProps={{ forceRender: true }}
-        className="w-[640px] max-w-[640px] overflow-hidden p-0"
+        className="flex w-[640px] max-w-[640px] flex-col overflow-hidden p-0"
       >
         <DialogCloseButton className="top-5 right-5 h-8 w-8" />
-        <div className="p-6 pb-3">
+        <div className="shrink-0 p-6 pb-3">
           {modalTitle}
           {modalDesc}
           {modalModel}
         </div>
-        <div className="max-h-[calc(100vh-320px)] overflow-y-auto px-6 py-3">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
           {
             mode === ModelModalModeEnum.configCustomModel && (
               <AuthForm
@@ -365,7 +365,7 @@ const ModelModal: FC<ModelModalProps> = ({
             )
           }
         </div>
-        <div className="flex justify-between p-6 pt-5">
+        <div className="flex shrink-0 justify-between p-6 pt-5">
           {
             (provider.help && (provider.help.title || provider.help.url))
               ? (
@@ -410,7 +410,7 @@ const ModelModal: FC<ModelModalProps> = ({
         </div>
         {
           (mode === ModelModalModeEnum.configCustomModel || mode === ModelModalModeEnum.configProviderCredential) && (
-            <div className="border-t-[0.5px] border-t-divider-regular">
+            <div className="shrink-0 border-t-[0.5px] border-t-divider-regular">
               <div className="flex items-center justify-center rounded-b-2xl bg-background-section-burn py-3 text-xs text-text-tertiary">
                 <Lock01 className="mr-1 h-3 w-3 text-text-tertiary" />
                 {t('modelProvider.encrypted.front', { ns: 'common' })}


### PR DESCRIPTION
## Summary

- The Add model dialog's Save/Add button and encryption notice were being clipped off-screen when the form grew tall (notably when selecting `LLM` model type, which renders more fields than `Text Embedding` or `Rerank`).
- Root cause: `DialogContent` caps popup height at `max-h-[80dvh]`, but the modal's inner scroll region sized itself against the full viewport (`max-h-[calc(100vh-320px)]`). Combined with `overflow-hidden` on the outer container, anything below the form got pushed past the 80dvh boundary and clipped.
- Fix: switch the dialog to a flex column — header, footer button row, and encryption strip use `shrink-0`; the form region uses `min-h-0 flex-1 overflow-y-auto` so it absorbs the remaining space within the 80dvh budget.

Closes #35486
Closes #35423
Closes langgenius/dify-official-plugins#2923

## Test plan

- [x] Existing `model-modal` unit tests pass (`pnpm test app/components/header/account-setting/model-provider-page/model-modal/__tests__/index.spec.tsx`)
- [ ] Manually verify in-browser: Settings → Model Providers → add an OpenAI-API-compatible / GPUStack model with `LLM` type selected, confirm the Add button and `PKCS1_OAEP` notice are both visible without clipping
- [ ] Verify with `Text Embedding` and `Rerank` types (regression check)
- [ ] Verify at short viewport heights (e.g. 700–800px) that the inner form scrolls and the footer stays pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)