### PR TITLE
test: make WordExtractor close test deterministic

### DIFF
--- a/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
@@ -383,7 +383,6 @@ def test_close_handles_awaitable_close_result():
         def __await__(self):
             if False:
                 yield
-            return None
 
     close_result = CloseResult()
     extractor = object.__new__(WordExtractor)

--- a/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
@@ -1,14 +1,12 @@
 """Primarily used for testing merged cell scenarios"""
 
-import gc
 import io
 import os
 import tempfile
-import warnings
 from collections import UserDict
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from docx import Document
@@ -377,23 +375,26 @@ def test_close_is_idempotent():
     extractor.temp_file.close.assert_called_once()
 
 
-def test_close_handles_async_close_mock():
+def test_close_handles_awaitable_close_result():
+    class CloseResult:
+        def __init__(self):
+            self.close = MagicMock()
+
+        def __await__(self):
+            if False:
+                yield
+            return None
+
+    close_result = CloseResult()
     extractor = object.__new__(WordExtractor)
     extractor._closed = False
     extractor.temp_file = MagicMock()
-    extractor.temp_file.close = AsyncMock()
+    extractor.temp_file.close.return_value = close_result
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        extractor.close()
-        gc.collect()
+    extractor.close()
 
     extractor.temp_file.close.assert_called_once()
-    assert not [
-        warning
-        for warning in caught
-        if issubclass(warning.category, RuntimeWarning) and "AsyncMockMixin._execute_mock_call" in str(warning.message)
-    ]
+    close_result.close.assert_called_once()
 
 
 def test_extract_images_handles_invalid_external_cases(monkeypatch):


### PR DESCRIPTION
## Summary

- Makes `WordExtractor.close()` coverage deterministic.
- Replaces a runtime-warning based `AsyncMock`/GC assertion with a direct awaitable close-result stub.
- Keeps the test focused on the extractor behavior instead of unrelated coroutine cleanup timing.
- Removes now-unused `gc`, `warnings`, and `AsyncMock` imports.

## Why

The previous test could observe coroutine warnings emitted by earlier tests, which made the assertion flaky and unrelated to `WordExtractor.close()` itself.

## Validation

- `python3 -m py_compile api/tests/unit_tests/core/rag/extractor/test_word_extractor.py`

Not run: targeted pytest, because dependency setup failed locally with `No space left on device` while downloading packages.

Fixes #35651
close https://github.com/langgenius/dify/pull/35652
