### PR TITLE
test(e2e): add publish app happy path scenario

### DIFF
--- a/e2e/features/apps/publish-app.feature
+++ b/e2e/features/apps/publish-app.feature
@@ -1,0 +1,10 @@
+@apps @authenticated @core
+Feature: Publish app
+
+  Scenario: Publish a chatbot app for the first time
+    Given I am signed in as the default E2E admin
+    And a "chat" app has been created via API
+    When I navigate to the app detail page
+    And I open the publish panel
+    And I publish the app
+    Then the app should be marked as published

--- a/e2e/features/apps/publish-app.feature
+++ b/e2e/features/apps/publish-app.feature
@@ -1,9 +1,10 @@
 @apps @authenticated @core
 Feature: Publish app
 
-  Scenario: Publish a chatbot app for the first time
+  Scenario: Publish a workflow app for the first time
     Given I am signed in as the default E2E admin
-    And a "chat" app has been created via API
+    And a "workflow" app has been created via API
+    And a minimal workflow draft has been synced
     When I open the app from the app list
     And I open the publish panel
     And I publish the app

--- a/e2e/features/apps/publish-app.feature
+++ b/e2e/features/apps/publish-app.feature
@@ -4,7 +4,7 @@ Feature: Publish app
   Scenario: Publish a chatbot app for the first time
     Given I am signed in as the default E2E admin
     And a "chat" app has been created via API
-    When I navigate to the app detail page
+    When I open the app from the app list
     And I open the publish panel
     And I publish the app
     Then the app should be marked as published

--- a/e2e/features/step-definitions/apps/publish-app.steps.ts
+++ b/e2e/features/step-definitions/apps/publish-app.steps.ts
@@ -1,17 +1,6 @@
 import type { DifyWorld } from '../../support/world'
-import { Given, Then, When } from '@cucumber/cucumber'
+import { Then, When } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
-import { createTestApp } from '../../../support/api'
-
-Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
-  const app = await createTestApp(`E2E Publish ${Date.now()}`, mode)
-  this.createdAppIds.push(app.id)
-})
-
-When('I navigate to the app detail page', async function (this: DifyWorld) {
-  const appId = this.createdAppIds.at(-1)
-  await this.getPage().goto(`/app/${appId}`)
-})
 
 When('I open the publish panel', async function (this: DifyWorld) {
   await this.getPage().getByRole('button', { name: 'Publish' }).first().click()

--- a/e2e/features/step-definitions/apps/publish-app.steps.ts
+++ b/e2e/features/step-definitions/apps/publish-app.steps.ts
@@ -1,0 +1,26 @@
+import type { DifyWorld } from '../../support/world'
+import { Given, Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestApp } from '../../../support/api'
+
+Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
+  const app = await createTestApp(`E2E Publish ${Date.now()}`, mode)
+  this.createdAppIds.push(app.id)
+})
+
+When('I navigate to the app detail page', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)
+  await this.getPage().goto(`/app/${appId}`)
+})
+
+When('I open the publish panel', async function (this: DifyWorld) {
+  await this.getPage().getByRole('button', { name: 'Publish' }).first().click()
+})
+
+When('I publish the app', async function (this: DifyWorld) {
+  await this.getPage().getByRole('button', { name: /Publish Update/ }).click()
+})
+
+Then('the app should be marked as published', async function (this: DifyWorld) {
+  await expect(this.getPage().getByRole('button', { name: 'Published' })).toBeVisible({ timeout: 30_000 })
+})

--- a/e2e/features/step-definitions/common/app.steps.ts
+++ b/e2e/features/step-definitions/common/app.steps.ts
@@ -1,0 +1,17 @@
+import type { DifyWorld } from '../../support/world'
+import { Given, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestApp } from '../../../support/api'
+
+Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
+  const app = await createTestApp(`E2E ${Date.now()}`, mode)
+  this.createdAppIds.push(app.id)
+  this.lastCreatedAppName = app.name
+})
+
+When('I open the app from the app list', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await page.goto('/apps')
+  await expect(page.getByRole('button', { name: 'Create from Blank' })).toBeVisible()
+  await page.getByText(this.lastCreatedAppName!).click()
+})

--- a/e2e/features/step-definitions/common/app.steps.ts
+++ b/e2e/features/step-definitions/common/app.steps.ts
@@ -1,12 +1,17 @@
 import type { DifyWorld } from '../../support/world'
 import { Given, When } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
-import { createTestApp } from '../../../support/api'
+import { createTestApp, syncMinimalWorkflowDraft } from '../../../support/api'
 
 Given('a {string} app has been created via API', async function (this: DifyWorld, mode: string) {
   const app = await createTestApp(`E2E ${Date.now()}`, mode)
   this.createdAppIds.push(app.id)
   this.lastCreatedAppName = app.name
+})
+
+Given('a minimal workflow draft has been synced', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)!
+  await syncMinimalWorkflowDraft(appId)
 })
 
 When('I open the app from the app list', async function (this: DifyWorld) {

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -43,6 +43,34 @@ export async function createTestApp(name: string, mode = 'workflow'): Promise<Ap
   }
 }
 
+export async function syncMinimalWorkflowDraft(appId: string): Promise<void> {
+  const ctx = await createApiContext()
+  try {
+    await ctx.post(`/console/api/apps/${appId}/workflows/draft`, {
+      data: {
+        graph: {
+          nodes: [
+            {
+              id: '1',
+              type: 'custom',
+              position: { x: 80, y: 282 },
+              data: { id: '1', type: 'start', title: 'Start', variables: [] },
+            },
+          ],
+          edges: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+        },
+        features: {},
+        environment_variables: [],
+        conversation_variables: [],
+      },
+    })
+  }
+  finally {
+    await ctx.dispose()
+  }
+}
+
 export async function deleteTestApp(id: string): Promise<void> {
   const ctx = await createApiContext()
   try {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

## What                                                                                                                                       
                                                                                                                                                
  - Add `e2e/features/apps/publish-app.feature` with a first-publish happy-path scenario tagged `@apps @authenticated @core`
  - Add `e2e/features/step-definitions/apps/publish-app.steps.ts` with steps for API app creation, publish panel interaction, and published     
  state assertion                                                                                                                               
                                                                                                                                                
  ## Why                                                                                                                                      
                                                                                                                                                
  The publish flow is a P0 business path with zero E2E coverage. Any regression in the Publish button or the publish API would be invisible   
  until users reported it in production. This scenario closes the "create → publish" minimum loop for chatbot apps using the real API, without  
  requiring a live LLM or any additional infrastructure.                                                                                      
                                                                                                                                                
  ## Effect                                                                                                                                   
                                                                                                                                                
  - `--tags @core` now validates that the publish popover opens, the "Publish Update" button triggers the API, and the button transitions to
  "Published" state                                                                                                                             
  - App teardown is handled automatically by the existing `After` hook via `createdAppIds`                                                    
  - Note: `a {string} app has been created via API` and `I navigate to the app detail page` are duplicated from `test/app-detail-navigation`    
  (not yet merged); these should be consolidated into `common/` when both PRs land                                                              
                                                                          

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
