### PR TITLE
chore(ci): move image builds to depot

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -110,6 +110,30 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  fork-build-validate:
+    if: github.repository != 'langgenius/dify'
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - service_name: "validate-api-amd64"
+            build_context: "{{defaultContext}}:api"
+            file: "Dockerfile"
+          - service_name: "validate-web-amd64"
+            build_context: "{{defaultContext}}"
+            file: "web/Dockerfile"
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@98e3b2c9eab4f4f98a95c0c0a3ea5e5e672fd2a8 # v3.10.0
+
+      - name: Validate Docker image
+        uses: docker/build-push-action@5cd29d66b4a8d8e6f4d5dfe2e9329f0b1d446289 # v6.18.0
+        with:
+          push: false
+          context: ${{ matrix.build_context }}
+          file: ${{ matrix.file }}
+          platforms: linux/amd64
+
   create-manifest:
     needs: build
     runs-on: depot-ubuntu-24.04

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -26,6 +26,9 @@ jobs:
   build:
     runs-on: ${{ matrix.runs_on }}
     if: github.repository == 'langgenius/dify'
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         include:
@@ -42,7 +45,7 @@ jobs:
             build_context: "{{defaultContext}}:api"
             file: "Dockerfile"
             platform: linux/arm64
-            runs_on: ubuntu-24.04-arm
+            runs_on: depot-ubuntu-24.04-4
           - service_name: "build-web-amd64"
             image_name_env: "DIFY_WEB_IMAGE_NAME"
             artifact_context: "web"
@@ -56,7 +59,7 @@ jobs:
             build_context: "{{defaultContext}}"
             file: "web/Dockerfile"
             platform: linux/arm64
-            runs_on: ubuntu-24.04-arm
+            runs_on: depot-ubuntu-24.04-4
 
     steps:
       - name: Prepare
@@ -70,8 +73,8 @@ jobs:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
 
       - name: Extract metadata for Docker
         id: meta
@@ -81,16 +84,15 @@ jobs:
 
       - name: Build Docker image
         id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: ${{ matrix.build_context }}
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
           build-args: COMMIT_SHA=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env[matrix.image_name_env] }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.service_name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service_name }}
 
       - name: Export digest
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   build-docker:
     runs-on: ${{ matrix.runs_on }}
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         include:
@@ -25,7 +28,7 @@ jobs:
             file: "Dockerfile"
           - service_name: "api-arm64"
             platform: linux/arm64
-            runs_on: ubuntu-24.04-arm
+            runs_on: depot-ubuntu-24.04-4
             context: "{{defaultContext}}:api"
             file: "Dockerfile"
           - service_name: "web-amd64"
@@ -35,19 +38,18 @@ jobs:
             file: "web/Dockerfile"
           - service_name: "web-arm64"
             platform: linux/arm64
-            runs_on: ubuntu-24.04-arm
+            runs_on: depot-ubuntu-24.04-4
             context: "{{defaultContext}}"
             file: "web/Dockerfile"
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
 
       - name: Build Docker Image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
           push: false
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   build-docker:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.runs_on }}
     permissions:
       contents: read
@@ -53,3 +54,29 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
+
+  build-docker-fork:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - service_name: "api-amd64"
+            context: "{{defaultContext}}:api"
+            file: "Dockerfile"
+          - service_name: "web-amd64"
+            context: "{{defaultContext}}"
+            file: "web/Dockerfile"
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@98e3b2c9eab4f4f98a95c0c0a3ea5e5e672fd2a8 # v3.10.0
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@5cd29d66b4a8d8e6f4d5dfe2e9329f0b1d446289 # v6.18.0
+        with:
+          push: false
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: linux/amd64

--- a/depot.json
+++ b/depot.json
@@ -1,0 +1,1 @@
+{"id":"smkxz53ddb"}


### PR DESCRIPTION
Moves Dify's image builds to Depot remote builds while keeping the public fork workflow usable.

What changed:
- added `depot.json` and configured the workflows to use `DEPOT_PROJECT_ID`
- switched the upstream image build jobs to `depot/setup-action@v1` + `depot/build-push-action@v1`
- added `permissions.id-token: write` for OIDC auth on the Depot-backed jobs
- kept image publishing and multi-arch manifest creation on Depot for the upstream repository
- added GitHub-hosted fallback jobs for forked repositories and forked PRs so external contributors can still validate Docker builds without Depot

Fork compatibility:
- upstream `push` / release-style image publishing stays on Depot
- same-repo PRs stay on Depot
- forked PRs use GitHub-hosted `ubuntu-24.04` plus `docker/build-push-action`
- forked repository pushes also fall back to GitHub-hosted validation
- fork fallbacks are intentionally validation-only: `linux/amd64`, `push: false`, no OIDC, no registry push

Why the split exists:
- `depot-*` runners require a repository owned by a GitHub organization
- external forks should not need Depot setup just to validate Dockerfile changes
- untrusted fork code should not be granted Depot-backed build or publish credentials

Benchmark summary for `build-push.yml`:
- baseline old path: `run 24963901211` on `main`
- first Depot remote build sample: `run 24968978541`
- warm-cache Depot remote build sample: `run 24969064552`

Whole workflow wall-clock:
- old path: `8m26s`
- Depot cold: `3m45s` (`55.5%` faster)
- Depot warm: `1m12s` (`85.8%` faster)

`Build Docker image` step timings:
- `api-amd64`: `3m42s` -> `58s` cold -> `8s` warm (`96.4%` faster warm)
- `api-arm64`: `21s` -> `1m40s` cold -> `5s` warm (`76.2%` faster warm)
- `web-amd64`: `3m28s` -> `1m52s` cold -> `9s` warm (`95.7%` faster warm)
- `web-arm64`: `3m54s` -> `2m35s` cold -> `8s` warm (`96.6%` faster warm)

Notes:
- the warm sample reflects Depot layer cache after one prior run on the same workflow path
- manifest creation times stayed roughly flat; the gains came from the four image build jobs
- only GitHub Actions workflows were changed; local developer build scripts were left alone
