### PR TITLE
fix: ensure generated password satisfies the password policy

### DIFF
--- a/api/commands/account.py
+++ b/api/commands/account.py
@@ -113,8 +113,18 @@ def create_tenant(email: str, language: str | None = None, name: str | None = No
     # Validates name encoding for non-Latin characters.
     name = name.strip().encode("utf-8").decode("utf-8") if name else None
 
-    # generate random password
-    new_password = secrets.token_urlsafe(16)
+    # Generate a random password that satisfies the password policy.
+    # The iteration limit guards against infinite loops caused by unexpected bugs in valid_password.
+    for _ in range(100):
+        new_password = secrets.token_urlsafe(16)
+        try:
+            valid_password(new_password)
+            break
+        except Exception:
+            continue
+    else:
+        click.echo(click.style("Failed to generate a valid password. Please try again.", fg="red"))
+        return
 
     # register account
     account = RegisterService.register(


### PR DESCRIPTION
## Summary

This PR includes following changes for `create-tenant` command:

- Added a retry loop to keep generating a new password until it passes `valid_password`
- Set an iteration limit of 100 to guard against infinite loops caused by unexpected bugs in `valid_password`
- If the limit is reached, an error message is displayed and the command exits gracefully

Existing similar logic (for tests): https://github.com/langgenius/dify/blob/main/api/tests/test_containers_integration_tests/helpers/__init__.py

Closes #35671 

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods