### PR TITLE
fix: reset ContextVar tokens when leaving ExecutionContext

### DIFF
--- a/api/context/execution_context.py
+++ b/api/context/execution_context.py
@@ -100,15 +100,20 @@ class ExecutionContext:
     @contextmanager
     def enter(self) -> Generator[None, None, None]:
         """Enter this execution context."""
-        if self._context_vars:
-            for var, val in self._context_vars.items():
-                var.set(val)
+        tokens: list[contextvars.Token[Any]] = []
+        try:
+            if self._context_vars:
+                for var, val in self._context_vars.items():
+                    tokens.append(var.set(val))
 
-        if self._app_context is not None:
-            with self._app_context.enter():
+            if self._app_context is not None:
+                with self._app_context.enter():
+                    yield
+            else:
                 yield
-        else:
-            yield
+        finally:
+            for token in reversed(tokens):
+                token.var.reset(token)
 
     def __enter__(self) -> "ExecutionContext":
         """Enter the execution context."""

--- a/api/context/flask_app_context.py
+++ b/api/context/flask_app_context.py
@@ -134,9 +134,10 @@ class FlaskExecutionContext:
 
     def __enter__(self) -> "FlaskExecutionContext":
         """Enter the Flask execution context."""
-        # Restore non-Flask context variables to avoid leaking Flask tokens across threads
+        tokens: list[contextvars.Token[Any]] = []
         for var, val in self._context_vars.items():
-            var.set(val)
+            tokens.append(var.set(val))
+        self._local.ctx_var_tokens = tokens
 
         # Enter Flask app context
         cm = self._app_context.enter()
@@ -151,23 +152,31 @@ class FlaskExecutionContext:
 
     def __exit__(self, *args: Any) -> None:
         """Exit the Flask execution context."""
-        cm = getattr(self._local, "cm", None)
-        if cm is not None:
-            cm.__exit__(*args)
+        try:
+            cm = getattr(self._local, "cm", None)
+            if cm is not None:
+                cm.__exit__(*args)
+        finally:
+            tokens = getattr(self._local, "ctx_var_tokens", None)
+            if tokens:
+                for token in reversed(tokens):
+                    token.var.reset(token)
 
     @contextmanager
     def enter(self) -> Generator[None, None, None]:
         """Enter Flask execution context as context manager."""
-        # Restore non-Flask context variables to avoid leaking Flask tokens across threads
-        for var, val in self._context_vars.items():
-            var.set(val)
+        tokens: list[contextvars.Token[Any]] = []
+        try:
+            for var, val in self._context_vars.items():
+                tokens.append(var.set(val))
 
-        # Enter Flask app context
-        with self._flask_app.app_context():
-            # Restore user in new app context
-            if self._user is not None:
-                g._login_user = self._user
-            yield
+            with self._flask_app.app_context():
+                if self._user is not None:
+                    g._login_user = self._user
+                yield
+        finally:
+            for token in reversed(tokens):
+                token.var.reset(token)
 
 
 def init_flask_context() -> None:

--- a/api/tests/unit_tests/core/workflow/context/test_execution_context.py
+++ b/api/tests/unit_tests/core/workflow/context/test_execution_context.py
@@ -98,26 +98,56 @@ class TestExecutionContext:
         assert ctx.user is None
 
     def test_enter_with_context_vars(self):
-        """Test enter restores context variables."""
+        """Inside enter(), captured values apply; on exit, outer ContextVar state is restored."""
         test_var = contextvars.ContextVar("test_var")
         test_var.set("original_value")
 
         # Copy context with the variable
         context_vars = contextvars.copy_context()
 
-        # Change the variable
+        # Change the variable in the outer scope before entering
         test_var.set("new_value")
 
         # Create execution context and enter it
         ctx = ExecutionContext(context_vars=context_vars)
 
         with ctx.enter():
-            # Variable should be restored to original value
+            # Captured snapshot value is applied for the duration of the block
             assert test_var.get() == "original_value"
 
