### PR TITLE
fix: batch workflow online users requests

### DIFF
--- a/web/service/__tests__/apps.spec.ts
+++ b/web/service/__tests__/apps.spec.ts
@@ -1,0 +1,63 @@
+import { fetchWorkflowOnlineUsers } from '../apps'
+import { consoleClient } from '../client'
+
+vi.mock('../client', () => ({
+  consoleClient: {
+    apps: {
+      workflowOnlineUsers: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/utils/var', () => ({
+  basePath: '/app',
+  API_PREFIX: '/console/api',
+  PUBLIC_API_PREFIX: '/api',
+  IS_CE_EDITION: false,
+}))
+
+describe('fetchWorkflowOnlineUsers', () => {
+  const workflowOnlineUsers = vi.mocked(consoleClient.apps.workflowOnlineUsers)
+
+  beforeEach(() => {
+    workflowOnlineUsers.mockReset()
+  })
+
+  it('returns empty result without requesting when app ids are empty', async () => {
+    await expect(fetchWorkflowOnlineUsers({ appIds: [] })).resolves.toEqual({})
+
+    expect(workflowOnlineUsers).not.toHaveBeenCalled()
+  })
+
+  it('fetches workflow online users in batches of 50 app ids', async () => {
+    const appIds = Array.from({ length: 51 }, (_, index) => `app-${index + 1}`)
+
+    workflowOnlineUsers
+      .mockResolvedValueOnce({
+        data: {
+          'app-1': [{ user_id: 'user-1', username: 'Alice' }],
+          'app-50': [{ user_id: 'user-50', username: 'Bob' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: [{
+          app_id: 'app-51',
+          users: [{ user_id: 'user-51', username: 'Carol' }],
+        }],
+      })
+
+    await expect(fetchWorkflowOnlineUsers({ appIds })).resolves.toEqual({
+      'app-1': [{ user_id: 'user-1', username: 'Alice' }],
+      'app-50': [{ user_id: 'user-50', username: 'Bob' }],
+      'app-51': [{ user_id: 'user-51', username: 'Carol' }],
+    })
+
+    expect(workflowOnlineUsers).toHaveBeenCalledTimes(2)
+    expect(workflowOnlineUsers).toHaveBeenNthCalledWith(1, {
+      query: { app_ids: appIds.slice(0, 50).join(',') },
+    })
+    expect(workflowOnlineUsers).toHaveBeenNthCalledWith(2, {
+      query: { app_ids: appIds.slice(50).join(',') },
+    })
+  })
+})

--- a/web/service/apps.ts
+++ b/web/service/apps.ts
@@ -1,5 +1,5 @@
 import type { TracingProvider } from '@/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type'
-import type { AppDetailResponse, AppListResponse, CreateApiKeyResponse, DSLImportMode, DSLImportResponse, TracingConfig, TracingStatus, UpdateAppModelConfigResponse, UpdateAppSiteCodeResponse, WebhookTriggerResponse, WorkflowOnlineUser } from '@/models/app'
+import type { AppDetailResponse, AppListResponse, CreateApiKeyResponse, DSLImportMode, DSLImportResponse, TracingConfig, TracingStatus, UpdateAppModelConfigResponse, UpdateAppSiteCodeResponse, WebhookTriggerResponse, WorkflowOnlineUser, WorkflowOnlineUsersResponse } from '@/models/app'
 import type { CommonResponse } from '@/models/common'
 import type { AppIconType, AppModeEnum, ModelConfig } from '@/types/app'
 import { del, get, patch, post, put } from './base'
@@ -9,29 +9,45 @@ export const fetchAppList = ({ url, params }: { url: string, params?: Record<str
   return get<AppListResponse>(url, { params })
 }
 
-export const fetchWorkflowOnlineUsers = async ({ appIds }: { appIds: string[] }): Promise<Record<string, WorkflowOnlineUser[]>> => {
-  if (!appIds.length)
+const MAX_WORKFLOW_ONLINE_USERS_QUERY_IDS = 50
+
+const normalizeWorkflowOnlineUsersResponse = (data?: WorkflowOnlineUsersResponse['data']): Record<string, WorkflowOnlineUser[]> => {
+  if (!data)
     return {}
 
-  const response = await consoleClient.apps.workflowOnlineUsers({
-    query: { app_ids: appIds.join(',') },
-  })
-
-  if (!response?.data)
-    return {}
-
-  if (Array.isArray(response.data)) {
-    return response.data.reduce<Record<string, WorkflowOnlineUser[]>>((acc, item) => {
+  if (Array.isArray(data)) {
+    return data.reduce<Record<string, WorkflowOnlineUser[]>>((acc, item) => {
       if (item?.app_id)
         acc[item.app_id] = item.users || []
       return acc
     }, {})
   }
 
-  return Object.entries(response.data).reduce<Record<string, WorkflowOnlineUser[]>>((acc, [appId, users]) => {
+  return Object.entries(data).reduce<Record<string, WorkflowOnlineUser[]>>((acc, [appId, users]) => {
     if (appId)
       acc[appId] = users || []
     return acc
+  }, {})
+}
+
+export const fetchWorkflowOnlineUsers = async ({ appIds }: { appIds: string[] }): Promise<Record<string, WorkflowOnlineUser[]>> => {
+  if (!appIds.length)
+    return {}
+
+  const appIdBatches = Array.from({ length: Math.ceil(appIds.length / MAX_WORKFLOW_ONLINE_USERS_QUERY_IDS) }, (_, index) => {
+    const start = index * MAX_WORKFLOW_ONLINE_USERS_QUERY_IDS
+    return appIds.slice(start, start + MAX_WORKFLOW_ONLINE_USERS_QUERY_IDS)
+  })
+
+  const responses = await Promise.all(appIdBatches.map(batch => consoleClient.apps.workflowOnlineUsers({
+    query: { app_ids: batch.join(',') },
+  })))
+
+  return responses.reduce<Record<string, WorkflowOnlineUser[]>>((acc, response) => {
+    return {
+      ...acc,
+      ...normalizeWorkflowOnlineUsersResponse(response?.data),
+    }
   }, {})
 }
 


### PR DESCRIPTION
## Summary
- split workflow online users lookups into batches of 50 app IDs
- preserve support for both object-map and array response shapes
- add coverage for empty input and batched requests

## Tests
- git diff --check
- cd web && corepack pnpm test service/__tests__/apps.spec.ts
- cd web && corepack pnpm type-check