### PR TITLE
fix(workflow): move onClick to row div in KB metadata filter field selector

### DIFF
--- a/web/app/components/workflow/nodes/knowledge-retrieval/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/__tests__/integration.spec.tsx
@@ -16,6 +16,7 @@ import { RETRIEVE_METHOD, RETRIEVE_TYPE } from '@/types/app'
 import { DatasetsDetailContext } from '../../../datasets-detail-store/provider'
 import { createDatasetsDetailStore } from '../../../datasets-detail-store/store'
 import { BlockEnum, VarType } from '../../../types'
+import AddCondition from '../components/metadata/add-condition'
 import AddDataset from '../components/add-dataset'
 import DatasetItem from '../components/dataset-item'
 import DatasetList from '../components/dataset-list'
@@ -412,6 +413,38 @@ describe('knowledge-retrieval path', () => {
   })
 
   describe('Metadata controls', () => {
+    it('should call handleAddCondition with the correct metadata item when clicking any part of the row', async () => {
+      // Regression test for: https://github.com/langgenius/dify/issues/35844
+      // The onClick was previously on the inner text <div> only, causing clicks on the
+      // icon or type label to not register, which defaulted to the first field (document_name).
+      const user = userEvent.setup()
+      const handleAddCondition = vi.fn()
+      const permissionMetadata = createMetadata({ id: 'meta-perm', name: 'permission', type: MetadataFilteringVariableType.string })
+      const topicMetadata = createMetadata({ id: 'meta-topic', name: 'topic', type: MetadataFilteringVariableType.string })
+
+      const { unmount } = render(
+        <AddCondition
+          metadataList={[permissionMetadata, topicMetadata]}
+          handleAddCondition={handleAddCondition}
+        />,
+      )
+
+      // Open the dropdown
+      await user.click(screen.getByRole('button', { name: /workflow.nodes.knowledgeRetrieval.metadata.panel.add/i }))
+
+      // Click anywhere on the 'permission' row — clicking on the type label which was not covered before
+      const typeLabel = screen.getByText('string', { selector: 'div.shrink-0' })
+      await user.click(typeLabel)
+
+      expect(handleAddCondition).toHaveBeenCalledTimes(1)
+      expect(handleAddCondition).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'meta-perm',
+        name: 'permission',
+      }))
+
+      unmount()
+    })
+
     it('should select metadata filter mode from the dropdown', async () => {
       const user = userEvent.setup()
       const onSelect = vi.fn()

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx
@@ -65,6 +65,7 @@ const AddCondition = ({
               <div
                 key={metadata.name}
                 className="flex h-6 cursor-pointer items-center rounded-md px-3 system-sm-medium text-text-secondary hover:bg-state-base-hover"
+                onClick={() => handleAddConditionWrapped(metadata)}
               >
                 <div className="mr-1 p-px">
                   <MetadataIcon type={metadata.type} />
@@ -72,7 +73,6 @@ const AddCondition = ({
                 <div
                   className="grow truncate"
                   title={metadata.name}
-                  onClick={() => handleAddConditionWrapped(metadata)}
                 >
                   {metadata.name}
                 </div>


### PR DESCRIPTION
## Summary

Fixes #35844.

The `onClick` handler in the `AddCondition` component (Knowledge Retrieval node → Metadata Filter Conditions) was attached to the inner text `<div>` rather than the outer row `<div>`. This meant that clicks landing on the field icon, the type label (`string`, `number`, etc.), or the row padding were silently dropped — the event never reached the handler. As a result, the UI always fell back to the first field in the list (`document_name`), regardless of which field the user intended to select.

**Root cause (one-line diff):**

```diff
-<div key={metadata.name} className="flex h-6 cursor-pointer ...">
+<div key={metadata.name} className="flex h-6 cursor-pointer ..." onClick={() => handleAddConditionWrapped(metadata)}>
   <div className="mr-1 p-px"><MetadataIcon type={metadata.type} /></div>
-  <div className="grow truncate" title={metadata.name} onClick={() => handleAddConditionWrapped(metadata)}>
+  <div className="grow truncate" title={metadata.name}>
     {metadata.name}
   </div>
   <div className="shrink-0 ...">string</div>
</div>
```

Moving the handler to the outer row element ensures the entire clickable area (icon, name, type, padding) correctly maps to the intended metadata item.

## Test plan

- Added a regression test in `integration.spec.tsx` that renders `AddCondition` with two metadata items, opens the dropdown, and clicks the **type label** span (the area that was previously uncovered). Asserts that `handleAddCondition` is called exactly once with the correct `id` and `name` of the intended field.
- Manually verified in the running app: selecting any built-in or custom field by clicking anywhere on the row now correctly adds the condition for that field.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)