### PR TITLE
fix: restore app nav create submenu interaction

### DIFF
--- a/web/__tests__/header/nav-flow.test.tsx
+++ b/web/__tests__/header/nav-flow.test.tsx
@@ -195,9 +195,19 @@ describe('Header Nav Flow', () => {
     renderNav()
 
     fireEvent.click(screen.getByRole('button', { name: /Alpha/i }))
-    fireEvent.click(await screen.findByText('menus.newApp'))
+
+    const openCreateMenu = async () => {
+      fireEvent.click(await screen.findByText('menus.newApp'))
+      return screen.findByText('newApp.startFromBlank')
+    }
+
+    await openCreateMenu()
     fireEvent.click(await screen.findByText('newApp.startFromBlank'))
+
+    await openCreateMenu()
     fireEvent.click(await screen.findByText('newApp.startFromTemplate'))
+
+    await openCreateMenu()
     fireEvent.click(await screen.findByText('importDSL'))
 
     expect(mockOnCreate).toHaveBeenNthCalledWith(1, 'blank')

--- a/web/app/components/header/nav/__tests__/index.spec.tsx
+++ b/web/app/components/header/nav/__tests__/index.spec.tsx
@@ -298,11 +298,15 @@ describe('Nav Component', () => {
         fireEvent.click(selectorButton)
       })
 
-      const createButton = await screen.findByText('Create New')
-      await act(async () => {
-        fireEvent.click(createButton)
-      })
+      const openCreateMenu = async () => {
+        const createButton = await screen.findByText('Create New')
+        await act(async () => {
+          fireEvent.click(createButton)
+        })
+        return screen.findByText(/app\.newApp\.startFromBlank/i)
+      }
 
+      await openCreateMenu()
       const blankOption = await screen.findByText(
         /app\.newApp\.startFromBlank/i,
       )
@@ -311,6 +315,7 @@ describe('Nav Component', () => {
       })
       expect(mockOnCreate).toHaveBeenCalledWith('blank')
 
+      await openCreateMenu()
       const templateOption = await screen.findByText(
         /app\.newApp\.startFromTemplate/i,
       )
@@ -319,6 +324,7 @@ describe('Nav Component', () => {
       })
       expect(mockOnCreate).toHaveBeenCalledWith('template')
 
+      await openCreateMenu()
       const dslOption = await screen.findByText(/app\.importDSL/i)
       await act(async () => {
         fireEvent.click(dslOption)

--- a/web/app/components/header/nav/nav-selector/__tests__/index.spec.tsx
+++ b/web/app/components/header/nav/nav-selector/__tests__/index.spec.tsx
@@ -203,28 +203,50 @@ describe('NavSelector Component', () => {
       await act(async () => {
         fireEvent.click(button)
       })
-      const createBtn = screen.getByText('Create New')
-      await act(async () => {
-        fireEvent.click(createBtn)
-      })
 
+      const openCreateMenu = async () => {
+        const createBtn = screen.getByText('Create New')
+        await act(async () => {
+          fireEvent.click(createBtn)
+        })
+        return screen.findByText(/app\.newApp\.startFromBlank/i)
+      }
+
+      await openCreateMenu()
       const blank = await screen.findByText(/app\.newApp\.startFromBlank/i)
       await act(async () => {
         fireEvent.click(blank)
       })
       expect(mockOnCreate).toHaveBeenCalledWith('blank')
 
+      await openCreateMenu()
       const template = await screen.findByText(/app\.newApp\.startFromTemplate/i)
       await act(async () => {
         fireEvent.click(template)
       })
       expect(mockOnCreate).toHaveBeenCalledWith('template')
 
+      await openCreateMenu()
       const dsl = await screen.findByText(/app\.importDSL/i)
       await act(async () => {
         fireEvent.click(dsl)
       })
       expect(mockOnCreate).toHaveBeenCalledWith('dsl')
+    })
+
+    it('should open extended create menu on hover in app mode', async () => {
+      render(<NavSelector {...defaultProps} isApp />)
+      const button = screen.getByRole('button')
+      await act(async () => {
+        fireEvent.click(button)
+      })
+
+      const createBtn = screen.getByText('Create New')
+      await act(async () => {
+        fireEvent.mouseEnter(createBtn)
+      })
+
+      expect(await screen.findByText(/app\.newApp\.startFromBlank/i))!.toBeInTheDocument()
     })
 
     it('should not show create button for non-editors', async () => {

--- a/web/app/components/header/nav/nav-selector/index.tsx
+++ b/web/app/components/header/nav/nav-selector/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { AppIconType, AppModeEnum } from '@/types/app'
-import { Menu, MenuButton, MenuItem, MenuItems, Transition } from '@headlessui/react'
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   RiAddLine,
@@ -8,7 +8,7 @@ import {
   RiArrowRightSLine,
 } from '@remixicon/react'
 import { debounce } from 'es-toolkit/compat'
-import { Fragment, useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { AppTypeIcon } from '@/app/components/app/type-selector'
@@ -36,6 +36,75 @@ export type INavSelectorProps = {
   onCreate: (state: string) => void
   onLoadMore?: () => void
   isLoadingMore?: boolean
+}
+
+type AppCreateMenuProps = {
+  createText: string
+  startFromBlankText: string
+  startFromTemplateText: string
+  importDSLText: string
+  onCreate: (state: string) => void
+}
+
+const AppCreateMenu = ({
+  createText,
+  startFromBlankText,
+  startFromTemplateText,
+  importDSLText,
+  onCreate,
+}: AppCreateMenuProps) => {
+  const [open, setOpen] = useState(false)
+
+  const handleCreate = (state: string) => {
+    setOpen(false)
+    onCreate(state)
+  }
+
+  return (
+    <div className="relative h-full w-full" onMouseLeave={() => setOpen(false)}>
+      <button
+        type="button"
+        className="w-full p-1 text-left"
+        onClick={() => setOpen(value => !value)}
+        onMouseEnter={() => setOpen(true)}
+      >
+        <div className={cn(
+          'flex cursor-pointer items-center gap-2 rounded-lg px-3 py-[6px] hover:bg-state-base-hover',
+          open && 'bg-state-base-hover!',
+        )}
+        >
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border-[0.5px] border-divider-regular bg-background-default">
+            <RiAddLine className="h-4 w-4 text-text-primary" />
+          </div>
+          <div className="grow text-left text-[14px] font-normal text-text-secondary">{createText}</div>
+          <RiArrowRightSLine className="h-3.5 w-3.5 shrink-0 text-text-primary" />
+        </div>
+      </button>
+      {open && (
+        <div
+          className="absolute top-[3px] right-[-198px] z-10 min-w-[200px] rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg"
+          onMouseEnter={() => setOpen(true)}
+        >
+          <div className="p-1">
+            <button type="button" className={cn('flex w-full cursor-pointer items-center rounded-lg px-3 py-[6px] text-left font-normal text-text-secondary hover:bg-state-base-hover')} onClick={() => handleCreate('blank')}>
+              <FilePlus01 className="mr-2 h-4 w-4 shrink-0 text-text-secondary" />
+              {startFromBlankText}
+            </button>
+            <button type="button" className={cn('flex w-full cursor-pointer items-center rounded-lg px-3 py-[6px] text-left font-normal text-text-secondary hover:bg-state-base-hover')} onClick={() => handleCreate('template')}>
+              <FilePlus02 className="mr-2 h-4 w-4 shrink-0 text-text-secondary" />
+              {startFromTemplateText}
+            </button>
+          </div>
+          <div className="border-t border-divider-regular p-1">
+            <button type="button" className={cn('flex w-full cursor-pointer items-center rounded-lg px-3 py-[6px] text-left font-normal text-text-secondary hover:bg-state-base-hover')} onClick={() => handleCreate('dsl')}>
+              <FileArrow01 className="mr-2 h-4 w-4 shrink-0 text-text-secondary" />
+              {importDSLText}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
 }
 
 const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onLoadMore, isLoadingMore }: INavSelectorProps) => {
@@ -72,7 +141,7 @@ const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onL
             className="
               absolute right-0 -left-11 mt-1.5 w-60 max-w-80
               origin-top-right divide-y divide-divider-regular rounded-lg bg-components-panel-bg-blur
-              shadow-lg
+              shadow-lg outline-none
             "
           >
             <div className="overflow-auto px-1 py-1" style={{ maxHeight: '50vh' }} onScroll={handleScroll}>
@@ -130,56 +199,13 @@ const NavSelector = ({ curNav, navigationItems, createText, isApp, onCreate, onL
               </MenuItem>
             )}
             {isApp && isCurrentWorkspaceEditor && (
-              <Menu as="div" className="relative h-full w-full">
-                {({ open }) => (
-                  <>
-                    <MenuButton className="w-full p-1">
-                      <div className={cn(
-                        'flex cursor-pointer items-center gap-2 rounded-lg px-3 py-[6px] hover:bg-state-base-hover',
-                        open && 'bg-state-base-hover!',
-                      )}
-                      >
-                        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border-[0.5px] border-divider-regular bg-background-default">
-                          <RiAddLine className="h-4 w-4 text-text-primary" />
-                        </div>
-                        <div className="grow text-left text-[14px] font-normal text-text-secondary">{createText}</div>
-                        <RiArrowRightSLine className="h-3.5 w-3.5 shrink-0 text-text-primary" />
-                      </div>
-                    </MenuButton>
-                    <Transition
-                      as={Fragment}
-                      enter="transition ease-out duration-100"
-                      enterFrom="transform opacity-0 scale-95"
-                      enterTo="transform opacity-100 scale-100"
-                      leave="transition ease-in duration-75"
-                      leaveFrom="transform opacity-100 scale-100"
-                      leaveTo="transform opacity-0 scale-95"
-                    >
-                      <MenuItems className={cn(
-                        'absolute top-[3px] right-[-198px] z-10 min-w-[200px] rounded-lg bg-components-panel-bg-blur shadow-lg',
-                      )}
-                      >
-                        <div className="p-1">
-                          <div className={cn('flex cursor-pointer items-center rounded-lg px-3 py-[6px] font-normal text-text-secondary hover:bg-state-base-hover')} onClick={() => onCreate('blank')}>
-                            <FilePlus01 className="mr-2 h-4 w-4 shrink-0 text-text-secondary" />
-                            {t('newApp.startFromBlank', { ns: 'app' })}
-                          </div>
-                          <div className={cn('flex cursor-pointer items-center rounded-lg px-3 py-[6px] font-normal text-text-secondary hover:bg-state-base-hover')} onClick={() => onCreate('template')}>
-                            <FilePlus02 className="mr-2 h-4 w-4 shrink-0 text-text-secondary" />
-                            {t('newApp.startFromTemplate', { ns: 'app' })}
-                          </div>
-                        </div>
-                        <div className="border-t border-divider-regular p-1">
-                          <div className={cn('flex cursor-pointer items-center rounded-lg px-3 py-[6px] font-normal text-text-secondary hover:bg-state-base-hover')} onClick={() => onCreate('dsl')}>
-                            <FileArrow01 className="mr-2 h-4 w-4 shrink-0 text-text-secondary" />
-                            {t('importDSL', { ns: 'app' })}
-                          </div>
-                        </div>
-                      </MenuItems>
-                    </Transition>
-                  </>
-                )}
-              </Menu>
+              <AppCreateMenu
+                createText={createText}
+                startFromBlankText={t('newApp.startFromBlank', { ns: 'app' })}
+                startFromTemplateText={t('newApp.startFromTemplate', { ns: 'app' })}
+                importDSLText={t('importDSL', { ns: 'app' })}
+                onCreate={onCreate}
+              />
             )}
           </MenuItems>
         </>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

fix https://github.com/langgenius/dify/issues/35680

Fix the app navigation "New App" submenu interaction.

The previous implementation nested a Headless UI `Menu` inside another `MenuItems`. With the current Headless UI behavior, clicking the nested `MenuButton` could close the parent menu before the submenu interaction completed, so the submenu appeared unresponsive.

This change replaces the nested menu with a locally controlled inline submenu inside the parent menu. It also removes the default focus outline from the parent menu panel.


## Screenshots

<img width="1046" height="602" alt="img_v3_02117_ef306ba7-8df5-499c-add7-32985e6063eg" src="https://github.com/user-attachments/assets/75010d2f-9b15-40b9-9be7-ab7e893c82fc" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
