### PR TITLE
Improve automatic knowledge metadata filtering context

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -32,6 +32,7 @@ from core.prompt.advanced_prompt_transform import AdvancedPromptTransform
 from core.prompt.entities.advanced_prompt_entities import ChatModelMessage, CompletionModelPromptTemplate
 from core.prompt.simple_prompt_transform import ModelMode
 from core.rag.data_post_processor.data_post_processor import DataPostProcessor, RerankingModelDict, WeightsDict
+from core.rag.index_processor.constant.built_in_field import BuiltInField
 from core.rag.datasource.keyword.jieba.jieba_keyword_table_handler import JiebaKeywordTableHandler
 from core.rag.datasource.retrieval_service import DefaultRetrievalModelDict, RetrievalService
 from core.rag.entities import Condition, DocumentContext, RetrievalSourceMetadata
@@ -96,6 +97,8 @@ default_retrieval_model: DefaultRetrievalModelDict = {
 }
 
 logger = logging.getLogger(__name__)
+
+MetadataPromptField = dict[str, str]
 
 
 class DatasetRetrieval:
@@ -1438,10 +1441,8 @@ class DatasetRetrieval:
     def _automatic_metadata_filter_func(
         self, dataset_ids: list[str], query: str, tenant_id: str, user_id: str, metadata_model_config: ModelConfig
     ) -> list[dict[str, Any]] | None:
-        # get all metadata field
-        metadata_stmt = select(DatasetMetadata).where(DatasetMetadata.dataset_id.in_(dataset_ids))
-        metadata_fields = db.session.scalars(metadata_stmt).all()
-        all_metadata_fields = [metadata_field.name for metadata_field in metadata_fields]
+        metadata_prompt_fields = self._get_metadata_prompt_fields(dataset_ids)
+        all_metadata_fields = [metadata_field["name"] for metadata_field in metadata_prompt_fields]
         # get metadata model config
         if metadata_model_config is None:
             raise ValueError("metadata_model_config is required")
@@ -1453,7 +1454,7 @@ class DatasetRetrieval:
         prompt_messages, stop = self._get_prompt_template(
             model_config=model_config,
             mode=metadata_model_config.mode,
-            metadata_fields=all_metadata_fields,
+            metadata_fields=metadata_prompt_fields,
             query=query or "",
         )
 
@@ -1490,6 +1491,52 @@ class DatasetRetrieval:
             logger.warning(e, exc_info=True)
             return None
         return automatic_metadata_filters
+
+    def _get_metadata_prompt_fields(self, dataset_ids: list[str]) -> list[MetadataPromptField]:
+        """Build the metadata field list exposed to automatic metadata filtering.
+
+        Automatic filtering previously only exposed custom metadata names. That
+        prevented the LLM from selecting built-in document metadata such as
+        ``document_name`` or ``upload_date`` even when those fields were
+        available for manual filtering in the UI.
+        """
+
+        metadata_stmt = select(DatasetMetadata).where(DatasetMetadata.dataset_id.in_(dataset_ids))
+        metadata_fields = db.session.scalars(metadata_stmt).all()
+
+        prompt_fields_by_name: dict[str, MetadataPromptField] = {
+            metadata_field.name: {
+                "name": metadata_field.name,
+                "type": str(metadata_field.type),
+            }
+            for metadata_field in metadata_fields
+        }
+
+        dataset_stmt = select(Dataset).where(Dataset.id.in_(dataset_ids))
+        datasets = db.session.scalars(dataset_stmt).all()
+        if any(dataset.built_in_field_enabled for dataset in datasets):
+            prompt_fields_by_name.setdefault(
+                BuiltInField.document_name,
+                {"name": BuiltInField.document_name, "type": "string"},
+            )
+            prompt_fields_by_name.setdefault(
+                BuiltInField.uploader,
+                {"name": BuiltInField.uploader, "type": "string"},
+            )
+            prompt_fields_by_name.setdefault(
+                BuiltInField.upload_date,
+                {"name": BuiltInField.upload_date, "type": "time"},
+            )
+            prompt_fields_by_name.setdefault(
+                BuiltInField.last_update_date,
+                {"name": BuiltInField.last_update_date, "type": "time"},
+            )
+            prompt_fields_by_name.setdefault(
+                BuiltInField.source,
+                {"name": BuiltInField.source, "type": "string"},
+            )
+
+        return list(prompt_fields_by_name.values())
 
     @classmethod
     def process_metadata_filter_func(
@@ -1633,7 +1680,7 @@ class DatasetRetrieval:
         )
 
     def _get_prompt_template(
-        self, model_config: ModelConfigWithCredentialsEntity, mode: str, metadata_fields: list[str], query: str
+        self, model_config: ModelConfigWithCredentialsEntity, mode: str, metadata_fields: list[MetadataPromptField], query: str
     ):
         model_mode = ModelMode(mode)
         input_text = query

