### PR TITLE
chore: update eslint suppressions codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,9 @@
 
 * @crazywoola @laipz8200 @Yeuoly
 
+# ESLint suppression file is maintained by autofix.ci pruning.
+/eslint-suppressions.json
+
 # CODEOWNERS file
 /.github/CODEOWNERS @laipz8200 @crazywoola
 


### PR DESCRIPTION
## Summary
- exclude `eslint-suppressions.json` from the global CODEOWNERS fallback
- avoid unrelated code owner review requests from autofix.ci pruning

Fixes #35678

## Tests
- Not run; CODEOWNERS-only change.