### PR TITLE
fix: suggest questions more max_tokens

### DIFF
--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -13,8 +13,6 @@ from core.llm_generator.output_parser.rule_config_generator import RuleConfigGen
 from core.llm_generator.output_parser.suggested_questions_after_answer import SuggestedQuestionsAfterAnswerOutputParser
 from core.llm_generator.prompts import (
     CONVERSATION_TITLE_PROMPT,
-    DEFAULT_SUGGESTED_QUESTIONS_MAX_TOKENS,
-    DEFAULT_SUGGESTED_QUESTIONS_TEMPERATURE,
     GENERATOR_QA_PROMPT,
     JAVASCRIPT_CODE_GENERATOR_PROMPT_TEMPLATE,
     LLM_MODIFY_CODE_SYSTEM,
@@ -217,8 +215,8 @@ class LLMGenerator:
             else:
                 # Default-model generation keeps the built-in suggested-questions tuning.
                 model_parameters = {
-                    "max_tokens": DEFAULT_SUGGESTED_QUESTIONS_MAX_TOKENS,
-                    "temperature": DEFAULT_SUGGESTED_QUESTIONS_TEMPERATURE,
+                    "max_tokens": 2560,
+                    "temperature": 0.0,
                 }
                 stop = []
 

--- a/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
+++ b/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
@@ -10,7 +10,14 @@ logger = logging.getLogger(__name__)
 
 class SuggestedQuestionsAfterAnswerOutputParser:
     def __init__(self, instruction_prompt: str | None = None) -> None:
-        self._instruction_prompt = instruction_prompt or DEFAULT_SUGGESTED_QUESTIONS_AFTER_ANSWER_INSTRUCTION_PROMPT
+        self._instruction_prompt = self._build_instruction_prompt(instruction_prompt)
+
+    @staticmethod
+    def _build_instruction_prompt(instruction_prompt: str | None) -> str:
+        if not instruction_prompt or not instruction_prompt.strip():
+            return DEFAULT_SUGGESTED_QUESTIONS_AFTER_ANSWER_INSTRUCTION_PROMPT
+
+        return f'{instruction_prompt}\nYou must output a JSON array like ["question1", "question2", "question3"].'
 
     def get_format_instructions(self) -> str:
         return self._instruction_prompt

--- a/api/core/llm_generator/prompts.py
+++ b/api/core/llm_generator/prompts.py
@@ -104,9 +104,6 @@ DEFAULT_SUGGESTED_QUESTIONS_AFTER_ANSWER_INSTRUCTION_PROMPT = (
     '["question1","question2","question3"]\n'
 )
 
-DEFAULT_SUGGESTED_QUESTIONS_MAX_TOKENS = 256
-DEFAULT_SUGGESTED_QUESTIONS_TEMPERATURE = 0.0
-
 GENERATOR_QA_PROMPT = (
     "<Task> The user will send a long text. Generate a Question and Answer pairs only using the knowledge"
     " in the long text. Please think step by step."

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -6,10 +6,6 @@ import pytest
 from core.app.app_config.entities import ModelConfig
 from core.llm_generator.entities import RuleCodeGeneratePayload, RuleGeneratePayload, RuleStructuredOutputPayload
 from core.llm_generator.llm_generator import LLMGenerator
-from core.llm_generator.prompts import (
-    DEFAULT_SUGGESTED_QUESTIONS_MAX_TOKENS,
-    DEFAULT_SUGGESTED_QUESTIONS_TEMPERATURE,
-)
 from graphon.model_runtime.entities.llm_entities import LLMMode, LLMResult
 from graphon.model_runtime.entities.model_entities import ModelType
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
@@ -102,8 +98,8 @@ class TestLLMGenerator:
         assert len(questions) == 2
         assert questions[0] == "Question 1?"
         assert mock_model_instance.invoke_llm.call_args.kwargs["model_parameters"] == {
-            "max_tokens": DEFAULT_SUGGESTED_QUESTIONS_MAX_TOKENS,
-            "temperature": DEFAULT_SUGGESTED_QUESTIONS_TEMPERATURE,
+            "max_tokens": 2560,
+            "temperature": 0.0,
         }
 
     def test_generate_suggested_questions_after_answer_auth_error(self, mock_model_instance):
@@ -181,8 +177,8 @@ class TestLLMGenerator:
             model_type=ModelType.LLM,
         )
         assert default_model_instance.invoke_llm.call_args.kwargs["model_parameters"] == {
-            "max_tokens": DEFAULT_SUGGESTED_QUESTIONS_MAX_TOKENS,
-            "temperature": DEFAULT_SUGGESTED_QUESTIONS_TEMPERATURE,
+            "max_tokens": 2560,
+            "temperature": 0.0,
         }
         assert default_model_instance.invoke_llm.call_args.kwargs["stop"] == []
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

the follow of https://github.com/langgenius/dify/pull/35442

1. increase the `max_token` from `256` to `2560`. as my tests, lots of reasoning model require 300~500 tokens to generate the suggested questions.  `256` was set in two years ago.
2. for custom config prompt,  the users usually don't know it's require a JsonArray for the suggested question generation, we should add a prompt on the background

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