--- a/api/core/rag/retrieval/template_prompts.py
+++ b/api/core/rag/retrieval/template_prompts.py
@@ -4,14 +4,15 @@ METADATA_FILTER_SYSTEM_PROMPT = """
     ### Task
     Your task is to ONLY extract the metadatas that exist in the input text from the provided metadata list and Use the following operators ["contains", "not contains", "start with", "end with", "is", "is not", "empty", "not empty", "=", "≠", ">", "<", "≥", "≤", "before", "after"] to express logical relationships, then return result in JSON format with the key "metadata_fields" and value "metadata_field_value" and comparison operator "comparison_operator".
     ### Format
-    The input text is in the variable input_text. Metadata are specified as a list in the variable metadata_fields.
+    The input text is in the variable input_text. Metadata are specified as a list of objects in the variable metadata_fields, where each object contains "name" and "type".
+    Use string operators for metadata fields with type "string". Use numeric/date comparison operators for metadata fields with type "number" or "time".
     ### Constraint
     DO NOT include anything other than the JSON array in your response.
 """  # noqa: E501
 
 METADATA_FILTER_USER_PROMPT_1 = """
     { "input_text": "I want to know which company’s email address test@example.com is?",
-    "metadata_fields": ["filename", "email", "phone", "address"]
+    "metadata_fields": [{"name": "filename", "type": "string"}, {"name": "email", "type": "string"}, {"name": "phone", "type": "string"}, {"name": "address", "type": "string"}]
     }
 """
 
@@ -26,7 +27,7 @@ METADATA_FILTER_ASSISTANT_PROMPT_1 = """
 
 METADATA_FILTER_USER_PROMPT_2 = """
     {"input_text": "What are the movies with a score of more than 9 in 2024?",
-    "metadata_fields": ["name", "year", "rating", "country"]}
+    "metadata_fields": [{"name": "name", "type": "string"}, {"name": "year", "type": "number"}, {"name": "rating", "type": "number"}, {"name": "country", "type": "string"}]}
 """
 
 METADATA_FILTER_ASSISTANT_PROMPT_2 = """
@@ -49,15 +50,15 @@ You are a text metadata extract engine that extract text's metadata based on use
 ### Task
 # Your task is to ONLY extract the metadatas that exist in the input text from the provided metadata list and Use the following operators ["=", "!=", ">", "<", ">=", "<="] to express logical relationships, then return result in JSON format with the key "metadata_fields" and value "metadata_field_value" and comparison operator "comparison_operator".
 ### Format
-The input text is in the variable input_text. Metadata are specified as a list in the variable metadata_fields.
+The input text is in the variable input_text. Metadata are specified as a list of objects in the variable metadata_fields, where each object contains "name" and "type".
 ### Constraint
 DO NOT include anything other than the JSON array in your response.
 ### Example
 Here is the chat example between human and assistant, inside <example></example> XML tags.
 <example>
-User:{{"input_text": ["I want to know which company’s email address test@example.com is?"], "metadata_fields": ["filename", "email", "phone", "address"]}}
+User:{{"input_text": ["I want to know which company’s email address test@example.com is?"], "metadata_fields": [{{"name": "filename", "type": "string"}}, {{"name": "email", "type": "string"}}, {{"name": "phone", "type": "string"}}, {{"name": "address", "type": "string"}}]}}
 Assistant:{{"metadata_map": [{{"metadata_field_name": "email", "metadata_field_value": "test@example.com", "comparison_operator": "="}}]}}
