### PR TITLE
test: cover shared workflow app run

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test:
     name: Web Full-Stack E2E
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     defaults:
       run:
         shell: bash

--- a/e2e/features/apps/share-app.feature
+++ b/e2e/features/apps/share-app.feature
@@ -17,3 +17,10 @@ Feature: Share app publicly
     Given a workflow app has been published and shared via API
     When I open the shared app URL
     Then the shared app page should be accessible
+
+  @unauthenticated
+  Scenario: Run a shared workflow app without authentication
+    Given a workflow app has been published and shared via API
+    When I open the shared app URL
+    And I run the shared workflow app
+    Then the shared workflow run should succeed

--- a/e2e/features/step-definitions/apps/share-app.steps.ts
+++ b/e2e/features/step-definitions/apps/share-app.steps.ts
@@ -37,3 +37,15 @@ Then('the shared app page should be accessible', async function (this: DifyWorld
   await expect(this.getPage()).toHaveURL(/\/(workflow|chat)\/[a-zA-Z0-9]+/, { timeout: 15_000 })
   await expect(this.getPage().locator('body')).toBeVisible({ timeout: 10_000 })
 })
+
+When('I run the shared workflow app', async function (this: DifyWorld) {
+  const page = this.getPage()
+  const runButton = page.getByTestId('run-button')
+
+  await expect(runButton).toBeEnabled({ timeout: 15_000 })
+  await runButton.click()
+})
+
+Then('the shared workflow run should succeed', async function (this: DifyWorld) {
+  await expect(this.getPage().getByTestId('status-icon-success')).toBeVisible({ timeout: 55_000 })
+})

--- a/e2e/features/step-definitions/apps/workflow-run.steps.ts
+++ b/e2e/features/step-definitions/apps/workflow-run.steps.ts
@@ -12,8 +12,10 @@ Given('a minimal runnable workflow draft has been synced', async function (this:
 
 When('I run the workflow', async function (this: DifyWorld) {
   const page = this.getPage()
-  await page.getByText('Test Run').click()
-  await expect(page.getByText('Running').first()).toBeVisible({ timeout: 15_000 })
+  const testRunButton = page.getByText('Test Run')
+
+  await expect(testRunButton).toBeVisible({ timeout: 15_000 })
+  await testRunButton.click()
 })
 
 Then('the workflow run should succeed', async function (this: DifyWorld) {


### PR DESCRIPTION
## Summary
- add an unauthenticated E2E scenario that opens a shared workflow app and runs it through the public Web App UI
- assert the shared workflow reaches the success state via the existing workflow success icon
- upgrade the Web Full-Stack E2E runner to depot-ubuntu-24.04-4 for 4 CPU / 16 GB capacity
- avoid a flaky existing console workflow run assertion by no longer depending on the transient `Running` state before checking the final `SUCCESS` state

## Verification
- pnpm -C e2e type-check
- pnpm -C e2e exec vp check --no-fmt features/apps/share-app.feature features/step-definitions/apps/share-app.steps.ts
- pnpm -C e2e exec vp check --no-fmt features/step-definitions/apps/workflow-run.steps.ts features/apps/workflow-run-publish.feature
- pnpm -C e2e exec tsx ./node_modules/@cucumber/cucumber/bin/cucumber.js --config ./cucumber.config.ts --dry-run --tags "@apps and @unauthenticated"
- pnpm -C e2e exec tsx ./node_modules/@cucumber/cucumber/bin/cucumber.js --config ./cucumber.config.ts --dry-run --tags "@mode-matrix and @apps"