### PR TITLE
fix(security): enforce tenant scoping on app trace-config endpoints (GHSA-48xc-wmw8-3jr3)

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -841,10 +841,11 @@ class AppTraceApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self, app_id: UUID):
+    @get_app_model
+    def get(self, app_model):
         """Get app trace"""
         with session_factory.create_session() as session:
-            app_trace_config = OpsTraceManager.get_app_tracing_config(str(app_id), session)
+            app_trace_config = OpsTraceManager.get_app_tracing_config(app_model.id, session)
 
         return app_trace_config
 
@@ -858,12 +859,13 @@ class AppTraceApi(Resource):
     @login_required
     @account_initialization_required
     @edit_permission_required
-    def post(self, app_id: UUID):
+    @get_app_model
+    def post(self, app_model):
         # add app trace
         args = AppTracePayload.model_validate(console_ns.payload)
 
         OpsTraceManager.update_app_tracing_config(
-            app_id=str(app_id),
+            app_id=app_model.id,
             enabled=args.enabled,
             tracing_provider=args.tracing_provider,
         )

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -3,7 +3,6 @@ import re
 import uuid
 from datetime import datetime
 from typing import Any, Literal
-from uuid import UUID
 
 from flask import request
 from flask_restx import Resource

--- a/api/controllers/console/app/ops_trace.py
+++ b/api/controllers/console/app/ops_trace.py
@@ -1,5 +1,4 @@
 from typing import Any
-from uuid import UUID
 
 from flask import request
 from flask_restx import Resource, fields
@@ -9,8 +8,10 @@ from werkzeug.exceptions import BadRequest
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
 from controllers.console.app.error import TracingConfigCheckError, TracingConfigIsExist, TracingConfigNotExist
+from controllers.console.app.wraps import get_app_model
 from controllers.console.wraps import account_initialization_required, setup_required
 from libs.login import login_required
+from models import App
 from services.ops_service import OpsService
 
 
@@ -43,11 +44,12 @@ class TraceAppConfigApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self, app_id: UUID):
-        args = TraceProviderQuery.model_validate(request.args.to_dict(flat=True))
+    @get_app_model
+    def get(self, app_model: App):
+        args = TraceProviderQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
 
         try:
-            trace_config = OpsService.get_tracing_app_config(app_id=str(app_id), tracing_provider=args.tracing_provider)
+            trace_config = OpsService.get_tracing_app_config(app_id=app_model.id, tracing_provider=args.tracing_provider)
             if not trace_config:
                 return {"has_not_configured": True}
             return trace_config
@@ -65,13 +67,14 @@ class TraceAppConfigApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def post(self, app_id: UUID):
+    @get_app_model
+    def post(self, app_model: App):
         """Create a new trace app configuration"""
         args = TraceConfigPayload.model_validate(console_ns.payload)
 
         try:
             result = OpsService.create_tracing_app_config(
-                app_id=str(app_id), tracing_provider=args.tracing_provider, tracing_config=args.tracing_config
+                app_id=app_model.id, tracing_provider=args.tracing_provider, tracing_config=args.tracing_config
             )
             if not result:
                 raise TracingConfigIsExist()
@@ -90,13 +93,14 @@ class TraceAppConfigApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def patch(self, app_id: UUID):
+    @get_app_model
+    def patch(self, app_model: App):
         """Update an existing trace app configuration"""
         args = TraceConfigPayload.model_validate(console_ns.payload)
 
         try:
             result = OpsService.update_tracing_app_config(
-                app_id=str(app_id), tracing_provider=args.tracing_provider, tracing_config=args.tracing_config
+                app_id=app_model.id, tracing_provider=args.tracing_provider, tracing_config=args.tracing_config
             )
             if not result:
                 raise TracingConfigNotExist()
@@ -113,12 +117,13 @@ class TraceAppConfigApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def delete(self, app_id: UUID):
+    @get_app_model
+    def delete(self, app_model: App):
         """Delete an existing trace app configuration"""
         args = TraceProviderQuery.model_validate(request.args.to_dict(flat=True))
 
         try:
-            result = OpsService.delete_tracing_app_config(app_id=str(app_id), tracing_provider=args.tracing_provider)
+            result = OpsService.delete_tracing_app_config(app_id=app_model.id, tracing_provider=args.tracing_provider)
             if not result:
                 raise TracingConfigNotExist()
             return {"result": "success"}, 204

--- a/api/controllers/console/app/ops_trace.py
+++ b/api/controllers/console/app/ops_trace.py
@@ -49,7 +49,9 @@ class TraceAppConfigApi(Resource):
         args = TraceProviderQuery.model_validate(request.args.to_dict(flat=True))  # type: ignore
 
         try:
-            trace_config = OpsService.get_tracing_app_config(app_id=app_model.id, tracing_provider=args.tracing_provider)
+            trace_config = OpsService.get_tracing_app_config(
+                app_id=app_model.id, tracing_provider=args.tracing_provider
+            )
             if not trace_config:
                 return {"has_not_configured": True}
             return trace_config

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_app_apis.py
@@ -8,7 +8,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from flask.testing import FlaskClient
 from pydantic import ValidationError
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, NotFound
 
 from controllers.console import console_ns
@@ -57,6 +59,12 @@ from controllers.console.app.workflow_app_log import WorkflowAppLogQuery
 from controllers.console.app.workflow_draft_variable import WorkflowDraftVariableUpdatePayload
 from controllers.console.app.workflow_statistic import WorkflowStatisticQuery
 from controllers.console.app.workflow_trigger import Parser, ParserEnable
+from models.model import AppMode
+from tests.test_containers_integration_tests.controllers.console.helpers import (
+    authenticate_console_client,
+    create_console_account_and_tenant,
+    create_console_app,
+)
 
 
 def _unwrap(func):
@@ -269,6 +277,35 @@ class TestOpsTraceEndpoints:
     @pytest.fixture
     def app(self, flask_app_with_containers: Flask):
         return flask_app_with_containers
+
+    @pytest.mark.parametrize(
+        "path_template",
+        [
+            "/console/api/apps/{app_id}/trace-config?tracing_provider=langfuse",
+            "/console/api/apps/{app_id}/trace",
+        ],
+    )
+    def test_trace_endpoints_hide_apps_from_other_tenants(
+        self,
+        db_session_with_containers: Session,
+        test_client_with_containers: FlaskClient,
+        path_template: str,
+    ):
+        account, _tenant = create_console_account_and_tenant(db_session_with_containers)
+        foreign_account, foreign_tenant = create_console_account_and_tenant(db_session_with_containers)
+        foreign_app = create_console_app(
+            db_session_with_containers,
+            tenant_id=foreign_tenant.id,
+            account_id=foreign_account.id,
+            mode=AppMode.CHAT,
+        )
+
+        response = test_client_with_containers.get(
+            path_template.format(app_id=foreign_app.id),
+            headers=authenticate_console_client(test_client_with_containers, account),
+        )
+
+        assert response.status_code == 404
 
     def test_ops_trace_query_basic(self):
         query = TraceProviderQuery(tracing_provider="langfuse")

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_app_apis.py
@@ -289,7 +289,7 @@ class TestOpsTraceEndpoints:
         )
 
         with app.test_request_context("/?tracing_provider=langfuse"):
-            result = method(app_id="app-1")
+            result = method(app_model=MagicMock(id="app-1"))
 
         assert result == {"has_not_configured": True}
 
@@ -308,7 +308,7 @@ class TestOpsTraceEndpoints:
             json={"tracing_provider": "langfuse", "tracing_config": {"api_key": "k"}},
         ):
             with pytest.raises(BadRequest):
-                method(app_id="app-1")
+                method(app_model=MagicMock(id="app-1"))
 
     def test_trace_app_config_delete_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch):
         api = ops_trace_module.TraceAppConfigApi()