-User:{{"input_text": "What are the movies with a score of more than 9 in 2024?", "metadata_fields": ["name", "year", "rating", "country"]}}
+User:{{"input_text": "What are the movies with a score of more than 9 in 2024?", "metadata_fields": [{{"name": "name", "type": "string"}}, {{"name": "year", "type": "number"}}, {{"name": "rating", "type": "number"}}, {{"name": "country", "type": "string"}}]}}
 Assistant:{{"metadata_map": [{{"metadata_field_name": "year", "metadata_field_value": "2024", "comparison_operator": "="}, {{"metadata_field_name": "rating", "metadata_field_value": "9", "comparison_operator": ">"}}]}}
 </example>
 ### User Input

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -3813,11 +3813,14 @@ class TestDatasetRetrievalAdditionalHelpers:
             prompt_messages, stop = retrieval._get_prompt_template(
                 model_config=model_config_chat,
                 mode="chat",
-                metadata_fields=["author"],
+                metadata_fields=[{"name": "author", "type": "string"}],
                 query="python",
             )
             assert prompt_messages == ["prompt"]
             assert stop == ["x"]
+            prompt_template = mock_prompt_transform.return_value.get_prompt.call_args.kwargs["prompt_template"]
+            assert '"name": "author"' in prompt_template[-1].text
+            assert '"type": "string"' in prompt_template[-1].text
 
             with patch(
                 "core.rag.retrieval.dataset_retrieval.METADATA_FILTER_COMPLETION_PROMPT",
@@ -3826,11 +3829,15 @@ class TestDatasetRetrievalAdditionalHelpers:
                 prompt_messages_completion, stop_completion = retrieval._get_prompt_template(
                     model_config=model_config_completion,
                     mode="completion",
-                    metadata_fields=["author"],
+                    metadata_fields=[{"name": "author", "type": "string"}],
                     query="python",
                 )
                 assert prompt_messages_completion == ["prompt"]
                 assert stop_completion == []
+                prompt_template_completion = mock_prompt_transform.return_value.get_prompt.call_args.kwargs[
+                    "prompt_template"
+                ]
+                assert '"name": "author"' in prompt_template_completion.text
 
         with pytest.raises(ValueError):
             retrieval._get_prompt_template(
@@ -3904,7 +3911,7 @@ class TestDatasetRetrievalAdditionalHelpers:
             assert "stop" not in config.parameters
 
     def test_automatic_metadata_filter_func(self, retrieval: DatasetRetrieval) -> None:
-        metadata_field = SimpleNamespace(name="author")
+        metadata_field = SimpleNamespace(name="author", type="string")
         model_instance = Mock()
         model_instance.invoke_llm.return_value = iter([Mock()])
         model_config = ModelConfigWithCredentialsEntity.model_construct(
@@ -3918,13 +3925,18 @@ class TestDatasetRetrievalAdditionalHelpers:
             stop=[],
         )
         usage = LLMUsage.from_metadata({"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
-        session_scalars = Mock()
-        session_scalars.all.return_value = [metadata_field]
+        metadata_scalars = Mock()
+        metadata_scalars.all.return_value = [metadata_field]
+        dataset_scalars = Mock()
+        dataset_scalars.all.return_value = [SimpleNamespace(built_in_field_enabled=False)]
 
         with (
-            patch("core.rag.retrieval.dataset_retrieval.db.session.scalars", return_value=session_scalars),
+            patch(
+                "core.rag.retrieval.dataset_retrieval.db.session.scalars",
+                side_effect=[metadata_scalars, dataset_scalars],
+            ),
             patch.object(retrieval, "_fetch_model_config", return_value=(model_instance, model_config)),
-            patch.object(retrieval, "_get_prompt_template", return_value=(["prompt"], [])),
+            patch.object(retrieval, "_get_prompt_template", return_value=(["prompt"], [])) as mock_get_prompt_template,
             patch.object(retrieval, "_handle_invoke_result", return_value=('{"metadata_map":[]}', usage)),
             patch("core.rag.retrieval.dataset_retrieval.parse_and_check_json_markdown") as mock_parse,
             patch.object(retrieval, "_record_usage") as mock_record_usage,
@@ -3951,11 +3963,18 @@ class TestDatasetRetrievalAdditionalHelpers:
                 metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
             )
 
+            assert mock_get_prompt_template.call_args.kwargs["metadata_fields"] == [
+                {"name": "author", "type": "string"},
+            ]
+
         assert result == [{"metadata_name": "author", "value": "Alice", "condition": "contains"}]
         mock_record_usage.assert_called_once_with(usage)
 
         with (
-            patch("core.rag.retrieval.dataset_retrieval.db.session.scalars", return_value=session_scalars),
+            patch(
+                "core.rag.retrieval.dataset_retrieval.db.session.scalars",
+                side_effect=[metadata_scalars, dataset_scalars],
+            ),
             patch.object(retrieval, "_fetch_model_config", side_effect=RuntimeError("boom")),
         ):
             with pytest.raises(RuntimeError, match="boom"):
@@ -3966,6 +3985,35 @@ class TestDatasetRetrievalAdditionalHelpers:
                     user_id="u1",
                     metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
                 )
+
+    def test_get_metadata_prompt_fields_includes_built_in_fields(self, retrieval: DatasetRetrieval) -> None:
+        custom_metadata_scalars = Mock()
+        custom_metadata_scalars.all.return_value = [
+            SimpleNamespace(name="author", type="string"),
+            SimpleNamespace(name="author", type="string"),
+            SimpleNamespace(name="published_at", type="time"),
+        ]
+        dataset_scalars = Mock()
+        dataset_scalars.all.return_value = [
+            SimpleNamespace(built_in_field_enabled=True),
+            SimpleNamespace(built_in_field_enabled=False),
+        ]
+
+        with patch(
+            "core.rag.retrieval.dataset_retrieval.db.session.scalars",
+            side_effect=[custom_metadata_scalars, dataset_scalars],
+        ):
+            result = retrieval._get_metadata_prompt_fields(["d1", "d2"])
+
+        assert result == [
+            {"name": "author", "type": "string"},
+            {"name": "published_at", "type": "time"},
+            {"name": "document_name", "type": "string"},
+            {"name": "uploader", "type": "string"},
+            {"name": "upload_date", "type": "time"},
+            {"name": "last_update_date", "type": "time"},
+            {"name": "source", "type": "string"},
+        ]
 
     def test_get_metadata_filter_condition(self, retrieval: DatasetRetrieval) -> None:
         scalars_result = Mock()
@@ -5093,10 +5141,15 @@ class TestInternalHooksCoverage:
                     metadata_model_config=None,  # type: ignore[arg-type]
                 )
 
-        session_scalars = Mock()
-        session_scalars.all.return_value = [SimpleNamespace(name="author")]
+        metadata_scalars = Mock()
+        metadata_scalars.all.return_value = [SimpleNamespace(name="author", type="string")]
+        dataset_scalars = Mock()
+        dataset_scalars.all.return_value = [SimpleNamespace(built_in_field_enabled=False)]
         with (
-            patch("core.rag.retrieval.dataset_retrieval.db.session.scalars", return_value=session_scalars),
+            patch(
+                "core.rag.retrieval.dataset_retrieval.db.session.scalars",
+                side_effect=[metadata_scalars, dataset_scalars],
+            ),
             patch.object(retrieval, "_fetch_model_config", return_value=(Mock(), Mock())),
             patch.object(retrieval, "_get_prompt_template", return_value=(["prompt"], [])),
             patch.object(retrieval, "_record_usage"),


### PR DESCRIPTION
## Summary
- include built-in knowledge metadata fields in automatic metadata filtering
- pass typed metadata descriptors to the LLM prompt instead of bare field names
- add backend unit coverage for prompt generation and built-in metadata support

## Related Issue
- Related to #35607

## Testing
- uv run --project api pytest -o addopts='' api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py