### PR TITLE
fix(web): prompt-editor variable picker doesn't auto-hide on internal focus

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -118,7 +118,15 @@ const ComponentPicker = ({
         BLUR_COMMAND,
         (event) => {
           clearBlurTimer()
-          const target = event?.relatedTarget as HTMLElement
+          const target = event?.relatedTarget as HTMLElement | null
+          // ITX patch: when focus moves into ANY element inside the picker
+          // popup (not just the search box), don't schedule the hide timer.
+          // Upstream only whitelisted `.var-search-input`, so clicking a
+          // variable item, scrolling the list, or moving onto a sibling
+          // input would race the 200ms blur timer and the picker would
+          // disappear before the user could pick. CLAUDE.md §10.
+          if (target?.closest?.('[data-prompt-editor-picker]'))
+            return false
           if (!target?.classList?.contains('var-search-input'))
             blurTimerRef.current = setTimeout(() => setBlurHidden(true), 200)
           return false
@@ -237,6 +245,11 @@ const ComponentPicker = ({
             // See https://github.com/facebook/lexical/blob/ac97dfa9e14a73ea2d6934ff566282d7f758e8bb/packages/lexical-react/src/shared/LexicalMenu.ts#L493
             <div className="h-0 w-0">
               <div
+                // ITX marker: the BLUR_COMMAND handler above checks for this
+                // attribute on the focus target so clicks/keyboard nav inside
+                // the picker don't trip the auto-hide timer. Don't rename
+                // without also updating the handler.
+                data-prompt-editor-picker
                 className="w-[260px] rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg"
                 style={{
                   ...floatingStyles,


### PR DESCRIPTION
## Summary

The prompt-editor's component picker (the popup that opens on `/`) schedules a 200 ms hide whenever the editor blurs, unless the focus target has the `.var-search-input` class. That whitelist is too narrow:

- clicking a variable item to insert it
- scrolling the variable list
- moving focus to a sibling form field (e.g. the next prompt slot, the body editor next to a header field, etc.)

…all race the timer and the picker disappears before the user can finish picking.

This PR marks the picker's outer popup div with `[data-prompt-editor-picker]` and short-circuits the hide schedule when `relatedTarget` sits anywhere inside that subtree. The `.var-search-input` check is kept as-is for backward compatibility.

## Repro

1. Open any HTTP Request node body field (or any prompt slot in any node).
2. Type `/` to summon the picker.
3. Move the cursor into the variable list.
4. Picker vanishes mid-select.

After this PR the picker stays open as long as the focus is inside it.

## Test plan

- [ ] Picker stays open while clicking variable items.
- [ ] Picker stays open while scrolling.
- [ ] Picker still hides when focus moves to a genuinely unrelated element (different node, click outside the panel).