### PR TITLE
test: add P0 workflow run, publish, and share scenarios  

### DIFF
--- a/e2e/features/apps/share-app.feature
+++ b/e2e/features/apps/share-app.feature
@@ -1,0 +1,19 @@
+@apps @authenticated @core
+Feature: Share app publicly
+
+  Scenario: Enable public share for a published workflow app
+    Given I am signed in as the default E2E admin
+    And a "workflow" app has been created via API
+    And a minimal runnable workflow draft has been synced
+    When I open the app from the app list
+    And I open the publish panel
+    And I publish the app
+    And I navigate to the app overview page
+    And I enable the Web App share
+    Then the Web App should be in service
+
+  @unauthenticated
+  Scenario: Access a shared workflow app without authentication
+    Given a workflow app has been published and shared via API
+    When I open the shared app URL
+    Then the shared app page should be accessible

--- a/e2e/features/apps/workflow-run-publish.feature
+++ b/e2e/features/apps/workflow-run-publish.feature
@@ -1,0 +1,13 @@
+@apps @authenticated @core @mode-matrix
+Feature: Workflow run and publish
+
+  Scenario: Run and publish a minimal workflow app
+    Given I am signed in as the default E2E admin
+    And a "workflow" app has been created via API
+    And a minimal runnable workflow draft has been synced
+    When I open the app from the app list
+    And I run the workflow
+    Then the workflow run should succeed
+    When I open the publish panel
+    And I publish the app
+    Then the app should be marked as published

--- a/e2e/features/step-definitions/apps/share-app.steps.ts
+++ b/e2e/features/step-definitions/apps/share-app.steps.ts
@@ -5,13 +5,17 @@ import { createTestApp, enableAppSiteAndGetURL, publishWorkflowApp, syncRunnable
 
 When('I enable the Web App share', async function (this: DifyWorld) {
   const page = this.getPage()
-  await expect(page.getByText('Web App')).toBeVisible({ timeout: 15_000 })
-  const webAppCard = page.locator('div').filter({ hasText: /^Web App/ }).filter({ has: page.getByRole('switch') }).first()
-  await webAppCard.getByRole('switch').click()
+  const appName = this.lastCreatedAppName
+  if (!appName)
+    throw new Error('No app name available. Run "a \\"workflow\\" app has been created via API" first.')
+
+  await page.locator('button').filter({ hasText: appName }).filter({ hasText: 'Workflow' }).click()
+  await expect(page.getByRole('switch').first()).toBeEnabled({ timeout: 15_000 })
+  await page.getByRole('switch').first().click()
 })
 
 Then('the Web App should be in service', async function (this: DifyWorld) {
-  await expect(this.getPage().getByText('In Service')).toBeVisible({ timeout: 10_000 })
+  await expect(this.getPage().getByText('In Service').first()).toBeVisible({ timeout: 10_000 })
 })
 
 Given('a workflow app has been published and shared via API', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/apps/share-app.steps.ts
+++ b/e2e/features/step-definitions/apps/share-app.steps.ts
@@ -3,12 +3,6 @@ import { Given, Then, When } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { createTestApp, enableAppSiteAndGetURL, publishWorkflowApp, syncRunnableWorkflowDraft } from '../../../support/api'
 
-When('I navigate to the app overview page', async function (this: DifyWorld) {
-  const page = this.getPage()
-  await page.getByRole('link', { name: 'Overview' }).click()
-  await expect(page).toHaveURL(/\/overview/, { timeout: 15_000 })
-})
-
 When('I enable the Web App share', async function (this: DifyWorld) {
   const page = this.getPage()
   await expect(page.getByText('Web App')).toBeVisible({ timeout: 15_000 })

--- a/e2e/features/step-definitions/apps/share-app.steps.ts
+++ b/e2e/features/step-definitions/apps/share-app.steps.ts
@@ -1,0 +1,41 @@
+import type { DifyWorld } from '../../support/world'
+import { Given, Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestApp, enableAppSiteAndGetURL, publishWorkflowApp, syncRunnableWorkflowDraft } from '../../../support/api'
+
+When('I navigate to the app overview page', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await page.getByRole('link', { name: 'Overview' }).click()
+  await expect(page).toHaveURL(/\/overview/, { timeout: 15_000 })
+})
+
+When('I enable the Web App share', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await expect(page.getByText('Web App')).toBeVisible({ timeout: 15_000 })
+  const webAppCard = page.locator('div').filter({ hasText: /^Web App/ }).filter({ has: page.getByRole('switch') }).first()
+  await webAppCard.getByRole('switch').click()
+})
+
+Then('the Web App should be in service', async function (this: DifyWorld) {
+  await expect(this.getPage().getByText('In Service')).toBeVisible({ timeout: 10_000 })
+})
+
+Given('a workflow app has been published and shared via API', async function (this: DifyWorld) {
+  const app = await createTestApp(`E2E Share ${Date.now()}`, 'workflow')
+  this.createdAppIds.push(app.id)
+  this.lastCreatedAppName = app.name
+  await syncRunnableWorkflowDraft(app.id)
+  await publishWorkflowApp(app.id)
+  this.shareURL = await enableAppSiteAndGetURL(app.id)
+})
+
+When('I open the shared app URL', async function (this: DifyWorld) {
+  if (!this.shareURL)
+    throw new Error('No share URL available. Run "a workflow app has been published and shared via API" first.')
+  await this.getPage().goto(this.shareURL, { timeout: 20_000 })
+})
+
+Then('the shared app page should be accessible', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/(workflow|chat)\/[a-zA-Z0-9]+/, { timeout: 15_000 })
+  await expect(this.getPage().locator('body')).toBeVisible({ timeout: 10_000 })
+})

