### PR TITLE
test(auth): add sign-in smoke test and core validation 

### DIFF
--- a/e2e/features/apps/create-app.feature
+++ b/e2e/features/apps/create-app.feature
@@ -1,4 +1,4 @@
-@apps @authenticated
+@apps @authenticated @core
 Feature: Create app
   Scenario: Create a new blank app and redirect to the editor
     Given I am signed in as the default E2E admin

--- a/e2e/features/apps/create-chatbot-app.feature
+++ b/e2e/features/apps/create-chatbot-app.feature
@@ -1,4 +1,4 @@
-@apps @authenticated
+@apps @authenticated @core @mode-matrix
 Feature: Create Chatbot app
   Scenario: Create a new Chatbot app and redirect to the configuration page
     Given I am signed in as the default E2E admin

--- a/e2e/features/apps/create-workflow-app.feature
+++ b/e2e/features/apps/create-workflow-app.feature
@@ -1,4 +1,4 @@
-@apps @authenticated
+@apps @authenticated @core @mode-matrix
 Feature: Create Workflow app
   Scenario: Create a new Workflow app and redirect to the workflow editor
     Given I am signed in as the default E2E admin

--- a/e2e/features/auth/sign-in.feature
+++ b/e2e/features/auth/sign-in.feature
@@ -1,0 +1,8 @@
+@auth @smoke @core @unauthenticated
+Feature: Sign in
+
+  Scenario: Sign in with valid credentials and reach the apps console
+    Given I am not signed in
+    When I open the sign-in page
+    And I sign in as the default E2E admin
+    Then I should be on the apps console

--- a/e2e/features/auth/sign-out.feature
+++ b/e2e/features/auth/sign-out.feature
@@ -1,4 +1,4 @@
-@auth @authenticated
+@auth @authenticated @core
 Feature: Sign out
   Scenario: Sign out from the apps console
     Given I am signed in as the default E2E admin

--- a/e2e/features/step-definitions/auth/sign-in.steps.ts
+++ b/e2e/features/step-definitions/auth/sign-in.steps.ts
@@ -1,0 +1,20 @@
+import type { DifyWorld } from '../../support/world'
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { adminCredentials } from '../../../fixtures/auth'
+
+When('I open the sign-in page', async function (this: DifyWorld) {
+  await this.getPage().goto('/signin')
+})
+
+When('I sign in as the default E2E admin', async function (this: DifyWorld) {
+  const page = this.getPage()
+
+  await page.getByLabel('Email address').fill(adminCredentials.email)
+  await page.getByLabel('Password').fill(adminCredentials.password)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+})
+
+Then('I should be on the apps console', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/apps(?:\?.*)?$/, { timeout: 30_000 })
+})


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

## What         
         
  - Add `e2e/features/auth/sign-in.feature` with a happy-path sign-in scenario tagged `@smoke @core @unauthenticated`
  - Add `e2e/features/step-definitions/auth/sign-in.steps.ts` with three step definitions: open sign-in page, submit credentials, assert landing on apps console                                          
  - Add `@core` tag to `create-app.feature` and `sign-out.feature`; add `@core @mode-matrix` to `create-chatbot-app.feature` and `create-workflow-app.feature`  
                                                                                                                                                                                                          
  ## Why                                                                                                                                                                                                  
                                                                                                                                                                                                          
  The existing E2E suite covered sign-out and unauthenticated redirect but had no explicit sign-in scenario. Every authenticated scenario implicitly depends on sign-in working, but it was never directly
   tested. The tag additions align existing scenarios with the planned @smoke / @core / @mode-matrix suite structure for CI-level targeted runs.                                                          
                                                                                                                                                
  ## Effect                                                                                                                                                                                               
                  
  - `--tags @smoke` now includes a sign-in scenario that runs on every PR
  - Step definitions reuse `adminCredentials` from `fixtures/auth.ts` and existing locator patterns — no new infrastructure required                                                                      
  - Pre-existing lint errors in unrelated e2e files are not introduced or worsened by this change                                   
                                        
## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
