### PR TITLE
fix(web): restore button clears draft when collaboration mode is disable

### DIFF
--- a/web/app/components/workflow-app/components/workflow-header/index.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/index.tsx
@@ -51,9 +51,10 @@ const WorkflowHeader = () => {
       },
       restoring: {
         onRestoreSettled: resetWorkflowVersionHistory,
+        restoreVersionUrl: (versionId: string) => `/apps/${appDetail!.id}/workflows/${versionId}/restore`,
       },
     }
-  }, [resetWorkflowVersionHistory, isChatMode, viewHistoryProps])
+  }, [resetWorkflowVersionHistory, isChatMode, viewHistoryProps, appDetail])
   return (
     <Header {...headerProps} />
   )

--- a/web/app/components/workflow/header/__tests__/header-in-restoring.spec.tsx
+++ b/web/app/components/workflow/header/__tests__/header-in-restoring.spec.tsx
@@ -1,5 +1,7 @@
 import type { VersionHistory } from '@/types/workflow'
-import { screen } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { seedSystemFeatures } from '@/__tests__/utils/mock-system-features'
 import { FlowType } from '@/types/common'
 import { renderWorkflowComponent } from '../../__tests__/workflow-test-env'
 import { WorkflowVersion } from '../../types'
@@ -74,9 +76,16 @@ const createVersion = (overrides: Partial<VersionHistory> = {}): VersionHistory 
   ...overrides,
 })
 
+const defaultConfigsMap = {
+  flowId: 'app-1',
+  flowType: FlowType.appFlow,
+  fileSettings: {} as never,
+}
+
 describe('HeaderInRestoring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockRestoreWorkflow.mockResolvedValue({})
   })
 
   it('should disable restore when the flow id is not ready yet', () => {
@@ -98,11 +107,7 @@ describe('HeaderInRestoring', () => {
         currentVersion: createVersion(),
       },
       hooksStoreProps: {
-        configsMap: {
-          flowId: 'app-1',
-          flowType: FlowType.appFlow,
-          fileSettings: {} as never,
-        },
+        configsMap: defaultConfigsMap,
       },
     })
 
@@ -117,14 +122,150 @@ describe('HeaderInRestoring', () => {
         }),
       },
       hooksStoreProps: {
-        configsMap: {
-          flowId: 'app-1',
-          flowType: FlowType.appFlow,
-          fileSettings: {} as never,
-        },
+        configsMap: defaultConfigsMap,
       },
     })
 
     expect(screen.getByRole('button', { name: 'workflow.common.restore' })).toBeDisabled()
