### PR TITLE
chore(ci): increase tsslint heap limit

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -110,6 +110,8 @@ jobs:
       - name: Web tsslint
         if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: ./web
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: vp run lint:tss
 
       - name: Web type check


### PR DESCRIPTION
## Summary
- set `NODE_OPTIONS=--max-old-space-size=4096` only for the `Web tsslint` CI step
- keep the local `web/package.json` `lint:tss` script unchanged

## Why
`Style Check / Web Style` started failing after the runner moved to `depot-ubuntu-24.04`. The failed job shows Node OOMing near the default ~2GB old-space limit while tsslint processes the full web TypeScript project.

Failed job: https://github.com/langgenius/dify/actions/runs/24975691944/job/73127248400?pr=35590

## Verification
- `NODE_OPTIONS=--max-old-space-size=4096 vp run lint:tss --force`