### PR TITLE
fix(api): sanitize CSV values starting with line feed

### DIFF
--- a/api/core/helper/csv_sanitizer.py
+++ b/api/core/helper/csv_sanitizer.py
@@ -12,12 +12,12 @@ class CSVSanitizer:
     (Excel, LibreOffice, Google Sheets).
 
     Formula injection occurs when user-controlled data starting with special
-    characters (=, +, -, @, tab, carriage return) is exported to CSV and opened
+    characters (=, +, -, @, tab, carriage return, line feed) is exported to CSV and opened
     in a spreadsheet application, potentially executing malicious commands.
     """
 
     # Characters that can start a formula in Excel/LibreOffice/Google Sheets
-    FORMULA_CHARS = frozenset(("=", "+", "-", "@", "\t", "\r"))
+    FORMULA_CHARS = frozenset(("=", "+", "-", "@", "\t", "\r", "\n"))
 
     @classmethod
     def sanitize_value(cls, value: Any) -> str:

--- a/api/tests/unit_tests/core/helper/test_csv_sanitizer.py
+++ b/api/tests/unit_tests/core/helper/test_csv_sanitizer.py
@@ -40,6 +40,11 @@ class TestCSVSanitizer:
         assert CSVSanitizer.sanitize_value("\r=1+1") == "'\r=1+1"
         assert CSVSanitizer.sanitize_value("\rcmd") == "'\rcmd"
 
+    def test_sanitize_formula_line_feed(self):
+        """Test sanitizing values starting with line feed."""
+        assert CSVSanitizer.sanitize_value("\n=1+1") == "'\n=1+1"
+        assert CSVSanitizer.sanitize_value("\ncmd") == "'\ncmd"
+
     def test_sanitize_safe_values(self):
         """Test that safe values are not modified."""
         assert CSVSanitizer.sanitize_value("Hello World") == "Hello World"
@@ -146,6 +151,6 @@ class TestCSVSanitizer:
     def test_whitespace_only_strings(self):
         """Test handling of whitespace-only strings."""
         assert CSVSanitizer.sanitize_value("   ") == "   "
-        assert CSVSanitizer.sanitize_value("\n\n") == "\n\n"
+        assert CSVSanitizer.sanitize_value("\n\n") == "'\n\n"
         # Tab at start should be escaped
         assert CSVSanitizer.sanitize_value("\t  ") == "'\t  "


### PR DESCRIPTION
## Summary

- treat leading line feed (`\n`) as a CSV formula injection prefix
- add unit coverage for values that start with a line feed
- update sanitizer docs to include line feed alongside tab and carriage return

## Test

- `PYTHONPATH=. python3 - <<'PY' ...` smoke checks for `CSVSanitizer.sanitize_value`
- `PYTHONPATH=. python3 - <<'PY' ...` executed all `TestCSVSanitizer` test methods directly

`uv run pytest tests/unit_tests/core/helper/test_csv_sanitizer.py -q` could not complete in this workspace because dependency setup hit `No space left on device` while populating the uv cache.
