### PR TITLE
fix(api): _resolve_workflow_app_tenant_id falls back to pipelines table

### DIFF
--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -80,9 +80,16 @@ SerializedWorkflowVariables = dict[str, SerializedWorkflowValue]
 
 
 def _resolve_workflow_app_tenant_id(app_id: str) -> str:
+    from .dataset import Pipeline
     from .model import App
 
     tenant_id = db.session.scalar(select(App.tenant_id).where(App.id == app_id))
+    if not tenant_id:
+        # ITX patch: rag-pipeline workflows reference the `pipelines` table, not
+        # `apps`. Without this fallback, every Test Run / sync that emits File
+        # outputs (Drive download, etc.) fails with "Unable to resolve tenant_id".
+        # Upstream bug; the same bug exists on Dify main as of the pin.
+        tenant_id = db.session.scalar(select(Pipeline.tenant_id).where(Pipeline.id == app_id))
     if not tenant_id:
         raise ValueError(f"Unable to resolve tenant_id for app {app_id}")
     return tenant_id


### PR DESCRIPTION
## Summary

For RAG-pipeline workflows, `app_id` references the `pipelines` table, not `apps`. The resolver in `api/models/workflow.py` only checks `apps`, so any rag-pipeline run that has to rebuild a `File` object from a stored mapping (Drive download, document_extractor with files, etc.) raises:

```
ValueError: Unable to resolve tenant_id for app <pipeline-id>
```

…and the run aborts.

This fallback also looks the id up in `pipelines` when `apps` misses. Same bug is reachable on `main` as of v1.14.0 — easy to repro by Test-Running any Knowledge Pipeline that emits a File output.

## Test plan

- [ ] Test Run a RAG pipeline whose first node is a Drive datasource (or any node producing a File output) — succeeds without the ValueError.
- [ ] Test Run a regular Workflow app with file inputs — unchanged behaviour (App lookup still wins first).