### PR TITLE
refactor(web): improve a11y and design-system consistency for date/time picker and auto-update strategy picker

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3506,11 +3506,6 @@
       "count": 1
     }
   },
-  "web/app/components/plugins/reference-setting-modal/auto-update-setting/strategy-picker.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/plugins/reference-setting-modal/auto-update-setting/types.ts": {
     "erasable-syntax-only/enums": {
       "count": 2

--- a/web/app/components/base/date-and-time-picker/common/__tests__/option-list-item.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/common/__tests__/option-list-item.spec.tsx
@@ -43,7 +43,7 @@ describe('OptionListItem', () => {
         </OptionListItem>,
       )
 
-      const item = screen.getByRole('listitem')
+      const item = screen.getByRole('button')
       expect(item).toHaveClass('bg-components-button-ghost-bg-hover')
     })
 
@@ -54,7 +54,7 @@ describe('OptionListItem', () => {
         </OptionListItem>,
       )
 
-      const item = screen.getByRole('listitem')
+      const item = screen.getByRole('button')
       expect(item).not.toHaveClass('bg-components-button-ghost-bg-hover')
     })
   })
@@ -100,7 +100,7 @@ describe('OptionListItem', () => {
           Clickable
         </OptionListItem>,
       )
-      fireEvent.click(screen.getByRole('listitem'))
+      fireEvent.click(screen.getByRole('button'))
 
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
@@ -111,7 +111,7 @@ describe('OptionListItem', () => {
           Item
         </OptionListItem>,
       )
-      fireEvent.click(screen.getByRole('listitem'))
+      fireEvent.click(screen.getByRole('button'))
 
       expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' })
     })
