### PR TITLE
fix: prevent workflow node titles from overflowing

### DIFF
--- a/web/app/components/base/chat/chat/answer/workflow-process.tsx
+++ b/web/app/components/base/chat/chat/answer/workflow-process.tsx
@@ -92,12 +92,12 @@ const WorkflowProcessItem = ({
           )
         }
         <div
-          className={cn('system-xs-medium text-text-secondary', !collapse && 'grow')}
+          className="min-w-0 grow truncate system-xs-medium text-text-secondary"
           data-testid="workflow-process-title"
         >
           {!collapse ? t('common.workflowProcess', { ns: 'workflow' }) : latestNode?.title}
         </div>
-        <div className={cn('ml-1 i-ri-arrow-right-s-line h-4 w-4 text-text-tertiary', !collapse && 'rotate-90')} />
+        <div className={cn('ml-1 i-ri-arrow-right-s-line h-4 w-4 shrink-0 text-text-tertiary', !collapse && 'rotate-90')} />
       </div>
       {
         !collapse && (

--- a/web/app/components/workflow/nodes/_base/node.tsx
+++ b/web/app/components/workflow/nodes/_base/node.tsx
@@ -284,13 +284,15 @@ const BaseNode: FC<BaseNodeProps> = ({
               </div>
             )}
           </div>
-          <NodeHeaderMeta
-            data={data}
-            hasVarValue={hasVarValue}
-            isLoading={isLoading}
-            loopIndex={LoopIndex}
-            t={t}
-          />
+          <div className="flex shrink-0 items-center">
+            <NodeHeaderMeta
+              data={data}
+              hasVarValue={hasVarValue}
+              isLoading={isLoading}
+              loopIndex={LoopIndex}
+              t={t}
+            />
+          </div>
         </div>
         <NodeBody
           data={data}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/35739

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

<img width="1354" height="794" alt="image" src="https://github.com/user-attachments/assets/6c1ac7df-01b5-46d9-acd8-0f3f157c1fc5" />


| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
