### PR TITLE
fix: IDOR on console `GET /account/avatar`

### DIFF
--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -8,6 +8,7 @@ from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import select
+from werkzeug.exceptions import NotFound
 
 from configs import dify_config
 from constants.languages import supported_language
@@ -45,6 +46,8 @@ from libs.helper import EmailStr, extract_remote_ip, timezone
 from libs.login import current_account_with_tenant, login_required
 from models import AccountIntegrate, InvitationCode
 from models.account import AccountStatus, InvitationCodeStatus
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 from services.account_service import AccountService
 from services.billing_service import BillingService
 from services.errors.account import CurrentPasswordIncorrectError as ServiceCurrentPasswordIncorrectError
@@ -322,9 +325,24 @@ class AccountAvatarApi(Resource):
     @login_required
     @account_initialization_required
     def get(self):
+        current_user, current_tenant_id = current_account_with_tenant()
         args = AccountAvatarQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
+        avatar = args.avatar
 
-        avatar_url = file_helpers.get_signed_file_url(args.avatar)
+        if avatar.startswith(("http://", "https://")):
+            return {"avatar_url": avatar}
+
+        upload_file = db.session.scalar(select(UploadFile).where(UploadFile.id == avatar).limit(1))
+        if upload_file is None:
+            raise NotFound("Avatar file not found")
+
+        if upload_file.tenant_id != current_tenant_id:
+            raise NotFound("Avatar file not found")
+
+        if upload_file.created_by_role != CreatorUserRole.ACCOUNT or upload_file.created_by != current_user.id:
+            raise NotFound("Avatar file not found")
+
+        avatar_url = file_helpers.get_signed_file_url(upload_file_id=upload_file.id)
         return {"avatar_url": avatar_url}
 
     @console_ns.expect(console_ns.models[AccountAvatarPayload.__name__])

