### PR TITLE
fix: improve variable picker text width allocation

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-reference-picker.helpers.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-reference-picker.helpers.spec.ts
@@ -182,6 +182,16 @@ describe('var-reference-picker.helpers', () => {
       maxVarNameWidth: expect.any(Number),
     })
 
+    expect(getWidthAllocations(240, '', 'sys.user_id', 'String')).toEqual({
+      maxNodeNameWidth: 0,
+      maxTypeWidth: 64,
+      maxVarNameWidth: 119,
+    })
+
+    expect(getWidthAllocations(240, 'User Input', 'aa', 'String')).toMatchObject({
+      maxVarNameWidth: 16,
+    })
+
     expect(getTooltipContent(true, true, true)).toBe('full-path')
     expect(getTooltipContent(true, false, false)).toBe('invalid-variable')
     expect(getTooltipContent(false, false, true)).toBeNull()

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.helpers.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.helpers.ts
@@ -168,11 +168,15 @@ export const getWidthAllocations = (
 ) => {
   const availableWidth = triggerWidth - 56
   const totalTextLength = (nodeTitle + varName + type).length || 1
-  const priorityWidth = 15
+  const priorityWidth = nodeTitle ? 15 : 0
+  const minVarNameWidth = varName ? 16 : 0
   return {
     maxNodeNameWidth: priorityWidth + Math.floor(nodeTitle.length / totalTextLength * availableWidth),
     maxTypeWidth: Math.floor(type.length / totalTextLength * availableWidth),
-    maxVarNameWidth: -priorityWidth + Math.floor(varName.length / totalTextLength * availableWidth),
+    maxVarNameWidth: Math.max(
+      minVarNameWidth,
+      -priorityWidth + Math.floor(varName.length / totalTextLength * availableWidth),
+    ),
   }
 }
 

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
@@ -279,13 +279,15 @@ const VarReferencePicker: FC<Props> = ({
     [outputVarNode?.type, varName],
   )
   const showErrorIcon = hasValue && !isValidVar
+  const shouldShowNodeName = isShowNodeName && !isEnv && !isChatVar && !isGlobal && !isRagVar
+  const visibleNodeTitle = shouldShowNodeName ? outputVarNode?.title || '' : ''
 
   // 8(left/right-padding) + 14(icon) + 4 + 14 + 2 = 42 + 17 buff
   const {
     maxNodeNameWidth,
     maxTypeWidth,
     maxVarNameWidth,
-  } = getWidthAllocations(triggerWidth, outputVarNode?.title || '', varName || '', type || '')
+  } = getWidthAllocations(triggerWidth, visibleNodeTitle, varName || '', type || '')
 
   const hoverPopup = useMemo<HoverPopup | null>(() => {
     const tooltipType = getTooltipContent(hasValue, isShowAPart, isValidVar)
@@ -380,7 +382,7 @@ const VarReferencePicker: FC<Props> = ({
             isJustShowValue={isJustShowValue}
             isLoading={isLoading}
             isShowAPart={isShowAPart}
-            isShowNodeName={isShowNodeName && !isEnv && !isChatVar && !isGlobal && !isRagVar}
+            isShowNodeName={shouldShowNodeName}
             isSupportConstantValue={isSupportConstantValue}
             maxNodeNameWidth={maxNodeNameWidth}
             maxTypeWidth={maxTypeWidth}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/35586

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
