### PR TITLE
feat: when copy across apps hint user install plugins

### DIFF
--- a/web/app/components/workflow/header/checklist/plugin-group.tsx
+++ b/web/app/components/workflow/header/checklist/plugin-group.tsx
@@ -7,13 +7,8 @@ import { memo, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import BlockIcon from '../../block-icon'
 import { useStore as usePluginDependencyStore } from '../../plugin-dependency/store'
+import { getVersionFromMarketplaceIdentifier } from '../../utils/plugin-install-check'
 import { ItemIndicator } from './item-indicator'
-
-function getVersionFromMarketplaceIdentifier(identifier: string): string | undefined {
-  const withoutHash = identifier.split('@')[0]
-  const [, version] = withoutHash!.split(':')
-  return version || undefined
-}
 
 export const ChecklistPluginGroup = memo(({
   items,

--- a/web/app/components/workflow/hooks/__tests__/use-nodes-interactions.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-nodes-interactions.spec.ts
@@ -1,10 +1,12 @@
 import type { Edge, Node } from '../../types'
 import { act } from '@testing-library/react'
+import { CollectionType } from '@/app/components/tools/types'
 import { createEdge, createNode } from '../../__tests__/fixtures'
 import { resetReactFlowMockState, rfState } from '../../__tests__/reactflow-mock-state'
 import { renderWorkflowHook } from '../../__tests__/workflow-test-env'
 import { collaborationManager } from '../../collaboration/core/collaboration-manager'
 import { CUSTOM_NOTE_NODE } from '../../note-node/constants'
+import { useStore as usePluginDependencyStore } from '../../plugin-dependency/store'
 import { BlockEnum, ControlMode } from '../../types'
 import { useNodesInteractions } from '../use-nodes-interactions'
 
@@ -27,6 +29,17 @@ const runtimeNodesMetaDataMap = vi.hoisted(() => ({
 const runtimeState = vi.hoisted(() => ({
   nodesReadOnly: false,
   workflowReadOnly: false,
+}))
+
+const toolServiceState = vi.hoisted(() => ({
+  builtInTools: [] as unknown[],
+  customTools: [] as unknown[],
+  workflowTools: [] as unknown[],
+  mcpTools: [] as unknown[],
+}))
+
+const triggerServiceState = vi.hoisted(() => ({
+  triggerPlugins: [] as unknown[],
 }))
 
 let currentNodes: Node[] = []
@@ -101,12 +114,29 @@ vi.mock('../use-workflow-history', async importOriginal => ({
   }),
 }))
 
+vi.mock('@/service/use-tools', () => ({
+  useAllBuiltInTools: () => ({ data: toolServiceState.builtInTools }),
+  useAllCustomTools: () => ({ data: toolServiceState.customTools }),
+  useAllWorkflowTools: () => ({ data: toolServiceState.workflowTools }),
+  useAllMCPTools: () => ({ data: toolServiceState.mcpTools }),
+}))
+
+vi.mock('@/service/use-triggers', () => ({
+  useAllTriggerPlugins: () => ({ data: triggerServiceState.triggerPlugins }),
+}))
+
 describe('useNodesInteractions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetReactFlowMockState()
     runtimeState.nodesReadOnly = false
     runtimeState.workflowReadOnly = false
+    toolServiceState.builtInTools = []
+    toolServiceState.customTools = []
+    toolServiceState.workflowTools = []
+    toolServiceState.mcpTools = []
+    triggerServiceState.triggerPlugins = []
+    usePluginDependencyStore.getState().setDependencies([])
     currentNodes = [
       createNode({
         id: 'node-1',
@@ -841,6 +871,154 @@ describe('useNodesInteractions', () => {
       const newNode = pastedNodes.find(node => !currentNodes.some(existingNode => existingNode.id === node.id))
 
       expect(newNode?.data.title).toBe('Clipboard (2)')
+    })
+  })
+
+  describe('paste plugin dependencies', () => {
+    beforeEach(() => {
+      runtimeNodesMetaDataMap.value = {
+        [BlockEnum.Tool]: {
+          defaultValue: {
+            type: BlockEnum.Tool,
+            title: 'Tool',
+            desc: '',
+            provider_type: CollectionType.builtIn,
+            provider_id: '',
+            provider_name: '',
+            tool_name: '',
+            tool_label: '',
+            tool_parameters: {},
+            tool_configurations: {},
+          },
+          metaData: {
+            isSingleton: false,
+          },
+        },
+      }
+    })
+
+    it('should open plugin dependency install modal data when pasted nodes use missing plugins', async () => {
+      currentNodes = [
+        createNode({
+          id: 'existing-node',
+          data: {
+            type: BlockEnum.Code,
+            title: 'Existing',
+            desc: '',
+          },
+        }),
+      ]
+      currentEdges = []
+      rfState.nodes = currentNodes as unknown as typeof rfState.nodes
+      rfState.edges = currentEdges as unknown as typeof rfState.edges
+      toolServiceState.builtInTools = [{
+        id: 'langgenius/other/other',
+        name: 'other',
+        plugin_id: 'other-plugin',
+        provider: 'other-provider',
+        plugin_unique_identifier: 'langgenius/other:1.0.0',
+      }]
+
+      const { result, store } = renderWorkflowHook(() => useNodesInteractions(), {
+        historyStore: {
+          nodes: currentNodes,
+          edges: currentEdges,
+        },
+      })
+
+      store.setState({
+        clipboardElements: [
+          createNode({
+            id: 'clipboard-tool',
+            data: {
+              type: BlockEnum.Tool,
+              title: 'Search',
+              desc: '',
+              provider_type: CollectionType.builtIn,
+              provider_id: 'missing-search',
+              provider_name: 'search',
+              tool_name: 'search',
+              tool_label: 'Search',
+              tool_parameters: {},
+              tool_configurations: {},
+              plugin_unique_identifier: 'langgenius/search:1.2.3',
+            },
+          }),
+        ] as never,
+        clipboardEdges: [] as never,
+        mousePosition: {
+          pageX: 60,
+          pageY: 80,
+        } as never,
+      })
+
+      await act(async () => {
+        await result.current.handleNodesPaste()
+      })
+
+      expect(usePluginDependencyStore.getState().dependencies).toEqual([
+        {
+          type: 'marketplace',
+          value: {
+            marketplace_plugin_unique_identifier: 'langgenius/search:1.2.3',
+            plugin_unique_identifier: 'langgenius/search:1.2.3',
+            version: '1.2.3',
+          },
+        },
+      ])
+    })
+
+    it('should not open plugin dependency install modal data when pasted plugin is installed', async () => {
+      currentNodes = []
+      currentEdges = []
+      rfState.nodes = currentNodes as unknown as typeof rfState.nodes
+      rfState.edges = currentEdges as unknown as typeof rfState.edges
+      toolServiceState.builtInTools = [{
+        id: 'missing-search',
+        name: 'search',
+        plugin_id: 'search-plugin',
+        provider: 'search',
+        plugin_unique_identifier: 'langgenius/search:1.2.3',
+      }]
+
+      const { result, store } = renderWorkflowHook(() => useNodesInteractions(), {
+        historyStore: {
+          nodes: currentNodes,
+          edges: currentEdges,
+        },
+      })
+
+      store.setState({
+        clipboardElements: [
+          createNode({
+            id: 'clipboard-tool',
+            data: {
+              type: BlockEnum.Tool,
+              title: 'Search',
+              desc: '',
+              provider_type: CollectionType.builtIn,
+              provider_id: 'missing-search',
+              provider_name: 'search',
+              tool_name: 'search',
+              tool_label: 'Search',
+              tool_parameters: {},
+              tool_configurations: {},
+              plugin_unique_identifier: 'langgenius/search:1.2.3',
+            },
+          }),
+        ] as never,
+        clipboardEdges: [] as never,
+        mousePosition: {
+          pageX: 60,
+          pageY: 80,
+        } as never,
+      })
+
+      await act(async () => {
+        await result.current.handleNodesPaste()
+      })
+
+      expect(usePluginDependencyStore.getState().dependencies).toEqual([])
     })
   })
 

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -24,6 +24,13 @@ import {
   useReactFlow,
 } from 'reactflow'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
+import {
+  useAllBuiltInTools,
+  useAllCustomTools,
+  useAllMCPTools,
+  useAllWorkflowTools,
+} from '@/service/use-tools'
+import { useAllTriggerPlugins } from '@/service/use-triggers'
 import { collaborationManager } from '../collaboration/core/collaboration-manager'
 import {
   CUSTOM_EDGE,
@@ -41,7 +48,8 @@ import { useNodeIterationInteractions } from '../nodes/iteration/use-interaction
 import { CUSTOM_LOOP_START_NODE } from '../nodes/loop-start/constants'
 import { useNodeLoopInteractions } from '../nodes/loop/use-interactions'
 import { CUSTOM_NOTE_NODE } from '../note-node/constants'
-import { useWorkflowStore } from '../store'
+import { useStore as usePluginDependencyStore } from '../plugin-dependency/store'
+import { useStore, useWorkflowStore } from '../store'
 import { BlockEnum, ControlMode, isTriggerNode } from '../types'
 
 import {
@@ -58,6 +66,7 @@ import {
   sanitizeClipboardValueByDefault,
   writeWorkflowClipboard,
 } from '../utils'
+import { getMissingPluginDependenciesFromNodes } from '../utils/plugin-install-check'
 import { useWorkflowHistoryStore } from '../workflow-history-store'
 import { useAutoGenerateWebhookUrl } from './use-auto-generate-webhook-url'
 import { useCollaborativeWorkflow } from './use-collaborative-workflow'
@@ -149,6 +158,12 @@ export const useNodesInteractions = () => {
     ...systemFeaturesQueryOptions(),
     select: s => s.app_dsl_version,
   })
+  const { data: builtInTools } = useAllBuiltInTools()
+  const { data: customTools } = useAllCustomTools()
+  const { data: workflowTools } = useAllWorkflowTools()
+  const { data: mcpTools } = useAllMCPTools()
+  const { data: triggerPlugins } = useAllTriggerPlugins()
+  const dataSourceList = useStore(s => s.dataSourceList)
   const collaborativeWorkflow = useCollaborativeWorkflow()
   const workflowStore = useWorkflowStore()
   const reactflow = useReactFlow()
@@ -1920,6 +1935,23 @@ export const useNodesInteractions = () => {
     if (!compatibleClipboardElements.length)
       return
 
+    const missingPluginDependencies = getMissingPluginDependenciesFromNodes(
+      compatibleClipboardElements,
+      {
+        builtInTools,
+        customTools,
+        workflowTools,
+        mcpTools,
+        triggerPlugins,
+        dataSourceList,
+      },
+    )
+    if (missingPluginDependencies.length) {
+      usePluginDependencyStore.getState().setDependencies(
+        missingPluginDependencies,
+      )
+    }
+
     const rootClipboardNodes = compatibleClipboardElements.filter(
       node => !node.parentId || !compatibleClipboardNodeIds.has(node.parentId),
     )
@@ -2316,6 +2348,12 @@ export const useNodesInteractions = () => {
     handleNodeLoopChildrenCopy,
     getNodeDefaultValueForPaste,
     appDslVersion,
+    builtInTools,
+    customTools,
+    workflowTools,
+    mcpTools,
+    triggerPlugins,
+    dataSourceList,
   ])
 
   const handleNodesDuplicate = useCallback(

--- a/web/app/components/workflow/utils/__tests__/plugin-install-check.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/plugin-install-check.spec.ts
@@ -1,8 +1,11 @@
 import type { TriggerWithProvider } from '../../block-selector/types'
-import type { CommonNodeType, ToolWithProvider } from '../../types'
+import type { CommonNodeType, Node, ToolWithProvider } from '../../types'
 import { CollectionType } from '@/app/components/tools/types'
 import { BlockEnum } from '../../types'
 import {
+  createMarketplaceDependencyFromIdentifier,
+  getMissingPluginDependenciesFromNodes,
+  getVersionFromMarketplaceIdentifier,
   isNodePluginMissing,
   isPluginDependentNode,
   matchDataSource,
@@ -190,6 +193,55 @@ describe('plugin install check', () => {
       } as CommonNodeType
 
       expect(isNodePluginMissing(node, {})).toBe(false)
+    })
+  })
+
+  describe('dependency helpers', () => {
+    it('should parse the version from marketplace identifiers', () => {
+      expect(getVersionFromMarketplaceIdentifier('langgenius/search:1.2.3@sha256:abc')).toBe('1.2.3')
+      expect(getVersionFromMarketplaceIdentifier('langgenius/search')).toBeUndefined()
+    })
+
+    it('should create marketplace dependencies from plugin identifiers', () => {
+      expect(createMarketplaceDependencyFromIdentifier('langgenius/search:1.2.3')).toEqual({
+        type: 'marketplace',
+        value: {
+          marketplace_plugin_unique_identifier: 'langgenius/search:1.2.3',
+          plugin_unique_identifier: 'langgenius/search:1.2.3',
+          version: '1.2.3',
+        },
+      })
+    })
+
+    it('should collect unique dependencies from missing plugin nodes', () => {
+      const node = {
+        id: 'node-1',
+        type: 'custom',
+        position: { x: 0, y: 0 },
+        data: {
+          type: BlockEnum.Tool,
+          title: 'Tool',
+          desc: '',
+          provider_type: CollectionType.builtIn,
+          provider_id: 'missing-provider',
+          plugin_unique_identifier: 'langgenius/search:1.2.3',
+        },
+      } as unknown as Node
+
+      const dependencies = getMissingPluginDependenciesFromNodes([node, node], {
+        builtInTools: [createTool()],
+      })
+
+      expect(dependencies).toEqual([
+        {
+          type: 'marketplace',
+          value: {
+            marketplace_plugin_unique_identifier: 'langgenius/search:1.2.3',
+            plugin_unique_identifier: 'langgenius/search:1.2.3',
+            version: '1.2.3',
+          },
+        },
+      ])
     })
   })
 })

--- a/web/app/components/workflow/utils/plugin-install-check.ts
+++ b/web/app/components/workflow/utils/plugin-install-check.ts
@@ -2,7 +2,8 @@ import type { TriggerWithProvider } from '../block-selector/types'
 import type { DataSourceNodeType } from '../nodes/data-source/types'
 import type { ToolNodeType } from '../nodes/tool/types'
 import type { PluginTriggerNodeType } from '../nodes/trigger-plugin/types'
-import type { CommonNodeType, ToolWithProvider } from '../types'
+import type { CommonNodeType, Node, ToolWithProvider } from '../types'
+import type { Dependency } from '@/app/components/plugins/types'
 import { CollectionType } from '@/app/components/tools/types'
 import { canFindTool } from '@/utils'
 import { BlockEnum } from '../types'
@@ -50,13 +51,30 @@ export function matchDataSource(
   )
 }
 
-type PluginInstallCheckContext = {
+export type PluginInstallCheckContext = {
   builtInTools?: ToolWithProvider[]
   customTools?: ToolWithProvider[]
   workflowTools?: ToolWithProvider[]
   mcpTools?: ToolWithProvider[]
   triggerPlugins?: TriggerWithProvider[]
   dataSourceList?: ToolWithProvider[]
+}
+
+export function getVersionFromMarketplaceIdentifier(identifier: string): string | undefined {
+  const withoutHash = identifier.split('@')[0]
+  const [, version] = withoutHash!.split(':')
+  return version || undefined
+}
+
+export function createMarketplaceDependencyFromIdentifier(identifier: string): Dependency {
+  return {
+    type: 'marketplace',
+    value: {
+      marketplace_plugin_unique_identifier: identifier,
+      plugin_unique_identifier: identifier,
+      version: getVersionFromMarketplaceIdentifier(identifier),
+    },
+  }
 }
 
 export function isNodePluginMissing(
@@ -92,4 +110,22 @@ export function isNodePluginMissing(
     default:
       return false
   }
+}
+
+export function getMissingPluginDependenciesFromNodes(
+  nodes: Node[],
+  context: PluginInstallCheckContext,
+): Dependency[] {
+  const identifiers = new Set<string>()
+
+  nodes.forEach((node) => {
+    if (!isNodePluginMissing(node.data, context))
+      return
+
+    const identifier = (node.data as { plugin_unique_identifier?: string }).plugin_unique_identifier
+    if (identifier)
+      identifiers.add(identifier)
+  })
+
+  return Array.from(identifiers).map(createMarketplaceDependencyFromIdentifier)
 }

--- a/web/app/components/workflow/utils/plugin-install-check.ts
+++ b/web/app/components/workflow/utils/plugin-install-check.ts
@@ -51,7 +51,7 @@ export function matchDataSource(
   )
 }
 
-export type PluginInstallCheckContext = {
+type PluginInstallCheckContext = {
   builtInTools?: ToolWithProvider[]
   customTools?: ToolWithProvider[]
   workflowTools?: ToolWithProvider[]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

the follow of https://github.com/langgenius/dify/pull/33273

When users paste workflow nodes copied from another app, detect missing plugin dependencies for tool, data source, and trigger plugin nodes, then show the existing plugin installation prompt.

Model provider plugins are intentionally excluded because pasted graph data does not include model plugin version metadata.


## Screenshots

<img width="1244" height="960" alt="image" src="https://github.com/user-attachments/assets/0665a034-a41b-4b96-a415-75449ad74d5a" />


| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