--- a/api/tests/unit_tests/controllers/console/workspace/test_accounts.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_accounts.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+from werkzeug.exceptions import NotFound
 
 from controllers.console import console_ns
 from controllers.console.auth.error import (
@@ -29,6 +30,7 @@ from controllers.console.workspace.error import (
     CurrentPasswordIncorrectError,
     InvalidAccountDeletionCodeError,
 )
+from models.enums import CreatorUserRole
 from services.errors.account import CurrentPasswordIncorrectError as ServicePwdError
 
 
@@ -133,6 +135,131 @@ class TestAccountUpdateApis:
             result = method(api)
 
         assert result["id"] == "u1"
+
+
+class TestAccountAvatarApiGet:
+    """GET /account/avatar must not sign arbitrary upload_file IDs (IDOR)."""
+
+    def test_get_avatar_signed_url_when_upload_owned_by_current_account(self, app):
+        api = AccountAvatarApi()
+        method = unwrap(api.get)
+
+        user = MagicMock()
+        user.id = "acc-owner"
+        tenant_id = "tenant-1"
+        file_id = "550e8400-e29b-41d4-a716-446655440000"
+
+        upload_file = MagicMock()
+        upload_file.id = file_id
+        upload_file.tenant_id = tenant_id
+        upload_file.created_by = user.id
+        upload_file.created_by_role = CreatorUserRole.ACCOUNT
+
+        with (
+            app.test_request_context(f"/account/avatar?avatar={file_id}"),
+            patch(
+                "controllers.console.workspace.account.current_account_with_tenant",
+                return_value=(user, tenant_id),
+            ),
+            patch("controllers.console.workspace.account.db.session.scalar", return_value=upload_file),
+            patch(
+                "controllers.console.workspace.account.file_helpers.get_signed_file_url",
+                return_value="https://signed/example",
+            ) as sign_mock,
+        ):
+            result = method(api)
+
+        assert result == {"avatar_url": "https://signed/example"}
+        sign_mock.assert_called_once_with(upload_file_id=file_id)
+
+    def test_get_avatar_not_found_when_upload_created_by_other_account_same_tenant(self, app):
+        api = AccountAvatarApi()
+        method = unwrap(api.get)
+
+        user = MagicMock()
+        user.id = "acc-a"
+        tenant_id = "tenant-1"
+        file_id = "550e8400-e29b-41d4-a716-446655440001"
+
+        upload_file = MagicMock()
+        upload_file.id = file_id
+        upload_file.tenant_id = tenant_id
+        upload_file.created_by = "acc-b"
+        upload_file.created_by_role = CreatorUserRole.ACCOUNT
+
+        with (
+            app.test_request_context(f"/account/avatar?avatar={file_id}"),
+            patch(
+                "controllers.console.workspace.account.current_account_with_tenant",
+                return_value=(user, tenant_id),
+            ),
+            patch("controllers.console.workspace.account.db.session.scalar", return_value=upload_file),
+            patch(
+                "controllers.console.workspace.account.file_helpers.get_signed_file_url",
+                return_value="https://signed/leak",
+            ) as sign_mock,
+        ):
+            with pytest.raises(NotFound):
+                method(api)
+
+        sign_mock.assert_not_called()
+
+    def test_get_avatar_not_found_when_upload_belongs_to_other_tenant(self, app):
+        api = AccountAvatarApi()
+        method = unwrap(api.get)
+
+        user = MagicMock()
+        user.id = "acc-owner"
+        tenant_id = "tenant-1"
+        file_id = "550e8400-e29b-41d4-a716-446655440002"
+
+        upload_file = MagicMock()
+        upload_file.id = file_id
+        upload_file.tenant_id = "tenant-other"
+        upload_file.created_by = user.id
+        upload_file.created_by_role = CreatorUserRole.ACCOUNT
+
+        with (
+            app.test_request_context(f"/account/avatar?avatar={file_id}"),
+            patch(
+                "controllers.console.workspace.account.current_account_with_tenant",
+                return_value=(user, tenant_id),
+            ),
+            patch("controllers.console.workspace.account.db.session.scalar", return_value=upload_file),
+            patch(
+                "controllers.console.workspace.account.file_helpers.get_signed_file_url",
+                return_value="https://signed/leak",
+            ) as sign_mock,
+        ):
+            with pytest.raises(NotFound):
+                method(api)
+
+        sign_mock.assert_not_called()
+
+    def test_get_avatar_https_pass_through_without_signing(self, app):
+        api = AccountAvatarApi()
+        method = unwrap(api.get)
+
+        user = MagicMock()
+        user.id = "acc-owner"
+        tenant_id = "tenant-1"
+        external = "https://cdn.example/avatar.png"
+
+        with (
+            app.test_request_context(f"/account/avatar?avatar={external}"),
+            patch(
+                "controllers.console.workspace.account.current_account_with_tenant",
+                return_value=(user, tenant_id),
+            ),
+            patch(
+                "controllers.console.workspace.account.file_helpers.get_signed_file_url",
+                return_value="https://signed/should-not-use",
+            ) as sign_mock,
+        ):
+            result = method(api)
+
+        assert result == {"avatar_url": external}
+        sign_mock.assert_not_called()
 
 
 class TestAccountPasswordApi:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes an insecure direct object reference (IDOR) on `AccountAvatarApi.get`: the handler previously signed any caller-supplied `avatar` upload file ID via `file_helpers.get_signed_file_url` without verifying that the file belongs to the current workspace tenant and the current console account.

The endpoint now loads `UploadFile` by id, requires `tenant_id` to match `current_account_with_tenant()`’s tenant, requires `created_by_role == ACCOUNT` and `created_by == current_user.id`, and only then signs with `upload_file_id=`. Absolute `http://` / `https://` avatar values are returned unchanged (aligned with `fields/member_fields.py` `_build_avatar_url`).



## Security fix

- **Authorize** storage-backed avatars against `upload_files` (`tenant_id`, `created_by`, `created_by_role`).
- **Reject** missing file, wrong tenant, or non-owning account with generic **404** (`NotFound`) to limit enumeration leakage.
- **Preserve** external URL avatars without invoking signing.

## Technical details

**Before (vulnerable):**

```python
def get(self):
    args = AccountAvatarQuery.model_validate(request.args.to_dict(flat=True))
    avatar_url = file_helpers.get_signed_file_url(args.avatar)
    return {"avatar_url": avatar_url}
```

**After (fixed):**

```python
def get(self):
    current_user, current_tenant_id = current_account_with_tenant()
    args = AccountAvatarQuery.model_validate(request.args.to_dict(flat=True))
    avatar = args.avatar

    if avatar.startswith(("http://", "https://")):
        return {"avatar_url": avatar}

    upload_file = db.session.scalar(select(UploadFile).where(UploadFile.id == avatar).limit(1))
    if upload_file is None:
        raise NotFound("Avatar file not found")

    if upload_file.tenant_id != current_tenant_id:
        raise NotFound("Avatar file not found")

    if upload_file.created_by_role != CreatorUserRole.ACCOUNT or upload_file.created_by != current_user.id:
        raise NotFound("Avatar file not found")

    avatar_url = file_helpers.get_signed_file_url(upload_file_id=upload_file.id)
    return {"avatar_url": avatar_url}
```

## Screenshots

| Before | After |
|--------|-------|
| Any authenticated user could obtain a signed URL for another user’s `upload_files.id` via query param | Signing only after tenant + account ownership checks; otherwise 404 |

## Testing

- Added unit tests: `TestAccountAvatarApiGet` in `dify/api/tests/unit_tests/controllers/console/workspace/test_accounts.py`.
- Run: `cd dify/api && uv run pytest tests/unit_tests/controllers/console/workspace/test_accounts.py::TestAccountAvatarApiGet -v`

## Files changed

- `dify/api/controllers/console/workspace/account.py` — `AccountAvatarApi.get` authorization + imports (`NotFound`, `UploadFile`, `CreatorUserRole`).
- `dify/api/tests/unit_tests/controllers/console/workspace/test_accounts.py` — `TestAccountAvatarApiGet`.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Related issue

Fixes #35770 