@@ -126,7 +126,7 @@ describe('OptionListItem', () => {
         </OptionListItem>,
       )
 
-      const item = screen.getByRole('listitem')
+      const item = screen.getByRole('button')
       fireEvent.click(item)
       fireEvent.click(item)
       fireEvent.click(item)

--- a/web/app/components/base/date-and-time-picker/common/__tests__/option-list.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/common/__tests__/option-list.spec.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import OptionList from '../option-list'
+
+describe('OptionList', () => {
+  it('should render a scrollable list with hidden scrollbar styles', () => {
+    render(
+      <OptionList>
+        <li>Item</li>
+      </OptionList>,
+    )
+
+    const list = screen.getByRole('list')
+
+    expect(list).toHaveClass('overflow-y-auto')
+    expect(list).toHaveClass('[scrollbar-width:none]')
+    expect(list).toHaveClass('[&::-webkit-scrollbar]:hidden')
+  })
+
+  it('should append caller className after default classes', () => {
+    render(
+      <OptionList className="custom-list">
+        <li>Item</li>
+      </OptionList>,
+    )
+
+    expect(screen.getByRole('list')).toHaveClass('custom-list')
+  })
+})

--- a/web/app/components/base/date-and-time-picker/common/option-list-item.tsx
+++ b/web/app/components/base/date-and-time-picker/common/option-list-item.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import type { FC, ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
 import { useEffect, useRef } from 'react'
@@ -7,7 +7,8 @@ type OptionListItemProps = {
   isSelected: boolean
   onClick: () => void
   noAutoScroll?: boolean
-} & React.LiHTMLAttributes<HTMLLIElement>
+  children: ReactNode
+}
 
 const OptionListItem: FC<OptionListItemProps> = ({
   isSelected,
@@ -25,16 +26,21 @@ const OptionListItem: FC<OptionListItemProps> = ({
   return (
     <li
       ref={listItemRef}
-      className={cn(
-        'flex cursor-pointer items-center justify-center rounded-md px-1.5 py-1 system-xs-medium text-components-button-ghost-text',
-        isSelected ? 'bg-components-button-ghost-bg-hover' : 'hover:bg-components-button-ghost-bg-hover',
-      )}
-      onClick={() => {
-        listItemRef.current?.scrollIntoView({ behavior: 'smooth' })
-        onClick()
-      }}
     >
-      {children}
+      <button
+        type="button"
+        className={cn(
+          'flex w-full cursor-pointer items-center justify-center rounded-md px-1.5 py-1 system-xs-medium text-components-button-ghost-text outline-hidden',
+          'focus-visible:ring-1 focus-visible:ring-components-input-border-hover focus-visible:ring-inset',
+          isSelected ? 'bg-components-button-ghost-bg-hover' : 'hover:bg-components-button-ghost-bg-hover',
+        )}
+        onClick={() => {
+          listItemRef.current?.scrollIntoView({ behavior: 'smooth' })
+          onClick()
+        }}
+      >
+        {children}
+      </button>
     </li>
   )
 }

--- a/web/app/components/base/date-and-time-picker/common/option-list.tsx
+++ b/web/app/components/base/date-and-time-picker/common/option-list.tsx
@@ -1,0 +1,26 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { cn } from '@langgenius/dify-ui/cn'
+import * as React from 'react'
+
+type OptionListProps = {
+  children: ReactNode
+} & HTMLAttributes<HTMLUListElement>
+
+const optionListClassName = cn(
+  'flex h-[208px] flex-col gap-y-0.5 overflow-y-auto pb-[184px]',
+  '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+)
+
+const OptionList = ({
+  children,
+  className,
+  ...props
+}: OptionListProps) => {
+  return (
+    <ul className={cn(optionListClassName, className)} {...props}>
+      {children}
+    </ul>
+  )
+}
+
+export default React.memo(OptionList)

--- a/web/app/components/base/date-and-time-picker/time-picker/__tests__/options.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/time-picker/__tests__/options.spec.tsx
@@ -64,13 +64,13 @@ describe('TimePickerOptions', () => {
     it('should render selected hour in the list', () => {
       const props = createOptionsProps({ selectedTime: dayjs('2024-01-01 05:30:00') })
       render(<Options {...props} />)
-      const selectedHour = screen.getAllByRole('listitem').find(item => item.textContent === '05')
+      const selectedHour = screen.getAllByRole('button').find(item => item.textContent === '05')
       expect(selectedHour)!.toHaveClass('bg-components-button-ghost-bg-hover')
     })
     it('should render selected minute in the list', () => {
       const props = createOptionsProps({ selectedTime: dayjs('2024-01-01 05:30:00') })
       render(<Options {...props} />)
-      const selectedMinute = screen.getAllByRole('listitem').find(item => item.textContent === '30')
+      const selectedMinute = screen.getAllByRole('button').find(item => item.textContent === '30')
       expect(selectedMinute)!.toHaveClass('bg-components-button-ghost-bg-hover')
     })
 

--- a/web/app/components/base/date-and-time-picker/time-picker/options.tsx
+++ b/web/app/components/base/date-and-time-picker/time-picker/options.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import type { TimeOptionsProps } from '../types'
 import * as React from 'react'
+import OptionList from '../common/option-list'
 import OptionListItem from '../common/option-list-item'
 import { useTimeOptions } from '../hooks'
 
@@ -16,7 +17,7 @@ const Options: FC<TimeOptionsProps> = ({
   return (
     <div className="grid grid-cols-3 gap-x-1 p-2">
       {/* Hour */}
-      <ul className="scrollbar-none flex h-[208px] flex-col gap-y-0.5 overflow-y-auto pb-[184px]">
+      <OptionList>
         {
           hourOptions.map((hour) => {
             const isSelected = selectedTime?.format('hh') === hour
@@ -31,9 +32,9 @@ const Options: FC<TimeOptionsProps> = ({
             )
           })
         }
-      </ul>
+      </OptionList>
       {/* Minute */}
-      <ul className="scrollbar-none flex h-[208px] flex-col gap-y-0.5 overflow-y-auto pb-[184px]">
+      <OptionList>
         {
           (minuteFilter ? minuteFilter(minuteOptions) : minuteOptions).map((minute) => {
             const isSelected = selectedTime?.format('mm') === minute
@@ -48,9 +49,9 @@ const Options: FC<TimeOptionsProps> = ({
             )
           })
         }
-      </ul>
+      </OptionList>
       {/* Period */}
-      <ul className="scrollbar-none flex h-[208px] flex-col gap-y-0.5 overflow-y-auto pb-[184px]">
+      <OptionList>
         {
           periodOptions.map((period) => {
             const isSelected = selectedTime?.format('A') === period
@@ -66,7 +67,7 @@ const Options: FC<TimeOptionsProps> = ({
             )
           })
         }
-      </ul>
+      </OptionList>
     </div>
   )
 }

--- a/web/app/components/base/date-and-time-picker/year-and-month-picker/options.tsx
+++ b/web/app/components/base/date-and-time-picker/year-and-month-picker/options.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import type { YearAndMonthPickerOptionsProps } from '../types'
 import * as React from 'react'
+import OptionList from '../common/option-list'
 import OptionListItem from '../common/option-list-item'
 import { useMonths, useYearOptions } from '../hooks'
 
@@ -16,7 +17,7 @@ const Options: FC<YearAndMonthPickerOptionsProps> = ({
   return (
     <div className="grid grid-cols-2 gap-x-1 p-2">
       {/* Month Picker */}
-      <ul className="scrollbar-none flex h-[208px] flex-col gap-y-0.5 overflow-y-auto pb-[184px]">
+      <OptionList>
         {
           months.map((month, index) => {
             const isSelected = selectedMonth === index
@@ -31,9 +32,9 @@ const Options: FC<YearAndMonthPickerOptionsProps> = ({
             )
           })
         }
-      </ul>
+      </OptionList>
       {/* Year Picker */}
-      <ul className="scrollbar-none flex h-[208px] flex-col gap-y-0.5 overflow-y-auto pb-[184px]">
+      <OptionList>
         {
           yearOptions.map((year) => {
             const isSelected = selectedYear === year
@@ -48,7 +49,7 @@ const Options: FC<YearAndMonthPickerOptionsProps> = ({
             )
           })
         }
-      </ul>
+      </OptionList>
     </div>
   )
 }

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/index.spec.tsx
@@ -106,6 +106,99 @@ vi.mock('@langgenius/dify-ui/popover', () => ({
   },
 }))
 
+vi.mock('@langgenius/dify-ui/dropdown-menu', async () => {
+  const React = await import('react')
+  const DropdownMenuContext = React.createContext<{
+    open: boolean
+    onOpenChange?: (open: boolean) => void
+    value?: string
+    itemValue?: string
+    onValueChange?: (value: string) => void
+  }>({ open: false })
+
+  return {
+    DropdownMenu: ({ children, open = false, onOpenChange }: {
+      children: React.ReactNode
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      mockPortalOpen = open
+      mockPortalOnOpenChange = onOpenChange
+      return (
+        <DropdownMenuContext.Provider value={{ open, onOpenChange }}>
+          <div data-testid="portal-elem" data-open={open}>{children}</div>
+        </DropdownMenuContext.Provider>
+      )
+    },
+    DropdownMenuTrigger: ({ children, onClick, className }: {
+      children?: React.ReactNode
+      onClick?: (e: React.MouseEvent) => void
+      className?: string
+    }) => {
+      const { open, onOpenChange } = React.useContext(DropdownMenuContext)
+      const handleClick = (e: React.MouseEvent) => {
+        onClick?.(e)
+        if (!onClick)
+          onOpenChange?.(!open)
+      }
+
+      return (
+        <button
+          data-testid="portal-trigger"
+          onClick={handleClick}
+          className={className}
+        >
+          {children}
+        </button>
+      )
+    },
+    DropdownMenuContent: ({ children, className, popupClassName }: {
+      children: React.ReactNode
+      className?: string
+      popupClassName?: string
+    }) => {
+      if (!mockPortalOpen && !forcePortalContentVisible)
+        return null
+      return <div data-testid="portal-content" className={[className, popupClassName].filter(Boolean).join(' ')}>{children}</div>
+    },
+    DropdownMenuRadioGroup: ({ children, value, onValueChange }: {
+      children: React.ReactNode
+      value: string
+      onValueChange: (value: string) => void
+    }) => (
+      <DropdownMenuContext.Provider value={{ open: mockPortalOpen, value, onValueChange }}>
+        <div role="radiogroup">{children}</div>
+      </DropdownMenuContext.Provider>
+    ),
+    DropdownMenuRadioItem: ({ children, value, className }: {
+      children: React.ReactNode
+      value: string
+      className?: string
+    }) => {
+      const { value: selectedValue, onValueChange } = React.useContext(DropdownMenuContext)
+      return (
+        <DropdownMenuContext.Provider value={{ open: mockPortalOpen, value: selectedValue, itemValue: value, onValueChange }}>
+          <div
+            role="radio"
+            aria-checked={selectedValue === value}
+            className={[className, 'cursor-pointer'].filter(Boolean).join(' ')}
+            onClick={(e) => {
+              e.stopPropagation()
+              onValueChange?.(value)
+            }}
+          >
+            {children}
+          </div>
+        </DropdownMenuContext.Provider>
+      )
+    },
+    DropdownMenuRadioItemIndicator: () => {
+      const { value, itemValue } = React.useContext(DropdownMenuContext)
+      return value === itemValue ? <span data-testid="strategy-indicator">✓</span> : null
+    },
+  }
+})
+
 vi.mock('@/app/components/base/portal-to-follow-elem', () => ({
   PortalToFollowElem: ({ children, open = false, onOpenChange }: {
     children: React.ReactNode
@@ -939,14 +1032,13 @@ describe('auto-update-setting', () => {
         // Act - render with fixOnly selected
         render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.fixOnly} onChange={vi.fn()} />)
 
-        // Assert - RiCheckLine should be rendered (check icon)
+        // Assert - selected indicator should be rendered.
         // Find all "Bug Fixes Only" texts and get the one in the dropdown (has cursor-pointer parent)
         const allFixOnlyTexts = screen.getAllByText('plugin.autoUpdate.strategy.fixOnly.name')
         const dropdownOption = allFixOnlyTexts.find(el => el.closest('div[class*="cursor-pointer"]'))
         const optionContainer = dropdownOption?.closest('div[class*="cursor-pointer"]')
         expect(optionContainer).toBeInTheDocument()
-        // The check icon SVG should exist within the option
-        expect(optionContainer?.querySelector('svg')).toBeInTheDocument()
+        expect(optionContainer?.querySelector('[data-testid="strategy-indicator"]')).toBeInTheDocument()
       })
 
       it('should not render check icon for non-selected options', () => {
@@ -958,10 +1050,8 @@ describe('auto-update-setting', () => {
 
         // Assert - check the Latest Version option should not have check icon
         const latestOption = screen.getByText('plugin.autoUpdate.strategy.latest.name').closest('div[class*="cursor-pointer"]')
-        // The svg should only be in selected option, not in non-selected
         const checkIconContainer = latestOption?.querySelector('div.mr-1')
-        // Non-selected option should have empty check icon container
-        expect(checkIconContainer?.querySelector('svg')).toBeNull()
+        expect(checkIconContainer?.querySelector('[data-testid="strategy-indicator"]')).toBeNull()
       })
     })
   })

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/index.spec.tsx
@@ -2,6 +2,7 @@ import type { AutoUpdateConfig } from '../types'
 import type { PluginDeclaration, PluginDetail } from '@/app/components/plugins/types'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
@@ -105,99 +106,6 @@ vi.mock('@langgenius/dify-ui/popover', () => ({
     return <div data-testid="portal-content" className={[className, popupClassName].filter(Boolean).join(' ')}>{children}</div>
   },
 }))
-
-vi.mock('@langgenius/dify-ui/dropdown-menu', async () => {
-  const React = await import('react')
-  const DropdownMenuContext = React.createContext<{
-    open: boolean
-    onOpenChange?: (open: boolean) => void
-    value?: string
-    itemValue?: string
-    onValueChange?: (value: string) => void
-  }>({ open: false })
-
-  return {
-    DropdownMenu: ({ children, open = false, onOpenChange }: {
-      children: React.ReactNode
-      open?: boolean
-      onOpenChange?: (open: boolean) => void
-    }) => {
-      mockPortalOpen = open
-      mockPortalOnOpenChange = onOpenChange
-      return (
-        <DropdownMenuContext.Provider value={{ open, onOpenChange }}>
-          <div data-testid="portal-elem" data-open={open}>{children}</div>
-        </DropdownMenuContext.Provider>
-      )
-    },
-    DropdownMenuTrigger: ({ children, onClick, className }: {
-      children?: React.ReactNode
-      onClick?: (e: React.MouseEvent) => void
-      className?: string
-    }) => {
-      const { open, onOpenChange } = React.useContext(DropdownMenuContext)
-      const handleClick = (e: React.MouseEvent) => {
-        onClick?.(e)
-        if (!onClick)
-          onOpenChange?.(!open)
-      }
-
-      return (
-        <button
-          data-testid="portal-trigger"
-          onClick={handleClick}
-          className={className}
-        >
-          {children}
-        </button>
-      )
-    },
-    DropdownMenuContent: ({ children, className, popupClassName }: {
-      children: React.ReactNode
-      className?: string
-      popupClassName?: string
-    }) => {
-      if (!mockPortalOpen && !forcePortalContentVisible)
-        return null
-      return <div data-testid="portal-content" className={[className, popupClassName].filter(Boolean).join(' ')}>{children}</div>
-    },
-    DropdownMenuRadioGroup: ({ children, value, onValueChange }: {
-      children: React.ReactNode
-      value: string
-      onValueChange: (value: string) => void
-    }) => (
-      <DropdownMenuContext.Provider value={{ open: mockPortalOpen, value, onValueChange }}>
-        <div role="radiogroup">{children}</div>
-      </DropdownMenuContext.Provider>
-    ),
-    DropdownMenuRadioItem: ({ children, value, className }: {
-      children: React.ReactNode
-      value: string
-      className?: string
-    }) => {
-      const { value: selectedValue, onValueChange } = React.useContext(DropdownMenuContext)
-      return (
-        <DropdownMenuContext.Provider value={{ open: mockPortalOpen, value: selectedValue, itemValue: value, onValueChange }}>
-          <div
-            role="radio"
-            aria-checked={selectedValue === value}
-            className={[className, 'cursor-pointer'].filter(Boolean).join(' ')}
-            onClick={(e) => {
-              e.stopPropagation()
-              onValueChange?.(value)
-            }}
-          >
-            {children}
-          </div>
-        </DropdownMenuContext.Provider>
-      )
-    },
-    DropdownMenuRadioItemIndicator: () => {
-      const { value, itemValue } = React.useContext(DropdownMenuContext)
-      return value === itemValue ? <span data-testid="strategy-indicator">✓</span> : null
-    },
-  }
-})
 
 vi.mock('@/app/components/base/portal-to-follow-elem', () => ({
   PortalToFollowElem: ({ children, open = false, onOpenChange }: {
@@ -896,162 +804,103 @@ describe('auto-update-setting', () => {
   })
 
   describe('StrategyPicker (strategy-picker.tsx)', () => {
-    const defaultProps = {
-      value: AUTO_UPDATE_STRATEGY.disabled,
-      onChange: vi.fn(),
+    const i18nKeyByStrategy: Record<AUTO_UPDATE_STRATEGY, 'disabled' | 'fixOnly' | 'latest'> = {
+      [AUTO_UPDATE_STRATEGY.disabled]: 'disabled',
+      [AUTO_UPDATE_STRATEGY.fixOnly]: 'fixOnly',
+      [AUTO_UPDATE_STRATEGY.latest]: 'latest',
+    }
+
+    const triggerName = (strategy: AUTO_UPDATE_STRATEGY) =>
+      new RegExp(`plugin\\.autoUpdate\\.strategy\\.${i18nKeyByStrategy[strategy]}\\.name`, 'i')
+
+    const findOption = async (key: 'disabled' | 'fixOnly' | 'latest') => {
+      const options = await screen.findAllByRole('menuitemradio')
+      const option = options.find(item =>
+        item.textContent?.includes(`plugin.autoUpdate.strategy.${key}.name`),
+      )
+      if (!option)
+        throw new Error(`Strategy option "${key}" not found`)
+      return option
     }
 
     describe('Rendering', () => {
       it('should render trigger button with current strategy label', () => {
-        // Act
-        render(<StrategyPicker {...defaultProps} value={AUTO_UPDATE_STRATEGY.disabled} />)
+        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={vi.fn()} />)
 
-        // Assert
-        expect(screen.getByRole('button', { name: /plugin\.autoUpdate\.strategy\.disabled\.name/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: triggerName(AUTO_UPDATE_STRATEGY.disabled) })).toBeInTheDocument()
       })
 
       it('should not render dropdown content when closed', () => {
-        // Act
-        render(<StrategyPicker {...defaultProps} />)
+        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={vi.fn()} />)
 
-        // Assert
-        expect(screen.queryByTestId('portal-content')).not.toBeInTheDocument()
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       })
 
-      it('should render all strategy options when open', () => {
-        // Arrange
-        mockPortalOpen = true
+      it('should render all strategy options when open', async () => {
+        const user = userEvent.setup()
+        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={vi.fn()} />)
 
-        // Act
-        render(<StrategyPicker {...defaultProps} />)
-        fireEvent.click(screen.getByTestId('portal-trigger'))
+        await user.click(screen.getByRole('button', { name: triggerName(AUTO_UPDATE_STRATEGY.disabled) }))
 
-        // Wait for portal to open
-        if (mockPortalOpen) {
-          // Assert all options visible (use getAllByText for strategy name as it appears in both trigger and dropdown)
-          expect(screen.getAllByText('plugin.autoUpdate.strategy.disabled.name').length).toBeGreaterThanOrEqual(1)
-          expect(screen.getByText('plugin.autoUpdate.strategy.fixOnly.name')).toBeInTheDocument()
-          expect(screen.getByText('plugin.autoUpdate.strategy.latest.name')).toBeInTheDocument()
-        }
+        const options = await screen.findAllByRole('menuitemradio')
+        expect(options).toHaveLength(3)
+        expect(options.some(o => o.textContent?.includes('plugin.autoUpdate.strategy.disabled.name'))).toBe(true)
+        expect(options.some(o => o.textContent?.includes('plugin.autoUpdate.strategy.fixOnly.name'))).toBe(true)
+        expect(options.some(o => o.textContent?.includes('plugin.autoUpdate.strategy.latest.name'))).toBe(true)
       })
     })
 
     describe('User Interactions', () => {
-      it('should toggle dropdown when trigger is clicked', () => {
-        // Act
-        render(<StrategyPicker {...defaultProps} />)
-
-        // Assert - initially closed
-        expect(mockPortalOpen).toBe(false)
-
-        // Act - click trigger
-        fireEvent.click(screen.getByTestId('portal-trigger'))
-
-        // Assert - portal trigger element should still be in document
-        expect(screen.getByTestId('portal-trigger')).toBeInTheDocument()
-      })
-
-      it('should call onChange with fixOnly when Bug Fixes Only option is clicked', () => {
-        // Arrange - force portal content to be visible for testing option selection
-        forcePortalContentVisible = true
-        const onChange = vi.fn()
-
-        // Act
-        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={onChange} />)
-
-        // Find and click the "Bug Fixes Only" option
-        const fixOnlyOption = screen.getByText('plugin.autoUpdate.strategy.fixOnly.name').closest('div[class*="cursor-pointer"]')
-        expect(fixOnlyOption).toBeInTheDocument()
-        fireEvent.click(fixOnlyOption!)
-
-        // Assert
-        expect(onChange).toHaveBeenCalledWith(AUTO_UPDATE_STRATEGY.fixOnly)
-      })
-
-      it('should call onChange with latest when Latest Version option is clicked', () => {
-        // Arrange - force portal content to be visible for testing option selection
-        forcePortalContentVisible = true
-        const onChange = vi.fn()
-
-        // Act
-        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={onChange} />)
-
-        // Find and click the "Latest Version" option
-        const latestOption = screen.getByText('plugin.autoUpdate.strategy.latest.name').closest('div[class*="cursor-pointer"]')
-        expect(latestOption).toBeInTheDocument()
-        fireEvent.click(latestOption!)
-
-        // Assert
-        expect(onChange).toHaveBeenCalledWith(AUTO_UPDATE_STRATEGY.latest)
-      })
-
-      it('should call onChange with disabled when Disabled option is clicked', () => {
-        // Arrange - force portal content to be visible for testing option selection
-        forcePortalContentVisible = true
-        const onChange = vi.fn()
-
-        // Act
-        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.fixOnly} onChange={onChange} />)
-
-        // Find and click the "Disabled" option - need to find the one in the dropdown, not the button
-        const disabledOptions = screen.getAllByText('plugin.autoUpdate.strategy.disabled.name')
-        // The second one should be in the dropdown
-        const dropdownOption = disabledOptions.find(el => el.closest('div[class*="cursor-pointer"]'))
-        expect(dropdownOption).toBeInTheDocument()
-        fireEvent.click(dropdownOption!.closest('div[class*="cursor-pointer"]')!)
-
-        // Assert
-        expect(onChange).toHaveBeenCalledWith(AUTO_UPDATE_STRATEGY.disabled)
-      })
-
-      it('should stop event propagation when option is clicked', () => {
-        // Arrange - force portal content to be visible
-        forcePortalContentVisible = true
-        const onChange = vi.fn()
-        const parentClickHandler = vi.fn()
-
-        // Act
-        render(
-          <div onClick={parentClickHandler}>
-            <StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={onChange} />
-          </div>,
-        )
-
-        // Click an option
-        const fixOnlyOption = screen.getByText('plugin.autoUpdate.strategy.fixOnly.name').closest('div[class*="cursor-pointer"]')
-        fireEvent.click(fixOnlyOption!)
-
-        // Assert - onChange is called but parent click handler should not propagate
-        expect(onChange).toHaveBeenCalledWith(AUTO_UPDATE_STRATEGY.fixOnly)
-      })
-
-      it('should render check icon for currently selected option', () => {
-        // Arrange - force portal content to be visible
-        forcePortalContentVisible = true
-
-        // Act - render with fixOnly selected
-        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.fixOnly} onChange={vi.fn()} />)
-
-        // Assert - selected indicator should be rendered.
-        // Find all "Bug Fixes Only" texts and get the one in the dropdown (has cursor-pointer parent)
-        const allFixOnlyTexts = screen.getAllByText('plugin.autoUpdate.strategy.fixOnly.name')
-        const dropdownOption = allFixOnlyTexts.find(el => el.closest('div[class*="cursor-pointer"]'))
-        const optionContainer = dropdownOption?.closest('div[class*="cursor-pointer"]')
-        expect(optionContainer).toBeInTheDocument()
-        expect(optionContainer?.querySelector('[data-testid="strategy-indicator"]')).toBeInTheDocument()
-      })
-
-      it('should not render check icon for non-selected options', () => {
-        // Arrange - force portal content to be visible
-        forcePortalContentVisible = true
-
-        // Act - render with disabled selected
+      it('should open and close the menu when the trigger is clicked', async () => {
+        const user = userEvent.setup()
         render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.disabled} onChange={vi.fn()} />)
 
-        // Assert - check the Latest Version option should not have check icon
-        const latestOption = screen.getByText('plugin.autoUpdate.strategy.latest.name').closest('div[class*="cursor-pointer"]')
-        const checkIconContainer = latestOption?.querySelector('div.mr-1')
-        expect(checkIconContainer?.querySelector('[data-testid="strategy-indicator"]')).toBeNull()
+        const trigger = screen.getByRole('button', { name: triggerName(AUTO_UPDATE_STRATEGY.disabled) })
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+        await user.click(trigger)
+        expect(await screen.findByRole('menu')).toBeInTheDocument()
+      })
+
+      it.each<[AUTO_UPDATE_STRATEGY, 'disabled' | 'fixOnly' | 'latest', AUTO_UPDATE_STRATEGY]>([
+        [AUTO_UPDATE_STRATEGY.disabled, 'fixOnly', AUTO_UPDATE_STRATEGY.fixOnly],
+        [AUTO_UPDATE_STRATEGY.disabled, 'latest', AUTO_UPDATE_STRATEGY.latest],
+        [AUTO_UPDATE_STRATEGY.fixOnly, 'disabled', AUTO_UPDATE_STRATEGY.disabled],
+      ])('should call onChange with %s -> %s when option is selected', async (initial, optionKey, expected) => {
+        const user = userEvent.setup()
+        const onChange = vi.fn()
+        render(<StrategyPicker value={initial} onChange={onChange} />)
+
+        await user.click(screen.getByRole('button', { name: triggerName(initial) }))
+        await user.click(await findOption(optionKey))
+
+        expect(onChange).toHaveBeenCalledWith(expected)
+      })
+
+      it('should mark only the currently selected option with aria-checked', async () => {
+        const user = userEvent.setup()
+        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.fixOnly} onChange={vi.fn()} />)
+
+        await user.click(screen.getByRole('button', { name: triggerName(AUTO_UPDATE_STRATEGY.fixOnly) }))
+
+        const options = await screen.findAllByRole('menuitemradio')
+        const checked = options.filter(o => o.getAttribute('aria-checked') === 'true')
+
+        expect(checked).toHaveLength(1)
+        expect(checked[0]).toHaveTextContent('plugin.autoUpdate.strategy.fixOnly.name')
+      })
+
+      it('should render the check indicator inside the selected option only', async () => {
+        const user = userEvent.setup()
+        render(<StrategyPicker value={AUTO_UPDATE_STRATEGY.fixOnly} onChange={vi.fn()} />)
+
+        await user.click(screen.getByRole('button', { name: triggerName(AUTO_UPDATE_STRATEGY.fixOnly) }))
+
+        const fixOnlyOption = await findOption('fixOnly')
+        const latestOption = await findOption('latest')
+
+        expect(fixOnlyOption.querySelector('.i-ri-check-line')).toBeInTheDocument()
+        expect(latestOption.querySelector('.i-ri-check-line')).toBeNull()
       })
     })
   })
@@ -1370,7 +1219,9 @@ describe('auto-update-setting', () => {
         render(<AutoUpdateSetting {...defaultProps} />)
 
         // Assert
-        expect(screen.getByTestId('portal-elem')).toBeInTheDocument()
+        expect(
+          screen.getByRole('button', { name: /plugin\.autoUpdate\.strategy\.fixOnly\.name/i }),
+        ).toBeInTheDocument()
       })
 
       it('should show time picker when strategy is not disabled', () => {
@@ -1497,16 +1348,27 @@ describe('auto-update-setting', () => {
     })
 
     describe('User Interactions', () => {
-      it('should call onChange with updated strategy when strategy changes', () => {
+      it('should call onChange with updated strategy when strategy changes', async () => {
         // Arrange
+        const user = userEvent.setup()
         const onChange = vi.fn()
-        const payload = createMockAutoUpdateConfig()
+        const payload = createMockAutoUpdateConfig({ strategy_setting: AUTO_UPDATE_STRATEGY.fixOnly })
 
         // Act
         render(<AutoUpdateSetting payload={payload} onChange={onChange} />)
 
-        // Assert - component renders with strategy picker
-        expect(screen.getByTestId('portal-elem')).toBeInTheDocument()
+        await user.click(
+          screen.getByRole('button', { name: /plugin\.autoUpdate\.strategy\.fixOnly\.name/i }),
+        )
+        const latestOption = (await screen.findAllByRole('menuitemradio')).find(item =>
+          item.textContent?.includes('plugin.autoUpdate.strategy.latest.name'),
+        )!
+        await user.click(latestOption)
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith(
+          expect.objectContaining({ strategy_setting: AUTO_UPDATE_STRATEGY.latest }),
+        )
       })
 
       it('should call onChange with updated time when time changes', () => {

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/strategy-picker.spec.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/strategy-picker.spec.tsx
@@ -1,112 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
 import StrategyPicker from '../strategy-picker'
 import { AUTO_UPDATE_STRATEGY } from '../types'
 
-let portalOpen = false
-
-vi.mock('@langgenius/dify-ui/button', () => ({
-  Button: ({
-    children,
-  }: {
-    children: React.ReactNode
-  }) => <span data-testid="picker-button">{children}</span>,
-}))
-
-vi.mock('@langgenius/dify-ui/dropdown-menu', async () => {
-  const React = await import('react')
-  const DropdownMenuContext = React.createContext<{
-    open: boolean
-    onOpenChange?: (open: boolean) => void
-    value?: string
-    itemValue?: string
-    onValueChange?: (value: string) => void
-  }>({ open: false })
-
-  return {
-    DropdownMenu: ({
-      open,
-      onOpenChange,
-      children,
-    }: {
-      open: boolean
-      onOpenChange: (open: boolean) => void
-      children: React.ReactNode
-    }) => {
-      portalOpen = open
-      return (
-        <DropdownMenuContext.Provider value={{ open, onOpenChange }}>
-          <div>{children}</div>
-        </DropdownMenuContext.Provider>
-      )
-    },
-    DropdownMenuTrigger: ({
-      children,
-    }: {
-      children: React.ReactNode
-    }) => {
-      const { open, onOpenChange } = React.useContext(DropdownMenuContext)
-      return (
-        <button
-          data-testid="trigger"
-          onClick={() => onOpenChange?.(!open)}
-        >
-          {children}
-        </button>
-      )
-    },
-    DropdownMenuContent: ({
-      children,
-    }: {
-      children: React.ReactNode
-    }) => portalOpen ? <div data-testid="portal-content">{children}</div> : null,
-    DropdownMenuRadioGroup: ({
-      children,
-      value,
-      onValueChange,
-    }: {
-      children: React.ReactNode
-      value: string
-      onValueChange: (value: string) => void
-    }) => (
-      <DropdownMenuContext.Provider value={{ open: portalOpen, value, onValueChange }}>
-        <div role="radiogroup">{children}</div>
-      </DropdownMenuContext.Provider>
-    ),
-    DropdownMenuRadioItem: ({
-      children,
-      value,
-    }: {
-      children: React.ReactNode
-      value: string
-    }) => {
-      const { value: selectedValue, onValueChange } = React.useContext(DropdownMenuContext)
-      return (
-        <DropdownMenuContext.Provider value={{ open: portalOpen, value: selectedValue, itemValue: value, onValueChange }}>
-          <button
-            role="radio"
-            aria-checked={selectedValue === value}
-            data-testid={`strategy-option-${value}`}
-            onClick={() => onValueChange?.(value)}
-          >
-            {children}
-          </button>
-        </DropdownMenuContext.Provider>
-      )
-    },
-    DropdownMenuRadioItemIndicator: () => {
-      const { value, itemValue } = React.useContext(DropdownMenuContext)
-      return value === itemValue ? <span data-testid="strategy-indicator">✓</span> : null
-    },
-  }
-})
+const triggerName = (key: string) => new RegExp(`plugin\\.autoUpdate\\.strategy\\.${key}\\.name`, 'i')
 
 describe('StrategyPicker', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    portalOpen = false
-  })
-
   it('renders the selected strategy label in the trigger', () => {
     render(
       <StrategyPicker
@@ -115,10 +15,12 @@ describe('StrategyPicker', () => {
       />,
     )
 
-    expect(screen.getByTestId('trigger')).toHaveTextContent('plugin.autoUpdate.strategy.fixOnly.name')
+    expect(screen.getByRole('button', { name: triggerName('fixOnly') })).toBeInTheDocument()
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
 
-  it('opens the option list when the trigger is clicked', () => {
+  it('opens the option list when the trigger is clicked', async () => {
+    const user = userEvent.setup()
     render(
       <StrategyPicker
         value={AUTO_UPDATE_STRATEGY.disabled}
@@ -126,13 +28,33 @@ describe('StrategyPicker', () => {
       />,
     )
 
-    fireEvent.click(screen.getByTestId('trigger'))
+    await user.click(screen.getByRole('button', { name: triggerName('disabled') }))
 
-    expect(screen.getByTestId('portal-content')).toBeInTheDocument()
+    const options = await screen.findAllByRole('menuitemradio')
+    expect(options).toHaveLength(3)
     expect(screen.getByText('plugin.autoUpdate.strategy.latest.description')).toBeInTheDocument()
   })
 
-  it('calls onChange when a new strategy is selected', () => {
+  it('marks only the currently selected strategy as checked', async () => {
+    const user = userEvent.setup()
+    render(
+      <StrategyPicker
+        value={AUTO_UPDATE_STRATEGY.fixOnly}
+        onChange={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: triggerName('fixOnly') }))
+
+    const checkedOptions = (await screen.findAllByRole('menuitemradio'))
+      .filter(item => item.getAttribute('aria-checked') === 'true')
+
+    expect(checkedOptions).toHaveLength(1)
+    expect(checkedOptions[0]).toHaveTextContent('plugin.autoUpdate.strategy.fixOnly.name')
+  })
+
+  it('calls onChange and closes the menu when a new strategy is selected', async () => {
+    const user = userEvent.setup()
     const onChange = vi.fn()
     render(
       <StrategyPicker
@@ -141,9 +63,12 @@ describe('StrategyPicker', () => {
       />,
     )
 
-    fireEvent.click(screen.getByTestId('trigger'))
-    fireEvent.click(screen.getByText('plugin.autoUpdate.strategy.latest.name'))
+    await user.click(screen.getByRole('button', { name: triggerName('disabled') }))
+    const latestOption = (await screen.findAllByRole('menuitemradio'))
+      .find(item => item.textContent?.includes('plugin.autoUpdate.strategy.latest.name'))!
+    await user.click(latestOption)
 
     expect(onChange).toHaveBeenCalledWith(AUTO_UPDATE_STRATEGY.latest)
+    expect(await screen.findByRole('button', { name: triggerName('disabled') })).toBeInTheDocument()
   })
 })

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/strategy-picker.spec.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/strategy-picker.spec.tsx
@@ -13,41 +13,91 @@ vi.mock('@langgenius/dify-ui/button', () => ({
   }) => <span data-testid="picker-button">{children}</span>,
 }))
 
-vi.mock('@/app/components/base/portal-to-follow-elem', async () => {
-  const _React = await import('react')
+vi.mock('@langgenius/dify-ui/dropdown-menu', async () => {
+  const React = await import('react')
+  const DropdownMenuContext = React.createContext<{
+    open: boolean
+    onOpenChange?: (open: boolean) => void
+    value?: string
+    itemValue?: string
+    onValueChange?: (value: string) => void
+  }>({ open: false })
+
   return {
-    PortalToFollowElem: ({
+    DropdownMenu: ({
       open,
+      onOpenChange,
       children,
     }: {
       open: boolean
+      onOpenChange: (open: boolean) => void
       children: React.ReactNode
     }) => {
       portalOpen = open
-      return <div>{children}</div>
+      return (
+        <DropdownMenuContext.Provider value={{ open, onOpenChange }}>
+          <div>{children}</div>
+        </DropdownMenuContext.Provider>
+      )
     },
-    PortalToFollowElemTrigger: ({
+    DropdownMenuTrigger: ({
       children,
-      onClick,
     }: {
       children: React.ReactNode
-      onClick: (event: { stopPropagation: () => void, nativeEvent: { stopImmediatePropagation: () => void } }) => void
-    }) => (
-      <button
-        data-testid="trigger"
-        onClick={() => onClick({
-          stopPropagation: vi.fn(),
-          nativeEvent: { stopImmediatePropagation: vi.fn() },
-        })}
-      >
-        {children}
-      </button>
-    ),
-    PortalToFollowElemContent: ({
+    }) => {
+      const { open, onOpenChange } = React.useContext(DropdownMenuContext)
+      return (
+        <button
+          data-testid="trigger"
+          onClick={() => onOpenChange?.(!open)}
+        >
+          {children}
+        </button>
+      )
+    },
+    DropdownMenuContent: ({
       children,
     }: {
       children: React.ReactNode
     }) => portalOpen ? <div data-testid="portal-content">{children}</div> : null,
+    DropdownMenuRadioGroup: ({
+      children,
+      value,
+      onValueChange,
+    }: {
+      children: React.ReactNode
+      value: string
+      onValueChange: (value: string) => void
+    }) => (
+      <DropdownMenuContext.Provider value={{ open: portalOpen, value, onValueChange }}>
+        <div role="radiogroup">{children}</div>
+      </DropdownMenuContext.Provider>
+    ),
+    DropdownMenuRadioItem: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode
+      value: string
+    }) => {
+      const { value: selectedValue, onValueChange } = React.useContext(DropdownMenuContext)
+      return (
+        <DropdownMenuContext.Provider value={{ open: portalOpen, value: selectedValue, itemValue: value, onValueChange }}>
+          <button
+            role="radio"
+            aria-checked={selectedValue === value}
+            data-testid={`strategy-option-${value}`}
+            onClick={() => onValueChange?.(value)}
+          >
+            {children}
+          </button>
+        </DropdownMenuContext.Provider>
+      )
+    },
+    DropdownMenuRadioItemIndicator: () => {
+      const { value, itemValue } = React.useContext(DropdownMenuContext)
+      return value === itemValue ? <span data-testid="strategy-indicator">✓</span> : null
+    },
   }
 })
 
@@ -79,7 +129,6 @@ describe('StrategyPicker', () => {
     fireEvent.click(screen.getByTestId('trigger'))
 
     expect(screen.getByTestId('portal-content')).toBeInTheDocument()
-    expect(screen.getByTestId('portal-content').querySelectorAll('svg')).toHaveLength(1)
     expect(screen.getByText('plugin.autoUpdate.strategy.latest.description')).toBeInTheDocument()
   })
 

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/strategy-picker.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/strategy-picker.tsx
@@ -1,15 +1,14 @@
 import { Button } from '@langgenius/dify-ui/button'
 import {
-  RiArrowDownSLine,
-  RiCheckLine,
-} from '@remixicon/react'
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuRadioItemIndicator,
+  DropdownMenuTrigger,
+} from '@langgenius/dify-ui/dropdown-menu'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  PortalToFollowElem,
-  PortalToFollowElemContent,
-  PortalToFollowElemTrigger,
-} from '@/app/components/base/portal-to-follow-elem'
 import { AUTO_UPDATE_STRATEGY } from './types'
 
 const i18nPrefix = 'autoUpdate.strategy'
@@ -42,58 +41,48 @@ const StrategyPicker = ({
     },
   ]
   const selectedOption = options.find(option => option.value === value)
+  const handleValueChange = (nextValue: string) => {
+    onChange(nextValue as AUTO_UPDATE_STRATEGY)
+    setOpen(false)
+  }
 
   return (
-    <PortalToFollowElem
+    <DropdownMenu
       open={open}
       onOpenChange={setOpen}
-      placement="top-end"
-      offset={4}
     >
-      <PortalToFollowElemTrigger onClick={(e) => {
-        e.stopPropagation()
-        e.nativeEvent.stopImmediatePropagation()
-        setOpen(v => !v)
-      }}
+      <DropdownMenuTrigger render={<Button size="small" />}>
+        {selectedOption?.label}
+        <span aria-hidden className="i-ri-arrow-down-s-line h-3.5 w-3.5" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        placement="top-end"
+        sideOffset={4}
+        className="z-99"
+        popupClassName="w-[280px] p-1"
       >
-        <Button
-          size="small"
+        <DropdownMenuRadioGroup
+          value={value}
+          onValueChange={handleValueChange}
         >
-          {selectedOption?.label}
-          <RiArrowDownSLine className="h-3.5 w-3.5" />
-        </Button>
-      </PortalToFollowElemTrigger>
-      <PortalToFollowElemContent className="z-99">
-        <div className="w-[280px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg">
-          {
-            options.map(option => (
-              <div
-                key={option.value}
-                className="flex cursor-pointer rounded-lg p-2 pr-3 hover:bg-state-base-hover"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  e.nativeEvent.stopImmediatePropagation()
-                  onChange(option.value)
-                  setOpen(false)
-                }}
-              >
-                <div className="mr-1 w-4 shrink-0">
-                  {
-                    value === option.value && (
-                      <RiCheckLine className="h-4 w-4 text-text-accent" />
-                    )
-                  }
-                </div>
-                <div className="grow">
-                  <div className="mb-0.5 system-sm-semibold text-text-secondary">{option.label}</div>
-                  <div className="system-xs-regular text-text-tertiary">{option.description}</div>
-                </div>
+          {options.map(option => (
+            <DropdownMenuRadioItem
+              key={option.value}
+              value={option.value}
+              className="mx-0 h-auto items-start gap-1 p-2 pr-3"
+            >
+              <div className="mr-1 flex w-4 shrink-0 justify-center pt-0.5">
+                <DropdownMenuRadioItemIndicator className="ml-0" />
               </div>
-            ))
-          }
-        </div>
-      </PortalToFollowElemContent>
-    </PortalToFollowElem>
+              <div className="grow">
+                <div className="mb-0.5 system-sm-semibold text-text-secondary">{option.label}</div>
+                <div className="system-xs-regular text-text-tertiary">{option.description}</div>
+              </div>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 


### PR DESCRIPTION
## Summary

Fixes #35626.

This PR addresses two related accessibility and consistency gaps in the web app:

### 1. Date/time picker option columns

- Extract a new `OptionList` component (`web/app/components/base/date-and-time-picker/common/option-list.tsx`) that owns the column layout (height, gap, padding, overflow) and hides the scrollbar with CSS only (`[scrollbar-width:none]` and `[&::-webkit-scrollbar]:hidden`), removing the dependency on the global `scrollbar-none` utility and de-duplicating the same set of classes that was repeated for the hour / minute / period columns and for the year / month columns.
- Use `OptionList` in both `time-picker/options.tsx` and `year-and-month-picker/options.tsx`.
- In `OptionListItem`, wrap the children in a real `<button type=\"button\">` with `focus-visible:ring-1` so each option is a proper interactive control: focusable from the keyboard, exposed with the `button` role to assistive technologies, and with a visible focus indicator. The `<li>` continues to provide the list semantics for the surrounding `<ul>`.

### 2. Auto-update strategy picker

- Migrate `strategy-picker.tsx` from the hand-rolled `PortalToFollowElem` + `<div onClick>` implementation to the design system's `DropdownMenu`:
  - `DropdownMenuTrigger` renders the existing `Button`.
  - `DropdownMenuRadioGroup` / `DropdownMenuRadioItem` express the single-select strategy choice with proper radio semantics and keyboard navigation.
  - `DropdownMenuRadioItemIndicator` replaces the manually conditional `RiCheckLine` and the `e.stopPropagation()` / `e.nativeEvent.stopImmediatePropagation()` plumbing on each option.

### Tests

- `option-list-item.spec.tsx` is updated to look up the option by its new `button` role.
- A new `option-list.spec.tsx` covers the scrollbar-hiding classes and the `className` merging.
- `time-picker/__tests__/options.spec.tsx` is updated for the new `button` role.
- `strategy-picker.spec.tsx` and the wider `auto-update-setting/__tests__/index.spec.tsx` mock the `@langgenius/dify-ui/dropdown-menu` primitives and assert against the `strategy-indicator` test id and `radio` role instead of querying for SVG check icons.

## Test plan

- [x] `pnpm --filter web test web/app/components/base/date-and-time-picker` (option list + items + time picker options).
- [x] `pnpm --filter web test web/app/components/plugins/reference-setting-modal/auto-update-setting` (strategy picker + auto-update setting).
- [ ] Manually open the time picker / year-month picker and confirm the columns scroll without a visible scrollbar and that options can be focused with `Tab` and activated with `Enter` / `Space`.
- [ ] Manually open the plugin auto-update strategy picker and confirm the dropdown opens, can be navigated with the arrow keys, shows the indicator next to the selected strategy, and dismisses on selection / outside click / `Escape`.

## Notes

- No user-facing copy changes; no i18n updates required.
- No backend changes.

Made with [Cursor](https://cursor.com)