### PR TITLE
fix(web): Summary Auto-Gen toggle preserves model_name and summary_prompt

### DIFF
--- a/web/app/components/datasets/settings/summary-index-setting.tsx
+++ b/web/app/components/datasets/settings/summary-index-setting.tsx
@@ -40,11 +40,22 @@ const SummaryIndexSetting = ({
     }
   }, [summaryIndexSetting?.model_name, summaryIndexSetting?.model_provider_name])
 
+  // ITX patch: emit enable changes alongside default-safe values for
+  // model_name / summary_prompt. Without this, toggling the switch sends only
+  // {enable: value}; the upstream merge keeps whatever was there (often null
+  // when the user just enabled summarisation and hasn't yet picked a model
+  // or filled the textarea), and Dify's KnowledgeIndexNodeData pydantic
+  // schema then rejects publish with "summary_prompt: input should be a
+  // valid string" because null isn't a string. CLAUDE.md §8.5.
   const handleSummaryIndexEnableChange = useCallback((value: boolean) => {
     onSummaryIndexSettingChange?.({
       enable: value,
+      // Coerce nullish to empty string so the merged shape is always all-strings.
+      model_name: summaryIndexSetting?.model_name ?? '',
+      model_provider_name: summaryIndexSetting?.model_provider_name ?? '',
+      summary_prompt: summaryIndexSetting?.summary_prompt ?? '',
     })
-  }, [onSummaryIndexSettingChange])
+  }, [onSummaryIndexSettingChange, summaryIndexSetting])
 
   const handleSummaryIndexModelChange = useCallback((model: DefaultModel) => {
     onSummaryIndexSettingChange?.({
@@ -54,8 +65,9 @@ const SummaryIndexSetting = ({
   }, [onSummaryIndexSettingChange])
 
   const handleSummaryIndexPromptChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    // ITX patch: never emit null/undefined — same reason as enable handler above.
     onSummaryIndexSettingChange?.({
-      summary_prompt: e.target.value,
+      summary_prompt: e.target.value ?? '',
     })
   }, [onSummaryIndexSettingChange])
 


### PR DESCRIPTION
## Summary

Toggling the switch on `summary_index_setting` emits only `{enable: value}`. The merge in `use-config.ts` overlays this onto the existing setting — but if the user enabled summarisation without first picking a model and filling the prompt, those fields are still nullish in the merged shape, and `KnowledgeIndexNodeData`'s pydantic schema rejects null on string fields:

```
summary_index_setting.summary_prompt
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

The publish call then 422s.

This patch coerces nullish strings to `''` in both the toggle and prompt-change handlers, so the merged shape is always all-strings. Same fix applies to all three entry points (`knowledge-base`, `dataset-settings`, `create-document`).

## Repro

1. Create a new Knowledge Base in pipeline mode.
2. On the Knowledge Base node, toggle Summary Auto-Gen ON.
3. Don't pick a model or fill the instructions textarea.
4. Try to Publish — fails with the 422 above.

After this PR: publish succeeds with empty model/prompt strings (the user can fill them later or toggle OFF, which now also preserves whatever they did fill).

## Test plan

- [ ] Toggle Summary Auto-Gen on without filling fields → publish succeeds.
- [ ] Toggle off → fields preserved (turn back on, model selection is still there).