### PR TITLE
fix(api): dedup retriever resources within a single event

### DIFF
--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -194,6 +194,8 @@ class MessageCycleManager:
 
                 if not is_duplicate:
                     merged_resources.append(resource)
+                    if resource.dataset_id and resource.document_id:
+                        existing_ids.add((resource.dataset_id, resource.document_id))
 
             for i, resource in enumerate(merged_resources, 1):
                 resource.position = i

--- a/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
@@ -439,6 +439,31 @@ class TestMessageCycleManagerOptimization:
         assert message_cycle_manager._task_state.metadata.retriever_resources[0].position == 1
         assert message_cycle_manager._task_state.metadata.retriever_resources[1].position == 2
 
+    def test_handle_retriever_resources_dedupes_within_single_event(self, message_cycle_manager):
+        """Deduplicate within a single event payload, not just against pre-existing items.
+
+        Regression test for https://github.com/langgenius/dify/issues/34664: when the
+        retriever event itself contained the same (dataset_id, document_id) pair more
+        than once, every occurrence after the first was still appended because
+        ``existing_ids`` was not updated as new resources were merged in.
+        """
+        message_cycle_manager._application_generate_entity.app_config = SimpleNamespace(
+            additional_features=SimpleNamespace(show_retrieve_source=True)
+        )
+        message_cycle_manager._task_state = SimpleNamespace(metadata=TaskStateMetadata(retriever_resources=[]))
+
+        first = RetrievalSourceMetadata(dataset_id="d1", document_id="doc1")
+        duplicate_in_event = RetrievalSourceMetadata(dataset_id="d1", document_id="doc1")
+        another = RetrievalSourceMetadata(dataset_id="d2", document_id="doc2")
+
+        event = QueueRetrieverResourcesEvent(retriever_resources=[first, duplicate_in_event, another])
+        message_cycle_manager.handle_retriever_resources(event)
+
+        resources = message_cycle_manager._task_state.metadata.retriever_resources
+        assert len(resources) == 2
+        assert {(r.dataset_id, r.document_id) for r in resources} == {("d1", "doc1"), ("d2", "doc2")}
+        assert [r.position for r in resources] == [1, 2]
+
     def test_message_file_to_stream_response_builds_signed_url(self, message_cycle_manager):
         """Build a stream response with a signed tool file URL.
 


### PR DESCRIPTION
## Summary

Fixes #34664 (repeated knowledge citations in chat output).

`handle_retriever_resources` deduplicates retriever resources by `(dataset_id, document_id)` against an `existing_ids` set built **once before** the loop, but never updates the set as new resources are merged in. So duplicate pairs that arrive inside the **same** `QueueRetrieverResourcesEvent` all pass the `is_duplicate` check (since the in-event dupes never get added to the set) and end up appended to the citation list. The existing test only covered the cross-event case (a duplicate against pre-existing metadata), which masked the issue.

**Fix:** add the new resource's id to `existing_ids` immediately after appending, so subsequent duplicates in the same event are dropped.

**Files**

- `api/core/app/task_pipeline/message_cycle_manager.py` — 2 lines added inside the loop.
- `api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py` — regression test asserting an event with `[A, A, B]` only yields `[A, B]` with positions `[1, 2]`.

## Test plan

```
uv run python -m pytest tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py -v
```

```
27 passed in 0.53s
```

The new `test_handle_retriever_resources_dedupes_within_single_event` fails on `main` (asserts 2 resources, gets 3), confirming the regression guard. All 27 tests in the file pass with the fix applied.