@@ -322,7 +322,7 @@ class TestOpsTraceEndpoints:
 
         with app.test_request_context("/?tracing_provider=langfuse"):
             with pytest.raises(BadRequest):
-                method(app_id="app-1")
+                method(app_model=MagicMock(id="app-1"))
 
 
 class TestSiteEndpoints:

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
@@ -6,17 +6,17 @@ import uuid
 from flask.testing import FlaskClient
 from sqlalchemy.orm import Session
 
-from configs import dify_config
 from constants import HEADER_NAME_CSRF_TOKEN
 from graphon.enums import WorkflowExecutionStatus
 from libs.datetime_utils import naive_utc_now
 from libs.token import _real_cookie_name, generate_csrf_token
-from models import Account, DifySetup, Tenant, TenantAccountJoin
+from models import Account, Tenant, TenantAccountJoin
 from models.account import AccountStatus, TenantAccountRole, TenantStatus
 from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import App, AppMode, Conversation, Message
 from models.workflow import WorkflowRun
 from services.account_service import AccountService
+from tests.test_containers_integration_tests.controllers.console.helpers import ensure_dify_setup
 
 
 def _create_account_and_tenant(db_session: Session) -> tuple[Account, Tenant]:
@@ -47,9 +47,7 @@ def _create_account_and_tenant(db_session: Session) -> tuple[Account, Tenant]:
     account.timezone = "UTC"
     db_session.commit()
 
-    dify_setup = DifySetup(version=dify_config.project.version)
-    db_session.add(dify_setup)
-    db_session.commit()
+    ensure_dify_setup(db_session)
 
     return account, tenant
 


### PR DESCRIPTION
## Summary

The `/console/api/apps/<app_id>/trace-config` endpoints (GET/POST/PATCH/DELETE in `api/controllers/console/app/ops_trace.py`) checked authentication but **did not verify the target `app_id` belonged to the caller's tenant**. An authenticated user from tenant A could read, modify, or delete the tracing configuration of any app in tenant B — including redirecting outbound traces to an attacker-controlled Langfuse / OpenTelemetry endpoint to exfiltrate prompts and outputs.

## Fix

Apply the established `@get_app_model` decorator (defined in `api/controllers/console/app/wraps.py`) to all four verbs. That decorator:

- Loads the App with `App.tenant_id == current_tenant_id` filter
- Raises `AppNotFoundError` (404) on mismatch — same response shape as a non-existent app, no info leak

This follows the same pattern already used in `mcp_server.py`, `workflow_trigger.py`, and other tenant-scoped console routes.

## Scope

- One file (`api/controllers/console/app/ops_trace.py`), 14 inserts / 8 deletes
- View signatures change `(self, app_id)` → `(self, app_model: App)`; service calls now pass `app_model.id`
- No service-layer changes — defense at controller boundary is appropriate here since `OpsService` is also called from internal task queues that already trust their inputs

## Refs

- GHSA-48xc-wmw8-3jr3 (private advisory, reporter: @zafido via Huntr)
- Public follow-up: #35699

Per @crazywoola's note in #35699, security coordination should happen in the GHSA thread rather than this PR's discussion. Happy to revise based on the reporter's draft patch (which I haven't seen — opening this so the GHSA thread has a concrete community contribution to react to). Marking as draft until the reporter / a maintainer signs off.

## Tests

No regression test included. Dify's controller test infra requires fixtures (multi-tenant DB setup) that would significantly expand this PR's scope. Happy to add one if the maintainer team prefers — the assertion would be: authenticated user from tenant A → 404 for app_id in tenant B (instead of the current 200 + leak / 200 + write).

## Sibling endpoints

I scanned `api/controllers/console/app/` for similar `(self, app_id)` patterns without `@get_app_model`. `annotation.py` and parts of `app.py` also take `app_id` without the decorator, but their service layers do their own `tenant_id == current_tenant_id` filtering. Not bundling them — keeps this PR scoped to the disclosed advisory.
