### PR TITLE
fix(web): restore "Copied" feedback state on copy buttons

### DIFF
--- a/web/app/components/base/copy-feedback/__tests__/index.spec.tsx
+++ b/web/app/components/base/copy-feedback/__tests__/index.spec.tsx
@@ -40,11 +40,11 @@ describe('CopyFeedback', () => {
       expect(mockCopy).toHaveBeenCalledWith('test content')
     })
 
-    it('calls reset on mouse leave', () => {
+    it('does not reset on mouse leave (relies on hook timeout)', () => {
       render(<CopyFeedback content="test content" />)
       const button = screen.getByRole('button')
       fireEvent.mouseLeave(button.firstChild as Element)
-      expect(mockReset).toHaveBeenCalledTimes(1)
+      expect(mockReset).not.toHaveBeenCalled()
     })
   })
 })
@@ -88,11 +88,11 @@ describe('CopyFeedbackNew', () => {
       expect(mockCopy).toHaveBeenCalledWith('test content')
     })
 
-    it('calls reset on mouse leave', () => {
+    it('does not reset on mouse leave (relies on hook timeout)', () => {
       const { container } = render(<CopyFeedbackNew content="test content" />)
       const clickableArea = container.querySelector('.cursor-pointer')!.firstChild as HTMLElement
       fireEvent.mouseLeave(clickableArea)
-      expect(mockReset).toHaveBeenCalledTimes(1)
+      expect(mockReset).not.toHaveBeenCalled()
     })
   })
 })

--- a/web/app/components/base/copy-feedback/index.tsx
+++ b/web/app/components/base/copy-feedback/index.tsx
@@ -19,7 +19,10 @@ const prefixEmbedded = 'overview.appInfo.embedded'
 
 const CopyFeedback = ({ content }: Props) => {
   const { t } = useTranslation()
-  const { copied, copy, reset } = useClipboard()
+  // Rely on useClipboard's own timer to flip `copied` back to false so the
+  // "Copied" tooltip stays visible long enough to be read, matching the
+  // KeyValueItem pattern. Do NOT reset on mouse leave.
+  const { copied, copy } = useClipboard({ timeout: 2000 })
 
   const tooltipText = copied
     ? t(`${prefixEmbedded}.copied`, { ns: 'appOverview' })
@@ -36,10 +39,7 @@ const CopyFeedback = ({ content }: Props) => {
       popupContent={safeText}
     >
       <ActionButton>
-        <div
-          onClick={handleCopy}
-          onMouseLeave={reset}
-        >
+        <div onClick={handleCopy}>
           {copied && <RiClipboardFill className="h-4 w-4" />}
           {!copied && <RiClipboardLine className="h-4 w-4" />}
         </div>
@@ -52,7 +52,7 @@ export default CopyFeedback
 
 export const CopyFeedbackNew = ({ content, className }: Pick<Props, 'className' | 'content'>) => {
   const { t } = useTranslation()
-  const { copied, copy, reset } = useClipboard()
+  const { copied, copy } = useClipboard({ timeout: 2000 })
 
   const tooltipText = copied
     ? t(`${prefixEmbedded}.copied`, { ns: 'appOverview' })
@@ -73,7 +73,6 @@ export const CopyFeedbackNew = ({ content, className }: Pick<Props, 'className' 
       >
         <div
           onClick={handleCopy}
-          onMouseLeave={reset}
           className={`h-full w-full ${copyStyle.copyIcon} ${copied ? copyStyle.copied : ''}`}
         >
         </div>

--- a/web/hooks/use-clipboard.ts
+++ b/web/hooks/use-clipboard.ts
@@ -43,12 +43,14 @@ export function useClipboard({
   const copy = useCallback(async (valueToCopy: string) => {
     try {
       await writeTextToClipboard(valueToCopy)
+      handleCopyResult(true)
     }
     catch (e) {
       if (usePromptAsFallback) {
         try {
           // eslint-disable-next-line no-alert -- prompt as fallback in case of copy error
           window.prompt(promptFallbackText, valueToCopy)
+          handleCopyResult(true)
         }
         catch (e2) {
           handleCopyError(e2 as Error)


### PR DESCRIPTION
> [!IMPORTANT]
>
> Fixes #35512.

## Summary

`useClipboard` never flipped `copied` to `true` on a successful write, so every UI built on it (icon swap, `Copy → Copied` tooltip) was stuck on the pre-copy state. The most visible regression is the copy-icon next to the API endpoint URL on `/datasets` (Service API card), but this hook is shared by several surfaces.

`CopyFeedback` / `CopyFeedbackNew` also wired `onMouseLeave={reset}` on the click target, which would clear the "Copied" state the instant the cursor left the icon — even after fixing the hook, users could not read the confirmation.

### Changes

- `web/hooks/use-clipboard.ts` — call `handleCopyResult(true)` after a successful `writeTextToClipboard`, and after the prompt-fallback path when `usePromptAsFallback` is enabled.
- `web/app/components/base/copy-feedback/index.tsx` — drop the `onMouseLeave={reset}` handler on both `CopyFeedback` and `CopyFeedbackNew`; rely on the hook's timer instead. Bump the timeout to `2000ms` for these surfaces to match the `KeyValueItem` copy feedback used by the plugin Debug info popover.
- `web/app/components/base/copy-feedback/__tests__/index.spec.tsx` — update the mouse-leave assertion to verify `reset` is **not** called (the timeout drives the revert now).

## Screenshots

| Before | After |
|--------|-------|
| Clicking the copy icon copies the text, but the tooltip stays on `Copy` and the icon never swaps. | Clicking copies the text, the icon swaps to the filled variant, and the tooltip shows `Copied` for ~2s before reverting. |

## Checklist

- [x] This change does not require a documentation update.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've updated the existing test for each behavior change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `pnpm exec vp staged` on the touched files.

Made with [Cursor](https://cursor.com)