-        # After exiting, variable stays at the value from within the context
-        # (this is expected Python contextvars behavior)
-        assert test_var.get() == "original_value"
+        # Tokens from var.set() must be reset so we return to the pre-enter outer value
+        assert test_var.get() == "new_value"
+
+    def test_enter_resets_contextvars_after_inner_exception(self):
+        """ContextVar tokens are reset even when the guarded block raises."""
+        test_var = contextvars.ContextVar("test_exc_var")
+        test_var.set("outer")
+
+        captured = contextvars.copy_context()
+        test_var.set("before_enter")
+
+        ctx = ExecutionContext(context_vars=captured)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with ctx.enter():
+                assert test_var.get() == "outer"
+                raise RuntimeError("boom")
+
+        assert test_var.get() == "before_enter"
+
+    def test_enter_context_manager_protocol_restores_after_exit(self):
+        """__enter__/__exit__ delegates to enter(); outer ContextVar state restored."""
+        test_var = contextvars.ContextVar("test_cm_var")
+        test_var.set("snap")
+        captured = contextvars.copy_context()
+        test_var.set("outer_after_snap")
+
+        ctx = ExecutionContext(context_vars=captured)
+
+        with ctx:
+            assert test_var.get() == "snap"
+
+        assert test_var.get() == "outer_after_snap"
 
     def test_enter_with_app_context(self):
         """Test enter enters app context if available."""

--- a/api/tests/unit_tests/core/workflow/context/test_execution_context.py
+++ b/api/tests/unit_tests/core/workflow/context/test_execution_context.py
@@ -128,10 +128,13 @@ class TestExecutionContext:
 
         ctx = ExecutionContext(context_vars=captured)
 
-        with pytest.raises(RuntimeError, match="boom"):
+        def _enter_and_raise() -> None:
             with ctx.enter():
                 assert test_var.get() == "outer"
                 raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _enter_and_raise()
 
         assert test_var.get() == "before_enter"
 

--- a/api/tests/unit_tests/core/workflow/context/test_flask_app_context.py
+++ b/api/tests/unit_tests/core/workflow/context/test_flask_app_context.py
@@ -227,18 +227,14 @@ class TestFlaskExecutionContextIntegration:
         return app
 
     def test_enter_restores_context_vars(self, mock_flask_app):
-        """Test that enter restores captured context variables."""
-        # Create a context variable and set a value
+        """Captured values apply inside the block; outer ContextVar state is restored on exit."""
         test_var = contextvars.ContextVar("integration_test_var")
         test_var.set("original_value")
 
-        # Capture the context
         context_vars = contextvars.copy_context()
 
-        # Change the value
         test_var.set("new_value")
 
-        # Create FlaskExecutionContext and enter it
         from context.flask_app_context import FlaskExecutionContext
 
         ctx = FlaskExecutionContext(
@@ -247,12 +243,9 @@ class TestFlaskExecutionContextIntegration:
         )
 
         with ctx:
-            # Value should be restored to original
             assert test_var.get() == "original_value"
 
-        # After exiting, variable stays at the value from within the context
-        # (this is expected Python contextvars behavior)
-        assert test_var.get() == "original_value"
+        assert test_var.get() == "new_value"
 
     def test_enter_enters_flask_app_context(self, mock_flask_app):
         """Test that enter enters Flask app context."""


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

`ExecutionContext.enter()` only called `ContextVar.set()` for captured keys and never reset the returned tokens, so leaving the context manager did not restore the worker thread’s prior `contextvars` state. Graphon’s `Worker` wraps **each node** in `with execution_context`, so this leaked snapshot values between exits.

This PR collects tokens from each `set()`, resets them in `finally` (reverse order), and applies the same pattern to `FlaskExecutionContext` (`__enter__`/`__exit__` and `enter()`).

Draft issue: `BUG_ISSUE_EXECUTION_CONTEXT_CONTEXTVAR_RESET.md`.

## Screenshots

| Before | After |
|--------|-------|
| Context vars stayed at captured values after each `with execution_context` exit | Tokens reset; outer thread state restored after exit |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Testing

```bash
cd dify/api && uv run pytest \
  tests/unit_tests/core/workflow/context/test_execution_context.py \
  tests/unit_tests/core/workflow/context/test_flask_app_context.py -v
```

## Files changed

- `dify/api/context/execution_context.py`
- `dify/api/context/flask_app_context.py`
- `dify/api/tests/unit_tests/core/workflow/context/test_execution_context.py`
- `dify/api/tests/unit_tests/core/workflow/context/test_flask_app_context.py`
