### PR TITLE
fix(api): preserve dataset metadata filters

### DIFF
--- a/api/services/entities/knowledge_entities/knowledge_entities.py
+++ b/api/services/entities/knowledge_entities/knowledge_entities.py
@@ -3,6 +3,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, field_validator
 
 from core.rag.entities import Rule
+from core.rag.entities.metadata_entities import MetadataFilteringCondition
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 
@@ -83,6 +84,7 @@ class RetrievalModel(BaseModel):
     score_threshold_enabled: bool
     score_threshold: float | None = None
     weights: WeightModel | None = None
+    metadata_filtering_conditions: MetadataFilteringCondition | None = None
 
 
 class MetaDataConfig(BaseModel):

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py
@@ -176,6 +176,62 @@ class TestHitTestingApiPost:
     @patch("controllers.console.datasets.hit_testing_base.HitTestingService")
     @patch("controllers.console.datasets.hit_testing_base.DatasetService")
     @patch("controllers.console.datasets.hit_testing_base.current_user", new_callable=lambda: Mock(spec=Account))
+    def test_post_preserves_retrieval_model_metadata_filtering_conditions(
+        self,
+        mock_current_user,
+        mock_dataset_svc,
+        mock_hit_svc,
+        mock_marshal,
+        mock_ns,
+        app,
+    ):
+        """Service API retrieval payload should not drop metadata filters."""
+        dataset_id = str(uuid.uuid4())
+        tenant_id = str(uuid.uuid4())
+
+        mock_dataset = Mock()
+        mock_dataset.id = dataset_id
+
+        mock_dataset_svc.get_dataset.return_value = mock_dataset
+        mock_dataset_svc.check_dataset_permission.return_value = None
+        mock_hit_svc.retrieve.return_value = {"query": "filtered query", "records": []}
+        mock_hit_svc.hit_testing_args_check.return_value = None
+        mock_marshal.return_value = []
+
+        metadata_filtering_conditions = {
+            "logical_operator": "and",
+            "conditions": [
+                {
+                    "name": "category",
+                    "comparison_operator": "is",
+                    "value": "finance",
+                }
+            ],
+        }
+        mock_ns.payload = {
+            "query": "filtered query",
+            "retrieval_model": {
+                "search_method": "semantic_search",
+                "reranking_enable": False,
+                "score_threshold_enabled": False,
+                "top_k": 4,
+                "metadata_filtering_conditions": metadata_filtering_conditions,
+            },
+        }
+
+        with app.test_request_context():
+            api = HitTestingApi()
+            HitTestingApi.post.__wrapped__(api, tenant_id, dataset_id)
+
+        passed_retrieval_model = mock_hit_svc.retrieve.call_args.kwargs.get("retrieval_model")
+        assert passed_retrieval_model is not None
+        assert passed_retrieval_model["metadata_filtering_conditions"] == metadata_filtering_conditions
+
+    @patch("controllers.service_api.dataset.hit_testing.service_api_ns")
+    @patch("controllers.console.datasets.hit_testing_base.marshal")
+    @patch("controllers.console.datasets.hit_testing_base.HitTestingService")
+    @patch("controllers.console.datasets.hit_testing_base.DatasetService")
+    @patch("controllers.console.datasets.hit_testing_base.current_user", new_callable=lambda: Mock(spec=Account))
     def test_post_normalizes_legacy_query_and_nullable_list_fields(
         self,
         mock_current_user,


### PR DESCRIPTION
## Summary

Fixes #35666.

The Service API hit-testing/retrieve endpoints already pass `retrieval_model` into `HitTestingService.retrieve`, and that service already knows how to apply `metadata_filtering_conditions` when present. However, the request schema model for `retrieval_model` did not include `metadata_filtering_conditions`, so Pydantic validation/model dumping dropped the field before it reached the retrieval layer.

This adds `metadata_filtering_conditions` to the shared `RetrievalModel` schema and adds a service API regression test proving the filter survives request parsing and is forwarded to `HitTestingService.retrieve`.

## Why this matters

Requests like this should filter by metadata:

```json
{
  "query": "some query",
  "retrieval_model": {
    "search_method": "semantic_search",
    "reranking_enable": false,
    "top_k": 4,
    "score_threshold_enabled": false,
    "metadata_filtering_conditions": {
      "logical_operator": "and",
      "conditions": [
        {"name": "category", "comparison_operator": "is", "value": "finance"}
      ]
    }
  }
}
```

Before this change, the metadata filter was silently removed during payload validation.

## Validation

- `python3 -m py_compile api/services/entities/knowledge_entities/knowledge_entities.py api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py`
- `git diff --check`

I also attempted the focused pytest command:

- `UV_CACHE_DIR=/tmp/uv-cache uv run --frozen pytest tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py -q`

but the local runner could not complete dependency setup because this workspace ran out of disk while uv was downloading/building Dify's full API dependency graph.
