### PR TITLE
test(e2e): add app detail navigation and redirect scenarios

### DIFF
--- a/e2e/features/apps/app-detail-navigation.feature
+++ b/e2e/features/apps/app-detail-navigation.feature
@@ -4,13 +4,13 @@ Feature: App detail navigation
   Scenario: Opening a workflow app navigates to the workflow editor
     Given I am signed in as the default E2E admin
     And a "workflow" app has been created via API
-    When I navigate to the app detail page
+    When I open the app from the app list
     Then I should land on the workflow editor
 
   Scenario: Opening a chatbot app navigates to the configuration page
     Given I am signed in as the default E2E admin
     And a "chat" app has been created via API
-    When I navigate to the app detail page
+    When I open the app from the app list
     Then I should land on the app configuration page
 
   Scenario: The develop tab is accessible from a workflow app

--- a/e2e/features/apps/app-detail-navigation.feature
+++ b/e2e/features/apps/app-detail-navigation.feature
@@ -1,0 +1,26 @@
+@apps @authenticated @core
+Feature: App detail navigation
+
+  Scenario: Opening a workflow app navigates to the workflow editor
+    Given I am signed in as the default E2E admin
+    And a "workflow" app has been created via API
+    When I navigate to the app detail page
+    Then I should land on the workflow editor
+
+  Scenario: Opening a chatbot app navigates to the configuration page
+    Given I am signed in as the default E2E admin
+    And a "chat" app has been created via API
+    When I navigate to the app detail page
+    Then I should land on the app configuration page
+
+  Scenario: The develop tab is accessible from a workflow app
+    Given I am signed in as the default E2E admin
+    And a "workflow" app has been created via API
+    When I navigate to the app develop page
+    Then I should be on the app develop page
+
+  Scenario: The overview tab is accessible from a workflow app
+    Given I am signed in as the default E2E admin
+    And a "workflow" app has been created via API
+    When I navigate to the app overview page
+    Then I should be on the app overview page

--- a/e2e/features/step-definitions/apps/app-detail-navigation.steps.ts
+++ b/e2e/features/step-definitions/apps/app-detail-navigation.steps.ts
@@ -1,0 +1,32 @@
+import type { DifyWorld } from '../../support/world'
+import { Given, Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestApp } from '../../../support/api'
+
+Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
+  const app = await createTestApp(`E2E Nav ${Date.now()}`, mode)
+  this.createdAppIds.push(app.id)
+})
+
+When('I navigate to the app detail page', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)
+  await this.getPage().goto(`/app/${appId}`)
+})
+
+When('I navigate to the app develop page', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)
+  await this.getPage().goto(`/app/${appId}/develop`)
+})
+
+When('I navigate to the app overview page', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)
+  await this.getPage().goto(`/app/${appId}/overview`)
+})
+
+Then('I should be on the app develop page', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/develop(?:\?.*)?$/, { timeout: 30_000 })
+})
+
+Then('I should be on the app overview page', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/overview(?:\?.*)?$/, { timeout: 30_000 })
+})

--- a/e2e/features/step-definitions/apps/app-detail-navigation.steps.ts
+++ b/e2e/features/step-definitions/apps/app-detail-navigation.steps.ts
@@ -6,11 +6,14 @@ import { createTestApp } from '../../../support/api'
 Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
   const app = await createTestApp(`E2E Nav ${Date.now()}`, mode)
   this.createdAppIds.push(app.id)
+  this.lastCreatedAppName = app.name
 })
 
-When('I navigate to the app detail page', async function (this: DifyWorld) {
-  const appId = this.createdAppIds.at(-1)
-  await this.getPage().goto(`/app/${appId}`)
+When('I open the app from the app list', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await page.goto('/apps')
+  await expect(page.getByRole('button', { name: 'Create from Blank' })).toBeVisible()
+  await page.getByText(this.lastCreatedAppName!).click()
 })
 
 When('I navigate to the app develop page', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/apps/app-detail-navigation.steps.ts
+++ b/e2e/features/step-definitions/apps/app-detail-navigation.steps.ts
@@ -1,20 +1,6 @@
 import type { DifyWorld } from '../../support/world'
-import { Given, Then, When } from '@cucumber/cucumber'
+import { Then, When } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
-import { createTestApp } from '../../../support/api'
-
-Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
-  const app = await createTestApp(`E2E Nav ${Date.now()}`, mode)
-  this.createdAppIds.push(app.id)
-  this.lastCreatedAppName = app.name
-})
-
-When('I open the app from the app list', async function (this: DifyWorld) {
-  const page = this.getPage()
-  await page.goto('/apps')
-  await expect(page.getByRole('button', { name: 'Create from Blank' })).toBeVisible()
-  await page.getByText(this.lastCreatedAppName!).click()
-})
 
 When('I navigate to the app develop page', async function (this: DifyWorld) {
   const appId = this.createdAppIds.at(-1)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

## What                                                                                                                                       
                                                                                                                                              
  - Add `e2e/features/apps/app-detail-navigation.feature` with 4 scenarios tagged `@apps @authenticated @core`                                  
  - Add `e2e/features/step-definitions/apps/app-detail-navigation.steps.ts` with API-seeded setup and URL assertions
  - Scenarios cover: workflow app → workflow editor redirect, chatbot app → configuration redirect, develop tab accessibility, overview tab     
  accessibility                                                                                                                                 
                                                                                                                                                
  ## Why                                                                                                                                        
                                                                                                                                              
  App detail routing is one of the highest-risk areas in the frontend: different app modes redirect to different initial pages, and the         
  develop/overview tabs must remain accessible regardless of mode. These redirects were entirely untested before this change. Any regression
  here would silently break the main user journey of opening an app after creation. Using API-level app creation (via `support/api.ts`) keeps   
  the scenarios fast and decoupled from the app-creation UI.                                                                                  

  ## Effect

  - `--tags @core` now includes 4 navigation scenarios that validate the mode-based redirect logic on every pre-release run                     
  - App cleanup is handled automatically by the existing `After` hook via `createdAppIds`, introducing no teardown boilerplate in step
  definitions                                                                                                                                   
  - Reuses existing step definitions (`I am signed in as the default E2E admin`, `I should land on the workflow editor`, `I should land on the
  app configuration page`) to minimise new step surface area                                                                                    
  - No new infrastructure required; `createTestApp` and `deleteTestApp` were already present in `support/api.ts`

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