+  })
+
+  describe('when collaboration mode is disabled (default)', () => {
+    it('should call the REST API restore endpoint and refresh draft on success', async () => {
+      const restoreVersionUrl = vi.fn((id: string) => `/apps/app-1/workflows/${id}/restore`)
+      const onRestoreSettled = vi.fn()
+      const deleteAllInspectVars = vi.fn()
+
+      const { store } = renderWorkflowComponent(
+        <HeaderInRestoring
+          restoreVersionUrl={restoreVersionUrl}
+          onRestoreSettled={onRestoreSettled}
+        />,
+        {
+          initialStoreState: {
+            isRestoring: true,
+            showWorkflowVersionHistoryPanel: true,
+            currentVersion: createVersion(),
+            deleteAllInspectVars,
+          },
+          hooksStoreProps: { configsMap: defaultConfigsMap },
+        },
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'workflow.common.restore' }))
+
+      await waitFor(() => {
+        expect(restoreVersionUrl).toHaveBeenCalledWith('version-1')
+        expect(mockRestoreWorkflow).toHaveBeenCalledWith('/apps/app-1/workflows/version-1/restore')
+        expect(mockHandleRefreshWorkflowDraft).toHaveBeenCalledTimes(1)
+        expect(deleteAllInspectVars).toHaveBeenCalledTimes(1)
+        expect(mockInvalidAllLastRun).toHaveBeenCalledTimes(1)
+        expect(onRestoreSettled).toHaveBeenCalledTimes(1)
+      })
+
+      expect(store.getState().isRestoring).toBe(false)
+      expect(store.getState().showWorkflowVersionHistoryPanel).toBe(false)
+      expect(store.getState().backupDraft).toBeUndefined()
+      // Must NOT use the CRDT path
+      expect(mockRequestRestore).not.toHaveBeenCalled()
+    })
+
+    it('should call onRestoreSettled even when the REST API call fails', async () => {
+      mockRestoreWorkflow.mockRejectedValue(new Error('network error'))
+      const onRestoreSettled = vi.fn()
+
+      renderWorkflowComponent(
+        <HeaderInRestoring
+          restoreVersionUrl={(id: string) => `/apps/app-1/workflows/${id}/restore`}
+          onRestoreSettled={onRestoreSettled}
+        />,
+        {
+          initialStoreState: {
+            isRestoring: true,
+            showWorkflowVersionHistoryPanel: true,
+            currentVersion: createVersion(),
+          },
+          hooksStoreProps: { configsMap: defaultConfigsMap },
+        },
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'workflow.common.restore' }))
+
+      await waitFor(() => {
+        expect(onRestoreSettled).toHaveBeenCalledTimes(1)
+        expect(mockHandleRefreshWorkflowDraft).not.toHaveBeenCalled()
+      })
+    })
+
+    it('should fall back to the CRDT path when restoreVersionUrl is not provided', async () => {
+      mockRequestRestore.mockImplementation((_payload: unknown, callbacks?: {
+        onSuccess?: () => void
+        onSettled?: () => void
+      }) => {
+        callbacks?.onSuccess?.()
+        callbacks?.onSettled?.()
+      })
+
+      renderWorkflowComponent(
+        // restoreVersionUrl intentionally omitted
+        <HeaderInRestoring />,
+        {
+          initialStoreState: {
+            isRestoring: true,
+            currentVersion: createVersion(),
+          },
+          hooksStoreProps: { configsMap: defaultConfigsMap },
+        },
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'workflow.common.restore' }))
+
+      await waitFor(() => {
+        expect(mockRequestRestore).toHaveBeenCalledTimes(1)
+        expect(mockRestoreWorkflow).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when collaboration mode is enabled', () => {
+    const createCollabQueryClient = () => {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      seedSystemFeatures(queryClient, { enable_collaboration_mode: true })
+      return queryClient
+    }
+
+    it('should use the CRDT path and not call the REST API', async () => {
+      mockRequestRestore.mockImplementation((_payload: unknown, callbacks?: {
+        onSuccess?: () => void
+        onSettled?: () => void
+      }) => {
+        callbacks?.onSuccess?.()
+        callbacks?.onSettled?.()
+      })
+      const restoreVersionUrl = vi.fn((id: string) => `/apps/app-1/workflows/${id}/restore`)
+      const onRestoreSettled = vi.fn()
+
+      renderWorkflowComponent(
+        <HeaderInRestoring
+          restoreVersionUrl={restoreVersionUrl}
+          onRestoreSettled={onRestoreSettled}
+        />,
+        {
+          queryClient: createCollabQueryClient(),
+          initialStoreState: {
+            isRestoring: true,
+            currentVersion: createVersion(),
+          },
+          hooksStoreProps: { configsMap: defaultConfigsMap },
+        },
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'workflow.common.restore' }))
+
+      await waitFor(() => {
+        expect(mockRequestRestore).toHaveBeenCalledTimes(1)
+        expect(mockRestoreWorkflow).not.toHaveBeenCalled()
+        expect(onRestoreSettled).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 })

--- a/web/app/components/workflow/header/__tests__/header-layouts.spec.tsx
+++ b/web/app/components/workflow/header/__tests__/header-layouts.spec.tsx
@@ -58,6 +58,9 @@ vi.mock('@/hooks/use-theme', () => ({
 
 vi.mock('@/service/use-workflow', () => ({
   useInvalidAllLastRun: () => mockInvalidAllLastRun,
+  useRestoreWorkflow: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+  }),
 }))
 
 vi.mock('@langgenius/dify-ui/toast', () => ({

--- a/web/app/components/workflow/header/header-in-restoring.tsx
+++ b/web/app/components/workflow/header/header-in-restoring.tsx
@@ -2,6 +2,7 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiHistoryLine } from '@remixicon/react'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import {
   useCallback,
 } from 'react'
@@ -9,7 +10,8 @@ import { useTranslation } from 'react-i18next'
 import { useFeaturesStore } from '@/app/components/base/features/hooks'
 import { useSelector as useAppContextSelector } from '@/context/app-context'
 import useTheme from '@/hooks/use-theme'
-import { useInvalidAllLastRun } from '@/service/use-workflow'
+import { systemFeaturesQueryOptions } from '@/service/system-features'
+import { useInvalidAllLastRun, useRestoreWorkflow } from '@/service/use-workflow'
 import {
   useLeaderRestore,
   useWorkflowRefreshDraft,
@@ -27,9 +29,11 @@ import RestoringTitle from './restoring-title'
 
 export type HeaderInRestoringProps = {
   onRestoreSettled?: () => void
+  restoreVersionUrl?: (versionId: string) => string
 }
 const HeaderInRestoring = ({
   onRestoreSettled,
+  restoreVersionUrl,
 }: HeaderInRestoringProps) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
@@ -38,6 +42,10 @@ const HeaderInRestoring = ({
   const featuresStore = useFeaturesStore()
   const configsMap = useHooksStore(s => s.configsMap)
   const invalidAllLastRun = useInvalidAllLastRun(configsMap?.flowType, configsMap?.flowId)
+  const { data: isCollaborationEnabled } = useSuspenseQuery({
+    ...systemFeaturesQueryOptions(),
+    select: s => s.enable_collaboration_mode,
+  })
   const {
     deleteAllInspectVars,
   } = workflowStore.getState()
@@ -49,6 +57,7 @@ const HeaderInRestoring = ({
   } = useWorkflowRun()
   const { requestRestore } = useLeaderRestore()
   const { handleRefreshWorkflowDraft } = useWorkflowRefreshDraft()
+  const { mutateAsync: restoreWorkflow } = useRestoreWorkflow()
   const canRestore = !!currentVersion?.id && !!configsMap?.flowId && currentVersion.version !== WorkflowVersion.Draft
 
   const handleCancelRestore = useCallback(() => {
@@ -57,7 +66,7 @@ const HeaderInRestoring = ({
     setShowWorkflowVersionHistoryPanel(false)
   }, [workflowStore, handleLoadBackupDraft, setShowWorkflowVersionHistoryPanel])
 
-  const handleRestore = useCallback(() => {
+  const handleRestore = useCallback(async () => {
     if (!canRestore || !currentVersion)
       return
 
@@ -65,6 +74,31 @@ const HeaderInRestoring = ({
     workflowStore.setState({ isRestoring: false })
     workflowStore.setState({ backupDraft: undefined })
 
+    // When collaboration mode is disabled the CRDT layer is never initialised, so
+    // setNodes/setEdges are no-ops and refreshGraphSynchronously emits an empty
+    // graphImport event that wipes the canvas.  Use the REST API path instead,
+    // which is identical to what the context-menu "Restore" option does.
+    // NOTE: restoreVersionUrl must always be provided when collaboration is disabled.
+    if (!isCollaborationEnabled && restoreVersionUrl) {
+      // Non-collaboration path: call the dedicated restore API endpoint, then
+      // refresh the draft from the server — same mechanism as context menu restore.
+      try {
+        await restoreWorkflow(restoreVersionUrl(currentVersion.id))
+        handleRefreshWorkflowDraft()
+        toast.success(t('versionHistory.action.restoreSuccess', { ns: 'workflow' }))
+        deleteAllInspectVars()
+        invalidAllLastRun()
+      }
+      catch {
+        toast.error(t('versionHistory.action.restoreFailure', { ns: 'workflow' }))
+      }
+      finally {
+        onRestoreSettled?.()
+      }
+      return
+    }
+
+    // Collaboration path: apply graph locally via CRDT then sync draft.
     const { graph } = currentVersion
     const features = featuresStore?.getState().features
     const environmentVariables = currentVersion.environment_variables || []
@@ -97,7 +131,7 @@ const HeaderInRestoring = ({
         onRestoreSettled?.()
       },
     })
-  }, [canRestore, currentVersion, setShowWorkflowVersionHistoryPanel, workflowStore, featuresStore, requestRestore, userProfile, handleRefreshWorkflowDraft, deleteAllInspectVars, invalidAllLastRun, t, onRestoreSettled])
+  }, [canRestore, currentVersion, setShowWorkflowVersionHistoryPanel, workflowStore, isCollaborationEnabled, restoreVersionUrl, restoreWorkflow, handleRefreshWorkflowDraft, featuresStore, requestRestore, userProfile, deleteAllInspectVars, invalidAllLastRun, t, onRestoreSettled])
 
   return (
     <>


### PR DESCRIPTION
When ENABLE_COLLABORATION_MODE=false the CRDT layer is never initialised, so collaborationManager.setNodes/setEdges are silent no-ops and refreshGraphSynchronously emits graphImport with empty nodes/edges, wiping the canvas and saving an empty draft to the backend.

The top-right Restore button in the version-history panel now takes the same REST API path as the context-menu Restore when collaboration is disabled: POST /apps/{id}/workflows/{versionId}/restore followed by handleRefreshWorkflowDraft(). The CRDT path is preserved unchanged for when collaboration is enabled.

- Add restoreVersionUrl prop to HeaderInRestoringProps
- Pass restoreVersionUrl from WorkflowHeader
- Split handleRestore into non-collab (REST) and collab (CRDT) branches
- Add tests covering both branches and error/fallback cases

Fixes #35790

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