--- a/e2e/features/step-definitions/apps/workflow-run.steps.ts
+++ b/e2e/features/step-definitions/apps/workflow-run.steps.ts
@@ -1,0 +1,22 @@
+import type { DifyWorld } from '../../support/world'
+import { Given, Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { syncRunnableWorkflowDraft } from '../../../support/api'
+
+Given('a minimal runnable workflow draft has been synced', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)
+  if (!appId)
+    throw new Error('No app ID found. Run "a \\"workflow\\" app has been created via API" first.')
+  await syncRunnableWorkflowDraft(appId)
+})
+
+When('I run the workflow', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await page.getByText('Test Run').click()
+  await expect(page.getByRole('button', { name: 'Start Run' })).toBeVisible({ timeout: 15_000 })
+  await page.getByRole('button', { name: 'Start Run' }).click()
+})
+
+Then('the workflow run should succeed', async function (this: DifyWorld) {
+  await expect(this.getPage().getByText('SUCCESS')).toBeVisible({ timeout: 30_000 })
+})

--- a/e2e/features/step-definitions/apps/workflow-run.steps.ts
+++ b/e2e/features/step-definitions/apps/workflow-run.steps.ts
@@ -13,10 +13,11 @@ Given('a minimal runnable workflow draft has been synced', async function (this:
 When('I run the workflow', async function (this: DifyWorld) {
   const page = this.getPage()
   await page.getByText('Test Run').click()
-  await expect(page.getByRole('button', { name: 'Start Run' })).toBeVisible({ timeout: 15_000 })
-  await page.getByRole('button', { name: 'Start Run' }).click()
+  await expect(page.getByText('Running').first()).toBeVisible({ timeout: 15_000 })
 })
 
 Then('the workflow run should succeed', async function (this: DifyWorld) {
-  await expect(this.getPage().getByText('SUCCESS')).toBeVisible({ timeout: 30_000 })
+  const page = this.getPage()
+  await page.getByText('DETAIL').click()
+  await expect(page.getByText('SUCCESS').first()).toBeVisible({ timeout: 55_000 })
 })

--- a/e2e/features/support/world.ts
+++ b/e2e/features/support/world.ts
@@ -15,6 +15,7 @@ export class DifyWorld extends World {
   lastCreatedAppName: string | undefined
   createdAppIds: string[] = []
   capturedDownloads: Download[] = []
+  shareURL: string | undefined
 
   constructor(options: IWorldOptions) {
     super(options)
@@ -27,6 +28,7 @@ export class DifyWorld extends World {
     this.lastCreatedAppName = undefined
     this.createdAppIds = []
     this.capturedDownloads = []
+    this.shareURL = undefined
   }
 
   async startSession(browser: Browser, authenticated: boolean) {

--- a/e2e/scripts/run-cucumber.ts
+++ b/e2e/scripts/run-cucumber.ts
@@ -67,11 +67,20 @@ const main = async () => {
     logFilePath: path.join(logDir, 'cucumber-api.log'),
   })
 
+  const celeryProcess = await startLoggedProcess({
+    command: 'npx',
+    args: ['tsx', './scripts/setup.ts', 'celery'],
+    cwd: e2eDir,
+    label: 'celery worker',
+    logFilePath: path.join(logDir, 'cucumber-celery.log'),
+  })
+
   let cleanupPromise: Promise<void> | undefined
   const cleanup = async () => {
     if (!cleanupPromise) {
       cleanupPromise = (async () => {
         await stopWebServer()
+        await stopManagedProcess(celeryProcess)
         await stopManagedProcess(apiProcess)
 
         if (startMiddlewareForRun) {

--- a/e2e/scripts/setup.ts
+++ b/e2e/scripts/setup.ts
@@ -202,6 +202,32 @@ export const startApi = async () => {
   })
 }
 
+export const startCelery = async () => {
+  const env = await getApiEnvironment()
+
+  await runForegroundProcess({
+    command: 'uv',
+    args: [
+      'run',
+      '--project',
+      '.',
+      '--no-sync',
+      'celery',
+      '-A',
+      'app.celery',
+      'worker',
+      '--pool',
+      'solo',
+      '--loglevel',
+      'INFO',
+      '-Q',
+      'workflow_based_app_execution',
+    ],
+    cwd: apiDir,
+    env,
+  })
+}
+
 export const stopMiddleware = async () => {
   await runCommandOrThrow({
     command: 'docker',
@@ -308,7 +334,7 @@ export const startMiddleware = async () => {
 }
 
 const printUsage = () => {
-  console.log('Usage: tsx ./scripts/setup.ts <reset|middleware-up|middleware-down|api|web>')
+  console.log('Usage: tsx ./scripts/setup.ts <reset|middleware-up|middleware-down|api|celery|web>')
 }
 
 const main = async () => {
@@ -317,6 +343,9 @@ const main = async () => {
   switch (command) {
     case 'api':
       await startApi()
+      return
+    case 'celery':
+      await startCelery()
       return
     case 'middleware-down':
       await stopMiddleware()

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -98,7 +98,12 @@ export async function syncRunnableWorkflowDraft(appId: string): Promise<void> {
               id: 'end',
               type: 'custom',
               position: { x: 480, y: 282 },
-              data: { id: 'end', type: 'end', title: 'End', outputs: [] },
+              data: {
+                id: 'end',
+                type: 'end',
+                title: 'End',
+                outputs: [{ variable: 'result', value_selector: ['sys', 'workflow_run_id'] }],
+              },
             },
           ],
           edges: [
@@ -107,6 +112,8 @@ export async function syncRunnableWorkflowDraft(appId: string): Promise<void> {
               type: 'custom',
               source: 'start',
               target: 'end',
+              sourceHandle: 'source',
+              targetHandle: 'target',
             },
           ],
           viewport: { x: 0, y: 0, zoom: 1 },

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -80,3 +80,76 @@ export async function deleteTestApp(id: string): Promise<void> {
     await ctx.dispose()
   }
 }
+
+export async function syncRunnableWorkflowDraft(appId: string): Promise<void> {
+  const ctx = await createApiContext()
+  try {
+    await ctx.post(`/console/api/apps/${appId}/workflows/draft`, {
+      data: {
+        graph: {
+          nodes: [
+            {
+              id: 'start',
+              type: 'custom',
+              position: { x: 80, y: 282 },
+              data: { id: 'start', type: 'start', title: 'Start', variables: [] },
+            },
+            {
+              id: 'end',
+              type: 'custom',
+              position: { x: 480, y: 282 },
+              data: { id: 'end', type: 'end', title: 'End', outputs: [] },
+            },
+          ],
+          edges: [
+            {
+              id: 'start-end',
+              type: 'custom',
+              source: 'start',
+              target: 'end',
+            },
+          ],
+          viewport: { x: 0, y: 0, zoom: 1 },
+        },
+        features: {},
+        environment_variables: [],
+        conversation_variables: [],
+      },
+    })
+  }
+  finally {
+    await ctx.dispose()
+  }
+}
+
+export async function publishWorkflowApp(appId: string): Promise<void> {
+  const ctx = await createApiContext()
+  try {
+    await ctx.post(`/console/api/apps/${appId}/workflows/publish`, {
+      data: { marked_name: '', marked_comment: '' },
+    })
+  }
+  finally {
+    await ctx.dispose()
+  }
+}
+
+type AppDetailWithSite = {
+  site: { access_token: string, app_base_url: string, enable_site: boolean }
+}
+
+export async function enableAppSiteAndGetURL(appId: string): Promise<string> {
+  const ctx = await createApiContext()
+  try {
+    await ctx.post(`/console/api/apps/${appId}/site-enable`, {
+      data: { enable_site: true },
+    })
+    const res = await ctx.get(`/console/api/apps/${appId}`)
+    const body = (await res.json()) as AppDetailWithSite
+    const { app_base_url, access_token } = body.site
+    return `${app_base_url}/workflow/${access_token}`
+  }
+  finally {
+    await ctx.dispose()
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
Summary:                                                                                           
                                                                                                   
  Adds two new P0 feature files and their step definitions covering the core workflow lifecycle:     
  running a draft, publishing it, and sharing it publicly.                                           
   
  What changed                                                                                       
                                                                                                   
  New scenarios (@core):                                                                             
   
  - workflow-run-publish.feature — runs a minimal workflow draft via the Test Run button, asserts    
  SUCCESS, then publishes and confirms the Published state
  - share-app.feature — two scenarios:                                                               
    a. Authenticated: enables Web App share for a published workflow and asserts "In Service"        
    b. @unauthenticated: opens a shared app URL via token and asserts the page is accessible         
                                                                                                     
  New step definitions:                                                                              
  - workflow-run.steps.ts — syncs a runnable draft via API, triggers Test Run, waits for RUNNING     
  confirmation, then polls DETAIL panel for SUCCESS                                                  
  - share-app.steps.ts — enables Web App share via the sidebar panel, plus a full API-seeded Given
  that creates, publishes, and shares the app in one step for the unauthenticated scenario           
                                                                                                     
  New API helpers (support/api.ts):
  - syncRunnableWorkflowDraft — pushes a minimal but publish-valid START→END graph (END node requires
   a non-empty output to pass frontend publish validation; sys.workflow_run_id is used as it is      
  always present in the variable pool)                                                               
  - publishWorkflowApp — publishes the workflow draft                                                
  - enableAppSiteAndGetURL — enables the site and returns the public share URL
                                                                              
  DifyWorld: added shareURL field for the unauthenticated share scenario                             
                                                                                                     
  E2E orchestration: added a Celery worker process (--pool solo) to run-cucumber.ts so               
  workflow_based_app_execution tasks are processed during the test run — without it, streaming       
  workflow runs dispatched via task.delay() never complete                                           
                  
  Test plan

  - pnpm -C e2e e2e -- --tags @core — all new scenarios pass                                         
  - pnpm -C e2e e2e -- --tags @unauthenticated — share URL scenario passes without auth state
  - pnpm -C e2e check — no lint or type errors           

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
