### PR TITLE
fix(web): secure external form help links

### DIFF
--- a/web/app/components/workflow/block-selector/market-place-plugin/action.tsx
+++ b/web/app/components/workflow/block-selector/market-place-plugin/action.tsx
@@ -96,7 +96,7 @@ const OperationDropdown: FC<Props> = ({
           className="system-md-regular"
           href={getMarketplaceUrl(`/plugins/${author}/${name}`, { theme })}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
         >
           {t('operation.viewDetails', { ns: 'common' })}
         </DropdownMenuLinkItem>

--- a/web/app/components/workflow/block-selector/market-place-plugin/list.tsx
+++ b/web/app/components/workflow/block-selector/market-place-plugin/list.tsx
@@ -82,6 +82,7 @@ const List = ({
         className="sticky bottom-0 z-10 flex h-8 cursor-pointer items-center rounded-b-lg border-[0.5px] border-t border-components-panel-border bg-components-panel-bg-blur px-4 py-1 system-sm-medium text-text-accent-light-mode-only shadow-lg"
         href={getMarketplaceUrl('', { category })}
         target="_blank"
+        rel="noopener noreferrer"
       >
         <span>{t('findMoreInMarketplace', { ns: 'plugin' })}</span>
         <RiArrowRightUpLine className="ml-0.5 h-3 w-3" />
@@ -102,6 +103,7 @@ const List = ({
           <Link
             href={urlWithSearchText}
             target="_blank"
+            rel="noopener noreferrer"
             className="flex items-center text-text-accent-light-mode-only"
             onClick={e => e.stopPropagation()}
           >
@@ -124,6 +126,7 @@ const List = ({
             <Link
               href={urlWithSearchText}
               target="_blank"
+              rel="noopener noreferrer"
               className="flex h-4 shrink-0 items-center system-sm-medium text-text-accent-light-mode-only"
             >
               <RiSearchLine className="mr-0.5 h-3 w-3" />

--- a/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
@@ -266,6 +266,7 @@ export const AgentStrategy = memo((props: AgentStrategyProps) => {
                       href={docLink('/use-dify/nodes/agent')}
                       className="text-text-accent-secondary"
                       target="_blank"
+                      rel="noopener noreferrer"
                     >
                       {t('nodes.agent.learnMore', { ns: 'workflow' })}
                     </Link>

--- a/web/app/components/workflow/nodes/_base/components/error-handle/fail-branch-card.tsx
+++ b/web/app/components/workflow/nodes/_base/components/error-handle/fail-branch-card.tsx
@@ -21,6 +21,7 @@ const FailBranchCard = () => {
           <a
             href={docLink('/use-dify/debug/error-type')}
             target="_blank"
+            rel="noopener noreferrer"
             className="text-text-accent"
           >
             {t('common.learnMore', { ns: 'workflow' })}

--- a/web/app/components/workflow/nodes/_base/components/help-link.tsx
+++ b/web/app/components/workflow/nodes/_base/components/help-link.tsx
@@ -26,7 +26,7 @@ const HelpLink = ({
             aria-label={label}
             href={link}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="mr-1 flex h-6 w-6 items-center justify-center rounded-md hover:bg-state-base-hover"
           >
             <span aria-hidden className="i-ri-book-open-line h-4 w-4 text-gray-500" />

--- a/web/app/components/workflow/nodes/_base/components/panel-operator/panel-operator-popup.tsx
+++ b/web/app/components/workflow/nodes/_base/components/panel-operator/panel-operator-popup.tsx
@@ -162,6 +162,7 @@ const PanelOperatorPopup = ({
               <a
                 href={`/app/${workflowAppId}/workflow`}
                 target="_blank"
+                rel="noopener noreferrer"
                 className="flex h-8 cursor-pointer items-center rounded-lg px-3 text-sm text-text-secondary hover:bg-state-base-hover"
               >
                 {t('panel.openWorkflow', { ns: 'workflow' })}
@@ -178,6 +179,7 @@ const PanelOperatorPopup = ({
               <a
                 href={nodeMetaData.helpLinkUri}
                 target="_blank"
+                rel="noopener noreferrer"
                 className="flex h-8 cursor-pointer items-center rounded-lg px-3 text-sm text-text-secondary hover:bg-state-base-hover"
               >
                 {t('panel.helpLink', { ns: 'workflow' })}

--- a/web/app/components/workflow/nodes/_base/components/switch-plugin-version.tsx
+++ b/web/app/components/workflow/nodes/_base/components/switch-plugin-version.tsx
@@ -95,6 +95,7 @@ export const SwitchPluginVersion: FC<SwitchPluginVersionProps> = (props) => {
                 className="flex items-center justify-center gap-1"
                 href={getMarketplaceUrl(`/plugins/${pluginDetail.declaration.author}/${pluginDetail.declaration.name}`)}
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <span className="system-xs-regular text-xs text-text-accent">
                   {t('nodes.agent.installPlugin.changelog', { ns: 'workflow' })}

--- a/web/app/components/workflow/nodes/document-extractor/panel.tsx
+++ b/web/app/components/workflow/nodes/document-extractor/panel.tsx
@@ -66,7 +66,7 @@ const Panel: FC<NodePanelProps<DocExtractorNodeType>> = ({
             />
             <div className="mt-1 py-0.5 body-xs-regular text-text-tertiary">
               {t(`${i18nPrefix}.supportFileTypes`, { ns: 'workflow', types: supportTypesShowNames })}
-              <a className="text-text-accent" href={link} target="_blank">{t(`${i18nPrefix}.learnMore`, { ns: 'workflow' })}</a>
+              <a className="text-text-accent" href={link} target="_blank" rel="noopener noreferrer">{t(`${i18nPrefix}.learnMore`, { ns: 'workflow' })}</a>
             </div>
           </>
         </Field>

--- a/web/app/components/workflow/nodes/template-transform/panel.tsx
+++ b/web/app/components/workflow/nodes/template-transform/panel.tsx
@@ -77,6 +77,7 @@ const Panel: FC<NodePanelProps<TemplateTransformNodeType>> = ({
                 className="flex h-[18px] items-center space-x-0.5 text-xs font-normal text-text-tertiary"
                 href="https://jinja.palletsprojects.com/en/3.1.x/templates/"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <span>{t(`${i18nPrefix}.codeSupportTip`, { ns: 'workflow' })}</span>
                 <RiQuestionLine className="h-3 w-3" />

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
@@ -135,7 +135,7 @@ const LinkEditorComponent = ({
                       className="flex h-6 items-center rounded-md px-2 hover:bg-state-base-hover"
                       href={escape(url)}
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                     >
                       <RiExternalLinkLine className="mr-1 h-3 w-3" />
                       <div className="mr-1">

--- a/web/app/components/workflow/run/node.tsx
+++ b/web/app/components/workflow/run/node.tsx
@@ -232,6 +232,7 @@ const NodePanel: FC<Props> = ({
                   <a
                     href={docLink('/use-dify/debug/error-type')}
                     target="_blank"
+                    rel="noopener noreferrer"
                     className="text-text-accent"
                   >
                     {t('common.learnMore', { ns: 'workflow' })}

--- a/web/app/components/workflow/run/status.tsx
+++ b/web/app/components/workflow/run/status.tsx
@@ -212,6 +212,7 @@ const StatusPanel: FC<ResultProps> = ({
               <a
                 href={docLink('/use-dify/debug/error-type')}
                 target="_blank"
+                rel="noopener noreferrer"
                 className="text-text-accent"
               >
                 {t('common.learnMore', { ns: 'workflow' })}
@@ -244,6 +245,7 @@ const StatusPanel: FC<ResultProps> = ({
                     key={url}
                     href={url}
                     target="_blank"
+                    rel="noopener noreferrer"
                     className="system-xs-medium text-text-accent"
                   >
                     {url}

--- a/web/app/components/workflow/variable-inspect/right.tsx
+++ b/web/app/components/workflow/variable-inspect/right.tsx
@@ -241,6 +241,7 @@ const Right = ({
                         <a
                           href={fullContent?.download_url}
                           target="_blank"
+                          rel="noopener noreferrer"
                         >
                           <RiFileDownloadFill className="size-4" />
                         </a>

--- a/web/app/education-apply/education-apply-page.tsx
+++ b/web/app/education-apply/education-apply-page.tsx
@@ -123,11 +123,11 @@ const EducationApplyAge = () => {
             <div className="mb-1 system-md-regular text-text-tertiary">
               {t('form.terms.desc.front', { ns: 'education' })}
 &nbsp;
-              <a href="https://dify.ai/terms" target="_blank" className="text-text-secondary hover:underline">{t('form.terms.desc.termsOfService', { ns: 'education' })}</a>
+              <a href="https://dify.ai/terms" target="_blank" rel="noopener noreferrer" className="text-text-secondary hover:underline">{t('form.terms.desc.termsOfService', { ns: 'education' })}</a>
 &nbsp;
               {t('form.terms.desc.and', { ns: 'education' })}
 &nbsp;
-              <a href="https://dify.ai/privacy" target="_blank" className="text-text-secondary hover:underline">{t('form.terms.desc.privacyPolicy', { ns: 'education' })}</a>
+              <a href="https://dify.ai/privacy" target="_blank" rel="noopener noreferrer" className="text-text-secondary hover:underline">{t('form.terms.desc.privacyPolicy', { ns: 'education' })}</a>
               {t('form.terms.desc.end', { ns: 'education' })}
             </div>
             <div className="py-2 system-md-regular text-text-primary">
@@ -161,6 +161,7 @@ const EducationApplyAge = () => {
             className="flex items-center system-xs-regular text-text-accent"
             href={docLink('/use-dify/workspace/subscription-management#dify-for-education')}
             target="_blank"
+            rel="noopener noreferrer"
           >
             {t('learn', { ns: 'education' })}
             <RiExternalLinkLine className="ml-1 h-3 w-3" />

--- a/web/app/education-apply/verify-state-modal.tsx
+++ b/web/app/education-apply/verify-state-modal.tsx
@@ -101,7 +101,7 @@ function Confirm({
             <div className="flex items-center gap-1">
               {showLink && (
                 <>
-                  <a onClick={handleClick} href={eduDocLink} target="_blank" className="cursor-pointer system-xs-regular text-text-accent">{t('learn', { ns: 'education' })}</a>
+                  <a onClick={handleClick} href={eduDocLink} target="_blank" rel="noopener noreferrer" className="cursor-pointer system-xs-regular text-text-accent">{t('learn', { ns: 'education' })}</a>
                   <RiExternalLinkLine className="h-3 w-3 text-text-accent" />
                 </>
               )}


### PR DESCRIPTION
# Summary

Fixes #35691
  This PR addresses issue by adding rel="noopener noreferrer" to all external form help links that use target="_blank". This prevents reverse tabnabbing attacks where newly opened pages could access window.opener.
Added rel="noopener noreferrer" to all identified links while preserving existing link behavior.

# Changes
Fixed 13 files with ~18 links:
1. Added missing rel="noopener noreferrer" (10 files) 
education-apply-page.tsx - Terms of Service & Privacy Policy links
right.tsx - File download link
status.tsx - Error documentation links
node.tsx - Error documentation link
panel-operator-popup.tsx - Workflow & help links
fail-branch-card.tsx - Error documentation link
agent-strategy.tsx - Agent documentation link
panel.tsx - Jinja template documentation
panel.tsx - Learn more link
verify-state-modal.tsx - Education documentation link
2. Updated incomplete rel attributes (3 files)
help-link.tsx - rel="noreferrer" → rel="noopener noreferrer"
component.tsx - rel="noreferrer" → rel="noopener noreferrer"
action.tsx - rel="noreferrer" → rel="noopener noreferrer"
3. Additional fixes discovered during review
list.tsx - 3 marketplace links
switch-plugin-version.tsx - Plugin changelog link

# Test
✅ Manual verification that links still open in new tabs
✅ Visual inspection of all changed files
✅ No functional changes to link behavior
✅ Security vulnerability eliminated