### PR TITLE
fix(test): register baidu_obs mock as pytest plugin

### DIFF
--- a/api/tests/unit_tests/oss/baidu_obs/test_baidu_obs.py
+++ b/api/tests/unit_tests/oss/baidu_obs/test_baidu_obs.py
@@ -5,11 +5,12 @@ from baidubce.auth.bce_credentials import BceCredentials
 from baidubce.bce_client_configuration import BceClientConfiguration
 
 from extensions.storage.baidu_obs_storage import BaiduObsStorage
-from tests.unit_tests.oss.__mock.baidu_obs import setup_baidu_obs_mock
 from tests.unit_tests.oss.__mock.base import (
     BaseStorageTest,
     get_example_bucket,
 )
+
+pytest_plugins = ("tests.unit_tests.oss.__mock.baidu_obs",)
 
 
 class TestBaiduObs(BaseStorageTest):


### PR DESCRIPTION
Fixes #35623

## Summary

`api/tests/unit_tests/oss/baidu_obs/test_baidu_obs.py` (added in #34330) imports the mock fixture as a regular module-level symbol:

```python
from tests.unit_tests.oss.__mock.baidu_obs import setup_baidu_obs_mock
```

That imports the function but does **not** register it as a pytest fixture, so any run that actually collects this file fails with `fixture 'setup_baidu_obs_mock' not found` and 6 ERROR entries (one per test in `TestBaiduObs`).

This PR replaces the unused import with the standard `pytest_plugins` declaration, matching `test_aliyun_oss.py`, `test_tencent_cos.py` and `test_volcengine_tos.py`:

```python
pytest_plugins = ("tests.unit_tests.oss.__mock.baidu_obs",)
```

**Why this slipped through CI**: `Run API Tests / API Unit Tests (3.12)` is gated by a path filter. PR #34330 only touched files under `api/tests/unit_tests/oss/baidu_obs/`, which the filter does not recognize as an "API change", so the unit-test job was skipped on that PR and on every subsequent main push. The first PRs that touch broader `api/` paths (e.g. #35515) hit the failure. Verified by inspecting the job conclusions on recent main runs: `Run API Tests` is `skipped` on every one of them.

**Verification**:

```
$ MOCK_SWITCH=true pytest tests/unit_tests/oss/baidu_obs/test_baidu_obs.py
======================== 7 passed, 2 warnings in 0.46s =========================
```

## Screenshots

| Before | After |
|--------|-------|
| `ERROR ... fixture 'setup_baidu_obs_mock' not found` (×6) | `7 passed` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

> Note on `make type-check`: the command surfaces several pre-existing errors on `main` (e.g. `app_factory.py:132`, `services/model_load_balancing_service.py:623`, several in `providers/trace/trace-tencent/...`) that are unrelated to this one-line test fix. Confirmed identical errors on `upstream/main` HEAD.

