### PR TITLE
fix(plugin): preserve multi-value HTTP response headers

### DIFF
--- a/api/core/plugin/utils/http_parser.py
+++ b/api/core/plugin/utils/http_parser.py
@@ -151,6 +151,12 @@ def deserialize_response(raw_data: bytes) -> Response:
 
     response = Response(response=body, status=status_code)
 
+    # Replace Flask's default headers (e.g. Content-Type, Content-Length) with the
+    # parsed ones so we faithfully reproduce the original response. Use Headers.add
+    # rather than dict-style assignment so that repeated headers such as Set-Cookie
+    # (and any other multi-valued header per RFC 9110) are preserved instead of
+    # being overwritten.
+    response.headers.clear()
     for line in lines[1:]:
         if not line:
             continue
@@ -158,6 +164,6 @@ def deserialize_response(raw_data: bytes) -> Response:
         if ":" not in line_str:
             continue
         name, value = line_str.split(":", 1)
-        response.headers[name] = value.strip()
+        response.headers.add(name, value.strip())
 
     return response

--- a/api/tests/unit_tests/core/plugin/utils/test_http_parser.py
+++ b/api/tests/unit_tests/core/plugin/utils/test_http_parser.py
@@ -323,6 +323,50 @@ class TestDeserializeResponse:
         with pytest.raises(ValueError, match="Invalid status line"):
             deserialize_response(raw_data)
 
+    def test_deserialize_response_preserves_duplicate_set_cookie_headers(self):
+        # Regression test for https://github.com/langgenius/dify/issues/35722
+        # Multiple Set-Cookie headers must be preserved per RFC 9110, not collapsed
+        # into a single value by dict-style assignment.
+        raw_data = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Set-Cookie: session=abc; Path=/; HttpOnly\r\n"
+            b"Set-Cookie: tracking=xyz; Path=/; Secure\r\n"
+            b"\r\n"
+            b"ok"
+        )
+
+        response = deserialize_response(raw_data)
+
+        cookies = response.headers.getlist("Set-Cookie")
+        assert cookies == [
+            "session=abc; Path=/; HttpOnly",
+            "tracking=xyz; Path=/; Secure",
+        ]
+        # Single-valued headers should still be readable normally.
+        assert response.headers.get("Content-Type") == "text/plain"
+
+    def test_deserialize_response_preserves_duplicate_generic_headers(self):
+        # Any header name (not just Set-Cookie) may legitimately repeat; verify the
+        # parser preserves all values rather than overwriting earlier ones.
+        raw_data = b"HTTP/1.1 200 OK\r\nX-Custom: first\r\nX-Custom: second\r\n\r\n"
+
+        response = deserialize_response(raw_data)
+
+        assert response.headers.getlist("X-Custom") == ["first", "second"]
+
+    def test_deserialize_response_does_not_inject_default_content_type(self):
+        # Flask's Response constructor adds a default Content-Type header. When the
+        # raw response has no Content-Type, the parsed response should not silently
+        # gain one from the framework default.
+        raw_data = b"HTTP/1.1 204 No Content\r\nX-Trace-Id: abc\r\n\r\n"
+
+        response = deserialize_response(raw_data)
+
+        header_names = [name for name, _ in response.headers.items()]
+        assert "Content-Type" not in header_names
+        assert response.headers.get("X-Trace-Id") == "abc"
+
     def test_roundtrip_response(self):
         # Test that serialize -> deserialize produces equivalent response
         original_response = Response(


### PR DESCRIPTION
## Summary
Closes #35722. `deserialize_response` in `api/core/plugin/utils/http_parser.py` used dict-style assignment (`response.headers[name] = value.strip()`) on a `flask.Response` object. Same-named headers — most importantly `Set-Cookie`, but also any custom multi-value header — were silently overwritten so only the last occurrence survived.

close https://github.com/langgenius/dify/pull/35724
## Root cause
The parser splits `header_data` on `\r\n` and produces one entry per line, so multiple `Set-Cookie` lines do reach the loop. The defect is the dict-style assignment in the loop body, which clobbers prior values for duplicate keys. Sibling function `deserialize_request` already uses `headers.add()` (line 68), so this is purely a correctness gap in `deserialize_response`.

## Fix
Switch to `Headers.add()`, but first call `response.headers.clear()` to drop the defaults Flask injects in `Response(...)` (`Content-Type: text/html; charset=utf-8` and `Content-Length`). Without `clear()`, every plugin response would acquire a duplicate `Content-Type` header.

## Changes
- `api/core/plugin/utils/http_parser.py`: `response.headers.clear()` then `response.headers.add(name, value)` per parsed header
- `api/tests/unit_tests/core/plugin/utils/test_http_parser.py`: 3 new tests
  - duplicate `Set-Cookie` headers preserved
  - duplicate generic headers (`X-Custom`) preserved
  - default `Content-Type` not injected when the upstream response had none

## Test plan
- [x] `cd api && PYTHONPATH=. python3 -m pytest tests/unit_tests/core/plugin/utils/test_http_parser.py -v` → 43/43 pass
- [x] `ruff check` and `ruff format --check` clean (per `api/.ruff.toml`)
- [x] No other dict-style `headers[...] =` assignments in the file (grep confirmed)
- [x] Verified the only caller (`TriggerDispatchResponse.convert_response` in `core/plugin/entities/request.py`) intends to faithfully relay the plugin's response, so dropping Flask's injected default Content-Type is a positive correction, not a regression.

## Compliance with HTTP semantics
- `Set-Cookie` cannot be comma-merged (RFC 6265 §3), so the `Headers.add()` approach (one entry per occurrence) is the correct preservation strategy.
- `werkzeug.Headers.items()` yields each occurrence individually, so downstream `serialize_response` continues to round-trip multi-value headers correctly.