### PR TITLE
fix(rag): decouple hybrid recall from top_k for stable merged ranking…

### DIFF
--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -85,6 +85,14 @@ default_retrieval_model: DefaultRetrievalModelDict = {
     "score_threshold_enabled": False,
 }
 
+# Hybrid search fetches from vector and full-text in parallel, then deduplicates and merges
+# scores (weighted or rerank). Using the *final* top_k as the per-channel limit is wrong:
+# a chunk can rank below k in *both* channels but still be top after fusion, so a larger
+# final top_k changes the candidate pool and reorders the head (#35482). Use a floor so
+# changing only top_k does not change which documents participate in merge.
+_HYBRID_PER_CHANNEL_RECALL_FLOOR: int = 50
+_HYBRID_PER_CHANNEL_RECALL_MAX: int = 200
+
 logger = logging.getLogger(__name__)
 
 
@@ -168,6 +176,20 @@ class RetrievalService:
             raise ValueError(";\n".join(exceptions))
 
         return all_documents
+
+    @staticmethod
+    def _hybrid_recall_top_k_for_merge(final_top_k: int) -> int:
+        """How many hits to request from each hybrid sub-retriever (vector, full-text).
+
+        Must not equal ``final_top_k`` alone: per-channel top-k must be large enough that
+        fusion/rerank sees a stable candidate set when the user only changes final top_k.
+        """
+        if final_top_k <= 0:
+            return final_top_k
+        return min(
+            _HYBRID_PER_CHANNEL_RECALL_MAX,
+            max(_HYBRID_PER_CHANNEL_RECALL_FLOOR, final_top_k),
+        )
 
     @classmethod
     def external_retrieve(
@@ -770,6 +792,14 @@ class RetrievalService:
             return
         with flask_app.app_context():
             all_documents_item: list[Document] = []
+            # For hybrid, per-channel top_k must not be tied to the final top_k only (see
+            # _hybrid_recall_top_k_for_merge). Otherwise the merged head changes when the user
+            # only raises final top_k.
+            recall_top_k = (
+                self._hybrid_recall_top_k_for_merge(top_k)
+                if retrieval_method == RetrievalMethod.HYBRID_SEARCH
+                else top_k
+            )
             # Optimize multithreading with thread pools
             with ThreadPoolExecutor(max_workers=dify_config.RETRIEVAL_SERVICE_EXECUTORS) as executor:  # type: ignore
                 futures = []
@@ -794,7 +824,7 @@ class RetrievalService:
                                 flask_app=current_app._get_current_object(),  # type: ignore
                                 dataset_id=dataset.id,
                                 query=query,
-                                top_k=top_k,
+                                top_k=recall_top_k,
                                 score_threshold=score_threshold,
                                 reranking_model=reranking_model,
                                 all_documents=all_documents_item,
@@ -811,7 +841,7 @@ class RetrievalService:
                                 flask_app=current_app._get_current_object(),  # type: ignore
                                 dataset_id=dataset.id,
                                 query=attachment_id,
-                                top_k=top_k,
+                                top_k=recall_top_k,
                                 score_threshold=score_threshold,
                                 reranking_model=reranking_model,
                                 all_documents=all_documents_item,
@@ -828,7 +858,7 @@ class RetrievalService:
                             flask_app=current_app._get_current_object(),  # type: ignore
                             dataset_id=dataset.id,
                             query=query,
-                            top_k=top_k,
+                            top_k=recall_top_k,
                             score_threshold=score_threshold,
                             reranking_model=reranking_model,
                             all_documents=all_documents_item,

--- a/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
@@ -61,6 +61,15 @@ def create_mock_document(
     )
 
 
+def test_hybrid_recall_top_k_for_merge_contract():
+    """Hybrid sub-retrievers use a floor so final top_k does not cap recall too low (#35482)."""
+    assert RetrievalService._hybrid_recall_top_k_for_merge(0) == 0
+    assert RetrievalService._hybrid_recall_top_k_for_merge(3) == 50
+    assert RetrievalService._hybrid_recall_top_k_for_merge(8) == 50
+    assert RetrievalService._hybrid_recall_top_k_for_merge(120) == 120
+    assert RetrievalService._hybrid_recall_top_k_for_merge(250) == 200
+
+
 class _ImmediateFuture:
     def __init__(self, exception: Exception | None = None) -> None:
         self._exception = exception


### PR DESCRIPTION
## Summary
Fixes mixed (hybrid) RAG retrieval so **changing only Top K** no longer changes **which segments participate in score fusion**, which could reorder the head and make the first *N* results differ between a small Top K and a large Top K for the same query.
## Problem
Hybrid search runs **vector** and **full-text** in parallel, deduplicates, then merges scores (weighted score or reranker). The **final** `top_k` was also used as the **per-channel** limit for each sub-retriever. A segment can sit below `k` in *both* channels but still get a high **combined** score. With a small `k` it never entered the candidate pool; with a larger `k` it did—so the merged top results were inconsistent with user expectations (reported in #35482).
## Solution
- Introduce a dedicated **per-channel recall** for hybrid: `min(200, max(50, final_top_k))`.
- Use it for `embedding_search` and `full_text_index_search` in hybrid mode.
- Keep **post-merge** cut at the user’s `top_k` via `DataPostProcessor.invoke(..., top_n=top_k)`.
## Trade-offs
Slightly more work per hybrid query (larger per-channel fetch) in exchange for stable, correct fusion behavior.
## Test plan
- [ ] `uv run pytest tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py::test_hybrid_recall_top_k_for_merge_contract -q`
- [ ] `uv run pytest tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py -k hybrid -q`
- [ ] Manual: same query, hybrid + weighted / rerank, Top K 3 vs 8 — first 3 should match (same ordering and segments).
## Related
- Closes / fixes #35482