### PR TITLE
fix: datasource oauth settings can't input

### DIFF
--- a/web/app/components/header/account-setting/data-source-page-new/configure.tsx
+++ b/web/app/components/header/account-setting/data-source-page-new/configure.tsx
@@ -39,6 +39,13 @@ const Configure = ({
 }: ConfigureProps) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
+  const [isOAuthSettingsOpen, setIsOAuthSettingsOpen] = useState(false)
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen && isOAuthSettingsOpen)
+      return
+
+    setOpen(nextOpen)
+  }, [isOAuthSettingsOpen])
   const canApiKey = item.credential_schema?.length
   const oAuthData = item.oauth_schema || {}
   const canOAuth = oAuthData.client_schema?.length
@@ -65,7 +72,7 @@ const Configure = ({
     <>
       <Popover
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleOpenChange}
       >
         <PopoverTrigger
           render={(
@@ -97,6 +104,7 @@ const Configure = ({
                     redirect_uri: oAuthData.redirect_uri,
                   }}
                   disabled={disabled}
+                  onSettingsOpenChange={setIsOAuthSettingsOpen}
                 />
               )
             }

--- a/web/app/components/plugins/plugin-auth/authorize/add-oauth-button.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/add-oauth-button.tsx
@@ -31,6 +31,7 @@ export type AddOAuthButtonProps = {
   dividerClassName?: string
   disabled?: boolean
   onUpdate?: () => void
+  onSettingsOpenChange?: (open: boolean) => void
   oAuthData?: {
     schema?: FormSchema[]
     is_oauth_custom_client_enabled?: boolean
@@ -51,6 +52,7 @@ const AddOAuthButton = ({
   dividerClassName,
   disabled,
   onUpdate,
+  onSettingsOpenChange,
   oAuthData,
 }: AddOAuthButtonProps) => {
   const { t } = useTranslation()
@@ -73,10 +75,14 @@ const AddOAuthButton = ({
     redirect_uri,
   } = mergedOAuthData
   const isConfigured = is_system_oauth_params_exists || is_oauth_custom_client_enabled
+  const handleSettingsOpenChange = useCallback((open: boolean) => {
+    setIsOAuthSettingsOpen(open)
+    onSettingsOpenChange?.(open)
+  }, [onSettingsOpenChange])
   const openOAuthSettings = useCallback(() => {
     setIsOAuthSettingsMounted(true)
-    setIsOAuthSettingsOpen(true)
-  }, [])
+    handleSettingsOpenChange(true)
+  }, [handleSettingsOpenChange])
   const handleOAuth = useCallback(async () => {
     const { authorization_url } = await getPluginOAuthUrl()
 
@@ -259,9 +265,9 @@ const AddOAuthButton = ({
         isOAuthSettingsMounted && (
           <OAuthClientSettings
             open={isOAuthSettingsOpen}
-            onOpenChange={setIsOAuthSettingsOpen}
+            onOpenChange={handleSettingsOpenChange}
             pluginPayload={pluginPayload}
-            onClose={() => setIsOAuthSettingsOpen(false)}
+            onClose={() => handleSettingsOpenChange(false)}
             disabled={disabled || isLoading}
             schemas={memorizedSchemas}
             onAuth={handleOAuth}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

fix https://github.com/langgenius/dify/issues/35717


The datasource configure menu renders AddOAuthButton inside a Popover. The OAuth client settings modal is rendered through a Dialog portal, so clicks inside the modal form can be interpreted by the parent Popover as outside interactions. When the Popover closes, it unmounts AddOAuthButton and drops the modal open state, causing the OAuth settings dialog to disappear.

This change lets AddOAuthButton notify its parent when the OAuth settings dialog is open, and the datasource Configure Popover ignores close requests while that dialog is active. This keeps the modal stable without changing the existing component structure.


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
